### PR TITLE
Fix mysql.index.reads/updates/deletes submitted as gauge instead of monotonic_count

### DIFF
--- a/mysql/changelog.d/24125.fixed
+++ b/mysql/changelog.d/24125.fixed
@@ -1,0 +1,1 @@
+Fix `mysql.index.reads`, `mysql.index.updates`, and `mysql.index.deletes` being submitted as gauge instead of monotonic_count, causing them to report raw cumulative totals rather than per-interval counts.

--- a/mysql/changelog.d/24125.fixed
+++ b/mysql/changelog.d/24125.fixed
@@ -1,1 +1,1 @@
-Fix `mysql.index.reads`, `mysql.index.updates`, and `mysql.index.deletes` being submitted as gauge instead of monotonic_count, causing them to report raw cumulative totals rather than per-interval counts.
+Fixes `mysql.index.reads`, `mysql.index.updates`, and `mysql.index.deletes` metrics by submitting them as monotonic counts instead of gauges, so they correctly reflect per-interval operations rather than cumulative `performance_schema` lifetime totals.

--- a/mysql/datadog_checks/mysql/index_metrics.py
+++ b/mysql/datadog_checks/mysql/index_metrics.py
@@ -70,9 +70,9 @@ QUERY_INDEX_USAGE = {
         {'name': 'db', 'type': 'tag'},
         {'name': 'table', 'type': 'tag'},
         {'name': 'index', 'type': 'tag'},
-        {'name': 'mysql.index.reads', 'type': 'gauge'},
-        {'name': 'mysql.index.updates', 'type': 'gauge'},
-        {'name': 'mysql.index.deletes', 'type': 'gauge'},
+        {'name': 'mysql.index.reads', 'type': 'monotonic_count'},
+        {'name': 'mysql.index.updates', 'type': 'monotonic_count'},
+        {'name': 'mysql.index.deletes', 'type': 'monotonic_count'},
     ],
 }
 

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -17,10 +17,10 @@ mysql.galera.wsrep_local_state,gauge,,,,Internal Galera cluster state number,0,m
 mysql.galera.wsrep_received,gauge,,,,Total number of write-sets received from other nodes.,0,mysql,mysql galera wsrep_received,
 mysql.galera.wsrep_received_bytes,gauge,,,,Total size (in bytes) of writesets received from other nodes.,0,mysql,mysql galera wsrep_received_bytes,
 mysql.galera.wsrep_replicated_bytes,gauge,,,,Total size (in bytes) of writesets sent to other nodes.,0,mysql,mysql galera wsrep_replicated_bytes,
-mysql.index.deletes,monotonic_count,,operation,,The number of delete operations using an index. Resets to 0 upon database restart.,0,mysql,mysql index delete usage,
-mysql.index.reads,monotonic_count,,operation,,The number of read operations using an index. Resets to 0 upon database restart.,0,mysql,mysql index read usage,
+mysql.index.deletes,count,,operation,,The number of delete operations using an index. Resets to 0 upon database restart.,0,mysql,mysql index delete usage,
+mysql.index.reads,count,,operation,,The number of read operations using an index. Resets to 0 upon database restart.,0,mysql,mysql index read usage,
 mysql.index.size,gauge,,byte,,Size of index in bytes,0,mysql,mysql index size,
-mysql.index.updates,monotonic_count,,operation,,The number of update operations using an index. Resets to 0 upon database restart.,0,mysql,mysql index update usage,
+mysql.index.updates,count,,operation,,The number of update operations using an index. Resets to 0 upon database restart.,0,mysql,mysql index update usage,
 mysql.info.schema.size,gauge,,mebibyte,,Size of schemas in MiB,0,mysql,mysql schema size,
 mysql.info.table.data_size,gauge,,mebibyte,,Size of tables data in MiB,0,mysql,mysql data table size,memory
 mysql.info.table.index_size,gauge,,mebibyte,,Size of tables index in MiB,0,mysql,mysql index table size,

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -17,10 +17,10 @@ mysql.galera.wsrep_local_state,gauge,,,,Internal Galera cluster state number,0,m
 mysql.galera.wsrep_received,gauge,,,,Total number of write-sets received from other nodes.,0,mysql,mysql galera wsrep_received,
 mysql.galera.wsrep_received_bytes,gauge,,,,Total size (in bytes) of writesets received from other nodes.,0,mysql,mysql galera wsrep_received_bytes,
 mysql.galera.wsrep_replicated_bytes,gauge,,,,Total size (in bytes) of writesets sent to other nodes.,0,mysql,mysql galera wsrep_replicated_bytes,
-mysql.index.deletes,gauge,,operation,,The number of delete operations using an index. Resets to 0 upon database restart.,0,mysql,mysql index delete usage,
-mysql.index.reads,gauge,,operation,,The number of read operations using an index. Resets to 0 upon database restart.,0,mysql,mysql index read usage,
+mysql.index.deletes,monotonic_count,,operation,,The number of delete operations using an index. Resets to 0 upon database restart.,0,mysql,mysql index delete usage,
+mysql.index.reads,monotonic_count,,operation,,The number of read operations using an index. Resets to 0 upon database restart.,0,mysql,mysql index read usage,
 mysql.index.size,gauge,,byte,,Size of index in bytes,0,mysql,mysql index size,
-mysql.index.updates,gauge,,operation,,The number of update operations using an index. Resets to 0 upon database restart.,0,mysql,mysql index update usage,
+mysql.index.updates,monotonic_count,,operation,,The number of update operations using an index. Resets to 0 upon database restart.,0,mysql,mysql index update usage,
 mysql.info.schema.size,gauge,,mebibyte,,Size of schemas in MiB,0,mysql,mysql schema size,
 mysql.info.table.data_size,gauge,,mebibyte,,Size of tables data in MiB,0,mysql,mysql data table size,memory
 mysql.info.table.index_size,gauge,,mebibyte,,Size of tables index in MiB,0,mysql,mysql index table size,

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -339,7 +339,7 @@ def _assert_complex_config(
     aggregator.assert_metric('alice.age', value=25)
     aggregator.assert_metric('bob.age', value=20)
 
-    _test_index_metrics(aggregator, variables.INDEX_USAGE_VARS + variables.INDEX_SIZE_VARS, metric_tags)
+    _test_index_metrics(aggregator, variables.INDEX_USAGE_VARS + variables.INDEX_SIZE_VARS, metric_tags, e2e=e2e)
     # test optional metrics
     optional_metrics = (
         variables.TRADITIONAL_REPLICATION_METRICS
@@ -599,14 +599,18 @@ def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, agg
         aggregator.assert_metric(mname, hostname=expected_hostname, at_least=0)
 
 
-def _test_index_metrics(aggregator, index_metrics, metric_tags):
+def _test_index_metrics(aggregator, index_metrics, metric_tags, e2e=False):
+    # In E2E, monotonic_count metrics with collection_interval=300 aren't emitted:
+    # check_rate=True runs the check twice but the second run skips the query (interval not elapsed),
+    # so no delta is ever flushed. Use at_least=0 to avoid false failures in E2E.
+    usage_count = 0 if e2e else 1
     for mname in index_metrics:
         if mname in ['mysql.index.reads', 'mysql.index.updates', 'mysql.index.deletes']:
             aggregator.assert_metric(
                 mname,
                 metric_type=aggregator.MONOTONIC_COUNT,
                 tags=metric_tags + ('db:testdb', 'table:users', 'index:id'),
-                count=1,
+                at_least=usage_count,
             )
             aggregator.assert_metric(
                 mname,
@@ -617,13 +621,13 @@ def _test_index_metrics(aggregator, index_metrics, metric_tags):
                     'table:cities',
                     'index:single_column_index',
                 ),
-                count=1,
+                at_least=usage_count,
             )
             aggregator.assert_metric(
                 mname,
                 metric_type=aggregator.MONOTONIC_COUNT,
                 tags=metric_tags + ('db:datadog_test_schemas', 'table:cities', 'index:two_columns_index'),
-                count=1,
+                at_least=usage_count,
             )
         if mname == 'mysql.index.size':
             aggregator.assert_metric(mname, tags=metric_tags + ('db:testdb', 'table:users', 'index:id'), count=1)

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -604,11 +604,13 @@ def _test_index_metrics(aggregator, index_metrics, metric_tags):
         if mname in ['mysql.index.reads', 'mysql.index.updates', 'mysql.index.deletes']:
             aggregator.assert_metric(
                 mname,
+                metric_type=aggregator.MONOTONIC_COUNT,
                 tags=metric_tags + ('db:testdb', 'table:users', 'index:id'),
                 count=1,
             )
             aggregator.assert_metric(
                 mname,
+                metric_type=aggregator.MONOTONIC_COUNT,
                 tags=metric_tags
                 + (
                     'db:datadog_test_schemas',
@@ -619,6 +621,7 @@ def _test_index_metrics(aggregator, index_metrics, metric_tags):
             )
             aggregator.assert_metric(
                 mname,
+                metric_type=aggregator.MONOTONIC_COUNT,
                 tags=metric_tags + ('db:datadog_test_schemas', 'table:cities', 'index:two_columns_index'),
                 count=1,
             )


### PR DESCRIPTION
### What does this PR do?

`QUERY_INDEX_USAGE` in `index_metrics.py` collects `count_read`, `count_update`, and `count_delete` from `performance_schema.table_io_waits_summary_by_index_usage`. These are cumulative counters, but they were submitted with `'type': 'gauge'`, causing `mysql.index.reads`, `mysql.index.updates`, and `mysql.index.deletes` to report raw monotonically increasing totals rather than per-interval counts.

This PR changes the metric type to `monotonic_count`, consistent with how other cumulative performance_schema counters are handled in this check (e.g. `mysql.innodb.deadlocks`, `mysql.performance.wait_event.count`).

### Motivation

Customer escalation (SDBM-2685): after upgrading from MariaDB 10.6 to 11.4, `mysql.index.reads/updates/deletes` appeared as continuously increasing values in dashboards. Root cause confirmed in code and reproduced in staging (datad0g.com): all MySQL/MariaDB/Aurora hosts with `performance_schema` enabled show the same monotonically increasing pattern.

The bug affects all agents ≥ 7.63.0 (when `index_metrics` shipped in integration 14.5.0). It is not MariaDB-specific — confirmed present on Aurora MySQL in staging as well.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged