### PR TITLE
Simplify ddev sign and upload job conditions

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -53,27 +53,6 @@ jobs:
         fi
         echo "base_tags=team:agent-integrations,service:ddev,context:$context" >> $GITHUB_OUTPUT
 
-  should-sign-and-upload:
-    name: Determine signing conditions
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        # Override workflow-level working-directory since this job does not checkout code
-        working-directory: .
-    outputs:
-      result: ${{ steps.check.outputs.result }}
-    steps:
-    - id: check
-      env:
-        EVENT_NAME: ${{ github.event_name }}
-        REF: ${{ github.ref }}
-      run: |
-        result=false
-        if [[ "$EVENT_NAME" == "schedule" || ( "$EVENT_NAME" == "push" && "$REF" == refs/tags/* ) ]]; then
-          result=true
-        fi
-        echo "result=$result" >> $GITHUB_OUTPUT
-
   python-artifacts:
     name: Build wheel and source distribution
     runs-on: ubuntu-latest
@@ -352,7 +331,6 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - define-tags
-    - should-sign-and-upload
     - binaries
     runs-on: windows-2022
     permissions:
@@ -464,7 +442,7 @@ jobs:
         mv build/*/release/*/*.{exe,msi} installers
 
     - name: Upload installers
-      if: needs.should-sign-and-upload.outputs.result == 'true'
+      if: github.event_name == 'schedule' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: installers-${{ runner.os }}


### PR DESCRIPTION
### What does this PR do?
Simplifies Macos sign and upload job conditions
### Motivation
this comment: https://github.com/DataDog/integrations-core/pull/23456/changes#r3207163004; the condition is only needed in one other job so I cam move it inline.
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
