### PR TITLE
Add context flags to TaskConfig

### DIFF
--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -149,7 +149,7 @@ class AgenticPhase(Phase):
         last_result: ReActResult | None,
     ) -> ReActResult:
         """Run one task and return the result to use for the next task."""
-        await self._compact_context(process, last_result)
+        await self._manage_context(process, task, last_result)
 
         has_goal = self._task_has_goal(task)
         prompt = self._render_task_prompt(task, context, has_goal)
@@ -160,11 +160,21 @@ class AgenticPhase(Phase):
 
         return await self._run_goal_validation(process, task, context, prompt, result)
 
-    async def _compact_context(
+    async def _manage_context(
         self,
         process: ReActProcess,
+        task: TaskConfig,
         last_result: ReActResult | None,
     ) -> None:
+        if task.clear_context_before:
+            process.reset()
+            return
+
+        if task.compact_context_before:
+            input_tokens, output_tokens = await process.compact()
+            self._add_tokens(input_tokens, output_tokens)
+            return
+
         input_tokens, output_tokens = await self._compact_if_needed(process, last_result)
         self._add_tokens(input_tokens, output_tokens)
 

--- a/ddev/src/ddev/ai/phases/config.py
+++ b/ddev/src/ddev/ai/phases/config.py
@@ -59,11 +59,19 @@ class TaskConfig(BaseModel):
     goal: str | None = None
     goal_path: Path | None = None
     max_goal_attempts: int = 5
+    clear_context_before: bool = False
+    compact_context_before: bool = False
 
     @model_validator(mode="after")
     def exactly_one_prompt_source(self) -> TaskConfig:
         if (self.prompt_path is None) == (self.prompt is None):
             raise ValueError("Exactly one of 'prompt_path' or 'prompt' must be set")
+        return self
+
+    @model_validator(mode="after")
+    def context_flags_mutually_exclusive(self) -> TaskConfig:
+        if self.clear_context_before and self.compact_context_before:
+            raise ValueError("'clear_context_before' and 'compact_context_before' are mutually exclusive")
         return self
 
     @model_validator(mode="after")

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -29,6 +29,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
         file_access_policy: FileAccessPolicy,
         callbacks: Callbacks | None = None,
         grace_period: float = 10,
+        max_timeout: float = 600,
         logger: logging.Logger | None = None,
     ) -> None:
         """Initialize the orchestrator.
@@ -39,8 +40,15 @@ class PhaseOrchestrator(EventBusOrchestrator):
 
         ``file_access_policy`` must have ``write_root`` set to the integration
         output directory so that agent writes are confined to that path.
+
+        ``max_timeout`` is the maximum time in seconds to wait for the whole run of the
+        orchestrator to complete.
         """
-        super().__init__(logger=logger or logging.getLogger(__name__), grace_period=grace_period)
+        super().__init__(
+            logger=logger or logging.getLogger(__name__),
+            grace_period=grace_period,
+            max_timeout=max_timeout,
+        )
         self._flow_yaml_path = flow_yaml_path
         self._checkpoint_path = checkpoint_path
         self._runtime_variables = runtime_variables

--- a/ddev/tests/ai/phases/conftest.py
+++ b/ddev/tests/ai/phases/conftest.py
@@ -66,6 +66,7 @@ class MockAgent:
         self._index = 0
         self.send_calls: list[str | list[ToolResultMessage]] = []
         self.compact_call_count: int = 0
+        self.reset_call_count: int = 0
         self.name = "mock"
         self._system_prompt = ""
         self._history: list[Any] = []
@@ -86,6 +87,7 @@ class MockAgent:
 
     def reset(self) -> None:
         self._history = []
+        self.reset_call_count += 1
 
     async def compact(self) -> AgentResponse | None:
         self.compact_call_count += 1

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -649,6 +649,177 @@ async def test_on_error_writes_tokens_and_goal_validations_to_checkpoint(flow_di
     assert cp["error"] == "something went wrong"
 
 
+# ---------------------------------------------------------------------------
+# process_message — per-task context management flags
+# ---------------------------------------------------------------------------
+
+
+async def test_clear_context_before_resets_history(flow_dir, monkeypatch, message_queue):
+    mock_agent = MockAgent(
+        [
+            make_response("t1 done", 100, 50),
+            make_response("t2 done", 200, 80),
+            make_response("summary", 10, 5),
+        ]
+    )
+    phase, _ = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        tasks=[
+            TaskConfig(name="t1", prompt="First."),
+            TaskConfig(name="t2", prompt="Second.", clear_context_before=True),
+        ],
+    )
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert mock_agent.reset_call_count == 1
+    assert mock_agent.compact_call_count == 0
+
+
+async def test_clear_context_before_skips_auto_compact(flow_dir, monkeypatch, message_queue):
+    """clear_context_before takes priority — no auto-compact even when context is full."""
+    mock_agent = MockAgent(
+        [
+            make_response("t1 done", 100, 50, context_pct=95),
+            make_response("t2 done", 200, 80),
+            make_response("summary", 10, 5),
+        ]
+    )
+    phase, _ = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        tasks=[
+            TaskConfig(name="t1", prompt="First."),
+            TaskConfig(name="t2", prompt="Second.", clear_context_before=True),
+        ],
+    )
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert mock_agent.reset_call_count == 1
+    assert mock_agent.compact_call_count == 0
+
+
+async def test_compact_context_before_compacts_unconditionally(flow_dir, monkeypatch, message_queue):
+    mock_agent = MockAgent(
+        [
+            make_response("t1 done", 100, 50, context_pct=10),
+            make_response("t2 done", 200, 80),
+            make_response("summary", 10, 5),
+        ]
+    )
+    phase, _ = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        tasks=[
+            TaskConfig(name="t1", prompt="First."),
+            TaskConfig(name="t2", prompt="Second.", compact_context_before=True),
+        ],
+    )
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert mock_agent.compact_call_count == 1
+    assert mock_agent.reset_call_count == 0
+
+
+async def test_compact_context_before_skips_auto_compact(flow_dir, monkeypatch, message_queue):
+    """compact_context_before takes priority — auto-compact does not fire a second time."""
+    mock_agent = MockAgent(
+        [
+            make_response("t1 done", 100, 50, context_pct=95),
+            make_response("t2 done", 200, 80),
+            make_response("summary", 10, 5),
+        ]
+    )
+    phase, _ = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        tasks=[
+            TaskConfig(name="t1", prompt="First."),
+            TaskConfig(name="t2", prompt="Second.", compact_context_before=True),
+        ],
+    )
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert mock_agent.compact_call_count == 1
+
+
+async def test_clear_context_before_on_first_task_is_harmless(flow_dir, monkeypatch, message_queue):
+    mock_agent = MockAgent(
+        [
+            make_response("t1 done", 100, 50),
+            make_response("summary", 10, 5),
+        ]
+    )
+    phase, mgr = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        tasks=[TaskConfig(name="t1", prompt="First.", clear_context_before=True)],
+    )
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert mgr.read()["p1"]["status"] == "success"
+    assert mock_agent.reset_call_count == 1
+
+
+async def test_compact_context_before_on_first_task_is_noop(flow_dir, monkeypatch, message_queue):
+    mock_agent = MockAgent(
+        [
+            make_response("t1 done", 100, 50),
+            make_response("summary", 10, 5),
+        ]
+    )
+    phase, mgr = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        tasks=[TaskConfig(name="t1", prompt="First.", compact_context_before=True)],
+    )
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert mgr.read()["p1"]["status"] == "success"
+    assert mgr.read()["p1"]["tokens"] == {"total_input": 110, "total_output": 55}
+    assert mock_agent.compact_call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# TaskConfig — context flag validation
+# ---------------------------------------------------------------------------
+
+
+def test_task_config_rejects_both_context_flags():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        TaskConfig(name="t1", prompt="x", clear_context_before=True, compact_context_before=True)
+
+
+def test_task_config_accepts_clear_context_alone():
+    t = TaskConfig(name="t1", prompt="x", clear_context_before=True)
+    assert t.clear_context_before is True
+    assert t.compact_context_before is False
+
+
+def test_task_config_accepts_compact_context_alone():
+    t = TaskConfig(name="t1", prompt="x", compact_context_before=True)
+    assert t.compact_context_before is True
+    assert t.clear_context_before is False
+
+
 async def test_goal_parse_error_logged_and_tokens_captured(flow_dir, monkeypatch, message_queue):
     """GoalParseError is treated the same as GoalAttemptsExhausted: logged with final_valid=False."""
     from ddev.ai.phases.goal import GoalParseError


### PR DESCRIPTION
### What does this PR do?

Adds two optional boolean flags to `TaskConfig` — `clear_context_before` and `compact_context_before` — that give flow authors explicit control over context management before a task runs. When `clear_context_before` is set, the agent's history is fully reset before the task. When `compact_context_before` is set, the context is compacted unconditionally, regardless of usage thresholds. Both flags take priority over the automatic compaction logic and are mutually exclusive (validated at config parse time).

### Motivation
The existing automatic compaction only triggers when context usage crosses a threshold, which is not always the right behavior. Some tasks benefit from starting with a completely clean slate (e.g., independent subtasks that should not see prior work), while others benefit from a forced compaction regardless of how full the context is. These flags give flow authors the control they need without relying on heuristic-based auto-compaction.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
