### PR TITLE
Add test to run all configurations generated by config discovery

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -1,9 +1,14 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+import logging
 import os
+import re
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import contextmanager
-from typing import Iterator  # noqa: F401
+from types import SimpleNamespace
+from typing import Any, Iterator  # noqa: F401
 from urllib.parse import urlparse
 
 from .conditions import CheckDockerLogs
@@ -18,6 +23,16 @@ try:
     from contextlib import ExitStack
 except ImportError:
     from contextlib2 import ExitStack
+
+
+CONTAINER_STABILITY_LOG_PATTERNS = (
+    r'error',
+    r'panic',
+    r'fatal',
+    r'segmentation fault',
+    r'core dumped',
+    r'Traceback',
+)
 
 
 def get_docker_hostname():
@@ -40,6 +55,178 @@ def get_container_ip(container_id_or_name):
     ]
 
     return run_command(command, capture='out', check=True).stdout.strip()
+
+
+def assert_all_discovery_candidates_stable(
+    dd_agent_check: Callable[..., Any],
+    check_cls: type[Any],
+    compose_file: str | os.PathLike[str] | None = None,
+    compose_service: str | None = None,
+    *,
+    project_name: str | None = None,
+    service_id: str | None = None,
+    dd_agent_check_kwargs: Mapping[str, Any] | None = None,
+    log_patterns: Sequence[str] = CONTAINER_STABILITY_LOG_PATTERNS,
+) -> None:
+    """Run generated discovery candidates directly and assert the target container stays stable."""
+    compose_service = compose_service or _get_default_compose_service()
+    container_id = _get_compose_container_id(compose_file, compose_service, project_name=project_name)
+    initial_state = _inspect_container(container_id)
+    previous_logs = _get_container_logs(container_id)
+
+    ports = tuple(SimpleNamespace(number=port, name='') for port in _get_container_ports(initial_state))
+    service = SimpleNamespace(
+        id=service_id or compose_service,
+        host=_get_container_ip_from_inspect(initial_state),
+        ports=ports,
+    )
+    candidates = tuple(check_cls.generate_configs(service))
+    if not candidates:
+        raise AssertionError(f'No discovery candidates generated for service {service.id!r}')
+
+    check_kwargs = {'check_rate': True}
+    if dd_agent_check_kwargs:
+        check_kwargs.update(dd_agent_check_kwargs)
+
+    for index, candidate in enumerate(candidates, 1):
+        logging.debug('Probing candidate #%d: %r', index, candidate)
+        try:
+            dd_agent_check(candidate, **check_kwargs)
+        except Exception:
+            logging.debug('Error probing candidate #%d: %r', index, candidate)
+            pass
+
+        current_container_id = _get_compose_container_id(compose_file, compose_service, project_name=project_name)
+        current_state = _inspect_container(current_container_id)
+        _assert_container_stable(initial_state, current_state, index)
+
+        current_logs = _get_container_logs(current_container_id)
+        new_logs = current_logs[len(previous_logs) :] if current_logs.startswith(previous_logs) else current_logs
+        for line in new_logs.splitlines():
+            logging.debug('New log line: %s', line)
+        _assert_no_log_patterns(new_logs, log_patterns, index)
+        previous_logs = current_logs
+
+
+def _get_compose_container_id(
+    compose_file: str | os.PathLike[str] | None, compose_service: str, *, project_name: str | None = None
+) -> str:
+    compose_file = compose_file or _get_default_compose_file()
+    project_name = project_name or _get_default_compose_project_name()
+
+    command = ['docker', 'compose']
+    if project_name:
+        command.extend(['-p', project_name])
+    command.extend(['-f', os.fspath(compose_file), 'ps', '-q', compose_service])
+
+    container_id = run_command(command, capture='out', check=True).stdout.strip()
+    if not container_id:
+        raise AssertionError(f'No container found for compose service {compose_service!r}')
+
+    return container_id
+
+
+def _get_default_compose_service() -> str:
+    docker_metadata = get_state('docker_compose_metadata', {})
+    if docker_metadata.get('service_name'):
+        return docker_metadata['service_name']
+
+    return os.path.basename(find_check_root(depth=2))
+
+
+def _get_default_compose_file() -> str:
+    docker_metadata = get_state('docker_compose_metadata', {})
+    if docker_metadata.get('compose_file'):
+        return docker_metadata['compose_file']
+
+    compose_file = os.path.join(find_check_root(depth=3), 'tests', 'docker', 'docker-compose.yml')
+    if os.path.exists(compose_file):
+        return compose_file
+
+    raise AssertionError(
+        'Could not determine the compose file. Pass compose_file explicitly or use docker_run with a compose file.'
+    )
+
+
+def _get_default_compose_project_name() -> str | None:
+    docker_metadata = get_state('docker_compose_metadata', {})
+    return docker_metadata.get('project_name') or os.getenv('COMPOSE_PROJECT_NAME')
+
+
+def _inspect_container(container_id: str) -> dict[str, Any]:
+    raw_inspect = run_command(['docker', 'inspect', container_id], capture='out', check=True).stdout
+    return json.loads(raw_inspect)[0]
+
+
+def _get_container_ip_from_inspect(inspect_data: Mapping[str, Any]) -> str:
+    networks = inspect_data.get('NetworkSettings', {}).get('Networks', {})
+    for network in networks.values():
+        ip_address = network.get('IPAddress')
+        if ip_address:
+            return ip_address
+
+    raise AssertionError(f"Could not determine container IP for {inspect_data.get('Name', '<unknown>')}")
+
+
+def _get_container_ports(inspect_data: Mapping[str, Any]) -> list[int]:
+    ports: set[int] = set()
+    exposed_ports = inspect_data.get('Config', {}).get('ExposedPorts') or {}
+    network_ports = inspect_data.get('NetworkSettings', {}).get('Ports') or {}
+
+    for raw_port in list(exposed_ports) + list(network_ports):
+        port, _, protocol = raw_port.partition('/')
+        if protocol and protocol != 'tcp':
+            continue
+        try:
+            ports.add(int(port))
+        except ValueError:
+            continue
+
+    if not ports:
+        raise AssertionError(f"No TCP ports found for container {inspect_data.get('Name', '<unknown>')}")
+
+    return sorted(ports)
+
+
+def _get_container_logs(container_id: str) -> str:
+    result = run_command(['docker', 'logs', container_id], capture=True)
+    return result.stdout + result.stderr
+
+
+def _assert_container_stable(
+    initial_state: Mapping[str, Any], current_state: Mapping[str, Any], candidate_index: int
+) -> None:
+    initial_id = initial_state['Id']
+    current_id = current_state['Id']
+    if current_id != initial_id:
+        raise AssertionError(
+            f'Container changed while probing candidate #{candidate_index}: {initial_id} -> {current_id}'
+        )
+
+    state = current_state.get('State', {})
+    if not state.get('Running'):
+        raise AssertionError(f'Container is not running after probing candidate #{candidate_index}')
+
+    initial_restart_count = initial_state.get('RestartCount', 0)
+    current_restart_count = current_state.get('RestartCount', 0)
+    if current_restart_count != initial_restart_count:
+        raise AssertionError(
+            f'Container restart count changed while probing candidate #{candidate_index}: '
+            f'{initial_restart_count} -> {current_restart_count}'
+        )
+
+    health = state.get('Health')
+    if health and health.get('Status') != 'healthy':
+        raise AssertionError(f"Container health is {health.get('Status')!r} after probing candidate #{candidate_index}")
+
+
+def _assert_no_log_patterns(logs: str, patterns: Sequence[str], candidate_index: int) -> None:
+    for pattern in patterns:
+        match = re.search(pattern, logs, re.IGNORECASE)
+        if match:
+            raise AssertionError(
+                f'Container logs matched {pattern!r} after probing candidate #{candidate_index}: {match.group(0)!r}'
+            )
 
 
 def get_e2e_discovery_metadata(
@@ -244,6 +431,16 @@ def docker_run(
                 raise TypeError(
                     'mount_logs: expected True, a list or a set, but got {}'.format(type(mount_logs).__name__)
                 )
+
+    if compose_file is not None:
+        save_state(
+            'docker_compose_metadata',
+            {
+                'compose_file': compose_file,
+                'project_name': (env_vars or {}).get('COMPOSE_PROJECT_NAME') or os.getenv('COMPOSE_PROJECT_NAME'),
+                'service_name': service_name,
+            },
+        )
 
     with environment_run(
         up=set_up,

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -1,14 +1,23 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+import logging
 import os
+from contextlib import contextmanager
 
 import mock
 import pytest
 import tenacity
 
 from datadog_checks.dev.ci import running_on_ci
-from datadog_checks.dev.docker import ComposeFileUp, compose_file_active, docker_run, get_e2e_discovery_metadata
+from datadog_checks.dev.docker import (
+    ComposeFileUp,
+    assert_all_discovery_candidates_stable,
+    compose_file_active,
+    docker_run,
+    get_e2e_discovery_metadata,
+)
 from datadog_checks.dev.subprocess import run_command
 
 from .common import not_windows_ci
@@ -16,6 +25,29 @@ from .common import not_windows_ci
 pytestmark = [not_windows_ci]
 HERE = os.path.dirname(os.path.abspath(__file__))
 DOCKER_DIR = os.path.join(HERE, 'docker')
+
+
+def _docker_result(stdout='', stderr='', code=0):
+    return mock.Mock(stdout=stdout, stderr=stderr, code=code)
+
+
+def _container_inspect(*, restart_count=0, running=True, health='healthy', ports=None):
+    ports = ports or ('8080/tcp', '9090/tcp')
+    state = {'Running': running}
+    if health is not None:
+        state['Health'] = {'Status': health}
+
+    return {
+        'Id': 'container-id',
+        'Name': '/service',
+        'Config': {'ExposedPorts': {port: {} for port in ports}},
+        'NetworkSettings': {
+            'Networks': {'default': {'IPAddress': '172.18.0.2'}},
+            'Ports': dict.fromkeys(ports),
+        },
+        'RestartCount': restart_count,
+        'State': state,
+    }
 
 
 def test_get_e2e_discovery_metadata(tmp_path):
@@ -162,3 +194,203 @@ class TestComposeFileUp:
 
         with pytest.raises(TypeError, match='unexpected keyword argument'):
             ComposeFileUp(compose_file, waith_for_health=False)
+
+
+def test_assert_all_discovery_candidates_stable_generates_and_runs_candidates():
+    class DiscoveryCheck:
+        service = None
+
+        @classmethod
+        def generate_configs(cls, service):
+            cls.service = service
+            for port in service.ports:
+                yield {'init_config': {}, 'instances': [{'url': f'http://{service.host}:{port.number}/metrics'}]}
+
+    inspect_data = _container_inspect(ports=('8080/tcp', '9090/tcp'))
+    logs = iter(
+        [
+            _docker_result(stdout='ready\n'),
+            _docker_result(stdout='ready\n'),
+            _docker_result(stdout='ready\n'),
+        ]
+    )
+
+    def fake_run_command(command, **kwargs):
+        if command[:2] == ['docker', 'compose']:
+            return _docker_result(stdout='container-id\n')
+        if command[:2] == ['docker', 'inspect']:
+            return _docker_result(stdout=json.dumps([inspect_data]))
+        if command[:2] == ['docker', 'logs']:
+            return next(logs)
+        raise AssertionError(f'Unexpected command: {command}')
+
+    dd_agent_check = mock.Mock(side_effect=[ValueError('expected failure'), None])
+
+    with mock.patch('datadog_checks.dev.docker.run_command', side_effect=fake_run_command):
+        assert_all_discovery_candidates_stable(
+            dd_agent_check,
+            DiscoveryCheck,
+            '/tmp/docker-compose.yml',
+            'service',
+            project_name='project',
+        )
+
+    assert DiscoveryCheck.service.id == 'service'
+    assert DiscoveryCheck.service.host == '172.18.0.2'
+    assert [port.number for port in DiscoveryCheck.service.ports] == [8080, 9090]
+    assert dd_agent_check.call_args_list == [
+        mock.call({'init_config': {}, 'instances': [{'url': 'http://172.18.0.2:8080/metrics'}]}, check_rate=True),
+        mock.call({'init_config': {}, 'instances': [{'url': 'http://172.18.0.2:9090/metrics'}]}, check_rate=True),
+    ]
+
+
+def test_assert_all_discovery_candidates_stable_uses_docker_run_metadata():
+    class DiscoveryCheck:
+        service = None
+
+        @classmethod
+        def generate_configs(cls, service):
+            cls.service = service
+            yield {'init_config': {}, 'instances': [{'url': f'http://{service.host}:8080/metrics'}]}
+
+    commands = []
+
+    def fake_run_command(command, **kwargs):
+        commands.append(command)
+        if command[:2] == ['docker', 'compose']:
+            return _docker_result(stdout='container-id\n')
+        if command[:2] == ['docker', 'inspect']:
+            return _docker_result(stdout=json.dumps([_container_inspect(ports=('8080/tcp',))]))
+        if command[:2] == ['docker', 'logs']:
+            return _docker_result(stdout='ready\n')
+        raise AssertionError(f'Unexpected command: {command}')
+
+    docker_metadata = {'compose_file': '/tmp/docker-compose.yml', 'project_name': 'project', 'service_name': 'service'}
+
+    with mock.patch('datadog_checks.dev.docker.get_state', return_value=docker_metadata):
+        with mock.patch('datadog_checks.dev.docker.run_command', side_effect=fake_run_command):
+            assert_all_discovery_candidates_stable(mock.Mock(), DiscoveryCheck)
+
+    assert commands[0] == ['docker', 'compose', '-p', 'project', '-f', '/tmp/docker-compose.yml', 'ps', '-q', 'service']
+    assert DiscoveryCheck.service.id == 'service'
+
+
+def test_docker_run_saves_compose_metadata(monkeypatch):
+    @contextmanager
+    def fake_environment_run(**kwargs):
+        yield None
+
+    monkeypatch.delenv('DDEV_E2E_ENV_docker_compose_metadata', raising=False)
+
+    with mock.patch('datadog_checks.dev.docker.environment_run', fake_environment_run):
+        with docker_run(
+            '/tmp/docker-compose.yml',
+            env_vars={'COMPOSE_PROJECT_NAME': 'project'},
+            service_name='service',
+        ):
+            pass
+
+    assert os.environ['DDEV_E2E_ENV_docker_compose_metadata']
+
+
+def test_assert_all_discovery_candidates_stable_reports_incremental_logs(caplog):
+    class DiscoveryCheck:
+        @classmethod
+        def generate_configs(cls, service):
+            yield {'init_config': {}, 'instances': [{'url': f'http://{service.host}:8080/metrics'}]}
+            yield {'init_config': {}, 'instances': [{'url': f'http://{service.host}:9090/metrics'}]}
+
+    logs = iter(
+        [
+            _docker_result(stdout='ready\n'),
+            _docker_result(stdout='ready\nfirst\n'),
+            _docker_result(stdout='ready\nfirst\nsecond\n'),
+        ]
+    )
+
+    def fake_run_command(command, **kwargs):
+        if command[:2] == ['docker', 'compose']:
+            return _docker_result(stdout='container-id\n')
+        if command[:2] == ['docker', 'inspect']:
+            return _docker_result(stdout=json.dumps([_container_inspect()]))
+        if command[:2] == ['docker', 'logs']:
+            return next(logs)
+        raise AssertionError(f'Unexpected command: {command}')
+
+    with mock.patch('datadog_checks.dev.docker.run_command', side_effect=fake_run_command):
+        with caplog.at_level(logging.DEBUG):
+            assert_all_discovery_candidates_stable(
+                mock.Mock(),
+                DiscoveryCheck,
+                '/tmp/docker-compose.yml',
+                'service',
+            )
+
+    assert [record.message for record in caplog.records if record.message.startswith('New log line:')] == [
+        'New log line: first',
+        'New log line: second',
+    ]
+
+
+def test_assert_all_discovery_candidates_stable_detects_restarts():
+    class DiscoveryCheck:
+        @classmethod
+        def generate_configs(cls, service):
+            yield {'init_config': {}, 'instances': [{'url': f'http://{service.host}:8080/metrics'}]}
+
+    inspect_results = iter(
+        [
+            _container_inspect(restart_count=0),
+            _container_inspect(restart_count=1),
+        ]
+    )
+
+    def fake_run_command(command, **kwargs):
+        if command[:2] == ['docker', 'compose']:
+            return _docker_result(stdout='container-id\n')
+        if command[:2] == ['docker', 'inspect']:
+            return _docker_result(stdout=json.dumps([next(inspect_results)]))
+        if command[:2] == ['docker', 'logs']:
+            return _docker_result(stdout='ready\n')
+        raise AssertionError(f'Unexpected command: {command}')
+
+    with mock.patch('datadog_checks.dev.docker.run_command', side_effect=fake_run_command):
+        with pytest.raises(AssertionError, match='restart count changed'):
+            assert_all_discovery_candidates_stable(
+                mock.Mock(),
+                DiscoveryCheck,
+                '/tmp/docker-compose.yml',
+                'service',
+            )
+
+
+def test_assert_all_discovery_candidates_stable_detects_new_crash_logs():
+    class DiscoveryCheck:
+        @classmethod
+        def generate_configs(cls, service):
+            yield {'init_config': {}, 'instances': [{'url': f'http://{service.host}:8080/metrics'}]}
+
+    logs = iter(
+        [
+            _docker_result(stdout='ready\n'),
+            _docker_result(stdout='ready\npanic: boom\n'),
+        ]
+    )
+
+    def fake_run_command(command, **kwargs):
+        if command[:2] == ['docker', 'compose']:
+            return _docker_result(stdout='container-id\n')
+        if command[:2] == ['docker', 'inspect']:
+            return _docker_result(stdout=json.dumps([_container_inspect()]))
+        if command[:2] == ['docker', 'logs']:
+            return next(logs)
+        raise AssertionError(f'Unexpected command: {command}')
+
+    with mock.patch('datadog_checks.dev.docker.run_command', side_effect=fake_run_command):
+        with pytest.raises(AssertionError, match='Container logs matched'):
+            assert_all_discovery_candidates_stable(
+                mock.Mock(),
+                DiscoveryCheck,
+                '/tmp/docker-compose.yml',
+                'service',
+            )

--- a/krakend/tests/test_e2e.py
+++ b/krakend/tests/test_e2e.py
@@ -3,7 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
-from datadog_checks.dev.docker import get_docker_hostname
+from datadog_checks.dev.docker import assert_all_discovery_candidates_stable, get_docker_hostname
+from datadog_checks.krakend import KrakendCheck
 from tests.helpers import get_metrics_from_metadata
 from tests.types import InstanceBuilder
 
@@ -40,3 +41,8 @@ def test_e2e_discovery(dd_agent_check_discovery, is_lab):
         check_submission_type=True,
         check_symmetric_inclusion=True,
     )
+
+
+@pytest.mark.e2e
+def test_e2e_discovery_all_candidates(dd_agent_check):
+    assert_all_discovery_candidates_stable(dd_agent_check, KrakendCheck)


### PR DESCRIPTION
### What does this PR do?

To ensure that there is no risk with probing all the ports of the container for
configuration discovery, add a test which instantiates the integration which
each of the generated configurations in turn and checks that the container
doesn't crash and the container logs don't have any obvious crashes.

The test is mostly generic; it is hooked up to krakend in this PR since that's the only
one with configuration discovery support at the moment.

The logic for detecting "bad" effects is best-effort (it's possible we may have
to tweak the log patterns in the future for example), but the test also allows
the container logs for the different candidates to be easily manually inspected
during development:

For example, for krakend:

```
$ ddev env test --base --new-env krakend py3.13-2.10 -- -k test_e2e_discovery_all_candidates -rP --log-level=DEBUG
...
______________________ test_e2e_discovery_all_candidates _______________________
------------------------------ Captured log call -------------------------------
DEBUG    root:docker.py:92 Probing candidate #1: {'init_config': {}, 'instances': [{'openmetrics_endpoint': 'http://172.17.129.3:9090/metrics'}]}
DEBUG    root:docker.py:92 Probing candidate #2: {'init_config': {}, 'instances': [{'openmetrics_endpoint': 'http://172.17.129.3:8080/metrics'}]}
DEBUG    root:docker.py:96 Error probing candidate #2: {'init_config': {}, 'instances': [{'openmetrics_endpoint': 'http://172.17.129.3:8080/metrics'}]}
DEBUG    root:docker.py:106 New log line: [GIN] 2026/06/18 - 10:26:34 | 404 |        2.83µs |    172.17.129.1 | GET      "/metrics"
DEBUG    root:docker.py:106 New log line: [GIN] 2026/06/18 - 10:26:35 | 404 |       3.295µs |    172.17.129.1 | GET      "/metrics"
DEBUG    root:docker.py:92 Probing candidate #3: {'init_config': {}, 'instances': [{'openmetrics_endpoint': 'http://172.17.129.3:8090/metrics'}]}
DEBUG    root:docker.py:96 Error probing candidate #3: {'init_config': {}, 'instances': [{'openmetrics_endpoint': 'http://172.17.129.3:8090/metrics'}]}
```

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-501
https://datadoghq.atlassian.net/wiki/spaces/DSCVR/pages/6671862234/#Probing-causes-problems

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
