### PR TITLE
Add group_per_user_services option to windows_service

### DIFF
--- a/windows_service/assets/configuration/spec.yaml
+++ b/windows_service/assets/configuration/spec.yaml
@@ -82,4 +82,18 @@ files:
             value:
               type: boolean
               example: false
+          - name: group_per_user_services
+            description: |
+              Whether or not to group Windows per-user services under their template name.
+
+              Per-user services are instantiated per user logon session and named
+              `<service name>_<LUID>` (for example `OneSyncSvc_443f50`), which creates high
+              cardinality in the `windows_service` and `display_name` tags. When enabled, the
+              LUID suffix is stripped so all instances of a per-user service report under the
+              same template name.
+              See https://learn.microsoft.com/en-us/windows/application-management/per-user-services-in-windows
+            fleet_configurable: true
+            value:
+              type: boolean
+              example: false
           - template: instances/default

--- a/windows_service/changelog.d/24087.added
+++ b/windows_service/changelog.d/24087.added
@@ -1,0 +1,1 @@
+Add the `group_per_user_services` option to report Windows per-user service instances under their template name, reducing `windows_service` tag cardinality.

--- a/windows_service/datadog_checks/windows_service/config_models/defaults.py
+++ b/windows_service/datadog_checks/windows_service/config_models/defaults.py
@@ -28,6 +28,10 @@ def instance_enable_legacy_tags_normalization():
     return True
 
 
+def instance_group_per_user_services():
+    return False
+
+
 def instance_min_collection_interval():
     return 15
 

--- a/windows_service/datadog_checks/windows_service/config_models/instance.py
+++ b/windows_service/datadog_checks/windows_service/config_models/instance.py
@@ -40,6 +40,7 @@ class InstanceConfig(BaseModel):
     disable_legacy_service_tag: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
     enable_legacy_tags_normalization: Optional[bool] = None
+    group_per_user_services: Optional[bool] = None
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None
     service: Optional[str] = None

--- a/windows_service/datadog_checks/windows_service/data/conf.yaml.example
+++ b/windows_service/datadog_checks/windows_service/data/conf.yaml.example
@@ -73,6 +73,18 @@ instances:
     #
     # collect_display_name_as_tag: false
 
+    ## @param group_per_user_services - boolean - optional - default: false
+    ## Whether or not to group Windows per-user services under their template name.
+    ##
+    ## Per-user services are instantiated per user logon session and named
+    ## `<service name>_<LUID>` (for example `OneSyncSvc_443f50`), which creates high
+    ## cardinality in the `windows_service` and `display_name` tags. When enabled, the
+    ## LUID suffix is stripped so all instances of a per-user service report under the
+    ## same template name.
+    ## See https://learn.microsoft.com/en-us/windows/application-management/per-user-services-in-windows
+    #
+    # group_per_user_services: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -22,9 +22,9 @@ SERVICE_USERSERVICE_INSTANCE = 0x80
 USER_SERVICE_LUID_SUFFIX_RE = re.compile(r'_[0-9A-Fa-f]+$')
 
 
-def _group_per_user_service_name(name, service_type):
+def _group_per_user_service_name(name: str, service_type: int) -> str:
     """Strip the per-user LUID suffix so instances group under their template name."""
-    if service_type & SERVICE_USERSERVICE_INSTANCE and USER_SERVICE_LUID_SUFFIX_RE.search(name):
+    if service_type & SERVICE_USERSERVICE_INSTANCE:
         return USER_SERVICE_LUID_SUFFIX_RE.sub('', name)
     return name
 
@@ -327,8 +327,13 @@ class WindowsService(AgentCheck):
             service_view = ServiceView(scm_handle, service_name)
 
             # Names used for tags; for per-user services these collapse the per-session LUID suffix
-            # so all instances report under their template name. The full instance name is kept for
-            # service handles and the restart PID cache.
+            # so all instances report under their template name.
+            # The full instance name is kept for service handles and the restart PID cache.
+            # Multiple instances thus collapse into a single series; if they are in different states
+            # the reported state reflects whichever instance is emitted last.
+            # We generally expect multiple per-user instances per host to be rare (terminal service
+            # sessions only); the main win is grouping the windows_service tag across hosts (and thus
+            # service checks) for easier monitoring.
             reported_name = service_name
             reported_display_name = display_name
             if group_per_user_services:

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -16,6 +16,18 @@ SERVICE_PATTERN_FLAGS = re.IGNORECASE
 
 SERVICE_CONFIG_TRIGGER_INFO = 8
 
+# Per-user service instance flag (SERVICE_USERSERVICE_INSTANCE in winsvc.h). Set on the
+# per-session instances of a per-user service (named <template>_<LUID>), not on the template.
+SERVICE_USERSERVICE_INSTANCE = 0x80
+USER_SERVICE_LUID_SUFFIX_RE = re.compile(r'_[0-9A-Fa-f]+$')
+
+
+def _group_per_user_service_name(name, service_type):
+    """Strip the per-user LUID suffix so instances group under their template name."""
+    if service_type & SERVICE_USERSERVICE_INSTANCE and USER_SERVICE_LUID_SUFFIX_RE.search(name):
+        return USER_SERVICE_LUID_SUFFIX_RE.sub('', name)
+    return name
+
 
 def QueryServiceConfig2W(*args):
     """
@@ -303,13 +315,25 @@ class WindowsService(AgentCheck):
         # See test_name_regex_order()
         service_filters = sorted(service_filters, reverse=True, key=lambda x: len(x.name or ""))
 
+        group_per_user_services = instance.get('group_per_user_services', False)
+
         for service_status_process_enum in service_status_process_enums:
             service_name = service_status_process_enum["ServiceName"]
             display_name = service_status_process_enum["DisplayName"]
             state = service_status_process_enum["CurrentState"]
             service_pid = service_status_process_enum["ProcessId"]
+            service_type = service_status_process_enum.get("ServiceType", 0)
 
             service_view = ServiceView(scm_handle, service_name)
+
+            # Names used for tags; for per-user services these collapse the per-session LUID suffix
+            # so all instances report under their template name. The full instance name is kept for
+            # service handles and the restart PID cache.
+            reported_name = service_name
+            reported_display_name = display_name
+            if group_per_user_services:
+                reported_name = _group_per_user_service_name(service_name, service_type)
+                reported_display_name = _group_per_user_service_name(display_name, service_type)
 
             if 'ALL' not in services:
                 for service_filter in service_filters:
@@ -338,11 +362,11 @@ class WindowsService(AgentCheck):
             status = self.STATE_TO_STATUS.get(state, self.UNKNOWN)
             state_string = self.STATE_TO_STRING.get(state, self.UNKNOWN_LITERAL)
 
-            tags = ['windows_service:{}'.format(service_name), 'windows_service_state:{}'.format(state_string)]
+            tags = ['windows_service:{}'.format(reported_name), 'windows_service_state:{}'.format(state_string)]
             tags.extend(custom_tags)
 
             if instance.get('collect_display_name_as_tag', False):
-                tags.append('display_name:{}'.format(display_name))
+                tags.append('display_name:{}'.format(reported_display_name))
 
             if instance.get('windows_service_startup_type_tag', False):
                 try:
@@ -355,7 +379,7 @@ class WindowsService(AgentCheck):
 
             if not instance.get('disable_legacy_service_tag', False):
                 self._log_deprecation('service_tag', 'windows_service')
-                tags.append('service:{}'.format(service_name))
+                tags.append('service:{}'.format(reported_name))
 
             self.service_check(self.SERVICE_CHECK_NAME, status, tags=tags)
             self.log.debug('service state for %s %s', service_name, status)

--- a/windows_service/tests/common.py
+++ b/windows_service/tests/common.py
@@ -44,6 +44,12 @@ INSTANCE_PREFIX_MATCH = {
     ],
     'disable_legacy_service_tag': True,
 }
+INSTANCE_GROUP_PER_USER_SERVICES = {
+    'services': ['ALL'],
+    'group_per_user_services': True,
+    'collect_display_name_as_tag': True,
+    'disable_legacy_service_tag': True,
+}
 INSTANCE_TRIGGER_START = {
     'services': [
         {'name': 'eventlog', 'startup_type': 'automatic', 'trigger_start': False},

--- a/windows_service/tests/conftest.py
+++ b/windows_service/tests/conftest.py
@@ -66,5 +66,10 @@ def instance_trigger_start():
 
 
 @pytest.fixture
+def instance_group_per_user_services():
+    return deepcopy(common.INSTANCE_GROUP_PER_USER_SERVICES)
+
+
+@pytest.fixture
 def instance_name_regex_prefix():
     return deepcopy(common.INSTANCE_PREFIX_MATCH)

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -389,6 +389,112 @@ def test_service_restart_detection(aggregator, check, instance_basic):
     )
 
 
+# Per-user service instances carry SERVICE_USER_OWN_PROCESS (0x50) plus the
+# SERVICE_USERSERVICE_INSTANCE flag (0x80). Templates (not enumerated) lack the 0x80 bit.
+USER_SERVICE_INSTANCE_TYPE = 0x10 | 0x40 | 0x80
+WIN32_OWN_PROCESS_TYPE = 0x10
+
+
+def _per_user_mock_services():
+    return [
+        {
+            'ServiceName': 'OneSyncSvc_443f50',
+            'DisplayName': 'Sync Host_443f50',
+            'CurrentState': win32service.SERVICE_RUNNING,
+            'ProcessId': 1234,
+            'ServiceType': USER_SERVICE_INSTANCE_TYPE,
+        },
+        {
+            'ServiceName': 'OneSyncSvc_18f113',
+            'DisplayName': 'Sync Host_18f113',
+            'CurrentState': win32service.SERVICE_RUNNING,
+            'ProcessId': 5678,
+            'ServiceType': USER_SERVICE_INSTANCE_TYPE,
+        },
+        {
+            'ServiceName': 'Dnscache',
+            'DisplayName': 'DNS Client',
+            'CurrentState': win32service.SERVICE_RUNNING,
+            'ProcessId': 9999,
+            'ServiceType': WIN32_OWN_PROCESS_TYPE,
+        },
+    ]
+
+
+def test_group_per_user_services(aggregator, check, instance_group_per_user_services):
+    c = check(instance_group_per_user_services)
+
+    with patch('win32service.EnumServicesStatusEx', return_value=_per_user_mock_services()):
+        c.check(instance_group_per_user_services)
+
+    # Both per-user instances collapse to the template name, so the grouped tag is submitted twice
+    grouped_tags = ['windows_service:OneSyncSvc', 'windows_service_state:running', 'display_name:Sync Host']
+    aggregator.assert_service_check(c.SERVICE_CHECK_NAME, status=c.OK, tags=grouped_tags, count=2)
+    aggregator.assert_metric('windows_service.state', value=1, tags=grouped_tags, count=2)
+
+    # The LUID-suffixed names must no longer be emitted
+    for suffixed in ('OneSyncSvc_443f50', 'OneSyncSvc_18f113'):
+        aggregator.assert_service_check(
+            c.SERVICE_CHECK_NAME,
+            status=c.OK,
+            tags=[f'windows_service:{suffixed}', 'windows_service_state:running'],
+            count=0,
+        )
+
+    # Non per-user services are untouched
+    dnscache_tags = ['windows_service:Dnscache', 'windows_service_state:running', 'display_name:DNS Client']
+    aggregator.assert_service_check(c.SERVICE_CHECK_NAME, status=c.OK, tags=dnscache_tags, count=1)
+
+
+def test_group_per_user_services_disabled(aggregator, check, instance_group_per_user_services):
+    instance_group_per_user_services['group_per_user_services'] = False
+    c = check(instance_group_per_user_services)
+
+    with patch('win32service.EnumServicesStatusEx', return_value=_per_user_mock_services()):
+        c.check(instance_group_per_user_services)
+
+    # Without grouping each instance keeps its full LUID-suffixed name
+    for suffix in ('443f50', '18f113'):
+        aggregator.assert_service_check(
+            c.SERVICE_CHECK_NAME,
+            status=c.OK,
+            tags=[
+                f'windows_service:OneSyncSvc_{suffix}',
+                'windows_service_state:running',
+                f'display_name:Sync Host_{suffix}',
+            ],
+            count=1,
+        )
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME, status=c.OK, tags=['windows_service:OneSyncSvc', 'windows_service_state:running'], count=0
+    )
+
+
+def test_group_per_user_services_ignores_non_user_service(aggregator, check, instance_group_per_user_services):
+    # A regular service whose name happens to end in _<hex> must not be stripped: it lacks the
+    # SERVICE_USERSERVICE_INSTANCE flag.
+    mock_services = [
+        {
+            'ServiceName': 'MyService_abc123',
+            'DisplayName': 'My Service_abc123',
+            'CurrentState': win32service.SERVICE_RUNNING,
+            'ProcessId': 4242,
+            'ServiceType': WIN32_OWN_PROCESS_TYPE,
+        },
+    ]
+    c = check(instance_group_per_user_services)
+
+    with patch('win32service.EnumServicesStatusEx', return_value=mock_services):
+        c.check(instance_group_per_user_services)
+
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME,
+        status=c.OK,
+        tags=['windows_service:MyService_abc123', 'windows_service_state:running', 'display_name:My Service_abc123'],
+        count=1,
+    )
+
+
 @pytest.mark.e2e
 def test_basic_e2e(dd_agent_check, check, instance_basic):
     aggregator = dd_agent_check(instance_basic)

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -427,23 +427,16 @@ def test_group_per_user_services(aggregator, check, instance_group_per_user_serv
     with patch('win32service.EnumServicesStatusEx', return_value=_per_user_mock_services()):
         c.check(instance_group_per_user_services)
 
-    # Both per-user instances collapse to the template name, so the grouped tag is submitted twice
-    grouped_tags = ['windows_service:OneSyncSvc', 'windows_service_state:running', 'display_name:Sync Host']
-    aggregator.assert_service_check(c.SERVICE_CHECK_NAME, status=c.OK, tags=grouped_tags, count=2)
-    aggregator.assert_metric('windows_service.state', value=1, tags=grouped_tags, count=2)
-
-    # The LUID-suffixed names must no longer be emitted
-    for suffixed in ('OneSyncSvc_443f50', 'OneSyncSvc_18f113'):
-        aggregator.assert_service_check(
-            c.SERVICE_CHECK_NAME,
-            status=c.OK,
-            tags=[f'windows_service:{suffixed}', 'windows_service_state:running'],
-            count=0,
-        )
-
-    # Non per-user services are untouched
-    dnscache_tags = ['windows_service:Dnscache', 'windows_service_state:running', 'display_name:DNS Client']
-    aggregator.assert_service_check(c.SERVICE_CHECK_NAME, status=c.OK, tags=dnscache_tags, count=1)
+    services = [
+        # Both per-user instances collapse to the template name, so the grouped tag is submitted twice
+        ServiceAssertion('OneSyncSvc', win32service.SERVICE_RUNNING, extra_tags=['display_name:Sync Host'], count=2),
+        # The LUID-suffixed names must no longer be emitted
+        ServiceAssertion('OneSyncSvc_443f50', win32service.SERVICE_RUNNING, count=0),
+        ServiceAssertion('OneSyncSvc_18f113', win32service.SERVICE_RUNNING, count=0),
+        # Non per-user services are untouched
+        ServiceAssertion('Dnscache', win32service.SERVICE_RUNNING, extra_tags=['display_name:DNS Client']),
+    ]
+    assert_service_check_and_metrics(aggregator, services)
 
 
 def test_group_per_user_services_disabled(aggregator, check, instance_group_per_user_services):
@@ -453,21 +446,18 @@ def test_group_per_user_services_disabled(aggregator, check, instance_group_per_
     with patch('win32service.EnumServicesStatusEx', return_value=_per_user_mock_services()):
         c.check(instance_group_per_user_services)
 
-    # Without grouping each instance keeps its full LUID-suffixed name
-    for suffix in ('443f50', '18f113'):
-        aggregator.assert_service_check(
-            c.SERVICE_CHECK_NAME,
-            status=c.OK,
-            tags=[
-                f'windows_service:OneSyncSvc_{suffix}',
-                'windows_service_state:running',
-                f'display_name:Sync Host_{suffix}',
-            ],
-            count=1,
-        )
-    aggregator.assert_service_check(
-        c.SERVICE_CHECK_NAME, status=c.OK, tags=['windows_service:OneSyncSvc', 'windows_service_state:running'], count=0
-    )
+    services = [
+        # Without grouping each instance keeps its full LUID-suffixed name
+        ServiceAssertion(
+            'OneSyncSvc_443f50', win32service.SERVICE_RUNNING, extra_tags=['display_name:Sync Host_443f50']
+        ),
+        ServiceAssertion(
+            'OneSyncSvc_18f113', win32service.SERVICE_RUNNING, extra_tags=['display_name:Sync Host_18f113']
+        ),
+        # The grouped template name is not emitted
+        ServiceAssertion('OneSyncSvc', win32service.SERVICE_RUNNING, count=0),
+    ]
+    assert_service_check_and_metrics(aggregator, services)
 
 
 def test_group_per_user_services_ignores_non_user_service(aggregator, check, instance_group_per_user_services):
@@ -487,12 +477,12 @@ def test_group_per_user_services_ignores_non_user_service(aggregator, check, ins
     with patch('win32service.EnumServicesStatusEx', return_value=mock_services):
         c.check(instance_group_per_user_services)
 
-    aggregator.assert_service_check(
-        c.SERVICE_CHECK_NAME,
-        status=c.OK,
-        tags=['windows_service:MyService_abc123', 'windows_service_state:running', 'display_name:My Service_abc123'],
-        count=1,
-    )
+    services = [
+        ServiceAssertion(
+            'MyService_abc123', win32service.SERVICE_RUNNING, extra_tags=['display_name:My Service_abc123']
+        ),
+    ]
+    assert_service_check_and_metrics(aggregator, services)
 
 
 def test_group_per_user_services_with_name_filter(aggregator, check, instance_group_per_user_services):
@@ -505,23 +495,14 @@ def test_group_per_user_services_with_name_filter(aggregator, check, instance_gr
     with patch('win32service.EnumServicesStatusEx', return_value=_per_user_mock_services()):
         c.check(instance_group_per_user_services)
 
-    grouped_tags = ['windows_service:OneSyncSvc', 'windows_service_state:running', 'display_name:Sync Host']
-    aggregator.assert_service_check(c.SERVICE_CHECK_NAME, status=c.OK, tags=grouped_tags, count=2)
-
-    # The grouped template name must not be reported UNKNOWN by the services_unseen path
-    aggregator.assert_service_check(
-        c.SERVICE_CHECK_NAME,
-        status=c.UNKNOWN,
-        tags=['windows_service:OneSyncSvc', 'windows_service_state:unknown'],
-        count=0,
-    )
-    # The non-matching service is not reported
-    aggregator.assert_service_check(
-        c.SERVICE_CHECK_NAME,
-        status=c.OK,
-        tags=['windows_service:Dnscache', 'windows_service_state:running', 'display_name:DNS Client'],
-        count=0,
-    )
+    services = [
+        ServiceAssertion('OneSyncSvc', win32service.SERVICE_RUNNING, extra_tags=['display_name:Sync Host'], count=2),
+        # The grouped template name must not be reported UNKNOWN by the services_unseen path
+        ServiceAssertion('OneSyncSvc', -1, count=0),
+        # The non-matching service is not reported
+        ServiceAssertion('Dnscache', win32service.SERVICE_RUNNING, count=0),
+    ]
+    assert_service_check_and_metrics(aggregator, services)
 
 
 @pytest.mark.e2e

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -495,6 +495,35 @@ def test_group_per_user_services_ignores_non_user_service(aggregator, check, ins
     )
 
 
+def test_group_per_user_services_with_name_filter(aggregator, check, instance_group_per_user_services):
+    # Grouping must also apply when services are selected by a name filter (not just ALL). The
+    # prefix regex matches the full LUID-suffixed instance names, but the emitted tag is grouped.
+    instance_group_per_user_services['services'] = ['OneSyncSvc']
+
+    c = check(instance_group_per_user_services)
+
+    with patch('win32service.EnumServicesStatusEx', return_value=_per_user_mock_services()):
+        c.check(instance_group_per_user_services)
+
+    grouped_tags = ['windows_service:OneSyncSvc', 'windows_service_state:running', 'display_name:Sync Host']
+    aggregator.assert_service_check(c.SERVICE_CHECK_NAME, status=c.OK, tags=grouped_tags, count=2)
+
+    # The grouped template name must not be reported UNKNOWN by the services_unseen path
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME,
+        status=c.UNKNOWN,
+        tags=['windows_service:OneSyncSvc', 'windows_service_state:unknown'],
+        count=0,
+    )
+    # The non-matching service is not reported
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME,
+        status=c.OK,
+        tags=['windows_service:Dnscache', 'windows_service_state:running', 'display_name:DNS Client'],
+        count=0,
+    )
+
+
 @pytest.mark.e2e
 def test_basic_e2e(dd_agent_check, check, instance_basic):
     aggregator = dd_agent_check(instance_basic)


### PR DESCRIPTION
### What does this PR do?
Adds an opt-in `group_per_user_services` instance option (default `false`) to the `windows_service` check. When enabled, Windows per-user service instances — named `<template>_<LUID>` (e.g. `OneSyncSvc_443f50`) — are reported under their template name in the `windows_service`, `display_name`, and legacy `service` tags. Detection gates on the `SERVICE_USERSERVICE_INSTANCE` service-type flag plus a trailing `_<LUID>` suffix, so regular services are never rewritten.

### Motivation
The OS derives a unique LUID for each user logon session, and that LUID is appended to every per-user service name. Because the LUID differs **per host** (and per session), a single per-user service like `OneSyncSvc` becomes a distinct `windows_service` tag value on every host reporting it. Across a fleet, that is up to one unique tag value per host × ~15-20 per-user services, which explodes `windows_service`/`display_name` tag cardinality in the backend — most visibly with `services: [ALL]`. Grouping collapses all of those into a single template-named series org-wide.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
