### PR TITLE
[TEST] NTP manifest with invalid classifier tag (triggers ddev validate failure)

### DIFF
--- a/ddev/src/ddev/cli/size/utils/common_funcs.py
+++ b/ddev/src/ddev/cli/size/utils/common_funcs.py
@@ -405,7 +405,7 @@ def get_dependencies_sizes(
 
         file_data.append(
             {
-                "Name": str(dep),
+                "Names": str(dep),
                 "Version": version,
                 "Size_Bytes": int(size),
                 "Size": convert_to_human_readable_size(size),

--- a/ddev/src/ddev/cli/size/utils/common_funcs.py
+++ b/ddev/src/ddev/cli/size/utils/common_funcs.py
@@ -49,16 +49,16 @@ class FileDataEntryPlatformVersion(FileDataEntry):
 
 
 class CommitEntry(TypedDict):
-    Size_Bytes: int  # Total size in bytes at commit
-    Version: str  # Version of the Integration/Dependency at commit
+    Size_Bytes: int  # Total size in bytes at commit (uncompressed)
+    Version: str  # Version of the Integration/Dependency at commit (uncompressed)
     Date: date  # Commit date
-    Author: str  # Commit author
+    Author: str  # Commit author (uncompressed)
     Commit_Message: str  # Commit message
     Commit_SHA: str  # Commit SHA hash
 
 
 class CommitEntryWithDelta(CommitEntry):
-    Delta_Bytes: int  # Size change in bytes compared to previous commit
+    Delta_Bytes: int  # Size change in bytes compared to previous commit (uncompressed)
     Delta: str  # Human-readable size change
 
 
@@ -405,7 +405,7 @@ def get_dependencies_sizes(
 
         file_data.append(
             {
-                "Names": str(dep),
+                "Name": str(dep),
                 "Version": version,
                 "Size_Bytes": int(size),
                 "Size": convert_to_human_readable_size(size),

--- a/ntp/manifest.json
+++ b/ntp/manifest.json
@@ -18,7 +18,6 @@
       "Supported OS::Windows",
       "Category::Network",
       "Offering::Integration",
-      "Category::NotARealCategory"
     ]
   },
   "author": {

--- a/ntp/manifest.json
+++ b/ntp/manifest.json
@@ -17,7 +17,7 @@
       "Supported OS::macOS",
       "Supported OS::Windows",
       "Category::Network",
-      "Offering::Integration",
+      "Offering::Integration"
     ]
   },
   "author": {

--- a/ntp/manifest.json
+++ b/ntp/manifest.json
@@ -17,7 +17,8 @@
       "Supported OS::macOS",
       "Supported OS::Windows",
       "Category::Network",
-      "Offering::Integration"
+      "Offering::Integration",
+      "Category::NotARealCategory"
     ]
   },
   "author": {


### PR DESCRIPTION
## What does this PR do?

**This is an intentional test PR for the agent-integrations-review-bot.**

Adds an invalid classifier tag (`Category::NotARealCategory`) to `ntp/manifest.json` to cause `ddev validate manifests` to fail in the `Run Validations / Validate` CI check.

## Motivation

Testing the review bot's behavior when the `Run Validations / Validate` CI step fails (per TODO item #8 — CI readiness gating).

## Review checklist (to be filled by reviewers)

- [ ] This PR is safe to ignore / close once testing is done.