### PR TITLE
[DOCS-14092] Remove DCGM button and add GPU Monitoring link

### DIFF
--- a/dcgm/README.md
+++ b/dcgm/README.md
@@ -5,7 +5,7 @@ This is a legacy integration that is no longer being developed or fully supporte
 {{< /callout >}}
 
 ## Overview
-We recommend using [GPU Monitoring][18], which not only provides metric parity with this integration, but even more metrics and guided remediation actions across your AI stack. [See the Datadog GPU Monitoring documentation][19] for setup instructions. 
+We recommend using [GPU Monitoring][18], which not only provides metric parity with this integration, but even more metrics and guided remediation actions across your AI stack. [See the Datadog GPU Monitoring documentation][19] for setup instructions.
 
 This legacy check submits metrics exposed by the [NVIDIA DCGM Exporter][16] in Datadog Agent format. For more information on NVIDIA Data Center GPU Manager (DCGM), see [NVIDIA DCGM][15].
 

--- a/dcgm/README.md
+++ b/dcgm/README.md
@@ -1,7 +1,7 @@
 # Agent Check: DCGM Exporter
-{{< callout url="https://docs.datadoghq.com/gpu_monitoring/setup/?tab=datadogoperator" >}}
+{{< callout >}}
 
-This is a legacy integration that is no longer being developed or fully supported. For advanced insights into your GPU fleet, use Datadog's GPU Monitoring instead of installing this integration.
+This is a legacy integration that is no longer being developed or fully supported. For advanced insights into your GPU fleet, use Datadog's [GPU Monitoring](https://docs.datadoghq.com/gpu_monitoring/) instead of installing this integration.
 {{< /callout >}}
 
 ## Overview


### PR DESCRIPTION
### What does this PR do?
Updates the README for the legacy DCGM Exporter integration.
- Deletes the URL from the `callout` shortcode to remove the **Request access** button.
- Adds a link to Datadog GPU Monitoring.

### Motivation
<!-- What inspired you to submit this pull request? -->
The DCGM Exporter integration is no longer supported or developed, so users should be redirected to GPU Monitoring instead.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
