### PR TITLE
Fix macos-x86_64 dep-resolution build by restoring pkg-config and openssl@3

### DIFF
--- a/.github/workflows/resolve-build-deps.yaml
+++ b/.github/workflows/resolve-build-deps.yaml
@@ -272,9 +272,18 @@ jobs:
     - name: Set up environment
       run: |
         # We remove everything that comes pre-installed via Homebrew to avoid depending on or shipping stuff that
-        # comes in the runner through Homebrew to better control what might get shipped in the wheels via `delocate`
+        # comes in the runner through Homebrew to better control what might get shipped in the wheels via `delocate`.
+        # pkg-config and openssl@3 are needed by the management-deps install step: pip resolves cryptography via
+        # transitive deps of google-cloud-storage and falls back to building from source when no wheel matches the
+        # PBS Python's tags. These are host-side build tools — they're not bundled by `delocate` into the output
+        # wheels, which are produced by the later "Run the build" step and processed in isolation.
         brew remove --force --ignore-dependencies $(brew list --formula)
-        brew install coreutils
+        brew install coreutils pkg-config openssl@3
+        OPENSSL_PREFIX="$(brew --prefix openssl@3)"
+        {
+          echo "OPENSSL_DIR=${OPENSSL_PREFIX}"
+          echo "PKG_CONFIG_PATH=${OPENSSL_PREFIX}/lib/pkgconfig"
+        } >> "$GITHUB_ENV"
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## What does this PR do?

Restores `pkg-config` and `openssl@3` (plus `OPENSSL_DIR` / `PKG_CONFIG_PATH` env vars) in the macOS leg of `.github/workflows/resolve-build-deps.yaml` so the `management-deps` install step can compile `cryptography` from source when pip falls back to an sdist build.

## Motivation

The `resolve-build-deps` workflow's macOS step deliberately wipes Homebrew (`brew remove --force --ignore-dependencies $(brew list --formula)`) so that `delocate` doesn't pull random brew libraries into the produced wheels. The step then reinstalls only `coreutils`.

That worked fine while pip resolved `cryptography` to a prebuilt wheel for the host Python. Then commit `3b4fb9d0e2` "Upgrade Python version (#24019)" landed on 2026-06-11 and bumped the macOS PBS Python from `3.13.13` (release `20260414`) to `3.13.14` (release `20260610`). The new PBS Python's platform tags no longer match cryptography's `macosx_10_9_universal2` wheel, so pip falls back to building from sdist — which uses the `openssl-sys` Rust crate and immediately fails:

```
error: failed to run custom build command for `openssl-sys v0.9.117`
Could not find directory of OpenSSL installation [...] try installing `pkg-config`
```

**Timeline:**
- 2026-06-11 11:59 — last passing macos-x86_64 run (run `27345165538`, PR #24014, 15m17s)
- 2026-06-11 19:26 — PR #24019 merged, bumping PBS Python 3.13.13 → 3.13.14
- 2026-06-15 03:01 — first failing macos-x86_64 run (bot PR #24041)

Reinstating `pkg-config` and `openssl@3` (both keg-only so they won't be picked up by `delocate` from the wheel build step that runs in isolation later) lets the sdist build complete. These are host-side build tools; they don't end up in the produced wheels.

## Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry ([see why](https://datadoghq.dev/integrations-core/guidelines/pr/#title))
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` label attached
- [x] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.
