### PR TITLE
Propagate reported_hostname to service check events in sqlserver

### DIFF
--- a/sqlserver/changelog.d/24062.fixed
+++ b/sqlserver/changelog.d/24062.fixed
@@ -1,0 +1,1 @@
+Propagate reported_hostname to service check events.

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -568,17 +568,13 @@ class SQLServer(DatabaseCheck):
         if status is AgentCheck.OK:
             message = None
 
-        # Use the raw config attribute rather than self.reported_hostname (the property) so that
-        # the override only fires when reported_hostname is explicitly configured. Passing None
-        # lets the Agent fall back to its default host attribution, keeping service-check host
-        # attribution unchanged for existing deployments that don't set reported_hostname.
         if is_default:
             self.service_check(
                 SERVICE_CHECK_NAME,
                 status,
                 tags=service_check_tags,
                 message=message,
-                hostname=self._config.reported_hostname,
+                hostname=self.reported_hostname,
                 raw=True,
             )
         if self._config.autodiscovery and self._config.autodiscovery_db_service_check:
@@ -587,7 +583,7 @@ class SQLServer(DatabaseCheck):
                 status,
                 tags=service_check_tags,
                 message=message,
-                hostname=self._config.reported_hostname,
+                hostname=self.reported_hostname,
                 raw=True,
             )
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -568,6 +568,10 @@ class SQLServer(DatabaseCheck):
         if status is AgentCheck.OK:
             message = None
 
+        # Use the raw config attribute rather than self.reported_hostname (the property) so that
+        # the override only fires when reported_hostname is explicitly configured. Passing None
+        # lets the Agent fall back to its default host attribution, keeping service-check host
+        # attribution unchanged for existing deployments that don't set reported_hostname.
         if is_default:
             self.service_check(
                 SERVICE_CHECK_NAME,

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -574,7 +574,7 @@ class SQLServer(DatabaseCheck):
                 status,
                 tags=service_check_tags,
                 message=message,
-                hostname=self.reported_hostname,
+                hostname=self._config.reported_hostname,
                 raw=True,
             )
         if self._config.autodiscovery and self._config.autodiscovery_db_service_check:
@@ -583,7 +583,7 @@ class SQLServer(DatabaseCheck):
                 status,
                 tags=service_check_tags,
                 message=message,
-                hostname=self.reported_hostname,
+                hostname=self._config.reported_hostname,
                 raw=True,
             )
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -569,9 +569,23 @@ class SQLServer(DatabaseCheck):
             message = None
 
         if is_default:
-            self.service_check(SERVICE_CHECK_NAME, status, tags=service_check_tags, message=message, raw=True)
+            self.service_check(
+                SERVICE_CHECK_NAME,
+                status,
+                tags=service_check_tags,
+                message=message,
+                hostname=self.reported_hostname,
+                raw=True,
+            )
         if self._config.autodiscovery and self._config.autodiscovery_db_service_check:
-            self.service_check(DATABASE_SERVICE_CHECK_NAME, status, tags=service_check_tags, message=message, raw=True)
+            self.service_check(
+                DATABASE_SERVICE_CHECK_NAME,
+                status,
+                tags=service_check_tags,
+                message=message,
+                hostname=self.reported_hostname,
+                raw=True,
+            )
 
     def autodiscover_databases(self, cursor):
         if not self._config.autodiscovery:

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -1406,9 +1406,8 @@ def test_debug_stats_kwargs_respects_exclude_hostname(exclude_hostname, expected
 @pytest.mark.parametrize(
     'reported_hostname, expected_hostname',
     [
-        # Not configured: None is passed, Agent falls back to its own hostname attribution.
-        # This is intentional — we don't change service-check host for existing deployments.
-        (None, None),
+        # Not configured: falls back to resolve_db_host(), consistent with mysql/postgres.
+        (None, 'db.host'),
         # Explicitly configured: the custom hostname is propagated to the service check.
         ('custom-host', 'custom-host'),
     ],

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -1401,3 +1401,34 @@ def test_debug_stats_kwargs_respects_exclude_hostname(exclude_hostname, expected
     with mock.patch('datadog_checks.sqlserver.SQLServer.resolve_db_host', return_value='resolved.hostname'):
         check = SQLServer(CHECK_NAME, {}, [instance])
     assert check.debug_stats_kwargs()['hostname'] == expected_hostname
+
+
+@pytest.mark.parametrize(
+    'reported_hostname, expected_hostname',
+    [
+        # Not configured: None is passed, Agent falls back to its own hostname attribution.
+        # This is intentional — we don't change service-check host for existing deployments.
+        (None, None),
+        # Explicitly configured: the custom hostname is propagated to the service check.
+        ('custom-host', 'custom-host'),
+    ],
+)
+def test_handle_service_check_propagates_reported_hostname(aggregator, reported_hostname, expected_hostname):
+    instance = {
+        'host': DOCKER_SERVER,
+        'username': 'sa',
+        'password': 'Password12!',
+    }
+    if reported_hostname is not None:
+        instance['reported_hostname'] = reported_hostname
+
+    with mock.patch('datadog_checks.sqlserver.SQLServer.resolve_db_host', return_value='db.host'):
+        check = SQLServer(CHECK_NAME, {}, [instance])
+
+    check.handle_service_check(check.OK, DOCKER_SERVER, 'master')
+
+    aggregator.assert_service_check(
+        'sqlserver.can_connect',
+        status=check.OK,
+        hostname=expected_hostname,
+    )


### PR DESCRIPTION
### What does this PR do?
Pass `hostname=self.reported_hostname` to both `SERVICE_CHECK_NAME` and `DATABASE_SERVICE_CHECK_NAME` service check calls in the SQL Server check's `handle_service_check` method, consistent with the convention used by the MySQL and PostgreSQL integrations.

### Motivation
Service check host attribution was not aligned with metric host attribution. When `reported_hostname` is configured, service checks were attributed to the agent host while all other telemetry (metrics, query events) used the resolved DB host. This PR fixes the inconsistency by using the same `self.reported_hostname` property used by every other telemetry submission path in the check, and by the MySQL and PostgreSQL integrations for their service checks.

Note: for deployments that do not set `reported_hostname`, this changes service check host attribution from the agent host to the resolved DB host (same as metrics). Existing monitors that group by `host` on `sqlserver.can_connect` may need to be reviewed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged