### PR TITLE
Gracefully skip mongo collection on non-readable replica states

### DIFF
--- a/mongo/changelog.d/24017.fixed
+++ b/mongo/changelog.d/24017.fixed
@@ -1,0 +1,1 @@
+Gracefully skip collection when a replica set node is not in a readable (primary/secondary) state instead of reporting the check as CRITICAL.

--- a/mongo/datadog_checks/mongo/common.py
+++ b/mongo/datadog_checks/mongo/common.py
@@ -31,6 +31,9 @@ PRIMARY_STATE_ID = 1
 SECONDARY_STATE_ID = 2
 ARBITER_STATE_ID = 7
 
+# States in which a replica set node can serve reads.
+READABLE_STATE_IDS = frozenset({PRIMARY_STATE_ID, SECONDARY_STATE_ID})
+
 DEFAULT_TIMEOUT = 30
 ALLOWED_CUSTOM_METRICS_TYPES = ['gauge', 'rate', 'count', 'monotonic_count']
 ALLOWED_CUSTOM_QUERIES_COMMANDS = ['aggregate', 'count', 'find']
@@ -171,6 +174,11 @@ class ReplicaSetDeployment(Deployment):
         # There is only ever one primary node in a replica set.
         # In case sharding is disabled, the primary can be considered the master.
         return not self.use_shards and self.is_primary
+
+    @property
+    def is_readable(self):
+        """Whether the node can serve reads (PRIMARY or SECONDARY)."""
+        return self.replset_state in READABLE_STATE_IDS
 
     @property
     def cluster_type(self):

--- a/mongo/datadog_checks/mongo/dbm/operation_samples.py
+++ b/mongo/datadog_checks/mongo/dbm/operation_samples.py
@@ -108,12 +108,15 @@ class MongoOperationSamples(DBMAsyncJob):
 
     def _should_collect_operation_samples(self) -> bool:
         deployment = self._check.deployment_type
-        if isinstance(deployment, ReplicaSetDeployment) and deployment.is_arbiter:
-            self._check.log.debug("Skipping operation samples collection on arbiter node")
-            return False
-        elif isinstance(deployment, ReplicaSetDeployment) and deployment.replset_state == 3:
-            self._check.log.debug("Skipping operation samples collection on node in recovering state")
-            return False
+        if isinstance(deployment, ReplicaSetDeployment):
+            if deployment.is_arbiter:
+                self._check.log.debug("Skipping operation samples collection on arbiter node")
+                return False
+            if not deployment.is_readable:
+                self._check.log.debug(
+                    "Skipping operation samples collection on node in %s state", deployment.replset_state_name
+                )
+                return False
         return True
 
     def _get_operation_samples(self, now, databases_monitored: List[str]):

--- a/mongo/datadog_checks/mongo/dbm/query_metrics.py
+++ b/mongo/datadog_checks/mongo/dbm/query_metrics.py
@@ -8,7 +8,7 @@ from typing import Iterator
 
 from cachetools import TTLCache
 from packaging.version import Version
-from pymongo.errors import OperationFailure
+from pymongo.errors import NotPrimaryError, OperationFailure
 
 from datadog_checks.base.utils.db.sql import compute_exec_plan_signature
 from datadog_checks.base.utils.db.statement_metrics import StatementMetrics
@@ -110,8 +110,10 @@ class MongoQueryMetrics(DBMAsyncJob):
             if deployment.is_arbiter:
                 self._check.log.debug("Skipping query metrics collection on arbiter node")
                 return False
-            if deployment.replset_state == 3:  # RECOVERING
-                self._check.log.debug("Skipping query metrics collection on node in recovering state")
+            if not deployment.is_readable:
+                self._check.log.debug(
+                    "Skipping query metrics collection on node in %s state", deployment.replset_state_name
+                )
                 return False
 
         # Check MongoDB version
@@ -223,6 +225,9 @@ class MongoQueryMetrics(DBMAsyncJob):
         try:
             for doc in self._check.api_client.query_stats():
                 yield doc
+        except NotPrimaryError as e:
+            self._check.log.warning("Could not collect query metrics, node is not primary or secondary")
+            self._check.log.debug("Error details: %s", e)
         except OperationFailure as e:
             self._check.log.warning("Failed to query $queryStats: %s", e)
             raise

--- a/mongo/datadog_checks/mongo/discovery.py
+++ b/mongo/datadog_checks/mongo/discovery.py
@@ -33,8 +33,8 @@ class MongoDBDatabaseAutodiscovery(Discovery):
         databases = []
         if isinstance(deployment, ReplicaSetDeployment) and deployment.is_arbiter:
             self._log.debug("Replicaset and arbiter deployment, no databases will be checked")
-        elif isinstance(deployment, ReplicaSetDeployment) and deployment.replset_state == 3:
-            self._log.debug("Replicaset is in recovering state, will skip reading database names")
+        elif isinstance(deployment, ReplicaSetDeployment) and not deployment.is_readable:
+            self._log.debug("Node is in %s state, will skip reading database names", deployment.replset_state_name)
         else:
             databases = self._check.api_client.list_database_names()
             self.database_count = len(databases)

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 
 from cachetools import TTLCache
 from packaging.version import Version
+from pymongo.errors import NotPrimaryError
 
 from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.db.utils import default_json_event_encoding
@@ -295,6 +296,13 @@ class MongoDb(AgentCheck):
                 self._slow_operations.run_job_loop(tags=self._get_tags(include_internal_resource_tags=True))
                 self._schemas.run_job_loop(tags=self._get_tags(include_internal_resource_tags=True))
                 self._query_metrics.run_job_loop(tags=self._get_tags(include_internal_resource_tags=True))
+        except NotPrimaryError as e:
+            # The node is reachable but not in a readable (primary/secondary) state, so reads fail.
+            # This is usually a transient condition (e.g. recovering, rollback), not a connection failure.
+            self.log.warning(
+                "Node is not in a readable (primary/secondary) state, skipping collection for this run: %s", e
+            )
+            self.service_check(SERVICE_CHECK_NAME, AgentCheck.OK, tags=self._get_service_check_tags())
         except CRITICAL_FAILURE as e:
             self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=self._get_service_check_tags())
             self._unset_metadata()
@@ -333,6 +341,11 @@ class MongoDb(AgentCheck):
         for collector in self.collectors:
             try:
                 collector.collect(self.api_client)
+            except NotPrimaryError:
+                self.log.warning(
+                    "Skipping collector %s because the node is not in a readable (primary/secondary) state.",
+                    collector,
+                )
             except CRITICAL_FAILURE as e:
                 self.log.info(
                     "Unable to collect logs from collector %s. Some metrics will be missing.", collector, exc_info=True

--- a/mongo/tests/test_dbm_query_metrics.py
+++ b/mongo/tests/test_dbm_query_metrics.py
@@ -4,6 +4,7 @@
 
 import mock
 import pytest
+from pymongo.errors import NotPrimaryError
 
 from . import common
 from .conftest import mock_now, mock_pymongo
@@ -83,6 +84,31 @@ def test_mongo_query_metrics_version_check(aggregator, instance_integration_clus
         run_check_once(mongo_check, dd_run_check)
 
     # No query metrics events should be emitted for MongoDB < 8.0
+    dbm_samples = aggregator.get_event_platform_events("dbm-samples")
+    fqt_samples = [event for event in dbm_samples if event.get('dbm_type') == 'fqt']
+    assert len(fqt_samples) == 0
+
+
+@mock_now(1715911398.1112723)
+@common.standalone
+def test_mongo_query_metrics_not_primary(aggregator, instance_integration_cluster_autodiscovery, check, dd_run_check):
+    """Test that a NotPrimaryError during $queryStats does not fail the check."""
+    instance_integration_cluster_autodiscovery['dbm'] = True
+    instance_integration_cluster_autodiscovery['query_metrics'] = {'enabled': True, 'run_sync': True}
+    instance_integration_cluster_autodiscovery['operation_samples'] = {'enabled': False}
+    instance_integration_cluster_autodiscovery['slow_operations'] = {'enabled': False}
+    instance_integration_cluster_autodiscovery['schemas'] = {'enabled': False}
+
+    mongo_check = check(instance_integration_cluster_autodiscovery)
+    with mock_pymongo("standalone"):
+        with mock.patch.object(mongo_check, '_mongo_version', '8.0.0'):
+            with mock.patch(
+                'datadog_checks.mongo.api.MongoApi.query_stats', side_effect=NotPrimaryError("node is recovering")
+            ):
+                aggregator.reset()
+                run_check_once(mongo_check, dd_run_check)
+
+    aggregator.assert_service_check('mongodb.can_connect', common.MongoDb.OK)
     dbm_samples = aggregator.get_event_platform_events("dbm-samples")
     fqt_samples = [event for event in dbm_samples if event.get('dbm_type') == 'fqt']
     assert len(fqt_samples) == 0

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -11,7 +11,7 @@ from urllib.parse import quote_plus
 import mock
 import pytest
 from bson import json_util
-from pymongo.errors import ConnectionFailure, OperationFailure
+from pymongo.errors import ConnectionFailure, NotPrimaryError, OperationFailure
 
 from datadog_checks.base import ConfigurationError
 from datadog_checks.base.utils.db.sql import compute_exec_plan_signature
@@ -186,37 +186,65 @@ def test_emits_ok_service_check_when_alibaba_replicaset_role_configsvr_deploymen
     mock_list_database_names.assert_called_once()
 
 
+@pytest.mark.parametrize('replset_state', [0, 3, 5, 8, 9])
+def test_when_replicaset_state_not_readable_then_database_names_not_called(replset_state, dd_run_check, aggregator):
+    with mock.patch(
+        'pymongo.database.Database.command',
+        side_effect=[
+            {'host': 'test-hostname'},  # serverStatus
+            Exception('getCmdLineOpts exception'),  # getCmdLineOpts
+            {},  # isMaster
+            {'configsvr': True, 'set': 'replset', "myState": replset_state},  # replSetGetStatus
+        ],
+    ), mock.patch(
+        'pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'}
+    ), mock.patch(
+        'pymongo.mongo_client.MongoClient.list_database_names', return_value=[]
+    ) as mock_list_database_names:
+        # Given
+        check = MongoDb('mongo', {}, [{'hosts': ['localhost']}])
+        check.refresh_collectors = mock.MagicMock()
+        # When
+        dd_run_check(check)
+        # Then the node is reachable but not readable, so the check stays OK and skips reads
+        aggregator.assert_service_check('mongodb.can_connect', MongoDb.OK)
+        mock_list_database_names.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    'replset_state, expected_readable',
+    [(0, False), (1, True), (2, True), (3, False), (5, False), (7, False), (8, False), (9, False)],
+)
+def test_replicaset_deployment_is_readable(replset_state, expected_readable):
+    deployment = ReplicaSetDeployment(HostingType.SELF_HOSTED, 'replset', replset_state, [], 'me')
+    assert deployment.is_readable is expected_readable
+
+
 @mock.patch(
     'pymongo.database.Database.command',
     side_effect=[
         {'host': 'test-hostname'},  # serverStatus
         Exception('getCmdLineOpts exception'),  # getCmdLineOpts
         {},  # isMaster
-        {'configsvr': True, 'set': 'replset', "myState": 3},  # replSetGetStatus
+        {'configsvr': True, 'set': 'replset', "myState": 1},  # replSetGetStatus
     ],
 )
 @mock.patch('pymongo.mongo_client.MongoClient.server_info', return_value={'version': '5.0.0'})
 @mock.patch('pymongo.mongo_client.MongoClient.list_database_names', return_value=[])
-def test_when_replicaset_state_recovering_then_database_names_not_called(
+def test_collector_not_primary_error_does_not_fail_check(
     mock_list_database_names, mock_server_info, mock_command, dd_run_check, aggregator
 ):
-    # Given
+    # Given a readable node where a collector raises NotPrimaryError mid-collection (state transition)
     check = MongoDb('mongo', {}, [{'hosts': ['localhost']}])
+    failing_collector = mock.MagicMock()
+    failing_collector.collect.side_effect = NotPrimaryError("node is recovering")
     check.refresh_collectors = mock.MagicMock()
+    check.collectors = [failing_collector]
     # When
     dd_run_check(check)
-    # Then
+    # Then the NotPrimaryError is swallowed and the check stays OK
     aggregator.assert_service_check('mongodb.can_connect', MongoDb.OK)
-    mock_command.assert_has_calls(
-        [
-            mock.call('serverStatus'),
-            mock.call('getCmdLineOpts'),
-            mock.call('isMaster'),
-            mock.call('replSetGetStatus'),
-        ]
-    )
-    mock_server_info.assert_called_once()
-    mock_list_database_names.assert_not_called()
+    failing_collector.collect.assert_called_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

Makes the `mongo` check tolerate replica-set nodes that are not in a readable (PRIMARY/SECONDARY) state instead of crashing.

When a monitored mongod is in a state that is neither PRIMARY(1) nor SECONDARY(2) — e.g. RECOVERING(3), STARTUP(0), STARTUP2(5), ROLLBACK(9), DOWN(8) — read commands fail with `pymongo.errors.NotPrimaryError` (code 13436, `NotPrimaryOrSecondary`). Since `NotPrimaryError` subclasses `ConnectionFailure`, it was caught by the check's `CRITICAL_FAILURE` handling, marking the whole instance **CRITICAL** and dumping a traceback even though the node is reachable.

Changes:
- Add a centralized `ReplicaSetDeployment.is_readable` property (`replset_state in {PRIMARY, SECONDARY}`).
- Replace the scattered `replset_state == 3` guards in `operation_samples.py`, `query_metrics.py`, and `discovery.py` with `is_readable`, so all non-readable states are skipped (not just RECOVERING).
- Catch `NotPrimaryError` as a non-critical, transient condition in the synchronous collector loop (`_collect_metrics`) and at the `check()` level — the run is skipped and the service check stays **OK** instead of going CRITICAL.
- Add `NotPrimaryError` handling to the `$queryStats` read path, mirroring the existing handling in operation samples' `$currentOp`.

### Motivation

Users running the check against a replica-set member that briefly enters a non-readable state (recovering, rollback, etc.) saw the whole check fail with a `NotPrimaryError` traceback and a CRITICAL service check, when the correct behavior is to skip collection for that run and recover automatically.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)