### PR TITLE
Bump datadog-checks-base to >=37.39.1 in DBM integrations

### DIFF
--- a/clickhouse/changelog.d/23950.fixed
+++ b/clickhouse/changelog.d/23950.fixed
@@ -1,2 +1,1 @@
-Bump `datadog-checks-base` to `>=37.39.1`. Notable changes:
-  - Send each logical database as its own independent schema snapshot, so an error or partial collection for one database does not affect others. ([#23913](https://github.com/DataDog/integrations-core/pull/23913))
+Bump `datadog-checks-base` to `>=37.39.1`.

--- a/clickhouse/changelog.d/23950.fixed
+++ b/clickhouse/changelog.d/23950.fixed
@@ -1,0 +1,2 @@
+Bump `datadog-checks-base` to `>=37.39.1`. Notable changes:
+  - Send each logical database as its own independent schema snapshot, so an error or partial collection for one database does not affect others. ([#23913](https://github.com/DataDog/integrations-core/pull/23913))

--- a/clickhouse/pyproject.toml
+++ b/clickhouse/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.34.1",
+    "datadog-checks-base>=37.39.1",
 ]
 dynamic = [
     "version",

--- a/mongo/changelog.d/23950.fixed
+++ b/mongo/changelog.d/23950.fixed
@@ -1,2 +1,1 @@
-Bump `datadog-checks-base` to `>=37.39.1`. Notable changes:
-  - Send each logical database as its own independent schema snapshot, so an error or partial collection for one database does not affect others. ([#23913](https://github.com/DataDog/integrations-core/pull/23913))
+Bump `datadog-checks-base` to `>=37.39.1`.

--- a/mongo/changelog.d/23950.fixed
+++ b/mongo/changelog.d/23950.fixed
@@ -1,0 +1,2 @@
+Bump `datadog-checks-base` to `>=37.39.1`. Notable changes:
+  - Send each logical database as its own independent schema snapshot, so an error or partial collection for one database does not affect others. ([#23913](https://github.com/DataDog/integrations-core/pull/23913))

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.34.1",
+    "datadog-checks-base>=37.39.1",
 ]
 dynamic = [
     "version",

--- a/mysql/changelog.d/23950.fixed
+++ b/mysql/changelog.d/23950.fixed
@@ -1,2 +1,1 @@
-Bump `datadog-checks-base` to `>=37.39.1`. Notable changes:
-  - Send each logical database as its own independent schema snapshot, so an error or partial collection for one database does not affect others. ([#23913](https://github.com/DataDog/integrations-core/pull/23913))
+Bump `datadog-checks-base` to `>=37.39.1`.

--- a/mysql/changelog.d/23950.fixed
+++ b/mysql/changelog.d/23950.fixed
@@ -1,0 +1,2 @@
+Bump `datadog-checks-base` to `>=37.39.1`. Notable changes:
+  - Send each logical database as its own independent schema snapshot, so an error or partial collection for one database does not affect others. ([#23913](https://github.com/DataDog/integrations-core/pull/23913))

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.34.1",
+    "datadog-checks-base>=37.39.1",
 ]
 dynamic = [
     "version",

--- a/postgres/changelog.d/23950.fixed
+++ b/postgres/changelog.d/23950.fixed
@@ -1,2 +1,1 @@
-Bump `datadog-checks-base` to `>=37.39.1`. Notable changes:
-  - Send each logical database as its own independent schema snapshot, so an error or partial collection for one database does not affect others. ([#23913](https://github.com/DataDog/integrations-core/pull/23913))
+Bump `datadog-checks-base` to `>=37.39.1`.

--- a/postgres/changelog.d/23950.fixed
+++ b/postgres/changelog.d/23950.fixed
@@ -1,0 +1,2 @@
+Bump `datadog-checks-base` to `>=37.39.1`. Notable changes:
+  - Send each logical database as its own independent schema snapshot, so an error or partial collection for one database does not affect others. ([#23913](https://github.com/DataDog/integrations-core/pull/23913))

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.34.1",
+    "datadog-checks-base>=37.39.1",
 ]
 dynamic = [
     "version",

--- a/sqlserver/changelog.d/23950.fixed
+++ b/sqlserver/changelog.d/23950.fixed
@@ -1,2 +1,1 @@
-Bump `datadog-checks-base` to `>=37.39.1`. Notable changes:
-  - Send each logical database as its own independent schema snapshot, so an error or partial collection for one database does not affect others. ([#23913](https://github.com/DataDog/integrations-core/pull/23913))
+Bump `datadog-checks-base` to `>=37.39.1`.

--- a/sqlserver/changelog.d/23950.fixed
+++ b/sqlserver/changelog.d/23950.fixed
@@ -1,0 +1,2 @@
+Bump `datadog-checks-base` to `>=37.39.1`. Notable changes:
+  - Send each logical database as its own independent schema snapshot, so an error or partial collection for one database does not affect others. ([#23913](https://github.com/DataDog/integrations-core/pull/23913))

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.36.0",
+    "datadog-checks-base>=37.39.1",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?

Bumps `datadog-checks-base` minimum version to `>=37.39.1` in DBM integrations (postgres, mysql, sqlserver, mongo, clickhouse), following [#23948](https://github.com/DataDog/integrations-core/pull/23948).

### Motivation

[#23913](https://github.com/DataDog/integrations-core/pull/23913) fixed schema collection to send each logical database as its own independent snapshot, so an error on one database does not abort collection for others. This was released in `datadog-checks-base` 37.39.1.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged