### PR TITLE
Fixing metric typo in fluxcd dashboard

### DIFF
--- a/fluxcd/assets/dashboards/fluxcd.json
+++ b/fluxcd/assets/dashboards/fluxcd.json
@@ -117,7 +117,7 @@
                             "title_size": "16",
                             "title_align": "left",
                             "type": "check_status",
-                            "check": "cilium.prometheus.health",
+                            "check": "fluxcd.openmetrics.health",
                             "grouping": "cluster",
                             "group_by": [],
                             "tags": []


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fixes the fluxcd dashboard. It previously referenced a cilium service check. I fixed this to reference `fluxcd.openmetrics.health`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
