### PR TITLE
[SDBMON-2665] Cache parameterized-query explain failures caused by unresolvable parameter types

### DIFF
--- a/postgres/changelog.d/24102.fixed
+++ b/postgres/changelog.d/24102.fixed
@@ -1,0 +1,1 @@
+Cache parameterized-query explain failures caused by unresolvable parameter types so they aren't re-attempted on every collection.

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -112,10 +112,13 @@ class ExplainParameterizedQueries:
                 return None, error_code, err_msg
 
             try:
-                result = self._explain_prepared_statement(conn, statement, obfuscated_statement, query_signature)
-                if result is None:
-                    # an expected parameter type-resolution failure surfaced during EXPLAIN EXECUTE
-                    return None, DBExplainError.undefined_function, None
+                result, explain_error = self._explain_prepared_statement(
+                    conn, statement, obfuscated_statement, query_signature
+                )
+                if explain_error is not None:
+                    # an expected, deterministic parameter type-resolution failure surfaced during EXPLAIN EXECUTE
+                    error_code, err_msg = explain_error
+                    return None, error_code, err_msg
                 elif result:
                     plan = result[0][0][0]
                     return plan, DBExplainError.explained_with_prepared_statement, None
@@ -157,11 +160,7 @@ class ExplainParameterizedQueries:
                 query_signature,
                 e,
             )
-            if isinstance(e, psycopg.errors.IndeterminateDatatype):
-                return DBExplainError.indeterminate_datatype, '{}'.format(type(e))
-            if isinstance(e, psycopg.errors.DatatypeMismatch):
-                return DBExplainError.datatype_mismatch, '{}'.format(type(e))
-            return DBExplainError.undefined_function, '{}'.format(type(e))
+            return self._map_parameter_type_error(e)
         except Exception as e:
             self._log_failed_statement(
                 'Failed to create prepared statement when explaining statement(%s)=[%s] | err=[%s]',
@@ -171,6 +170,15 @@ class ExplainParameterizedQueries:
                 e,
             )
             raise
+
+    def _map_parameter_type_error(self, e: Exception) -> Tuple[DBExplainError, str]:
+        # Map an unresolved parameter-type error to its specific explain error code so cached responses
+        # and emitted error tags reflect the actual failure rather than a generic one.
+        if isinstance(e, psycopg.errors.IndeterminateDatatype):
+            return DBExplainError.indeterminate_datatype, '{}'.format(type(e))
+        if isinstance(e, psycopg.errors.DatatypeMismatch):
+            return DBExplainError.datatype_mismatch, '{}'.format(type(e))
+        return DBExplainError.undefined_function, '{}'.format(type(e))
 
     def _log_failed_statement(
         self, message: str, statement: str, obfuscated_statement: str, query_signature: str, e: Exception
@@ -201,14 +209,17 @@ class ExplainParameterizedQueries:
     @tracked_method(agent_check_getter=agent_check_getter)
     def _explain_prepared_statement(
         self, conn, statement: str, obfuscated_statement: str, query_signature: str
-    ) -> Optional[List]:
+    ) -> Tuple[Optional[List], Optional[Tuple[DBExplainError, str]]]:
+        # Returns (rows, None) on success, or (None, (DBExplainError, err_msg)) when a parameter's type can't be
+        # resolved during EXPLAIN EXECUTE. Other unexpected errors are re-raised.
         try:
             prepared_statement_query = self._generate_prepared_statement_query(conn, query_signature)
-            return self._execute_query_and_fetch_rows(
+            rows = self._execute_query_and_fetch_rows(
                 conn,
                 EXPLAIN_QUERY.format(explain_function=self._explain_function),
                 (prepared_statement_query,),
             )
+            return rows, None
         except EXPECTED_PARAMETER_TYPE_ERRORS as e:
             # The parameter types couldn't be resolved during EXPLAIN EXECUTE, so the query can't be explained.
             self._log_failed_statement(
@@ -218,7 +229,7 @@ class ExplainParameterizedQueries:
                 query_signature,
                 e,
             )
-            return None
+            return None, self._map_parameter_type_error(e)
         except Exception as e:
             self._log_failed_statement(
                 'Failed to explain parameterized statement(%s)=[%s] | err=[%s]',

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -4,6 +4,7 @@
 
 import logging
 import re
+from typing import Dict, List, Optional, Tuple
 
 import psycopg
 
@@ -25,6 +26,16 @@ SELECT CARDINALITY(parameter_types) FROM pg_prepared_statements WHERE name = 'dd
 EXECUTE_PREPARED_STATEMENT_QUERY = 'EXECUTE dd_{prepared_statement}{parameters}'
 
 EXPLAIN_QUERY = 'SELECT {explain_function}(%s)'
+
+# Errors raised when PostgreSQL can't resolve a parameter's type while preparing or explaining a parameterized
+# query (e.g. untyped NULL parameters from ORMs using the extended query protocol: "operator does not exist:
+# bigint = text"). The parameter types that made the original query valid aren't available in pg_stat_activity,
+# so these queries can't be explained and the failure is deterministic for a given query signature.
+EXPECTED_PARAMETER_TYPE_ERRORS = (
+    psycopg.errors.IndeterminateDatatype,
+    psycopg.errors.UndefinedFunction,
+    psycopg.errors.DatatypeMismatch,
+)
 
 
 def agent_check_getter(self):
@@ -73,7 +84,9 @@ class ExplainParameterizedQueries:
         self._explain_function = explain_function
 
     @tracked_method(agent_check_getter=agent_check_getter)
-    def explain_statement(self, dbname, statement, obfuscated_statement, query_signature):
+    def explain_statement(
+        self, dbname: str, statement: str, obfuscated_statement: str, query_signature: str
+    ) -> Tuple[Optional[Dict], Optional[DBExplainError], Optional[str]]:
         if self._check.version < V12:
             # if pg version < 12, skip explaining parameterized queries because
             # plan_cache_mode is not supported
@@ -86,18 +99,24 @@ class ExplainParameterizedQueries:
         with self._check.db_pool.get_connection(dbname) as conn:
             try:
                 self._set_plan_cache_mode(conn)
-                self._create_prepared_statement(conn, statement, obfuscated_statement, query_signature)
-            except psycopg.errors.IndeterminateDatatype as e:
-                return None, DBExplainError.indeterminate_datatype, '{}'.format(type(e))
-            except psycopg.errors.UndefinedFunction as e:
-                return None, DBExplainError.undefined_function, '{}'.format(type(e))
+                prepared_statement_error = self._create_prepared_statement(
+                    conn, statement, obfuscated_statement, query_signature
+                )
             except Exception as e:
-                # if we fail to create a prepared statement, we cannot explain the query
+                # an unexpected failure creating the prepared statement means we cannot explain the query
                 return None, DBExplainError.failed_to_explain_with_prepared_statement, '{}'.format(type(e))
+
+            if prepared_statement_error is not None:
+                # an expected, deterministic parameter type-resolution failure (e.g. untyped NULL parameters).
+                error_code, err_msg = prepared_statement_error
+                return None, error_code, err_msg
 
             try:
                 result = self._explain_prepared_statement(conn, statement, obfuscated_statement, query_signature)
-                if result:
+                if result is None:
+                    # an expected parameter type-resolution failure surfaced during EXPLAIN EXECUTE
+                    return None, DBExplainError.undefined_function, None
+                elif result:
                     plan = result[0][0][0]
                     return plan, DBExplainError.explained_with_prepared_statement, None
                 else:
@@ -117,23 +136,51 @@ class ExplainParameterizedQueries:
         self._execute_query(conn, "SET plan_cache_mode = force_generic_plan")
 
     @tracked_method(agent_check_getter=agent_check_getter)
-    def _create_prepared_statement(self, conn, statement, obfuscated_statement, query_signature):
+    def _create_prepared_statement(
+        self, conn, statement: str, obfuscated_statement: str, query_signature: str
+    ) -> Optional[Tuple[DBExplainError, str]]:
+        # Returns None on success, or a (DBExplainError, err_msg) tuple when the query can't be prepared because
+        # a parameter's type can't be resolved. Other unexpected errors are re-raised.
         try:
             self._execute_query(
                 conn,
                 PREPARE_STATEMENT_QUERY.format(query_signature=query_signature, statement=statement),
             )
-        except Exception as e:
-            logged_statement = obfuscated_statement
-            if self._config.log_unobfuscated_plans:
-                logged_statement = statement
-            logger.debug(
+            return None
+        except EXPECTED_PARAMETER_TYPE_ERRORS as e:
+            # The parameter types can't be resolved, so this query can't be prepared (and therefore can't be
+            # explained). Map the failure to the corresponding explain error code.
+            self._log_failed_statement(
                 'Failed to create prepared statement when explaining statement(%s)=[%s] | err=[%s]',
+                statement,
+                obfuscated_statement,
                 query_signature,
-                logged_statement,
+                e,
+            )
+            if isinstance(e, psycopg.errors.IndeterminateDatatype):
+                return DBExplainError.indeterminate_datatype, '{}'.format(type(e))
+            if isinstance(e, psycopg.errors.DatatypeMismatch):
+                return DBExplainError.datatype_mismatch, '{}'.format(type(e))
+            return DBExplainError.undefined_function, '{}'.format(type(e))
+        except Exception as e:
+            self._log_failed_statement(
+                'Failed to create prepared statement when explaining statement(%s)=[%s] | err=[%s]',
+                statement,
+                obfuscated_statement,
+                query_signature,
                 e,
             )
             raise
+
+    def _log_failed_statement(
+        self, message: str, statement: str, obfuscated_statement: str, query_signature: str, e: Exception
+    ) -> None:
+        # Logs the obfuscated statement by default, falling back to the raw statement only when explicitly
+        # configured. The message is expected to interpolate (query_signature, statement, error) in that order.
+        logged_statement = obfuscated_statement
+        if self._config.log_unobfuscated_plans:
+            logged_statement = statement
+        logger.debug(message, query_signature, logged_statement, e)
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _get_number_of_parameters_for_prepared_statement(self, conn, query_signature):
@@ -152,7 +199,9 @@ class ExplainParameterizedQueries:
         return EXECUTE_PREPARED_STATEMENT_QUERY.format(prepared_statement=query_signature, parameters=parameters)
 
     @tracked_method(agent_check_getter=agent_check_getter)
-    def _explain_prepared_statement(self, conn, statement, obfuscated_statement, query_signature):
+    def _explain_prepared_statement(
+        self, conn, statement: str, obfuscated_statement: str, query_signature: str
+    ) -> Optional[List]:
         try:
             prepared_statement_query = self._generate_prepared_statement_query(conn, query_signature)
             return self._execute_query_and_fetch_rows(
@@ -160,14 +209,22 @@ class ExplainParameterizedQueries:
                 EXPLAIN_QUERY.format(explain_function=self._explain_function),
                 (prepared_statement_query,),
             )
-        except Exception as e:
-            logged_statement = obfuscated_statement
-            if self._config.log_unobfuscated_plans:
-                logged_statement = statement
-            logger.debug(
+        except EXPECTED_PARAMETER_TYPE_ERRORS as e:
+            # The parameter types couldn't be resolved during EXPLAIN EXECUTE, so the query can't be explained.
+            self._log_failed_statement(
                 'Failed to explain parameterized statement(%s)=[%s] | err=[%s]',
+                statement,
+                obfuscated_statement,
                 query_signature,
-                logged_statement,
+                e,
+            )
+            return None
+        except Exception as e:
+            self._log_failed_statement(
+                'Failed to explain parameterized statement(%s)=[%s] | err=[%s]',
+                statement,
+                obfuscated_statement,
+                query_signature,
                 e,
             )
             raise

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -53,6 +53,16 @@ TRACK_ACTIVITY_QUERY_SIZE_SUGGESTED_VALUE = 4096
 
 SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update', 'with'})
 
+# Deterministic parameterized-query explain failures that will not succeed on retry for a given query signature
+# (e.g. a type mismatch caused by untyped parameters).
+PARAMETERIZED_EXPLAIN_ERRORS_TO_CACHE = frozenset(
+    {
+        DBExplainError.undefined_function,
+        DBExplainError.indeterminate_datatype,
+        DBExplainError.datatype_mismatch,
+    }
+)
+
 # columns from pg_stat_activity which correspond to attributes common to all databases and are therefore stored in
 # under other standard keys
 pg_stat_activity_sample_exclude_keys = {
@@ -806,9 +816,13 @@ class PostgresStatementSamples(DBMAsyncJob):
             # instead of trying to explain it then failing
             if self._explain_parameterized_queries._is_parameterized_query(statement):
                 if is_affirmative(self._config.query_samples.explain_parameterized_queries):
-                    return self._explain_parameterized_queries.explain_statement(
+                    plan, explain_err_code, err_msg = self._explain_parameterized_queries.explain_statement(
                         dbname, statement, obfuscated_statement, query_signature
                     )
+                    # Cache deterministic failures (e.g. type mismatches from untyped parameters)
+                    if explain_err_code in PARAMETERIZED_EXPLAIN_ERRORS_TO_CACHE:
+                        self._explain_errors_cache[query_signature] = (plan, explain_err_code, err_msg)
+                    return plan, explain_err_code, err_msg
                 e = psycopg.errors.UndefinedParameter("Unable to explain parameterized query")
                 self._log.debug(
                     "Unable to collect execution plan, clients using the extended query protocol or prepared statements"

--- a/postgres/tests/test_explain_parameterized_queries.py
+++ b/postgres/tests/test_explain_parameterized_queries.py
@@ -8,7 +8,6 @@ import psycopg
 import pytest
 
 from datadog_checks.base.utils.db.sql import compute_sql_signature
-from datadog_checks.postgres.explain_parameterized_queries import EXPECTED_PARAMETER_TYPE_ERRORS
 from datadog_checks.postgres.util import DBExplainError
 from datadog_checks.postgres.version_utils import V12
 
@@ -323,10 +322,19 @@ def test_create_prepared_statement_datatype_mismatch_maps_to_code(integration_ch
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("exception_class", EXPECTED_PARAMETER_TYPE_ERRORS)
-def test_explain_prepared_statement_type_mismatch_returns_none(integration_check, dbm_instance, exception_class):
+@pytest.mark.parametrize(
+    "exception_class,expected_error_code",
+    [
+        (psycopg.errors.IndeterminateDatatype, DBExplainError.indeterminate_datatype),
+        (psycopg.errors.DatatypeMismatch, DBExplainError.datatype_mismatch),
+        (psycopg.errors.UndefinedFunction, DBExplainError.undefined_function),
+    ],
+)
+def test_explain_prepared_statement_type_mismatch_maps_to_code(
+    integration_check, dbm_instance, exception_class, expected_error_code
+):
     """When EXPLAIN EXECUTE hits a parameter type-resolution error the statement can't be explained,
-    so _explain_prepared_statement returns None as a sentinel rather than raising."""
+    so _explain_prepared_statement returns the specific mapped error code rather than raising."""
     check = integration_check(dbm_instance)
     epq = check.statement_samples._explain_parameterized_queries
 
@@ -336,14 +344,16 @@ def test_explain_prepared_statement_type_mismatch_returns_none(integration_check
             '_execute_query_and_fetch_rows',
             side_effect=exception_class("operator does not exist: bigint = text"),
         ):
-            result = epq._explain_prepared_statement(
+            rows, explain_error = epq._explain_prepared_statement(
                 None,
                 "SELECT id FROM t WHERE id = $1",
                 "SELECT id FROM t WHERE id = $1",
                 "test_sig",
             )
 
-    assert result is None
+    assert rows is None
+    assert explain_error is not None
+    assert explain_error[0] == expected_error_code
 
 
 @pytest.mark.unit

--- a/postgres/tests/test_explain_parameterized_queries.py
+++ b/postgres/tests/test_explain_parameterized_queries.py
@@ -8,6 +8,7 @@ import psycopg
 import pytest
 
 from datadog_checks.base.utils.db.sql import compute_sql_signature
+from datadog_checks.postgres.explain_parameterized_queries import EXPECTED_PARAMETER_TYPE_ERRORS
 from datadog_checks.postgres.util import DBExplainError
 from datadog_checks.postgres.version_utils import V12
 
@@ -184,7 +185,7 @@ def test_explain_parameterized_queries_explain_prepared_statement_no_plan_return
 
     with mock.patch(
         'datadog_checks.postgres.explain_parameterized_queries.ExplainParameterizedQueries._execute_query_and_fetch_rows',
-        return_value=None,
+        return_value=[],
     ):
         plan_dict, explain_err_code, err = check.statement_samples._run_and_track_explain(
             DB_NAME,
@@ -195,6 +196,52 @@ def test_explain_parameterized_queries_explain_prepared_statement_no_plan_return
         assert plan_dict is None
         assert explain_err_code == DBExplainError.no_plan_returned_with_prepared_statement
         assert err is None
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("dd_environment")
+@requires_over_12
+@pytest.mark.parametrize(
+    "query,expected_error_code",
+    [
+        # the parameter appears only in `$1 IS NULL`, so its type can't be resolved while preparing
+        ("SELECT * FROM pg_settings WHERE $1 IS NULL", DBExplainError.indeterminate_datatype),
+        # `setting` is text but `$1::int` pins $1 to int, leaving no `text = integer` operator
+        (
+            "SELECT * FROM pg_settings WHERE setting = $1 AND name = $1::int",
+            DBExplainError.undefined_function,
+        ),
+    ],
+)
+def test_parameterized_explain_type_resolution_failure_is_handled(
+    integration_check, dbm_instance, query, expected_error_code
+):
+    """A parameterized query whose parameter types can't be resolved can't be prepared or explained.
+
+    Real Postgres raises the type-resolution error while preparing the statement. The failure should
+    surface as an explain error code (not raise) and be cached per query signature so we don't keep
+    attempting to prepare a statement we already know we can't prepare.
+    """
+    check = integration_check(dbm_instance)
+    check.check(dbm_instance)
+    query_signature = compute_sql_signature(query)
+
+    plan, explain_err_code, _ = check.statement_samples._run_and_track_explain(DB_NAME, query, query, query_signature)
+
+    assert plan is None
+    assert explain_err_code == expected_error_code
+    # the deterministic failure is cached so we don't re-attempt it every collection
+    assert query_signature in check.statement_samples._explain_errors_cache
+
+    # the cached failure short-circuits subsequent attempts without re-querying Postgres
+    with mock.patch.object(
+        check.statement_samples._explain_parameterized_queries,
+        'explain_statement',
+        return_value=(None, expected_error_code, None),
+    ) as mock_explain:
+        _, cached_err_code, _ = check.statement_samples._run_explain_safe(DB_NAME, query, query, query_signature)
+    assert cached_err_code == expected_error_code
+    mock_explain.assert_not_called()
 
 
 @requires_over_12
@@ -232,19 +279,71 @@ def test_generate_prepared_statement_query_three_parameters(integration_check, d
 
 @pytest.mark.unit
 @requires_over_12
-def test_create_prepared_statement_exception(integration_check, dbm_instance):
+# psycopg.errors.DatabaseError is the parent of the expected type-resolution errors, so it also guards that
+# the narrow except in _create_prepared_statement does not accidentally swallow unexpected database errors.
+@pytest.mark.parametrize("exception_class", [Exception, psycopg.errors.DatabaseError])
+def test_create_prepared_statement_exception(integration_check, dbm_instance, exception_class):
     check = integration_check(dbm_instance)
 
     query = "SELECT * FROM pg_settings WHERE name = $1"
     query_signature = compute_sql_signature(query)
     with mock.patch(
         'datadog_checks.postgres.explain_parameterized_queries.ExplainParameterizedQueries._execute_query',
-        side_effect=Exception,
+        side_effect=exception_class,
     ):
-        with pytest.raises(Exception):
+        with pytest.raises(exception_class):
             check.statement_samples._explain_parameterized_queries._create_prepared_statement(
                 DB_NAME, query, query, query_signature
             )
+
+
+@pytest.mark.unit
+@requires_over_12
+def test_create_prepared_statement_datatype_mismatch_maps_to_code(integration_check, dbm_instance):
+    """A DatatypeMismatch during PREPARE means the statement can't be prepared, so it maps to the
+    datatype_mismatch error code instead of raising.
+
+    IndeterminateDatatype and UndefinedFunction are covered end-to-end against real Postgres in
+    test_parameterized_explain_type_resolution_failure_is_handled. DatatypeMismatch is exercised here
+    because it isn't reliably triggered by a portable query.
+    """
+    check = integration_check(dbm_instance)
+    epq = check.statement_samples._explain_parameterized_queries
+
+    with mock.patch.object(epq, '_execute_query', side_effect=psycopg.errors.DatatypeMismatch("type mismatch")):
+        result = epq._create_prepared_statement(
+            None,
+            "SELECT id FROM t WHERE id = $1",
+            "SELECT id FROM t WHERE id = $1",
+            "test_sig",
+        )
+
+    assert result is not None
+    assert result[0] == DBExplainError.datatype_mismatch
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("exception_class", EXPECTED_PARAMETER_TYPE_ERRORS)
+def test_explain_prepared_statement_type_mismatch_returns_none(integration_check, dbm_instance, exception_class):
+    """When EXPLAIN EXECUTE hits a parameter type-resolution error the statement can't be explained,
+    so _explain_prepared_statement returns None as a sentinel rather than raising."""
+    check = integration_check(dbm_instance)
+    epq = check.statement_samples._explain_parameterized_queries
+
+    with mock.patch.object(epq, '_generate_prepared_statement_query', return_value="EXECUTE dd_test(null)"):
+        with mock.patch.object(
+            epq,
+            '_execute_query_and_fetch_rows',
+            side_effect=exception_class("operator does not exist: bigint = text"),
+        ):
+            result = epq._explain_prepared_statement(
+                None,
+                "SELECT id FROM t WHERE id = $1",
+                "SELECT id FROM t WHERE id = $1",
+                "test_sig",
+            )
+
+    assert result is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What does this PR do?

Caches deterministic explain failures for parameterized queries whose parameter
types can't be resolved, so the agent stops re-attempting (and re-failing) the
same `PREPARE`/`EXPLAIN EXECUTE` on every collection cycle.

- Catches expected parameter type-resolution errors (`IndeterminateDatatype`,
  `UndefinedFunction`, `DatatypeMismatch`) during the **PREPARE** phase inside
  `_create_prepared_statement`, returning a mapped `DBExplainError` code instead
  of letting the exception propagate.
- Caches these deterministic failures by `query_signature` in
  `_explain_errors_cache` (via the new `PARAMETERIZED_EXPLAIN_ERRORS_TO_CACHE`
  set), so a query signature that can't be explained isn't retried for the cache
  TTL.
- Extracts the duplicated obfuscation/log logic into a single
  `_log_failed_statement` helper and adds type annotations to the touched
  methods for clarity.

### Motivation

Clients using the extended query protocol (e.g. ORMs) frequently send untyped
parameters such as `NULL`. The original parameter types that made the query
valid aren't available in `pg_stat_activity`, so Postgres can't resolve them at
`PREPARE` time (e.g. `operator does not exist: bigint = text`). This failure is
**deterministic** for a given query signature.

### Testing
- Integration-style tests that exercise real Postgres behavior, driving genuine
  `IndeterminateDatatype` and `UndefinedFunction` errors through queries like
  `SELECT * FROM pg_settings WHERE $1 IS NULL`.
- Focused unit coverage for the `DatatypeMismatch` / EXECUTE-phase paths that are
  harder to reproduce against a live database.
- Manually verified against a local Postgres dev stack that the failure is cached
  and not re-attempted on subsequent collection cycles but we still emit sample events for the captured query with the correct event data at the expected intervals as before

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged