### PR TITLE
Add Anthropic web search as a native server tool in the AI framework

### DIFF
--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -37,7 +37,7 @@ DEFAULT_MODEL: Final[str] = "claude-sonnet-4-6"
 DEFAULT_MAX_TOKENS: Final[int] = 8192  # max tokens per response
 MAX_CONTINUATIONS: Final[int] = 10
 
-# web_search_20260209  is not ZDR-eligible by default.
+# Pinned to the ZDR-eligible version; web_search_20260209 is not ZDR-eligible by default.
 WEB_SEARCH_VERSION: Final[str] = "web_search_20250305"
 
 NATIVE_TOOL_DEFINITIONS: Final[dict[str, ToolParam]] = {
@@ -106,10 +106,8 @@ class AnthropicAgent(BaseAgent[MessageParam]):
     def _get_tool_definitions(self, allowed_tools: list[str] | None) -> list[ToolParam]:
         """Filter tool definitions by allowlist. None means all tools."""
         definitions = self._tools.definitions
-        if allowed_tools is None:
-            return definitions
-        allowed = set(allowed_tools)
-        return [d for d in definitions if d["name"] in allowed]
+        allowed_names = set(self._filter_by_allowed([d["name"] for d in definitions], allowed_tools))
+        return [d for d in definitions if d["name"] in allowed_names]
 
     def _map_stop_reason(self, raw: str) -> StopReason:
         """Map a raw Anthropic stop_reason string to the generic StopReason enum."""

--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -119,17 +119,12 @@ class AnthropicAgent(BaseAgent[MessageParam]):
             "refusal": StopReason.OTHER,
         }
         if raw == "pause_turn":
-            # pause_turn should be consumed by _create_until_complete before reaching here.
             raise AgentError("pause_turn leaked past continuation loop") from None
         if raw not in mapping:
             raise AgentError(f"Unknown stop_reason: {raw!r}") from None
         return mapping[raw]
 
     def _native_tool_defs(self, allowed_tools: list[str] | None) -> list[ToolParam]:
-        """Resolve the registry's native (server) tool names to Anthropic definitions.
-
-        Native tools are gated by allowed_tools just like client tools: None means all.
-        """
         names = self._filter_by_allowed(self._tools.native_tool_names, allowed_tools)
         return [NATIVE_TOOL_DEFINITIONS[name] for name in names]
 

--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -17,6 +17,7 @@ from ddev.ai.tools.registry import ToolRegistry
 if TYPE_CHECKING:
     from anthropic.types import (
         CacheControlEphemeralParam,
+        Message,
         TextBlockParam,
         ToolParam,
         ToolResultBlockParam,
@@ -24,6 +25,13 @@ if TYPE_CHECKING:
 
 DEFAULT_MODEL: Final[str] = "claude-sonnet-4-6"
 DEFAULT_MAX_TOKENS: Final[int] = 8192  # max tokens per response
+
+# web_search_20260209  is not ZDR-eligible by default.
+WEB_SEARCH_VERSION: Final[str] = "web_search_20250305"
+
+NATIVE_TOOL_DEFINITIONS: Final[dict[str, ToolParam]] = {
+    "web_search": {"type": WEB_SEARCH_VERSION, "name": "web_search"},
+}
 
 # 1h TTL for the static prefix (system + tools): paid once, read for the whole session.
 STATIC_CACHE_CONTROL: Final[CacheControlEphemeralParam] = {"type": "ephemeral", "ttl": "1h"}
@@ -86,9 +94,6 @@ class AnthropicAgent(BaseAgent[MessageParam]):
 
     def _map_stop_reason(self, raw: str) -> StopReason:
         """Map a raw Anthropic stop_reason string to the generic StopReason enum."""
-        # pause_turn gets an explicit check to provide a more informative message than "Unknown stop_reason"
-        if raw == "pause_turn":
-            raise AgentError("pause_turn is not supported in batch mode") from None
         mapping = {
             "end_turn": StopReason.END_TURN,
             "tool_use": StopReason.TOOL_USE,
@@ -96,9 +101,59 @@ class AnthropicAgent(BaseAgent[MessageParam]):
             "stop_sequence": StopReason.OTHER,
             "refusal": StopReason.OTHER,
         }
+        if raw == "pause_turn":
+            # pause_turn should be consumed by _create_until_complete before reaching here.
+            raise AgentError("pause_turn leaked past continuation loop") from None
         if raw not in mapping:
             raise AgentError(f"Unknown stop_reason: {raw!r}") from None
         return mapping[raw]
+
+    def _native_tool_defs(self, allowed_tools: list[str] | None) -> list[ToolParam]:
+        """Resolve the registry's native (server) tool names to Anthropic definitions.
+
+        Native tools are gated by allowed_tools just like client tools: None means all.
+        """
+        names = self._tools.native_tool_names
+        if allowed_tools is not None:
+            allowed = set(allowed_tools)
+            names = [n for n in names if n in allowed]
+        return [NATIVE_TOOL_DEFINITIONS[name] for name in names]
+
+    @staticmethod
+    def _web_search_requests(response: Message) -> int:
+        """Web search request count from one response (0 if absent). Robust to fakes/providers."""
+        server_use = getattr(response.usage, "server_tool_use", None)
+        return getattr(server_use, "web_search_requests", 0) or 0
+
+    async def _create_until_complete(
+        self,
+        *,
+        request_messages: list[MessageParam],
+        system_param: list[TextBlockParam],
+        tool_defs: list[ToolParam],
+    ) -> tuple[Message, list[MessageParam], list[Message]]:
+        """Call messages.create, transparently continuing across pause_turn.
+
+        Returns (final_response, paused_turns, all_responses). all_responses includes
+        all intermediate responses so the caller can sum token usage across calls.
+        """
+        paused_turns: list[MessageParam] = []
+        all_responses: list[Message] = []
+        messages = request_messages
+        while True:
+            response = await self._client.messages.create(
+                model=self._model,
+                max_tokens=self._max_tokens,
+                system=system_param,
+                messages=messages,
+                tools=tool_defs if tool_defs else anthropic.NOT_GIVEN,
+            )
+            all_responses.append(response)
+            if response.stop_reason != "pause_turn":
+                return response, paused_turns, all_responses
+            paused_turn: MessageParam = {"role": "assistant", "content": response.content}
+            paused_turns.append(paused_turn)
+            messages = [*messages, paused_turn]
 
     def _to_tool_result_params(self, messages: list[ToolResultMessage]) -> list[ToolResultBlockParam]:
         """Convert model-agnostic ToolResultMessages to Anthropic SDK ToolResultBlockParams."""
@@ -156,7 +211,8 @@ class AnthropicAgent(BaseAgent[MessageParam]):
         Returns:
             An AgentResponse object containing the response from the agent.
         """
-        tool_defs = self._with_tools_cache_breakpoint(self._get_tool_definitions(allowed_tools))
+        tool_defs = self._get_tool_definitions(allowed_tools) + self._native_tool_defs(allowed_tools)
+        tool_defs = self._with_tools_cache_breakpoint(tool_defs)
 
         api_content: str | list[ToolResultBlockParam] = (
             self._to_tool_result_params(content) if isinstance(content, list) else content
@@ -173,12 +229,10 @@ class AnthropicAgent(BaseAgent[MessageParam]):
         ]
 
         try:
-            response = await self._client.messages.create(
-                model=self._model,
-                max_tokens=self._max_tokens,
-                system=system_param,
-                messages=messages,
-                tools=tool_defs if tool_defs else anthropic.NOT_GIVEN,
+            response, paused_turns, all_responses = await self._create_until_complete(
+                request_messages=messages,
+                system_param=system_param,
+                tool_defs=tool_defs,
             )
         except anthropic.APIConnectionError as e:
             raise AgentConnectionError(f"Connection failed: {e}") from e
@@ -203,18 +257,28 @@ class AnthropicAgent(BaseAgent[MessageParam]):
                 text_parts.append(block.text)
             elif isinstance(block, anthropic.types.ToolUseBlock):
                 tool_calls.append(ToolCall(id=block.id, name=block.name, input=dict(block.input)))
-        # ThinkingBlock and RedactedThinkingBlock are intentionally ignored.
-        # Extended thinking support can add a `thinking: str` field to AgentResponse later.
+        # ThinkingBlock, RedactedThinkingBlock, ServerToolUseBlock, and WebSearchToolResultBlock
+        # are intentionally not parsed as tool_calls — server tool results are preserved verbatim
+        # in history so Anthropic can resolve encrypted_content / encrypted_index for citations.
 
-        cache_read = response.usage.cache_read_input_tokens or 0
-        cache_creation = response.usage.cache_creation_input_tokens or 0
-        used_tokens = response.usage.input_tokens + cache_read + cache_creation
+        # Sum token usage across all calls (paused turns also consume tokens).
+        # context_usage reflects the final call's position in the context window.
+        total_input = sum(r.usage.input_tokens for r in all_responses)
+        total_output = sum(r.usage.output_tokens for r in all_responses)
+        total_cache_read = sum(r.usage.cache_read_input_tokens or 0 for r in all_responses)
+        total_cache_creation = sum(r.usage.cache_creation_input_tokens or 0 for r in all_responses)
+        final_cache_read = response.usage.cache_read_input_tokens or 0
+        final_cache_creation = response.usage.cache_creation_input_tokens or 0
+        final_used_tokens = response.usage.input_tokens + final_cache_read + final_cache_creation
+        # Sum across all calls: searches in paused turns are reported on their own responses.
+        web_search_requests = sum(self._web_search_requests(r) for r in all_responses)
         usage = TokenUsage(
-            input_tokens=response.usage.input_tokens,
-            output_tokens=response.usage.output_tokens,
-            cache_read_input_tokens=cache_read,
-            cache_creation_input_tokens=cache_creation,
-            context_usage=ContextUsage(window_size=await self._get_context_window(), used_tokens=used_tokens),
+            input_tokens=total_input,
+            output_tokens=total_output,
+            cache_read_input_tokens=total_cache_read,
+            cache_creation_input_tokens=total_cache_creation,
+            context_usage=ContextUsage(window_size=await self._get_context_window(), used_tokens=final_used_tokens),
+            web_search_requests=web_search_requests,
         )
 
         agent_response = AgentResponse(
@@ -227,6 +291,9 @@ class AnthropicAgent(BaseAgent[MessageParam]):
         # Save to history only after a successful response. Use the unmarked form so the
         # cache_control breakpoint is only ever on the latest user message — this keeps the
         # request below the 4-marker limit regardless of conversation length.
-        self._history.extend([user_msg_for_history, {"role": "assistant", "content": response.content}])
+        # Paused turns are inserted before the final turn so multi-turn citations remain valid.
+        self._history.append(user_msg_for_history)
+        self._history.extend(paused_turns)
+        self._history.append({"role": "assistant", "content": response.content})
 
         return agent_response

--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
 DEFAULT_MODEL: Final[str] = "claude-sonnet-4-6"
 DEFAULT_MAX_TOKENS: Final[int] = 8192  # max tokens per response
+MAX_CONTINUATIONS: Final[int] = 10
 
 # web_search_20260209  is not ZDR-eligible by default.
 WEB_SEARCH_VERSION: Final[str] = "web_search_20250305"
@@ -84,13 +85,21 @@ class AnthropicAgent(BaseAgent[MessageParam]):
             self._context_window = info.max_input_tokens
         return self._context_window
 
+    @staticmethod
+    def _filter_by_allowed(names: list[str], allowed_tools: list[str] | None) -> list[str]:
+        """Filter names by allowlist. None means all names."""
+        if allowed_tools is None:
+            return names
+        allowed = set(allowed_tools)
+        return [n for n in names if n in allowed]
+
     def _get_tool_definitions(self, allowed_tools: list[str] | None) -> list[ToolParam]:
         """Filter tool definitions by allowlist. None means all tools."""
         definitions = self._tools.definitions
-        if allowed_tools is not None:
-            allowed = set(allowed_tools)
-            definitions = [d for d in definitions if d["name"] in allowed]
-        return definitions
+        if allowed_tools is None:
+            return definitions
+        allowed = set(allowed_tools)
+        return [d for d in definitions if d["name"] in allowed]
 
     def _map_stop_reason(self, raw: str) -> StopReason:
         """Map a raw Anthropic stop_reason string to the generic StopReason enum."""
@@ -113,10 +122,7 @@ class AnthropicAgent(BaseAgent[MessageParam]):
 
         Native tools are gated by allowed_tools just like client tools: None means all.
         """
-        names = self._tools.native_tool_names
-        if allowed_tools is not None:
-            allowed = set(allowed_tools)
-            names = [n for n in names if n in allowed]
+        names = self._filter_by_allowed(self._tools.native_tool_names, allowed_tools)
         return [NATIVE_TOOL_DEFINITIONS[name] for name in names]
 
     @staticmethod
@@ -140,7 +146,7 @@ class AnthropicAgent(BaseAgent[MessageParam]):
         paused_turns: list[MessageParam] = []
         all_responses: list[Message] = []
         messages = request_messages
-        while True:
+        for _ in range(MAX_CONTINUATIONS):
             response = await self._client.messages.create(
                 model=self._model,
                 max_tokens=self._max_tokens,
@@ -154,6 +160,7 @@ class AnthropicAgent(BaseAgent[MessageParam]):
             paused_turn: MessageParam = {"role": "assistant", "content": response.content}
             paused_turns.append(paused_turn)
             messages = [*messages, paused_turn]
+        raise AgentError(f"pause_turn did not resolve after {MAX_CONTINUATIONS} continuations")
 
     def _to_tool_result_params(self, messages: list[ToolResultMessage]) -> list[ToolResultBlockParam]:
         """Convert model-agnostic ToolResultMessages to Anthropic SDK ToolResultBlockParams."""

--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -132,7 +132,7 @@ class AnthropicAgent(BaseAgent[MessageParam]):
     def _web_search_requests(response: Message) -> int:
         """Web search request count from one response (0 if absent). Robust to fakes/providers."""
         server_use = getattr(response.usage, "server_tool_use", None)
-        return getattr(server_use, "web_search_requests", 0) or 0
+        return getattr(server_use, "web_search_requests", 0)
 
     @staticmethod
     def _extract_web_searches(responses: list[Message]) -> list[WebSearchCall]:
@@ -147,14 +147,14 @@ class AnthropicAgent(BaseAgent[MessageParam]):
         for response in responses:
             for block in response.content:
                 if isinstance(block, anthropic.types.ServerToolUseBlock) and block.name == "web_search":
-                    query = block.input.get("query", "") if isinstance(block.input, dict) else ""
+                    query = block.input.get("query", "")
                     queries[block.id] = str(query)
                 elif isinstance(block, anthropic.types.WebSearchToolResultBlock):
                     content = block.content
-                    if isinstance(content, list):
-                        results[block.tool_use_id] = (len(content), None)
+                    if isinstance(content, anthropic.types.WebSearchToolResultError):
+                        results[block.tool_use_id] = (0, content.error_code)
                     else:
-                        results[block.tool_use_id] = (0, getattr(content, "error_code", "error"))
+                        results[block.tool_use_id] = (len(content), None)
 
         searches: list[WebSearchCall] = []
         for use_id, query in queries.items():

--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -18,7 +18,9 @@ from ddev.ai.agent.types import (
     TokenUsage,
     ToolCall,
     ToolResultMessage,
+    WebSearchActivity,
     WebSearchCall,
+    WebSearchCitation,
 )
 from ddev.ai.tools.registry import ToolRegistry
 
@@ -289,10 +291,14 @@ class AnthropicAgent(BaseAgent[MessageParam]):
 
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
+        citations: list[WebSearchCitation] = []
 
         for block in response.content:
             if isinstance(block, anthropic.types.TextBlock):
                 text_parts.append(block.text)
+                for c in block.citations or []:
+                    if isinstance(c, anthropic.types.CitationsWebSearchResultLocation):
+                        citations.append(WebSearchCitation(url=c.url, title=c.title, cited_text=c.cited_text))
             elif isinstance(block, anthropic.types.ToolUseBlock):
                 tool_calls.append(ToolCall(id=block.id, name=block.name, input=dict(block.input)))
         # ThinkingBlock, RedactedThinkingBlock, ServerToolUseBlock, and WebSearchToolResultBlock
@@ -324,7 +330,10 @@ class AnthropicAgent(BaseAgent[MessageParam]):
             text="\n".join(text_parts),
             tool_calls=tool_calls,
             usage=usage,
-            web_searches=self._extract_web_searches(all_responses),
+            web_activity=WebSearchActivity(
+                searches=self._extract_web_searches(all_responses),
+                citations=citations,
+            ),
         )
 
         # Save to history only after a successful response. Use the unmarked form so the

--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -11,7 +11,15 @@ from anthropic.types import MessageParam
 
 from ddev.ai.agent.base import BaseAgent
 from ddev.ai.agent.exceptions import AgentAPIError, AgentConnectionError, AgentError, AgentRateLimitError
-from ddev.ai.agent.types import AgentResponse, ContextUsage, StopReason, TokenUsage, ToolCall, ToolResultMessage
+from ddev.ai.agent.types import (
+    AgentResponse,
+    ContextUsage,
+    StopReason,
+    TokenUsage,
+    ToolCall,
+    ToolResultMessage,
+    WebSearchCall,
+)
 from ddev.ai.tools.registry import ToolRegistry
 
 if TYPE_CHECKING:
@@ -130,6 +138,34 @@ class AnthropicAgent(BaseAgent[MessageParam]):
         """Web search request count from one response (0 if absent). Robust to fakes/providers."""
         server_use = getattr(response.usage, "server_tool_use", None)
         return getattr(server_use, "web_search_requests", 0) or 0
+
+    @staticmethod
+    def _extract_web_searches(responses: list[Message]) -> list[WebSearchCall]:
+        """Collect server-side web searches (query + result count) across all responses.
+
+        Web searches are server tools: the model emits a ``ServerToolUseBlock`` (the query)
+        and Anthropic answers inline with a ``WebSearchToolResultBlock`` (the results). They
+        never become client ``ToolCall``s, so we surface them here for logging.
+        """
+        queries: dict[str, str] = {}
+        results: dict[str, tuple[int, str | None]] = {}
+        for response in responses:
+            for block in response.content:
+                if isinstance(block, anthropic.types.ServerToolUseBlock) and block.name == "web_search":
+                    query = block.input.get("query", "") if isinstance(block.input, dict) else ""
+                    queries[block.id] = str(query)
+                elif isinstance(block, anthropic.types.WebSearchToolResultBlock):
+                    content = block.content
+                    if isinstance(content, list):
+                        results[block.tool_use_id] = (len(content), None)
+                    else:
+                        results[block.tool_use_id] = (0, getattr(content, "error_code", "error"))
+
+        searches: list[WebSearchCall] = []
+        for use_id, query in queries.items():
+            count, error = results.get(use_id, (0, None))
+            searches.append(WebSearchCall(query=query, result_count=count, error=error))
+        return searches
 
     async def _create_until_complete(
         self,
@@ -293,6 +329,7 @@ class AnthropicAgent(BaseAgent[MessageParam]):
             text="\n".join(text_parts),
             tool_calls=tool_calls,
             usage=usage,
+            web_searches=self._extract_web_searches(all_responses),
         )
 
         # Save to history only after a successful response. Use the unmarked form so the

--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final, overload
 
 import anthropic
@@ -41,7 +42,8 @@ MAX_CONTINUATIONS: Final[int] = 10
 WEB_SEARCH_VERSION: Final[str] = "web_search_20250305"
 
 NATIVE_TOOL_DEFINITIONS: Final[dict[str, ToolParam]] = {
-    "web_search": {"type": WEB_SEARCH_VERSION, "name": "web_search"},
+    # max_uses stays below MAX_CONTINUATIONS so a turn is always left to receive the final response.
+    "web_search": {"type": WEB_SEARCH_VERSION, "name": "web_search", "max_uses": MAX_CONTINUATIONS - 1},
 }
 
 # 1h TTL for the static prefix (system + tools): paid once, read for the whole session.
@@ -49,6 +51,24 @@ STATIC_CACHE_CONTROL: Final[CacheControlEphemeralParam] = {"type": "ephemeral", 
 # Default TTL (currently 5 min, but Anthropic may change it) for the sliding breakpoint
 # on the last user message: re-written each turn, so a longer TTL would be wasted.
 SLIDING_CACHE_CONTROL: Final[CacheControlEphemeralParam] = {"type": "ephemeral"}
+
+
+@dataclass(frozen=True)
+class CompletionResult:
+    """Outcome of driving messages.create across pause_turn continuations."""
+
+    final_response: Message
+    paused_turns: list[MessageParam]
+    all_responses: list[Message]
+
+
+@dataclass(frozen=True)
+class ResponseContent:
+    """Parsed pieces of a single response's content blocks."""
+
+    text: str
+    tool_calls: list[ToolCall]
+    citations: list[WebSearchCitation]
 
 
 class AnthropicAgent(BaseAgent[MessageParam]):
@@ -168,11 +188,11 @@ class AnthropicAgent(BaseAgent[MessageParam]):
         request_messages: list[MessageParam],
         system_param: list[TextBlockParam],
         tool_defs: list[ToolParam],
-    ) -> tuple[Message, list[MessageParam], list[Message]]:
+    ) -> CompletionResult:
         """Call messages.create, transparently continuing across pause_turn.
 
-        Returns (final_response, paused_turns, all_responses). all_responses includes
-        all intermediate responses so the caller can sum token usage across calls.
+        all_responses includes all intermediate responses so the caller can sum
+        token usage across calls.
         """
         paused_turns: list[MessageParam] = []
         all_responses: list[Message] = []
@@ -187,7 +207,7 @@ class AnthropicAgent(BaseAgent[MessageParam]):
             )
             all_responses.append(response)
             if response.stop_reason != "pause_turn":
-                return response, paused_turns, all_responses
+                return CompletionResult(final_response=response, paused_turns=paused_turns, all_responses=all_responses)
             paused_turn: MessageParam = {"role": "assistant", "content": response.content}
             paused_turns.append(paused_turn)
             messages = [*messages, paused_turn]
@@ -237,37 +257,21 @@ class AnthropicAgent(BaseAgent[MessageParam]):
             return tool_defs
         return [*tool_defs[:-1], {**tool_defs[-1], "cache_control": STATIC_CACHE_CONTROL}]
 
-    async def send(
-        self,
-        content: str | list[ToolResultMessage],
-        allowed_tools: list[str] | None = None,
-    ) -> AgentResponse:
-        """Send a message to the agent and return the response.
-        Args:
-            content: The content to send to the agent.
-            allowed_tools: The tools in the ToolRegistry to allow the agent to use.
-        Returns:
-            An AgentResponse object containing the response from the agent.
-        """
+    def _assemble_tool_defs(self, allowed_tools: list[str] | None) -> list[ToolParam]:
+        """Combine client and native tool defs, with the static cache breakpoint on the last."""
         tool_defs = self._get_tool_definitions(allowed_tools) + self._native_tool_defs(allowed_tools)
-        tool_defs = self._with_tools_cache_breakpoint(tool_defs)
+        return self._with_tools_cache_breakpoint(tool_defs)
 
-        api_content: str | list[ToolResultBlockParam] = (
-            self._to_tool_result_params(content) if isinstance(content, list) else content
-        )
-        user_msg_for_history: MessageParam = {"role": "user", "content": api_content}
-        user_msg_for_request: MessageParam = {
-            "role": "user",
-            "content": self._with_user_cache_breakpoint(api_content),
-        }
-        messages = [*self._history, user_msg_for_request]
-
-        system_param: list[TextBlockParam] = [
-            {"type": "text", "text": self._system_prompt, "cache_control": STATIC_CACHE_CONTROL}
-        ]
-
+    async def _call_api(
+        self,
+        *,
+        messages: list[MessageParam],
+        system_param: list[TextBlockParam],
+        tool_defs: list[ToolParam],
+    ) -> CompletionResult:
+        """Drive the continuation loop, mapping Anthropic SDK errors to agent errors."""
         try:
-            response, paused_turns, all_responses = await self._create_until_complete(
+            return await self._create_until_complete(
                 request_messages=messages,
                 system_param=system_param,
                 tool_defs=tool_defs,
@@ -281,16 +285,16 @@ class AnthropicAgent(BaseAgent[MessageParam]):
         except anthropic.APIResponseValidationError as e:
             raise AgentError(f"Response validation failed: {e}") from e
 
-        # stop_reason is None only in streaming responses; we use non-streaming, so None is unexpected
-        if response.stop_reason is None:
-            raise AgentError("Received null stop_reason from API")
+    @staticmethod
+    def _parse_response_content(response: Message) -> ResponseContent:
+        """Extract text, client tool calls, and web-search citations from response blocks.
 
-        stop_reason = self._map_stop_reason(response.stop_reason)
-
+        Server tool blocks are intentionally skipped: they stay verbatim in history so
+        Anthropic can resolve encrypted_content / encrypted_index for citations.
+        """
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
         citations: list[WebSearchCitation] = []
-
         for block in response.content:
             if isinstance(block, anthropic.types.TextBlock):
                 text_parts.append(block.text)
@@ -299,47 +303,83 @@ class AnthropicAgent(BaseAgent[MessageParam]):
                         citations.append(WebSearchCitation(url=c.url, title=c.title, cited_text=c.cited_text))
             elif isinstance(block, anthropic.types.ToolUseBlock):
                 tool_calls.append(ToolCall(id=block.id, name=block.name, input=dict(block.input)))
-        # ThinkingBlock, RedactedThinkingBlock, ServerToolUseBlock, and WebSearchToolResultBlock
-        # are intentionally not parsed as tool_calls — server tool results are preserved verbatim
-        # in history so Anthropic can resolve encrypted_content / encrypted_index for citations.
+        return ResponseContent(text="\n".join(text_parts), tool_calls=tool_calls, citations=citations)
 
-        # Sum token usage across all calls (paused turns also consume tokens).
-        # context_usage reflects the final call's position in the context window.
-        total_input = sum(r.usage.input_tokens for r in all_responses)
-        total_output = sum(r.usage.output_tokens for r in all_responses)
-        total_cache_read = sum(r.usage.cache_read_input_tokens or 0 for r in all_responses)
-        total_cache_creation = sum(r.usage.cache_creation_input_tokens or 0 for r in all_responses)
-        final_cache_read = response.usage.cache_read_input_tokens or 0
-        final_cache_creation = response.usage.cache_creation_input_tokens or 0
-        final_used_tokens = response.usage.input_tokens + final_cache_read + final_cache_creation
-        # Sum across all calls: searches in paused turns are reported on their own responses.
-        web_search_requests = sum(self._web_search_requests(r) for r in all_responses)
-        usage = TokenUsage(
-            input_tokens=total_input,
-            output_tokens=total_output,
-            cache_read_input_tokens=total_cache_read,
-            cache_creation_input_tokens=total_cache_creation,
-            context_usage=ContextUsage(window_size=await self._get_context_window(), used_tokens=final_used_tokens),
-            web_search_requests=web_search_requests,
+    async def _build_usage(self, completion: CompletionResult) -> TokenUsage:
+        """Sum token and web-search usage across all responses; context reflects the final call."""
+        all_responses = completion.all_responses
+        final = completion.final_response
+        final_cache_read = final.usage.cache_read_input_tokens or 0
+        final_cache_creation = final.usage.cache_creation_input_tokens or 0
+        return TokenUsage(
+            input_tokens=sum(r.usage.input_tokens for r in all_responses),
+            output_tokens=sum(r.usage.output_tokens for r in all_responses),
+            cache_read_input_tokens=sum(r.usage.cache_read_input_tokens or 0 for r in all_responses),
+            cache_creation_input_tokens=sum(r.usage.cache_creation_input_tokens or 0 for r in all_responses),
+            context_usage=ContextUsage(
+                window_size=await self._get_context_window(),
+                used_tokens=final.usage.input_tokens + final_cache_read + final_cache_creation,
+            ),
+            web_search_requests=sum(self._web_search_requests(r) for r in all_responses),
         )
 
+    def _append_history(
+        self, user_msg: MessageParam, paused_turns: list[MessageParam], final_response: Message
+    ) -> None:
+        """Append the user turn, any paused turns, and the final assistant turn to history.
+
+        Paused turns precede the final turn so multi-turn citations remain valid.
+        """
+        self._history.append(user_msg)
+        self._history.extend(paused_turns)
+        self._history.append({"role": "assistant", "content": final_response.content})
+
+    async def send(
+        self,
+        content: str | list[ToolResultMessage],
+        allowed_tools: list[str] | None = None,
+    ) -> AgentResponse:
+        """Send a message to the agent and return the response.
+        Args:
+            content: The content to send to the agent.
+            allowed_tools: The tools in the ToolRegistry to allow the agent to use.
+        Returns:
+            An AgentResponse object containing the response from the agent.
+        """
+        tool_defs = self._assemble_tool_defs(allowed_tools)
+
+        api_content: str | list[ToolResultBlockParam] = (
+            self._to_tool_result_params(content) if isinstance(content, list) else content
+        )
+        user_msg_for_history: MessageParam = {"role": "user", "content": api_content}
+        user_msg_for_request: MessageParam = {
+            "role": "user",
+            "content": self._with_user_cache_breakpoint(api_content),
+        }
+        messages = [*self._history, user_msg_for_request]
+        system_param: list[TextBlockParam] = [
+            {"type": "text", "text": self._system_prompt, "cache_control": STATIC_CACHE_CONTROL}
+        ]
+
+        completion = await self._call_api(messages=messages, system_param=system_param, tool_defs=tool_defs)
+        final = completion.final_response
+
+        # stop_reason is None only in streaming responses; we use non-streaming, so None is unexpected
+        if final.stop_reason is None:
+            raise AgentError("Received null stop_reason from API")
+
+        parsed = self._parse_response_content(final)
         agent_response = AgentResponse(
-            stop_reason=stop_reason,
-            text="\n".join(text_parts),
-            tool_calls=tool_calls,
-            usage=usage,
+            stop_reason=self._map_stop_reason(final.stop_reason),
+            text=parsed.text,
+            tool_calls=parsed.tool_calls,
+            usage=await self._build_usage(completion),
             web_activity=WebSearchActivity(
-                searches=self._extract_web_searches(all_responses),
-                citations=citations,
+                searches=self._extract_web_searches(completion.all_responses),
+                citations=parsed.citations,
             ),
         )
 
-        # Save to history only after a successful response. Use the unmarked form so the
-        # cache_control breakpoint is only ever on the latest user message — this keeps the
-        # request below the 4-marker limit regardless of conversation length.
-        # Paused turns are inserted before the final turn so multi-turn citations remain valid.
-        self._history.append(user_msg_for_history)
-        self._history.extend(paused_turns)
-        self._history.append({"role": "assistant", "content": response.content})
-
+        # Save to history only after a successful response.
+        self._append_history(user_msg_for_history, completion.paused_turns, final)
         return agent_response

--- a/ddev/src/ddev/ai/agent/types.py
+++ b/ddev/src/ddev/ai/agent/types.py
@@ -39,6 +39,23 @@ class WebSearchCall:
 
 
 @dataclass(frozen=True)
+class WebSearchCitation:
+    """A source cited by the model in a web-search-enabled response."""
+
+    url: str
+    cited_text: str
+    title: str | None = None
+
+
+@dataclass(frozen=True)
+class WebSearchActivity:
+    """All web search activity from a single agent turn: queries made and sources cited."""
+
+    searches: list[WebSearchCall] = field(default_factory=list)
+    citations: list[WebSearchCitation] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
 class ToolResultMessage:
     """Wraps a tool result to be sent back to the agent, keyed by the originating tool call ID."""
 
@@ -83,4 +100,4 @@ class AgentResponse:
     text: str
     tool_calls: list[ToolCall]
     usage: TokenUsage
-    web_searches: list[WebSearchCall] = field(default_factory=list)
+    web_activity: WebSearchActivity = field(default_factory=WebSearchActivity)

--- a/ddev/src/ddev/ai/agent/types.py
+++ b/ddev/src/ddev/ai/agent/types.py
@@ -4,7 +4,7 @@
 
 """Wire types for the agent layer: enums, dataclasses, and response shapes."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
@@ -27,6 +27,15 @@ class ToolCall:
     id: str
     name: str
     input: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class WebSearchCall:
+    """A server-side web search the model performed (Anthropic native tool)."""
+
+    query: str
+    result_count: int = 0
+    error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -74,3 +83,4 @@ class AgentResponse:
     text: str
     tool_calls: list[ToolCall]
     usage: TokenUsage
+    web_searches: list[WebSearchCall] = field(default_factory=list)

--- a/ddev/src/ddev/ai/agent/types.py
+++ b/ddev/src/ddev/ai/agent/types.py
@@ -62,6 +62,7 @@ class TokenUsage:
     cache_read_input_tokens: int  # tokens read from prompt cache
     cache_creation_input_tokens: int  # tokens written to prompt cache
     context_usage: ContextUsage | None = None  # None only for agents that don't provide context tracking
+    web_search_requests: int = 0  # number of web search requests (billed separately from tokens)
 
 
 @dataclass(frozen=True)

--- a/ddev/src/ddev/ai/agent/types.py
+++ b/ddev/src/ddev/ai/agent/types.py
@@ -31,7 +31,7 @@ class ToolCall:
 
 @dataclass(frozen=True)
 class WebSearchCall:
-    """A server-side web search the model performed (Anthropic native tool)."""
+    """A server-side web search the model performed."""
 
     query: str
     result_count: int = 0

--- a/ddev/src/ddev/ai/runtime/agent_log.py
+++ b/ddev/src/ddev/ai/runtime/agent_log.py
@@ -82,6 +82,14 @@ class AgentLogger:
                         "cache_read": response.usage.cache_read_input_tokens,
                         "cache_creation": response.usage.cache_creation_input_tokens,
                     },
+                    "web_searches": [
+                        {"query": ws.query, "result_count": ws.result_count, "error": ws.error}
+                        for ws in response.web_activity.searches
+                    ],
+                    "web_citations": [
+                        {"url": c.url, "title": c.title, "cited_text": c.cited_text}
+                        for c in response.web_activity.citations
+                    ],
                 },
             )
 

--- a/ddev/src/ddev/ai/runtime/agent_log.py
+++ b/ddev/src/ddev/ai/runtime/agent_log.py
@@ -81,6 +81,7 @@ class AgentLogger:
                         "output": response.usage.output_tokens,
                         "cache_read": response.usage.cache_read_input_tokens,
                         "cache_creation": response.usage.cache_creation_input_tokens,
+                        "web_search_requests": response.usage.web_search_requests,
                     },
                     "web_searches": [
                         {"query": ws.query, "result_count": ws.result_count, "error": ws.error}

--- a/ddev/src/ddev/ai/tools/registry.py
+++ b/ddev/src/ddev/ai/tools/registry.py
@@ -118,7 +118,12 @@ class ToolRegistry:
 
     @staticmethod
     def available_tool_names() -> list[str]:
-        """All tool names from_names can resolve: client tools + native (server) tools."""
+        """All tool names from_names can resolve: client tools + native (server) tools.
+
+        Native tools are appended last. The cache breakpoint in AnthropicAgent lands on
+        the final element of this list, so the last native tool in NATIVE_TOOL_NAMES acts
+        as the static-prefix cache anchor. Keep that tool last when adding new native tools.
+        """
         return [*TOOL_MANIFEST, *NATIVE_TOOL_NAMES]
 
     @classmethod

--- a/ddev/src/ddev/ai/tools/registry.py
+++ b/ddev/src/ddev/ai/tools/registry.py
@@ -75,7 +75,7 @@ class ToolSpec:
 NATIVE_TOOL_READ_ONLY: dict[str, bool] = {
     "web_search": True,
 }
-NATIVE_TOOL_NAMES: frozenset[str] = frozenset(NATIVE_TOOL_READ_ONLY)
+NATIVE_TOOL_NAMES: list[str] = list(NATIVE_TOOL_READ_ONLY)
 
 TOOL_MANIFEST: dict[str, ToolSpec] = {
     "read_file": ToolSpec("fs.read_file", "ReadFileTool", factory=_file_registry_factory, read_only=True),

--- a/ddev/src/ddev/ai/tools/registry.py
+++ b/ddev/src/ddev/ai/tools/registry.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from importlib import import_module
 from typing import TYPE_CHECKING
@@ -107,14 +107,14 @@ TOOL_MANIFEST: dict[str, ToolSpec] = {
 class ToolRegistry:
     """Registry holding all available tools."""
 
-    def __init__(self, tools: list[ToolProtocol], native_tool_names: list[str] | None = None) -> None:
+    def __init__(self, tools: list[ToolProtocol], native_tool_names: Sequence[str] | None = None) -> None:
         self._tools: dict[str, ToolProtocol] = {tool.name: tool for tool in tools}
-        self._native_tool_names: list[str] = native_tool_names or []
+        self._native_tool_names: tuple[str, ...] = tuple(native_tool_names or ())
 
     @property
-    def native_tool_names(self) -> list[str]:
+    def native_tool_names(self) -> Sequence[str]:
         """Provider-executed tool names selected for this registry (order preserved)."""
-        return list(self._native_tool_names)
+        return self._native_tool_names
 
     @staticmethod
     def available_tool_names() -> list[str]:

--- a/ddev/src/ddev/ai/tools/registry.py
+++ b/ddev/src/ddev/ai/tools/registry.py
@@ -71,6 +71,12 @@ class ToolSpec:
     read_only: bool = False
 
 
+# Server (provider-executed) tools.
+NATIVE_TOOL_READ_ONLY: dict[str, bool] = {
+    "web_search": True,
+}
+NATIVE_TOOL_NAMES: frozenset[str] = frozenset(NATIVE_TOOL_READ_ONLY)
+
 TOOL_MANIFEST: dict[str, ToolSpec] = {
     "read_file": ToolSpec("fs.read_file", "ReadFileTool", factory=_file_registry_factory, read_only=True),
     "create_file": ToolSpec("fs.create_file", "CreateFileTool", factory=_file_registry_factory, read_only=False),
@@ -101,13 +107,19 @@ TOOL_MANIFEST: dict[str, ToolSpec] = {
 class ToolRegistry:
     """Registry holding all available tools."""
 
-    def __init__(self, tools: list[ToolProtocol]) -> None:
+    def __init__(self, tools: list[ToolProtocol], native_tool_names: list[str] | None = None) -> None:
         self._tools: dict[str, ToolProtocol] = {tool.name: tool for tool in tools}
+        self._native_tool_names: list[str] = native_tool_names or []
+
+    @property
+    def native_tool_names(self) -> list[str]:
+        """Provider-executed tool names selected for this registry (order preserved)."""
+        return list(self._native_tool_names)
 
     @staticmethod
     def available_tool_names() -> list[str]:
-        """Return all tool names that from_names can resolve."""
-        return list(TOOL_MANIFEST)
+        """All tool names from_names can resolve: client tools + native (server) tools."""
+        return [*TOOL_MANIFEST, *NATIVE_TOOL_NAMES]
 
     @classmethod
     def from_names(
@@ -134,13 +146,17 @@ class ToolRegistry:
             process_factory=process_factory,
         )
         tools: list[ToolProtocol] = []
+        native_tool_names: list[str] = []
         for name in tool_names:
+            if name in NATIVE_TOOL_NAMES:
+                native_tool_names.append(name)
+                continue
             spec = TOOL_MANIFEST.get(name)
             if spec is None:
                 raise ValueError(f"Unknown tool name: {name!r}")
             tool_cls = getattr(import_module(f"{__package__}.{spec.module}"), spec.cls)
             tools.append(spec.factory(tool_cls, ctx))
-        return cls(tools)
+        return cls(tools, native_tool_names=native_tool_names)
 
     @property
     def definitions(self) -> list[ToolParam]:
@@ -156,9 +172,13 @@ class ToolRegistry:
 
 
 def filter_read_only(tool_names: list[str]) -> list[str]:
-    """Return only the names whose ToolSpec has read_only=True. Unknown names raise."""
+    """Return only the read-only names. Unknown names raise."""
     out: list[str] = []
     for name in tool_names:
+        if name in NATIVE_TOOL_READ_ONLY:
+            if NATIVE_TOOL_READ_ONLY[name]:
+                out.append(name)
+            continue
         spec = TOOL_MANIFEST.get(name)
         if spec is None:
             raise ValueError(f"Unknown tool name: {name!r}")

--- a/ddev/tests/ai/agent/test_anthropic_client.py
+++ b/ddev/tests/ai/agent/test_anthropic_client.py
@@ -536,7 +536,7 @@ def make_web_search_result(tool_use_id: str, result_count: int) -> anthropic.typ
 async def test_web_searches_surfaced_with_query_and_result_count() -> None:
     content = [
         make_text_block("Searching..."),
-        make_server_tool_use("srv1", "weather in Cáceres"),
+        make_server_tool_use("srv1", "weather in Tuvalu"),
         make_web_search_result("srv1", result_count=3),
         make_text_block("Here is the forecast."),
     ]
@@ -547,7 +547,7 @@ async def test_web_searches_surfaced_with_query_and_result_count() -> None:
 
     assert result.tool_calls == []
     assert len(result.web_searches) == 1
-    assert result.web_searches[0].query == "weather in Cáceres"
+    assert result.web_searches[0].query == "weather in Tuvalu"
     assert result.web_searches[0].result_count == 3
     assert result.web_searches[0].error is None
 

--- a/ddev/tests/ai/agent/test_anthropic_client.py
+++ b/ddev/tests/ai/agent/test_anthropic_client.py
@@ -546,10 +546,10 @@ async def test_web_searches_surfaced_with_query_and_result_count() -> None:
     result = await agent.send("Search for the weather")
 
     assert result.tool_calls == []
-    assert len(result.web_searches) == 1
-    assert result.web_searches[0].query == "weather in Tuvalu"
-    assert result.web_searches[0].result_count == 3
-    assert result.web_searches[0].error is None
+    assert len(result.web_activity.searches) == 1
+    assert result.web_activity.searches[0].query == "weather in Tuvalu"
+    assert result.web_activity.searches[0].result_count == 3
+    assert result.web_activity.searches[0].error is None
 
 
 async def test_web_search_error_surfaced() -> None:
@@ -564,17 +564,84 @@ async def test_web_search_error_surfaced() -> None:
 
     result = await agent.send("Search")
 
-    assert len(result.web_searches) == 1
-    assert result.web_searches[0].error == "max_uses_exceeded"
-    assert result.web_searches[0].result_count == 0
+    assert len(result.web_activity.searches) == 1
+    assert result.web_activity.searches[0].error == "max_uses_exceeded"
+    assert result.web_activity.searches[0].result_count == 0
 
 
-async def test_no_web_searches_yields_empty_list() -> None:
+async def test_no_web_searches_yields_empty_activity() -> None:
     agent, _ = make_agent(mock_response=make_response("end_turn", [make_text_block("hi")]))
 
     result = await agent.send("Hi")
 
-    assert result.web_searches == []
+    assert result.web_activity.searches == []
+    assert result.web_activity.citations == []
+
+
+async def test_web_search_citations_extracted_from_text_block() -> None:
+    citation = anthropic.types.CitationsWebSearchResultLocation(
+        type="web_search_result_location",
+        url="https://example.com/page",
+        title="Example Page",
+        cited_text="some cited excerpt",
+        encrypted_index="enc123",
+    )
+    block = anthropic.types.TextBlock(type="text", text="Here is the answer.", citations=[citation])
+    resp = make_response("end_turn", [block])
+    agent, _ = make_agent(mock_response=resp)
+
+    result = await agent.send("What is X?")
+
+    assert len(result.web_activity.citations) == 1
+    c = result.web_activity.citations[0]
+    assert c.url == "https://example.com/page"
+    assert c.title == "Example Page"
+    assert c.cited_text == "some cited excerpt"
+
+
+async def test_non_web_search_citations_are_ignored() -> None:
+    char_citation = anthropic.types.CitationCharLocation(
+        type="char_location",
+        cited_text="some text",
+        document_index=0,
+        document_title=None,
+        end_char_index=10,
+        start_char_index=0,
+    )
+    block = anthropic.types.TextBlock(type="text", text="Based on the doc.", citations=[char_citation])
+    resp = make_response("end_turn", [block])
+    agent, _ = make_agent(mock_response=resp)
+
+    result = await agent.send("Hi")
+
+    assert result.web_activity.citations == []
+
+
+async def test_citations_across_multiple_text_blocks() -> None:
+    citation1 = anthropic.types.CitationsWebSearchResultLocation(
+        type="web_search_result_location",
+        url="https://a.com",
+        title="A",
+        cited_text="text a",
+        encrypted_index="e1",
+    )
+    citation2 = anthropic.types.CitationsWebSearchResultLocation(
+        type="web_search_result_location",
+        url="https://b.com",
+        title="B",
+        cited_text="text b",
+        encrypted_index="e2",
+    )
+    block1 = anthropic.types.TextBlock(type="text", text="First.", citations=[citation1])
+    block2 = anthropic.types.TextBlock(type="text", text="Second.", citations=[citation2])
+    resp = make_response("end_turn", [block1, block2])
+    agent, _ = make_agent(mock_response=resp)
+
+    result = await agent.send("Hi")
+
+    assert len(result.web_activity.citations) == 2
+    assert result.web_activity.citations[0].url == "https://a.com"
+    assert result.web_activity.citations[1].url == "https://b.com"
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/agent/test_anthropic_client.py
+++ b/ddev/tests/ai/agent/test_anthropic_client.py
@@ -29,12 +29,15 @@ def make_usage(
     output_tokens: int = 20,
     cache_read: int | None = None,
     cache_creation: int | None = None,
+    web_search_requests: int = 0,
 ) -> SimpleNamespace:
+    server_tool_use = SimpleNamespace(web_search_requests=web_search_requests)
     return SimpleNamespace(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         cache_read_input_tokens=cache_read,
         cache_creation_input_tokens=cache_creation,
+        server_tool_use=server_tool_use,
     )
 
 
@@ -740,8 +743,8 @@ async def test_error_during_paused_continuation_leaves_history_unchanged() -> No
 
 
 async def test_pause_turn_token_usage_summed_across_calls() -> None:
-    pause_usage = make_usage(input_tokens=100, output_tokens=50)
-    final_usage = make_usage(input_tokens=200, output_tokens=80)
+    pause_usage = make_usage(input_tokens=100, output_tokens=50, web_search_requests=2)
+    final_usage = make_usage(input_tokens=200, output_tokens=80, web_search_requests=1)
     pause_resp = make_response("pause_turn", [make_text_block("p")], usage=pause_usage)
     final_resp = make_response("end_turn", [make_text_block("done")], usage=final_usage)
 
@@ -756,6 +759,7 @@ async def test_pause_turn_token_usage_summed_across_calls() -> None:
 
     assert result.usage.input_tokens == 300  # 100 + 200
     assert result.usage.output_tokens == 130  # 50 + 80
+    assert result.usage.web_search_requests == 3  # 2 + 1
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/agent/test_anthropic_client.py
+++ b/ddev/tests/ai/agent/test_anthropic_client.py
@@ -13,6 +13,7 @@ from ddev.ai.agent.anthropic_client import (
     NATIVE_TOOL_DEFINITIONS,
     WEB_SEARCH_VERSION,
     AnthropicAgent,
+    CompletionResult,
 )
 from ddev.ai.agent.exceptions import AgentAPIError, AgentConnectionError, AgentError, AgentRateLimitError
 from ddev.ai.agent.types import StopReason, ToolResultMessage
@@ -448,6 +449,29 @@ async def test_native_tool_injected_into_request() -> None:
 
     sent_tools = create_mock.call_args.kwargs["tools"]
     assert any(t.get("type") == WEB_SEARCH_VERSION for t in sent_tools)
+
+
+async def test_web_search_max_uses_stays_below_continuation_budget() -> None:
+    registry = ToolRegistry([], native_tool_names=["web_search"])
+    resp = make_response("end_turn", [make_text_block("ok")])
+    agent, create_mock = make_agent(tools=registry, mock_response=resp)
+
+    await agent.send("Search for something")
+
+    web_search = next(t for t in create_mock.call_args.kwargs["tools"] if t.get("type") == WEB_SEARCH_VERSION)
+    assert web_search["max_uses"] == MAX_CONTINUATIONS - 1
+
+
+async def test_create_until_complete_returns_completion_result() -> None:
+    final = make_response("end_turn", [make_text_block("done")])
+    agent, _ = make_agent(mock_response=final)
+
+    result = await agent._create_until_complete(request_messages=[], system_param=[], tool_defs=[])
+
+    assert isinstance(result, CompletionResult)
+    assert result.final_response is final
+    assert result.paused_turns == []
+    assert result.all_responses == [final]
 
 
 async def test_native_tool_appended_after_client_tools() -> None:

--- a/ddev/tests/ai/agent/test_anthropic_client.py
+++ b/ddev/tests/ai/agent/test_anthropic_client.py
@@ -8,11 +8,11 @@ from unittest.mock import AsyncMock, MagicMock
 import anthropic
 import pytest
 
-from ddev.ai.agent.anthropic_client import AnthropicAgent
+from ddev.ai.agent.anthropic_client import NATIVE_TOOL_DEFINITIONS, WEB_SEARCH_VERSION, AnthropicAgent
 from ddev.ai.agent.exceptions import AgentAPIError, AgentConnectionError, AgentError, AgentRateLimitError
 from ddev.ai.agent.types import StopReason, ToolResultMessage
 from ddev.ai.tools.core.types import ToolResult
-from ddev.ai.tools.registry import ToolRegistry
+from ddev.ai.tools.registry import NATIVE_TOOL_NAMES, ToolRegistry
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -422,18 +422,208 @@ async def test_reset_clears_history() -> None:
 
 
 # ---------------------------------------------------------------------------
-# pause_turn raises AgentError
+# Native (server) tool injection
 # ---------------------------------------------------------------------------
 
 
-async def test_pause_turn_raises_agent_error() -> None:
-    resp = make_response("pause_turn", [])
+def test_native_tool_definitions_cover_all_native_names() -> None:
+    """Every name in NATIVE_TOOL_NAMES must have an entry in NATIVE_TOOL_DEFINITIONS."""
+    assert set(NATIVE_TOOL_DEFINITIONS.keys()) == set(NATIVE_TOOL_NAMES)
+
+
+async def test_native_tool_injected_into_request() -> None:
+    registry = ToolRegistry([], native_tool_names=["web_search"])
+    resp = make_response("end_turn", [make_text_block("ok")])
+    agent, create_mock = make_agent(tools=registry, mock_response=resp)
+
+    await agent.send("Search for something")
+
+    sent_tools = create_mock.call_args.kwargs["tools"]
+    assert any(t.get("type") == WEB_SEARCH_VERSION for t in sent_tools)
+
+
+async def test_native_tool_appended_after_client_tools() -> None:
+    registry = ToolRegistry([FakeTool("read_file")], native_tool_names=["web_search"])
+    resp = make_response("end_turn", [make_text_block("ok")])
+    agent, create_mock = make_agent(tools=registry, mock_response=resp)
+
+    await agent.send("Hi")
+
+    sent_tools = create_mock.call_args.kwargs["tools"]
+    assert sent_tools[0]["name"] == "read_file"
+    assert sent_tools[-1]["name"] == "web_search"
+    # Cache breakpoint must be on the last tool (web_search), not on read_file.
+    assert "cache_control" not in sent_tools[0]
+    assert sent_tools[-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+async def test_allowed_tools_gates_native_tool() -> None:
+    registry = ToolRegistry([FakeTool("read_file")], native_tool_names=["web_search"])
+    resp = make_response("end_turn", [make_text_block("ok")])
+    agent, create_mock = make_agent(tools=registry, mock_response=resp)
+
+    await agent.send("Hi", allowed_tools=["read_file"])
+
+    sent_names = [t["name"] for t in create_mock.call_args.kwargs["tools"]]
+    assert "web_search" not in sent_names
+    assert "read_file" in sent_names
+
+
+async def test_allowed_tools_none_passes_all_including_native() -> None:
+    registry = ToolRegistry([FakeTool("read_file")], native_tool_names=["web_search"])
+    resp = make_response("end_turn", [make_text_block("ok")])
+    agent, create_mock = make_agent(tools=registry, mock_response=resp)
+
+    await agent.send("Hi", allowed_tools=None)
+
+    sent_names = [t["name"] for t in create_mock.call_args.kwargs["tools"]]
+    assert "read_file" in sent_names
+    assert "web_search" in sent_names
+
+
+async def test_no_native_tools_request_unchanged() -> None:
+    registry = ToolRegistry([FakeTool("read_file")])
+    resp = make_response("end_turn", [make_text_block("ok")])
+    agent, create_mock = make_agent(tools=registry, mock_response=resp)
+
+    await agent.send("Hi")
+
+    sent_names = [t["name"] for t in create_mock.call_args.kwargs["tools"]]
+    assert sent_names == ["read_file"]
+
+
+async def test_server_result_blocks_preserved_in_history_not_parsed() -> None:
+    server_use = SimpleNamespace(type="server_tool_use", id="srvtoolu_01", name="web_search")
+    search_result = SimpleNamespace(type="web_search_tool_result", tool_use_id="srvtoolu_01", content=[])
+    content = [
+        make_text_block("Searching..."),
+        server_use,
+        search_result,
+        make_text_block("Here are the results."),
+    ]
+    resp = make_response("end_turn", content)
     agent, _ = make_agent(mock_response=resp)
 
-    with pytest.raises(AgentError):
-        await agent.send("Hi")
+    result = await agent.send("Search for X")
 
-    assert agent.history == []
+    assert result.tool_calls == []
+    assert "Searching..." in result.text
+    assert "Here are the results." in result.text
+    assert agent.history[-1] == {"role": "assistant", "content": content}
+
+
+# ---------------------------------------------------------------------------
+# pause_turn continuation loop
+# ---------------------------------------------------------------------------
+
+
+async def test_pause_turn_triggers_continuation() -> None:
+    pause_content = [make_text_block("Searching...")]
+    pause_resp = make_response("pause_turn", pause_content)
+    final_resp = make_response("end_turn", [make_text_block("Done.")])
+
+    client = MagicMock(spec=anthropic.AsyncAnthropic)
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(side_effect=[pause_resp, final_resp])
+    client.models = MagicMock()
+    client.models.retrieve = AsyncMock(return_value=SimpleNamespace(max_input_tokens=FAKE_CONTEXT_WINDOW))
+    agent = AnthropicAgent(client=client, tools=ToolRegistry([]), system_prompt="", name="t")
+
+    result = await agent.send("Hi")
+
+    assert client.messages.create.await_count == 2
+    assert result.stop_reason is StopReason.END_TURN
+    # Paused turn must appear in history before the final assistant turn.
+    assert agent.history[-2] == {"role": "assistant", "content": pause_content}
+    assert agent.history[-1] == {"role": "assistant", "content": final_resp.content}
+
+
+async def test_pause_turn_second_call_includes_paused_turn_in_messages() -> None:
+    pause_content = [make_text_block("interim")]
+    pause_resp = make_response("pause_turn", pause_content)
+    final_resp = make_response("end_turn", [make_text_block("done")])
+
+    client = MagicMock(spec=anthropic.AsyncAnthropic)
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(side_effect=[pause_resp, final_resp])
+    client.models = MagicMock()
+    client.models.retrieve = AsyncMock(return_value=SimpleNamespace(max_input_tokens=FAKE_CONTEXT_WINDOW))
+    agent = AnthropicAgent(client=client, tools=ToolRegistry([]), system_prompt="", name="t")
+
+    await agent.send("Hi")
+
+    second_call_messages = client.messages.create.call_args_list[1].kwargs["messages"]
+    assert second_call_messages[-1] == {"role": "assistant", "content": pause_content}
+
+
+async def test_multiple_consecutive_pause_turns() -> None:
+    pause1_content = [make_text_block("p1")]
+    pause2_content = [make_text_block("p2")]
+    final_content = [make_text_block("done")]
+    pause1 = make_response("pause_turn", pause1_content)
+    pause2 = make_response("pause_turn", pause2_content)
+    final = make_response("end_turn", final_content)
+
+    client = MagicMock(spec=anthropic.AsyncAnthropic)
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(side_effect=[pause1, pause2, final])
+    client.models = MagicMock()
+    client.models.retrieve = AsyncMock(return_value=SimpleNamespace(max_input_tokens=FAKE_CONTEXT_WINDOW))
+    agent = AnthropicAgent(client=client, tools=ToolRegistry([]), system_prompt="", name="t")
+
+    result = await agent.send("Hi")
+
+    assert client.messages.create.await_count == 3
+    assert result.stop_reason is StopReason.END_TURN
+    # Both paused turns appear in history in order.
+    assert agent.history[-3] == {"role": "assistant", "content": pause1_content}
+    assert agent.history[-2] == {"role": "assistant", "content": pause2_content}
+    assert agent.history[-1] == {"role": "assistant", "content": final_content}
+
+
+async def test_error_during_paused_continuation_leaves_history_unchanged() -> None:
+    ok_resp = make_response("end_turn", [make_text_block("ok")])
+    pause_resp = make_response("pause_turn", [make_text_block("pausing")])
+
+    client = MagicMock(spec=anthropic.AsyncAnthropic)
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(
+        side_effect=[
+            ok_resp,
+            pause_resp,
+            anthropic.APIConnectionError(request=MagicMock()),
+        ]
+    )
+    client.models = MagicMock()
+    client.models.retrieve = AsyncMock(return_value=SimpleNamespace(max_input_tokens=FAKE_CONTEXT_WINDOW))
+    agent = AnthropicAgent(client=client, tools=ToolRegistry([]), system_prompt="", name="t")
+
+    await agent.send("First")
+    history_after_first = agent.history[:]
+
+    with pytest.raises(AgentConnectionError):
+        await agent.send("Second")
+
+    assert agent.history == history_after_first
+
+
+async def test_pause_turn_token_usage_summed_across_calls() -> None:
+    pause_usage = make_usage(input_tokens=100, output_tokens=50)
+    final_usage = make_usage(input_tokens=200, output_tokens=80)
+    pause_resp = make_response("pause_turn", [make_text_block("p")], usage=pause_usage)
+    final_resp = make_response("end_turn", [make_text_block("done")], usage=final_usage)
+
+    client = MagicMock(spec=anthropic.AsyncAnthropic)
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(side_effect=[pause_resp, final_resp])
+    client.models = MagicMock()
+    client.models.retrieve = AsyncMock(return_value=SimpleNamespace(max_input_tokens=FAKE_CONTEXT_WINDOW))
+    agent = AnthropicAgent(client=client, tools=ToolRegistry([]), system_prompt="", name="t")
+
+    result = await agent.send("Hi")
+
+    assert result.usage.input_tokens == 300  # 100 + 200
+    assert result.usage.output_tokens == 130  # 50 + 80
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/agent/test_anthropic_client.py
+++ b/ddev/tests/ai/agent/test_anthropic_client.py
@@ -517,6 +517,66 @@ async def test_server_result_blocks_preserved_in_history_not_parsed() -> None:
     assert agent.history[-1] == {"role": "assistant", "content": content}
 
 
+def make_server_tool_use(id: str, query: str) -> anthropic.types.ServerToolUseBlock:
+    return anthropic.types.ServerToolUseBlock(type="server_tool_use", id=id, name="web_search", input={"query": query})
+
+
+def make_web_search_result(tool_use_id: str, result_count: int) -> anthropic.types.WebSearchToolResultBlock:
+    results = [
+        anthropic.types.WebSearchResultBlock(
+            type="web_search_result", encrypted_content="x", page_age=None, title=f"r{i}", url=f"http://x/{i}"
+        )
+        for i in range(result_count)
+    ]
+    return anthropic.types.WebSearchToolResultBlock(
+        type="web_search_tool_result", tool_use_id=tool_use_id, content=results
+    )
+
+
+async def test_web_searches_surfaced_with_query_and_result_count() -> None:
+    content = [
+        make_text_block("Searching..."),
+        make_server_tool_use("srv1", "weather in Cáceres"),
+        make_web_search_result("srv1", result_count=3),
+        make_text_block("Here is the forecast."),
+    ]
+    resp = make_response("end_turn", content)
+    agent, _ = make_agent(mock_response=resp)
+
+    result = await agent.send("Search for the weather")
+
+    assert result.tool_calls == []
+    assert len(result.web_searches) == 1
+    assert result.web_searches[0].query == "weather in Cáceres"
+    assert result.web_searches[0].result_count == 3
+    assert result.web_searches[0].error is None
+
+
+async def test_web_search_error_surfaced() -> None:
+    error = anthropic.types.WebSearchToolResultError(
+        type="web_search_tool_result_error", error_code="max_uses_exceeded"
+    )
+    content = [
+        make_server_tool_use("srv1", "too many"),
+        anthropic.types.WebSearchToolResultBlock(type="web_search_tool_result", tool_use_id="srv1", content=error),
+    ]
+    agent, _ = make_agent(mock_response=make_response("end_turn", content))
+
+    result = await agent.send("Search")
+
+    assert len(result.web_searches) == 1
+    assert result.web_searches[0].error == "max_uses_exceeded"
+    assert result.web_searches[0].result_count == 0
+
+
+async def test_no_web_searches_yields_empty_list() -> None:
+    agent, _ = make_agent(mock_response=make_response("end_turn", [make_text_block("hi")]))
+
+    result = await agent.send("Hi")
+
+    assert result.web_searches == []
+
+
 # ---------------------------------------------------------------------------
 # pause_turn continuation loop
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/agent/test_anthropic_client.py
+++ b/ddev/tests/ai/agent/test_anthropic_client.py
@@ -8,7 +8,12 @@ from unittest.mock import AsyncMock, MagicMock
 import anthropic
 import pytest
 
-from ddev.ai.agent.anthropic_client import NATIVE_TOOL_DEFINITIONS, WEB_SEARCH_VERSION, AnthropicAgent
+from ddev.ai.agent.anthropic_client import (
+    MAX_CONTINUATIONS,
+    NATIVE_TOOL_DEFINITIONS,
+    WEB_SEARCH_VERSION,
+    AnthropicAgent,
+)
 from ddev.ai.agent.exceptions import AgentAPIError, AgentConnectionError, AgentError, AgentRateLimitError
 from ddev.ai.agent.types import StopReason, ToolResultMessage
 from ddev.ai.tools.core.types import ToolResult
@@ -823,3 +828,24 @@ async def test_multi_turn_only_latest_user_message_in_request_has_cache_control(
     latest_blocks = second_call_messages[-1]["content"]
     assert all("cache_control" not in b for b in latest_blocks[:-1])
     assert latest_blocks[-1]["cache_control"] == {"type": "ephemeral"}
+
+
+# ---------------------------------------------------------------------------
+# pause_turn continuation cap
+# ---------------------------------------------------------------------------
+
+
+async def test_pause_turn_raises_after_max_continuations() -> None:
+    pause_resp = make_response("pause_turn", [make_text_block("still searching...")])
+
+    client = MagicMock(spec=anthropic.AsyncAnthropic)
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(return_value=pause_resp)
+    client.models = MagicMock()
+    client.models.retrieve = AsyncMock(return_value=SimpleNamespace(max_input_tokens=FAKE_CONTEXT_WINDOW))
+    agent = AnthropicAgent(client=client, tools=ToolRegistry([]), system_prompt="", name="t")
+
+    with pytest.raises(AgentError, match=f"pause_turn did not resolve after {MAX_CONTINUATIONS} continuations"):
+        await agent.send("Hi")
+
+    assert client.messages.create.await_count == MAX_CONTINUATIONS

--- a/ddev/tests/ai/agent/test_build.py
+++ b/ddev/tests/ai/agent/test_build.py
@@ -139,7 +139,7 @@ def test_build_runtime_native_tool_in_registry(file_registry, clients):
     config = AgentConfig(provider="anthropic", tools=["read_file", "web_search"])
     runtime = build_runtime(make_factory(clients, file_registry), config)
 
-    assert list(runtime.tool_registry.native_tool_names) == ["web_search"]
+    assert runtime.tool_registry.native_tool_names == ("web_search",)
     assert len(runtime.tool_registry.definitions) == 1
     assert runtime.tool_registry.definitions[0]["name"] == "read_file"
 
@@ -148,7 +148,7 @@ def test_build_runtime_no_native_tools_empty_list(file_registry, clients):
     config = AgentConfig(provider="anthropic", tools=["read_file"])
     runtime = build_runtime(make_factory(clients, file_registry), config)
 
-    assert list(runtime.tool_registry.native_tool_names) == []
+    assert runtime.tool_registry.native_tool_names == ()
 
 
 async def test_shared_registry_does_not_share_parent_read_authorization(file_registry, clients, tmp_path):

--- a/ddev/tests/ai/agent/test_build.py
+++ b/ddev/tests/ai/agent/test_build.py
@@ -135,6 +135,22 @@ def test_build_runtime_reuses_shared_file_registry(file_registry, clients):
         assert tool._owner_id == "owner"
 
 
+def test_build_runtime_native_tool_in_registry(file_registry, clients):
+    config = AgentConfig(provider="anthropic", tools=["read_file", "web_search"])
+    runtime = build_runtime(make_factory(clients, file_registry), config)
+
+    assert runtime.tool_registry.native_tool_names == ["web_search"]
+    assert len(runtime.tool_registry.definitions) == 1
+    assert runtime.tool_registry.definitions[0]["name"] == "read_file"
+
+
+def test_build_runtime_no_native_tools_empty_list(file_registry, clients):
+    config = AgentConfig(provider="anthropic", tools=["read_file"])
+    runtime = build_runtime(make_factory(clients, file_registry), config)
+
+    assert runtime.tool_registry.native_tool_names == []
+
+
 async def test_shared_registry_does_not_share_parent_read_authorization(file_registry, clients, tmp_path):
     config = AgentConfig(provider="anthropic", tools=[])
     path = tmp_path / "file.txt"

--- a/ddev/tests/ai/agent/test_build.py
+++ b/ddev/tests/ai/agent/test_build.py
@@ -139,7 +139,7 @@ def test_build_runtime_native_tool_in_registry(file_registry, clients):
     config = AgentConfig(provider="anthropic", tools=["read_file", "web_search"])
     runtime = build_runtime(make_factory(clients, file_registry), config)
 
-    assert runtime.tool_registry.native_tool_names == ["web_search"]
+    assert list(runtime.tool_registry.native_tool_names) == ["web_search"]
     assert len(runtime.tool_registry.definitions) == 1
     assert runtime.tool_registry.definitions[0]["name"] == "read_file"
 
@@ -148,7 +148,7 @@ def test_build_runtime_no_native_tools_empty_list(file_registry, clients):
     config = AgentConfig(provider="anthropic", tools=["read_file"])
     runtime = build_runtime(make_factory(clients, file_registry), config)
 
-    assert runtime.tool_registry.native_tool_names == []
+    assert list(runtime.tool_registry.native_tool_names) == []
 
 
 async def test_shared_registry_does_not_share_parent_read_authorization(file_registry, clients, tmp_path):

--- a/ddev/tests/ai/phases/test_config.py
+++ b/ddev/tests/ai/phases/test_config.py
@@ -110,6 +110,11 @@ def test_agent_config_valid_tools():
     assert ac.tools == ["read_file", "grep"]
 
 
+def test_agent_config_web_search_validates():
+    ac = AgentConfig(tools=["read_file", "web_search"])
+    assert "web_search" in ac.tools
+
+
 def test_agent_config_unknown_tool_raises():
     with pytest.raises(ValidationError, match="Unknown tool names"):
         AgentConfig(tools=["read_file", "teleport"])

--- a/ddev/tests/ai/runtime/test_agent_log.py
+++ b/ddev/tests/ai/runtime/test_agent_log.py
@@ -6,7 +6,15 @@ import json
 from pathlib import Path
 
 from ddev.ai.agent.scope import AgentRole, AgentScope
-from ddev.ai.agent.types import AgentResponse, StopReason, TokenUsage, ToolCall
+from ddev.ai.agent.types import (
+    AgentResponse,
+    StopReason,
+    TokenUsage,
+    ToolCall,
+    WebSearchActivity,
+    WebSearchCall,
+    WebSearchCitation,
+)
 from ddev.ai.react.types import ReActResult
 from ddev.ai.runtime.agent_log import AgentLogger
 from ddev.ai.tools.core.types import ToolResult
@@ -125,6 +133,40 @@ async def test_emit_after_close_is_silently_dropped(tmp_path):
     cb = logger.as_callback_set()
     await cb.fire_agent_start(scope, "sys", [])
     assert not (tmp_path / AgentRole.PHASE.value / "p1.jsonl").exists()
+
+
+async def test_agent_response_logs_web_searches_and_citations(tmp_path):
+    activity = WebSearchActivity(
+        searches=[WebSearchCall(query="python typing", result_count=5)],
+        citations=[WebSearchCitation(url="https://docs.python.org", cited_text="PEP 484", title="PEP 484")],
+    )
+    response = AgentResponse(
+        stop_reason=StopReason.END_TURN,
+        text="here",
+        tool_calls=[],
+        usage=TokenUsage(input_tokens=10, output_tokens=5, cache_read_input_tokens=0, cache_creation_input_tokens=0),
+        web_activity=activity,
+    )
+    logger = AgentLogger(tmp_path)
+    cb = logger.as_callback_set()
+
+    await cb.fire_agent_response(PHASE, response, 1)
+
+    events = read_events(tmp_path / "phase" / "p1.jsonl")
+    ev = events[0]
+    assert ev["web_searches"] == [{"query": "python typing", "result_count": 5, "error": None}]
+    assert ev["web_citations"] == [{"url": "https://docs.python.org", "title": "PEP 484", "cited_text": "PEP 484"}]
+
+
+async def test_agent_response_logs_empty_web_activity(tmp_path):
+    logger = AgentLogger(tmp_path)
+    cb = logger.as_callback_set()
+
+    await cb.fire_agent_response(PHASE, make_response("hi"), 1)
+
+    events = read_events(tmp_path / "phase" / "p1.jsonl")
+    assert events[0]["web_searches"] == []
+    assert events[0]["web_citations"] == []
 
 
 async def test_non_serializable_values_fall_back_to_str(tmp_path):

--- a/ddev/tests/ai/tools/test_registry.py
+++ b/ddev/tests/ai/tools/test_registry.py
@@ -9,7 +9,7 @@ from ddev.ai.tools.agents.spawn_subagent import SpawnSubagentTool
 from ddev.ai.tools.core.types import ToolResult
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.fs.file_registry import FileRegistry
-from ddev.ai.tools.registry import ToolRegistry, filter_read_only
+from ddev.ai.tools.registry import NATIVE_TOOL_NAMES, ToolRegistry, filter_read_only
 
 # ---------------------------------------------------------------------------
 # Fake tools — implement ToolProtocol without depending on BaseTool
@@ -155,7 +155,10 @@ def test_available_tool_names_returns_fresh_copy():
 
 
 OWNER_ID = "test-agent"
-TOOLS_WITHOUT_EXTRA_DEPS = [n for n in ToolRegistry.available_tool_names() if n != "spawn_subagent"]
+# Exclude spawn_subagent (needs process_factory wiring) and native tools (no ToolProtocol instance).
+TOOLS_WITHOUT_EXTRA_DEPS = [
+    n for n in ToolRegistry.available_tool_names() if n not in ("spawn_subagent", *NATIVE_TOOL_NAMES)
+]
 
 PROCESS_FACTORY = object()  # opaque sentinel — from_names only stores it on the spawn tool
 
@@ -237,6 +240,55 @@ def test_filter_read_only(input_names, expected):
 def test_filter_read_only_unknown_name_raises():
     with pytest.raises(ValueError, match="Unknown tool name"):
         filter_read_only(["read_file", "teleport"])
+
+
+# ---------------------------------------------------------------------------
+# Native (server) tool support
+# ---------------------------------------------------------------------------
+
+
+def test_available_tool_names_includes_web_search():
+    assert "web_search" in ToolRegistry.available_tool_names()
+
+
+def test_from_names_native_only(tmp_path):
+    registry = from_names(["web_search"], tmp_path)
+    assert registry.definitions == []
+    assert registry.native_tool_names == ["web_search"]
+
+
+def test_from_names_client_and_native(tmp_path):
+    registry = from_names(["read_file", "web_search"], tmp_path)
+    assert len(registry.definitions) == 1
+    assert registry.definitions[0]["name"] == "read_file"
+    assert registry.native_tool_names == ["web_search"]
+
+
+def test_from_names_native_not_in_tools_dict(tmp_path):
+    registry = from_names(["web_search"], tmp_path)
+    assert "web_search" not in registry._tools
+
+
+def test_from_names_bogus_raises(tmp_path):
+    with pytest.raises(ValueError, match="Unknown tool name: 'bogus'"):
+        from_names(["bogus"], tmp_path)
+
+
+def test_native_tool_names_property_returns_copy(tmp_path):
+    registry = from_names(["web_search"], tmp_path)
+    snapshot = registry.native_tool_names
+    snapshot.clear()
+    assert registry.native_tool_names == ["web_search"]
+
+
+def test_filter_read_only_includes_native_read_only():
+    result = filter_read_only(["read_file", "web_search", "create_file"])
+    assert result == ["read_file", "web_search"]
+
+
+def test_filter_read_only_unknown_still_raises():
+    with pytest.raises(ValueError, match="Unknown tool name"):
+        filter_read_only(["web_search", "bogus"])
 
 
 def test_from_names_reuses_supplied_file_registry(tmp_path):

--- a/ddev/tests/ai/tools/test_registry.py
+++ b/ddev/tests/ai/tools/test_registry.py
@@ -254,14 +254,14 @@ def test_available_tool_names_includes_web_search():
 def test_from_names_native_only(tmp_path):
     registry = from_names(["web_search"], tmp_path)
     assert registry.definitions == []
-    assert registry.native_tool_names == ["web_search"]
+    assert list(registry.native_tool_names) == ["web_search"]
 
 
 def test_from_names_client_and_native(tmp_path):
     registry = from_names(["read_file", "web_search"], tmp_path)
     assert len(registry.definitions) == 1
     assert registry.definitions[0]["name"] == "read_file"
-    assert registry.native_tool_names == ["web_search"]
+    assert list(registry.native_tool_names) == ["web_search"]
 
 
 def test_from_names_native_not_in_tools_dict(tmp_path):
@@ -274,11 +274,11 @@ def test_from_names_bogus_raises(tmp_path):
         from_names(["bogus"], tmp_path)
 
 
-def test_native_tool_names_property_returns_copy(tmp_path):
-    registry = from_names(["web_search"], tmp_path)
-    snapshot = registry.native_tool_names
-    snapshot.clear()
-    assert registry.native_tool_names == ["web_search"]
+def test_native_tool_names_not_affected_by_input_mutation():
+    names = ["web_search"]
+    registry = ToolRegistry([], native_tool_names=names)
+    names.append("web_fetch")
+    assert list(registry.native_tool_names) == ["web_search"]
 
 
 def test_filter_read_only_includes_native_read_only():


### PR DESCRIPTION
### What does this PR do?

Adds Anthropic's built-in web search (`web_search_20250305`) as a provider-native server tool in the `ddev` AI framework. Flow authors list `web_search` in the same flat `tools:` list as any other tool — the framework handles the split internally.

Key changes:

- **`ToolRegistry`** — recognizes native (server-executed) tool names in the `tools` list, skips building a `ToolProtocol` instance for them, and records them in `native_tool_names`. Exposes them through `available_tool_names()` and `filter_read_only()` so config validation and read-only gating work without any change to `flow.yaml` authoring.
- **`AnthropicAgent`** — maps native capability names to their Anthropic server-tool definitions (`{"type": "web_search_20250305", "name": "web_search"}`) and injects them into every `messages.create` call after client tools. The `allowed_tools` gate applies uniformly to both.
- **`pause_turn` continuation loop** — server tools return `pause_turn` when the search is still running. `_create_until_complete` retries transparently until a terminal stop reason is received, appending each intermediate assistant turn to history so Anthropic can resolve `encrypted_content`/`encrypted_index` for multi-turn citations.
- **Token accounting** — input/output/cache tokens are summed across all calls in a paused sequence. `web_search_requests` (billed at $10/1k searches) is surfaced on `TokenUsage` from `response.usage.server_tool_use`.
- **Web search observability** — `ServerToolUseBlock`/`WebSearchToolResultBlock` pairs are parsed across all responses and exposed as `AgentResponse.web_activity.searches` (query, result count, error) so web searches — which are fully server-side and never appear as client `tool_use` blocks — are visible downstream and logged.
- **Web citations** — `CitationsDeltaBlock` events are collected and surfaced as `AgentResponse.web_activity.citations` (URL, title, cited text). Both searches and citations are grouped under a single `WebSearchActivity` dataclass and written to the agent log.

### Motivation

Agents in flows that need current information (documentation versions, CVE details, release notes) must be able to search the web. The existing `http_get` tool requires the agent to already know the URL; web search lets it discover sources autonomously.

The `web_search_20250305` version is pinned deliberately: it is Zero Data Retention-eligible because it does not run Anthropic's internal code-execution / dynamic-filtering step.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged