### PR TITLE
Add DBM Postgres setup module and extract configure_connection

### DIFF
--- a/postgres/changelog.d/24052.added
+++ b/postgres/changelog.d/24052.added
@@ -1,0 +1,1 @@
+Add the DBM setup module (`datadog_checks.postgres.setup`) used by the `datadog-agent integration setup postgres` CLI, and extract `configure_connection` as a standalone function so setup reuses the integration's connection layer.

--- a/postgres/datadog_checks/postgres/connection_pool.py
+++ b/postgres/datadog_checks/postgres/connection_pool.py
@@ -173,6 +173,40 @@ class PostgresConnectionArgs:
         return kwargs
 
 
+def configure_connection(
+    conn: Connection,
+    *,
+    sqlascii_encodings: Optional[list] = None,
+    statement_timeout: Optional[int] = None,
+) -> None:
+    """Configure a psycopg connection for use with the Datadog Postgres integration.
+
+    Sets autocommit, SQL_ASCII text decoding, CommenterCursor cursor factory, and an
+    optional statement timeout. Extracted as a standalone function so it can be shared
+    by LRUConnectionPoolManager and the standalone integration-setup CLI without
+    either duplicating logic or requiring a pool instance.
+
+    Args:
+        conn: An open psycopg Connection to configure.
+        sqlascii_encodings: Encodings to pass to SQLASCIITextLoader when the
+            server encoding is SQL_ASCII. Pass None to leave the loader default.
+        statement_timeout: Statement timeout in milliseconds, or None to skip.
+    """
+    conn.autocommit = True
+
+    if conn.info.encoding.lower() in ('ascii', 'sqlascii', 'sql_ascii'):
+        text_loader = SQLASCIITextLoader
+        text_loader.encodings = sqlascii_encodings
+        for typ in ("text", "varchar", "name", "regclass"):
+            conn.adapters.register_loader(typ, text_loader)
+
+    conn.cursor_factory = CommenterCursor
+
+    if statement_timeout is not None:
+        with conn.cursor() as cur:
+            cur.execute("SET statement_timeout = %s", (statement_timeout,))
+
+
 class LRUConnectionPoolManager:
     """
     Manages a fixed-size set of psycopg3 ConnectionPools, one per database name (dbname),
@@ -226,19 +260,11 @@ class LRUConnectionPoolManager:
         self._closed = False
 
     def _configure_connection(self, conn: Connection) -> None:
-        conn.autocommit = True
-
-        if conn.info.encoding.lower() in ['ascii', 'sqlascii', 'sql_ascii']:
-            text_loader = SQLASCIITextLoader
-            text_loader.encodings = self.sqlascii_encodings
-            for typ in ["text", "varchar", "name", "regclass"]:
-                conn.adapters.register_loader(typ, text_loader)
-
-        conn.cursor_factory = CommenterCursor
-
-        with conn.cursor() as cur:
-            if self.statement_timeout is not None:
-                cur.execute("SET statement_timeout = %s", (self.statement_timeout,))
+        configure_connection(
+            conn,
+            sqlascii_encodings=self.sqlascii_encodings,
+            statement_timeout=self.statement_timeout,
+        )
 
     def _create_pool(self, dbname: str) -> ConnectionPool:
         """

--- a/postgres/datadog_checks/postgres/setup.py
+++ b/postgres/datadog_checks/postgres/setup.py
@@ -1,0 +1,674 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""
+DBM Postgres setup — Detect → Plan → Apply.
+
+Invoked by ``datadog-agent integration setup postgres`` via the embedded Python
+interpreter (``python -m datadog_checks.postgres.setup``). Reads a JSON config
+from stdin and writes a JSON result to stdout, so the Go CLI stays a thin tunnel
+that owns flags, prompts, exit codes, and output rendering while this module owns
+all database logic.
+
+Setup cannot run as part of the check the way ``diagnose`` does: it runs before
+the instance config exists and connects as a superuser supplied on the CLI. It
+does, however, reuse the same building blocks as the running check —
+``configure_connection`` for psycopg setup, ``AUTODISCOVERY_QUERY`` for database
+navigation, and ``parse_shared_preload_libraries`` — so setup connects and reasons
+about the server exactly like the integration. The canonical ``datadog`` helper
+function definitions live here as constants alongside the test compose resources,
+so there is a single source of truth in this repository instead of a copy drifting
+in the agent.
+"""
+
+import json
+import sys
+
+import psycopg
+from psycopg import sql
+
+from .connection_pool import configure_connection
+from .discovery import AUTODISCOVERY_QUERY
+from .util import parse_shared_preload_libraries
+
+# (name, desired_value, requires_restart, required)
+# required=False means the setting is optional per DBM docs — DBM works without it,
+# but it improves query coverage and performance visibility.
+#
+# pg_stat_statements.max is intentionally excluded. It can only be set after
+# pg_stat_statements is loaded (which requires a restart), and it is itself a
+# postmaster-context GUC that requires a second restart. Requiring two restarts
+# on a fresh install is poor UX; the PostgreSQL default of 5000 is sufficient
+# for most deployments.
+SETTINGS = [
+    ("shared_preload_libraries", "pg_stat_statements", True, True),
+    ("track_activity_query_size", "4096", True, True),
+    ("pg_stat_statements.track", "all", False, False),
+    ("track_io_timing", "on", False, False),
+    ("pg_stat_statements.track_utility", "on", False, False),
+]
+
+# Canonical definitions of the datadog helper functions. Kept verbatim in sync with
+# tests/compose/resources/03_setup.sh so the setup CLI and the test fixtures agree.
+SQL_FUNC_PG_STAT_ACTIVITY = """
+CREATE OR REPLACE FUNCTION datadog.pg_stat_activity() RETURNS SETOF pg_stat_activity AS
+  $$ SELECT * FROM pg_catalog.pg_stat_activity; $$
+LANGUAGE sql SECURITY DEFINER"""
+
+SQL_FUNC_PG_STAT_STATEMENTS = """
+CREATE OR REPLACE FUNCTION datadog.pg_stat_statements() RETURNS SETOF pg_stat_statements AS
+  $$ SELECT * FROM pg_stat_statements; $$
+LANGUAGE sql SECURITY DEFINER"""
+
+SQL_FUNC_EXPLAIN_STATEMENT = """
+CREATE OR REPLACE FUNCTION datadog.explain_statement(
+    l_query TEXT,
+    OUT explain JSON
+)
+RETURNS SETOF JSON AS
+$$
+DECLARE
+curs REFCURSOR;
+plan JSON;
+
+BEGIN
+    SET TRANSACTION READ ONLY;
+
+    OPEN curs FOR EXECUTE pg_catalog.concat('EXPLAIN (FORMAT JSON) ', l_query);
+    FETCH curs INTO plan;
+    CLOSE curs;
+    RETURN QUERY SELECT plan;
+END;
+$$
+LANGUAGE 'plpgsql'
+RETURNS NULL ON NULL INPUT
+SECURITY DEFINER"""
+
+
+# ---------------------------------------------------------------------------
+# Connections
+# ---------------------------------------------------------------------------
+
+
+def _connect(uri, dbname=None):
+    """Open a psycopg (v3) connection configured like the running check.
+
+    ``configure_connection`` sets autocommit, SQL_ASCII text decoding, and the
+    CommenterCursor cursor factory. CommenterCursor subclasses ClientCursor, which
+    is required — not just stylistic: PostgreSQL rejects server-side bound parameters
+    in utility statements (CREATE USER ... WITH PASSWORD %s), so client-side binding
+    is mandatory for setup. ``dbname``, when given, overrides the database in ``uri``
+    for per-database operations.
+    """
+    kwargs = {"dbname": dbname} if dbname else {}
+    conn = psycopg.connect(uri, **kwargs)
+    configure_connection(conn)
+    return conn
+
+
+def _query(cur, composed):
+    """Render a psycopg.sql composition to a plain string. CommenterCursor runs
+    add_sql_comment(), which calls .strip() on the query, so it needs a str —
+    not a sql.Composed. Identifiers stay safely quoted by as_string()."""
+    return composed.as_string(cur)
+
+
+# ---------------------------------------------------------------------------
+# Detect
+# ---------------------------------------------------------------------------
+
+
+def _detect(cur, config):
+    # Fail immediately if connected to a standby/read replica.
+    cur.execute("SELECT pg_is_in_recovery()")
+    if cur.fetchone()[0]:
+        raise RuntimeError(
+            "Connected to a read replica (pg_is_in_recovery() = true); connect to the primary instance to run setup"
+        )
+
+    flavor = _detect_flavor(cur)
+    pg_version = _detect_version(cur)
+    current_settings, pending_restart = _detect_settings(cur)
+    user_exists = _detect_user_exists(cur, config["datadog_user"])
+    databases = _detect_databases(cur, config)
+
+    return {
+        "flavor": flavor,
+        "pg_version": pg_version,
+        "user_exists": user_exists,
+        "current_settings": current_settings,
+        "pending_restart": pending_restart,
+        "databases": databases,
+    }
+
+
+def _detect_flavor(cur):
+    if _role_exists(cur, "cloudsqladmin"):
+        return "cloud_sql"
+    if _role_exists(cur, "azure_superuser"):
+        return "azure"
+
+    try:
+        cur.execute("SELECT current_setting('rds.extensions', true)")
+        result = cur.fetchone()
+        if result and result[0]:
+            cur.execute("SELECT version()")
+            version_str = cur.fetchone()[0]
+            return "aurora" if "Aurora" in version_str else "rds"
+    except psycopg.Error:
+        # rds.extensions is an RDS-specific GUC; a plain Postgres rejects it. Any
+        # other error (network blip, permissions) should surface rather than be
+        # silently treated as self-hosted, so only swallow psycopg errors here.
+        pass
+
+    return "self_hosted"
+
+
+def _role_exists(cur, rolname):
+    cur.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (rolname,))
+    return cur.fetchone() is not None
+
+
+def _detect_version(cur):
+    cur.execute("SHOW server_version_num")
+    return int(cur.fetchone()[0]) // 10000
+
+
+def _detect_settings(cur):
+    cur.execute("""
+        SELECT name, setting, pending_restart
+        FROM pg_settings
+        WHERE name IN (
+            'shared_preload_libraries', 'track_activity_query_size',
+            'pg_stat_statements.max', 'pg_stat_statements.track',
+            'track_io_timing', 'pg_stat_statements.track_utility'
+        )
+    """)
+    current_settings = {}
+    pending_restart = []
+    for name, setting, is_pending in cur.fetchall():
+        current_settings[name] = setting
+        if is_pending:
+            pending_restart.append(name)
+    return current_settings, pending_restart
+
+
+def _detect_user_exists(cur, username):
+    return _role_exists(cur, username)
+
+
+def _detect_databases(cur, config):
+    if config.get("all_databases"):
+        # Reuse the integration's autodiscovery query; sort for stable output.
+        cur.execute(AUTODISCOVERY_QUERY)
+        return sorted(row[0] for row in cur.fetchall())
+    return config.get("databases", [])
+
+
+# ---------------------------------------------------------------------------
+# Plan
+# ---------------------------------------------------------------------------
+
+
+def _plan(state, config):
+    ops = []
+    ops.extend(_plan_user_ops(state, config))
+    ops.extend(_plan_grant_ops(state, config))
+    setting_ops, optional_restart_pending = _plan_setting_ops(state, config)
+    ops.extend(setting_ops)
+    for db in state["databases"]:
+        ops.extend(_plan_per_db_ops(config, db))
+    return ops, optional_restart_pending
+
+
+def _plan_user_ops(state, config):
+    user = config["datadog_user"]
+    if not state["user_exists"]:
+        if not config.get("datadog_password"):
+            raise RuntimeError(f"--datadog-password is required when creating user {user!r} for the first time")
+        return [
+            {
+                "kind": "SQL",
+                "description": f"create user {user!r}",
+                "op_type": "create_user",
+                "args": [user, config["datadog_password"]],
+                "redact": True,
+            }
+        ]
+    if config.get("datadog_password") and config.get("update_password"):
+        return [
+            {
+                "kind": "SQL",
+                "description": f"sync password for user {user!r}",
+                "op_type": "alter_user_password",
+                "args": [user, config["datadog_password"]],
+                "redact": True,
+            }
+        ]
+    return [{"kind": "SKIP", "description": f"user {user!r} — already exists", "status": "skipped"}]
+
+
+def _plan_grant_ops(state, config):
+    user = config["datadog_user"]
+    ops = []
+    if state["pg_version"] >= 10:
+        ops.append(
+            {
+                "kind": "SQL",
+                "description": f"GRANT pg_monitor TO {user!r}",
+                "op_type": "grant_pg_monitor",
+                "args": [user],
+            }
+        )
+    else:
+        ops.append(
+            {
+                "kind": "SQL",
+                "description": f"GRANT pg_stat_* tables to {user!r} (PG 9.6)",
+                "op_type": "grant_pg96",
+                "args": [user],
+            }
+        )
+    if state["pg_version"] >= 15 and state["flavor"] in ("rds", "aurora"):
+        ops.append(
+            {
+                "kind": "SQL",
+                "description": f"ALTER ROLE {user!r} INHERIT (RDS/Aurora PG 15+)",
+                "op_type": "alter_role_inherit",
+                "args": [user],
+            }
+        )
+    return ops
+
+
+def _plan_setting_ops(state, config):
+    # pg_stat_statements GUCs are only registered after the library is loaded.
+    # pg_stat_statements explicitly blocks mid-session LOAD, so these GUCs
+    # cannot be set until after the first restart that loads the library.
+    spl_active = state["current_settings"].get("shared_preload_libraries", "")
+    pg_stat_loaded = "pg_stat_statements" in parse_shared_preload_libraries(spl_active)
+
+    apply_optional_restart = config.get("apply_optional_restart", False)
+
+    ops = []
+    optional_restart_pending = []
+
+    for name, desired, requires_restart, required in SETTINGS:
+        current = state["current_settings"].get(name, "")
+        flavor = state["flavor"]
+
+        # Skip pg_stat_statements.* GUCs until the library is loaded.
+        if flavor == "self_hosted" and name.startswith("pg_stat_statements.") and not pg_stat_loaded:
+            ops.append(
+                {
+                    "kind": "SKIP",
+                    "description": f"{name} — applied on next run after pg_stat_statements loads",
+                    "setting_name": name,
+                    "status": "skipped",
+                }
+            )
+            continue
+
+        # Optional restart-required settings: skip unless explicitly requested.
+        if not required and requires_restart and flavor == "self_hosted":
+            if not apply_optional_restart:
+                # Check if it already has the desired value before deferring.
+                if current == desired or (name == "shared_preload_libraries" and desired in current.split(",")):
+                    pass  # already set — fall through to normal planning (will show SKIP)
+                else:
+                    optional_restart_pending.append(
+                        {
+                            "name": name,
+                            "desired": desired,
+                            "current": current,
+                            "description": f"optional — set {name}={desired} (requires one more restart)",
+                        }
+                    )
+                    ops.append(
+                        {
+                            "kind": "SKIP",
+                            "description": f"{name} — optional, skipped (add --yes to apply, requires restart)",
+                            "setting_name": name,
+                            "status": "skipped",
+                        }
+                    )
+                    continue
+
+        if flavor == "self_hosted":
+            ops.extend(_plan_self_hosted_setting(state, name, desired, current, requires_restart))
+        elif flavor in ("rds", "aurora"):
+            ops.extend(_plan_aws_setting(name, desired, current))
+        elif flavor == "cloud_sql":
+            ops.extend(_plan_cloud_sql_setting(name, desired, current))
+        elif flavor == "azure":
+            ops.extend(_plan_azure_setting(name, desired, current))
+
+    return ops, optional_restart_pending
+
+
+def _plan_self_hosted_setting(state, name, desired, current, requires_restart):
+    if name == "shared_preload_libraries":
+        return _plan_spl(state, desired, current)
+    if current == desired:
+        return [_skip_setting(name, f"{name} = {desired} — already set")]
+    if name in state["pending_restart"]:
+        return [_skip_setting(name, f"{name} — restart already pending, skipping ALTER SYSTEM")]
+    kind = "ALTER_SYSTEM" if requires_restart else "ALTER_SYSTEM_RELOAD"
+    return [
+        {
+            "kind": kind,
+            "description": f"ALTER SYSTEM SET {name} = '{desired}'",
+            "sql": f"ALTER SYSTEM SET {name} = '{desired}'",
+            "setting_name": name,
+            "requires_restart": requires_restart,
+        }
+    ]
+
+
+def _plan_spl(state, desired, current):
+    libs = parse_shared_preload_libraries(current)
+    if desired in libs:
+        return [_skip_setting("shared_preload_libraries", f"shared_preload_libraries already contains '{desired}'")]
+    if "shared_preload_libraries" in state["pending_restart"]:
+        return [
+            _skip_setting(
+                "shared_preload_libraries",
+                "shared_preload_libraries — restart already pending; check postgresql.auto.conf before restarting",
+            )
+        ]
+    new_value = f"{current},{desired}" if current else desired
+    return [
+        {
+            "kind": "ALTER_SYSTEM",
+            "description": f"ALTER SYSTEM SET shared_preload_libraries = '{new_value}'",
+            "sql": f"ALTER SYSTEM SET shared_preload_libraries = '{new_value}'",
+            "setting_name": "shared_preload_libraries",
+            "requires_restart": True,
+        }
+    ]
+
+
+def _plan_aws_setting(name, desired, current):
+    # Idempotent re-runs: once the user has applied the parameter-group change,
+    # current == desired (or the library is already loaded), so skip instead of
+    # emitting a MANUAL_STEP forever and exiting non-zero.
+    if name == "shared_preload_libraries" and desired in parse_shared_preload_libraries(current):
+        return [_skip_setting(name, f"shared_preload_libraries already contains '{desired}' — skipped")]
+    if current == desired:
+        return [_skip_setting(name, f"{name} = {desired} — already set")]
+    instruction = (
+        f"Set {name} = '{desired}'\n    → RDS Console → Parameter Groups → your group → save → reboot instance"
+    )
+    return [_manual_step(name, f"[AWS Parameter Group] {name} = '{desired}'", instruction)]
+
+
+def _plan_cloud_sql_setting(name, desired, current):
+    if name == "shared_preload_libraries":
+        return [_skip_setting(name, "shared_preload_libraries — pre-loaded on Cloud SQL")]
+    if current == desired:
+        return [_skip_setting(name, f"{name} = {desired} — already set")]
+    instruction = (
+        f"Set {name} = '{desired}'\n"
+        f"    → Cloud SQL Console → your instance → Edit → Database flags → save → restart instance"
+    )
+    return [_manual_step(name, f"[Cloud SQL Database Flag] {name} = '{desired}'", instruction)]
+
+
+def _plan_azure_setting(name, desired, current):
+    if name == "shared_preload_libraries" and desired in parse_shared_preload_libraries(current):
+        return [_skip_setting(name, f"shared_preload_libraries already contains '{desired}' — skipped")]
+    if current == desired:
+        return [_skip_setting(name, f"{name} = {desired} — already set")]
+    instruction = (
+        f"Set {name} = '{desired}'\n    → Azure Portal → your server → Server parameters → save → restart if required"
+    )
+    return [_manual_step(name, f"[Azure Server Parameters] {name} = '{desired}'", instruction)]
+
+
+def _skip_setting(name, description):
+    return {"kind": "SKIP", "description": description, "setting_name": name, "status": "skipped"}
+
+
+def _manual_step(name, description, instruction):
+    return {
+        "kind": "MANUAL_STEP",
+        "description": description,
+        "setting_name": name,
+        "manual_instruction": instruction,
+        "status": "manual",
+    }
+
+
+def _plan_per_db_ops(config, db):
+    user = config["datadog_user"]
+    return [
+        {
+            "kind": "SQL",
+            "description": "CREATE EXTENSION IF NOT EXISTS pg_stat_statements",
+            "op_type": "create_extension",
+            "database": db,
+        },
+        {
+            "kind": "SQL",
+            "description": "CREATE SCHEMA IF NOT EXISTS datadog",
+            "op_type": "create_schema",
+            "database": db,
+        },
+        {
+            "kind": "SQL",
+            "description": f"GRANT USAGE ON SCHEMA datadog TO {user!r}",
+            "op_type": "grant_schema_usage",
+            "args": [user],
+            "database": db,
+        },
+        {
+            "kind": "SQL",
+            "description": "CREATE OR REPLACE FUNCTION datadog.pg_stat_activity()",
+            "op_type": "func_pg_stat_activity",
+            "database": db,
+        },
+        {
+            "kind": "SQL",
+            "description": "CREATE OR REPLACE FUNCTION datadog.pg_stat_statements()",
+            "op_type": "func_pg_stat_statements",
+            "database": db,
+        },
+        {
+            "kind": "SQL",
+            "description": "CREATE OR REPLACE FUNCTION datadog.explain_statement()",
+            "op_type": "func_explain_statement",
+            "database": db,
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+
+def _execute_op(cur, op):
+    """Execute a single operation using psycopg (v3) with safe identifier handling."""
+    op_type = op.get("op_type")
+    args = op.get("args", [])
+
+    if op_type == "create_user":
+        cur.execute(
+            _query(cur, sql.SQL("CREATE USER {} WITH PASSWORD %s").format(sql.Identifier(args[0]))),
+            (args[1],),
+        )
+    elif op_type == "alter_user_password":
+        cur.execute(
+            _query(cur, sql.SQL("ALTER USER {} WITH PASSWORD %s").format(sql.Identifier(args[0]))),
+            (args[1],),
+        )
+    elif op_type == "grant_pg_monitor":
+        cur.execute(_query(cur, sql.SQL("GRANT pg_monitor TO {}").format(sql.Identifier(args[0]))))
+    elif op_type == "grant_pg96":
+        cur.execute(
+            _query(
+                cur,
+                sql.SQL(
+                    "GRANT SELECT ON pg_stat_database TO {};"
+                    "GRANT SELECT ON pg_stat_database_conflicts TO {};"
+                    "GRANT SELECT ON pg_stat_bgwriter TO {}"
+                ).format(
+                    sql.Identifier(args[0]),
+                    sql.Identifier(args[0]),
+                    sql.Identifier(args[0]),
+                ),
+            )
+        )
+    elif op_type == "alter_role_inherit":
+        cur.execute(_query(cur, sql.SQL("ALTER ROLE {} INHERIT").format(sql.Identifier(args[0]))))
+    elif op_type == "create_extension":
+        cur.execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+    elif op_type == "create_schema":
+        cur.execute("CREATE SCHEMA IF NOT EXISTS datadog")
+    elif op_type == "grant_schema_usage":
+        cur.execute(_query(cur, sql.SQL("GRANT USAGE ON SCHEMA datadog TO {}").format(sql.Identifier(args[0]))))
+    elif op_type == "func_pg_stat_activity":
+        cur.execute(SQL_FUNC_PG_STAT_ACTIVITY)
+    elif op_type == "func_pg_stat_statements":
+        cur.execute(SQL_FUNC_PG_STAT_STATEMENTS)
+    elif op_type == "func_explain_statement":
+        cur.execute(SQL_FUNC_EXPLAIN_STATEMENT)
+    elif "sql" in op:
+        cur.execute(op["sql"])
+    else:
+        raise RuntimeError(f"Unknown op_type: {op_type!r}")
+
+
+def _apply(ops, uri, state, optional_restart_pending=None):
+    base_conn = _connect(uri)
+
+    db_conns = {}
+    failed = False
+
+    try:
+        for op in ops:
+            if op.get("status") in ("skipped", "manual"):
+                continue
+            if op["kind"] == "MANUAL_STEP":
+                op["status"] = "manual"
+                continue
+            if op["kind"] == "SKIP":
+                op["status"] = "skipped"
+                continue
+            if failed:
+                op["status"] = "pending"
+                continue
+
+            db = op.get("database")
+            try:
+                if db:
+                    if db not in db_conns:
+                        db_conns[db] = _connect(uri, dbname=db)
+                    conn = db_conns[db]
+                else:
+                    conn = base_conn
+
+                cur = conn.cursor()
+                _execute_op(cur, op)
+
+                if op["kind"] == "ALTER_SYSTEM_RELOAD":
+                    base_conn.cursor().execute("SELECT pg_reload_conf()")
+
+                op["status"] = "completed"
+            except Exception as exc:
+                op["status"] = "failed"
+                op["error"] = str(exc)
+                failed = True
+    finally:
+        for c in db_conns.values():
+            try:
+                c.close()
+            except Exception:
+                pass
+        base_conn.close()
+
+    return _build_result(ops, state, failed, optional_restart_pending)
+
+
+def _build_result(ops, state, failed, optional_restart_pending=None):
+    manual_steps = any(op["kind"] == "MANUAL_STEP" for op in ops)
+    restart_needed = any(op.get("requires_restart") and op.get("status") == "completed" for op in ops) or bool(
+        state.get("pending_restart")
+    )
+    if failed:
+        outcome = "failure"
+    elif manual_steps or restart_needed:
+        outcome = "success_with_manual_steps"
+    else:
+        outcome = "success"
+    return {
+        "operations": ops,
+        "flavor": state["flavor"],
+        "pg_version": state["pg_version"],
+        "restart_needed": restart_needed,
+        "manual_steps": manual_steps,
+        "outcome": outcome,
+        "optional_restart_pending": optional_restart_pending or [],
+    }
+
+
+def _dry_run_result(ops, state, optional_restart_pending=None):
+    for op in ops:
+        if op.get("status") == "skipped" or op["kind"] == "SKIP":
+            op["status"] = "skipped"
+        elif op["kind"] == "MANUAL_STEP":
+            op["status"] = "manual"
+        else:
+            op["status"] = "pending"
+    manual_steps = any(op["kind"] == "MANUAL_STEP" for op in ops)
+    return {
+        "operations": ops,
+        "flavor": state["flavor"],
+        "pg_version": state["pg_version"],
+        "restart_needed": False,
+        "manual_steps": manual_steps,
+        "outcome": "dry_run",
+        "optional_restart_pending": optional_restart_pending or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def run_setup(args):
+    """Run Detect → Plan → Apply for the given parsed JSON args and return the result dict."""
+    uri = args["connection_uri"]
+    config = args["config"]
+
+    conn = _connect(uri)
+    try:
+        state = _detect(conn.cursor(), config)
+    finally:
+        conn.close()
+
+    if not state["user_exists"] and not config.get("datadog_password"):
+        raise RuntimeError(
+            f"--datadog-password is required when creating user {config['datadog_user']!r} for the first time"
+        )
+
+    ops, optional_restart_pending = _plan(state, config)
+
+    if config.get("dry_run"):
+        return _dry_run_result(ops, state, optional_restart_pending)
+    return _apply(ops, uri, state, optional_restart_pending)
+
+
+def main():
+    args = json.loads(sys.stdin.read())
+    try:
+        result = run_setup(args)
+        print(json.dumps({"success": True, "result": result}))
+    except Exception as exc:
+        print(json.dumps({"success": False, "error": str(exc)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/postgres/tests/test_setup.py
+++ b/postgres/tests/test_setup.py
@@ -1,0 +1,199 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Smoke tests for the DBM Postgres setup module.
+
+These run against the live containerized Postgres provided by ``dd_environment``,
+which the hatch matrix spins up once per supported server version (9.6 -> 18). The
+goal is to prove that ``datadog_checks.postgres.setup`` *executes* correctly across
+every version: the Detect/Plan SQL introspection runs without error, version
+branching is correct, the stdin/stdout contract the Go agent relies on works, and a
+real Apply is idempotent on re-runs.
+"""
+
+import json
+import subprocess
+import sys
+
+import psycopg
+import pytest
+
+from datadog_checks.postgres import setup
+
+from .common import DB_NAME, HOST, PASSWORD_ADMIN, PORT, POSTGRES_VERSION, USER_ADMIN
+
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
+
+SMOKE_USER = 'dd_setup_smoke'
+SMOKE_PASSWORD = 'dd_setup_smoke'
+
+ADMIN_URI = f"postgresql://{USER_ADMIN}:{PASSWORD_ADMIN}@{HOST}:{PORT}/{DB_NAME}"
+
+
+def _admin_connect(dbname=DB_NAME):
+    """Autocommit superuser connection for test fixtures/teardown (not via the module)."""
+    return psycopg.connect(
+        host=HOST, port=PORT, user=USER_ADMIN, password=PASSWORD_ADMIN, dbname=dbname, autocommit=True
+    )
+
+
+def _run(config):
+    return setup.run_setup({"connection_uri": ADMIN_URI, "config": config})
+
+
+def _op_types(result):
+    return {op.get("op_type") for op in result["operations"]}
+
+
+def _failed_ops(result):
+    return [op for op in result["operations"] if op.get("status") == "failed"]
+
+
+def _expected_major():
+    """The major version we expect the module to detect, or None when unknown (latest/unpinned)."""
+    try:
+        return int(float(POSTGRES_VERSION))
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Dry run — the core version smoke test. Exercises all live Detect/Plan SQL
+# against every server version with zero mutation.
+# ---------------------------------------------------------------------------
+
+
+def test_setup_dry_run_across_versions():
+    result = _run(
+        {
+            "datadog_user": "datadog",  # pre-created by the test fixtures, so no password needed
+            "databases": [DB_NAME],
+            "dry_run": True,
+        }
+    )
+
+    assert result["outcome"] == "dry_run"
+    assert result["flavor"] == "self_hosted"
+    assert not _failed_ops(result)
+
+    major = result["pg_version"]
+    assert isinstance(major, int) and major >= 9
+    expected = _expected_major()
+    if expected is not None:
+        assert major == expected
+
+    # Version-specific grant branch: pg_monitor exists on 10+, table grants on 9.6.
+    op_types = _op_types(result)
+    if major >= 10:
+        assert "grant_pg_monitor" in op_types
+        assert "grant_pg96" not in op_types
+    else:
+        assert "grant_pg96" in op_types
+        assert "grant_pg_monitor" not in op_types
+
+    # Per-database objects are always planned for the requested database.
+    for expected_op in ("create_extension", "create_schema", "func_explain_statement"):
+        assert expected_op in op_types
+
+
+def test_setup_rejects_read_replica_detection_path():
+    """Detect runs pg_is_in_recovery() on every version; on a primary it must not raise."""
+    result = _run({"datadog_user": "datadog", "databases": [DB_NAME], "dry_run": True})
+    # Reaching a dry_run result at all proves the primary/standby probe executed and passed.
+    assert result["outcome"] == "dry_run"
+
+
+# ---------------------------------------------------------------------------
+# stdin/stdout contract — the actual interface the Go agent tunnels into.
+# ---------------------------------------------------------------------------
+
+
+def test_setup_cli_stdin_stdout_contract():
+    payload = json.dumps(
+        {
+            "connection_uri": ADMIN_URI,
+            "config": {"datadog_user": "datadog", "databases": [DB_NAME], "dry_run": True},
+        }
+    )
+    proc = subprocess.run(
+        [sys.executable, "-m", "datadog_checks.postgres.setup"],
+        input=payload,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    envelope = json.loads(proc.stdout)
+    assert envelope["success"] is True
+    assert envelope["result"]["outcome"] == "dry_run"
+
+
+def test_setup_cli_reports_failure_nonzero():
+    """A bad connection must surface as success=False and a non-zero exit code."""
+    payload = json.dumps(
+        {
+            "connection_uri": f"postgresql://{USER_ADMIN}:wrong-password@{HOST}:{PORT}/{DB_NAME}",
+            "config": {"datadog_user": "datadog", "databases": [DB_NAME], "dry_run": True},
+        }
+    )
+    proc = subprocess.run(
+        [sys.executable, "-m", "datadog_checks.postgres.setup"],
+        input=payload,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 1
+    envelope = json.loads(proc.stdout)
+    assert envelope["success"] is False
+    assert envelope["error"]
+
+
+# ---------------------------------------------------------------------------
+# Real apply + idempotency. Creates a throwaway user and real DB objects, then
+# re-runs to prove the second pass is a clean no-op (the RDS/Aurora re-run fix).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def smoke_user_cleanup():
+    yield
+    with _admin_connect() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (SMOKE_USER,))
+            if cur.fetchone():
+                # Drop privileges the user was granted (schema usage, etc.) before dropping the role.
+                cur.execute(f'DROP OWNED BY "{SMOKE_USER}"')
+                cur.execute(f'DROP ROLE "{SMOKE_USER}"')
+    # Restore the only server-global settings a self-hosted apply can touch here.
+    with _admin_connect() as conn:
+        with conn.cursor() as cur:
+            cur.execute("ALTER SYSTEM RESET track_activity_query_size")
+            cur.execute('ALTER SYSTEM RESET "pg_stat_statements.track_utility"')
+            cur.execute("SELECT pg_reload_conf()")
+
+
+def test_setup_apply_and_idempotency(smoke_user_cleanup):
+    config = {
+        "datadog_user": SMOKE_USER,
+        "datadog_password": SMOKE_PASSWORD,
+        "databases": [DB_NAME],
+    }
+
+    first = _run(config)
+    assert first["outcome"] in ("success", "success_with_manual_steps")
+    assert not _failed_ops(first), _failed_ops(first)
+
+    # The user did not exist, so it must have been created and granted monitoring access.
+    create_user = next(op for op in first["operations"] if op.get("op_type") == "create_user")
+    assert create_user["status"] == "completed"
+    # Password must be redacted from the recorded operation.
+    assert create_user.get("redact") is True
+
+    # The role really exists and can authenticate now.
+    with psycopg.connect(host=HOST, port=PORT, user=SMOKE_USER, password=SMOKE_PASSWORD, dbname=DB_NAME) as conn:
+        assert conn.info.status is not None
+
+    # Second run: nothing should fail, and the user is now detected as existing (no re-create).
+    second = _run(config)
+    assert second["outcome"] in ("success", "success_with_manual_steps")
+    assert not _failed_ops(second), _failed_ops(second)
+    assert "create_user" not in _op_types(second)


### PR DESCRIPTION
### What does this PR do?

Hosts the DBM Postgres **setup** logic in the integration so the
`datadog-agent integration setup postgres` CLI can tunnel into it
(`python -m datadog_checks.postgres.setup`) rather than shipping a standalone
copy in the agent.

- Adds `datadog_checks/postgres/setup.py` — the Detect → Plan → Apply logic that
  idempotently configures a Postgres instance for DBM (user, grants, server
  settings, per-database extension/schema/helper functions). Reads a JSON config
  from stdin and writes a JSON result to stdout.
- Extracts `configure_connection` out of `LRUConnectionPoolManager._configure_connection`
  into a module-level function so setup configures connections exactly like the
  running check (autocommit, SQL_ASCII decoding, CommenterCursor) without a pool
  instance. The pool manager now delegates to it; behavior is unchanged.
- Setup reuses the integration's building blocks instead of duplicating them:
  `configure_connection`, `AUTODISCOVERY_QUERY` (database navigation for
  `--all-databases`), and `parse_shared_preload_libraries`.
- Keeps the canonical `datadog.*` helper-function SQL as constants alongside
  `tests/compose/resources/03_setup.sh`, giving a single source of truth in this
  repo (resolves the SQL-drift risk).
- On RDS/Aurora re-runs, skips the parameter-group manual step once the value
  already matches, so an already-configured instance verifies cleanly instead of
  reporting manual steps forever.

### Motivation

Review feedback on DataDog/datadog-agent#51751: the setup logic belongs in the
Python integration where the connection-management and database-navigation code
already lives, with the Go agent acting only as the tunnel to it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged