### PR TITLE
Add copy_path tool

### DIFF
--- a/ddev/src/ddev/ai/tools/fs/copy_path.py
+++ b/ddev/src/ddev/ai/tools/fs/copy_path.py
@@ -22,6 +22,13 @@ class CopyPathInput(BaseToolInput):
             " for a directory source it is the target directory."
         ),
     ]
+    overwrite: Annotated[
+        bool,
+        Field(
+            description="If True, overwrite existing files at the destination. "
+            "Defaults to False; set to True only when you are sure you want to replace existing files.",
+        ),
+    ] = False
 
 
 class CopyPathTool(BaseTool[CopyPathInput]):
@@ -56,10 +63,32 @@ class CopyPathTool(BaseTool[CopyPathInput]):
 
         try:
             if source.is_dir():
+                if not tool_input.overwrite:
+                    conflicts = [
+                        str(destination / p.relative_to(source))
+                        for p in source.rglob("*")
+                        if p.is_file() and (destination / p.relative_to(source)).exists()
+                    ]
+                    if conflicts:
+                        listed = "\n".join(f"  {c}" for c in conflicts)
+                        return ToolResult(
+                            success=False,
+                            error=(
+                                f"Copy aborted: {len(conflicts)} file(s) already exist at the destination "
+                                f"and would be overwritten:\n{listed}"
+                            ),
+                            hint="Set overwrite=True to replace them.",
+                        )
                 shutil.copytree(source, destination, dirs_exist_ok=True)
                 file_count = sum(1 for p in source.rglob("*") if p.is_file())
                 return ToolResult(success=True, data=f"Copied directory tree to {destination} ({file_count} files).")
             destination.parent.mkdir(parents=True, exist_ok=True)
+            if not tool_input.overwrite and destination.exists():
+                return ToolResult(
+                    success=False,
+                    error=(f"Copy aborted: destination already exists: {destination}. "),
+                    hint="Set overwrite=True to replace it.",
+                )
             shutil.copy2(source, destination)
             size = Path(destination).stat().st_size
             return ToolResult(success=True, data=f"Copied file to {destination} ({size} bytes).")

--- a/ddev/src/ddev/ai/tools/fs/copy_path.py
+++ b/ddev/src/ddev/ai/tools/fs/copy_path.py
@@ -1,0 +1,60 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import shutil
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import Field
+
+from ddev.ai.tools.core.base import BaseTool, BaseToolInput
+from ddev.ai.tools.core.types import ToolResult
+
+from .file_access_policy import FileAccessError, FileAccessPolicy
+
+
+class CopyPathInput(BaseToolInput):
+    source: Annotated[str, Field(description="Path to copy from (a file or a directory).")]
+    destination: Annotated[
+        str,
+        Field(
+            description="Path to copy to. For a file source this is the target file path;"
+            " for a directory source it is the target directory."
+        ),
+    ]
+
+
+class CopyPathTool(BaseTool[CopyPathInput]):
+    """Copies a file or a whole directory tree from source to destination, byte-for-byte,
+    without reading the content into the conversation.
+    It is the only correct way to copy large or binary files.
+    Missing parent directories are created."""
+
+    def __init__(self, policy: FileAccessPolicy) -> None:
+        self._policy = policy
+
+    @property
+    def name(self) -> str:
+        return "copy_path"
+
+    async def __call__(self, tool_input: CopyPathInput) -> ToolResult:
+        try:
+            source = self._policy.assert_readable(tool_input.source)
+            destination = self._policy.assert_writable(tool_input.destination)
+        except FileAccessError as e:
+            return ToolResult(success=False, error=str(e))
+
+        if not source.exists():
+            return ToolResult(success=False, error=f"Source does not exist: {source}")
+
+        try:
+            if source.is_dir():
+                shutil.copytree(source, destination, dirs_exist_ok=True)
+                file_count = sum(1 for p in destination.rglob("*") if p.is_file())
+                return ToolResult(success=True, data=f"Copied directory tree to {destination} ({file_count} files).")
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+            size = Path(destination).stat().st_size
+            return ToolResult(success=True, data=f"Copied file to {destination} ({size} bytes).")
+        except OSError as e:
+            return ToolResult(success=False, error=str(e))

--- a/ddev/src/ddev/ai/tools/fs/copy_path.py
+++ b/ddev/src/ddev/ai/tools/fs/copy_path.py
@@ -49,6 +49,11 @@ class CopyPathTool(BaseTool[CopyPathInput]):
 
         try:
             if source.is_dir():
+                for entry in source.rglob("*"):
+                    try:
+                        self._policy.assert_readable(entry)
+                    except FileAccessError as e:
+                        return ToolResult(success=False, error=str(e))
                 shutil.copytree(source, destination, dirs_exist_ok=True)
                 file_count = sum(1 for p in destination.rglob("*") if p.is_file())
                 return ToolResult(success=True, data=f"Copied directory tree to {destination} ({file_count} files).")

--- a/ddev/src/ddev/ai/tools/fs/copy_path.py
+++ b/ddev/src/ddev/ai/tools/fs/copy_path.py
@@ -49,12 +49,16 @@ class CopyPathTool(BaseTool[CopyPathInput]):
             source = self._policy.assert_readable(tool_input.source)
             if source.is_dir():
                 for entry in source.rglob("*"):
-                    if entry.is_file():
+                    if entry.is_file() or entry.is_symlink():
                         try:
                             self._policy.assert_readable(entry)
                         except FileAccessError as e:
                             return ToolResult(success=False, error=str(e))
             destination = self._policy.assert_writable(tool_input.destination)
+            if destination.is_dir():
+                for entry in destination.rglob("*"):
+                    if entry.is_symlink() and entry.is_dir():
+                        self._policy.assert_writable(entry.resolve())
         except FileAccessError as e:
             return ToolResult(success=False, error=str(e))
 

--- a/ddev/src/ddev/ai/tools/fs/copy_path.py
+++ b/ddev/src/ddev/ai/tools/fs/copy_path.py
@@ -40,6 +40,13 @@ class CopyPathTool(BaseTool[CopyPathInput]):
     async def __call__(self, tool_input: CopyPathInput) -> ToolResult:
         try:
             source = self._policy.assert_readable(tool_input.source)
+            if source.is_dir():
+                for entry in source.rglob("*"):
+                    if entry.is_file():
+                        try:
+                            self._policy.assert_readable(entry)
+                        except FileAccessError as e:
+                            return ToolResult(success=False, error=str(e))
             destination = self._policy.assert_writable(tool_input.destination)
         except FileAccessError as e:
             return ToolResult(success=False, error=str(e))
@@ -49,13 +56,8 @@ class CopyPathTool(BaseTool[CopyPathInput]):
 
         try:
             if source.is_dir():
-                for entry in source.rglob("*"):
-                    try:
-                        self._policy.assert_readable(entry)
-                    except FileAccessError as e:
-                        return ToolResult(success=False, error=str(e))
                 shutil.copytree(source, destination, dirs_exist_ok=True)
-                file_count = sum(1 for p in destination.rglob("*") if p.is_file())
+                file_count = sum(1 for p in source.rglob("*") if p.is_file())
                 return ToolResult(success=True, data=f"Copied directory tree to {destination} ({file_count} files).")
             destination.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source, destination)

--- a/ddev/src/ddev/ai/tools/registry.py
+++ b/ddev/src/ddev/ai/tools/registry.py
@@ -86,6 +86,7 @@ TOOL_MANIFEST: dict[str, ToolSpec] = {
     "create_file": ToolSpec("fs.create_file", "CreateFileTool", factory=_file_registry_factory, read_only=False),
     "edit_file": ToolSpec("fs.edit_file", "EditFileTool", factory=_file_registry_factory, read_only=False),
     "append_file": ToolSpec("fs.append_file", "AppendFileTool", factory=_file_registry_factory, read_only=False),
+    "copy_path": ToolSpec("fs.copy_path", "CopyPathTool", factory=_file_policy_factory, read_only=False),
     "grep": ToolSpec("shell.grep", "GrepTool", factory=_file_policy_factory, read_only=True),
     "list_files": ToolSpec("shell.list_files", "ListFilesTool", read_only=True),
     "mkdir": ToolSpec("fs.mkdir", "MkdirTool", factory=_file_policy_factory, read_only=False),

--- a/ddev/tests/ai/tools/fs/conftest.py
+++ b/ddev/tests/ai/tools/fs/conftest.py
@@ -5,6 +5,7 @@
 import pytest
 
 from ddev.ai.tools.fs.append_file import AppendFileTool
+from ddev.ai.tools.fs.copy_path import CopyPathTool
 from ddev.ai.tools.fs.create_file import CreateFileTool
 from ddev.ai.tools.fs.edit_file import EditFileTool
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
@@ -53,6 +54,11 @@ def append_tool(registry: FileRegistry, owner_id: str) -> AppendFileTool:
 @pytest.fixture
 def mkdir_tool(permissive_policy: FileAccessPolicy) -> MkdirTool:
     return MkdirTool(permissive_policy)
+
+
+@pytest.fixture
+def copy_tool(permissive_policy: FileAccessPolicy) -> CopyPathTool:
+    return CopyPathTool(permissive_policy)
 
 
 @pytest.fixture

--- a/ddev/tests/ai/tools/fs/test_copy_path.py
+++ b/ddev/tests/ai/tools/fs/test_copy_path.py
@@ -127,3 +127,23 @@ async def test_copy_read_denied(tmp_path) -> None:
 
     assert result.success is False
     assert result.error is not None
+
+
+async def test_copy_directory_denied_child_is_rejected(tmp_path) -> None:
+    # write_root is a subdirectory; src lives outside it so deny patterns apply to its contents.
+    write_root = tmp_path / "write_root"
+    write_root.mkdir()
+    policy = FileAccessPolicy(write_root=write_root, deny_patterns=(".env",))
+    tool = CopyPathTool(policy)
+
+    src = tmp_path / "src_dir"
+    src.mkdir()
+    (src / "safe.txt").write_text("ok", encoding="utf-8")
+    (src / ".env").write_text("SECRET=hunter2", encoding="utf-8")
+    dst = write_root / "dst_dir"
+
+    result = await tool.run({"source": str(src), "destination": str(dst)})
+
+    assert result.success is False
+    assert result.error is not None
+    assert not dst.exists()

--- a/ddev/tests/ai/tools/fs/test_copy_path.py
+++ b/ddev/tests/ai/tools/fs/test_copy_path.py
@@ -1,0 +1,129 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from unittest.mock import patch
+
+import pytest
+
+from ddev.ai.tools.fs.copy_path import CopyPathTool
+from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
+
+
+def test_tool_name(copy_tool: CopyPathTool) -> None:
+    assert copy_tool.name == "copy_path"
+
+
+async def test_copy_file_success(copy_tool: CopyPathTool, tmp_path) -> None:
+    src = tmp_path / "src.txt"
+    dst = tmp_path / "dst.txt"
+    src.write_bytes(b"hello world")
+
+    result = await copy_tool.run({"source": str(src), "destination": str(dst)})
+
+    assert result.success is True
+    assert dst.read_bytes() == b"hello world"
+    assert str(dst) in result.data
+    assert "11" in result.data  # byte count
+
+
+async def test_copy_directory_success(copy_tool: CopyPathTool, tmp_path) -> None:
+    src = tmp_path / "src_dir"
+    src.mkdir()
+    (src / "a.txt").write_text("a", encoding="utf-8")
+    (src / "sub").mkdir()
+    (src / "sub" / "b.txt").write_text("b", encoding="utf-8")
+    dst = tmp_path / "dst_dir"
+
+    result = await copy_tool.run({"source": str(src), "destination": str(dst)})
+
+    assert result.success is True
+    assert (dst / "a.txt").read_text(encoding="utf-8") == "a"
+    assert (dst / "sub" / "b.txt").read_text(encoding="utf-8") == "b"
+    assert "2" in result.data  # file count
+
+
+async def test_copy_file_creates_missing_parent_dirs(copy_tool: CopyPathTool, tmp_path) -> None:
+    src = tmp_path / "src.txt"
+    src.write_text("content", encoding="utf-8")
+    dst = tmp_path / "a" / "b" / "c" / "dst.txt"
+
+    result = await copy_tool.run({"source": str(src), "destination": str(dst)})
+
+    assert result.success is True
+    assert dst.exists()
+    assert dst.read_text(encoding="utf-8") == "content"
+
+
+async def test_copy_directory_merges_with_existing_destination(copy_tool: CopyPathTool, tmp_path) -> None:
+    src = tmp_path / "src_dir"
+    src.mkdir()
+    (src / "new.txt").write_text("new", encoding="utf-8")
+
+    dst = tmp_path / "dst_dir"
+    dst.mkdir()
+    (dst / "existing.txt").write_text("existing", encoding="utf-8")
+
+    result = await copy_tool.run({"source": str(src), "destination": str(dst)})
+
+    assert result.success is True
+    assert (dst / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (dst / "existing.txt").read_text(encoding="utf-8") == "existing"
+
+
+async def test_copy_source_not_found(copy_tool: CopyPathTool, tmp_path) -> None:
+    result = await copy_tool.run({"source": str(tmp_path / "missing.txt"), "destination": str(tmp_path / "dst.txt")})
+
+    assert result.success is False
+    assert "does not exist" in result.error
+
+
+@pytest.mark.parametrize(
+    "mock_target",
+    [
+        "shutil.copy2",
+        "shutil.copytree",
+    ],
+)
+async def test_copy_oserror(copy_tool: CopyPathTool, tmp_path, mock_target) -> None:
+    if mock_target == "shutil.copy2":
+        src = tmp_path / "src.txt"
+        src.write_text("data", encoding="utf-8")
+    else:
+        src = tmp_path / "src_dir"
+        src.mkdir()
+        (src / "f.txt").write_text("data", encoding="utf-8")
+
+    dst = tmp_path / "dst"
+
+    with patch(mock_target, side_effect=OSError("permission denied")):
+        result = await copy_tool.run({"source": str(src), "destination": str(dst)})
+
+    assert result.success is False
+    assert result.error is not None
+
+
+async def test_copy_write_denied(tmp_path) -> None:
+    policy = FileAccessPolicy(write_root=tmp_path, deny_patterns=())
+    tool = CopyPathTool(policy)
+
+    src = tmp_path / "src.txt"
+    src.write_text("data", encoding="utf-8")
+    dst = tmp_path.parent / "outside_write_root.txt"
+
+    result = await tool.run({"source": str(src), "destination": str(dst)})
+
+    assert result.success is False
+    assert result.error is not None
+
+
+async def test_copy_read_denied(tmp_path) -> None:
+    policy = FileAccessPolicy(write_root=tmp_path, deny_patterns=("*.secret",))
+    tool = CopyPathTool(policy)
+
+    src = tmp_path.parent / "credentials.secret"
+    dst = tmp_path / "dst.txt"
+
+    result = await tool.run({"source": str(src), "destination": str(dst)})
+
+    assert result.success is False
+    assert result.error is not None

--- a/ddev/tests/ai/tools/fs/test_copy_path.py
+++ b/ddev/tests/ai/tools/fs/test_copy_path.py
@@ -185,6 +185,31 @@ async def test_copy_directory_overwrite_flag_replaces_conflicts(copy_tool: CopyP
     assert (dst / "conflict.txt").read_text(encoding="utf-8") == "new"
 
 
+async def test_copy_directory_destination_symlink_outside_write_root_is_rejected(tmp_path) -> None:
+    write_root = tmp_path / "write_root"
+    write_root.mkdir()
+    policy = FileAccessPolicy(write_root=write_root, deny_patterns=())
+    tool = CopyPathTool(policy)
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    dst = write_root / "dst_dir"
+    dst.mkdir()
+    (dst / "sub").symlink_to(outside, target_is_directory=True)
+
+    src = tmp_path / "src_dir"
+    src.mkdir()
+    (src / "sub" / "file.txt").parent.mkdir(parents=True)
+    (src / "sub" / "file.txt").write_text("secret", encoding="utf-8")
+
+    result = await tool.run({"source": str(src), "destination": str(dst)})
+
+    assert result.success is False
+    assert result.error is not None
+    assert not (outside / "file.txt").exists()
+
+
 async def test_copy_directory_denied_child_is_rejected(tmp_path) -> None:
     # write_root is a subdirectory; src lives outside it so deny patterns apply to its contents.
     write_root = tmp_path / "write_root"

--- a/ddev/tests/ai/tools/fs/test_copy_path.py
+++ b/ddev/tests/ai/tools/fs/test_copy_path.py
@@ -3,8 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from unittest.mock import patch
 
-import pytest
-
 from ddev.ai.tools.fs.copy_path import CopyPathTool
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 
@@ -77,25 +75,25 @@ async def test_copy_source_not_found(copy_tool: CopyPathTool, tmp_path) -> None:
     assert "does not exist" in result.error
 
 
-@pytest.mark.parametrize(
-    "mock_target",
-    [
-        "shutil.copy2",
-        "shutil.copytree",
-    ],
-)
-async def test_copy_oserror(copy_tool: CopyPathTool, tmp_path, mock_target) -> None:
-    if mock_target == "shutil.copy2":
-        src = tmp_path / "src.txt"
-        src.write_text("data", encoding="utf-8")
-    else:
-        src = tmp_path / "src_dir"
-        src.mkdir()
-        (src / "f.txt").write_text("data", encoding="utf-8")
-
+async def test_copy_file_oserror(copy_tool: CopyPathTool, tmp_path) -> None:
+    src = tmp_path / "src.txt"
+    src.write_text("data", encoding="utf-8")
     dst = tmp_path / "dst"
 
-    with patch(mock_target, side_effect=OSError("permission denied")):
+    with patch("ddev.ai.tools.fs.copy_path.shutil.copy2", side_effect=OSError("permission denied")):
+        result = await copy_tool.run({"source": str(src), "destination": str(dst)})
+
+    assert result.success is False
+    assert result.error is not None
+
+
+async def test_copy_directory_oserror(copy_tool: CopyPathTool, tmp_path) -> None:
+    src = tmp_path / "src_dir"
+    src.mkdir()
+    (src / "f.txt").write_text("data", encoding="utf-8")
+    dst = tmp_path / "dst"
+
+    with patch("ddev.ai.tools.fs.copy_path.shutil.copytree", side_effect=OSError("permission denied")):
         result = await copy_tool.run({"source": str(src), "destination": str(dst)})
 
     assert result.success is False

--- a/ddev/tests/ai/tools/fs/test_copy_path.py
+++ b/ddev/tests/ai/tools/fs/test_copy_path.py
@@ -127,6 +127,64 @@ async def test_copy_read_denied(tmp_path) -> None:
     assert result.error is not None
 
 
+async def test_copy_file_no_overwrite_by_default(copy_tool: CopyPathTool, tmp_path) -> None:
+    src = tmp_path / "src.txt"
+    dst = tmp_path / "dst.txt"
+    src.write_text("new content", encoding="utf-8")
+    dst.write_text("original content", encoding="utf-8")
+
+    result = await copy_tool.run({"source": str(src), "destination": str(dst)})
+
+    assert result.success is False
+    assert "overwrite=True" in result.hint
+    assert dst.read_text(encoding="utf-8") == "original content"
+
+
+async def test_copy_file_overwrite_flag_replaces_existing(copy_tool: CopyPathTool, tmp_path) -> None:
+    src = tmp_path / "src.txt"
+    dst = tmp_path / "dst.txt"
+    src.write_text("new content", encoding="utf-8")
+    dst.write_text("original content", encoding="utf-8")
+
+    result = await copy_tool.run({"source": str(src), "destination": str(dst), "overwrite": True})
+
+    assert result.success is True
+    assert dst.read_text(encoding="utf-8") == "new content"
+
+
+async def test_copy_directory_no_overwrite_reports_conflicts(copy_tool: CopyPathTool, tmp_path) -> None:
+    src = tmp_path / "src_dir"
+    src.mkdir()
+    (src / "conflict.txt").write_text("new", encoding="utf-8")
+    (src / "new.txt").write_text("also new", encoding="utf-8")
+
+    dst = tmp_path / "dst_dir"
+    dst.mkdir()
+    (dst / "conflict.txt").write_text("original", encoding="utf-8")
+
+    result = await copy_tool.run({"source": str(src), "destination": str(dst)})
+
+    assert result.success is False
+    assert "overwrite=True" in result.hint
+    assert "conflict.txt" in result.error
+    assert (dst / "conflict.txt").read_text(encoding="utf-8") == "original"
+
+
+async def test_copy_directory_overwrite_flag_replaces_conflicts(copy_tool: CopyPathTool, tmp_path) -> None:
+    src = tmp_path / "src_dir"
+    src.mkdir()
+    (src / "conflict.txt").write_text("new", encoding="utf-8")
+
+    dst = tmp_path / "dst_dir"
+    dst.mkdir()
+    (dst / "conflict.txt").write_text("original", encoding="utf-8")
+
+    result = await copy_tool.run({"source": str(src), "destination": str(dst), "overwrite": True})
+
+    assert result.success is True
+    assert (dst / "conflict.txt").read_text(encoding="utf-8") == "new"
+
+
 async def test_copy_directory_denied_child_is_rejected(tmp_path) -> None:
     # write_root is a subdirectory; src lives outside it so deny patterns apply to its contents.
     write_root = tmp_path / "write_root"


### PR DESCRIPTION
### What does this PR do?

Adds a `copy_path` tool to the AI agent filesystem toolkit. It copies a file or an entire directory tree from a source path to a destination path without reading the content into the conversation context.

- Delegates to `shutil.copy2` for files and `shutil.copytree` (with `dirs_exist_ok=True`) for directories.
- Creates missing parent directories automatically.
- Enforces the existing `FileAccessPolicy`: source must pass `assert_readable` (if source is a directory, every child must pass it), destination must pass `assert_writable`.
- Returns a brief confirmation (byte count for files, file count for directories) rather than the content itself.

### Motivation

The OpenMetrics flow needs to copy files like `metrics.txt` between working directories as part of its pipeline. Using `read_file` + `create_file` for this would pull potentially large or binary content into the agent's context window unnecessarily. `copy_path` handles the operation at the OS level, keeping the agent context clean and making binary-safe copies the default.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged