### PR TITLE
Remove Old Network Path Metrics from Docs

### DIFF
--- a/network_path/metadata.csv
+++ b/network_path/metadata.csv
@@ -26,7 +26,4 @@ datadog.network_path.collector.worker.task_duration.count,gauge,,second,,Duratio
 datadog.network_path.collector.worker.task_duration.max,gauge,,second,,Duration of a worker task.,0,network_path,,,
 datadog.network_path.collector.worker.task_duration.median,gauge,,second,,Duration of a worker task.,0,network_path,,,
 datadog.network_path.collector.workers,gauge,,,,The number of workers used to process pathtests concurrently.,0,network_path,,,
-datadog.network_path.path.hops,gauge,,,,The number of hops of the collected pathtrace (traceroute).,0,network_path,,,
 datadog.network_path.path.monitored,gauge,,,,Paths monitored count. Make 'sum by {X}' queries to count all the Paths with the tag X,0,network_path,,,
-datadog.network_path.path.reachable,gauge,,,,"The value is 1 if the path is reachable, 0 otherwise. Reachability is determined by the status of the destination/target of the pathtest.",0,network_path,,,
-datadog.network_path.path.unreachable,gauge,,,,"The value is 1 if the path is unreachable, 0 otherwise. Reachability is determined by the status of the destination/target of the pathtest.",0,network_path,,,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removes the following metrics:
* `datadog.network_path.path.hops`
* `datadog.network_path.path.reachable`
* `datadog.network_path.path.unreachable`

### Motivation
<!-- What inspired you to submit this pull request? -->

These metrics are no longer available for Network Path. They were removed in this [commit](https://github.com/DataDog/datadog-agent/commit/285ad9d4024f92482c87e2cf684a1bcec827dc1e) due to a schema change.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
