### PR TITLE
Add per_user services filter to windows_service

### DIFF
--- a/windows_service/assets/configuration/spec.yaml
+++ b/windows_service/assets/configuration/spec.yaml
@@ -24,6 +24,14 @@ files:
                 - true
                 - false
 
+              Services can also be selectively monitored by whether they are Windows per-user services,
+              which are instantiated per user logon session and named `<service name>_<LUID>`
+              (for example `OneSyncSvc_443f50`). The possible values for `per_user` are:
+                - true
+                - false
+              To exclude per-user services from collection, monitor only non-per-user services with
+              `per_user: false`.
+
               If any service is set to `ALL`, all services registered with the SCM will be monitored, and
               all other patterns provided in this instance will be ignored.
 
@@ -45,6 +53,7 @@ files:
                 - name: <SERVICE_NAME_2>
                 - startup_type: automatic
                   trigger_start: false
+                - per_user: false
           - name: disable_legacy_service_tag
             description: |
               Whether or not to stop submitting the tag `service` that has been renamed

--- a/windows_service/changelog.d/24088.added
+++ b/windows_service/changelog.d/24088.added
@@ -1,0 +1,1 @@
+Add a `per_user` services filter criterion to select or exclude Windows per-user services (use `per_user: false` to exclude them from collection).

--- a/windows_service/datadog_checks/windows_service/data/conf.yaml.example
+++ b/windows_service/datadog_checks/windows_service/data/conf.yaml.example
@@ -27,6 +27,14 @@ instances:
     ##   - true
     ##   - false
     ##
+    ## Services can also be selectively monitored by whether they are Windows per-user services,
+    ## which are instantiated per user logon session and named `<service name>_<LUID>`
+    ## (for example `OneSyncSvc_443f50`). The possible values for `per_user` are:
+    ##   - true
+    ##   - false
+    ## To exclude per-user services from collection, monitor only non-per-user services with
+    ## `per_user: false`.
+    ##
     ## If any service is set to `ALL`, all services registered with the SCM will be monitored, and
     ## all other patterns provided in this instance will be ignored.
     ##
@@ -41,6 +49,7 @@ instances:
       - name: <SERVICE_NAME_2>
       - startup_type: automatic
         trigger_start: false
+      - per_user: false
 
     ## @param disable_legacy_service_tag - boolean - optional - default: false
     ## Whether or not to stop submitting the tag `service` that has been renamed

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -63,12 +63,12 @@ class ServiceFilter(object):
         except re.error as e:
             raise Exception("Regular expression syntax error in '{}': {}".format(pattern, str(e))) from None
 
-    def match(self, service_view, service_type):
+    def match(self, service_view):
         if self.name is not None:
             if not self._name_re.match(service_view.name):
                 return False
         if self.per_user is not None:
-            if self.per_user != _is_per_user_service(service_type):
+            if self.per_user != _is_per_user_service(service_view.service_type):
                 return False
         if self.startup_type is not None:
             if self.startup_type.lower() != service_view.startup_type_string().lower():
@@ -142,9 +142,11 @@ class ServiceView(object):
     STARTUP_TYPE_UNKNOWN = "unknown"
     DISPLAY_NAME_UNKNOWN = "Not_Found"
 
-    def __init__(self, scm_handle, name):
+    def __init__(self, scm_handle, name, service_type=0):
         self.scm_handle = scm_handle
         self.name = name
+        # Provided by EnumServicesStatusEx; carries the SERVICE_USERSERVICE_INSTANCE flag.
+        self.service_type = service_type
 
         self._hSvc = None
         self._startup_type = None
@@ -344,7 +346,7 @@ class WindowsService(AgentCheck):
             service_pid = service_status_process_enum["ProcessId"]
             service_type = service_status_process_enum.get("ServiceType", 0)
 
-            service_view = ServiceView(scm_handle, service_name)
+            service_view = ServiceView(scm_handle, service_name, service_type)
 
             # Names used for tags; for per-user services these collapse the per-session LUID suffix
             # so all instances report under their template name.
@@ -363,7 +365,7 @@ class WindowsService(AgentCheck):
             if 'ALL' not in services:
                 for service_filter in service_filters:
                     try:
-                        if service_filter.match(service_view, service_type):
+                        if service_filter.match(service_view):
                             self.log.debug('Matched %s with %s', service_view, service_filter)
                             services_unseen.discard(service_filter.name)
                             break

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -22,9 +22,14 @@ SERVICE_USERSERVICE_INSTANCE = 0x80
 USER_SERVICE_LUID_SUFFIX_RE = re.compile(r'_[0-9A-Fa-f]+$')
 
 
+def _is_per_user_service(service_type: int) -> bool:
+    """True for per-user service instances (named <template>_<LUID>)."""
+    return bool(service_type & SERVICE_USERSERVICE_INSTANCE)
+
+
 def _group_per_user_service_name(name: str, service_type: int) -> str:
     """Strip the per-user LUID suffix so instances group under their template name."""
-    if service_type & SERVICE_USERSERVICE_INSTANCE:
+    if _is_per_user_service(service_type):
         return USER_SERVICE_LUID_SUFFIX_RE.sub('', name)
     return name
 
@@ -42,10 +47,11 @@ class TriggerInfo(ctypes.Structure):
 
 
 class ServiceFilter(object):
-    def __init__(self, name=None, startup_type=None, trigger_start=None):
+    def __init__(self, name=None, startup_type=None, trigger_start=None, per_user=None):
         self.name = name
         self.startup_type = startup_type
         self.trigger_start = trigger_start
+        self.per_user = per_user
 
         self._init_patterns()
 
@@ -57,9 +63,12 @@ class ServiceFilter(object):
         except re.error as e:
             raise Exception("Regular expression syntax error in '{}': {}".format(pattern, str(e))) from None
 
-    def match(self, service_view):
+    def match(self, service_view, service_type):
         if self.name is not None:
             if not self._name_re.match(service_view.name):
+                return False
+        if self.per_user is not None:
+            if self.per_user != _is_per_user_service(service_type):
                 return False
         if self.startup_type is not None:
             if self.startup_type.lower() != service_view.startup_type_string().lower():
@@ -79,6 +88,8 @@ class ServiceFilter(object):
             vals.append('startup_type={}'.format(self.startup_type))
         if self.trigger_start is not None:
             vals.append('trigger_start={}'.format(self.trigger_start))
+        if self.per_user is not None:
+            vals.append('per_user={}'.format(self.per_user))
         # Example:
         #   - ServiceFilter(name=EventLog)
         #   - ServiceFilter(startup_type=automatic)
@@ -113,7 +124,8 @@ class ServiceFilter(object):
                 name = cls._wmi_compat_name(name)
             startup_type = item.get('startup_type', None)
             trigger_start = item.get('trigger_start', None)
-            obj = cls(name=name, startup_type=startup_type, trigger_start=trigger_start)
+            per_user = item.get('per_user', None)
+            obj = cls(name=name, startup_type=startup_type, trigger_start=trigger_start, per_user=per_user)
         else:
             raise Exception("Invalid type '{}' for service".format(type(item).__name__))
         return obj
@@ -317,6 +329,14 @@ class WindowsService(AgentCheck):
 
         group_per_user_services = instance.get('group_per_user_services', False)
 
+        # Exclusion (per_user: false) takes precedence over grouping; excluded services are never
+        # collected, so they can't be grouped.
+        if group_per_user_services and any(f.per_user is False for f in service_filters):
+            self.warning(
+                "group_per_user_services is enabled but a services filter excludes per-user services "
+                "(per_user: false); excluded services are not collected and will not be grouped."
+            )
+
         for service_status_process_enum in service_status_process_enums:
             service_name = service_status_process_enum["ServiceName"]
             display_name = service_status_process_enum["DisplayName"]
@@ -343,7 +363,7 @@ class WindowsService(AgentCheck):
             if 'ALL' not in services:
                 for service_filter in service_filters:
                     try:
-                        if service_filter.match(service_view):
+                        if service_filter.match(service_view, service_type):
                             self.log.debug('Matched %s with %s', service_view, service_filter)
                             services_unseen.discard(service_filter.name)
                             break

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -142,22 +142,23 @@ class ServiceView(object):
     STARTUP_TYPE_UNKNOWN = "unknown"
     DISPLAY_NAME_UNKNOWN = "Not_Found"
 
-    def __init__(self, scm_handle, name, service_type=0):
+    def __init__(self, scm_handle, name, service_type=None):
         self.scm_handle = scm_handle
         self.name = name
-        # Provided by EnumServicesStatusEx; carries the SERVICE_USERSERVICE_INSTANCE flag.
-        self.service_type = service_type
 
         self._hSvc = None
         self._startup_type = None
         self._service_config = None
         self._is_delayed_auto = None
         self._trigger_count = None
+        self._service_type = service_type
 
     def __str__(self):
         vals = []
         if self.name is not None:
             vals.append('name={}'.format(self.name))
+        if self._service_type is not None:
+            vals.append('service_type=0x{:X}'.format(self._service_type))
         if self._startup_type is not None:
             vals.append('startup_type={}'.format(self.startup_type_string()))
         if self._trigger_count is not None:
@@ -180,6 +181,12 @@ class ServiceView(object):
         if self._service_config is None:
             self._service_config = win32service.QueryServiceConfig(self.hSvc)
         return self._service_config
+
+    @property
+    def service_type(self):
+        if self._service_type is None:
+            self._service_type = self.service_config[0]
+        return self._service_type
 
     @property
     def startup_type(self):

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -513,18 +513,12 @@ def test_per_user_false_excludes_per_user_services(aggregator, check):
     with patch('win32service.EnumServicesStatusEx', return_value=_per_user_mock_services()):
         c.check(instance)
 
-    aggregator.assert_service_check(
-        c.SERVICE_CHECK_NAME,
-        status=c.OK,
-        tags=['windows_service:Dnscache', 'windows_service_state:running'],
-        count=1,
-    )
-    for suffixed in ('OneSyncSvc_443f50', 'OneSyncSvc_18f113'):
-        aggregator.assert_service_check(
-            c.SERVICE_CHECK_NAME,
-            tags=[f'windows_service:{suffixed}', 'windows_service_state:running'],
-            count=0,
-        )
+    services = [
+        ServiceAssertion('Dnscache', win32service.SERVICE_RUNNING),
+        ServiceAssertion('OneSyncSvc_443f50', win32service.SERVICE_RUNNING, count=0),
+        ServiceAssertion('OneSyncSvc_18f113', win32service.SERVICE_RUNNING, count=0),
+    ]
+    assert_service_check_and_metrics(aggregator, services)
 
 
 def test_per_user_true_collects_only_per_user_services(aggregator, check):
@@ -534,18 +528,12 @@ def test_per_user_true_collects_only_per_user_services(aggregator, check):
     with patch('win32service.EnumServicesStatusEx', return_value=_per_user_mock_services()):
         c.check(instance)
 
-    for suffixed in ('OneSyncSvc_443f50', 'OneSyncSvc_18f113'):
-        aggregator.assert_service_check(
-            c.SERVICE_CHECK_NAME,
-            status=c.OK,
-            tags=[f'windows_service:{suffixed}', 'windows_service_state:running'],
-            count=1,
-        )
-    aggregator.assert_service_check(
-        c.SERVICE_CHECK_NAME,
-        tags=['windows_service:Dnscache', 'windows_service_state:running'],
-        count=0,
-    )
+    services = [
+        ServiceAssertion('OneSyncSvc_443f50', win32service.SERVICE_RUNNING),
+        ServiceAssertion('OneSyncSvc_18f113', win32service.SERVICE_RUNNING),
+        ServiceAssertion('Dnscache', win32service.SERVICE_RUNNING, count=0),
+    ]
+    assert_service_check_and_metrics(aggregator, services)
 
 
 def test_per_user_composes_with_name_filter(aggregator, check):
@@ -556,19 +544,13 @@ def test_per_user_composes_with_name_filter(aggregator, check):
     with patch('win32service.EnumServicesStatusEx', return_value=_per_user_mock_services()):
         c.check(instance)
 
-    for suffixed in ('OneSyncSvc_443f50', 'OneSyncSvc_18f113'):
-        aggregator.assert_service_check(
-            c.SERVICE_CHECK_NAME,
-            tags=[f'windows_service:{suffixed}', 'windows_service_state:running'],
-            count=0,
-        )
-    # The named filter still goes unmatched and reports UNKNOWN once.
-    aggregator.assert_service_check(
-        c.SERVICE_CHECK_NAME,
-        status=c.UNKNOWN,
-        tags=['windows_service:OneSyncSvc', 'windows_service_state:unknown'],
-        count=1,
-    )
+    services = [
+        ServiceAssertion('OneSyncSvc_443f50', win32service.SERVICE_RUNNING, count=0),
+        ServiceAssertion('OneSyncSvc_18f113', win32service.SERVICE_RUNNING, count=0),
+        # The named filter still goes unmatched and reports UNKNOWN once.
+        ServiceAssertion('OneSyncSvc', -1, count=1),
+    ]
+    assert_service_check_and_metrics(aggregator, services)
 
 
 def test_per_user_false_with_grouping_warns(aggregator, check):

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -505,6 +505,86 @@ def test_group_per_user_services_with_name_filter(aggregator, check, instance_gr
     assert_service_check_and_metrics(aggregator, services)
 
 
+def test_per_user_false_excludes_per_user_services(aggregator, check):
+    # `per_user: false` collects only non-per-user services, so per-user instances are dropped.
+    instance = {'services': [{'per_user': False}], 'disable_legacy_service_tag': True}
+    c = check(instance)
+
+    with patch('win32service.EnumServicesStatusEx', return_value=_per_user_mock_services()):
+        c.check(instance)
+
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME,
+        status=c.OK,
+        tags=['windows_service:Dnscache', 'windows_service_state:running'],
+        count=1,
+    )
+    for suffixed in ('OneSyncSvc_443f50', 'OneSyncSvc_18f113'):
+        aggregator.assert_service_check(
+            c.SERVICE_CHECK_NAME,
+            tags=[f'windows_service:{suffixed}', 'windows_service_state:running'],
+            count=0,
+        )
+
+
+def test_per_user_true_collects_only_per_user_services(aggregator, check):
+    instance = {'services': [{'per_user': True}], 'disable_legacy_service_tag': True}
+    c = check(instance)
+
+    with patch('win32service.EnumServicesStatusEx', return_value=_per_user_mock_services()):
+        c.check(instance)
+
+    for suffixed in ('OneSyncSvc_443f50', 'OneSyncSvc_18f113'):
+        aggregator.assert_service_check(
+            c.SERVICE_CHECK_NAME,
+            status=c.OK,
+            tags=[f'windows_service:{suffixed}', 'windows_service_state:running'],
+            count=1,
+        )
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME,
+        tags=['windows_service:Dnscache', 'windows_service_state:running'],
+        count=0,
+    )
+
+
+def test_per_user_composes_with_name_filter(aggregator, check):
+    # A name filter that matches the per-user instances but is gated to non-per-user collects nothing.
+    instance = {'services': [{'name': 'OneSyncSvc', 'per_user': False}], 'disable_legacy_service_tag': True}
+    c = check(instance)
+
+    with patch('win32service.EnumServicesStatusEx', return_value=_per_user_mock_services()):
+        c.check(instance)
+
+    for suffixed in ('OneSyncSvc_443f50', 'OneSyncSvc_18f113'):
+        aggregator.assert_service_check(
+            c.SERVICE_CHECK_NAME,
+            tags=[f'windows_service:{suffixed}', 'windows_service_state:running'],
+            count=0,
+        )
+    # The named filter still goes unmatched and reports UNKNOWN once.
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME,
+        status=c.UNKNOWN,
+        tags=['windows_service:OneSyncSvc', 'windows_service_state:unknown'],
+        count=1,
+    )
+
+
+def test_per_user_false_with_grouping_warns(aggregator, check):
+    instance = {
+        'services': [{'per_user': False}],
+        'group_per_user_services': True,
+        'disable_legacy_service_tag': True,
+    }
+    c = check(instance)
+
+    with patch('win32service.EnumServicesStatusEx', return_value=_per_user_mock_services()):
+        c.check(instance)
+
+    assert any('will not be grouped' in w for w in c.warnings)
+
+
 @pytest.mark.e2e
 def test_basic_e2e(dd_agent_check, check, instance_basic):
     aggregator = dd_agent_check(instance_basic)


### PR DESCRIPTION
### What does this PR do?
Adds a `per_user` boolean criterion to the `windows_service` `services` filter, mirroring the existing `trigger_start` criterion. A filter item can match services by whether they are Windows per-user service instances (named `<template>_<LUID>`, e.g. `OneSyncSvc_443f50`). To exclude per-user services from collection, configure `per_user: false` to collect only non-per-user services:

```yaml
services:
  - per_user: false
```

`per_user` composes with `name`, `startup_type`, and `trigger_start` in any filter item. When `group_per_user_services` is enabled alongside a `per_user: false` filter, a warning is logged since excluded services are never collected and cannot be grouped.

### Motivation
Per-user services are often pure noise on monitored hosts, and each carries a per-session/per-host LUID suffix that inflates `windows_service` tag cardinality. This complements the `group_per_user_services` option (parent PR) by letting users drop per-user services from collection entirely rather than grouping them.

> Stacked on #24087 — this PR targets `branden.clark/windows-service-group-per-user` and should be reviewed/merged after it.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
