### PR TITLE
win32_event_log: read host from EvtSystemComputer on each event

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -251,7 +251,7 @@ datadog-watchguard-firebox==1.2.0
 datadog-wazuh==1.3.0
 datadog-weaviate==4.4.1
 datadog-weblogic==3.3.0
-datadog-win32-event-log==5.6.0; sys_platform == 'win32'
+datadog-win32-event-log==5.6.1; sys_platform == 'win32'
 datadog-windows-performance-counters==3.5.0; sys_platform == 'win32'
 datadog-windows-service==6.7.1; sys_platform == 'win32'
 datadog-wmi-check==4.1.1; sys_platform == 'win32'

--- a/win32_event_log/changelog.d/23990.fixed
+++ b/win32_event_log/changelog.d/23990.fixed
@@ -1,0 +1,1 @@
+Set event host from EvtSystemComputer so forwarded events report the originating machine rather than the Agent host.

--- a/win32_event_log/datadog_checks/win32_event_log/__about__.py
+++ b/win32_event_log/datadog_checks/win32_event_log/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '5.6.0'
+__version__ = '5.6.1'

--- a/win32_event_log/datadog_checks/win32_event_log/check.py
+++ b/win32_event_log/datadog_checks/win32_event_log/check.py
@@ -186,7 +186,7 @@ class Win32EventLogCheck(AgentCheck, ConfigMixin):
 
     def collect_fqdn(self, event_payload, rendered_event, event_object):
         value, variant = rendered_event[win32evtlog.EvtSystemComputer]
-        if variant == win32evtlog.EvtVarTypeNull or self._session is None:
+        if variant == win32evtlog.EvtVarTypeNull:
             event_payload['host'] = self.hostname
             return
 


### PR DESCRIPTION
### What does this PR do?

Updates `collect_fqdn` in the win32_event_log check to always set the event host from the `EvtSystemComputer` attribute embedded in the Windows event, falling back to the Agent hostname only when that field is null.

### Motivation

This updates the extension to read the computer name from the Event as host. In the use case when Windows Event Collection is used to forward events to a central server, the current extension assumes the event originates from the host where the agent resides versus reporting the host from where the event is originated.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged