### PR TITLE
[postgres] Clarify relations config requires dbname or database_autodiscovery

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -239,7 +239,8 @@ files:
       fleet_configurable: true
       description: |
         The list of relations/tables must be specified here to track per-relation (table, index, view, etc.) metrics.
-        If enabled, `dbname` should be specified to collect database-specific relations metrics.
+        If enabled, `dbname` should be specified to collect relations metrics for a single database, or
+        `database_autodiscovery` should be enabled to collect relation metrics across all databases on the instance.
         You can either specify a single relation by its exact name in 'relation_name' or use a regex to track metrics
         from all matching relations (useful in cases where relation names are dynamically generated, e.g. TimescaleDB).
         Each relation generates many metrics (10 + 10 per index).

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -97,7 +97,7 @@ instances:
     #
     # dbstrict: false
 
-    ## @param ignore_databases - list of strings - optional - default: ['template0', 'template1', 'rdsadmin', 'azure_maintenance', 'cloudsqladmin', 'alloydbadmin', 'alloydbmetadata']
+    ## @param ignore_databases - list of strings - optional
     ## A list of databases to ignore. No metrics or statement samples will be collected for these databases.
     ## Each value can be a plain string or a Postgres pattern. If you want to ignore the postgres database,
     ## set collect_default_database to false in addition to adding it to this array.
@@ -112,7 +112,7 @@ instances:
     #   - alloydbadmin
     #   - alloydbmetadata
 
-    ## @param ignore_schemas_owned_by - list of strings - optional - default: ['rds_superuser', 'rdsadmin']
+    ## @param ignore_schemas_owned_by - list of strings - optional
     ## A list of database users which own schemas to ignore.
     ## No metrics will be collected for these schemas.
     ## Each value can be a plain string or a Postgres pattern.
@@ -179,9 +179,10 @@ instances:
     #
     # query_timeout: 5000
 
-    ## @param relations - (list of string or mapping) - optional - default: []
+    ## @param relations - (list of string or mapping) - optional
     ## The list of relations/tables must be specified here to track per-relation (table, index, view, etc.) metrics.
-    ## If enabled, `dbname` should be specified to collect database-specific relations metrics.
+    ## If enabled, `dbname` should be specified to collect relations metrics for a single database, or
+    ## `database_autodiscovery` should be enabled to collect relation metrics across all databases on the instance.
     ## You can either specify a single relation by its exact name in 'relation_name' or use a regex to track metrics
     ## from all matching relations (useful in cases where relation names are dynamically generated, e.g. TimescaleDB).
     ## Each relation generates many metrics (10 + 10 per index).
@@ -242,7 +243,7 @@ instances:
     #
     # collect_activity_metrics: false
 
-    ## @param activity_metrics_excluded_aggregations - list of strings - optional - default: []
+    ## @param activity_metrics_excluded_aggregations - list of strings - optional
     ## A list of columns to remove from the pg_stat_activity aggregation.
     ## By default, datname, usename and application_name will be used.
     ## If applications with different application_name are creating a lot of short-lived queries,
@@ -314,48 +315,51 @@ instances:
     ## Each query must have 2 fields, and can have a third optional field:
     ##
     ## 1. query - The SQL to execute. It can be a simple statement or a multi-line script.
-    ##     Use the pipe `|` if you require a multi-line script.
+    ##            Use the pipe `|` if you require a multi-line script.
     ## 2. columns - The list representing each column, ordered sequentially from left to right.
-    ##     The number of columns must equal the number of columns returned in the query.
-    ##     There are 2 required pieces of data:
-    ##       1. name - The suffix to append to `<INTEGRATION>.` to form
-    ##           the full metric name. If `type` is a `tag` type, this column is considered a tag and applied
-    ##           to every metric collected by this particular query.
-    ##       2. type - The submission method (gauge, monotonic_count, etc.).
-    ##           This can also be set to the following `tag` types to tag each metric in the row with the name
-    ##           and value of the item in this column:
-    ##             1. tag - This is the default tag type
-    ##             2. tag_list - This allows multiple values to be attached to the tag name. For example: 
-    ##                 ```
-    ##                 query = {
-    ##                   "name": "example",
-    ##                   "query": "...",
-    ##                   "columns": [
-    ##                     {"name": "server_tag", "type": "tag_list"},
-    ##                     {"name": "foo", "type": "gauge"},
-    ##                   ]
-    ##                 }
-    ##                 ```
-    ##                 May result in:
-    ##                 ```
-    ##                 gauge("foo", tags=["server_tag:us", "server_tag:primary", "server_tag:default"])
-    ##                 gauge("foo", tags=["server_tag:eu"])
-    ##                 gauge("foo", tags=["server_tag:eu", "server_tag:primary"])
-    ##                 ```
-    ##             3. tag_not_null - This only sets tags in the metric if the value is not null
-    ##           You can use the `count` type to perform aggregation for queries that return multiple rows with
-    ##           the same or no tags.
-    ##     Columns without a name are ignored. To skip a column, enter:
-    ##     ```
-    ##       - {}
-    ##     ```
+    ##              The number of columns must equal the number of columns returned in the query.
+    ##              There are 2 required pieces of data:
+    ##                a. name - The suffix to append to `<INTEGRATION>.` to form
+    ##                          the full metric name. If `type` is a `tag` type, this column is
+    ##                          considered a tag and applied to every
+    ##                          metric collected by this particular query.
+    ##                b. type - The submission method (gauge, monotonic_count, etc.).
+    ##                          This can also be set to the following `tag` types to
+    ##                          tag each metric in the row with the name and value
+    ##                          of the item in this column:
+    ##                           i. tag           - This is the default tag type
+    ##                           ii. tag_list     - This allows multiple values to be attached
+    ##                                             to the tag name. For example: 
+    ##
+    ##                                             query = {
+    ##                                               "name": "example",
+    ##                                               "query": "...",
+    ##                                               "columns": [
+    ##                                                 {"name": "server_tag", "type": "tag_list"},
+    ##                                                 {"name": "foo", "type": "gauge"},
+    ##                                               ]
+    ##                                             }
+    ##
+    ##                                             May result in:
+    ##                                             gauge("foo", tags=[
+    ##                                                                 "server_tag:us",
+    ##                                                                 "server_tag:primary",
+    ##                                                                 "server_tag:default"
+    ##                                                               ])
+    ##                                             gauge("foo", tags=["server_tag:eu"])
+    ##                                             gauge("foo", tags=["server_tag:eu", "server_tag:primary"])
+    ##                           iii. tag_not_null - This only sets tags in the metric if the value is not null
+    ##                          You can use the `count` type to perform aggregation
+    ##                          for queries that return multiple rows with the same or no tags.
+    ##              Columns without a name are ignored. To skip a column, enter:
+    ##                - {}
     ## 3. tags (optional) - A list of tags to apply to each metric.
     ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
     ##     If collection_interval is not set, the query will be run every check run.
-    ##     If the collection interval is less than check collection interval, the query will be run every check
-    ##     run.
-    ##     If the collection interval is greater than check collection interval, the query will NOT BE RUN
-    ##     exactly at the collection interval.
+    ##     If the collection interval is less than check collection interval, 
+    ##     the query will be run every check run.
+    ##     If the collection interval is greater than check collection interval, 
+    ##     the query will NOT BE RUN exactly at the collection interval.
     ##     The query will be run at the next check run after the collection interval has passed.
     ## 5. metric_prefix (optional) - The prefix to apply to each metric.
     #
@@ -568,7 +572,7 @@ instances:
         #
         # collection_interval: 600
 
-        ## @param ignored_settings_patterns - list of strings - optional - default: ['plpgsql%']
+        ## @param ignored_settings_patterns - list of strings - optional
         ## A list of setting patterns to ignore. Any setting key matching one of the values in this list will
         ## not be collected. This uses the traditional LIKE pattern-matching approach.
         #
@@ -614,7 +618,7 @@ instances:
         # include_databases:
         #   - mydb
 
-        ## @param exclude_databases - list of strings - optional - default: ['template0', 'template1', 'rdsadmin', 'azure_maintenance', 'cloudsqladmin', 'alloydbadmin', 'alloydbmetadata']
+        ## @param exclude_databases - list of strings - optional
         ## A list of regex patterns to exclude databases.
         ## Any database whose name matches any one of these patterns will be excluded.
         ## If empty, all databases matching other filters are included.


### PR DESCRIPTION
## Summary
- The `relations` parameter description in `spec.yaml` only mentioned `dbname` as a requirement, omitting `database_autodiscovery` as a valid alternative
- Updated the description to clarify that either `dbname` (single database) or `database_autodiscovery` (all databases on the instance) must be configured when using `relations`
- Regenerated `conf.yaml.example` from the updated spec via `ddev validate config -s postgres`

## Test plan
- [ ] Verify `conf.yaml.example` description for the `relations` parameter matches the updated spec