### PR TITLE
Bump datadog-checks-dev pin to >=39.0,<41 in ddev

### DIFF
--- a/ddev/changelog.d/24110.changed
+++ b/ddev/changelog.d/24110.changed
@@ -1,0 +1,1 @@
+Bump `datadog-checks-dev` pin to `>=39.0,<41` to track the v39 release.

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -30,13 +30,7 @@ dependencies = [
     "click~=8.1.6",
     "coverage",
     "datadog-api-client==2.20.0",
-    # TEMPORARY: relaxed from the usual `~=38.0` pin to span the gap between
-    # this PR landing (which bumps datadog-checks-dev to 39 because black is
-    # dropped from its [cli] extras) and the next ddev release. Without this,
-    # GitHub Actions that install ddev from the local repo can't resolve dcd
-    # 39 against ddev's tighter pin. The PR that releases ddev MUST tighten
-    # this back to `~=39.0` (see https://github.com/DataDog/integrations-core/pull/23588).
-    "datadog-checks-dev[cli]>=38.0,<40",
+    "datadog-checks-dev[cli]>=39.0,<41",
     "hatch>=1.13.0",
     "httpx",
     "jsonpointer",


### PR DESCRIPTION
### What does this PR do?

Bumps the `datadog-checks-dev[cli]` pin in `ddev/pyproject.toml` from `>=38.0,<40` to `>=39.0,<41`.

### Motivation

PR #23588 (remove black, use ruff for config model generation) landed with a temporary relaxed pin of `>=38.0,<40` to bridge the gap between that PR shipping a new `datadog-checks-dev` v39 and the next ddev release. Now that #23588 is merged and v39 is out, the floor can be raised to `>=39.0` and the upper bound extended to `<41` so the same pattern holds for the next bump.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged