### PR TITLE
NTP: update metadata.csv descriptions with precision info

### DIFF
--- a/ntp/metadata.csv
+++ b/ntp/metadata.csv
@@ -1,3 +1,3 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
-ntp.offset,gauge,,second,,The time difference between the NTP reference clock and the local clock.,-1,system,ntp offset,
-ntp.intake_offset,gauge,,second,,"The time difference between the Datadog intake server clock and the local clock, derived from the HTTP Date response header. Available from Agent 7.79.",-1,system,ntp intake offset,
+ntp.offset,gauge,,second,,The time difference between the NTP reference clock and the local clock. Precision: milliseconds.,-1,system,ntp offset,
+ntp.intake_offset,gauge,,second,,"Time difference between the Datadog intake server clock and the local clock, derived from the HTTP Date response header. Precision: seconds. Available from Agent 7.79.",-1,system,ntp intake offset,


### PR DESCRIPTION
### What does this PR do?

Updates `ntp/metadata.csv` to add precision information to both NTP metric descriptions.

### Motivation

The two NTP offset metrics have meaningfully different precision characteristics — `ntp.offset` uses the NTP protocol and has millisecond-level precision, while `ntp.intake_offset` is derived from the HTTP `Date` response header and is limited to second-level precision. Making this explicit in the metric descriptions helps users understand the trade-offs between the two metrics.

Follow up to: https://github.com/DataDog/datadog-agent/issues/48789

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged