### PR TITLE
Add blog post resources to Claude Compliance integration

### DIFF
--- a/anthropic/manifest.json
+++ b/anthropic/manifest.json
@@ -23,14 +23,6 @@
     ],
     "resources": [
       {
-        "resource_type": "blog",
-        "url": "https://www.datadoghq.com/blog/cloud-siem-claude-compliance-api-integration/"
-      },
-      {
-        "resource_type": "blog",
-        "url": "https://claude.com/blog/compliance-api-security-partners"
-      },
-      {
         "url": "https://docs.datadoghq.com/integrations/anthropic/",
         "resource_type": "documentation"
       }

--- a/anthropic/manifest.json
+++ b/anthropic/manifest.json
@@ -23,6 +23,14 @@
     ],
     "resources": [
       {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/cloud-siem-claude-compliance-api-integration/"
+      },
+      {
+        "resource_type": "blog",
+        "url": "https://claude.com/blog/compliance-api-security-partners"
+      },
+      {
         "url": "https://docs.datadoghq.com/integrations/anthropic/",
         "resource_type": "documentation"
       }

--- a/anthropic_compliance_logs/manifest.json
+++ b/anthropic_compliance_logs/manifest.json
@@ -33,6 +33,16 @@
         "media_type": "image"
       }
     ],
+    "resources": [
+      {
+        "resource_type": "blog",
+        "url": "https://www.datadoghq.com/blog/cloud-siem-claude-compliance-api-integration/"
+      },
+      {
+        "resource_type": "blog",
+        "url": "https://claude.com/blog/compliance-api-security-partners"
+      }
+    ],
     "classifier_tags": [
       "Category::AI/ML",
       "Category::Log Collection",


### PR DESCRIPTION
## Summary
- Adds two blog post resources to `anthropic/manifest.json`:
  - [Cloud SIEM Claude Compliance API Integration](https://www.datadoghq.com/blog/cloud-siem-claude-compliance-api-integration/)
  - [Compliance API Security Partners](https://claude.com/blog/compliance-api-security-partners)

## Test plan
- [ ] Verify resources appear on the Anthropic integration tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)