### PR TITLE
Add allowDiskUse=True to mongo query_stats aggregate to fix sort memory limit error

### DIFF
--- a/mongo/changelog.d/24105.fixed
+++ b/mongo/changelog.d/24105.fixed
@@ -1,0 +1,1 @@
+Fix query metrics collection failure on Atlas clusters caused by sort memory limit when using `$queryStats` without `allowDiskUse=True`.

--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -258,7 +258,7 @@ class MongoApi(object):
             {'$queryStats': {}},
             {'$sort': {'metrics.execCount': -1}},
         ]
-        return self['admin'].aggregate(pipeline, session=session, maxTimeMS=self._timeout)
+        return self['admin'].aggregate(pipeline, session=session, maxTimeMS=self._timeout, allowDiskUse=True)
 
     @property
     def hostname(self):


### PR DESCRIPTION
### What does this PR do?

Adds `allowDiskUse=True` to the `$queryStats` aggregation call in `query_stats()` ([`api.py:261`](https://github.com/DataDog/integrations-core/blob/master/mongo/datadog_checks/mongo/api.py#L261)).

### Motivation

On Atlas clusters with high query cardinality, the `$queryStats` + `$sort` aggregation pipeline exceeds MongoDB's 100MB in-memory sort limit. If `allowDiskUseByDefault: false` is false, sort operations must explicitly opt in to disk spilling via `allowDiskUse=True` — otherwise MongoDB rejects the operation entirely with:

```
pymongo.errors.OperationFailure: Sort exceeded memory limit of 104857600 bytes, but did not opt in to external sorting.
```

This causes query metrics collection to fail completely for affected customers. See SDBM-2683.

**Testing:** Since Atlas is a managed cloud service, reproduction was done locally using MongoDB 8.0 with `allowDiskUseByDefault: false` (replicating Atlas default behavior) and 5,000+ unique query shapes to push `$queryStats` output past the 100MB sort limit. The exact customer error was reproduced from the agent daemon. With the fix applied, query metrics collected cleanly every ~10s (~500ms per collection) with no interference to standard metric collection. Tested in both same-host and remote agent scenarios.

`allowDiskUse=True` is supported on both Atlas and self-hosted MongoDB.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged