### PR TITLE
Fix outdated relation-metrics count in Postgres config comment

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -74,7 +74,7 @@ files:
         If enabled, `dbname` should be specified to collect database-specific relations metrics.
         You can either specify a single relation by its exact name in 'relation_name' or use a regex to track metrics
         from all matching relations (useful in cases where relation names are dynamically generated, e.g. TimescaleDB).
-        Each relation generates many metrics (10 + 10 per index).
+        Each relation generates many metrics (dozens per relation, plus several more for each index).
 
         By default all schemas are included. To track relations from specific schemas only,
         you can specify the `schemas` attribute and provide a list of schemas to use for filtering.

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -75,6 +75,8 @@ files:
         You can either specify a single relation by its exact name in 'relation_name' or use a regex to track metrics
         from all matching relations (useful in cases where relation names are dynamically generated, e.g. TimescaleDB).
         Each relation generates many metrics (dozens per relation, plus several more for each index).
+        Be mindful of the metric volume this can produce: on large instances, broad `relation_regex`
+        patterns that match many relations can emit metrics in the thousands.
 
         By default all schemas are included. To track relations from specific schemas only,
         you can specify the `schemas` attribute and provide a list of schemas to use for filtering.

--- a/postgres/changelog.d/24096.fixed
+++ b/postgres/changelog.d/24096.fixed
@@ -1,0 +1,1 @@
+Update the relations config comment to reflect the current number of metrics generated per relation.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -78,7 +78,7 @@ instances:
     ## If enabled, `dbname` should be specified to collect database-specific relations metrics.
     ## You can either specify a single relation by its exact name in 'relation_name' or use a regex to track metrics
     ## from all matching relations (useful in cases where relation names are dynamically generated, e.g. TimescaleDB).
-    ## Each relation generates many metrics (10 + 10 per index).
+    ## Each relation generates many metrics (dozens per relation, plus several more for each index).
     ##
     ## By default all schemas are included. To track relations from specific schemas only,
     ## you can specify the `schemas` attribute and provide a list of schemas to use for filtering.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -79,6 +79,8 @@ instances:
     ## You can either specify a single relation by its exact name in 'relation_name' or use a regex to track metrics
     ## from all matching relations (useful in cases where relation names are dynamically generated, e.g. TimescaleDB).
     ## Each relation generates many metrics (dozens per relation, plus several more for each index).
+    ## Be mindful of the metric volume this can produce: on large instances, broad `relation_regex`
+    ## patterns that match many relations can emit metrics in the thousands.
     ##
     ## By default all schemas are included. To track relations from specific schemas only,
     ## you can specify the `schemas` attribute and provide a list of schemas to use for filtering.


### PR DESCRIPTION
### What does this PR do?
Updates the Postgres `relations` config comment that claimed each tracked relation generates "10 + 10 per index" metrics. The comment is reworded to "dozens per relation, plus several more for each index" so it stays accurate without a hardcoded count. The change is made in `spec.yaml` and `conf.yaml.example` is regenerated from it.

### Motivation
The "10 + 10 per index" figure is outdated — `RELATION_METRICS` now defines ~29 distinct metrics (table stats, sizes, lock metrics, heap/index/toast block I/O, plus per-index metrics). The exact number also depends on which metric groups and relkinds apply, so a precise number is fragile. Reported in #11642.

Closes #11642

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)