### PR TITLE
Add socksio for HTTPX2Wrapper SOCKS proxy parity

### DIFF
--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -64,6 +64,7 @@ http = [
     "requests-kerberos==0.15.0",
     "requests-ntlm==1.3.0",
     "requests-oauthlib==2.0.0",
+    "socksio==1.0.0",
 ]
 json = [
     "orjson==3.11.7",

--- a/datadog_checks_base/tests/base/utils/httpx2/test_proxy.py
+++ b/datadog_checks_base/tests/base/utils/httpx2/test_proxy.py
@@ -257,6 +257,13 @@ def test_build_proxy_transport_builds_router_when_proxy_set():
     transport.close()
 
 
+def test_build_proxy_transport_builds_router_for_socks_proxy():
+    """A socks5h:// proxy URL builds a routing transport, matching RequestsWrapper's documented SOCKS support."""
+    transport = _build_proxy_transport({'http': 'socks5h://1.2.3.4:1080'}, None, True, None)
+    assert isinstance(transport, _ProxyRoutingTransport)
+    transport.close()
+
+
 def test_build_proxy_transport_skips_direct_allocation_when_no_scheme_usable():
     with mock.patch('datadog_checks.base.utils.httpx2.httpx2.HTTPTransport') as transport_cls:
         result = _build_proxy_transport({'all_proxy': 'http://p:3128'}, None, True, None)

--- a/datadog_checks_base/tests/base/utils/httpx2/test_socks5_proxy_integration.py
+++ b/datadog_checks_base/tests/base/utils/httpx2/test_socks5_proxy_integration.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.base.utils.httpx2 import HTTPX2Wrapper
+from datadog_checks.dev.ci import running_on_ci, running_on_windows_ci
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(running_on_windows_ci(), reason='Test cannot be run on Windows CI'),
+    pytest.mark.skipif(running_on_ci(), reason='Test is failing on CI'),
+]
+
+
+def test_socks5_proxy(socks5_proxy):
+    instance = {'proxy': {'http': 'socks5h://{}'.format(socks5_proxy)}}
+    init_config = {}
+    http = HTTPX2Wrapper(instance, init_config)
+    http.get('http://www.google.com')
+    http.get('http://nginx')


### PR DESCRIPTION
### What does this PR do?

Adds the `socksio` package to `datadog_checks_base` so `HTTPX2Wrapper` supports SOCKS (`socks5` / `socks5h`) proxies, matching `RequestsWrapper`. Stacked on top of #24023.

### Motivation

`HTTPX2Wrapper` raised `ImportError` when handed a documented `socks5://` proxy, because httpx2 requires `socksio` and it was not installed. `RequestsWrapper` already has SOCKS support via the shipped PySocks, so this was a parity gap. The wrapper itself needed no code change: httpcore2 (already shipped as httpx2's pinned dependency) provides the SOCKS transport once `socksio` is importable. The path sits behind the default-off `use_httpx2` flag, so no shipped integration is affected.

Adds one third-party package: `socksio==1.0.0` (BSD-3-Clause, pure-Python, the same dependency httpx uses for SOCKS). Flagging for dependency-review awareness. The agent-requirements freeze and license attribution are deferred downstream, mirroring how httpx2 is handled on the base branch.

Verified: the full httpx2 proxy unit suite passes, and a real SOCKS round-trip through the wrapper to an internal nginx returns HTTP 200.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged