### PR TITLE
sap_hana: add Data Observability RC query actions support

### DIFF
--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -162,7 +162,7 @@ remote_configuration:
       - sap_hana
 ```
 
-Without this entry, the Agent silently drops any query dispatched by the backend — no error is surfaced. After updating `datadog.yaml`, [restart the Agent][5].
+Without this entry, the Agent silently drops any query dispatched by the backend with no error surfaced. After updating `datadog.yaml`, [restart the Agent][5].
 
 ### Validation
 

--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -149,6 +149,21 @@ The Agent can collect SAP HANA catalog metadata (schemas, tables, views, and col
 
 See the [sample sap_hana.d/conf.yaml][4] for all available schema collection options, including `include_schemas` and `exclude_schemas`.
 
+#### Data Observability query actions
+
+The Datadog backend can deliver monitoring queries to the SAP HANA check via Remote Configuration. When enabled, the Agent executes these queries against HANA on a schedule and forwards the results as Data Observability events.
+
+To allow Remote Configuration to push query configs to the `sap_hana` check, add it to the allow list in `datadog.yaml`:
+
+```yaml
+remote_configuration:
+  agent_integrations:
+    allow_list:
+      - sap_hana
+```
+
+Without this entry, the Agent silently drops any query dispatched by the backend — no error is surfaced. After updating `datadog.yaml`, [restart the Agent][5].
+
 ### Validation
 
 Run the [Agent's status subcommand][6] and look for `sap_hana` under the Checks section.

--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -153,7 +153,7 @@ See the [sample sap_hana.d/conf.yaml][4] for all available schema collection opt
 
 The Datadog backend can deliver monitoring queries to the SAP HANA check via Remote Configuration. When enabled, the Agent executes these queries against HANA on a schedule and forwards the results as Data Observability events.
 
-To allow Remote Configuration to push query configs to the `sap_hana` check, add it to the allow list in `datadog.yaml`:
+To allow Remote Configuration to push query configs to the `sap_hana` check, add `sap_hana` to the allowlist in `datadog.yaml`:
 
 ```yaml
 remote_configuration:
@@ -162,9 +162,9 @@ remote_configuration:
       - sap_hana
 ```
 
-Without this entry, the Agent silently drops any query dispatched by the backend with no error surfaced. After updating `datadog.yaml`, [restart the Agent][5].
+Without this entry, the Agent silently drops any query delivered by the backend without surfacing an error. After updating `datadog.yaml`, [restart the Agent][5].
 
-Data Observability query actions require schema collection to be enabled. Ensure the `collect_schemas` block is present and `enabled: true` in your `sap_hana.d/conf.yaml` (see [Schema collection](#schema-collection)).
+Data Observability query actions require schema collection to be enabled. Verify that the `collect_schemas` block is present and `enabled: true` in your `sap_hana.d/conf.yaml` (see [Schema collection](#schema-collection)).
 
 ### Validation
 

--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -151,7 +151,7 @@ See the [sample sap_hana.d/conf.yaml][4] for all available schema collection opt
 
 #### Data Observability query actions
 
-The Datadog backend can deliver monitoring queries to the SAP HANA check via Remote Configuration. When enabled, the Agent executes these queries against HANA on a schedule and forwards the results as Data Observability events.
+The Datadog backend can deliver monitoring queries to the SAP HANA check through Remote Configuration. When enabled, the Agent executes these queries against HANA on a schedule and forwards the results as Data Observability events.
 
 To allow Remote Configuration to push query configs to the `sap_hana` check, add `sap_hana` to the allowlist in `datadog.yaml`:
 

--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -164,6 +164,8 @@ remote_configuration:
 
 Without this entry, the Agent silently drops any query dispatched by the backend with no error surfaced. After updating `datadog.yaml`, [restart the Agent][5].
 
+Data Observability query actions require schema collection to be enabled. Ensure the `collect_schemas` block is present and `enabled: true` in your `sap_hana.d/conf.yaml` (see [Schema collection](#schema-collection)).
+
 ### Validation
 
 Run the [Agent's status subcommand][6] and look for `sap_hana` under the Checks section.

--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -156,6 +156,7 @@ files:
               example:
                 - "TMP_SCHEMA"
       - name: data_observability
+        hidden: true
         display_priority: 0
         fleet_configurable: true
         description: |

--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -161,7 +161,7 @@ files:
         fleet_configurable: true
         description: |
           Configure the Data Observability async job, which executes monitoring
-          queries delivered via Remote Configuration.
+          queries delivered through Remote Configuration.
         options:
           - name: enabled
             fleet_configurable: true
@@ -224,9 +224,9 @@ files:
                     schedule wins and interval_seconds is ignored. If neither is set, the
                     query is skipped at runtime with a warning.
                   type: string
-                - name: timeout_seconds
+                - name: query_timeout
                   description: |
-                    Statement timeout for this query in seconds. Applied as a connection-level
+                    Statement timeout for this query in milliseconds. Applied as a connection-level
                     statementTimeout when executing the query.
                   type: integer
                 - name: dbname

--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -155,6 +155,104 @@ files:
                 type: string
               example:
                 - "TMP_SCHEMA"
+      - name: data_observability
+        display_priority: 0
+        fleet_configurable: true
+        description: |
+          Configure the Data Observability async job, which executes monitoring
+          queries delivered via Remote Configuration.
+        options:
+          - name: enabled
+            fleet_configurable: true
+            description: Enable the Data Observability job.
+            value:
+              type: boolean
+              example: false
+              display_default: false
+          - name: collection_interval
+            fleet_configurable: true
+            description: |
+              How often (in seconds) the job wakes up to check which queries are
+              due. Individual queries have their own interval_seconds.
+            value:
+              type: number
+              example: 10
+              display_default: 10
+          - name: run_sync
+            hidden: true
+            description: Run the job synchronously (for testing).
+            value:
+              type: boolean
+              example: false
+              display_default: false
+            fleet_configurable: false
+          - name: config_id
+            hidden: true
+            description: |
+              Unique identifier of the Remote Configuration payload that populated
+              this data_observability block. Set automatically by the Datadog Agent
+              Go RC handler; do not set this field manually.
+            value:
+              type: string
+            fleet_configurable: false
+          - name: queries
+            hidden: true
+            description: |
+              List of monitor queries to execute. Populated automatically by the
+              Datadog Agent Go RC handler; do not set this field manually.
+            value:
+              type: array
+              items:
+                type: object
+                required:
+                  - query
+                properties:
+                - name: monitor_id
+                  type: integer
+                - name: query
+                  type: string
+                - name: interval_seconds
+                  description: |
+                    How often (in seconds) to run this query. Ignored when schedule is set
+                    (see schedule for the precedence rule).
+                  type: integer
+                - name: schedule
+                  description: |
+                    A standard 5-field cron expression (minute hour dom month dow) specifying
+                    when to run this query. When both schedule and interval_seconds are set,
+                    schedule wins and interval_seconds is ignored. If neither is set, the
+                    query is skipped at runtime with a warning.
+                  type: string
+                - name: timeout_seconds
+                  description: |
+                    Statement timeout for this query in seconds. Applied as a connection-level
+                    statementTimeout when executing the query.
+                  type: integer
+                - name: dbname
+                  type: string
+                - name: type
+                  type: string
+                - name: entity
+                  type: object
+                  properties:
+                  - name: platform
+                    type: string
+                  - name: account
+                    type: string
+                  - name: database
+                    type: string
+                  - name: schema
+                    type: string
+                  - name: table
+                    type: string
+                - name: custom_sql_select_fields
+                  type: object
+                  properties:
+                  - name: metric_config_id
+                    type: integer
+                  - name: entity_id
+                    type: string
+            fleet_configurable: false
       - template: instances/default
   - template: logs
     example:

--- a/sap_hana/changelog.d/23965.added
+++ b/sap_hana/changelog.d/23965.added
@@ -1,0 +1,1 @@
+Add Data Observability RC query actions support: execute Remote Configuration-delivered monitoring queries against SAP HANA and forward results as `do-query-results` events.

--- a/sap_hana/changelog.d/23965.added
+++ b/sap_hana/changelog.d/23965.added
@@ -1,1 +1,2 @@
 Add Data Observability RC query actions support: execute Remote Configuration-delivered monitoring queries against SAP HANA and forward results as `do-query-results` events.
+Bump the minimum `datadog-checks-base` requirement to 37.39.0 for the `CronScheduler` used to schedule Data Observability queries.

--- a/sap_hana/datadog_checks/sap_hana/config_models/instance.py
+++ b/sap_hana/datadog_checks/sap_hana/config_models/instance.py
@@ -155,18 +155,14 @@ class InstanceConfig(BaseModel):
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):
-        return validation.core.initialize_config(
-            getattr(validators, 'initialize_instance', identity)(values)
-        )
+        return validation.core.initialize_config(getattr(validators, 'initialize_instance', identity)(values))
 
     @field_validator('*', mode='before')
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
-            value = getattr(validators, f'instance_{info.field_name}', identity)(
-                value, field=field
-            )
+            value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
 
             if info.field_name in SECURE_FIELD_NAMES:
                 validation.security.check_field_trusted_provider(
@@ -179,6 +175,4 @@ class InstanceConfig(BaseModel):
 
     @model_validator(mode='after')
     def _final_validation(cls, model):
-        return validation.core.check_model(
-            getattr(validators, 'check_instance', identity)(model)
-        )
+        return validation.core.check_model(getattr(validators, 'check_instance', identity)(model))

--- a/sap_hana/datadog_checks/sap_hana/config_models/instance.py
+++ b/sap_hana/datadog_checks/sap_hana/config_models/instance.py
@@ -84,13 +84,13 @@ class Query(BaseModel):
     )
     monitor_id: Optional[int] = None
     query: str
+    query_timeout: Optional[int] = Field(
+        None,
+        description='Statement timeout for this query in milliseconds. Applied as a connection-level\nstatementTimeout when executing the query.\n',
+    )
     schedule: Optional[str] = Field(
         None,
         description='A standard 5-field cron expression (minute hour dom month dow) specifying\nwhen to run this query. When both schedule and interval_seconds are set,\nschedule wins and interval_seconds is ignored. If neither is set, the\nquery is skipped at runtime with a warning.\n',
-    )
-    timeout_seconds: Optional[int] = Field(
-        None,
-        description='Statement timeout for this query in seconds. Applied as a connection-level\nstatementTimeout when executing the query.\n',
     )
     type: Optional[str] = None
 

--- a/sap_hana/datadog_checks/sap_hana/config_models/instance.py
+++ b/sap_hana/datadog_checks/sap_hana/config_models/instance.py
@@ -49,6 +49,64 @@ class CustomQuery(BaseModel):
     tags: Optional[tuple[str, ...]] = None
 
 
+class CustomSqlSelectFields(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    entity_id: Optional[str] = None
+    metric_config_id: Optional[int] = None
+
+
+class Entity(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    account: Optional[str] = None
+    database: Optional[str] = None
+    platform: Optional[str] = None
+    schema_: Optional[str] = Field(None, alias='schema')
+    table: Optional[str] = None
+
+
+class Query(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    custom_sql_select_fields: Optional[CustomSqlSelectFields] = None
+    dbname: Optional[str] = None
+    entity: Optional[Entity] = None
+    interval_seconds: Optional[int] = Field(
+        None,
+        description='How often (in seconds) to run this query. Ignored when schedule is set\n(see schedule for the precedence rule).\n',
+    )
+    monitor_id: Optional[int] = None
+    query: str
+    schedule: Optional[str] = Field(
+        None,
+        description='A standard 5-field cron expression (minute hour dom month dow) specifying\nwhen to run this query. When both schedule and interval_seconds are set,\nschedule wins and interval_seconds is ignored. If neither is set, the\nquery is skipped at runtime with a warning.\n',
+    )
+    timeout_seconds: Optional[int] = Field(
+        None,
+        description='Statement timeout for this query in seconds. Applied as a connection-level\nstatementTimeout when executing the query.\n',
+    )
+    type: Optional[str] = None
+
+
+class DataObservability(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    collection_interval: Optional[float] = None
+    config_id: Optional[str] = None
+    enabled: Optional[bool] = None
+    queries: Optional[tuple[Query, ...]] = None
+    run_sync: Optional[bool] = None
+
+
 class MetricPatterns(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,

--- a/sap_hana/datadog_checks/sap_hana/config_models/instance.py
+++ b/sap_hana/datadog_checks/sap_hana/config_models/instance.py
@@ -126,6 +126,7 @@ class InstanceConfig(BaseModel):
     collect_schemas: Optional[CollectSchemas] = None
     connection_properties: Optional[MappingProxyType[str, Any]] = None
     custom_queries: Optional[tuple[CustomQuery, ...]] = None
+    data_observability: Optional[DataObservability] = None
     disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     enable_legacy_tags_normalization: Optional[bool] = None
@@ -154,14 +155,18 @@ class InstanceConfig(BaseModel):
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):
-        return validation.core.initialize_config(getattr(validators, 'initialize_instance', identity)(values))
+        return validation.core.initialize_config(
+            getattr(validators, 'initialize_instance', identity)(values)
+        )
 
     @field_validator('*', mode='before')
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
-            value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+            value = getattr(validators, f'instance_{info.field_name}', identity)(
+                value, field=field
+            )
 
             if info.field_name in SECURE_FIELD_NAMES:
                 validation.security.check_field_trusted_provider(
@@ -174,4 +179,6 @@ class InstanceConfig(BaseModel):
 
     @model_validator(mode='after')
     def _final_validation(cls, model):
-        return validation.core.check_model(getattr(validators, 'check_instance', identity)(model))
+        return validation.core.check_model(
+            getattr(validators, 'check_instance', identity)(model)
+        )

--- a/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
+++ b/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
@@ -220,22 +220,6 @@ instances:
     #   - TLS_CHACHA20_POLY1305_SHA256
     #   - TLS_AES_128_GCM_SHA256
 
-    ## Configure the Data Observability async job, which executes monitoring
-    ## queries delivered via Remote Configuration.
-    #
-    # data_observability:
-
-        ## @param enabled - boolean - optional - default: false
-        ## Enable the Data Observability job.
-        #
-        # enabled: false
-
-        ## @param collection_interval - number - optional - default: 10
-        ## How often (in seconds) the job wakes up to check which queries are
-        ## due. Individual queries have their own interval_seconds.
-        #
-        # collection_interval: 10
-
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
+++ b/sap_hana/datadog_checks/sap_hana/data/conf.yaml.example
@@ -220,6 +220,22 @@ instances:
     #   - TLS_CHACHA20_POLY1305_SHA256
     #   - TLS_AES_128_GCM_SHA256
 
+    ## Configure the Data Observability async job, which executes monitoring
+    ## queries delivered via Remote Configuration.
+    #
+    # data_observability:
+
+        ## @param enabled - boolean - optional - default: false
+        ## Enable the Data Observability job.
+        #
+        # enabled: false
+
+        ## @param collection_interval - number - optional - default: 10
+        ## How often (in seconds) the job wakes up to check which queries are
+        ## due. Individual queries have their own interval_seconds.
+        #
+        # collection_interval: 10
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/sap_hana/datadog_checks/sap_hana/data_observability.py
+++ b/sap_hana/datadog_checks/sap_hana/data_observability.py
@@ -246,7 +246,7 @@ class SapHanaDataObservability(DBMAsyncJob):
 
     def run_job(self) -> None:
         if not self._queries:
-            self._log.warning(
+            self._log.debug(
                 "Data Observability job is enabled but no queries are configured. "
                 "Waiting for Remote Configuration to deliver DO_QUERY_ACTIONS."
             )

--- a/sap_hana/datadog_checks/sap_hana/data_observability.py
+++ b/sap_hana/datadog_checks/sap_hana/data_observability.py
@@ -69,6 +69,11 @@ class SapHanaDataObservability(DBMAsyncJob):
             job_name="data-observability",
         )
         self._queries, self._schedulers = self._filter_valid_queries(do_config.queries or ())
+        self._log.debug(
+            "Data Observability job initialized: %d valid queries, config_id=%s",
+            len(self._queries),
+            do_config.config_id,
+        )
 
     def _shutdown(self) -> None:
         if self._do_conn is not None:
@@ -81,6 +86,7 @@ class SapHanaDataObservability(DBMAsyncJob):
     def _filter_valid_queries(self, queries: Iterable[Query]) -> tuple[tuple[Query, ...], dict[str, CronScheduler]]:
         valid: list[Query] = []
         schedulers: dict[str, CronScheduler] = {}
+        n_skipped = 0
         for q in queries:
             key = _query_key(q)
             if q.schedule:
@@ -93,14 +99,22 @@ class SapHanaDataObservability(DBMAsyncJob):
                         q.schedule,
                         e,
                     )
+                    n_skipped += 1
                     continue
             elif not (q.interval_seconds and q.interval_seconds > 0):
                 self._log.warning(
                     "Skipping DO query key=%s: neither schedule nor positive interval_seconds set",
                     key,
                 )
+                n_skipped += 1
                 continue
             valid.append(q)
+        if n_skipped:
+            self._log.warning(
+                "Data Observability: %d of %d queries were skipped due to invalid scheduling configuration.",
+                n_skipped,
+                n_skipped + len(valid),
+            )
         return tuple(valid), schedulers
 
     def _get_due_queries(self) -> list[DueQuery]:
@@ -131,6 +145,11 @@ class SapHanaDataObservability(DBMAsyncJob):
         if self._do_conn is not None and self._do_conn_timeout_s == timeout_seconds:
             return self._do_conn
         if self._do_conn is not None:
+            self._log.debug(
+                "Data Observability: reopening DO connection (timeout changed from %ds to %ds).",
+                self._do_conn_timeout_s,
+                timeout_seconds,
+            )
             try:
                 self._do_conn.close()
             except Exception:
@@ -143,7 +162,20 @@ class SapHanaDataObservability(DBMAsyncJob):
         conn_props.setdefault('user', self._check._username)
         conn_props.setdefault('password', self._check._password)
         conn_props['statementTimeout'] = timeout_seconds * 1000
-        self._do_conn = hana_connect(**conn_props)
+        try:
+            self._do_conn = hana_connect(**conn_props)
+        except HanaError as e:
+            self._log.error(
+                "Data Observability: failed to open DO connection to %s:%s — %s",
+                self._check._server,
+                self._check._port,
+                e,
+            )
+            raise
+        self._log.debug(
+            "Data Observability: DO connection opened (statementTimeout=%dms).",
+            timeout_seconds * 1000,
+        )
         self._do_conn_timeout_s = timeout_seconds
         return self._do_conn
 
@@ -177,6 +209,7 @@ class SapHanaDataObservability(DBMAsyncJob):
                 e,
                 query_spec.query,
             )
+            self._log.warning("Data Observability: resetting DO connection after query failure.")
             self._do_conn = None
             self._do_conn_timeout_s = None
             return {
@@ -212,6 +245,12 @@ class SapHanaDataObservability(DBMAsyncJob):
         return payload
 
     def run_job(self) -> None:
+        if not self._queries:
+            self._log.warning(
+                "Data Observability job is enabled but no queries are configured. "
+                "Waiting for Remote Configuration to deliver DO_QUERY_ACTIONS."
+            )
+            return
         due_queries = self._get_due_queries()
         if not due_queries:
             self._log.debug("No data observability queries due for execution.")

--- a/sap_hana/datadog_checks/sap_hana/data_observability.py
+++ b/sap_hana/datadog_checks/sap_hana/data_observability.py
@@ -1,0 +1,278 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from collections.abc import Iterable
+from contextlib import closing
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from datadog_checks.base.utils.cron import CronScheduler
+from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding
+
+if TYPE_CHECKING:
+    from .config_models.instance import DataObservability, Query
+    from .sap_hana import SapHanaCheck
+
+try:
+    from hdbcli.dbapi import Error as HanaError
+except ImportError:
+    HanaError = Exception  # type: ignore[misc,assignment]
+
+EVENT_TRACK_TYPE = 'do-query-results'
+
+MAX_RESULT_ROWS = 10_000
+
+CRON_STARTUP_LOOKBACK_SECONDS = 300
+
+DEFAULT_DO_QUERY_TIMEOUT_S = 60
+
+Mode = Literal["cron", "interval"]
+
+
+def _query_key(q: Query) -> str:
+    """Stable per-query scheduling key derived from the query text."""
+    return hashlib.sha256(q.query.encode()).hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class DueQuery:
+    query: Query
+    query_key: str
+    scheduled_time: float
+    mode: Mode
+
+
+class SapHanaDataObservability(DBMAsyncJob):
+    def __init__(self, check: SapHanaCheck, do_config: DataObservability) -> None:
+        self._check = check
+        self._do_config = do_config
+        self._last_execution: dict[str, float] = {}
+        self._do_conn: Any = None
+        self._do_conn_timeout_s: int | None = None
+
+        collection_interval = do_config.collection_interval or 10
+        super().__init__(
+            check,
+            config_host=check._server,
+            rate_limit=1 / float(collection_interval),
+            run_sync=do_config.run_sync,
+            enabled=do_config.enabled,
+            dbms="saphana",
+            min_collection_interval=check.instance.get('min_collection_interval', 15),
+            expected_db_exceptions=(HanaError,),
+            shutdown_callback=self._shutdown,
+            job_name="data-observability",
+        )
+        self._queries, self._schedulers = self._filter_valid_queries(do_config.queries or ())
+
+    def _shutdown(self) -> None:
+        if self._do_conn is not None:
+            try:
+                self._do_conn.close()
+            except Exception:
+                pass
+            self._do_conn = None
+
+    def _filter_valid_queries(self, queries: Iterable[Query]) -> tuple[tuple[Query, ...], dict[str, CronScheduler]]:
+        valid: list[Query] = []
+        schedulers: dict[str, CronScheduler] = {}
+        for q in queries:
+            key = _query_key(q)
+            if q.schedule:
+                try:
+                    schedulers[key] = CronScheduler(q.schedule, startup_lookback=CRON_STARTUP_LOOKBACK_SECONDS)
+                except (ValueError, TypeError) as e:
+                    self._log.warning(
+                        "Skipping DO query key=%s: invalid cron schedule %r (%s).",
+                        key,
+                        q.schedule,
+                        e,
+                    )
+                    continue
+            elif not (q.interval_seconds and q.interval_seconds > 0):
+                self._log.warning(
+                    "Skipping DO query key=%s: neither schedule nor positive interval_seconds set",
+                    key,
+                )
+                continue
+            valid.append(q)
+        return tuple(valid), schedulers
+
+    def _get_due_queries(self) -> list[DueQuery]:
+        now = time.time()
+        due: list[DueQuery] = []
+        for q in self._queries:
+            key = _query_key(q)
+            if q.schedule:
+                ticks = self._schedulers[key].due_ticks(now + 0.001)
+                if ticks:
+                    due.append(DueQuery(q, key, ticks[-1], "cron"))
+            else:
+                last = self._last_execution.get(key)
+                if last is None or now - last >= q.interval_seconds:
+                    scheduled = (last + q.interval_seconds) if last is not None else now
+                    due.append(DueQuery(q, key, scheduled, "interval"))
+        return due
+
+    def _build_base_tags(self) -> list[str]:
+        tags = [t for t in self._tags if not t.startswith('dd.internal')] if self._tags else []
+        if self._do_config.config_id:
+            tags.append(f'config_id:{self._do_config.config_id}')
+        tags.append('db_type:saphana')
+        return tags
+
+    def _get_connection(self, timeout_seconds: int) -> Any:
+        """Return the persistent DO connection, (re)creating it when the timeout changes."""
+        if self._do_conn is not None and self._do_conn_timeout_s == timeout_seconds:
+            return self._do_conn
+        if self._do_conn is not None:
+            try:
+                self._do_conn.close()
+            except Exception:
+                pass
+        from hdbcli.dbapi import connect as hana_connect  # noqa: PLC0415
+
+        conn_props = self._check.instance.get('connection_properties', {}).copy()
+        conn_props.setdefault('address', self._check._server)
+        conn_props.setdefault('port', self._check._port)
+        conn_props.setdefault('user', self._check._username)
+        conn_props.setdefault('password', self._check._password)
+        conn_props['statementTimeout'] = timeout_seconds * 1000
+        self._do_conn = hana_connect(**conn_props)
+        self._do_conn_timeout_s = timeout_seconds
+        return self._do_conn
+
+    def _execute_single_query(self, query_spec: Query) -> dict[str, Any]:
+        timeout_s = query_spec.timeout_seconds or DEFAULT_DO_QUERY_TIMEOUT_S
+        conn = self._get_connection(timeout_s)
+        start = time.time()
+        try:
+            if self._cancel_event.is_set():
+                raise Exception("Job loop cancelled. Aborting query.")
+            with closing(conn.cursor()) as cursor:
+                cursor.execute(query_spec.query)
+                if cursor.description is None:
+                    raise HanaError("Query returned no result set — only SELECT statements are supported")
+                columns = [desc[0] for desc in cursor.description]
+                rows = [list(row) for row in cursor.fetchmany(MAX_RESULT_ROWS)]
+            duration = time.time() - start
+            return {
+                'status': 'success',
+                'columns': columns,
+                'rows': rows,
+                'row_count': len(rows),
+                'duration_s': duration,
+                'error': None,
+            }
+        except HanaError as e:
+            duration = time.time() - start
+            self._log.warning(
+                "Query failed (%.3fs): %s | SQL: %s",
+                duration,
+                e,
+                query_spec.query,
+            )
+            self._do_conn = None
+            self._do_conn_timeout_s = None
+            return {
+                'status': 'error',
+                'columns': [],
+                'rows': [],
+                'row_count': 0,
+                'duration_s': duration,
+                'error': str(e),
+            }
+
+    def _build_event_payload(self, query_spec: Query, result: dict[str, Any]) -> dict[str, Any]:
+        entity = query_spec.entity.model_dump(exclude_none=True, by_alias=True) if query_spec.entity else {}
+        custom_fields = (
+            query_spec.custom_sql_select_fields.model_dump(exclude_none=True)
+            if query_spec.custom_sql_select_fields
+            else None
+        )
+        payload: dict[str, Any] = {
+            'timestamp': int(time.time() * 1000),
+            'config_id': self._do_config.config_id or '',
+            'db_type': 'saphana',
+            'db_host': self._check._server,
+            'db_port': self._check._port,
+            'db_name': query_spec.dbname or '',
+            'query': query_spec.query,
+            'entity': entity,
+            'custom_sql_select_fields': custom_fields,
+            **result,
+        }
+        if query_spec.monitor_id is not None:
+            payload['monitor_id'] = query_spec.monitor_id
+        return payload
+
+    def run_job(self) -> None:
+        due_queries = self._get_due_queries()
+        if not due_queries:
+            self._log.debug("No data observability queries due for execution.")
+            return
+
+        base_tags = self._build_base_tags()
+
+        for due in due_queries:
+            q = due.query
+            tags = base_tags
+
+            now_at_fire_start = time.time()
+            result = self._execute_single_query(q)
+            now_at_fire_end = time.time()
+
+            if due.mode == "interval":
+                self._last_execution[due.query_key] = now_at_fire_end
+
+            try:
+                self._check.gauge(
+                    'dd.sap_hana.data_observability.query_execution_time',
+                    result['duration_s'],
+                    tags=tags,
+                    hostname=self._check.reported_hostname,
+                    raw=True,
+                )
+                self._check.count(
+                    'dd.sap_hana.data_observability.query_executions',
+                    1,
+                    tags=tags + [f'status:{result["status"]}'],
+                    hostname=self._check.reported_hostname,
+                    raw=True,
+                )
+
+                lateness = max(0.0, now_at_fire_start - due.scheduled_time)
+                self._check.gauge(
+                    'dd.sap_hana.data_observability.query_fire_lateness_seconds',
+                    lateness,
+                    tags=tags + [f'mode:{due.mode}'],
+                    hostname=self._check.reported_hostname,
+                    raw=True,
+                )
+
+                payload = self._build_event_payload(q, result)
+                raw_event = json.dumps(payload, default=default_json_event_encoding)
+                self._log.debug(
+                    "Query result key=%s: status=%s row_count=%d",
+                    due.query_key,
+                    result['status'],
+                    result['row_count'],
+                )
+                self._check.event_platform_event(raw_event, EVENT_TRACK_TYPE)
+            except Exception as e:
+                self._log.exception("Failed to emit metrics/event for query key=%s", due.query_key)
+                try:
+                    self._check.count(
+                        'dd.sap_hana.data_observability.emit_failures',
+                        1,
+                        tags=tags + [f'exc_class:{type(e).__name__}'],
+                        hostname=self._check.reported_hostname,
+                        raw=True,
+                    )
+                except Exception:
+                    pass

--- a/sap_hana/datadog_checks/sap_hana/data_observability.py
+++ b/sap_hana/datadog_checks/sap_hana/data_observability.py
@@ -156,11 +156,11 @@ class SapHanaDataObservability(DBMAsyncJob):
                 pass
         from hdbcli.dbapi import connect as hana_connect  # noqa: PLC0415
 
-        conn_props = self._check.instance.get('connection_properties', {}).copy()
-        conn_props.setdefault('address', self._check._server)
-        conn_props.setdefault('port', self._check._port)
-        conn_props.setdefault('user', self._check._username)
-        conn_props.setdefault('password', self._check._password)
+        # Use the check's connection-property builder so that TLS settings from
+        # use_tls/tls_* instance options are applied here too.  The DO job opens
+        # its own connection (instead of reusing self._check._conn) because it
+        # needs a per-query statementTimeout that must not affect main-check queries.
+        conn_props = self._check._get_connection_properties()
         conn_props['statementTimeout'] = timeout_seconds * 1000
         try:
             self._do_conn = hana_connect(**conn_props)

--- a/sap_hana/datadog_checks/sap_hana/data_observability.py
+++ b/sap_hana/datadog_checks/sap_hana/data_observability.py
@@ -29,13 +29,23 @@ MAX_RESULT_ROWS = 10_000
 
 CRON_STARTUP_LOOKBACK_SECONDS = 300
 
-DEFAULT_DO_QUERY_TIMEOUT_S = 60
+DEFAULT_DO_QUERY_TIMEOUT_MS = 60_000
 
 Mode = Literal["cron", "interval"]
 
 
 def _query_key(q: Query) -> str:
-    """Stable per-query scheduling key derived from the query text."""
+    """Stable per-query scheduling key.
+
+    Prefer the monitor id when the RC payload carries a real one — this is the
+    forward-looking contract shared with Postgres. Today the payload delivers no
+    per-query monitor id (it decodes to 0/None), so fall back to a hash of the query
+    text. That is sufficient because the SQL embeds the monitor id(s) it serves (in a
+    trailing "-- Datadog {\"monitor_ids\":[...]}" comment, or the column alias for
+    custom SQL), so distinct monitors always produce distinct query text.
+    """
+    if q.monitor_id:  # real, non-zero monitor id
+        return f"monitor:{q.monitor_id}"
     return hashlib.sha256(q.query.encode()).hexdigest()[:16]
 
 
@@ -53,7 +63,7 @@ class SapHanaDataObservability(DBMAsyncJob):
         self._do_config = do_config
         self._last_execution: dict[str, float] = {}
         self._do_conn: Any = None
-        self._do_conn_timeout_s: int | None = None
+        self._do_conn_timeout_ms: int | None = None
 
         collection_interval = do_config.collection_interval or 10
         super().__init__(
@@ -140,15 +150,15 @@ class SapHanaDataObservability(DBMAsyncJob):
         tags.append('db_type:saphana')
         return tags
 
-    def _get_connection(self, timeout_seconds: int) -> Any:
+    def _get_connection(self, timeout_ms: int) -> Any:
         """Return the persistent DO connection, (re)creating it when the timeout changes."""
-        if self._do_conn is not None and self._do_conn_timeout_s == timeout_seconds:
+        if self._do_conn is not None and self._do_conn_timeout_ms == timeout_ms:
             return self._do_conn
         if self._do_conn is not None:
             self._log.debug(
-                "Data Observability: reopening DO connection (timeout changed from %ds to %ds).",
-                self._do_conn_timeout_s,
-                timeout_seconds,
+                "Data Observability: reopening DO connection (timeout changed from %dms to %dms).",
+                self._do_conn_timeout_ms,
+                timeout_ms,
             )
             try:
                 self._do_conn.close()
@@ -161,7 +171,7 @@ class SapHanaDataObservability(DBMAsyncJob):
         # its own connection (instead of reusing self._check._conn) because it
         # needs a per-query statementTimeout that must not affect main-check queries.
         conn_props = self._check._get_connection_properties()
-        conn_props['statementTimeout'] = timeout_seconds * 1000
+        conn_props['statementTimeout'] = timeout_ms
         try:
             self._do_conn = hana_connect(**conn_props)
         except HanaError as e:
@@ -174,14 +184,14 @@ class SapHanaDataObservability(DBMAsyncJob):
             raise
         self._log.debug(
             "Data Observability: DO connection opened (statementTimeout=%dms).",
-            timeout_seconds * 1000,
+            timeout_ms,
         )
-        self._do_conn_timeout_s = timeout_seconds
+        self._do_conn_timeout_ms = timeout_ms
         return self._do_conn
 
     def _execute_single_query(self, query_spec: Query) -> dict[str, Any]:
-        timeout_s = query_spec.timeout_seconds or DEFAULT_DO_QUERY_TIMEOUT_S
-        conn = self._get_connection(timeout_s)
+        timeout_ms = query_spec.query_timeout or DEFAULT_DO_QUERY_TIMEOUT_MS
+        conn = self._get_connection(timeout_ms)
         start = time.time()
         try:
             if self._cancel_event.is_set():
@@ -211,7 +221,7 @@ class SapHanaDataObservability(DBMAsyncJob):
             )
             self._log.warning("Data Observability: resetting DO connection after query failure.")
             self._do_conn = None
-            self._do_conn_timeout_s = None
+            self._do_conn_timeout_ms = None
             return {
                 'status': 'error',
                 'columns': [],

--- a/sap_hana/datadog_checks/sap_hana/data_observability.py
+++ b/sap_hana/datadog_checks/sap_hana/data_observability.py
@@ -86,12 +86,17 @@ class SapHanaDataObservability(DBMAsyncJob):
         )
 
     def _shutdown(self) -> None:
+        self._close_connection()
+
+    def _close_connection(self) -> None:
+        """Close the persistent DO connection and clear its cached state."""
         if self._do_conn is not None:
             try:
                 self._do_conn.close()
             except Exception:
                 pass
-            self._do_conn = None
+        self._do_conn = None
+        self._do_conn_timeout_ms = None
 
     def _filter_valid_queries(self, queries: Iterable[Query]) -> tuple[tuple[Query, ...], dict[str, CronScheduler]]:
         valid: list[Query] = []
@@ -160,10 +165,7 @@ class SapHanaDataObservability(DBMAsyncJob):
                 self._do_conn_timeout_ms,
                 timeout_ms,
             )
-            try:
-                self._do_conn.close()
-            except Exception:
-                pass
+            self._close_connection()
         from hdbcli.dbapi import connect as hana_connect  # noqa: PLC0415
 
         # Use the check's connection-property builder so that TLS settings from
@@ -191,9 +193,11 @@ class SapHanaDataObservability(DBMAsyncJob):
 
     def _execute_single_query(self, query_spec: Query) -> dict[str, Any]:
         timeout_ms = query_spec.query_timeout or DEFAULT_DO_QUERY_TIMEOUT_MS
-        conn = self._get_connection(timeout_ms)
         start = time.time()
         try:
+            # Acquire the connection inside the try so a failure to (re)open it is
+            # reported as a per-query error instead of aborting the whole run_job cycle.
+            conn = self._get_connection(timeout_ms)
             if self._cancel_event.is_set():
                 raise Exception("Job loop cancelled. Aborting query.")
             with closing(conn.cursor()) as cursor:
@@ -220,8 +224,7 @@ class SapHanaDataObservability(DBMAsyncJob):
                 query_spec.query,
             )
             self._log.warning("Data Observability: resetting DO connection after query failure.")
-            self._do_conn = None
-            self._do_conn_timeout_ms = None
+            self._close_connection()
             return {
                 'status': 'error',
                 'columns': [],

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -27,7 +27,8 @@ from datadog_checks.base.utils.constants import MICROSECOND
 from datadog_checks.base.utils.containers import iter_unique
 
 from . import queries
-from .config_models.instance import CollectSchemas
+from .config_models.instance import CollectSchemas, DataObservability
+from .data_observability import SapHanaDataObservability
 from .diagnose import run_diagnostics
 from .exceptions import OperationalError, QueryExecutionError
 from .schemas import HanaSchemaCollector
@@ -97,6 +98,10 @@ class SapHanaCheck(AgentCheck):
         self._last_schema_collection_time = 0
         self._dbms_version = None
 
+        # Data Observability async job (RC-delivered queries)
+        self._do_config = DataObservability(**(self.instance.get('data_observability') or {}))
+        self.data_observability = SapHanaDataObservability(self, self._do_config)
+
         self.check_initializations.append(self.parse_config)
         self.check_initializations.append(self.set_default_methods)
         self.diagnosis.register(functools.partial(run_diagnostics, self))
@@ -125,6 +130,8 @@ class SapHanaCheck(AgentCheck):
                     self.log.exception('Unexpected error running `%s`: %s', query_method.__name__, str(e))
                     continue
             self._maybe_collect_schemas()
+            if self._do_config.enabled:
+                self.data_observability.run_job_loop(self._tags)
         finally:
             if self._connection_lost:
                 self.service_check(
@@ -706,39 +713,43 @@ class SapHanaCheck(AgentCheck):
         if password:
             self.register_secret(password)
 
+    def _get_connection_properties(self):
+        """Build hdbcli connection kwargs from instance config, including TLS.
+
+        Extracted so the Data Observability async job can open its own connection
+        (needed for per-query statementTimeout) with the same TLS settings as the
+        main check connection, instead of silently ignoring use_tls/tls_* options.
+        """
+        # https://help.sap.com/viewer/f1b440ded6144a54ada97ff95dac7adf/2.10/en-US/ee592e89dcce4480a99571a4ae7a702f.html
+        props = self.instance.get('connection_properties', {}).copy()
+        props.setdefault('address', self._server)
+        props.setdefault('port', self._port)
+        props.setdefault('user', self._username)
+        props.setdefault('password', self._password)
+        timeout_milliseconds = int(self._timeout * 1000)
+        props.setdefault('communicationTimeout', timeout_milliseconds)
+        props.setdefault('nodeConnectTimeout', timeout_milliseconds)
+        if self._use_tls:
+            props.setdefault('encrypt', True)
+            props.setdefault('sslHostNameInCertificate', self._server)
+            props.setdefault('sslSNIHostname', self._server)
+            tls_verify = self.instance.get('tls_verify', True)
+            if not tls_verify:
+                props.setdefault('sslValidateCertificate', False)
+            tls_cert = self.instance.get('tls_cert')
+            if tls_cert:
+                props.setdefault('sslKeyStore', tls_cert)
+            tls_ca_cert = self.instance.get('tls_ca_cert')
+            if tls_ca_cert:
+                props.setdefault('sslTrustStore', tls_ca_cert)
+            elif not props.get('sslUseDefaultTrustStore', True):
+                props.setdefault('sslTrustStore', certifi.where())
+        return props
+
     def get_connection(self):
         if HanaConnection is None:
             raise CheckException("hdbcli is not installed. Check the integration documentation to install it.")
-        # https://help.sap.com/viewer/f1b440ded6144a54ada97ff95dac7adf/2.10/en-US/ee592e89dcce4480a99571a4ae7a702f.html
-        connection_properties = self.instance.get('connection_properties', {}).copy()
-
-        connection_properties.setdefault('address', self._server)
-        connection_properties.setdefault('port', self._port)
-        connection_properties.setdefault('user', self._username)
-        connection_properties.setdefault('password', self._password)
-
-        timeout_milliseconds = int(self._timeout * 1000)
-        connection_properties.setdefault('communicationTimeout', timeout_milliseconds)
-        connection_properties.setdefault('nodeConnectTimeout', timeout_milliseconds)
-
-        if self._use_tls:
-            connection_properties.setdefault('encrypt', True)
-            connection_properties.setdefault('sslHostNameInCertificate', self._server)
-            connection_properties.setdefault('sslSNIHostname', self._server)
-
-            tls_verify = self.instance.get('tls_verify', True)
-            if not tls_verify:
-                connection_properties.setdefault('sslValidateCertificate', False)
-
-            tls_cert = self.instance.get('tls_cert')
-            if tls_cert:
-                connection_properties.setdefault('sslKeyStore', tls_cert)
-
-            tls_ca_cert = self.instance.get('tls_ca_cert')
-            if tls_ca_cert:
-                connection_properties.setdefault('sslTrustStore', tls_ca_cert)
-            elif not connection_properties.get('sslUseDefaultTrustStore', True):
-                connection_properties.setdefault('sslTrustStore', certifi.where())
+        connection_properties = self._get_connection_properties()
 
         try:
             connection = HanaConnection(**connection_properties)

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -159,6 +159,12 @@ class SapHanaCheck(AgentCheck):
                 )
                 self._connection_flaked = False
 
+    def cancel(self):
+        # Signal the Data Observability async job to stop so its executor thread is
+        # released when the check is unscheduled (e.g. cluster-agent flavor or one-off
+        # check invocations), instead of leaking the DBMAsyncJob thread pool.
+        self.data_observability.cancel()
+
     def set_default_methods(self):
         self._default_methods.extend(
             [

--- a/sap_hana/pyproject.toml
+++ b/sap_hana/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.39.0",
 ]
 dynamic = [
     "version",

--- a/sap_hana/tests/test_data_observability.py
+++ b/sap_hana/tests/test_data_observability.py
@@ -1,0 +1,371 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import threading
+import time
+from unittest import mock
+
+import pytest
+
+from datadog_checks.sap_hana.config_models.instance import CustomSqlSelectFields, Entity, Query
+from datadog_checks.sap_hana.data_observability import (
+    DEFAULT_DO_QUERY_TIMEOUT_S,
+    SapHanaDataObservability,
+    _query_key,
+)
+
+pytestmark = pytest.mark.unit
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_do(queries=(), config_id=None, tags=None):
+    """Build a SapHanaDataObservability with mocked dependencies, bypassing DBMAsyncJob.__init__."""
+    check = mock.MagicMock()
+    check._server = 'hana-host'
+    check._port = 39015
+    check._username = 'dd'
+    check._password = 'pass'
+    check.instance = {}
+    check.reported_hostname = 'hana-host'
+
+    do_config = mock.MagicMock()
+    do_config.config_id = config_id
+
+    do = SapHanaDataObservability.__new__(SapHanaDataObservability)
+    do._check = check
+    do._do_config = do_config
+    do._last_execution = {}
+    do._do_conn = None
+    do._do_conn_timeout_s = None
+    do._log = mock.MagicMock()
+    do._cancel_event = threading.Event()
+    do._tags = tags
+    do._queries, do._schedulers = do._filter_valid_queries(queries)
+    return do
+
+
+def _q(
+    sql='SELECT 1',
+    interval_seconds=None,
+    schedule=None,
+    monitor_id=None,
+    timeout_seconds=None,
+    dbname=None,
+):
+    return Query(
+        query=sql,
+        interval_seconds=interval_seconds,
+        schedule=schedule,
+        monitor_id=monitor_id,
+        timeout_seconds=timeout_seconds,
+        dbname=dbname,
+    )
+
+
+def _mock_conn(columns, rows):
+    """Return a (conn, cursor) pair for use in _execute_single_query tests."""
+    conn = mock.MagicMock()
+    cursor = mock.MagicMock()
+    conn.cursor.return_value = cursor
+    cursor.description = [(col,) for col in columns]
+    cursor.fetchmany.return_value = rows
+    return conn, cursor
+
+
+# ── _query_key ────────────────────────────────────────────────────────────────
+
+
+class TestQueryKey:
+    def test_same_sql_same_key(self):
+        assert _query_key(_q('SELECT 1')) == _query_key(_q('SELECT 1'))
+
+    def test_different_sql_different_key(self):
+        assert _query_key(_q('SELECT 1')) != _query_key(_q('SELECT 2'))
+
+    def test_key_is_16_hex_chars(self):
+        key = _query_key(_q('SELECT 1'))
+        assert len(key) == 16
+        assert all(c in '0123456789abcdef' for c in key)
+
+
+# ── _filter_valid_queries ──────────────────────────────────────────────────────
+
+
+class TestFilterValidQueries:
+    def test_interval_query_accepted(self):
+        do = _make_do([_q(interval_seconds=60)])
+        assert len(do._queries) == 1
+
+    def test_cron_query_accepted(self):
+        do = _make_do([_q(schedule='*/5 * * * *')])
+        assert len(do._queries) == 1
+        assert len(do._schedulers) == 1
+
+    def test_missing_scheduling_rejected(self):
+        do = _make_do([_q()])
+        assert do._queries == ()
+
+    def test_zero_interval_rejected(self):
+        do = _make_do([_q(interval_seconds=0)])
+        assert do._queries == ()
+
+    def test_negative_interval_rejected(self):
+        do = _make_do([_q(interval_seconds=-1)])
+        assert do._queries == ()
+
+    def test_invalid_cron_rejected(self):
+        do = _make_do([_q(schedule='not-a-cron')])
+        assert do._queries == ()
+
+    def test_mixed_valid_and_invalid(self):
+        queries = [_q(interval_seconds=30), _q(), _q(schedule='*/10 * * * *')]
+        do = _make_do(queries)
+        assert len(do._queries) == 2
+
+    def test_cron_scheduler_keyed_by_query_hash(self):
+        q = _q(schedule='0 * * * *')
+        do = _make_do([q])
+        assert _query_key(q) in do._schedulers
+
+    def test_interval_query_has_no_scheduler(self):
+        q = _q(interval_seconds=60)
+        do = _make_do([q])
+        assert _query_key(q) not in do._schedulers
+
+    def test_skipped_queries_emit_warning(self):
+        do = _make_do([_q(), _q(interval_seconds=30)])
+        do._log.warning.assert_called()
+
+
+# ── _get_due_queries ───────────────────────────────────────────────────────────
+
+
+class TestGetDueQueries:
+    def test_interval_first_run_is_due(self):
+        do = _make_do([_q(interval_seconds=60)])
+        due = do._get_due_queries()
+        assert len(due) == 1
+        assert due[0].mode == 'interval'
+
+    def test_interval_not_yet_elapsed(self):
+        q = _q(interval_seconds=60)
+        do = _make_do([q])
+        do._last_execution[_query_key(q)] = time.time()
+        assert do._get_due_queries() == []
+
+    def test_interval_elapsed_is_due(self):
+        q = _q(interval_seconds=60)
+        do = _make_do([q])
+        do._last_execution[_query_key(q)] = time.time() - 61
+        assert len(do._get_due_queries()) == 1
+
+    def test_interval_scheduled_time_is_last_plus_interval(self):
+        q = _q(interval_seconds=60)
+        do = _make_do([q])
+        last = time.time() - 90
+        do._last_execution[_query_key(q)] = last
+        due = do._get_due_queries()
+        assert abs(due[0].scheduled_time - (last + 60)) < 0.01
+
+    def test_interval_first_run_scheduled_time_is_now(self):
+        q = _q(interval_seconds=60)
+        do = _make_do([q])
+        before = time.time()
+        due = do._get_due_queries()
+        after = time.time()
+        assert before <= due[0].scheduled_time <= after
+
+    def test_cron_due_has_cron_mode(self):
+        # every-minute cron fires within the 300s startup lookback
+        q = _q(schedule='* * * * *')
+        do = _make_do([q])
+        due = do._get_due_queries()
+        assert len(due) == 1
+        assert due[0].mode == 'cron'
+
+    def test_no_queries_returns_empty(self):
+        do = _make_do([])
+        assert do._get_due_queries() == []
+
+
+# ── _build_base_tags ───────────────────────────────────────────────────────────
+
+
+class TestBuildBaseTags:
+    def test_db_type_always_present(self):
+        do = _make_do()
+        assert 'db_type:saphana' in do._build_base_tags()
+
+    def test_config_id_tag_added(self):
+        do = _make_do(config_id='cfg-42')
+        assert 'config_id:cfg-42' in do._build_base_tags()
+
+    def test_no_config_id_no_config_id_tag(self):
+        do = _make_do(config_id=None)
+        assert not any(t.startswith('config_id:') for t in do._build_base_tags())
+
+    def test_dd_internal_tags_filtered(self):
+        do = _make_do(tags=['dd.internal.resource:x', 'env:prod'])
+        tags = do._build_base_tags()
+        assert 'env:prod' in tags
+        assert not any(t.startswith('dd.internal') for t in tags)
+
+    def test_none_tags_does_not_error(self):
+        do = _make_do(tags=None)
+        assert 'db_type:saphana' in do._build_base_tags()
+
+
+# ── _build_event_payload ───────────────────────────────────────────────────────
+
+
+class TestBuildEventPayload:
+    _RESULT = {
+        'status': 'success',
+        'columns': ['id'],
+        'rows': [[1]],
+        'row_count': 1,
+        'duration_s': 0.1,
+        'error': None,
+    }
+
+    def test_monitor_id_present_when_set(self):
+        q = _q(monitor_id=42)
+        payload = _make_do()._build_event_payload(q, self._RESULT)
+        assert payload['monitor_id'] == 42
+
+    def test_monitor_id_absent_when_none(self):
+        q = _q()
+        payload = _make_do()._build_event_payload(q, self._RESULT)
+        assert 'monitor_id' not in payload
+
+    def test_entity_fields_serialized(self):
+        entity = Entity(platform='snowflake', table='my_table')
+        q = Query(query='SELECT 1', interval_seconds=60, entity=entity)
+        payload = _make_do()._build_event_payload(q, self._RESULT)
+        assert payload['entity'] == {'platform': 'snowflake', 'table': 'my_table'}
+
+    def test_entity_empty_dict_when_none(self):
+        payload = _make_do()._build_event_payload(_q(), self._RESULT)
+        assert payload['entity'] == {}
+
+    def test_custom_sql_select_fields_serialized(self):
+        fields = CustomSqlSelectFields(metric_config_id=7, entity_id='eid')
+        q = Query(query='SELECT 1', interval_seconds=60, custom_sql_select_fields=fields)
+        payload = _make_do()._build_event_payload(q, self._RESULT)
+        assert payload['custom_sql_select_fields'] == {'metric_config_id': 7, 'entity_id': 'eid'}
+
+    def test_custom_sql_select_fields_none(self):
+        payload = _make_do()._build_event_payload(_q(), self._RESULT)
+        assert payload['custom_sql_select_fields'] is None
+
+    def test_dbname_empty_string_when_none(self):
+        payload = _make_do()._build_event_payload(_q(), self._RESULT)
+        assert payload['db_name'] == ''
+
+    def test_dbname_present_when_set(self):
+        payload = _make_do()._build_event_payload(_q(dbname='PROD'), self._RESULT)
+        assert payload['db_name'] == 'PROD'
+
+    def test_config_id_in_payload(self):
+        payload = _make_do(config_id='abc-123')._build_event_payload(_q(), self._RESULT)
+        assert payload['config_id'] == 'abc-123'
+
+    def test_config_id_empty_string_when_none(self):
+        payload = _make_do(config_id=None)._build_event_payload(_q(), self._RESULT)
+        assert payload['config_id'] == ''
+
+    def test_result_fields_merged_into_payload(self):
+        payload = _make_do()._build_event_payload(_q(), self._RESULT)
+        assert payload['status'] == 'success'
+        assert payload['row_count'] == 1
+        assert payload['columns'] == ['id']
+        assert payload['error'] is None
+
+    def test_db_type_and_host_present(self):
+        payload = _make_do()._build_event_payload(_q(), self._RESULT)
+        assert payload['db_type'] == 'saphana'
+        assert payload['db_host'] == 'hana-host'
+        assert payload['db_port'] == 39015
+
+
+# ── _execute_single_query ──────────────────────────────────────────────────────
+
+
+class TestExecuteSingleQuery:
+    def test_success_returns_columns_and_rows(self):
+        q = _q('SELECT id FROM T', interval_seconds=60)
+        do = _make_do([q])
+        conn, _ = _mock_conn(['id', 'name'], [[1, 'alice'], [2, 'bob']])
+        do._do_conn = conn
+        do._do_conn_timeout_s = DEFAULT_DO_QUERY_TIMEOUT_S
+
+        result = do._execute_single_query(q)
+
+        assert result['status'] == 'success'
+        assert result['columns'] == ['id', 'name']
+        assert result['rows'] == [[1, 'alice'], [2, 'bob']]
+        assert result['row_count'] == 2
+        assert result['error'] is None
+
+    def test_hana_error_returns_error_status(self):
+        from hdbcli.dbapi import Error as HanaError
+
+        q = _q(interval_seconds=60)
+        do = _make_do([q])
+        conn, cursor = _mock_conn(['id'], [])
+        cursor.execute.side_effect = HanaError('connection lost')
+        do._do_conn = conn
+        do._do_conn_timeout_s = DEFAULT_DO_QUERY_TIMEOUT_S
+
+        result = do._execute_single_query(q)
+
+        assert result['status'] == 'error'
+        assert result['row_count'] == 0
+        assert result['columns'] == []
+        assert 'connection lost' in result['error']
+
+    def test_hana_error_resets_connection(self):
+        from hdbcli.dbapi import Error as HanaError
+
+        q = _q(interval_seconds=60)
+        do = _make_do([q])
+        conn, cursor = _mock_conn([], [])
+        cursor.execute.side_effect = HanaError('timeout')
+        do._do_conn = conn
+        do._do_conn_timeout_s = DEFAULT_DO_QUERY_TIMEOUT_S
+
+        do._execute_single_query(q)
+
+        assert do._do_conn is None
+        assert do._do_conn_timeout_s is None
+
+    def test_uses_default_timeout_when_none(self):
+        q = _q(interval_seconds=60)  # timeout_seconds is None
+        do = _make_do([q])
+        called_with = []
+
+        def fake_get_connection(timeout_s):
+            called_with.append(timeout_s)
+            conn, _ = _mock_conn(['x'], [])
+            return conn
+
+        do._get_connection = fake_get_connection
+        do._execute_single_query(q)
+        assert called_with == [DEFAULT_DO_QUERY_TIMEOUT_S]
+
+    def test_uses_query_timeout_when_set(self):
+        q = _q(interval_seconds=60, timeout_seconds=120)
+        do = _make_do([q])
+        called_with = []
+
+        def fake_get_connection(timeout_s):
+            called_with.append(timeout_s)
+            conn, _ = _mock_conn(['x'], [])
+            return conn
+
+        do._get_connection = fake_get_connection
+        do._execute_single_query(q)
+        assert called_with == [120]

--- a/sap_hana/tests/test_data_observability.py
+++ b/sap_hana/tests/test_data_observability.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
+import json
 import threading
 import time
 from unittest import mock
@@ -17,8 +18,6 @@ from datadog_checks.sap_hana.data_observability import (
 )
 
 pytestmark = pytest.mark.unit
-
-# ── Helpers ───────────────────────────────────────────────────────────────────
 
 
 def _make_do(queries=(), config_id=None, tags=None):
@@ -75,313 +74,391 @@ def _mock_conn(columns, rows):
     return conn, cursor
 
 
-# ── _query_key ────────────────────────────────────────────────────────────────
+SAMPLE_RESULT = {
+    'status': 'success',
+    'columns': ['id'],
+    'rows': [[1]],
+    'row_count': 1,
+    'duration_s': 0.1,
+    'error': None,
+}
 
 
-class TestQueryKey:
-    def test_same_query_same_key(self):
-        assert _query_key(_q('SELECT 1')) == _query_key(_q('SELECT 1'))
+def test_query_key_same_query_same_key():
+    assert _query_key(_q('SELECT 1')) == _query_key(_q('SELECT 1'))
 
-    def test_different_sql_different_key(self):
-        # Distinct monitors always yield distinct SQL (monitor ids are embedded in the query).
-        assert _query_key(_q('SELECT 1')) != _query_key(_q('SELECT 2'))
 
-    def test_key_is_16_hex_chars(self):
-        key = _query_key(_q('SELECT 1'))
-        assert len(key) == 16
-        assert all(c in '0123456789abcdef' for c in key)
+def test_query_key_different_sql_different_key():
+    # Distinct monitors always yield distinct SQL (monitor ids are embedded in the query).
+    assert _query_key(_q('SELECT 1')) != _query_key(_q('SELECT 2'))
 
-    def test_nonzero_monitor_id_used_as_key(self):
-        assert _query_key(_q('SELECT 1', monitor_id=42)) == 'monitor:42'
-
-    def test_different_monitor_ids_different_key(self):
-        # With a real monitor id, identity comes from the id, not the SQL.
-        assert _query_key(_q('SELECT 1', monitor_id=1)) != _query_key(_q('SELECT 1', monitor_id=2))
-
-    def test_same_monitor_id_same_key_regardless_of_sql(self):
-        assert _query_key(_q('SELECT 1', monitor_id=7)) == _query_key(_q('SELECT 2', monitor_id=7))
-
-    def test_zero_monitor_id_falls_back_to_query_hash(self):
-        # monitor_id 0 (the omitempty default) and None both fall back to the query hash.
-        assert _query_key(_q('SELECT 1', monitor_id=0)) == _query_key(_q('SELECT 1', monitor_id=None))
-        assert _query_key(_q('SELECT 1', monitor_id=0)) == _query_key(_q('SELECT 1'))
-
-
-# ── _filter_valid_queries ──────────────────────────────────────────────────────
-
 
-class TestFilterValidQueries:
-    def test_interval_query_accepted(self):
-        do = _make_do([_q(interval_seconds=60)])
-        assert len(do._queries) == 1
+def test_query_key_is_16_hex_chars():
+    key = _query_key(_q('SELECT 1'))
+    assert len(key) == 16
+    assert all(c in '0123456789abcdef' for c in key)
 
-    def test_cron_query_accepted(self):
-        do = _make_do([_q(schedule='*/5 * * * *')])
-        assert len(do._queries) == 1
-        assert len(do._schedulers) == 1
 
-    def test_missing_scheduling_rejected(self):
-        do = _make_do([_q()])
-        assert do._queries == ()
+def test_query_key_nonzero_monitor_id_used_as_key():
+    assert _query_key(_q('SELECT 1', monitor_id=42)) == 'monitor:42'
 
-    def test_zero_interval_rejected(self):
-        do = _make_do([_q(interval_seconds=0)])
-        assert do._queries == ()
 
-    def test_negative_interval_rejected(self):
-        do = _make_do([_q(interval_seconds=-1)])
-        assert do._queries == ()
+def test_query_key_different_monitor_ids_different_key():
+    # With a real monitor id, identity comes from the id, not the SQL.
+    assert _query_key(_q('SELECT 1', monitor_id=1)) != _query_key(_q('SELECT 1', monitor_id=2))
 
-    def test_invalid_cron_rejected(self):
-        do = _make_do([_q(schedule='not-a-cron')])
-        assert do._queries == ()
 
-    def test_mixed_valid_and_invalid(self):
-        queries = [_q('SELECT 1', interval_seconds=30), _q('SELECT 2'), _q('SELECT 3', schedule='*/10 * * * *')]
-        do = _make_do(queries)
-        assert len(do._queries) == 2
+def test_query_key_same_monitor_id_same_key_regardless_of_sql():
+    assert _query_key(_q('SELECT 1', monitor_id=7)) == _query_key(_q('SELECT 2', monitor_id=7))
 
-    def test_cron_scheduler_keyed_by_query_key(self):
-        q = _q(schedule='0 * * * *')
-        do = _make_do([q])
-        assert _query_key(q) in do._schedulers
 
-    def test_interval_query_has_no_scheduler(self):
-        q = _q(interval_seconds=60)
-        do = _make_do([q])
-        assert _query_key(q) not in do._schedulers
+def test_query_key_zero_monitor_id_falls_back_to_query_hash():
+    # monitor_id 0 (the omitempty default) and None both fall back to the query hash.
+    assert _query_key(_q('SELECT 1', monitor_id=0)) == _query_key(_q('SELECT 1', monitor_id=None))
+    assert _query_key(_q('SELECT 1', monitor_id=0)) == _query_key(_q('SELECT 1'))
 
-    def test_skipped_queries_emit_warning(self):
-        do = _make_do([_q('SELECT 1'), _q('SELECT 2', interval_seconds=30)])
-        do._log.warning.assert_called()
 
+def test_filter_interval_query_accepted():
+    do = _make_do([_q(interval_seconds=60)])
+    assert len(do._queries) == 1
 
-# ── _get_due_queries ───────────────────────────────────────────────────────────
 
+def test_filter_cron_query_accepted():
+    do = _make_do([_q(schedule='*/5 * * * *')])
+    assert len(do._queries) == 1
+    assert len(do._schedulers) == 1
 
-class TestGetDueQueries:
-    def test_interval_first_run_is_due(self):
-        do = _make_do([_q(interval_seconds=60)])
-        due = do._get_due_queries()
-        assert len(due) == 1
-        assert due[0].mode == 'interval'
-
-    def test_interval_not_yet_elapsed(self):
-        q = _q(interval_seconds=60)
-        do = _make_do([q])
-        do._last_execution[_query_key(q)] = time.time()
-        assert do._get_due_queries() == []
-
-    def test_interval_elapsed_is_due(self):
-        q = _q(interval_seconds=60)
-        do = _make_do([q])
-        do._last_execution[_query_key(q)] = time.time() - 61
-        assert len(do._get_due_queries()) == 1
-
-    def test_interval_scheduled_time_is_last_plus_interval(self):
-        q = _q(interval_seconds=60)
-        do = _make_do([q])
-        last = time.time() - 90
-        do._last_execution[_query_key(q)] = last
-        due = do._get_due_queries()
-        assert abs(due[0].scheduled_time - (last + 60)) < 0.01
-
-    def test_interval_first_run_scheduled_time_is_now(self):
-        q = _q(interval_seconds=60)
-        do = _make_do([q])
-        before = time.time()
-        due = do._get_due_queries()
-        after = time.time()
-        assert before <= due[0].scheduled_time <= after
-
-    def test_cron_due_has_cron_mode(self):
-        # every-minute cron fires within the 300s startup lookback
-        q = _q(schedule='* * * * *')
-        do = _make_do([q])
-        due = do._get_due_queries()
-        assert len(due) == 1
-        assert due[0].mode == 'cron'
-
-    def test_no_queries_returns_empty(self):
-        do = _make_do([])
-        assert do._get_due_queries() == []
-
-
-# ── _build_base_tags ───────────────────────────────────────────────────────────
-
-
-class TestBuildBaseTags:
-    def test_db_type_always_present(self):
-        do = _make_do()
-        assert 'db_type:saphana' in do._build_base_tags()
-
-    def test_config_id_tag_added(self):
-        do = _make_do(config_id='cfg-42')
-        assert 'config_id:cfg-42' in do._build_base_tags()
-
-    def test_no_config_id_no_config_id_tag(self):
-        do = _make_do(config_id=None)
-        assert not any(t.startswith('config_id:') for t in do._build_base_tags())
-
-    def test_dd_internal_tags_filtered(self):
-        do = _make_do(tags=['dd.internal.resource:x', 'env:prod'])
-        tags = do._build_base_tags()
-        assert 'env:prod' in tags
-        assert not any(t.startswith('dd.internal') for t in tags)
-
-    def test_none_tags_does_not_error(self):
-        do = _make_do(tags=None)
-        assert 'db_type:saphana' in do._build_base_tags()
-
-
-# ── _build_event_payload ───────────────────────────────────────────────────────
-
-
-class TestBuildEventPayload:
-    _RESULT = {
-        'status': 'success',
-        'columns': ['id'],
-        'rows': [[1]],
-        'row_count': 1,
-        'duration_s': 0.1,
-        'error': None,
-    }
-
-    def test_monitor_id_present_when_set(self):
-        q = _q(monitor_id=42)
-        payload = _make_do()._build_event_payload(q, self._RESULT)
-        assert payload['monitor_id'] == 42
-
-    def test_monitor_id_absent_when_none(self):
-        q = _q()  # monitor_id is None
-        payload = _make_do()._build_event_payload(q, self._RESULT)
-        assert 'monitor_id' not in payload
-
-    def test_entity_fields_serialized(self):
-        entity = Entity(platform='snowflake', table='my_table')
-        q = Query(query='SELECT 1', interval_seconds=60, entity=entity)
-        payload = _make_do()._build_event_payload(q, self._RESULT)
-        assert payload['entity'] == {'platform': 'snowflake', 'table': 'my_table'}
-
-    def test_entity_empty_dict_when_none(self):
-        payload = _make_do()._build_event_payload(_q(), self._RESULT)
-        assert payload['entity'] == {}
-
-    def test_custom_sql_select_fields_serialized(self):
-        fields = CustomSqlSelectFields(metric_config_id=7, entity_id='eid')
-        q = Query(query='SELECT 1', interval_seconds=60, custom_sql_select_fields=fields)
-        payload = _make_do()._build_event_payload(q, self._RESULT)
-        assert payload['custom_sql_select_fields'] == {'metric_config_id': 7, 'entity_id': 'eid'}
-
-    def test_custom_sql_select_fields_none(self):
-        payload = _make_do()._build_event_payload(_q(), self._RESULT)
-        assert payload['custom_sql_select_fields'] is None
-
-    def test_dbname_empty_string_when_none(self):
-        payload = _make_do()._build_event_payload(_q(), self._RESULT)
-        assert payload['db_name'] == ''
-
-    def test_dbname_present_when_set(self):
-        payload = _make_do()._build_event_payload(_q(dbname='PROD'), self._RESULT)
-        assert payload['db_name'] == 'PROD'
-
-    def test_config_id_in_payload(self):
-        payload = _make_do(config_id='abc-123')._build_event_payload(_q(), self._RESULT)
-        assert payload['config_id'] == 'abc-123'
-
-    def test_config_id_empty_string_when_none(self):
-        payload = _make_do(config_id=None)._build_event_payload(_q(), self._RESULT)
-        assert payload['config_id'] == ''
-
-    def test_result_fields_merged_into_payload(self):
-        payload = _make_do()._build_event_payload(_q(), self._RESULT)
-        assert payload['status'] == 'success'
-        assert payload['row_count'] == 1
-        assert payload['columns'] == ['id']
-        assert payload['error'] is None
-
-    def test_db_type_and_host_present(self):
-        payload = _make_do()._build_event_payload(_q(), self._RESULT)
-        assert payload['db_type'] == 'saphana'
-        assert payload['db_host'] == 'hana-host'
-        assert payload['db_port'] == 39015
-
-
-# ── _execute_single_query ──────────────────────────────────────────────────────
-
-
-class TestExecuteSingleQuery:
-    def test_success_returns_columns_and_rows(self):
-        q = _q('SELECT id FROM T', interval_seconds=60)
-        do = _make_do([q])
-        conn, _ = _mock_conn(['id', 'name'], [[1, 'alice'], [2, 'bob']])
-        do._do_conn = conn
-        do._do_conn_timeout_ms = DEFAULT_DO_QUERY_TIMEOUT_MS
-
-        result = do._execute_single_query(q)
-
-        assert result['status'] == 'success'
-        assert result['columns'] == ['id', 'name']
-        assert result['rows'] == [[1, 'alice'], [2, 'bob']]
-        assert result['row_count'] == 2
-        assert result['error'] is None
-
-    def test_hana_error_returns_error_status(self):
-        from hdbcli.dbapi import Error as HanaError
-
-        q = _q(interval_seconds=60)
-        do = _make_do([q])
-        conn, cursor = _mock_conn(['id'], [])
-        cursor.execute.side_effect = HanaError('connection lost')
-        do._do_conn = conn
-        do._do_conn_timeout_ms = DEFAULT_DO_QUERY_TIMEOUT_MS
-
-        result = do._execute_single_query(q)
-
-        assert result['status'] == 'error'
-        assert result['row_count'] == 0
-        assert result['columns'] == []
-        assert 'connection lost' in result['error']
-
-    def test_hana_error_resets_connection(self):
-        from hdbcli.dbapi import Error as HanaError
-
-        q = _q(interval_seconds=60)
-        do = _make_do([q])
-        conn, cursor = _mock_conn([], [])
-        cursor.execute.side_effect = HanaError('timeout')
-        do._do_conn = conn
-        do._do_conn_timeout_ms = DEFAULT_DO_QUERY_TIMEOUT_MS
-
-        do._execute_single_query(q)
-
-        assert do._do_conn is None
-        assert do._do_conn_timeout_ms is None
-
-    def test_uses_default_timeout_when_none(self):
-        q = _q(interval_seconds=60)  # query_timeout is None
-        do = _make_do([q])
-        called_with = []
-
-        def fake_get_connection(timeout_ms):
-            called_with.append(timeout_ms)
-            conn, _ = _mock_conn(['x'], [])
-            return conn
-
-        do._get_connection = fake_get_connection
-        do._execute_single_query(q)
-        assert called_with == [DEFAULT_DO_QUERY_TIMEOUT_MS]
-
-    def test_uses_query_timeout_when_set(self):
-        q = _q(interval_seconds=60, query_timeout=120)
-        do = _make_do([q])
-        called_with = []
-
-        def fake_get_connection(timeout_ms):
-            called_with.append(timeout_ms)
-            conn, _ = _mock_conn(['x'], [])
-            return conn
-
-        do._get_connection = fake_get_connection
-        do._execute_single_query(q)
-        assert called_with == [120]
+
+def test_filter_missing_scheduling_rejected():
+    do = _make_do([_q()])
+    assert do._queries == ()
+
+
+def test_filter_zero_interval_rejected():
+    do = _make_do([_q(interval_seconds=0)])
+    assert do._queries == ()
+
+
+def test_filter_negative_interval_rejected():
+    do = _make_do([_q(interval_seconds=-1)])
+    assert do._queries == ()
+
+
+def test_filter_invalid_cron_rejected():
+    do = _make_do([_q(schedule='not-a-cron')])
+    assert do._queries == ()
+
+
+def test_filter_mixed_valid_and_invalid():
+    queries = [_q('SELECT 1', interval_seconds=30), _q('SELECT 2'), _q('SELECT 3', schedule='*/10 * * * *')]
+    do = _make_do(queries)
+    assert len(do._queries) == 2
+
+
+def test_filter_cron_scheduler_keyed_by_query_key():
+    q = _q(schedule='0 * * * *')
+    do = _make_do([q])
+    assert _query_key(q) in do._schedulers
+
+
+def test_filter_interval_query_has_no_scheduler():
+    q = _q(interval_seconds=60)
+    do = _make_do([q])
+    assert _query_key(q) not in do._schedulers
+
+
+def test_filter_skipped_queries_emit_warning():
+    do = _make_do([_q('SELECT 1'), _q('SELECT 2', interval_seconds=30)])
+    do._log.warning.assert_called()
+
+
+def test_due_interval_first_run_is_due():
+    do = _make_do([_q(interval_seconds=60)])
+    due = do._get_due_queries()
+    assert len(due) == 1
+    assert due[0].mode == 'interval'
+
+
+def test_due_interval_not_yet_elapsed():
+    q = _q(interval_seconds=60)
+    do = _make_do([q])
+    do._last_execution[_query_key(q)] = time.time()
+    assert do._get_due_queries() == []
+
+
+def test_due_interval_elapsed_is_due():
+    q = _q(interval_seconds=60)
+    do = _make_do([q])
+    do._last_execution[_query_key(q)] = time.time() - 61
+    assert len(do._get_due_queries()) == 1
+
+
+def test_due_interval_scheduled_time_is_last_plus_interval():
+    q = _q(interval_seconds=60)
+    do = _make_do([q])
+    last = time.time() - 90
+    do._last_execution[_query_key(q)] = last
+    due = do._get_due_queries()
+    assert abs(due[0].scheduled_time - (last + 60)) < 0.01
+
+
+def test_due_interval_first_run_scheduled_time_is_now():
+    q = _q(interval_seconds=60)
+    do = _make_do([q])
+    before = time.time()
+    due = do._get_due_queries()
+    after = time.time()
+    assert before <= due[0].scheduled_time <= after
+
+
+def test_due_cron_has_cron_mode():
+    # every-minute cron fires within the 300s startup lookback
+    q = _q(schedule='* * * * *')
+    do = _make_do([q])
+    due = do._get_due_queries()
+    assert len(due) == 1
+    assert due[0].mode == 'cron'
+
+
+def test_due_no_queries_returns_empty():
+    do = _make_do([])
+    assert do._get_due_queries() == []
+
+
+def test_base_tags_db_type_always_present():
+    do = _make_do()
+    assert 'db_type:saphana' in do._build_base_tags()
+
+
+def test_base_tags_config_id_tag_added():
+    do = _make_do(config_id='cfg-42')
+    assert 'config_id:cfg-42' in do._build_base_tags()
+
+
+def test_base_tags_no_config_id_no_config_id_tag():
+    do = _make_do(config_id=None)
+    assert not any(t.startswith('config_id:') for t in do._build_base_tags())
+
+
+def test_base_tags_dd_internal_tags_filtered():
+    do = _make_do(tags=['dd.internal.resource:x', 'env:prod'])
+    tags = do._build_base_tags()
+    assert 'env:prod' in tags
+    assert not any(t.startswith('dd.internal') for t in tags)
+
+
+def test_base_tags_none_tags_does_not_error():
+    do = _make_do(tags=None)
+    assert 'db_type:saphana' in do._build_base_tags()
+
+
+def test_payload_monitor_id_present_when_set():
+    q = _q(monitor_id=42)
+    payload = _make_do()._build_event_payload(q, SAMPLE_RESULT)
+    assert payload['monitor_id'] == 42
+
+
+def test_payload_monitor_id_absent_when_none():
+    q = _q()  # monitor_id is None
+    payload = _make_do()._build_event_payload(q, SAMPLE_RESULT)
+    assert 'monitor_id' not in payload
+
+
+def test_payload_entity_fields_serialized():
+    entity = Entity(platform='snowflake', table='my_table')
+    q = Query(query='SELECT 1', interval_seconds=60, entity=entity)
+    payload = _make_do()._build_event_payload(q, SAMPLE_RESULT)
+    assert payload['entity'] == {'platform': 'snowflake', 'table': 'my_table'}
+
+
+def test_payload_entity_empty_dict_when_none():
+    payload = _make_do()._build_event_payload(_q(), SAMPLE_RESULT)
+    assert payload['entity'] == {}
+
+
+def test_payload_custom_sql_select_fields_serialized():
+    fields = CustomSqlSelectFields(metric_config_id=7, entity_id='eid')
+    q = Query(query='SELECT 1', interval_seconds=60, custom_sql_select_fields=fields)
+    payload = _make_do()._build_event_payload(q, SAMPLE_RESULT)
+    assert payload['custom_sql_select_fields'] == {'metric_config_id': 7, 'entity_id': 'eid'}
+
+
+def test_payload_custom_sql_select_fields_none():
+    payload = _make_do()._build_event_payload(_q(), SAMPLE_RESULT)
+    assert payload['custom_sql_select_fields'] is None
+
+
+def test_payload_dbname_empty_string_when_none():
+    payload = _make_do()._build_event_payload(_q(), SAMPLE_RESULT)
+    assert payload['db_name'] == ''
+
+
+def test_payload_dbname_present_when_set():
+    payload = _make_do()._build_event_payload(_q(dbname='PROD'), SAMPLE_RESULT)
+    assert payload['db_name'] == 'PROD'
+
+
+def test_payload_config_id_in_payload():
+    payload = _make_do(config_id='abc-123')._build_event_payload(_q(), SAMPLE_RESULT)
+    assert payload['config_id'] == 'abc-123'
+
+
+def test_payload_config_id_empty_string_when_none():
+    payload = _make_do(config_id=None)._build_event_payload(_q(), SAMPLE_RESULT)
+    assert payload['config_id'] == ''
+
+
+def test_payload_result_fields_merged_into_payload():
+    payload = _make_do()._build_event_payload(_q(), SAMPLE_RESULT)
+    assert payload['status'] == 'success'
+    assert payload['row_count'] == 1
+    assert payload['columns'] == ['id']
+    assert payload['error'] is None
+
+
+def test_payload_db_type_and_host_present():
+    payload = _make_do()._build_event_payload(_q(), SAMPLE_RESULT)
+    assert payload['db_type'] == 'saphana'
+    assert payload['db_host'] == 'hana-host'
+    assert payload['db_port'] == 39015
+
+
+def test_execute_success_returns_columns_and_rows():
+    q = _q('SELECT id FROM T', interval_seconds=60)
+    do = _make_do([q])
+    conn, _ = _mock_conn(['id', 'name'], [[1, 'alice'], [2, 'bob']])
+    do._do_conn = conn
+    do._do_conn_timeout_ms = DEFAULT_DO_QUERY_TIMEOUT_MS
+
+    result = do._execute_single_query(q)
+
+    assert result['status'] == 'success'
+    assert result['columns'] == ['id', 'name']
+    assert result['rows'] == [[1, 'alice'], [2, 'bob']]
+    assert result['row_count'] == 2
+    assert result['error'] is None
+
+
+def test_execute_hana_error_returns_error_status():
+    from hdbcli.dbapi import Error as HanaError
+
+    q = _q(interval_seconds=60)
+    do = _make_do([q])
+    conn, cursor = _mock_conn(['id'], [])
+    cursor.execute.side_effect = HanaError('connection lost')
+    do._do_conn = conn
+    do._do_conn_timeout_ms = DEFAULT_DO_QUERY_TIMEOUT_MS
+
+    result = do._execute_single_query(q)
+
+    assert result['status'] == 'error'
+    assert result['row_count'] == 0
+    assert result['columns'] == []
+    assert 'connection lost' in result['error']
+
+
+def test_execute_hana_error_resets_connection():
+    from hdbcli.dbapi import Error as HanaError
+
+    q = _q(interval_seconds=60)
+    do = _make_do([q])
+    conn, cursor = _mock_conn([], [])
+    cursor.execute.side_effect = HanaError('timeout')
+    do._do_conn = conn
+    do._do_conn_timeout_ms = DEFAULT_DO_QUERY_TIMEOUT_MS
+
+    do._execute_single_query(q)
+
+    assert do._do_conn is None
+    assert do._do_conn_timeout_ms is None
+
+
+def test_execute_uses_default_timeout_when_none():
+    q = _q(interval_seconds=60)  # query_timeout is None
+    do = _make_do([q])
+    called_with = []
+
+    def fake_get_connection(timeout_ms):
+        called_with.append(timeout_ms)
+        conn, _ = _mock_conn(['x'], [])
+        return conn
+
+    do._get_connection = fake_get_connection
+    do._execute_single_query(q)
+    assert called_with == [DEFAULT_DO_QUERY_TIMEOUT_MS]
+
+
+def test_execute_uses_query_timeout_when_set():
+    q = _q(interval_seconds=60, query_timeout=120)
+    do = _make_do([q])
+    called_with = []
+
+    def fake_get_connection(timeout_ms):
+        called_with.append(timeout_ms)
+        conn, _ = _mock_conn(['x'], [])
+        return conn
+
+    do._get_connection = fake_get_connection
+    do._execute_single_query(q)
+    assert called_with == [120]
+
+
+def test_run_job_no_queries_is_noop():
+    do = _make_do([])
+    do.run_job()
+    do._check.event_platform_event.assert_not_called()
+
+
+def test_run_job_no_due_queries_is_noop():
+    q = _q(interval_seconds=60)
+    do = _make_do([q])
+    do._last_execution[_query_key(q)] = time.time()  # just ran, not due yet
+    do.run_job()
+    do._check.event_platform_event.assert_not_called()
+
+
+def test_run_job_due_query_emits_event_and_metrics():
+    q = _q('SELECT id FROM T', interval_seconds=60)
+    do = _make_do([q])
+    conn, _ = _mock_conn(['id'], [[1], [2]])
+    do._do_conn = conn
+    do._do_conn_timeout_ms = DEFAULT_DO_QUERY_TIMEOUT_MS
+
+    do.run_job()
+
+    do._check.event_platform_event.assert_called_once()
+    raw_event, track_type = do._check.event_platform_event.call_args[0]
+    assert track_type == 'do-query-results'
+    payload = json.loads(raw_event)
+    assert payload['status'] == 'success'
+    assert payload['row_count'] == 2
+    # interval mode records the last execution so the query is not immediately due again
+    assert _query_key(q) in do._last_execution
+
+
+def test_run_job_connection_open_failure_does_not_skip_remaining_queries():
+    from hdbcli.dbapi import Error as HanaError
+
+    q1 = _q('SELECT 1', interval_seconds=60)
+    q2 = _q('SELECT 2', interval_seconds=60)
+    do = _make_do([q1, q2])
+
+    conn, _ = _mock_conn(['x'], [[1]])
+    calls = []
+
+    def fake_get_connection(timeout_ms):
+        calls.append(timeout_ms)
+        if len(calls) == 1:
+            raise HanaError('cannot open connection')
+        return conn
+
+    do._get_connection = fake_get_connection
+
+    do.run_job()
+
+    # Both queries were attempted despite the first connection failing, and both
+    # produced an event (the first an error, the second a success).
+    assert len(calls) == 2
+    assert do._check.event_platform_event.call_count == 2
+    statuses = {json.loads(c[0][0])['status'] for c in do._check.event_platform_event.call_args_list}
+    assert statuses == {'error', 'success'}

--- a/sap_hana/tests/test_data_observability.py
+++ b/sap_hana/tests/test_data_observability.py
@@ -11,7 +11,7 @@ import pytest
 
 from datadog_checks.sap_hana.config_models.instance import CustomSqlSelectFields, Entity, Query
 from datadog_checks.sap_hana.data_observability import (
-    DEFAULT_DO_QUERY_TIMEOUT_S,
+    DEFAULT_DO_QUERY_TIMEOUT_MS,
     SapHanaDataObservability,
     _query_key,
 )
@@ -39,7 +39,7 @@ def _make_do(queries=(), config_id=None, tags=None):
     do._do_config = do_config
     do._last_execution = {}
     do._do_conn = None
-    do._do_conn_timeout_s = None
+    do._do_conn_timeout_ms = None
     do._log = mock.MagicMock()
     do._cancel_event = threading.Event()
     do._tags = tags
@@ -52,7 +52,7 @@ def _q(
     interval_seconds=None,
     schedule=None,
     monitor_id=None,
-    timeout_seconds=None,
+    query_timeout=None,
     dbname=None,
 ):
     return Query(
@@ -60,7 +60,7 @@ def _q(
         interval_seconds=interval_seconds,
         schedule=schedule,
         monitor_id=monitor_id,
-        timeout_seconds=timeout_seconds,
+        query_timeout=query_timeout,
         dbname=dbname,
     )
 
@@ -79,16 +79,32 @@ def _mock_conn(columns, rows):
 
 
 class TestQueryKey:
-    def test_same_sql_same_key(self):
+    def test_same_query_same_key(self):
         assert _query_key(_q('SELECT 1')) == _query_key(_q('SELECT 1'))
 
     def test_different_sql_different_key(self):
+        # Distinct monitors always yield distinct SQL (monitor ids are embedded in the query).
         assert _query_key(_q('SELECT 1')) != _query_key(_q('SELECT 2'))
 
     def test_key_is_16_hex_chars(self):
         key = _query_key(_q('SELECT 1'))
         assert len(key) == 16
         assert all(c in '0123456789abcdef' for c in key)
+
+    def test_nonzero_monitor_id_used_as_key(self):
+        assert _query_key(_q('SELECT 1', monitor_id=42)) == 'monitor:42'
+
+    def test_different_monitor_ids_different_key(self):
+        # With a real monitor id, identity comes from the id, not the SQL.
+        assert _query_key(_q('SELECT 1', monitor_id=1)) != _query_key(_q('SELECT 1', monitor_id=2))
+
+    def test_same_monitor_id_same_key_regardless_of_sql(self):
+        assert _query_key(_q('SELECT 1', monitor_id=7)) == _query_key(_q('SELECT 2', monitor_id=7))
+
+    def test_zero_monitor_id_falls_back_to_query_hash(self):
+        # monitor_id 0 (the omitempty default) and None both fall back to the query hash.
+        assert _query_key(_q('SELECT 1', monitor_id=0)) == _query_key(_q('SELECT 1', monitor_id=None))
+        assert _query_key(_q('SELECT 1', monitor_id=0)) == _query_key(_q('SELECT 1'))
 
 
 # ── _filter_valid_queries ──────────────────────────────────────────────────────
@@ -121,11 +137,11 @@ class TestFilterValidQueries:
         assert do._queries == ()
 
     def test_mixed_valid_and_invalid(self):
-        queries = [_q(interval_seconds=30), _q(), _q(schedule='*/10 * * * *')]
+        queries = [_q('SELECT 1', interval_seconds=30), _q('SELECT 2'), _q('SELECT 3', schedule='*/10 * * * *')]
         do = _make_do(queries)
         assert len(do._queries) == 2
 
-    def test_cron_scheduler_keyed_by_query_hash(self):
+    def test_cron_scheduler_keyed_by_query_key(self):
         q = _q(schedule='0 * * * *')
         do = _make_do([q])
         assert _query_key(q) in do._schedulers
@@ -136,7 +152,7 @@ class TestFilterValidQueries:
         assert _query_key(q) not in do._schedulers
 
     def test_skipped_queries_emit_warning(self):
-        do = _make_do([_q(), _q(interval_seconds=30)])
+        do = _make_do([_q('SELECT 1'), _q('SELECT 2', interval_seconds=30)])
         do._log.warning.assert_called()
 
 
@@ -237,7 +253,7 @@ class TestBuildEventPayload:
         assert payload['monitor_id'] == 42
 
     def test_monitor_id_absent_when_none(self):
-        q = _q()
+        q = _q()  # monitor_id is None
         payload = _make_do()._build_event_payload(q, self._RESULT)
         assert 'monitor_id' not in payload
 
@@ -300,7 +316,7 @@ class TestExecuteSingleQuery:
         do = _make_do([q])
         conn, _ = _mock_conn(['id', 'name'], [[1, 'alice'], [2, 'bob']])
         do._do_conn = conn
-        do._do_conn_timeout_s = DEFAULT_DO_QUERY_TIMEOUT_S
+        do._do_conn_timeout_ms = DEFAULT_DO_QUERY_TIMEOUT_MS
 
         result = do._execute_single_query(q)
 
@@ -318,7 +334,7 @@ class TestExecuteSingleQuery:
         conn, cursor = _mock_conn(['id'], [])
         cursor.execute.side_effect = HanaError('connection lost')
         do._do_conn = conn
-        do._do_conn_timeout_s = DEFAULT_DO_QUERY_TIMEOUT_S
+        do._do_conn_timeout_ms = DEFAULT_DO_QUERY_TIMEOUT_MS
 
         result = do._execute_single_query(q)
 
@@ -335,34 +351,34 @@ class TestExecuteSingleQuery:
         conn, cursor = _mock_conn([], [])
         cursor.execute.side_effect = HanaError('timeout')
         do._do_conn = conn
-        do._do_conn_timeout_s = DEFAULT_DO_QUERY_TIMEOUT_S
+        do._do_conn_timeout_ms = DEFAULT_DO_QUERY_TIMEOUT_MS
 
         do._execute_single_query(q)
 
         assert do._do_conn is None
-        assert do._do_conn_timeout_s is None
+        assert do._do_conn_timeout_ms is None
 
     def test_uses_default_timeout_when_none(self):
-        q = _q(interval_seconds=60)  # timeout_seconds is None
+        q = _q(interval_seconds=60)  # query_timeout is None
         do = _make_do([q])
         called_with = []
 
-        def fake_get_connection(timeout_s):
-            called_with.append(timeout_s)
+        def fake_get_connection(timeout_ms):
+            called_with.append(timeout_ms)
             conn, _ = _mock_conn(['x'], [])
             return conn
 
         do._get_connection = fake_get_connection
         do._execute_single_query(q)
-        assert called_with == [DEFAULT_DO_QUERY_TIMEOUT_S]
+        assert called_with == [DEFAULT_DO_QUERY_TIMEOUT_MS]
 
     def test_uses_query_timeout_when_set(self):
-        q = _q(interval_seconds=60, timeout_seconds=120)
+        q = _q(interval_seconds=60, query_timeout=120)
         do = _make_do([q])
         called_with = []
 
-        def fake_get_connection(timeout_s):
-            called_with.append(timeout_s)
+        def fake_get_connection(timeout_ms):
+            called_with.append(timeout_ms)
             conn, _ = _mock_conn(['x'], [])
             return conn
 


### PR DESCRIPTION
sap_hana: add Data Observability RC query actions support

### What does this PR do?

[Data Quality for SAP HANA
](https://docs.google.com/document/d/1jvbwDQqSLzcNWZH2IqT0zQUj0PLMnL8p95vMQmISHrU/edit?usp=sharing)

Adds Data Observability RC query actions support to the SAP HANA integration — the Python-check side that receives and executes monitoring queries delivered via Remote Configuration.

- Adds `SapHanaDataObservability` (`data_observability.py`): reads the `data_observability` config block injected by the agent's RC query-actions component, schedules and executes due queries against HANA, and forwards results as `do-query-results` events via the event platform
- Adds `DataObservability`, `Query`, `Entity`, and `CustomSqlSelectFields` Pydantic models to `config_models/instance.py` (regenerated from `spec.yaml` via `ddev validate models`)
- Schedules queries by a hybrid key: the `monitor_id` when the RC payload carries a real (non-zero) one — matching the Postgres implementation — and a SHA-256 hash of the query text otherwise. `monitor_id` stays optional in the `Query` spec/model (see [Scheduling key and monitor_id](#scheduling-key-and-monitor_id) below)
- Names the per-query statement timeout `query_timeout` in **milliseconds**, matching the Postgres DO config and the agent RC handler, which delivers it as `timeout_seconds * 1000`
- Adds `SapHanaCheck.cancel()` so the `DBMAsyncJob` thread pool is released when the check is unscheduled (cluster-agent flavor / one-off check invocations) instead of leaking
- Omits `monitor_id` from the event payload when absent; includes it when the RC payload provides it
- Adds operational log messages: warn at startup when DO is enabled but no queries have been delivered yet, warn on skipped queries, debug-log connection open/reopen, error-log connection failures
- Adds unit tests covering scheduling logic (including the hybrid key), query filtering, payload construction, and query execution

### Scheduling key and monitor_id

Review feedback asked why this does not simply require `monitor_id` and key off it as Postgres does. Tracing the delivery path settled it:

- The RC payload delivered to agents (`dd-source` `rc-reconciler`'s `QueryEntry`, shared by Postgres and SAP HANA — only the config-id prefix differs, `do-` vs `do-hana-`) has **no per-query `monitor_id` field**. Monitor ids are embedded in a trailing `-- Datadog {"monitor_ids":[...]}` SQL comment and can be plural per bundled query.
- The agent handler's `QuerySpec.MonitorID` is `json:"monitor_id,omitempty"` and is not recovered from the SQL comment, so it decodes to `0` for every query today.
- A single RC config can contain multiple queries. Keying purely off `monitor_id` would therefore collapse every query onto `0`, sharing one scheduler slot (last cron schedule wins; interval timestamps clobber each other). Postgres is exposed to the same latent collision because it keys off `monitor_id` with no fallback — it only avoids it while configs happen to carry a single query.

The hybrid key sidesteps this: it uses `monitor_id` when present (so it upgrades to full Postgres parity automatically once the backend starts emitting it) and otherwise hashes the query text, which is a sufficient per-monitor identity because the SQL embeds the monitor id(s) it serves (comment, or column alias for custom SQL) — distinct monitors always produce distinct query text.

### Motivation

The agent-side `comp/dataobs/queryactions/` component injects a `data_observability` section into matching check instance configs via Remote Configuration. This PR adds the SAP HANA check-side support so it can receive and execute those RC-delivered queries. Rebased on top of `56de213565` (Add SAP HANA schema collection and diagnostics).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

End-to-end monitor based on agent's run queries for saphana: https://dd.datad0g.com/monitors/29887623
