### PR TITLE
Add step to verify ddev package was produced

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -555,6 +555,9 @@ jobs:
         --version ${{ env.VERSION }}
         staged
 
+    - name: Verify PKG was produced
+      run: ls staged/*.pkg
+
   macos-packaging:
     name: Build macOS installer and sign/notarize artifacts
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event_name == 'schedule'


### PR DESCRIPTION
### What does this PR do?
Adds step in ddev build job to verify the package was produced
### Motivation
comment from here: https://github.com/DataDog/integrations-core/pull/23456/changes#r3207163007
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
