### PR TITLE
Skip code coverage gate validation for extras repos

### DIFF
--- a/ddev/changelog.d/24099.fixed
+++ b/ddev/changelog.d/24099.fixed
@@ -1,0 +1,1 @@
+Skip code coverage gate validation for extras repos, which do not enforce a required per-integration coverage threshold.

--- a/ddev/src/ddev/cli/validate/ci.py
+++ b/ddev/src/ddev/cli/validate/ci.py
@@ -42,6 +42,7 @@ def ci(app: Application, sync: bool):
 
     is_core = app.repo.name == 'core'
     is_marketplace = app.repo.name == 'marketplace'
+    is_extras = app.repo.name == 'extras'
 
     # For non-core repos, extract the workflow reference from existing workflow files
     # This allows using either @master or @<commit-sha>
@@ -229,7 +230,7 @@ def ci(app: Application, sync: bool):
     if repo_choice not in valid_repos:
         app.abort(f'Unknown repository `{repo_choice}`')
 
-    if is_marketplace:
+    if is_marketplace or is_extras:
         validation_tracker.success()
         validation_tracker.display()
         return

--- a/ddev/tests/cli/validate/test_ci.py
+++ b/ddev/tests/cli/validate/test_ci.py
@@ -143,6 +143,23 @@ def test_code_coverage_file_missing(ddev, repository, helpers):
     assert "Unable to find the code coverage config file" in helpers.remove_trailing_spaces(result.output)
 
 
+def test_code_coverage_skipped_for_extras(ddev, repository, helpers, config_file):
+    config_file.model.repos['extras'] = str(repository.path)
+    config_file.model.repo = 'extras'
+    config_file.save()
+
+    # Remove the coverage file entirely — extras should not care
+    coverage_file = repository.path / 'code-coverage.datadog.yml'
+    if coverage_file.exists():
+        coverage_file.unlink()
+
+    result = ddev('validate', 'ci', '--sync')
+    assert result.exit_code == 0, result.output
+
+    result = ddev('validate', 'ci')
+    assert result.exit_code == 0, result.output
+
+
 @pytest.mark.parametrize(
     'repo_name',
     [


### PR DESCRIPTION
### What does this PR do?

Widens the early-return guard in `ddev validate ci` to skip the code coverage threshold validation when running against an `extras` repository.

### Motivation

The `extras` repository does not enforce a required per-integration code coverage threshold. Requiring `code-coverage.datadog.yml` gates in extras repos is therefore unnecessary and would cause `ddev validate ci` to fail. 

A unit test is added to cover the new skip path.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged