### PR TITLE
Move curror yield for Postgres schemas outside transaction

### DIFF
--- a/postgres/changelog.d/24051.fixed
+++ b/postgres/changelog.d/24051.fixed
@@ -1,0 +1,1 @@
+Move cursor yield for Postgres schemas outside transaction. This should avoid creating a broken pool connection on timeout

--- a/postgres/datadog_checks/postgres/schemas.py
+++ b/postgres/datadog_checks/postgres/schemas.py
@@ -235,7 +235,7 @@ class PostgresSchemaCollector(SchemaCollector):
                     query, params = self.get_rows_query()
                     cursor.execute(f"SET LOCAL statement_timeout = '{self._config.max_query_duration}s';")
                     cursor.execute(query, params)
-                    yield cursor
+                yield cursor
 
     def _get_schemas_query(self):
         query = SCHEMA_QUERY


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This change should fix a situation where the connection is returned to the pool in a broken state when it times out.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
