### PR TITLE
[AI-6502] Update dependency resolution `dd-octo-sts` policy

### DIFF
--- a/.github/chainguard/self.resolve-build-deps.push.sts.yaml
+++ b/.github/chainguard/self.resolve-build-deps.push.sts.yaml
@@ -1,20 +1,18 @@
 # Policy for: .github/workflows/resolve-build-deps.yaml publish job in DataDog/integrations-core
-# Triggered by push to master or release branches, or workflow_dispatch
+# Triggered by push to feature branches that update dependencies
 #
 # Naming convention:
 #   self:               Only this repository (DataDog/integrations-core) can use this policy
 #   resolve-build-deps: Specific workflow
-#   push:               Primary trigger is push to protected branches
+#   push:               Primary trigger is push to feature branches
 #
 # Security model:
-#   - Publish job runs on push or workflow_dispatch to protected branches (master and X.Y.x)
+#   - Publish job runs on push to any feature branch
 #   - Workflow file must be committed to the same branch
-#   - Pull request events are excluded by the job's if condition
+#   - Access is scoped to this specific workflow file via job_workflow_ref
 #
 # Permissions granted:
-#   - contents: write       - Push commits to branches
-#   - pull_requests: write  - Create pull requests
-#   - workflows: write      - Modify workflow files in generated commits
+#   - contents: write  - Push commits (lockfiles) back to the feature branch
 #
 # Usage in workflows:
 #   - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
@@ -24,15 +22,12 @@
 
 issuer: https://token.actions.githubusercontent.com
 
-subject_pattern: repo:DataDog/integrations-core:ref:refs/heads/(master|\d+\.\d+\..*)
+subject_pattern: repo:DataDog/integrations-core:ref:refs/heads/.*
 
 claim_pattern:
-  event_name: (push|workflow_dispatch)
-  job_workflow_ref: DataDog/integrations-core/\.github/workflows/resolve-build-deps\.yaml@refs/heads/(master|\d+\.\d+\..*)
-  ref: refs/heads/(master|\d+\.\d+\..*)
+  event_name: push
+  job_workflow_ref: DataDog/integrations-core/\.github/workflows/resolve-build-deps\.yaml@refs/heads/.*
   repository: DataDog/integrations-core
 
 permissions:
   contents: write
-  pull_requests: write
-  workflows: write

--- a/.github/workflows/resolve-build-deps.yaml
+++ b/.github/workflows/resolve-build-deps.yaml
@@ -357,12 +357,11 @@ jobs:
 
     steps:
     - name: Create token
-      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+      uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
       id: token-generator
       with:
-        app-id: ${{ vars.DD_AGENT_INTEGRATIONS_BOT_APP_ID }}
-        private-key: ${{ secrets.DD_AGENT_INTEGRATIONS_BOT_PRIVATE_KEY }}
-        repositories: integrations-core
+        scope: DataDog/integrations-core
+        policy: self.resolve-build-deps.push
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/resolve-build-deps.yaml
+++ b/.github/workflows/resolve-build-deps.yaml
@@ -357,11 +357,12 @@ jobs:
 
     steps:
     - name: Create token
-      uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+      uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: token-generator
       with:
-        scope: DataDog/integrations-core
-        policy: self.resolve-build-deps.push
+        app-id: ${{ vars.DD_AGENT_INTEGRATIONS_BOT_APP_ID }}
+        private-key: ${{ secrets.DD_AGENT_INTEGRATIONS_BOT_PRIVATE_KEY }}
+        repositories: integrations-core
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### What does this PR do?
Updates dependency resolution `dd-octo-sts` policy; the workflow was [refactored](https://github.com/DataDog/integrations-core/pull/23063) and no longer needs the existing policy; it needs to be able to write commits to any feature branch

### Motivation
Notes:
- this grants access to all feature branches, but the only permission granted is `contents: write`
- I will update the workflow to use this policy in a separate PR
- This is safe to change because we already moved away from the old dependency resolution method 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
