### PR TITLE
postgres: fix ERROR-level log spam from explain_parameterized_queries on type mismatch

### DIFF
--- a/postgres/changelog.d/23993.fixed
+++ b/postgres/changelog.d/23993.fixed
@@ -1,0 +1,1 @@
+Fix high-volume ERROR log spam from `explain_parameterized_queries` when `EXPLAIN EXECUTE` encounters a type mismatch on ORM-generated queries with untyped NULL parameters.

--- a/postgres/changelog.d/23993.fixed
+++ b/postgres/changelog.d/23993.fixed
@@ -1,1 +1,1 @@
-Fix high-volume ERROR log spam from `explain_parameterized_queries` when `EXPLAIN EXECUTE` encounters a type mismatch on ORM-generated queries with untyped NULL parameters.
+Fix ERROR log spam from `explain_parameterized_queries` when `EXPLAIN EXECUTE` encounters a type mismatch on queries with untyped NULL parameters.

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -97,7 +97,9 @@ class ExplainParameterizedQueries:
 
             try:
                 result = self._explain_prepared_statement(conn, statement, obfuscated_statement, query_signature)
-                if result:
+                if result is None:
+                    return None, DBExplainError.undefined_function, None
+                elif result:
                     plan = result[0][0][0]
                     return plan, DBExplainError.explained_with_prepared_statement, None
                 else:
@@ -160,6 +162,17 @@ class ExplainParameterizedQueries:
                 EXPLAIN_QUERY.format(explain_function=self._explain_function),
                 (prepared_statement_query,),
             )
+        except (psycopg.errors.UndefinedFunction, psycopg.errors.DatatypeMismatch) as e:
+            logged_statement = obfuscated_statement
+            if self._config.log_unobfuscated_plans:
+                logged_statement = statement
+            logger.debug(
+                'Failed to explain parameterized statement(%s)=[%s] due to type mismatch | err=[%s]',
+                query_signature,
+                logged_statement,
+                e,
+            )
+            return None
         except Exception as e:
             logged_statement = obfuscated_statement
             if self._config.log_unobfuscated_plans:

--- a/postgres/tests/test_explain_parameterized_queries.py
+++ b/postgres/tests/test_explain_parameterized_queries.py
@@ -287,7 +287,6 @@ def test_explain_prepared_statement_type_mismatch_no_error_log(integration_check
 
 
 @pytest.mark.unit
-@requires_over_12
 @pytest.mark.parametrize(
     "exception_class",
     [
@@ -299,20 +298,22 @@ def test_explain_statement_type_mismatch_maps_to_undefined_function(integration_
     check = integration_check(dbm_instance)
     epq = check.statement_samples._explain_parameterized_queries
 
-    with mock.patch.object(epq, '_set_plan_cache_mode'):
-        with mock.patch.object(epq, '_create_prepared_statement'):
-            with mock.patch.object(epq, '_deallocate_prepared_statement'):
-                with mock.patch.object(
-                    epq,
-                    '_explain_prepared_statement',
-                    return_value=None,
-                ):
-                    plan, err_code, err_msg = epq.explain_statement(
-                        'datadog_test',
-                        "SELECT id FROM t WHERE id = $1",
-                        "SELECT id FROM t WHERE id = $1",
-                        "test_sig",
-                    )
+    with mock.patch.object(check, 'version', V12):
+        with mock.patch.object(check, 'db_pool'):
+            with mock.patch.object(epq, '_set_plan_cache_mode'):
+                with mock.patch.object(epq, '_create_prepared_statement'):
+                    with mock.patch.object(epq, '_deallocate_prepared_statement'):
+                        with mock.patch.object(
+                            epq,
+                            '_explain_prepared_statement',
+                            return_value=None,
+                        ):
+                            plan, err_code, err_msg = epq.explain_statement(
+                                'datadog_test',
+                                "SELECT id FROM t WHERE id = $1",
+                                "SELECT id FROM t WHERE id = $1",
+                                "test_sig",
+                            )
 
     assert plan is None
     assert err_code == DBExplainError.undefined_function

--- a/postgres/tests/test_explain_parameterized_queries.py
+++ b/postgres/tests/test_explain_parameterized_queries.py
@@ -287,6 +287,39 @@ def test_explain_prepared_statement_type_mismatch_no_error_log(integration_check
 
 
 @pytest.mark.unit
+@requires_over_12
+@pytest.mark.parametrize(
+    "exception_class",
+    [
+        psycopg.errors.UndefinedFunction,
+        psycopg.errors.DatatypeMismatch,
+    ],
+)
+def test_explain_statement_type_mismatch_maps_to_undefined_function(integration_check, dbm_instance, exception_class):
+    check = integration_check(dbm_instance)
+    epq = check.statement_samples._explain_parameterized_queries
+
+    with mock.patch.object(epq, '_set_plan_cache_mode'):
+        with mock.patch.object(epq, '_create_prepared_statement'):
+            with mock.patch.object(epq, '_deallocate_prepared_statement'):
+                with mock.patch.object(
+                    epq,
+                    '_explain_prepared_statement',
+                    return_value=None,
+                ):
+                    plan, err_code, err_msg = epq.explain_statement(
+                        'datadog_test',
+                        "SELECT id FROM t WHERE id = $1",
+                        "SELECT id FROM t WHERE id = $1",
+                        "test_sig",
+                    )
+
+    assert plan is None
+    assert err_code == DBExplainError.undefined_function
+    assert err_msg is None
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "query,statement_is_parameterized_query",
     [

--- a/postgres/tests/test_explain_parameterized_queries.py
+++ b/postgres/tests/test_explain_parameterized_queries.py
@@ -248,6 +248,45 @@ def test_create_prepared_statement_exception(integration_check, dbm_instance):
 
 
 @pytest.mark.unit
+@requires_over_12
+@pytest.mark.parametrize(
+    "exception_class",
+    [
+        psycopg.errors.UndefinedFunction,
+        psycopg.errors.DatatypeMismatch,
+    ],
+)
+def test_explain_prepared_statement_type_mismatch_no_error_log(integration_check, dbm_instance, exception_class):
+    """Type mismatch errors from EXPLAIN EXECUTE must be handled at DEBUG, not ERROR.
+
+    When _explain_prepared_statement encounters UndefinedFunction or DatatypeMismatch (caused by
+    untyped NULL parameters against non-text columns), it must return None (sentinel) rather than
+    raise. If it raises, @tracked_method logs at ERROR level for every explain attempt on every
+    affected query signature with no rate limiting. explain_statement maps None -> undefined_function
+    so the failure is still observable in collection_errors telemetry.
+    """
+    check = integration_check(dbm_instance)
+    epq = check.statement_samples._explain_parameterized_queries
+
+    with mock.patch.object(epq, '_generate_prepared_statement_query', return_value="EXECUTE dd_test(null)"):
+        with mock.patch.object(
+            epq,
+            '_execute_query_and_fetch_rows',
+            side_effect=exception_class("operator does not exist: bigint = text"),
+        ):
+            with mock.patch.object(check.log, 'exception') as mock_exception:
+                result = epq._explain_prepared_statement(
+                    None,
+                    "SELECT id FROM t WHERE id = $1",
+                    "SELECT id FROM t WHERE id = $1",
+                    "test_sig",
+                )
+
+    assert result is None
+    mock_exception.assert_not_called()
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "query,statement_is_parameterized_query",
     [

--- a/postgres/tests/test_explain_parameterized_queries.py
+++ b/postgres/tests/test_explain_parameterized_queries.py
@@ -184,7 +184,7 @@ def test_explain_parameterized_queries_explain_prepared_statement_no_plan_return
 
     with mock.patch(
         'datadog_checks.postgres.explain_parameterized_queries.ExplainParameterizedQueries._execute_query_and_fetch_rows',
-        return_value=None,
+        return_value=[],
     ):
         plan_dict, explain_err_code, err = check.statement_samples._run_and_track_explain(
             DB_NAME,


### PR DESCRIPTION
### What does this PR do?

Catch `psycopg.errors.UndefinedFunction` and `psycopg.errors.DatatypeMismatch` inside `_explain_prepared_statement` before they escape to the `@tracked_method` decorator. Log at DEBUG, return `None` as a sentinel. `explain_statement` maps `None` → `DBExplainError.undefined_function` so the failure remains observable in `collection_errors` telemetry.

### Motivation

When `explain_parameterized_queries: true` is enabled and the agent runs `EXPLAIN EXECUTE dd_X(null, ...)` against a query that compares a non-text column to an untyped `$N` parameter, PostgreSQL raises `UndefinedFunction` (SQLSTATE 42883). This escaped `_explain_prepared_statement` to the `@tracked_method` decorator, which calls `check.log.exception()` at ERROR with no rate limiting — one ERROR per explain attempt per unique query signature.

The April 2025 PREPARE-phase fixes (#19969 / #19998) patched the same error classes in `_create_prepared_statement` but left the EXECUTE phase unpatched. This PR closes that gap.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged