### PR TITLE
Guard build_agent.yaml updates on Agent branch existence

### DIFF
--- a/.github/workflows/update-build-agent-yaml.yml
+++ b/.github/workflows/update-build-agent-yaml.yml
@@ -61,7 +61,8 @@ jobs:
             exit 0
           fi
           if ! git ls-remote --exit-code --heads https://github.com/DataDog/datadog-agent.git "$BRANCH" >/dev/null 2>&1; then
-            echo "::warning::Agent branch '$BRANCH' does not exist in DataDog/datadog-agent yet. Creating the PR anyway."
+            echo "::error::Agent branch '$BRANCH' does not exist in DataDog/datadog-agent. Refusing to open a PR pointing to a missing upstream branch. Re-dispatch this workflow once the upstream branch is cut."
+            exit 1
           fi
           echo "needs_update=true" >> "$GITHUB_ENV"
 

--- a/ddev/changelog.d/23987.fixed
+++ b/ddev/changelog.d/23987.fixed
@@ -1,0 +1,1 @@
+Gate `ddev release branch create` and `update-build-agent-yaml.yml` on the matching `DataDog/datadog-agent` branch existing so neither writer can produce a release-branch pointer to a missing upstream branch.

--- a/ddev/src/ddev/cli/release/branch/build_agent.py
+++ b/ddev/src/ddev/cli/release/branch/build_agent.py
@@ -1,0 +1,100 @@
+# (C) Datadog, Inc. 2024-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import re
+import subprocess
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ddev.cli.application import Application
+
+BUILD_AGENT_YAML_PATH = '.gitlab/build_agent.yaml'
+BUILD_AGENT_TEMPLATE_PATTERN = r'^\.build-agent-tpl:\n(?:[^\S\n].*(?:\n|$))*'
+BUILD_AGENT_MAIN_BRANCH_PATTERN = r'^(\s+branch:\s+)main([^\S\n]*)$'
+BUILD_AGENT_TEMPLATE_REGEX = re.compile(BUILD_AGENT_TEMPLATE_PATTERN, re.MULTILINE)
+BUILD_AGENT_MAIN_BRANCH_REGEX = re.compile(BUILD_AGENT_MAIN_BRANCH_PATTERN, re.MULTILINE)
+
+DATADOG_AGENT_REPO_URL = 'https://github.com/DataDog/datadog-agent.git'
+
+
+def agent_branch_exists(branch_name: str) -> bool:
+    """Return ``True`` if ``branch_name`` exists in ``DataDog/datadog-agent``."""
+    result = subprocess.run(
+        ['git', 'ls-remote', '--exit-code', '--heads', DATADOG_AGENT_REPO_URL, branch_name],
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def find_build_agent_template_main_branch_matches(content: str) -> list[re.Match[str]]:
+    template_match = BUILD_AGENT_TEMPLATE_REGEX.search(content)
+    if template_match is None:
+        return []
+    return list(BUILD_AGENT_MAIN_BRANCH_REGEX.finditer(template_match.group(0)))
+
+
+def replace_build_agent_template_main_branch(content: str, branch_name: str) -> tuple[str, int]:
+    template_match = BUILD_AGENT_TEMPLATE_REGEX.search(content)
+    if template_match is None:
+        return content, 0
+
+    def replacement(match: re.Match[str]) -> str:
+        return f'{match.group(1)}{branch_name}{match.group(2)}'
+
+    updated_template, replacement_count = BUILD_AGENT_MAIN_BRANCH_REGEX.subn(
+        replacement, template_match.group(0), count=1
+    )
+    if replacement_count == 0:
+        return content, 0
+
+    updated_content = content[: template_match.start()] + updated_template + content[template_match.end() :]
+    return updated_content, replacement_count
+
+
+def ensure_build_agent_yaml_updated(app: Application, branch_name: str) -> bool:
+    """Update build_agent.yaml to point to the release branch when it still targets main.
+
+    Returns False without modifying the file when the matching ``DataDog/datadog-agent``
+    branch does not exist yet, so callers can leave ``main`` in place for the recovery
+    path (``ddev release branch tag`` -> ``update-build-agent-yaml.yml``) to run later.
+    """
+    from ddev.utils.fs import Path
+
+    build_agent_yaml = Path(BUILD_AGENT_YAML_PATH)
+
+    if not build_agent_yaml.exists():
+        app.display_warning(f'Warning: {build_agent_yaml} not found')
+        return False
+
+    with open(build_agent_yaml, 'r') as f:
+        content = f.read()
+
+    matches = find_build_agent_template_main_branch_matches(content)
+    if not matches:
+        return False
+    if len(matches) > 1:
+        app.abort(
+            f'Expected exactly one `.build-agent-tpl` branch pointing to `main` in `{BUILD_AGENT_YAML_PATH}`; '
+            f'found {len(matches)}.'
+        )
+        return False
+
+    if not agent_branch_exists(branch_name):
+        app.display_warning(
+            f'Agent branch `{branch_name}` does not exist in `DataDog/datadog-agent` yet. '
+            f'Leaving `{BUILD_AGENT_YAML_PATH}` pointing to `main`. '
+            f'Run `ddev release branch tag` once the upstream branch exists to trigger the update PR.'
+        )
+        return False
+
+    updated_content, replacement_count = replace_build_agent_template_main_branch(content, branch_name)
+    assert replacement_count == 1
+
+    with open(build_agent_yaml, 'w') as f:
+        f.write(updated_content)
+
+    app.display_success(f'Updated build_agent.yaml file to use Agent branch: {branch_name}')
+    return True

--- a/ddev/src/ddev/cli/release/branch/build_agent.py
+++ b/ddev/src/ddev/cli/release/branch/build_agent.py
@@ -86,7 +86,8 @@ def ensure_build_agent_yaml_updated(app: Application, branch_name: str) -> bool:
         app.display_warning(
             f'Unable to verify that agent branch `{branch_name}` exists in `DataDog/datadog-agent`. '
             f'Leaving `{BUILD_AGENT_YAML_PATH}` pointing to `main`. '
-            f'Re-dispatch `update-build-agent-yaml.yml` (or re-run `ddev release branch tag`) once the upstream branch exists.'
+            f'Re-dispatch `update-build-agent-yaml.yml` (or re-run `ddev release branch tag`) '
+            f'once the upstream branch exists.'
         )
         return False
 

--- a/ddev/src/ddev/cli/release/branch/build_agent.py
+++ b/ddev/src/ddev/cli/release/branch/build_agent.py
@@ -84,9 +84,9 @@ def ensure_build_agent_yaml_updated(app: Application, branch_name: str) -> bool:
 
     if not agent_branch_exists(branch_name):
         app.display_warning(
-            f'Agent branch `{branch_name}` does not exist in `DataDog/datadog-agent` yet. '
+            f'Unable to verify that agent branch `{branch_name}` exists in `DataDog/datadog-agent`. '
             f'Leaving `{BUILD_AGENT_YAML_PATH}` pointing to `main`. '
-            f'Run `ddev release branch tag` once the upstream branch exists to trigger the update PR.'
+            f'Re-dispatch `update-build-agent-yaml.yml` (or re-run `ddev release branch tag`) once the upstream branch exists.'
         )
         return False
 

--- a/ddev/src/ddev/cli/release/branch/create.py
+++ b/ddev/src/ddev/cli/release/branch/create.py
@@ -12,12 +12,7 @@ import click
 from httpx import HTTPError, HTTPStatusError
 from packaging.version import Version
 
-from .build_agent import (
-    BUILD_AGENT_YAML_PATH,
-    ensure_build_agent_yaml_updated,
-    find_build_agent_template_main_branch_matches,
-    replace_build_agent_template_main_branch,
-)
+from .build_agent import BUILD_AGENT_YAML_PATH, ensure_build_agent_yaml_updated
 
 if TYPE_CHECKING:
     from ddev.cli.application import Application
@@ -25,21 +20,6 @@ if TYPE_CHECKING:
 BRANCH_NAME_PATTERN = r"^\d+\.\d+\.x$"
 BRANCH_NAME_REGEX = re.compile(BRANCH_NAME_PATTERN)
 GITHUB_LABEL_COLOR = '5319e7'
-
-__all__ = [
-    'BRANCH_NAME_PATTERN',
-    'BRANCH_NAME_REGEX',
-    'BUILD_AGENT_YAML_PATH',
-    'GITHUB_LABEL_COLOR',
-    'bump_milestone',
-    'compute_next_milestone',
-    'create',
-    'ensure_build_agent_yaml_updated',
-    'find_build_agent_template_main_branch_matches',
-    'replace_build_agent_template_main_branch',
-    'suggest_next_branch',
-    'update_release_json',
-]
 
 
 @click.command

--- a/ddev/src/ddev/cli/release/branch/create.py
+++ b/ddev/src/ddev/cli/release/branch/create.py
@@ -12,17 +12,34 @@ import click
 from httpx import HTTPError, HTTPStatusError
 from packaging.version import Version
 
+from .build_agent import (
+    BUILD_AGENT_YAML_PATH,
+    ensure_build_agent_yaml_updated,
+    find_build_agent_template_main_branch_matches,
+    replace_build_agent_template_main_branch,
+)
+
 if TYPE_CHECKING:
     from ddev.cli.application import Application
 
 BRANCH_NAME_PATTERN = r"^\d+\.\d+\.x$"
 BRANCH_NAME_REGEX = re.compile(BRANCH_NAME_PATTERN)
-BUILD_AGENT_YAML_PATH = '.gitlab/build_agent.yaml'
-BUILD_AGENT_TEMPLATE_PATTERN = r'^\.build-agent-tpl:\n(?:[^\S\n].*(?:\n|$))*'
-BUILD_AGENT_MAIN_BRANCH_PATTERN = r'^(\s+branch:\s+)main([^\S\n]*)$'
-BUILD_AGENT_TEMPLATE_REGEX = re.compile(BUILD_AGENT_TEMPLATE_PATTERN, re.MULTILINE)
-BUILD_AGENT_MAIN_BRANCH_REGEX = re.compile(BUILD_AGENT_MAIN_BRANCH_PATTERN, re.MULTILINE)
 GITHUB_LABEL_COLOR = '5319e7'
+
+__all__ = [
+    'BRANCH_NAME_PATTERN',
+    'BRANCH_NAME_REGEX',
+    'BUILD_AGENT_YAML_PATH',
+    'GITHUB_LABEL_COLOR',
+    'bump_milestone',
+    'compute_next_milestone',
+    'create',
+    'ensure_build_agent_yaml_updated',
+    'find_build_agent_template_main_branch_matches',
+    'replace_build_agent_template_main_branch',
+    'suggest_next_branch',
+    'update_release_json',
+]
 
 
 @click.command
@@ -108,6 +125,9 @@ def bump_milestone(app: Application, branch_name: str) -> None:
         app.display_waiting(f"Updating release.json with new milestone `{next_milestone}`...")
         app.repo.git.run('fetch', 'origin', 'master')
         app.repo.git.run('checkout', '-B', bump_branch, 'origin/master')
+        # Force-restore build_agent.yaml from origin/master so any prior in-process edit on the release
+        # branch cannot leak into the milestone-bump commit (root cause of the leak on PR #23977).
+        app.repo.git.run('checkout', 'origin/master', '--', BUILD_AGENT_YAML_PATH)
         update_release_json(app.repo.path / 'release.json', next_milestone)
         app.repo.git.run('add', 'release.json')
         app.repo.git.run('commit', '-m', f'Update current_milestone to {next_milestone}')
@@ -179,62 +199,3 @@ def suggest_next_branch(app: Application) -> str:
             return suggestion
 
     return f'{major}.{minors[-1] + 1}.x'
-
-
-def ensure_build_agent_yaml_updated(app: Application, branch_name: str) -> bool:
-    """Update build_agent.yaml to point to the release branch when it still targets main."""
-    from ddev.utils.fs import Path
-
-    build_agent_yaml = Path(BUILD_AGENT_YAML_PATH)
-
-    if not build_agent_yaml.exists():
-        app.display_warning(f'Warning: {build_agent_yaml} not found')
-        return False
-
-    with open(build_agent_yaml, 'r') as f:
-        content = f.read()
-
-    matches = find_build_agent_template_main_branch_matches(content)
-    if not matches:
-        return False
-    if len(matches) > 1:
-        app.abort(
-            f'Expected exactly one `.build-agent-tpl` branch pointing to `main` in `{BUILD_AGENT_YAML_PATH}`; '
-            f'found {len(matches)}.'
-        )
-        return False
-
-    updated_content, replacement_count = replace_build_agent_template_main_branch(content, branch_name)
-    assert replacement_count == 1
-
-    with open(build_agent_yaml, 'w') as f:
-        f.write(updated_content)
-
-    app.display_success(f'Updated build_agent.yaml file to use Agent branch: {branch_name}')
-    return True
-
-
-def find_build_agent_template_main_branch_matches(content: str) -> list[re.Match[str]]:
-    template_match = BUILD_AGENT_TEMPLATE_REGEX.search(content)
-    if template_match is None:
-        return []
-
-    return list(BUILD_AGENT_MAIN_BRANCH_REGEX.finditer(template_match.group(0)))
-
-
-def replace_build_agent_template_main_branch(content: str, branch_name: str) -> tuple[str, int]:
-    template_match = BUILD_AGENT_TEMPLATE_REGEX.search(content)
-    if template_match is None:
-        return content, 0
-
-    def replacement(match: re.Match[str]) -> str:
-        return f'{match.group(1)}{branch_name}{match.group(2)}'
-
-    updated_template, replacement_count = BUILD_AGENT_MAIN_BRANCH_REGEX.subn(
-        replacement, template_match.group(0), count=1
-    )
-    if replacement_count == 0:
-        return content, 0
-
-    updated_content = content[: template_match.start()] + updated_template + content[template_match.end() :]
-    return updated_content, replacement_count

--- a/ddev/src/ddev/cli/release/branch/tag.py
+++ b/ddev/src/ddev/cli/release/branch/tag.py
@@ -8,7 +8,8 @@ import click
 from httpx import HTTPStatusError
 from packaging.version import Version
 
-from .create import BRANCH_NAME_REGEX, BUILD_AGENT_YAML_PATH, find_build_agent_template_main_branch_matches
+from .build_agent import BUILD_AGENT_YAML_PATH, find_build_agent_template_main_branch_matches
+from .create import BRANCH_NAME_REGEX
 
 if TYPE_CHECKING:
     from ddev.cli.application import Application

--- a/ddev/tests/cli/release/branch/test_create.py
+++ b/ddev/tests/cli/release/branch/test_create.py
@@ -8,7 +8,8 @@ from unittest.mock import call
 
 import pytest
 
-from ddev.cli.release.branch.create import compute_next_milestone, ensure_build_agent_yaml_updated, update_release_json
+from ddev.cli.release.branch.build_agent import ensure_build_agent_yaml_updated
+from ddev.cli.release.branch.create import compute_next_milestone, update_release_json
 from ddev.utils.fs import Path
 
 

--- a/ddev/tests/cli/release/branch/test_create.py
+++ b/ddev/tests/cli/release/branch/test_create.py
@@ -70,6 +70,9 @@ def test_create_branch(ddev, mocker, yaml_updated):
     # Milestone bump workflow
     run_mock.assert_any_call('fetch', 'origin', 'master')
     run_mock.assert_any_call('checkout', '-B', 'release/bump-milestone-5.6.0', 'origin/master')
+    # Defensive restore prevents the build_agent.yaml change on the release branch
+    # from leaking into the milestone-bump commit (see PR #23977 leak).
+    run_mock.assert_any_call('checkout', 'origin/master', '--', '.gitlab/build_agent.yaml')
     run_mock.assert_any_call('add', 'release.json')
     run_mock.assert_any_call('commit', '-m', 'Update current_milestone to 5.6.0')
     run_mock.assert_any_call('push', 'origin', 'release/bump-milestone-5.6.0')
@@ -84,6 +87,7 @@ def test_ensure_build_agent_yaml_updated(mocker, tmp_path):
     build_agent_path.write_text('.build-agent-tpl:\n  trigger:\n    branch: main\n')
 
     app_mock = mocker.MagicMock()
+    mocker.patch('ddev.cli.release.branch.build_agent.agent_branch_exists', return_value=True)
 
     with Path(tmp_path).as_cwd():
         result = ensure_build_agent_yaml_updated(app_mock, '7.99.x')
@@ -100,6 +104,7 @@ def test_ensure_build_agent_yaml_updated_ignores_unrelated_main_branch(mocker, t
     build_agent_path.write_text(content)
 
     app_mock = mocker.MagicMock()
+    mocker.patch('ddev.cli.release.branch.build_agent.agent_branch_exists', return_value=True)
 
     with Path(tmp_path).as_cwd():
         result = ensure_build_agent_yaml_updated(app_mock, '7.99.x')
@@ -109,6 +114,27 @@ def test_ensure_build_agent_yaml_updated_ignores_unrelated_main_branch(mocker, t
         '.build-agent-tpl:\n  trigger:\n    branch: 7.99.x\nunrelated-job:\n  trigger:\n    branch: main\n'
     )
     app_mock.abort.assert_not_called()
+
+
+def test_ensure_build_agent_yaml_updated_skips_when_agent_branch_missing(mocker, tmp_path):
+    """Leave `main` in place when the matching DataDog/datadog-agent branch does not exist yet."""
+    build_agent_path = Path(tmp_path / '.gitlab' / 'build_agent.yaml')
+    build_agent_path.parent.ensure_dir_exists()
+    original_content = '.build-agent-tpl:\n  trigger:\n    branch: main\n'
+    build_agent_path.write_text(original_content)
+
+    app_mock = mocker.MagicMock()
+    mocker.patch('ddev.cli.release.branch.build_agent.agent_branch_exists', return_value=False)
+
+    with Path(tmp_path).as_cwd():
+        result = ensure_build_agent_yaml_updated(app_mock, '7.99.x')
+
+    assert result is False
+    assert build_agent_path.read_text() == original_content
+    app_mock.display_warning.assert_called_once()
+    warning_message = app_mock.display_warning.call_args[0][0]
+    assert '7.99.x' in warning_message
+    assert 'datadog-agent' in warning_message
 
 
 def test_ensure_build_agent_yaml_updated_aborts_on_multiple_template_main_branches(mocker, tmp_path):


### PR DESCRIPTION
### What does this PR do?

- Gate both writers of `.gitlab/build_agent.yaml` (`ddev release branch create` and the `update-build-agent-yaml.yml` workflow) on the matching `DataDog/datadog-agent` branch existing. The workflow now hard-fails; the CLI warns and leaves `branch: main` so `ddev release branch tag` can recover later.
- Consolidate the YAML parsing/update helpers into a new `ddev/src/ddev/cli/release/branch/build_agent.py` shared by `create.py` and `tag.py`.
- In `bump_milestone()`, force-restore `.gitlab/build_agent.yaml` from `origin/master` after checking out the bump branch, so a prior release-branch edit cannot leak into the milestone-bump commit.

### Motivation

When `7.81.x` was cut, `.gitlab/build_agent.yaml` ended up pointing at a `DataDog/datadog-agent` branch that did not yet exist, and the change leaked into the milestone-bump PR #23977 (later reverted). The existence check was missing from both writers and the working-tree state from the release-branch edit was reused for the bump commit.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
