### PR TITLE
Update datadog_checks_dev requirement

### DIFF
--- a/ddev/changelog.d/24050.fixed
+++ b/ddev/changelog.d/24050.fixed
@@ -1,0 +1,1 @@
+Bump datadog_checks_dev requirement.

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "click~=8.1.6",
     "coverage",
     "datadog-api-client==2.20.0",
-    "datadog-checks-dev[cli]~=38.0",
+    "datadog-checks-dev[cli]~=39.0",
     "hatch>=1.13.0",
     "httpx",
     "jsonpointer",


### PR DESCRIPTION
### What does this PR do?
Updates datadog_checks_dev requirement
### Motivation
We are releasing datadog_checks_dev 39.0.0: https://github.com/DataDog/integrations-core/pull/24049/changes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
