### PR TITLE
[checks_downloader] Use CloudFront entrypoint for v2 wheels repo

### DIFF
--- a/datadog_checks_downloader/changelog.d/24084.fixed
+++ b/datadog_checks_downloader/changelog.d/24084.fixed
@@ -1,0 +1,1 @@
+Use ``https://agent-integration-wheels.datadoghq.com`` (CloudFront) as the default v2 repository URL, replacing the direct S3 URL. The ``--repository`` flag still accepts any HTTPS base URL.

--- a/datadog_checks_downloader/datadog_checks/downloader/download_v2.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download_v2.py
@@ -30,7 +30,7 @@ from .exceptions import (
 
 logger = logging.getLogger(__name__)
 
-V2_REPOSITORY_URL = "https://agent-integration-wheels-prod.s3.amazonaws.com"
+V2_REPOSITORY_URL = "https://agent-integration-wheels.datadoghq.com"
 
 # tuf.ngclient sets its own fetcher timeout; this applies only to the raw wheel urlopen().
 WHEEL_FETCH_TIMEOUT_SECONDS = 60

--- a/datadog_checks_downloader/tests/test_v2_downloader.py
+++ b/datadog_checks_downloader/tests/test_v2_downloader.py
@@ -39,7 +39,7 @@ WHEEL_NAME = f'datadog_postgres-{VERSION}-py3-none-any.whl'
 WHEEL_CONTENT = b'fake wheel bytes for testing'
 WHEEL_DIGEST = hashlib.sha256(WHEEL_CONTENT).hexdigest()
 WHEEL_LENGTH = len(WHEEL_CONTENT)
-REPO_URL = 'https://agent-integration-wheels-staging.s3.amazonaws.com'
+REPO_URL = 'https://agent-integration-wheels.datadoghq.com'
 
 POINTER = {
     'digest': WHEEL_DIGEST,


### PR DESCRIPTION
### What does this PR do?

Point the v2 wheels downloader at the new CloudFront entrypoint:

```diff
-V2_REPOSITORY_URL = "https://agent-integration-wheels-prod.s3.amazonaws.com"
+V2_REPOSITORY_URL = "https://agent-integration-wheels.datadoghq.com"
```

Test fixtures updated to match.

### Motivation

Move shipped agents off the raw S3 hostname onto a stable CDN entrypoint defined in [DataDog/cloud-inventory#62697](https://github.com/DataDog/cloud-inventory/pull/62697). Because that hostname is the only URL the downloader knows about, the cloud-inventory side can fail the CDN over to a healthy mirror (e.g. the staging bucket) without an agent release.

No TUF, signing, or `--repository`-override behavior is changed. Merge **after** the cloud-inventory PR is applied and the new hostname is smoke-tested. Pipeline-side docs update: [DataDog/agent-integrations-tuf#59](https://github.com/DataDog/agent-integrations-tuf/pull/59).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

