### PR TITLE
[Release] Bumped ddev version to 17.0.1

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- towncrier release notes start -->
 
+## 17.0.1 / 2026-06-19
+
+***Fixed***:
+
+* Gate `ddev release branch create` and `update-build-agent-yaml.yml` on the matching `DataDog/datadog-agent` branch existing so neither writer can produce a release-branch pointer to a missing upstream branch. ([#23987](https://github.com/DataDog/integrations-core/pull/23987))
+* Skip code coverage gate validation for extras repos, which do not enforce a required per-integration coverage threshold. ([#24099](https://github.com/DataDog/integrations-core/pull/24099))
+
 ## 17.0.0 / 2026-06-16
 
 ***Changed***:

--- a/ddev/changelog.d/23987.fixed
+++ b/ddev/changelog.d/23987.fixed
@@ -1,1 +1,0 @@
-Gate `ddev release branch create` and `update-build-agent-yaml.yml` on the matching `DataDog/datadog-agent` branch existing so neither writer can produce a release-branch pointer to a missing upstream branch.

--- a/ddev/changelog.d/24099.fixed
+++ b/ddev/changelog.d/24099.fixed
@@ -1,1 +1,0 @@
-Skip code coverage gate validation for extras repos, which do not enforce a required per-integration coverage threshold.


### PR DESCRIPTION
### What does this PR do?
Releases ddev 17.0.1

### Motivation
Extras CI validation is requiring the Code Coverage PR gates to be added to the Code Coverage config, but they are not supposed to be required for that repo.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
