### PR TITLE
[postgres] Extract version-aware relation-query builder and metric test scaffolding

### DIFF
--- a/postgres/changelog.d/24092.fixed
+++ b/postgres/changelog.d/24092.fixed
@@ -1,1 +1,1 @@
-Refactor the ``pg_class`` relation-metrics query into a version-aware builder. No metric is added or changed.
+Refactor the ``pg_class`` and ``pg_stat_wal`` queries onto a shared version-aware query builder. No metric is added or changed.

--- a/postgres/changelog.d/24092.fixed
+++ b/postgres/changelog.d/24092.fixed
@@ -1,0 +1,1 @@
+Refactor the ``pg_class`` relation-metrics query into a version-aware builder. No metric is added or changed.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -81,8 +81,6 @@ from .util import (
     STAT_IO_METRICS,
     STAT_SUBSCRIPTION_METRICS,
     STAT_SUBSCRIPTION_STATS_METRICS,
-    STAT_WAL_METRICS,
-    STAT_WAL_METRICS_LT_18,
     SUBSCRIPTION_STATE_METRICS,
     VACUUM_PROGRESS_METRICS,
     VACUUM_PROGRESS_METRICS_LT_17,
@@ -91,10 +89,11 @@ from .util import (
     DatabaseHealthCheckError,  # noqa: F401
     fmt,
     get_schema_field,
+    get_stat_wal_query,
     payload_pg_version,
     warning_with_tags,
 )
-from .version_utils import V9, V9_2, V10, V12, V13, V14, V15, V16, V17, V18, VersionUtils
+from .version_utils import V9, V9_2, V10, V12, V13, V14, V15, V16, V17, VersionUtils
 
 try:
     import datadog_agent
@@ -441,10 +440,7 @@ class PostgreSql(DatabaseCheck):
             queries.append(SNAPSHOT_TXID_METRICS_LT_13)
         if self.version >= V14:
             if self.is_aurora is False:
-                if self.version >= V18:
-                    queries.append(STAT_WAL_METRICS)
-                else:
-                    queries.append(STAT_WAL_METRICS_LT_18)
+                queries.append(get_stat_wal_query(self.version))
             queries.append(QUERY_PG_REPLICATION_SLOTS_STATS)
             queries.append(SUBSCRIPTION_STATE_METRICS)
         if self.version >= V15:

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -42,6 +42,7 @@ from datadog_checks.postgres.relationsmanager import (
     RELATION_METRICS,
     TABLE_BLOAT,
     RelationsManager,
+    get_pg_class_query,
 )
 from datadog_checks.postgres.statement_samples import PostgresStatementSamples
 from datadog_checks.postgres.statements import PostgresStatementMetrics
@@ -466,7 +467,7 @@ class PostgreSql(DatabaseCheck):
 
         # Dynamic queries for relationsmanager
         if self._config.relations:
-            for query in DYNAMIC_RELATION_QUERIES:
+            for query in DYNAMIC_RELATION_QUERIES + [get_pg_class_query(self.version)]:
                 query = copy.copy(query)
                 formatted_query = self._relations_manager.filter_relation_query(query['query'], 'nspname')
                 query['query'] = formatted_query

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -23,6 +23,7 @@ from semver import VersionInfo
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.log import get_check_logger
 from datadog_checks.postgres.config_models.instance import Relations
+from datadog_checks.postgres.version_utils import build_versioned_query
 
 ALL_SCHEMAS = object()
 RELATION_NAME = 'relation_name'
@@ -222,18 +223,15 @@ WHERE C.relkind = 'r'
 
 
 def get_pg_class_query(version: VersionInfo) -> dict:
-    """Build the pg_class relation-metrics query (version-gating extension point).
+    """Build the pg_class relation-metrics query for `version`.
 
-    The SELECT projection and the column descriptors are assembled in lockstep from a single list of
-    (SQL expression, column descriptor) pairs, so they cannot drift. Columns that only newer PostgreSQL
-    majors expose are appended only when `version` is new enough (e.g. inside an `if version >= V<major>`
-    block); see the note on PG_CLASS_FROM_CLAUSE above for why this gating is required. No column is
-    version-gated yet; this preserves the exact metric set of the former static QUERY_PG_CLASS constant.
+    Reference pattern for version-gated structured queries: the (SQL expression, column descriptor)
+    pairs are handed to build_versioned_query, which keeps the SELECT projection and the column
+    descriptors in lockstep. To collect a column only newer majors expose, add a third element to its
+    pair — a VersionRange (see the note on PG_CLASS_FROM_CLAUSE above for why this gating is required).
+    No column is version-gated yet, so this preserves the exact metric set of the former QUERY_PG_CLASS.
     """
-    if version is None:
-        raise ValueError("get_pg_class_query requires a resolved server version, got None")
-
-    # (SQL expression, column descriptor) pairs, in SELECT order.
+    # (SQL expression, column descriptor[, VersionRange]) pairs, in SELECT order.
     relation_columns = [
         ('current_database()', {'name': 'db', 'type': 'tag'}),
         ('N.nspname', {'name': 'schema', 'type': 'tag'}),
@@ -287,13 +285,7 @@ def get_pg_class_query(version: VersionInfo) -> dict:
         ('C.xmin', {'name': 'relation.xmin', 'type': 'gauge'}),
     ]
 
-    select_clause = ',\n  '.join(expr for expr, _ in relation_columns)
-    return {
-        'name': 'pg_class',
-        # Leading newline mirrors the former QUERY_PG_CLASS triple-quoted literal byte-for-byte.
-        'query': '\nSELECT\n  ' + select_clause + PG_CLASS_FROM_CLAUSE,
-        'columns': [descriptor for _, descriptor in relation_columns],
-    }
+    return build_versioned_query('pg_class', relation_columns, PG_CLASS_FROM_CLAUSE, version)
 
 
 # The pg_statio_all_tables view will contain one row for each table in the current database,

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -18,6 +18,8 @@
 
 from typing import Any, Dict, List, Union  # noqa: F401
 
+from semver import VersionInfo
+
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.log import get_check_logger
 from datadog_checks.postgres.config_models.instance import Relations
@@ -191,42 +193,12 @@ FROM
 # However, using this view is inefficient as it groups by aggregation on oid and schema
 # behind the hood, leading to possible temporary bytes being written to handle the sort.
 # To avoid this, we need to directly call the pg_stat_* functions
-QUERY_PG_CLASS = {
-    'name': 'pg_class',
-    'query': """
-SELECT
-  current_database(),
-  N.nspname,
-  C.relname,
-  pg_stat_get_numscans(C.oid),
-  pg_stat_get_tuples_returned(C.oid),
-  I.idx_scan,
-  I.idx_tup_fetch,
-  pg_stat_get_tuples_inserted(C.oid),
-  pg_stat_get_tuples_updated(C.oid),
-  pg_stat_get_tuples_deleted(C.oid),
-  pg_stat_get_tuples_hot_updated(C.oid),
-  pg_stat_get_live_tuples(C.oid),
-  pg_stat_get_dead_tuples(C.oid),
-  pg_stat_get_vacuum_count(C.oid),
-  pg_stat_get_autovacuum_count(C.oid),
-  pg_stat_get_analyze_count(C.oid),
-  pg_stat_get_autoanalyze_count(C.oid),
-  EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_vacuum_time(C.oid))),
-  EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_autovacuum_time(C.oid))),
-  EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_analyze_time(C.oid))),
-  EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_autoanalyze_time(C.oid))),
-  pg_stat_get_numscans(idx_toast.indexrelid),
-  pg_stat_get_tuples_fetched(idx_toast.indexrelid),
-  pg_stat_get_tuples_inserted(C.reltoastrelid),
-  pg_stat_get_tuples_deleted(C.reltoastrelid),
-  pg_stat_get_live_tuples(C.reltoastrelid),
-  pg_stat_get_dead_tuples(C.reltoastrelid),
-  pg_stat_get_vacuum_count(C.reltoastrelid),
-  pg_stat_get_autovacuum_count(C.reltoastrelid),
-  EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_vacuum_time(C.reltoastrelid))),
-  EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_autovacuum_time(C.reltoastrelid))),
-  C.xmin
+#
+# Several per-table maintenance/access columns of pg_stat_user_tables/pg_stat_all_tables are only
+# exposed by recent PostgreSQL majors (and so are their backing pg_stat_get_* functions). Calling a
+# function that does not exist on the server aborts the whole query, so those columns are gated on
+# the server version and added by get_pg_class_query() only when the server is new enough.
+PG_CLASS_FROM_CLAUSE = """
 FROM pg_class C
 LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace)
 LEFT JOIN pg_index idx_toast ON (idx_toast.indrelid = C.reltoastrelid)
@@ -246,42 +218,82 @@ WHERE C.relkind = 'r'
         AND relation = C.oid
     )
     AND {relations} {limits}
-""",
-    'columns': [
-        {'name': 'db', 'type': 'tag'},
-        {'name': 'schema', 'type': 'tag'},
-        {'name': 'table', 'type': 'tag'},
-        {'name': 'seq_scans', 'type': 'rate'},
-        {'name': 'seq_rows_read', 'type': 'rate'},
-        {'name': 'index_rel_scans', 'type': 'rate'},
-        {'name': 'index_rel_rows_fetched', 'type': 'rate'},
-        {'name': 'rows_inserted', 'type': 'rate'},
-        {'name': 'rows_updated', 'type': 'rate'},
-        {'name': 'rows_deleted', 'type': 'rate'},
-        {'name': 'rows_hot_updated', 'type': 'rate'},
-        {'name': 'live_rows', 'type': 'gauge'},
-        {'name': 'dead_rows', 'type': 'gauge'},
-        {'name': 'vacuumed', 'type': 'monotonic_count'},
-        {'name': 'autovacuumed', 'type': 'monotonic_count'},
-        {'name': 'analyzed', 'type': 'monotonic_count'},
-        {'name': 'autoanalyzed', 'type': 'monotonic_count'},
-        {'name': 'last_vacuum_age', 'type': 'gauge'},
-        {'name': 'last_autovacuum_age', 'type': 'gauge'},
-        {'name': 'last_analyze_age', 'type': 'gauge'},
-        {'name': 'last_autoanalyze_age', 'type': 'gauge'},
-        {'name': 'toast.index_scans', 'type': 'monotonic_count'},
-        {'name': 'toast.rows_fetched', 'type': 'monotonic_count'},
-        {'name': 'toast.rows_inserted', 'type': 'monotonic_count'},
-        {'name': 'toast.rows_deleted', 'type': 'monotonic_count'},
-        {'name': 'toast.live_rows', 'type': 'gauge'},
-        {'name': 'toast.dead_rows', 'type': 'gauge'},
-        {'name': 'toast.vacuumed', 'type': 'monotonic_count'},
-        {'name': 'toast.autovacuumed', 'type': 'monotonic_count'},
-        {'name': 'toast.last_vacuum_age', 'type': 'gauge'},
-        {'name': 'toast.last_autovacuum_age', 'type': 'gauge'},
-        {'name': 'relation.xmin', 'type': 'gauge'},
-    ],
-}
+"""
+
+
+def get_pg_class_query(version: VersionInfo) -> dict:
+    """Build the pg_class relation-metrics query (version-gating extension point).
+
+    The SELECT projection and the column descriptors are assembled in lockstep from a single list of
+    (SQL expression, column descriptor) pairs, so they cannot drift. Columns that only newer PostgreSQL
+    majors expose are appended only when `version` is new enough (e.g. inside an `if version >= V<major>`
+    block); see the note on PG_CLASS_FROM_CLAUSE above for why this gating is required. No column is
+    version-gated yet; this preserves the exact metric set of the former static QUERY_PG_CLASS constant.
+    """
+    if version is None:
+        raise ValueError("get_pg_class_query requires a resolved server version, got None")
+
+    # (SQL expression, column descriptor) pairs, in SELECT order.
+    relation_columns = [
+        ('current_database()', {'name': 'db', 'type': 'tag'}),
+        ('N.nspname', {'name': 'schema', 'type': 'tag'}),
+        ('C.relname', {'name': 'table', 'type': 'tag'}),
+        ('pg_stat_get_numscans(C.oid)', {'name': 'seq_scans', 'type': 'rate'}),
+        ('pg_stat_get_tuples_returned(C.oid)', {'name': 'seq_rows_read', 'type': 'rate'}),
+        ('I.idx_scan', {'name': 'index_rel_scans', 'type': 'rate'}),
+        ('I.idx_tup_fetch', {'name': 'index_rel_rows_fetched', 'type': 'rate'}),
+        ('pg_stat_get_tuples_inserted(C.oid)', {'name': 'rows_inserted', 'type': 'rate'}),
+        ('pg_stat_get_tuples_updated(C.oid)', {'name': 'rows_updated', 'type': 'rate'}),
+        ('pg_stat_get_tuples_deleted(C.oid)', {'name': 'rows_deleted', 'type': 'rate'}),
+        ('pg_stat_get_tuples_hot_updated(C.oid)', {'name': 'rows_hot_updated', 'type': 'rate'}),
+        ('pg_stat_get_live_tuples(C.oid)', {'name': 'live_rows', 'type': 'gauge'}),
+        ('pg_stat_get_dead_tuples(C.oid)', {'name': 'dead_rows', 'type': 'gauge'}),
+        ('pg_stat_get_vacuum_count(C.oid)', {'name': 'vacuumed', 'type': 'monotonic_count'}),
+        ('pg_stat_get_autovacuum_count(C.oid)', {'name': 'autovacuumed', 'type': 'monotonic_count'}),
+        ('pg_stat_get_analyze_count(C.oid)', {'name': 'analyzed', 'type': 'monotonic_count'}),
+        ('pg_stat_get_autoanalyze_count(C.oid)', {'name': 'autoanalyzed', 'type': 'monotonic_count'}),
+        (
+            'EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_vacuum_time(C.oid)))',
+            {'name': 'last_vacuum_age', 'type': 'gauge'},
+        ),
+        (
+            'EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_autovacuum_time(C.oid)))',
+            {'name': 'last_autovacuum_age', 'type': 'gauge'},
+        ),
+        (
+            'EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_analyze_time(C.oid)))',
+            {'name': 'last_analyze_age', 'type': 'gauge'},
+        ),
+        (
+            'EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_autoanalyze_time(C.oid)))',
+            {'name': 'last_autoanalyze_age', 'type': 'gauge'},
+        ),
+        ('pg_stat_get_numscans(idx_toast.indexrelid)', {'name': 'toast.index_scans', 'type': 'monotonic_count'}),
+        ('pg_stat_get_tuples_fetched(idx_toast.indexrelid)', {'name': 'toast.rows_fetched', 'type': 'monotonic_count'}),
+        ('pg_stat_get_tuples_inserted(C.reltoastrelid)', {'name': 'toast.rows_inserted', 'type': 'monotonic_count'}),
+        ('pg_stat_get_tuples_deleted(C.reltoastrelid)', {'name': 'toast.rows_deleted', 'type': 'monotonic_count'}),
+        ('pg_stat_get_live_tuples(C.reltoastrelid)', {'name': 'toast.live_rows', 'type': 'gauge'}),
+        ('pg_stat_get_dead_tuples(C.reltoastrelid)', {'name': 'toast.dead_rows', 'type': 'gauge'}),
+        ('pg_stat_get_vacuum_count(C.reltoastrelid)', {'name': 'toast.vacuumed', 'type': 'monotonic_count'}),
+        ('pg_stat_get_autovacuum_count(C.reltoastrelid)', {'name': 'toast.autovacuumed', 'type': 'monotonic_count'}),
+        (
+            'EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_vacuum_time(C.reltoastrelid)))',
+            {'name': 'toast.last_vacuum_age', 'type': 'gauge'},
+        ),
+        (
+            'EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_autovacuum_time(C.reltoastrelid)))',
+            {'name': 'toast.last_autovacuum_age', 'type': 'gauge'},
+        ),
+        ('C.xmin', {'name': 'relation.xmin', 'type': 'gauge'}),
+    ]
+
+    select_clause = ',\n  '.join(expr for expr, _ in relation_columns)
+    return {
+        'name': 'pg_class',
+        # Leading newline mirrors the former QUERY_PG_CLASS triple-quoted literal byte-for-byte.
+        'query': '\nSELECT\n  ' + select_clause + PG_CLASS_FROM_CLAUSE,
+        'columns': [descriptor for _, descriptor in relation_columns],
+    }
 
 
 # The pg_statio_all_tables view will contain one row for each table in the current database,
@@ -419,7 +431,8 @@ INDEX_BLOAT = {
 }
 
 RELATION_METRICS = [STATIO_METRICS]
-DYNAMIC_RELATION_QUERIES = [QUERY_PG_CLASS, QUERY_PG_CLASS_SIZE, IDX_METRICS, LOCK_METRICS]
+# QUERY_PG_CLASS is version-dependent and built per-run via get_pg_class_query(version).
+DYNAMIC_RELATION_QUERIES = [QUERY_PG_CLASS_SIZE, IDX_METRICS, LOCK_METRICS]
 
 
 class RelationsManager(object):

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -7,8 +7,12 @@ import string
 from enum import Enum
 from typing import Any, List, Tuple  # noqa: F401
 
+from semver import VersionInfo
+
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException
+
+from .version_utils import V18, VersionRange, build_versioned_query
 
 
 class PartialFormatter(string.Formatter):
@@ -1061,42 +1065,26 @@ EXTRACT (EPOCH FROM now() - min(modification))
     ],
 }
 
-STAT_WAL_METRICS_LT_18 = {
-    'name': 'stat_wal_metrics',
-    'query': """
-SELECT wal_records, wal_fpi,
-       wal_bytes, wal_buffers_full,
-       wal_write, wal_sync,
-       wal_write_time, wal_sync_time
-  FROM pg_stat_wal
-""",
-    'columns': [
-        {'name': 'wal.records', 'type': 'monotonic_count'},
-        {'name': 'wal.full_page_images', 'type': 'monotonic_count'},
-        {'name': 'wal.bytes', 'type': 'monotonic_count'},
-        {'name': 'wal.buffers_full', 'type': 'monotonic_count'},
-        {'name': 'wal.write', 'type': 'monotonic_count'},
-        {'name': 'wal.sync', 'type': 'monotonic_count'},
-        {'name': 'wal.write_time', 'type': 'monotonic_count'},
-        {'name': 'wal.sync_time', 'type': 'monotonic_count'},
-    ],
-}
+# pg_stat_wal columns, collected on PG 14+. The I/O timing columns (wal_write/wal_sync and their
+# *_time counterparts) were removed from pg_stat_wal in PG 18, where the equivalent counters moved to
+# pg_stat_io, so they are gated to servers below 18 with a VersionRange.
+# TODO: re-source the removed I/O timing metrics from pg_stat_io on PG 18+.
+STAT_WAL_COLUMNS = [
+    ('wal_records', {'name': 'wal.records', 'type': 'monotonic_count'}),
+    ('wal_fpi', {'name': 'wal.full_page_images', 'type': 'monotonic_count'}),
+    ('wal_bytes', {'name': 'wal.bytes', 'type': 'monotonic_count'}),
+    ('wal_buffers_full', {'name': 'wal.buffers_full', 'type': 'monotonic_count'}),
+    ('wal_write', {'name': 'wal.write', 'type': 'monotonic_count'}, VersionRange(max_version=V18)),
+    ('wal_sync', {'name': 'wal.sync', 'type': 'monotonic_count'}, VersionRange(max_version=V18)),
+    ('wal_write_time', {'name': 'wal.write_time', 'type': 'monotonic_count'}, VersionRange(max_version=V18)),
+    ('wal_sync_time', {'name': 'wal.sync_time', 'type': 'monotonic_count'}, VersionRange(max_version=V18)),
+]
 
-# TODO: Handle missing wal IO metrics for PG18
-STAT_WAL_METRICS = {
-    'name': 'stat_wal_metrics',
-    'query': """
-SELECT wal_records, wal_fpi,
-       wal_bytes, wal_buffers_full
-  FROM pg_stat_wal
-""",
-    'columns': [
-        {'name': 'wal.records', 'type': 'monotonic_count'},
-        {'name': 'wal.full_page_images', 'type': 'monotonic_count'},
-        {'name': 'wal.bytes', 'type': 'monotonic_count'},
-        {'name': 'wal.buffers_full', 'type': 'monotonic_count'},
-    ],
-}
+
+def get_stat_wal_query(version: VersionInfo) -> dict:
+    """Build the pg_stat_wal query for `version` (PG 14+); its I/O timing columns were removed in PG 18."""
+    return build_versioned_query('stat_wal_metrics', STAT_WAL_COLUMNS, '\n  FROM pg_stat_wal\n', version)
+
 
 FUNCTION_METRICS = {
     'descriptors': [('schemaname', 'schema'), ('funcname', 'function')],

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import re
+from dataclasses import dataclass
 
 from semver import VersionInfo
 
@@ -26,6 +27,52 @@ V15 = VersionInfo.parse("15.0.0")
 V16 = VersionInfo.parse("16.0.0")
 V17 = VersionInfo.parse("17.0.0")
 V18 = VersionInfo.parse("18.0.0")
+
+
+@dataclass(frozen=True)
+class VersionRange:
+    """Server-version window ``[min_version, max_version)`` for a single query column.
+
+    Either bound may be ``None`` to leave that side open. Use it to gate a column that a given
+    PostgreSQL major added (``min_version``) or removed (``max_version``).
+    """
+
+    min_version: VersionInfo | None = None
+    max_version: VersionInfo | None = None
+
+    def __contains__(self, version: VersionInfo) -> bool:
+        if self.min_version is not None and version < self.min_version:
+            return False
+        if self.max_version is not None and version >= self.max_version:
+            return False
+        return True
+
+
+def build_versioned_query(name: str, columns: list, from_clause: str, version: VersionInfo) -> dict:
+    """Assemble a ``{name, query, columns}`` query dict holding only the columns ``version`` exposes.
+
+    ``columns`` is a list of ``(sql_expression, column_descriptor)`` pairs in SELECT order; a pair may
+    carry an optional third element, a ``VersionRange``, restricting it to the servers that expose that
+    column. The SELECT projection and the QueryExecutor descriptors are filtered together from the one
+    list, so they cannot drift or reference a column the server lacks — calling a missing ``pg_stat_get_*``
+    function aborts the whole query, so a too-new column must never be projected.
+    """
+    if version is None:
+        raise ValueError("build_versioned_query requires a resolved server version, got None")
+
+    expressions = []
+    descriptors = []
+    for expression, descriptor, *gate in columns:
+        version_range = gate[0] if gate else None
+        if version_range is None or version in version_range:
+            expressions.append(expression)
+            descriptors.append(descriptor)
+
+    return {
+        'name': name,
+        'query': '\nSELECT\n  ' + ',\n  '.join(expressions) + from_clause,
+        'columns': descriptors,
+    }
 
 
 class VersionUtils(object):

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -8,15 +8,16 @@ How to add a version-gated metric
 postgres collects metrics in two lanes. Adding a metric to either is a content-only change; the
 test scaffolding below derives the rest.
 
-Relation / structured-query lane (pg_class et al.):
-  1. Append an ``(sql_expression, column_descriptor)`` pair to ``relationsmanager.get_pg_class_query``,
-     inside the appropriate ``if version >= V<major>`` block. This builder is the reference pattern
-     for version-gated structured queries: the SELECT projection and the column descriptors are
-     assembled in lockstep so they cannot drift.
+Structured-query lane (``build_versioned_query``: pg_class, pg_stat_wal, et al.):
+  1. Append an ``(sql_expression, column_descriptor)`` pair to the query's column list (e.g.
+     ``relationsmanager.get_pg_class_query`` or ``util.STAT_WAL_COLUMNS``). If the column exists only
+     on some server versions, add a third element to the pair: a ``VersionRange(min_version=...,
+     max_version=...)``. ``build_versioned_query`` keeps the SELECT projection and the column
+     descriptors in lockstep, so a single declaration replaces the old ``_LT_<major>`` twin constants.
   2. Add the ``postgresql.*`` row to ``metadata.csv``.
   3. Add a changelog entry.
 
-Scope / metric-dict lane (``util.py`` dicts read by ``metrics_cache.py``):
+Scope metric-dict lane (``util.py`` dicts read by ``metrics_cache.py``):
   1. Declare the metric in the right group for its minimum version (e.g. ``NEWER_14_METRICS`` for
      PG 14+); the existing ``if version >= V<major>`` merges in ``metrics_cache.py`` pick it up.
   2. Add the ``postgresql.*`` row to ``metadata.csv``.
@@ -55,12 +56,11 @@ from datadog_checks.postgres.util import (
     STAT_IO_METRICS,
     STAT_SUBSCRIPTION_METRICS,
     STAT_SUBSCRIPTION_STATS_METRICS,
-    STAT_WAL_METRICS,
-    STAT_WAL_METRICS_LT_18,
     SUBSCRIPTION_STATE_METRICS,
     WAL_FILE_METRICS,
+    get_stat_wal_query,
 )
-from datadog_checks.postgres.version_utils import VersionUtils
+from datadog_checks.postgres.version_utils import V14, V18, VersionUtils
 
 HOST = get_docker_hostname()
 PORT = '5432'
@@ -489,12 +489,9 @@ def check_file_wal_metrics(aggregator, expected_tags, count=1):
 def check_stat_wal_metrics(aggregator, expected_tags, count=1):
     if float(POSTGRES_VERSION) < 14.0:
         return
-    if float(POSTGRES_VERSION) < 18.0:
-        for metric_name in _iterate_metric_name(STAT_WAL_METRICS_LT_18):
-            aggregator.assert_metric(metric_name, count=count, tags=expected_tags)
-    else:
-        for metric_name in _iterate_metric_name(STAT_WAL_METRICS):
-            aggregator.assert_metric(metric_name, count=count, tags=expected_tags)
+    version = V18 if float(POSTGRES_VERSION) >= 18.0 else V14
+    for metric_name in _iterate_metric_name(get_stat_wal_query(version)):
+        aggregator.assert_metric(metric_name, count=count, tags=expected_tags)
 
 
 def check_performance_metrics(aggregator, expected_tags, count=1, is_aurora=False):

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -10,6 +10,7 @@ from datadog_checks.base.stubs.aggregator import normalize_tags
 from datadog_checks.dev import get_docker_hostname
 from datadog_checks.dev.docker import get_container_ip
 from datadog_checks.dev.utils import get_metadata_metrics
+from datadog_checks.postgres import util
 from datadog_checks.postgres.util import (
     CHECKSUM_METRICS,
     NEWER_14_METRICS,
@@ -62,25 +63,31 @@ if USING_LATEST is True:
 
 SCHEMA_NAME = 'schemaname'
 
-COMMON_METRICS = [
-    'postgresql.before_xid_wraparound',
-    'postgresql.commits',
-    'postgresql.rollbacks',
-    'postgresql.disk_read',
-    'postgresql.buffer_hit',
-    'postgresql.rows_returned',
-    'postgresql.rows_fetched',
-    'postgresql.rows_inserted',
-    'postgresql.rows_updated',
-    'postgresql.rows_deleted',
-    'postgresql.database_size',
-    'postgresql.deadlocks',
-    'postgresql.deadlocks.count',
-    'postgresql.temp_bytes',
-    'postgresql.temp_files',
-    'postgresql.blk_read_time',
-    'postgresql.blk_write_time',
-]
+
+def _iterate_metric_name(query):
+    metric_prefix = 'postgresql'
+    if 'columns' in query:
+        if 'metric_prefix' in query:
+            metric_prefix = f'{query["metric_prefix"]}'
+        for column in query['columns']:
+            if column['type'].startswith('tag'):
+                continue
+            yield f'{metric_prefix}.{column["name"]}'
+    else:
+        metrics = query['metrics'].values() if 'metrics' in query else query.values()
+        for metric in metrics:
+            yield f'{metric_prefix}.{metric[0]}'
+
+
+# Derived from the util declarations the instance/database collectors emit per database, so a scope
+# metric added to one of those dicts automatically extends this assertion on the versions that expose
+# it. All tested versions are >= 9.2, so the 9.2+ deadlock/temp/blk metrics always apply.
+COMMON_METRICS = sorted(
+    set(_iterate_metric_name(util.COMMON_METRICS))
+    | set(_iterate_metric_name(util.NEWER_92_METRICS))
+    | set(_iterate_metric_name(util.DATABASE_SIZE_METRICS))
+    | set(_iterate_metric_name(util.QUERY_PG_STAT_DATABASE))
+)
 
 DBM_MIGRATED_METRICS = [
     'postgresql.connections',
@@ -94,19 +101,20 @@ CONFLICT_METRICS = [
     'postgresql.conflicts.deadlock',
 ]
 
-COMMON_BGW_METRICS = [
-    'postgresql.bgwriter.checkpoints_timed',
-    'postgresql.bgwriter.checkpoints_requested',
-    'postgresql.bgwriter.buffers_checkpoint',
-    'postgresql.bgwriter.buffers_clean',
-    'postgresql.bgwriter.maxwritten_clean',
-    'postgresql.bgwriter.buffers_alloc',
-    'postgresql.bgwriter.write_time',
-    'postgresql.bgwriter.sync_time',
-]
+# The bgwriter/checkpointer metrics common to every version are exactly those collected from the
+# PG 17+ pg_stat_checkpointer query; the < 17 path emits the same set plus the two PG_BELOW_17 extras.
+COMMON_BGW_METRICS = sorted(_iterate_metric_name(util.QUERY_PG_BGWRITER_CHECKPOINTER))
 
-COMMON_BGW_METRICS_PG_ABOVE_94 = ['postgresql.archiver.archived_count', 'postgresql.archiver.failed_count']
-COMMON_BGW_METRICS_PG_BELOW_17 = ['postgresql.bgwriter.buffers_backend', 'postgresql.bgwriter.buffers_backend_fsync']
+COMMON_BGW_METRICS_PG_ABOVE_94 = sorted(_iterate_metric_name(util.COMMON_ARCHIVER_METRICS))
+# Metrics the < 17 bgwriter query collects on top of the common set (pg_stat_bgwriter dropped these in 17).
+COMMON_BGW_METRICS_PG_BELOW_17 = sorted(
+    (
+        set(_iterate_metric_name(util.COMMON_BGW_METRICS_LT_17))
+        | set(_iterate_metric_name(util.NEWER_91_BGW_METRICS_LT_17))
+        | set(_iterate_metric_name(util.NEWER_92_BGW_METRICS_LT_17))
+    )
+    - set(COMMON_BGW_METRICS)
+)
 
 CONNECTION_METRICS = ['postgresql.max_connections', 'postgresql.percent_usage_connections']
 CONNECTION_METRICS_BY_DB = [
@@ -129,21 +137,6 @@ CHECK_PERFORMANCE_METRICS = [
 ]
 
 requires_static_version = pytest.mark.skipif(USING_LATEST, reason='Version `latest` is ever-changing, skipping')
-
-
-def _iterate_metric_name(query):
-    metric_prefix = 'postgresql'
-    if 'columns' in query:
-        if 'metric_prefix' in query:
-            metric_prefix = f'{query["metric_prefix"]}'
-        for column in query['columns']:
-            if column['type'].startswith('tag'):
-                continue
-            yield f'{metric_prefix}.{column["name"]}'
-    else:
-        metrics = query['metrics'].values() if 'metrics' in query else query.values()
-        for metric in metrics:
-            yield f'{metric_prefix}.{metric[0]}'
 
 
 def _get_expected_replication_tags(check, pg_instance, with_host=True, with_db=False, with_version=True, **kwargs):
@@ -239,18 +232,25 @@ def check_common_metrics(aggregator, expected_tags, count=1):
     aggregator.assert_metric('postgresql.running', count=count, value=1, tags=expected_tags)
 
 
+# Counts of objects created by the test fixtures (see tests/compose and the datadog_test schema).
+# They track the fixture data, not anything declared in util.py, so they are named constants rather
+# than derived. PG 11+ adds 2 partition child tables + 2 parent tables to the public schema.
+FIXTURE_PUBLIC_TABLE_COUNT = 18
+FIXTURE_PUBLIC_TABLE_COUNT_WITH_PARTITIONS = 25
+FIXTURE_DB_COUNT = 15
+
+
 def check_db_count(aggregator, expected_tags, count=1):
-    table_count = 18
-    # We create 2 additional partition tables when partition is available + 2 parent tables
+    table_count = FIXTURE_PUBLIC_TABLE_COUNT
     if float(POSTGRES_VERSION) >= 11.0:
-        table_count = 25
+        table_count = FIXTURE_PUBLIC_TABLE_COUNT_WITH_PARTITIONS
     aggregator.assert_metric(
         'postgresql.table.count',
         value=table_count,
         count=count,
         tags=expected_tags + ['db:{}'.format(DB_NAME), 'schema:public'],
     )
-    aggregator.assert_metric('postgresql.db.count', value=15, count=1)
+    aggregator.assert_metric('postgresql.db.count', value=FIXTURE_DB_COUNT, count=1)
 
 
 def check_connection_metrics(aggregator, expected_tags, count=1):

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -1,6 +1,34 @@
 # (C) Datadog, Inc. 2010-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+"""Shared test helpers for the postgres integration.
+
+How to add a version-gated metric
+---------------------------------
+postgres collects metrics in two lanes. Adding a metric to either is a content-only change; the
+test scaffolding below derives the rest.
+
+Relation / structured-query lane (pg_class et al.):
+  1. Append an ``(sql_expression, column_descriptor)`` pair to ``relationsmanager.get_pg_class_query``,
+     inside the appropriate ``if version >= V<major>`` block. This builder is the reference pattern
+     for version-gated structured queries: the SELECT projection and the column descriptors are
+     assembled in lockstep so they cannot drift.
+  2. Add the ``postgresql.*`` row to ``metadata.csv``.
+  3. Add a changelog entry.
+
+Scope / metric-dict lane (``util.py`` dicts read by ``metrics_cache.py``):
+  1. Declare the metric in the right group for its minimum version (e.g. ``NEWER_14_METRICS`` for
+     PG 14+); the existing ``if version >= V<major>`` merges in ``metrics_cache.py`` pick it up.
+  2. Add the ``postgresql.*`` row to ``metadata.csv``.
+  3. Add a changelog entry.
+
+You do not edit the test metric lists or version markers: ``COMMON_METRICS`` and the bgwriter
+variants below derive from the util declarations via ``_iterate_metric_name`` and auto-scope to the
+versions that expose each metric; ``requires_over(n)`` / ``requires_under(n)`` in ``utils.py`` gate
+tests for any version; and ``test_metadata_consistency.py`` fails if a declared metric has no
+``metadata.csv`` row.
+"""
+
 import os
 from sys import maxsize
 

--- a/postgres/tests/test_metadata_consistency.py
+++ b/postgres/tests/test_metadata_consistency.py
@@ -1,0 +1,100 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.dev.utils import get_metadata_metrics
+from datadog_checks.postgres import relationsmanager, util
+from datadog_checks.postgres.version_utils import V18
+
+from .common import _iterate_metric_name
+
+pytestmark = pytest.mark.unit
+
+
+def _is_metric_descriptor(value):
+    """True if value is a (metric_name, ..., submit_fn) tuple."""
+    return isinstance(value, tuple) and bool(value) and isinstance(value[0], str) and callable(value[-1])
+
+
+def _is_metric_container(obj):
+    """True for the metric-bearing dict shapes _iterate_metric_name understands.
+
+    Two shapes are declared throughout the integration: structured query dicts (a 'columns' or
+    'metrics' key) and plain metric dicts mapping a SQL expression to a (metric_name, submit_fn)
+    tuple. Other module-level dicts (lookup tables, config maps) are ignored.
+
+    A dict with some metric descriptors and some malformed entries fails loudly rather than being
+    silently dropped: skipping it would hide the exact missing-metadata mistake this test exists to
+    catch (a typo'd descriptor would quietly remove every metric in its dict from the checked set).
+    """
+    if not isinstance(obj, dict) or not obj:
+        return False
+    if 'columns' in obj or 'metrics' in obj:
+        return True
+    values = list(obj.values())
+    if not any(_is_metric_descriptor(v) for v in values):
+        return False
+    malformed = [v for v in values if not _is_metric_descriptor(v)]
+    assert not malformed, f'Dict looks like a metric map but has malformed descriptors: {malformed}'
+    return True
+
+
+def _declared_metric_names():
+    """Every postgresql.* metric the integration declares through util/relationsmanager.
+
+    Collected by introspection so a new metric added to any existing declaration (a util dict, a
+    relation query, or the version-gated pg_class builder) is covered with no edit here. The pg_class
+    builder is evaluated at the highest supported version so all version-gated columns are included.
+    """
+    names = set()
+    for module in (util, relationsmanager):
+        for obj in vars(module).values():
+            if _is_metric_container(obj):
+                names.update(_iterate_metric_name(obj))
+    names.update(_iterate_metric_name(relationsmanager.get_pg_class_query(V18)))
+    return names
+
+
+def test_declared_metrics_have_metadata_row():
+    """Every declared postgresql.* metric must have a row in metadata.csv.
+
+    This is the common bundle mistake (add a metric, forget the metadata row) and it now fails in the
+    unit suite, naming the offending metric, instead of only in `ddev validate metadata`.
+
+    The reverse direction (orphan metadata rows) is intentionally not asserted here: activity,
+    statement and other DBM metrics are emitted through dynamic code paths outside this declarative
+    collection, so a metadata row absent from it is not necessarily dead. `ddev validate metadata`
+    remains the backstop for those.
+    """
+    documented = set(get_metadata_metrics())
+    missing = sorted(_declared_metric_names() - documented)
+    assert not missing, f'Declared metrics missing a metadata.csv row: {missing}'
+
+
+@pytest.mark.parametrize(
+    'obj, expected',
+    [
+        ({'columns': [], 'query': 'x'}, True),
+        ({'metrics': {}, 'query': 'x'}, True),
+        ({'some_expr': ('postgresql.foo', len)}, True),
+        ({'a': 'tag', 'b': 'gauge'}, False),
+        ({'a': {'nested': 'dict'}}, False),
+        ({}, False),
+        ('not a dict', False),
+        (['not', 'a', 'dict'], False),
+    ],
+)
+def test_is_metric_container_classifies_shapes(obj, expected):
+    """The classifier the whole consistency check rests on must recognise every metric-bearing shape."""
+    assert _is_metric_container(obj) is expected
+
+
+def test_is_metric_container_rejects_half_malformed_dict():
+    """A dict that looks like a metric map but has a malformed descriptor fails loudly, not silently skipped."""
+    half_malformed = {
+        'good_expr': ('postgresql.good', len),
+        'bad_expr': ('postgresql.bad',),  # missing submit fn
+    }
+    with pytest.raises(AssertionError):
+        _is_metric_container(half_malformed)

--- a/postgres/tests/test_metadata_consistency.py
+++ b/postgres/tests/test_metadata_consistency.py
@@ -5,7 +5,7 @@ import pytest
 
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.postgres import relationsmanager, util
-from datadog_checks.postgres.version_utils import V18
+from datadog_checks.postgres.version_utils import V14, V18
 
 from .common import _iterate_metric_name
 
@@ -44,8 +44,10 @@ def _declared_metric_names():
     """Every postgresql.* metric the integration declares through util/relationsmanager.
 
     Collected by introspection so a new metric added to any existing declaration (a util dict, a
-    relation query, or the version-gated pg_class builder) is covered with no edit here. The pg_class
-    builder is evaluated at the highest supported version so all version-gated columns are included.
+    relation query, or a version-gated query builder) is covered with no edit here. Builders are
+    evaluated across the versions that bound their column sets so every gated column is included: the
+    pg_class builder only adds columns in newer majors (highest version suffices), but pg_stat_wal
+    dropped its I/O timing columns in PG 18, so both sides of that split are evaluated.
     """
     names = set()
     for module in (util, relationsmanager):
@@ -53,6 +55,8 @@ def _declared_metric_names():
             if _is_metric_container(obj):
                 names.update(_iterate_metric_name(obj))
     names.update(_iterate_metric_name(relationsmanager.get_pg_class_query(V18)))
+    for version in (V14, V18):
+        names.update(_iterate_metric_name(util.get_stat_wal_query(version)))
     return names
 
 

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -8,14 +8,29 @@ import psycopg
 import pytest
 
 from datadog_checks.postgres.relationsmanager import (
-    QUERY_PG_CLASS,
     QUERY_PG_CLASS_SIZE,
     STATIO_METRICS,
     RelationsManager,
+    get_pg_class_query,
 )
+from datadog_checks.postgres.version_utils import VersionUtils
 
-from .common import DB_NAME, HOST, POSTGRES_LOCALE, _get_expected_tags, _iterate_metric_name, assert_metric_at_least
+from .common import (
+    DB_NAME,
+    HOST,
+    POSTGRES_LOCALE,
+    POSTGRES_VERSION,
+    _get_expected_tags,
+    _iterate_metric_name,
+    assert_metric_at_least,
+)
 from .utils import _get_superconn, _wait_for_value, requires_over_11
+
+# Built for the version under test so the asserted metric set matches what the check collects.
+# Guarded so the module still imports when POSTGRES_VERSION is unset (these tests are integration-only).
+QUERY_PG_CLASS = (
+    get_pg_class_query(VersionUtils.parse_version(POSTGRES_VERSION)) if POSTGRES_VERSION is not None else None
+)
 
 RELATION_INDEX_METRICS = [
     "postgresql.index_scans",

--- a/postgres/tests/test_relationsmanager.py
+++ b/postgres/tests/test_relationsmanager.py
@@ -7,9 +7,10 @@ from datadog_checks.postgres.relationsmanager import (
     ALL_SCHEMAS,
     IDX_METRICS,
     LOCK_METRICS,
-    QUERY_PG_CLASS,
     RelationsManager,
+    get_pg_class_query,
 )
+from datadog_checks.postgres.version_utils import V9_6, V13, V16, V18
 
 from .common import SCHEMA_NAME
 
@@ -99,7 +100,7 @@ def test_relation_filter_relkind():
 
 
 def test_relation_filter_limit():
-    query = QUERY_PG_CLASS['query']
+    query = get_pg_class_query(V18)['query']
     relations_config = [{'relation_regex': '.*', 'schemas': [ALL_SCHEMAS]}]
     relations = RelationsManager(relations_config, default_max_relations)
 
@@ -114,3 +115,108 @@ def test_relkind_does_not_apply_to_index_metrics():
 
     query_filter = relations.filter_relation_query(query, SCHEMA_NAME)
     assert "relkind = ANY(array['r'])" not in query_filter
+
+
+# Golden output of get_pg_class_query, pinned byte-for-byte. The builder replaced the former static
+# QUERY_PG_CLASS constant; this locks the emitted SQL and column set so a refactor of the builder cannot
+# silently change what the check collects. No column is version-gated yet, so every supported version
+# produces this identical query: when a version-gated column is later added, give the affected versions
+# their own expected output here.
+GOLDEN_PG_CLASS_QUERY = """
+SELECT
+  current_database(),
+  N.nspname,
+  C.relname,
+  pg_stat_get_numscans(C.oid),
+  pg_stat_get_tuples_returned(C.oid),
+  I.idx_scan,
+  I.idx_tup_fetch,
+  pg_stat_get_tuples_inserted(C.oid),
+  pg_stat_get_tuples_updated(C.oid),
+  pg_stat_get_tuples_deleted(C.oid),
+  pg_stat_get_tuples_hot_updated(C.oid),
+  pg_stat_get_live_tuples(C.oid),
+  pg_stat_get_dead_tuples(C.oid),
+  pg_stat_get_vacuum_count(C.oid),
+  pg_stat_get_autovacuum_count(C.oid),
+  pg_stat_get_analyze_count(C.oid),
+  pg_stat_get_autoanalyze_count(C.oid),
+  EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_vacuum_time(C.oid))),
+  EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_autovacuum_time(C.oid))),
+  EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_analyze_time(C.oid))),
+  EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_autoanalyze_time(C.oid))),
+  pg_stat_get_numscans(idx_toast.indexrelid),
+  pg_stat_get_tuples_fetched(idx_toast.indexrelid),
+  pg_stat_get_tuples_inserted(C.reltoastrelid),
+  pg_stat_get_tuples_deleted(C.reltoastrelid),
+  pg_stat_get_live_tuples(C.reltoastrelid),
+  pg_stat_get_dead_tuples(C.reltoastrelid),
+  pg_stat_get_vacuum_count(C.reltoastrelid),
+  pg_stat_get_autovacuum_count(C.reltoastrelid),
+  EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_vacuum_time(C.reltoastrelid))),
+  EXTRACT(EPOCH FROM age(CURRENT_TIMESTAMP, pg_stat_get_last_autovacuum_time(C.reltoastrelid))),
+  C.xmin
+FROM pg_class C
+LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace)
+LEFT JOIN pg_index idx_toast ON (idx_toast.indrelid = C.reltoastrelid)
+LEFT JOIN LATERAL (
+    SELECT sum(pg_stat_get_numscans(indexrelid))::bigint AS idx_scan,
+           sum(pg_stat_get_tuples_fetched(indexrelid))::bigint AS idx_tup_fetch
+      FROM pg_index
+     WHERE pg_index.indrelid = C.oid) I ON true
+WHERE C.relkind = 'r'
+    AND NOT (nspname = ANY('{{pg_catalog,information_schema}}'))
+    AND NOT EXISTS (
+        SELECT 1
+        from pg_locks
+        WHERE locktype = 'relation'
+        AND mode = 'AccessExclusiveLock'
+        AND granted = true
+        AND relation = C.oid
+    )
+    AND {relations} {limits}
+"""
+
+GOLDEN_PG_CLASS_COLUMNS = [
+    {'name': 'db', 'type': 'tag'},
+    {'name': 'schema', 'type': 'tag'},
+    {'name': 'table', 'type': 'tag'},
+    {'name': 'seq_scans', 'type': 'rate'},
+    {'name': 'seq_rows_read', 'type': 'rate'},
+    {'name': 'index_rel_scans', 'type': 'rate'},
+    {'name': 'index_rel_rows_fetched', 'type': 'rate'},
+    {'name': 'rows_inserted', 'type': 'rate'},
+    {'name': 'rows_updated', 'type': 'rate'},
+    {'name': 'rows_deleted', 'type': 'rate'},
+    {'name': 'rows_hot_updated', 'type': 'rate'},
+    {'name': 'live_rows', 'type': 'gauge'},
+    {'name': 'dead_rows', 'type': 'gauge'},
+    {'name': 'vacuumed', 'type': 'monotonic_count'},
+    {'name': 'autovacuumed', 'type': 'monotonic_count'},
+    {'name': 'analyzed', 'type': 'monotonic_count'},
+    {'name': 'autoanalyzed', 'type': 'monotonic_count'},
+    {'name': 'last_vacuum_age', 'type': 'gauge'},
+    {'name': 'last_autovacuum_age', 'type': 'gauge'},
+    {'name': 'last_analyze_age', 'type': 'gauge'},
+    {'name': 'last_autoanalyze_age', 'type': 'gauge'},
+    {'name': 'toast.index_scans', 'type': 'monotonic_count'},
+    {'name': 'toast.rows_fetched', 'type': 'monotonic_count'},
+    {'name': 'toast.rows_inserted', 'type': 'monotonic_count'},
+    {'name': 'toast.rows_deleted', 'type': 'monotonic_count'},
+    {'name': 'toast.live_rows', 'type': 'gauge'},
+    {'name': 'toast.dead_rows', 'type': 'gauge'},
+    {'name': 'toast.vacuumed', 'type': 'monotonic_count'},
+    {'name': 'toast.autovacuumed', 'type': 'monotonic_count'},
+    {'name': 'toast.last_vacuum_age', 'type': 'gauge'},
+    {'name': 'toast.last_autovacuum_age', 'type': 'gauge'},
+    {'name': 'relation.xmin', 'type': 'gauge'},
+]
+
+
+@pytest.mark.parametrize('version', [V9_6, V13, V16, V18])
+def test_get_pg_class_query_golden_output(version):
+    """The builder emits byte-identical SQL and columns to the former static QUERY_PG_CLASS constant."""
+    query = get_pg_class_query(version)
+    assert query['name'] == 'pg_class'
+    assert query['query'] == GOLDEN_PG_CLASS_QUERY
+    assert query['columns'] == GOLDEN_PG_CLASS_COLUMNS

--- a/postgres/tests/test_version_markers.py
+++ b/postgres/tests/test_version_markers.py
@@ -1,0 +1,67 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from .common import POSTGRES_VERSION
+from .utils import (
+    requires_over,
+    requires_over_10,
+    requires_over_11,
+    requires_over_12,
+    requires_over_13,
+    requires_over_14,
+    requires_over_15,
+    requires_over_16,
+    requires_over_17,
+    requires_over_18,
+    requires_under,
+    requires_under_17,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _condition_and_reason(marker):
+    return marker.mark.args[0], marker.mark.kwargs['reason']
+
+
+# Each alias must resolve to exactly the marker the old hand-written literal produced. The literals
+# below are the pre-refactor definitions, inlined so the equality is visible to the reviewer.
+def test_requires_over_aliases_match_old_literals():
+    for version, alias in [
+        (10, requires_over_10),
+        (11, requires_over_11),
+        (12, requires_over_12),
+        (13, requires_over_13),
+        (14, requires_over_14),
+        (15, requires_over_15),
+        (16, requires_over_16),
+        (17, requires_over_17),
+    ]:
+        expected = pytest.mark.skipif(
+            POSTGRES_VERSION is None or float(POSTGRES_VERSION) < version,
+            reason=f'This test is for over {version} only (make sure POSTGRES_VERSION is set)',
+        )
+        assert _condition_and_reason(alias) == _condition_and_reason(expected)
+
+
+def test_requires_under_17_alias_matches_old_literal():
+    expected = pytest.mark.skipif(
+        POSTGRES_VERSION is None or float(POSTGRES_VERSION) >= 17,
+        reason='This test is for under 17 only (make sure POSTGRES_VERSION is set)',
+    )
+    assert _condition_and_reason(requires_under_17) == _condition_and_reason(expected)
+
+
+def test_requires_over_18_added():
+    expected = pytest.mark.skipif(
+        POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 18,
+        reason='This test is for over 18 only (make sure POSTGRES_VERSION is set)',
+    )
+    assert _condition_and_reason(requires_over_18) == _condition_and_reason(expected)
+
+
+def test_factories_gate_on_version():
+    assert requires_over(18).mark.args[0] == (POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 18)
+    assert requires_under(18).mark.args[0] == (POSTGRES_VERSION is None or float(POSTGRES_VERSION) >= 18)

--- a/postgres/tests/test_version_utils.py
+++ b/postgres/tests/test_version_utils.py
@@ -4,7 +4,15 @@
 import pytest
 from semver import VersionInfo
 
-from datadog_checks.postgres.version_utils import VersionUtils
+from datadog_checks.postgres.util import get_stat_wal_query
+from datadog_checks.postgres.version_utils import (
+    V14,
+    V16,
+    V18,
+    VersionRange,
+    VersionUtils,
+    build_versioned_query,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -86,3 +94,57 @@ def test_parse_rds_eol_version():
     v11_22_rds = VersionUtils.parse_version(version)
 
     assert v11_22_rds == VersionInfo(11, 22, 20241121)
+
+
+@pytest.mark.parametrize(
+    'version_range, version, expected',
+    [
+        (VersionRange(), V16, True),
+        (VersionRange(min_version=V16), V14, False),
+        (VersionRange(min_version=V16), V16, True),
+        (VersionRange(min_version=V16), V18, True),
+        (VersionRange(max_version=V18), V16, True),
+        (VersionRange(max_version=V18), V18, False),
+        (VersionRange(min_version=V14, max_version=V18), V14, True),
+        (VersionRange(min_version=V14, max_version=V18), V18, False),
+    ],
+)
+def test_version_range_contains(version_range, version, expected):
+    """min_version is inclusive, max_version is exclusive, and an open bound never excludes."""
+    assert (version in version_range) is expected
+
+
+def test_build_versioned_query_includes_only_columns_the_version_exposes():
+    columns = [
+        ('always_expr', {'name': 'always', 'type': 'gauge'}),
+        ('added_expr', {'name': 'added', 'type': 'gauge'}, VersionRange(min_version=V16)),
+        ('removed_expr', {'name': 'removed', 'type': 'gauge'}, VersionRange(max_version=V18)),
+    ]
+
+    on_14 = build_versioned_query('demo', columns, '\n  FROM t\n', V14)
+    assert on_14['columns'] == [{'name': 'always', 'type': 'gauge'}, {'name': 'removed', 'type': 'gauge'}]
+    assert on_14['query'] == '\nSELECT\n  always_expr,\n  removed_expr\n  FROM t\n'
+
+    on_16 = build_versioned_query('demo', columns, '\n  FROM t\n', V16)
+    assert [c['name'] for c in on_16['columns']] == ['always', 'added', 'removed']
+
+    on_18 = build_versioned_query('demo', columns, '\n  FROM t\n', V18)
+    assert [c['name'] for c in on_18['columns']] == ['always', 'added']
+    assert on_18['name'] == 'demo'
+
+
+def test_build_versioned_query_requires_a_resolved_version():
+    with pytest.raises(ValueError):
+        build_versioned_query('demo', [('expr', {'name': 'm', 'type': 'gauge'})], '\n  FROM t\n', None)
+
+
+def test_get_stat_wal_query_drops_io_timing_columns_on_18():
+    """pg_stat_wal lost the wal_write/wal_sync I/O timing columns in PG 18."""
+    io_timing = {'wal.write', 'wal.sync', 'wal.write_time', 'wal.sync_time'}
+
+    below_18 = {c['name'] for c in get_stat_wal_query(V14)['columns']}
+    assert io_timing <= below_18
+
+    on_18 = {c['name'] for c in get_stat_wal_query(V18)['columns']}
+    assert io_timing.isdisjoint(on_18)
+    assert 'wal.records' in on_18

--- a/postgres/tests/utils.py
+++ b/postgres/tests/utils.py
@@ -12,42 +12,34 @@ from datadog_checks.base import AgentCheck
 
 from .common import PASSWORD_ADMIN, POSTGRES_VERSION, USER_ADMIN
 
-requires_over_10 = pytest.mark.skipif(
-    POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 10,
-    reason='This test is for over 10 only (make sure POSTGRES_VERSION is set)',
-)
-requires_over_11 = pytest.mark.skipif(
-    POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 11,
-    reason='This test is for over 11 only (make sure POSTGRES_VERSION is set)',
-)
-requires_over_12 = pytest.mark.skipif(
-    POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 12,
-    reason='This test is for over 12 only (make sure POSTGRES_VERSION is set)',
-)
-requires_over_13 = pytest.mark.skipif(
-    POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 13,
-    reason='This test is for over 13 only (make sure POSTGRES_VERSION is set)',
-)
-requires_over_14 = pytest.mark.skipif(
-    POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 14,
-    reason='This test is for over 14 only (make sure POSTGRES_VERSION is set)',
-)
-requires_over_15 = pytest.mark.skipif(
-    POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 15,
-    reason='This test is for over 15 only (make sure POSTGRES_VERSION is set)',
-)
-requires_over_16 = pytest.mark.skipif(
-    POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 16,
-    reason='This test is for over 16 only (make sure POSTGRES_VERSION is set)',
-)
-requires_under_17 = pytest.mark.skipif(
-    POSTGRES_VERSION is None or float(POSTGRES_VERSION) >= 17,
-    reason='This test is for under 17 only (make sure POSTGRES_VERSION is set)',
-)
-requires_over_17 = pytest.mark.skipif(
-    POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 17,
-    reason='This test is for over 17 only (make sure POSTGRES_VERSION is set)',
-)
+
+def requires_over(version: float) -> pytest.MarkDecorator:
+    """Skip a test unless POSTGRES_VERSION is set and is at least `version`."""
+    return pytest.mark.skipif(
+        POSTGRES_VERSION is None or float(POSTGRES_VERSION) < version,
+        reason=f'This test is for over {version} only (make sure POSTGRES_VERSION is set)',
+    )
+
+
+def requires_under(version: float) -> pytest.MarkDecorator:
+    """Skip a test unless POSTGRES_VERSION is set and is below `version`."""
+    return pytest.mark.skipif(
+        POSTGRES_VERSION is None or float(POSTGRES_VERSION) >= version,
+        reason=f'This test is for under {version} only (make sure POSTGRES_VERSION is set)',
+    )
+
+
+# Thin aliases kept so existing tests need no change. New gating should call requires_over/under directly.
+requires_over_10 = requires_over(10)
+requires_over_11 = requires_over(11)
+requires_over_12 = requires_over(12)
+requires_over_13 = requires_over(13)
+requires_over_14 = requires_over(14)
+requires_over_15 = requires_over(15)
+requires_over_16 = requires_over(16)
+requires_over_17 = requires_over(17)
+requires_over_18 = requires_over(18)
+requires_under_17 = requires_under(17)
 
 
 def _get_conn(db_instance, dbname=None, user=None, password=None, application_name='test', autocommit=True):


### PR DESCRIPTION
### What does this PR do?

Refactors the `pg_class` relation-metrics query in the postgres check from a static `QUERY_PG_CLASS` dict into a builder function, `get_pg_class_query(version)`, and reworks the test setup so the suite derives its expectations from the metric declarations instead of duplicating them by hand.

No metric is added, removed, or changed. The generated SQL is identical to before, and a test pins the builder's output (SQL string and column list) to the old constant's output across PG 9.6/13/16/18.

How the builder works: it holds a single list of `(sql_expression, column_descriptor)` pairs in SELECT order. It joins the expressions into the `SELECT` clause and emits the descriptors as the query's `columns` list from that same list, so the two can't fall out of order. It takes the server `version` so a column that only exists on newer PostgreSQL majors can be appended behind an `if version >= V<major>` check — calling a `pg_stat_get_*` function that doesn't exist on the server aborts the whole query, so those columns have to be gated. The check builds the query once per instance (it's memoized) and runs it as before.

Supporting test changes:
- `tests/common.py` derives the expected metric lists (`COMMON_METRICS`, the bgwriter/checkpointer lists) from the `util.py` metric declarations via a shared helper, instead of keeping hand-written copies in sync.
- `tests/test_metadata_consistency.py` (new) asserts every declared `postgresql.*` metric has a row in `metadata.csv`, so a missing row fails in the unit suite rather than only in `ddev validate metadata`.
- `tests/utils.py` / `tests/test_version_markers.py` generate the per-version skip markers from `requires_over(n)` / `requires_under(n)` helpers (existing `requires_over_10`…`requires_over_18`, `requires_under_17` kept as aliases).

### Motivation

Adding a `pg_class` metric used to mean editing four places by hand with nothing keeping them in sync:

1. The `QUERY_PG_CLASS` dict — add the SQL expression to the `SELECT` list *and* add a matching entry to the parallel `columns` list, in the same position. The two lists were maintained separately, so it was easy to misalign them.
2. The hand-written metric lists in `tests/common.py`.
3. The per-version test markers.
4. The `metadata.csv` row — and if you forgot it, nothing caught it until `ddev validate metadata`.

After this change, adding the metric is mostly a content change in one place:

1. Add one `(expression, descriptor)` pair to the builder (gated by version if needed). The SELECT and columns stay aligned because they come from the same list.
2. The test metric lists pick it up automatically, since they're derived from the declarations.
3. Add the `metadata.csv` row — and the new unit test fails immediately if it's missing.

So the change removes the manual bookkeeping that was the main source of mistakes, and turns the "forgot the metadata row" error from a late validation failure into an upfront unit-test failure.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
