### PR TITLE
Add infra mode config option 

### DIFF
--- a/proxmox/assets/configuration/spec.yaml
+++ b/proxmox/assets/configuration/spec.yaml
@@ -30,6 +30,13 @@ files:
         example: true
         display_default: false
       required: false
+    - name: infrastructure_mode
+      description: |
+        The infrastructure mode to use. Valid values are 'full' (default) and 'basic'.
+      fleet_configurable: true
+      value:
+        type: string
+        example: full
     - name: resource_filters
       display_priority: 1
       description: |

--- a/proxmox/assets/configuration/spec.yaml
+++ b/proxmox/assets/configuration/spec.yaml
@@ -37,6 +37,9 @@ files:
       value:
         type: string
         example: full
+        enum:
+        - full
+        - basic
     - name: resource_filters
       display_priority: 1
       description: |

--- a/proxmox/changelog.d/24008.added
+++ b/proxmox/changelog.d/24008.added
@@ -1,0 +1,1 @@
+Add infra_mode tag to proxmox metrics.

--- a/proxmox/datadog_checks/proxmox/check.py
+++ b/proxmox/datadog_checks/proxmox/check.py
@@ -15,6 +15,7 @@ from .constants import (
     ALLOWED_FILTER_PROPERTIES,
     ALLOWED_FILTER_TYPES,
     EVENT_TYPE_TO_TITLE,
+    INFRA_MODE_METRIC,
     NODE_RESOURCE,
     OK_STATUS,
     PERF_METRIC_NAME,
@@ -138,7 +139,11 @@ class ProxmoxCheck(AgentCheck, ConfigMixin):
             metric_value = resource.get(metric_name)
             metric_method = self.count if metric_name in RESOURCE_COUNT_METRICS else self.gauge
             if metric_value is not None:
-                metric_method(f'{metric_name_remapped}', metric_value, tags=tags, hostname=hostname)
+                metric_tags = tags
+                infra_mode = self.config.infrastructure_mode
+                if metric_name_remapped == INFRA_MODE_METRIC and infra_mode and infra_mode != 'full':
+                    metric_tags = list(tags) + [f'infra_mode:{infra_mode}']
+                metric_method(f'{metric_name_remapped}', metric_value, tags=metric_tags, hostname=hostname)
 
     def _get_vm_hostname(self, vm_id, vm_name, node):
         try:

--- a/proxmox/datadog_checks/proxmox/check.py
+++ b/proxmox/datadog_checks/proxmox/check.py
@@ -141,7 +141,7 @@ class ProxmoxCheck(AgentCheck, ConfigMixin):
             if metric_value is not None:
                 metric_tags = tags
                 infra_mode = self.config.infrastructure_mode
-                if metric_name_remapped == INFRA_MODE_METRIC and hostname and infra_mode and infra_mode != 'full':
+                if metric_name_remapped == INFRA_MODE_METRIC and hostname and infra_mode != 'full':
                     metric_tags = list(tags) + [f'infra_mode:{infra_mode}']
                 metric_method(f'{metric_name_remapped}', metric_value, tags=metric_tags, hostname=hostname)
 

--- a/proxmox/datadog_checks/proxmox/check.py
+++ b/proxmox/datadog_checks/proxmox/check.py
@@ -141,7 +141,7 @@ class ProxmoxCheck(AgentCheck, ConfigMixin):
             if metric_value is not None:
                 metric_tags = tags
                 infra_mode = self.config.infrastructure_mode
-                if metric_name_remapped == INFRA_MODE_METRIC and infra_mode and infra_mode != 'full':
+                if metric_name_remapped == INFRA_MODE_METRIC and hostname and infra_mode and infra_mode != 'full':
                     metric_tags = list(tags) + [f'infra_mode:{infra_mode}']
                 metric_method(f'{metric_name_remapped}', metric_value, tags=metric_tags, hostname=hostname)
 

--- a/proxmox/datadog_checks/proxmox/config_models/defaults.py
+++ b/proxmox/datadog_checks/proxmox/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_enable_legacy_tags_normalization():
     return True
 
 
+def instance_infrastructure_mode():
+    return 'full'
+
+
 def instance_kerberos_auth():
     return 'disabled'
 

--- a/proxmox/datadog_checks/proxmox/config_models/instance.py
+++ b/proxmox/datadog_checks/proxmox/config_models/instance.py
@@ -85,6 +85,7 @@ class InstanceConfig(BaseModel):
     enable_legacy_tags_normalization: Optional[bool] = None
     extra_headers: Optional[MappingProxyType[str, Any]] = None
     headers: Optional[MappingProxyType[str, Any]] = None
+    infrastructure_mode: Optional[str] = None
     kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None

--- a/proxmox/datadog_checks/proxmox/config_models/instance.py
+++ b/proxmox/datadog_checks/proxmox/config_models/instance.py
@@ -85,7 +85,7 @@ class InstanceConfig(BaseModel):
     enable_legacy_tags_normalization: Optional[bool] = None
     extra_headers: Optional[MappingProxyType[str, Any]] = None
     headers: Optional[MappingProxyType[str, Any]] = None
-    infrastructure_mode: Optional[str] = None
+    infrastructure_mode: Optional[Literal['full', 'basic']] = None
     kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None

--- a/proxmox/datadog_checks/proxmox/constants.py
+++ b/proxmox/datadog_checks/proxmox/constants.py
@@ -67,3 +67,5 @@ EVENT_TYPE_TO_TITLE = {
 ALLOWED_FILTER_PROPERTIES = ['resource_name']
 ADDITIONAL_FILTER_PROPERTIES = ['hostname']
 ALLOWED_FILTER_TYPES = ['include', 'exclude']
+
+INFRA_MODE_METRIC = 'cpu'

--- a/proxmox/datadog_checks/proxmox/data/conf.yaml.example
+++ b/proxmox/datadog_checks/proxmox/data/conf.yaml.example
@@ -150,6 +150,11 @@ instances:
     #
     # empty_default_hostname: true
 
+    ## @param infrastructure_mode - string - optional - default: full
+    ## The infrastructure mode to use. Valid values are 'full' (default) and 'basic'.
+    #
+    # infrastructure_mode: full
+
     ## @param collected_task_types - list of strings - optional - default: ['qmstart', 'qmstop', 'qmshutdown', 'qmreboot', 'qmigrate', 'qmsuspend', 'vzstart', 'vzshutdown', 'vzsuspend', 'startall', 'stopall', 'suspendall', 'aptupdate']
     ## Which Proxmox task types to collect.
     ##

--- a/proxmox/tests/test_unit.py
+++ b/proxmox/tests/test_unit.py
@@ -577,6 +577,26 @@ def test_events(get_current_datetime, dd_run_check, aggregator, instance, collec
 
 
 @pytest.mark.parametrize(
+    ('infrastructure_mode', 'expected_tag', 'should_have_tag'),
+    [
+        pytest.param('basic', 'infra_mode:basic', True, id='basic mode adds infra_mode tag'),
+        pytest.param('full', 'infra_mode:full', False, id='full mode does not add infra_mode tag'),
+        pytest.param(None, 'infra_mode:full', False, id='unset mode does not add infra_mode tag'),
+    ],
+)
+@pytest.mark.usefixtures('mock_http_get')
+def test_infra_mode_tag(dd_run_check, aggregator, instance, infrastructure_mode, expected_tag, should_have_tag):
+    instance = copy.deepcopy(instance)
+    if infrastructure_mode is not None:
+        instance['infrastructure_mode'] = infrastructure_mode
+    check = ProxmoxCheck('proxmox', {}, [instance])
+    dd_run_check(check)
+
+    count = None if should_have_tag else 0
+    aggregator.assert_metric_has_tag('proxmox.cpu', expected_tag, count=count)
+
+
+@pytest.mark.parametrize(
     ('resource_filters, expected_vms, expected_nodes'),
     [
         pytest.param(

--- a/proxmox/tests/test_unit.py
+++ b/proxmox/tests/test_unit.py
@@ -594,15 +594,14 @@ def test_infra_mode_tag(dd_run_check, aggregator, instance, infrastructure_mode,
 
     aggregator.assert_metric_has_tag('proxmox.cpu', expected_tag, count=expected_count)
 
-    if expected_count > 0:
-        # assert that no container metrics have the infra_mode tag
-        for metric in aggregator.metrics('proxmox.cpu'):
-            if 'proxmox_type:container' in metric.tags:
-                assert expected_tag not in metric.tags
-        # assert only the cpu metric has the infra_mode tag
-        for metric_name in ALL_METRICS:
-            if metric_name != 'proxmox.cpu':
-                aggregator.assert_metric_has_tag(metric_name, expected_tag, count=0)
+    # assert that no container metrics have the infra_mode tag
+    for metric in aggregator.metrics('proxmox.cpu'):
+        if 'proxmox_type:container' in metric.tags:
+            assert expected_tag not in metric.tags
+    # assert only the cpu metric has the infra_mode tag
+    for metric_name in ALL_METRICS:
+        if metric_name != 'proxmox.cpu':
+            aggregator.assert_metric_has_tag(metric_name, expected_tag, count=0)
 
 
 @pytest.mark.parametrize(

--- a/proxmox/tests/test_unit.py
+++ b/proxmox/tests/test_unit.py
@@ -577,31 +577,31 @@ def test_events(get_current_datetime, dd_run_check, aggregator, instance, collec
 
 
 @pytest.mark.parametrize(
-    ('infrastructure_mode', 'expected_tag', 'expected_count'),
+    ('infrastructure_mode', 'expected_count'),
     [
-        pytest.param('basic', 'infra_mode:basic', 2, id='basic mode adds infra_mode tag'),
-        pytest.param('full', 'infra_mode:full', 0, id='full mode does not add infra_mode tag'),
-        pytest.param(None, 'infra_mode:full', 0, id='unset mode does not add infra_mode tag'),
+        pytest.param('basic', 2, id='basic mode adds infra_mode tag'),
+        pytest.param('full', 0, id='full mode does not add infra_mode tag'),
+        pytest.param(None, 0, id='unset mode does not add infra_mode tag'),
     ],
 )
 @pytest.mark.usefixtures('mock_http_get')
-def test_infra_mode_tag(dd_run_check, aggregator, instance, infrastructure_mode, expected_tag, expected_count):
+def test_infra_mode_tag(dd_run_check, aggregator, instance, infrastructure_mode, expected_count):
     instance = copy.deepcopy(instance)
     if infrastructure_mode is not None:
         instance['infrastructure_mode'] = infrastructure_mode
     check = ProxmoxCheck('proxmox', {}, [instance])
     dd_run_check(check)
 
-    aggregator.assert_metric_has_tag('proxmox.cpu', expected_tag, count=expected_count)
+    aggregator.assert_metric_has_tag_prefix('proxmox.cpu', 'infra_mode:', count=expected_count)
 
-    # assert that no container metrics have the infra_mode tag
+    # assert that no container metrics have an infra_mode tag
     for metric in aggregator.metrics('proxmox.cpu'):
         if 'proxmox_type:container' in metric.tags:
-            assert expected_tag not in metric.tags
-    # assert only the cpu metric has the infra_mode tag
+            assert not any(t.startswith('infra_mode:') for t in metric.tags)
+    # assert only the cpu metric has an infra_mode tag
     for metric_name in ALL_METRICS:
         if metric_name != 'proxmox.cpu':
-            aggregator.assert_metric_has_tag(metric_name, expected_tag, count=0)
+            aggregator.assert_metric_has_tag_prefix(metric_name, 'infra_mode:', count=0)
 
 
 @pytest.mark.parametrize(

--- a/proxmox/tests/test_unit.py
+++ b/proxmox/tests/test_unit.py
@@ -577,23 +577,32 @@ def test_events(get_current_datetime, dd_run_check, aggregator, instance, collec
 
 
 @pytest.mark.parametrize(
-    ('infrastructure_mode', 'expected_tag', 'should_have_tag'),
+    ('infrastructure_mode', 'expected_tag', 'expected_count'),
     [
-        pytest.param('basic', 'infra_mode:basic', True, id='basic mode adds infra_mode tag'),
-        pytest.param('full', 'infra_mode:full', False, id='full mode does not add infra_mode tag'),
-        pytest.param(None, 'infra_mode:full', False, id='unset mode does not add infra_mode tag'),
+        pytest.param('basic', 'infra_mode:basic', 2, id='basic mode adds infra_mode tag'),
+        pytest.param('full', 'infra_mode:full', 0, id='full mode does not add infra_mode tag'),
+        pytest.param(None, 'infra_mode:full', 0, id='unset mode does not add infra_mode tag'),
     ],
 )
 @pytest.mark.usefixtures('mock_http_get')
-def test_infra_mode_tag(dd_run_check, aggregator, instance, infrastructure_mode, expected_tag, should_have_tag):
+def test_infra_mode_tag(dd_run_check, aggregator, instance, infrastructure_mode, expected_tag, expected_count):
     instance = copy.deepcopy(instance)
     if infrastructure_mode is not None:
         instance['infrastructure_mode'] = infrastructure_mode
     check = ProxmoxCheck('proxmox', {}, [instance])
     dd_run_check(check)
 
-    count = None if should_have_tag else 0
-    aggregator.assert_metric_has_tag('proxmox.cpu', expected_tag, count=count)
+    aggregator.assert_metric_has_tag('proxmox.cpu', expected_tag, count=expected_count)
+
+    if expected_count > 0:
+        # assert that no container metrics have the infra_mode tag
+        for metric in aggregator.metrics('proxmox.cpu'):
+            if 'proxmox_type:container' in metric.tags:
+                assert expected_tag not in metric.tags
+        # assert only the cpu metric has the infra_mode tag
+        for metric_name in ALL_METRICS:
+            if metric_name != 'proxmox.cpu':
+                aggregator.assert_metric_has_tag(metric_name, expected_tag, count=0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?
Adds config option to control infra mode in proxmox
### Motivation
Add support for infra mode basic, similar to vSphere: https://github.com/DataDog/integrations-core/pull/21730/changes
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
