### PR TITLE
Update ddev env test tool

### DIFF
--- a/ddev/src/ddev/ai/tools/shell/ddev/env_test.py
+++ b/ddev/src/ddev/ai/tools/shell/ddev/env_test.py
@@ -11,14 +11,14 @@ from ddev.ai.tools.shell.base import CmdTool
 
 class EnvTestInput(BaseToolInput):
     integration: Annotated[str, Field(description="Integration name")]
-    environment: Annotated[str, Field(description="Environment name (e.g. py3.11-1.23)")]
-    dev: Annotated[bool, Field(description="Pass --dev flag (use if env was started with --dev)")] = False
+    environment: Annotated[
+        str, Field(description="Environment name (e.g. py3.11-1.23). Defaults to 'all' to test every environment.")
+    ] = "all"
 
 
 class DdevEnvTestTool(CmdTool[EnvTestInput]):
-    """Runs E2E tests for the given integration in the specified environment.
-    `ddev env test` starts the environment, runs the tests, and stops it automatically —
-    no prior `ddev_env_start` is needed. Use `dev=true` to pass the `--dev` flag."""
+    """Runs E2E tests for an integration. Always passes --dev and tests all environments by default.
+    Pass a specific environment name to target a single environment."""
 
     timeout = 600
 
@@ -27,8 +27,4 @@ class DdevEnvTestTool(CmdTool[EnvTestInput]):
         return "ddev_env_test"
 
     def cmd(self, tool_input: EnvTestInput) -> list[str]:
-        cmd = ["ddev", "--no-interactive", "env", "test"]
-        if tool_input.dev:
-            cmd.append("--dev")
-        cmd += [tool_input.integration, tool_input.environment]
-        return cmd
+        return ["ddev", "--no-interactive", "env", "test", "--dev", tool_input.integration, tool_input.environment]

--- a/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
+++ b/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
@@ -132,15 +132,28 @@ def test_env_start_cmd(dev, expected):
 # --- ddev env test ---
 
 
-@pytest.mark.parametrize(
-    "dev,expected",
-    [
-        (False, ["ddev", "--no-interactive", "env", "test", "mycheck", "py3.11-1.23"]),
-        (True, ["ddev", "--no-interactive", "env", "test", "--dev", "mycheck", "py3.11-1.23"]),
-    ],
-)
-def test_env_test_cmd(dev, expected):
-    assert DdevEnvTestTool().cmd(EnvTestInput(integration="mycheck", environment="py3.11-1.23", dev=dev)) == expected
+def test_env_test_cmd_default_env():
+    assert DdevEnvTestTool().cmd(EnvTestInput(integration="mycheck")) == [
+        "ddev",
+        "--no-interactive",
+        "env",
+        "test",
+        "--dev",
+        "mycheck",
+        "all",
+    ]
+
+
+def test_env_test_cmd_specific_env():
+    assert DdevEnvTestTool().cmd(EnvTestInput(integration="mycheck", environment="py3.11-1.23")) == [
+        "ddev",
+        "--no-interactive",
+        "env",
+        "test",
+        "--dev",
+        "mycheck",
+        "py3.11-1.23",
+    ]
 
 
 # --- ddev env stop ---


### PR DESCRIPTION
### What does this PR do?

Updates the `ddev_env_test` AI tool to always pass `--dev` and default the environment to `all` (runs every environment). A specific environment can still be passed to narrow the test run.

### Motivation

Simplifies tool usage — the agent no longer needs to decide whether to pass `--dev` or which environment to target when a full run is intended.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged