### PR TITLE
Add max_timeout to PhaseOrchestrator's arguments

### DIFF
--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -29,6 +29,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
         file_access_policy: FileAccessPolicy,
         callbacks: Callbacks | None = None,
         grace_period: float = 10,
+        max_timeout: float = 600,
         logger: logging.Logger | None = None,
     ) -> None:
         """Initialize the orchestrator.
@@ -39,8 +40,15 @@ class PhaseOrchestrator(EventBusOrchestrator):
 
         ``file_access_policy`` must have ``write_root`` set to the integration
         output directory so that agent writes are confined to that path.
+
+        ``max_timeout`` is the maximum time in seconds to wait for the whole run of the
+        orchestrator to complete.
         """
-        super().__init__(logger=logger or logging.getLogger(__name__), grace_period=grace_period)
+        super().__init__(
+            logger=logger or logging.getLogger(__name__),
+            grace_period=grace_period,
+            max_timeout=max_timeout,
+        )
         self._flow_yaml_path = flow_yaml_path
         self._checkpoint_path = checkpoint_path
         self._runtime_variables = runtime_variables


### PR DESCRIPTION
### What does this PR do?
Adds `max_timeout `to `PhaseOrchestrator's` arguments, so that long execution flows don't fail. When trying this in a real demo, the previous default (300 seconds) wasn't enough. Now, the default is 600 seconds and it can be set by the orchestrator's callers.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
