### PR TITLE
Fix legacy envoy benchmark test and add openmetrics benchmark

### DIFF
--- a/envoy/tests/legacy/test_bench.py
+++ b/envoy/tests/legacy/test_bench.py
@@ -24,7 +24,7 @@ def test_fixture(benchmark, fixture_path, mock_http_response):
     instance = INSTANCES['main']
     c = Envoy('envoy', {}, [instance])
 
-    mock_http_response(file_path=fixture_path('multiple_services'))
+    mock_http_response(file_path=fixture_path('legacy/multiple_services'))
 
     # Run once to get logging of unknown metrics out of the way.
     c.check(instance)

--- a/envoy/tests/test_bench.py
+++ b/envoy/tests/test_bench.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2025-present
+# (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 

--- a/envoy/tests/test_bench.py
+++ b/envoy/tests/test_bench.py
@@ -1,0 +1,18 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from datadog_checks.envoy import Envoy
+
+from .common import DEFAULT_INSTANCE, get_fixture_path
+
+
+def test_openmetrics_check(benchmark, mock_http_response):
+    mock_http_response(file_path=get_fixture_path('./openmetrics/openmetrics.txt'))
+
+    c = Envoy('envoy', {}, [DEFAULT_INSTANCE])
+
+    # Run once to get any first-run overhead out of the way.
+    c.check(DEFAULT_INSTANCE)
+
+    benchmark(c.check, DEFAULT_INSTANCE)

--- a/envoy/tests/test_bench.py
+++ b/envoy/tests/test_bench.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2026-present
+# (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -6,13 +6,13 @@ from datadog_checks.envoy import Envoy
 
 from .common import DEFAULT_INSTANCE, get_fixture_path
 
+OPENMETRICS_FIXTURE = get_fixture_path('./openmetrics/openmetrics.txt')
 
-def test_openmetrics_check(benchmark, mock_http_response):
-    mock_http_response(file_path=get_fixture_path('./openmetrics/openmetrics.txt'))
+
+def test_openmetrics_check(benchmark, dd_run_check, mock_http_response):
+    mock_http_response(file_path=OPENMETRICS_FIXTURE)
 
     c = Envoy('envoy', {}, [DEFAULT_INSTANCE])
-
-    # Run once to get any first-run overhead out of the way.
-    c.check(DEFAULT_INSTANCE)
+    dd_run_check(c)
 
     benchmark(c.check, DEFAULT_INSTANCE)


### PR DESCRIPTION
### What does this PR do?
Fixes legacy envoy benchmark test and add openmetrics benchmark

### Motivation
I was playing around with our benchmarking capabilities and discovered the envoy test was broken
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
