### PR TITLE
Make statement_timeout local for Postgres schemas

### DIFF
--- a/postgres/changelog.d/23954.fixed
+++ b/postgres/changelog.d/23954.fixed
@@ -1,0 +1,1 @@
+Make statement_timeout local for Postgres schemas collection

--- a/postgres/datadog_checks/postgres/connection_pool.py
+++ b/postgres/datadog_checks/postgres/connection_pool.py
@@ -263,7 +263,7 @@ class LRUConnectionPoolManager:
             **self.pool_config,
         )
 
-    def get_connection(self, dbname: str, persistent: bool = False, autocommit: bool = True):
+    def get_connection(self, dbname: str, persistent: bool = False):
         """
         Context-managed access to a single connection from the pool associated with the given dbname.
 
@@ -314,7 +314,7 @@ class LRUConnectionPoolManager:
                 self.pools[dbname] = (pool, now, persistent)
 
             # Return the pool's context manager directly
-            return pool.connection(autocommit=autocommit)
+            return pool.connection()
 
     def get_pool_stats(self, dbname: str) -> Optional[Dict[str, Any]]:
         """

--- a/postgres/datadog_checks/postgres/connection_pool.py
+++ b/postgres/datadog_checks/postgres/connection_pool.py
@@ -263,7 +263,7 @@ class LRUConnectionPoolManager:
             **self.pool_config,
         )
 
-    def get_connection(self, dbname: str, persistent: bool = False):
+    def get_connection(self, dbname: str, persistent: bool = False, autocommit: bool = True):
         """
         Context-managed access to a single connection from the pool associated with the given dbname.
 
@@ -314,7 +314,7 @@ class LRUConnectionPoolManager:
                 self.pools[dbname] = (pool, now, persistent)
 
             # Return the pool's context manager directly
-            return pool.connection()
+            return pool.connection(autocommit=autocommit)
 
     def get_pool_stats(self, dbname: str) -> Optional[Dict[str, Any]]:
         """

--- a/postgres/datadog_checks/postgres/schemas.py
+++ b/postgres/datadog_checks/postgres/schemas.py
@@ -229,18 +229,13 @@ class PostgresSchemaCollector(SchemaCollector):
     @contextlib.contextmanager
     def _get_cursor(self, database_name):
         with self._check.db_pool.get_connection(database_name) as conn:
-            # Disable statement level autocommit so we can set the statement timeout locally
-            conn.autocommit = False
-            try:
-                with conn.cursor(row_factory=dict_row) as cursor:
+            with conn.cursor(row_factory=dict_row) as cursor:
+                # Explicitly wrap these queries in a transaction so we can set the statement timeout locally
+                with conn.transaction():
                     query, params = self.get_rows_query()
                     cursor.execute(f"SET LOCAL statement_timeout = '{self._config.max_query_duration}s';")
                     cursor.execute(query, params)
                     yield cursor
-                conn.commit()
-            finally:
-                # Restore the autocommit behavior for the next connection
-                conn.autocommit = True
 
     def _get_schemas_query(self):
         query = SCHEMA_QUERY

--- a/postgres/datadog_checks/postgres/schemas.py
+++ b/postgres/datadog_checks/postgres/schemas.py
@@ -228,7 +228,7 @@ class PostgresSchemaCollector(SchemaCollector):
 
     @contextlib.contextmanager
     def _get_cursor(self, database_name):
-        with self._check.db_pool.get_connection(database_name) as conn:
+        with self._check.db_pool.get_connection(database_name, autocommit=False) as conn:
             with conn.cursor(row_factory=dict_row) as cursor:
                 query, params = self.get_rows_query()
                 cursor.execute(f"SET LOCAL statement_timeout = '{self._config.max_query_duration}s';")

--- a/postgres/datadog_checks/postgres/schemas.py
+++ b/postgres/datadog_checks/postgres/schemas.py
@@ -228,17 +228,19 @@ class PostgresSchemaCollector(SchemaCollector):
 
     @contextlib.contextmanager
     def _get_cursor(self, database_name):
-        conn = self._check.db_pool.get_connection(database_name)
-        # Disable statement level autocommit so we can set the statement timeout locally
-        conn.autocommit = False
-        with conn.cursor(row_factory=dict_row) as cursor:
-            query, params = self.get_rows_query()
-            cursor.execute(f"SET LOCAL statement_timeout = '{self._config.max_query_duration}s';")
-            cursor.execute(query, params)
-            yield cursor
-        conn.commit()
-        # Restore the autocommit behavior for the next connection
-        conn.autocommit = True
+        with self._check.db_pool.get_connection(database_name) as conn:
+            # Disable statement level autocommit so we can set the statement timeout locally
+            conn.autocommit = False
+            try:
+                with conn.cursor(row_factory=dict_row) as cursor:
+                    query, params = self.get_rows_query()
+                    cursor.execute(f"SET LOCAL statement_timeout = '{self._config.max_query_duration}s';")
+                    cursor.execute(query, params)
+                    yield cursor
+                conn.commit()
+            finally:
+                # Restore the autocommit behavior for the next connection
+                conn.autocommit = True
 
     def _get_schemas_query(self):
         query = SCHEMA_QUERY

--- a/postgres/datadog_checks/postgres/schemas.py
+++ b/postgres/datadog_checks/postgres/schemas.py
@@ -231,7 +231,7 @@ class PostgresSchemaCollector(SchemaCollector):
         with self._check.db_pool.get_connection(database_name) as conn:
             with conn.cursor(row_factory=dict_row) as cursor:
                 query, params = self.get_rows_query()
-                cursor.execute(f"SET statement_timeout = '{self._config.max_query_duration}s';")
+                cursor.execute(f"SET LOCAL statement_timeout = '{self._config.max_query_duration}s';")
                 cursor.execute(query, params)
                 yield cursor
 

--- a/postgres/datadog_checks/postgres/schemas.py
+++ b/postgres/datadog_checks/postgres/schemas.py
@@ -228,12 +228,15 @@ class PostgresSchemaCollector(SchemaCollector):
 
     @contextlib.contextmanager
     def _get_cursor(self, database_name):
-        with self._check.db_pool.get_connection(database_name, autocommit=False) as conn:
+        with self._check.db_pool.get_connection(database_name) as conn:
+            conn.autocommit = False
             with conn.cursor(row_factory=dict_row) as cursor:
                 query, params = self.get_rows_query()
                 cursor.execute(f"SET LOCAL statement_timeout = '{self._config.max_query_duration}s';")
                 cursor.execute(query, params)
                 yield cursor
+            # Restore the autocommit behavior for the next connection
+            conn.autocommit = True
 
     def _get_schemas_query(self):
         query = SCHEMA_QUERY

--- a/postgres/datadog_checks/postgres/schemas.py
+++ b/postgres/datadog_checks/postgres/schemas.py
@@ -228,15 +228,17 @@ class PostgresSchemaCollector(SchemaCollector):
 
     @contextlib.contextmanager
     def _get_cursor(self, database_name):
-        with self._check.db_pool.get_connection(database_name) as conn:
-            conn.autocommit = False
-            with conn.cursor(row_factory=dict_row) as cursor:
-                query, params = self.get_rows_query()
-                cursor.execute(f"SET LOCAL statement_timeout = '{self._config.max_query_duration}s';")
-                cursor.execute(query, params)
-                yield cursor
-            # Restore the autocommit behavior for the next connection
-            conn.autocommit = True
+        conn = self._check.db_pool.get_connection(database_name)
+        # Disable statement level autocommit so we can set the statement timeout locally
+        conn.autocommit = False
+        with conn.cursor(row_factory=dict_row) as cursor:
+            query, params = self.get_rows_query()
+            cursor.execute(f"SET LOCAL statement_timeout = '{self._config.max_query_duration}s';")
+            cursor.execute(query, params)
+            yield cursor
+        conn.commit()
+        # Restore the autocommit behavior for the next connection
+        conn.autocommit = True
 
     def _get_schemas_query(self):
         query = SCHEMA_QUERY

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1955,6 +1955,7 @@ def test_pg_stat_statements_max_warning(
 def test_pg_stat_statements_dealloc(aggregator, integration_check, dbm_instance_replica2):
     dbm_instance_replica2['query_samples'] = {'enabled': False}
     dbm_instance_replica2['query_activity'] = {'enabled': False}
+    dbm_instance_replica2['collect_schemas'] = {'enabled': False}
     with _get_superconn(dbm_instance_replica2) as superconn:
         with superconn.cursor() as cur:
             cur.execute("select pg_stat_statements_reset();")


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Constrains the increased statement timeout for schema collection to the local transaction.

### Motivation
<!-- What inspired you to submit this pull request? -->
We want to avoid bleeding the longer timeout to other parts of the integration.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
