### PR TITLE
sap_hana: run schema collection in a DBMAsyncJob background thread

### DIFF
--- a/sap_hana/assets/configuration/spec.yaml
+++ b/sap_hana/assets/configuration/spec.yaml
@@ -178,6 +178,13 @@ files:
                 type: string
               example:
                 - "TMP_SCHEMA"
+          - name: run_sync
+            hidden: true
+            description: Run the schema collection job synchronously.
+            value:
+              type: boolean
+              example: false
+              display_default: false
       - name: data_observability
         hidden: true
         display_priority: 0

--- a/sap_hana/changelog.d/24128.added
+++ b/sap_hana/changelog.d/24128.added
@@ -1,0 +1,1 @@
+Run SAP HANA schema collection in a background thread to avoid blocking the main check loop.

--- a/sap_hana/datadog_checks/sap_hana/config_models/instance.py
+++ b/sap_hana/datadog_checks/sap_hana/config_models/instance.py
@@ -35,6 +35,7 @@ class CollectSchemas(BaseModel):
     max_columns: Optional[int] = None
     max_tables: Optional[int] = None
     max_views: Optional[int] = None
+    run_sync: Optional[bool] = None
 
 
 class CustomQuery(BaseModel):

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -4,7 +4,6 @@
 from __future__ import division
 
 import functools
-import time
 from collections import defaultdict
 from contextlib import closing
 from datetime import datetime
@@ -32,7 +31,7 @@ from .config_models.instance import CollectSchemas, DataObservability
 from .data_observability import SapHanaDataObservability
 from .diagnose import run_diagnostics
 from .exceptions import OperationalError, QueryExecutionError
-from .schemas import HanaSchemaCollector
+from .schemas import HanaSchemaCollectionJob
 from .utils import compute_percent, positive
 
 
@@ -93,11 +92,9 @@ class SapHanaCheck(AgentCheck):
         # Save master database hostname to act as the default if `use_hana_hostnames` is true
         self._master_hostname = None
 
-        # Schema collection (DBM)
+        # Schema collection async job (DBM)
         collect_schemas = CollectSchemas(**(self.instance.get('collect_schemas') or {}))
-        self._schema_collector = HanaSchemaCollector(self, collect_schemas) if collect_schemas.enabled else None
-        self._schema_collection_interval = int(collect_schemas.collection_interval or 600)
-        self._last_schema_collection_time = 0
+        self._schema_collection_job = HanaSchemaCollectionJob(self, collect_schemas)
         self._dbms_version = None
 
         # Data Observability async job (RC-delivered queries)
@@ -131,7 +128,7 @@ class SapHanaCheck(AgentCheck):
                 except Exception as e:
                     self.log.exception('Unexpected error running `%s`: %s', query_method.__name__, str(e))
                     continue
-            self._maybe_collect_schemas()
+            self._schema_collection_job.run_job_loop(self._tags)
             if self._do_config.enabled:
                 self.data_observability.run_job_loop(self._tags)
         finally:
@@ -237,17 +234,6 @@ class SapHanaCheck(AgentCheck):
     @property
     def cloud_metadata(self):
         return {}
-
-    def _maybe_collect_schemas(self):
-        if not self._schema_collector or not self._conn:
-            return
-        if time.time() - self._last_schema_collection_time < self._schema_collection_interval:
-            return
-        try:
-            self._schema_collector.collect_schemas()
-            self._last_schema_collection_time = time.time()
-        except Exception as e:
-            self.log.error('Error collecting HANA schemas: %s', e)
 
     def query_master_database(self):
         # https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.02/en-US/20ae63aa7519101496f6b832ec86afbd.html

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -159,9 +159,11 @@ class SapHanaCheck(AgentCheck):
                 self._connection_flaked = False
 
     def cancel(self):
-        # Signal the Data Observability async job to stop so its executor thread is
-        # released when the check is unscheduled (e.g. cluster-agent flavor or one-off
-        # check invocations), instead of leaking the DBMAsyncJob thread pool.
+        # Signal both async jobs to stop so their executor threads (and the schema job's
+        # dedicated HANA connection) are released when the check is unscheduled (e.g.
+        # cluster-agent flavor or one-off check invocations), instead of leaking the
+        # DBMAsyncJob thread pool.
+        self._schema_collection_job.cancel()
         self.data_observability.cancel()
 
     def set_default_methods(self):

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -159,10 +159,10 @@ class SapHanaCheck(AgentCheck):
                 self._connection_flaked = False
 
     def cancel(self):
-        # Signal both async jobs to stop so their executor threads (and the schema job's
-        # dedicated HANA connection) are released when the check is unscheduled (e.g.
-        # cluster-agent flavor or one-off check invocations), instead of leaking the
-        # DBMAsyncJob thread pool.
+        # Signal both async jobs to stop so their executor threads are released when the
+        # check is unscheduled (e.g. cluster-agent flavor or one-off check invocations),
+        # instead of leaking the shared DBMAsyncJob thread pool. This only sets each job's
+        # cancel event; it does not itself close the schema job's dedicated HANA connection.
         self._schema_collection_job.cancel()
         self.data_observability.cancel()
 

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -219,15 +219,29 @@ class SapHanaCheck(AgentCheck):
 
     @property
     def dbms_version(self):
-        if self._dbms_version is None and self._conn is not None:
-            try:
-                with closing(self._conn.cursor()) as cursor:
-                    cursor.execute("SELECT VERSION FROM SYS.M_DATABASE")
-                    row = cursor.fetchone()
-                    self._dbms_version = str(row[0]).split()[0] if row else 'unknown'
-            except Exception:
-                self._dbms_version = 'unknown'
+        # Only returns the cached value; resolution happens via _resolve_dbms_version on the
+        # schema job's dedicated connection. The version is read from base_event on the job
+        # thread, and querying self._conn here would race with the main check loop's concurrent
+        # use of that same connection (there is no thread-safe pool, unlike DBM integrations).
         return self._dbms_version or 'unknown'
+
+    def _resolve_dbms_version(self, conn):
+        """Resolve and cache the HANA version using the given connection.
+
+        Called from the schema-collection job thread on its dedicated connection so the main
+        check connection is never touched off-thread. Caches on first success; a transient
+        failure leaves the value unresolved so the next cycle retries instead of caching
+        'unknown' permanently.
+        """
+        if self._dbms_version is not None:
+            return
+        try:
+            with closing(conn.cursor()) as cursor:
+                cursor.execute("SELECT VERSION FROM SYS.M_DATABASE")
+                row = cursor.fetchone()
+                self._dbms_version = str(row[0]).split()[0] if row else 'unknown'
+        except Exception:
+            pass
 
     @property
     def tags(self):

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -40,13 +40,19 @@ from __future__ import annotations
 
 import contextlib
 from contextlib import closing
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from datadog_checks.base.utils.db.schemas import DatabaseInfo, SchemaCollector, SchemaCollectorConfig
+from datadog_checks.base.utils.db.utils import DBMAsyncJob
 
 if TYPE_CHECKING:
     from .config_models.instance import CollectSchemas
     from .sap_hana import SapHanaCheck
+
+try:
+    from hdbcli.dbapi import Error as HanaError
+except ImportError:
+    HanaError = Exception  # type: ignore[misc,assignment]
 
 # Flush a schema payload once this many columns have accumulated. The base SchemaCollector
 # chunks payloads by table count (`payload_chunk_size`, default 10,000 tables), but a HANA
@@ -233,6 +239,10 @@ class HanaSchemaCollector(SchemaCollector):
         super().__init__(check, HanaSchemaCollectorConfig(config))
         self._query_builder = HanaSchemaQueryBuilder(self._config, self._log)
         self._pending_row = None
+        self._conn: Any = None  # injected by HanaSchemaCollectionJob; falls back to check._conn
+
+    def _active_conn(self) -> Any:
+        return self._conn if self._conn is not None else self._check._conn
 
     def _reset(self) -> None:
         super()._reset()
@@ -254,7 +264,7 @@ class HanaSchemaCollector(SchemaCollector):
 
     def _get_databases(self) -> list[DatabaseInfo]:
         try:
-            with closing(self._check._conn.cursor()) as cursor:
+            with closing(self._active_conn().cursor()) as cursor:
                 cursor.execute(CURRENT_DATABASE_QUERY)
                 row = cursor.fetchone()
                 if not row:
@@ -276,7 +286,7 @@ class HanaSchemaCollector(SchemaCollector):
 
     @contextlib.contextmanager
     def _get_cursor(self, _database_name):
-        conn = self._check._conn
+        conn = self._active_conn()
         self._query_builder.ensure_stats_permission(conn)
         query, params = self._query_builder.build()
         with closing(conn.cursor()) as cursor:
@@ -343,3 +353,52 @@ class HanaSchemaCollector(SchemaCollector):
                 }
             ],
         }
+
+
+class HanaSchemaCollectionJob(DBMAsyncJob):
+    """Background job that runs HanaSchemaCollector on its own dedicated connection."""
+
+    def __init__(self, check: SapHanaCheck, config: CollectSchemas) -> None:
+        self._check = check
+        self._schema_collector = HanaSchemaCollector(check, config)
+        self._job_conn: Any = None
+        collection_interval = int(config.collection_interval or 600)
+        super().__init__(
+            check,
+            config_host=check._server,
+            rate_limit=1.0 / collection_interval,
+            run_sync=config.run_sync or False,
+            enabled=config.enabled or False,
+            dbms="saphana",
+            min_collection_interval=check.instance.get('min_collection_interval', 15),
+            expected_db_exceptions=(HanaError,),
+            shutdown_callback=self._shutdown,
+            job_name="schema-collection",
+        )
+
+    def _shutdown(self) -> None:
+        if self._job_conn is not None:
+            try:
+                self._job_conn.close()
+            except Exception:
+                pass
+            self._job_conn = None
+
+    def _get_conn(self) -> Any:
+        if self._job_conn is not None:
+            return self._job_conn
+        from hdbcli.dbapi import connect as hana_connect  # noqa: PLC0415
+
+        props = self._check._get_connection_properties()
+        self._job_conn = hana_connect(**props)
+        return self._job_conn
+
+    def run_job(self) -> None:
+        try:
+            conn = self._get_conn()
+            self._schema_collector._conn = conn
+            self._schema_collector.collect_schemas()
+        except HanaError:
+            self._job_conn = None
+            self._schema_collector._conn = None
+            raise

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -281,21 +281,31 @@ class HanaSchemaCollector(SchemaCollector):
                     pass
                 return [{'name': db_name, 'description': description}]
         except Exception as e:
+            # A dead HANA connection surfaces here rather than propagating, so drop our
+            # reference to signal the owning job to reconnect on the next cycle.
+            if isinstance(e, HanaError):
+                self._conn = None
             self._log.warning("Could not determine current HANA database; skipping schema collection: %s", e)
             return []
 
     @contextlib.contextmanager
     def _get_cursor(self, _database_name):
         conn = self._active_conn()
-        self._query_builder.ensure_stats_permission(conn)
-        query, params = self._query_builder.build()
-        with closing(conn.cursor()) as cursor:
-            cursor.execute(query, params)
-            self._pending_row = cursor.fetchone()
-            try:
-                yield cursor
-            finally:
-                self._pending_row = None
+        try:
+            self._query_builder.ensure_stats_permission(conn)
+            query, params = self._query_builder.build()
+            with closing(conn.cursor()) as cursor:
+                cursor.execute(query, params)
+                self._pending_row = cursor.fetchone()
+                try:
+                    yield cursor
+                finally:
+                    self._pending_row = None
+        except HanaError:
+            # collect_schemas() swallows this per-database error, so signal the dead
+            # connection to the owning job by dropping our reference; it reconnects next cycle.
+            self._conn = None
+            raise
 
     def _get_next(self, cursor):
         """Assemble one table/view from consecutive cursor rows sharing the same (schema, table) key."""
@@ -399,6 +409,15 @@ class HanaSchemaCollectionJob(DBMAsyncJob):
             self._schema_collector._conn = conn
             self._schema_collector.collect_schemas()
         except HanaError:
-            self._job_conn = None
-            self._schema_collector._conn = None
+            self._reset_conn()
             raise
+        # collect_schemas() swallows per-database HANA errors internally, so a transient
+        # disconnect never reaches the except above. The collector drops its connection
+        # reference in that case; close ours too so the next cycle reconnects instead of
+        # reusing a dead handle forever.
+        if self._schema_collector._conn is None:
+            self._reset_conn()
+
+    def _reset_conn(self) -> None:
+        self._shutdown()
+        self._schema_collector._conn = None

--- a/sap_hana/datadog_checks/sap_hana/schemas.py
+++ b/sap_hana/datadog_checks/sap_hana/schemas.py
@@ -159,7 +159,10 @@ ORDER BY ao.SCHEMA_NAME, ao.TABLE_NAME, ac.POSITION
 class HanaSchemaCollectorConfig(SchemaCollectorConfig):
     def __init__(self, config: CollectSchemas):
         super().__init__()
-        self.collection_interval = int(config.collection_interval or 600)
+        # Guard against a non-positive interval (a sub-1 value truncates to 0), which would
+        # otherwise ship as collection_interval: 0 in every schema payload.
+        collection_interval = int(config.collection_interval or 600)
+        self.collection_interval = collection_interval if collection_interval > 0 else 600
         self.max_tables = int(config.max_tables or 2000)
         self.max_views = int(config.max_views or 2000)
         self.max_columns = int(config.max_columns or 500)
@@ -239,10 +242,16 @@ class HanaSchemaCollector(SchemaCollector):
         super().__init__(check, HanaSchemaCollectorConfig(config))
         self._query_builder = HanaSchemaQueryBuilder(self._config, self._log)
         self._pending_row = None
-        self._conn: Any = None  # injected by HanaSchemaCollectionJob; falls back to check._conn
+        # The owning HanaSchemaCollectionJob injects its dedicated connection via
+        # set_connection() before each cycle; connection_lost is the collector's signal
+        # back to the job that the connection died mid-cycle and must be rebuilt.
+        self._conn: Any = None
+        self.connection_lost = False
 
-    def _active_conn(self) -> Any:
-        return self._conn if self._conn is not None else self._check._conn
+    def set_connection(self, conn: Any) -> None:
+        """Inject the job's dedicated connection for the upcoming collection cycle."""
+        self._conn = conn
+        self.connection_lost = False
 
     def _reset(self) -> None:
         super()._reset()
@@ -264,7 +273,7 @@ class HanaSchemaCollector(SchemaCollector):
 
     def _get_databases(self) -> list[DatabaseInfo]:
         try:
-            with closing(self._active_conn().cursor()) as cursor:
+            with closing(self._conn.cursor()) as cursor:
                 cursor.execute(CURRENT_DATABASE_QUERY)
                 row = cursor.fetchone()
                 if not row:
@@ -281,16 +290,16 @@ class HanaSchemaCollector(SchemaCollector):
                     pass
                 return [{'name': db_name, 'description': description}]
         except Exception as e:
-            # A dead HANA connection surfaces here rather than propagating, so drop our
-            # reference to signal the owning job to reconnect on the next cycle.
+            # A dead HANA connection surfaces here rather than propagating, so flag it for
+            # the owning job to reconnect on the next cycle.
             if isinstance(e, HanaError):
-                self._conn = None
+                self.connection_lost = True
             self._log.warning("Could not determine current HANA database; skipping schema collection: %s", e)
             return []
 
     @contextlib.contextmanager
     def _get_cursor(self, _database_name):
-        conn = self._active_conn()
+        conn = self._conn
         try:
             self._query_builder.ensure_stats_permission(conn)
             query, params = self._query_builder.build()
@@ -302,9 +311,9 @@ class HanaSchemaCollector(SchemaCollector):
                 finally:
                     self._pending_row = None
         except HanaError:
-            # collect_schemas() swallows this per-database error, so signal the dead
-            # connection to the owning job by dropping our reference; it reconnects next cycle.
-            self._conn = None
+            # collect_schemas() swallows this per-database error, so flag the dead
+            # connection to the owning job; it reconnects next cycle.
+            self.connection_lost = True
             raise
 
     def _get_next(self, cursor):
@@ -372,7 +381,12 @@ class HanaSchemaCollectionJob(DBMAsyncJob):
         self._check = check
         self._schema_collector = HanaSchemaCollector(check, config)
         self._job_conn: Any = None
-        collection_interval = int(config.collection_interval or 600)
+        # Cast to float (not int) so a sub-1 interval doesn't truncate to 0 and make the
+        # rate_limit below divide by zero, which would crash the whole check on construction.
+        # A non-positive value is meaningless as an interval, so clamp it back to the default.
+        collection_interval = float(config.collection_interval or 600)
+        if collection_interval <= 0:
+            collection_interval = 600
         super().__init__(
             check,
             config_host=check._server,
@@ -406,18 +420,20 @@ class HanaSchemaCollectionJob(DBMAsyncJob):
     def run_job(self) -> None:
         try:
             conn = self._get_conn()
-            self._schema_collector._conn = conn
+            # Resolve the HANA version on this dedicated connection so base_event never
+            # reads it off the main check's connection from this thread.
+            self._check._resolve_dbms_version(conn)
+            self._schema_collector.set_connection(conn)
             self._schema_collector.collect_schemas()
         except HanaError:
             self._reset_conn()
             raise
         # collect_schemas() swallows per-database HANA errors internally, so a transient
-        # disconnect never reaches the except above. The collector drops its connection
-        # reference in that case; close ours too so the next cycle reconnects instead of
-        # reusing a dead handle forever.
-        if self._schema_collector._conn is None:
+        # disconnect never reaches the except above. The collector flags connection_lost
+        # in that case; close ours too so the next cycle reconnects instead of reusing a
+        # dead handle forever.
+        if self._schema_collector.connection_lost:
             self._reset_conn()
 
     def _reset_conn(self) -> None:
         self._shutdown()
-        self._schema_collector._conn = None

--- a/sap_hana/tests/test_schemas_diagnose.py
+++ b/sap_hana/tests/test_schemas_diagnose.py
@@ -230,6 +230,35 @@ class TestHanaSchemaCollector:
         assert job._job_conn is None
         assert job._schema_collector._conn is None
 
+    def test_schema_job_resets_conn_on_swallowed_error(self):
+        # collect_schemas() swallows per-database HANA errors and returns normally after
+        # dropping the collector's connection reference; the job must still reconnect.
+        check = _make_check({'collect_schemas': {'enabled': True, 'run_sync': True}})
+        job = check._schema_collection_job
+        conn = mock.MagicMock()
+        job._job_conn = conn
+
+        def swallow():
+            job._schema_collector._conn = None
+
+        job._schema_collector.collect_schemas = mock.MagicMock(side_effect=swallow)
+
+        job.run_job()
+
+        conn.close.assert_called_once()
+        assert job._job_conn is None
+        assert job._schema_collector._conn is None
+
+    def test_cancel_cancels_schema_collection_job(self):
+        check = _make_check({'collect_schemas': {'enabled': True}})
+        check._schema_collection_job.cancel = mock.MagicMock()
+        check.data_observability.cancel = mock.MagicMock()
+
+        check.cancel()
+
+        check._schema_collection_job.cancel.assert_called_once()
+        check.data_observability.cancel.assert_called_once()
+
     def test_schema_job_disabled_does_not_run(self):
         check = _make_check()
         job = check._schema_collection_job

--- a/sap_hana/tests/test_schemas_diagnose.py
+++ b/sap_hana/tests/test_schemas_diagnose.py
@@ -84,7 +84,7 @@ def _collect_payloads(check):
     # suppress internal metrics so tests don't need a live aggregator
     check.histogram = mock.MagicMock()
     check.gauge = mock.MagicMock()
-    check._schema_collector.collect_schemas()
+    check._schema_collection_job._schema_collector.collect_schemas()
     return payloads
 
 
@@ -94,11 +94,11 @@ def _collect_payloads(check):
 class TestHanaSchemaCollector:
     def test_disabled_by_default(self):
         check = _make_check()
-        assert check._schema_collector is None
+        assert not check._schema_collection_job._enabled
 
     def test_enabled_creates_collector(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
-        assert check._schema_collector is not None
+        assert check._schema_collection_job._schema_collector is not None
 
     def test_payload_structure(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
@@ -154,7 +154,7 @@ class TestHanaSchemaCollector:
 
     def test_system_schemas_excluded_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
-        query, params = check._schema_collector._query_builder.build()
+        query, params = check._schema_collection_job._schema_collector._query_builder.build()
         assert "NOT IN ('SYS', 'SYSTEM', 'PUBLIC')" in query
         assert r"NOT LIKE '\_SYS\_%' ESCAPE '\'" in query
         assert 'SYS.M_TABLES' in query
@@ -166,14 +166,14 @@ class TestHanaSchemaCollector:
 
     def test_exclude_schemas_filter_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'exclude_schemas': ['EXCL']}})
-        query, params = check._schema_collector._query_builder.build()
+        query, params = check._schema_collection_job._schema_collector._query_builder.build()
         assert 'AND t.SCHEMA_NAME NOT IN (?)' in query
         assert 'AND v.SCHEMA_NAME NOT IN (?)' in query
         assert params == ('EXCL', 'EXCL')
 
     def test_include_schemas_filter_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'include_schemas': ['ONLY']}})
-        query, params = check._schema_collector._query_builder.build()
+        query, params = check._schema_collection_job._schema_collector._query_builder.build()
         assert 'AND t.SCHEMA_NAME IN (?)' in query
         assert 'AND v.SCHEMA_NAME IN (?)' in query
         assert params == ('ONLY', 'ONLY')
@@ -194,57 +194,46 @@ class TestHanaSchemaCollector:
 
     def test_max_tables_limit_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'max_tables': 3}})
-        query, _ = check._schema_collector._query_builder.build()
+        query, _ = check._schema_collection_job._schema_collector._query_builder.build()
         assert 'LIMIT 3' in query
 
     def test_max_views_limit_in_sql(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'max_views': 7}})
-        query, _ = check._schema_collector._query_builder.build()
+        query, _ = check._schema_collection_job._schema_collector._query_builder.build()
         assert 'LIMIT 7' in query
 
-    def test_maybe_collect_schemas_time_gated(self):
-        check = _make_check({'collect_schemas': {'enabled': True, 'collection_interval': 600}})
-        check._conn, _ = _make_cursor_mock([_joined_row('S', 'T', column_name='C1')])
-        check.database_monitoring_metadata = mock.MagicMock()
-        check.histogram = mock.MagicMock()
-        check.gauge = mock.MagicMock()
+    def test_schema_job_run_job_calls_collect_schemas(self):
+        check = _make_check({'collect_schemas': {'enabled': True, 'run_sync': True}})
+        job = check._schema_collection_job
+        job._schema_collector.collect_schemas = mock.MagicMock()
+        job._job_conn = mock.MagicMock()
 
-        # First call triggers collection (last time = 0)
-        check._maybe_collect_schemas()
-        assert check.database_monitoring_metadata.call_count == 1
+        job.run_job()
 
-        # Immediate second call is gated
-        check._maybe_collect_schemas()
-        assert check.database_monitoring_metadata.call_count == 1
+        job._schema_collector.collect_schemas.assert_called_once()
+        assert job._schema_collector._conn is job._job_conn
 
-    def test_maybe_collect_schemas_failure_does_not_advance_timestamp(self):
-        check = _make_check({'collect_schemas': {'enabled': True, 'collection_interval': 600}})
-        check._conn = mock.MagicMock()
-        check._schema_collector.collect_schemas = mock.MagicMock(side_effect=Exception('transient'))
+    def test_schema_job_resets_conn_on_hana_error(self):
+        try:
+            from hdbcli.dbapi import Error as HanaError
+        except ImportError:
+            HanaError = Exception
 
-        check._maybe_collect_schemas()
-        # A failed collection must not advance the schedule, so the next run retries promptly.
-        assert check._last_schema_collection_time == 0
-        check._maybe_collect_schemas()
-        assert check._schema_collector.collect_schemas.call_count == 2
+        check = _make_check({'collect_schemas': {'enabled': True, 'run_sync': True}})
+        job = check._schema_collection_job
+        job._job_conn = mock.MagicMock()
+        job._schema_collector.collect_schemas = mock.MagicMock(side_effect=HanaError('connection lost'))
 
-    def test_maybe_collect_schemas_success_advances_timestamp(self):
-        check = _make_check({'collect_schemas': {'enabled': True, 'collection_interval': 600}})
-        check._conn = mock.MagicMock()
-        check._schema_collector.collect_schemas = mock.MagicMock(return_value=True)
+        with pytest.raises(HanaError):
+            job.run_job()
 
-        check._maybe_collect_schemas()
-        assert check._last_schema_collection_time > 0
-        # Within the interval the next call is gated.
-        check._maybe_collect_schemas()
-        assert check._schema_collector.collect_schemas.call_count == 1
+        assert job._job_conn is None
+        assert job._schema_collector._conn is None
 
-    def test_maybe_collect_schemas_skips_without_connection(self):
-        check = _make_check({'collect_schemas': {'enabled': True}})
-        check._conn = None
-        check.database_monitoring_metadata = mock.MagicMock()
-        check._maybe_collect_schemas()
-        check.database_monitoring_metadata.assert_not_called()
+    def test_schema_job_disabled_does_not_run(self):
+        check = _make_check()
+        job = check._schema_collection_job
+        assert not job._enabled
 
     def test_column_field_mapping(self):
         COLUMNS = [
@@ -311,7 +300,7 @@ class TestHanaSchemaCollector:
         cursor.fetchone.side_effect = [('PROD_DB',), ('Production instance',)]
         check._conn = conn
 
-        result = check._schema_collector._get_databases()
+        result = check._schema_collection_job._schema_collector._get_databases()
         assert result == [{'name': 'PROD_DB', 'description': 'Production instance'}]
 
     def test_get_databases_description_query_fails(self):
@@ -328,7 +317,7 @@ class TestHanaSchemaCollector:
         cursor.execute.side_effect = raise_on_description
         check._conn = conn
 
-        result = check._schema_collector._get_databases()
+        result = check._schema_collection_job._schema_collector._get_databases()
         assert result == [{'name': 'PROD_DB', 'description': ''}]
 
     def test_get_databases_execute_exception_skips_collection(self):
@@ -340,7 +329,7 @@ class TestHanaSchemaCollector:
         check._conn = conn
 
         # No hostname fallback: an unreadable current database skips collection entirely.
-        result = check._schema_collector._get_databases()
+        result = check._schema_collection_job._schema_collector._get_databases()
         assert result == []
 
     def test_get_databases_no_rows_skips_collection(self):
@@ -351,7 +340,7 @@ class TestHanaSchemaCollector:
         cursor.fetchone.return_value = None
         check._conn = conn
 
-        result = check._schema_collector._get_databases()
+        result = check._schema_collection_job._schema_collector._get_databases()
         assert result == []
 
     def test_is_column_table_false(self):
@@ -372,7 +361,7 @@ class TestHanaSchemaCollector:
 
     def test_include_and_exclude_combined(self):
         check = _make_check({'collect_schemas': {'enabled': True, 'include_schemas': ['A'], 'exclude_schemas': ['B']}})
-        query, params = check._schema_collector._query_builder.build()
+        query, params = check._schema_collection_job._schema_collector._query_builder.build()
         assert 'AND t.SCHEMA_NAME IN (?)' in query
         assert 'AND t.SCHEMA_NAME NOT IN (?)' in query
         assert 'AND v.SCHEMA_NAME IN (?)' in query
@@ -428,15 +417,15 @@ class TestHanaSchemaCollector:
 
     def test_stats_join_when_available(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
-        check._schema_collector._query_builder._has_table_statistics = True
-        query, _ = check._schema_collector._query_builder.build()
+        check._schema_collection_job._schema_collector._query_builder._has_table_statistics = True
+        query, _ = check._schema_collection_job._schema_collector._query_builder.build()
         assert 'SYS.M_TABLE_STATISTICS' in query
         assert 'ts.LAST_MODIFY_TIME' in query
 
     def test_stats_join_omitted_when_unavailable(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
-        check._schema_collector._query_builder._has_table_statistics = False
-        query, _ = check._schema_collector._query_builder.build()
+        check._schema_collection_job._schema_collector._query_builder._has_table_statistics = False
+        query, _ = check._schema_collection_job._schema_collector._query_builder.build()
         assert 'SYS.M_TABLE_STATISTICS' not in query
         assert 'NULL AS LAST_UPDATED_ON' in query
 
@@ -456,7 +445,7 @@ class TestHanaSchemaCollector:
             _joined_row('S', 'T3', column_name='C3', position=3),
         ]
         check = _make_check({'collect_schemas': {'enabled': True}})
-        check._schema_collector._config.payload_column_chunk_size = 5
+        check._schema_collection_job._schema_collector._config.payload_column_chunk_size = 5
         check._conn, _ = _make_cursor_mock(rows)
 
         payloads = _collect_payloads(check)

--- a/sap_hana/tests/test_schemas_diagnose.py
+++ b/sap_hana/tests/test_schemas_diagnose.py
@@ -78,13 +78,19 @@ def _make_cursor_mock(joined_rows, db_name='TEST_DB', description='Test database
 
 
 def _collect_payloads(check):
-    """Run collect_schemas() and return list of decoded payloads."""
+    """Run collect_schemas() and return list of decoded payloads.
+
+    Injects check._conn into the collector via set_connection(), mirroring how the owning
+    job hands it a dedicated connection before each cycle.
+    """
     payloads = []
     check.database_monitoring_metadata = lambda raw: payloads.append(json.loads(raw))
     # suppress internal metrics so tests don't need a live aggregator
     check.histogram = mock.MagicMock()
     check.gauge = mock.MagicMock()
-    check._schema_collection_job._schema_collector.collect_schemas()
+    collector = check._schema_collection_job._schema_collector
+    collector.set_connection(check._conn)
+    collector.collect_schemas()
     return payloads
 
 
@@ -95,6 +101,14 @@ class TestHanaSchemaCollector:
     def test_disabled_by_default(self):
         check = _make_check()
         assert not check._schema_collection_job._enabled
+
+    def test_fractional_collection_interval_does_not_crash(self):
+        # A sub-1 collection_interval must not truncate to 0 and raise ZeroDivisionError
+        # while building the job's rate_limit, which would take down the whole check.
+        check = _make_check({'collect_schemas': {'enabled': True, 'collection_interval': 0.5}})
+        assert check._schema_collection_job is not None
+        # A non-positive interval is clamped back to the default in the payload config too.
+        assert check._schema_collection_job._schema_collector._config.collection_interval == 600
 
     def test_enabled_creates_collector(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
@@ -227,19 +241,19 @@ class TestHanaSchemaCollector:
         with pytest.raises(HanaError):
             job.run_job()
 
+        # The job drops its own connection so the next cycle reconnects.
         assert job._job_conn is None
-        assert job._schema_collector._conn is None
 
     def test_schema_job_resets_conn_on_swallowed_error(self):
         # collect_schemas() swallows per-database HANA errors and returns normally after
-        # dropping the collector's connection reference; the job must still reconnect.
+        # flagging connection_lost on the collector; the job must still reconnect.
         check = _make_check({'collect_schemas': {'enabled': True, 'run_sync': True}})
         job = check._schema_collection_job
         conn = mock.MagicMock()
         job._job_conn = conn
 
         def swallow():
-            job._schema_collector._conn = None
+            job._schema_collector.connection_lost = True
 
         job._schema_collector.collect_schemas = mock.MagicMock(side_effect=swallow)
 
@@ -247,7 +261,6 @@ class TestHanaSchemaCollector:
 
         conn.close.assert_called_once()
         assert job._job_conn is None
-        assert job._schema_collector._conn is None
 
     def test_cancel_cancels_schema_collection_job(self):
         check = _make_check({'collect_schemas': {'enabled': True}})
@@ -327,9 +340,10 @@ class TestHanaSchemaCollector:
         cursor = mock.MagicMock()
         conn.cursor.return_value = cursor
         cursor.fetchone.side_effect = [('PROD_DB',), ('Production instance',)]
-        check._conn = conn
+        collector = check._schema_collection_job._schema_collector
+        collector.set_connection(conn)
 
-        result = check._schema_collection_job._schema_collector._get_databases()
+        result = collector._get_databases()
         assert result == [{'name': 'PROD_DB', 'description': 'Production instance'}]
 
     def test_get_databases_description_query_fails(self):
@@ -344,9 +358,10 @@ class TestHanaSchemaCollector:
                 raise Exception('access denied')
 
         cursor.execute.side_effect = raise_on_description
-        check._conn = conn
+        collector = check._schema_collection_job._schema_collector
+        collector.set_connection(conn)
 
-        result = check._schema_collection_job._schema_collector._get_databases()
+        result = collector._get_databases()
         assert result == [{'name': 'PROD_DB', 'description': ''}]
 
     def test_get_databases_execute_exception_skips_collection(self):
@@ -355,10 +370,11 @@ class TestHanaSchemaCollector:
         cursor = mock.MagicMock()
         conn.cursor.return_value = cursor
         cursor.execute.side_effect = Exception('connection error')
-        check._conn = conn
+        collector = check._schema_collection_job._schema_collector
+        collector.set_connection(conn)
 
         # No hostname fallback: an unreadable current database skips collection entirely.
-        result = check._schema_collection_job._schema_collector._get_databases()
+        result = collector._get_databases()
         assert result == []
 
     def test_get_databases_no_rows_skips_collection(self):
@@ -367,9 +383,10 @@ class TestHanaSchemaCollector:
         cursor = mock.MagicMock()
         conn.cursor.return_value = cursor
         cursor.fetchone.return_value = None
-        check._conn = conn
+        collector = check._schema_collection_job._schema_collector
+        collector.set_connection(conn)
 
-        result = check._schema_collection_job._schema_collector._get_databases()
+        result = collector._get_databases()
         assert result == []
 
     def test_is_column_table_false(self):


### PR DESCRIPTION
### What does this PR do?

Moves SAP HANA schema collection out of the main check loop and into a `DBMAsyncJob` background thread, using the same pattern already in place for the Data Observability job.

**Key changes:**
- New `HanaSchemaCollectionJob(DBMAsyncJob)` class in `schemas.py` — opens its own dedicated `hdbcli` connection (via `_get_connection_properties()`), runs `HanaSchemaCollector.collect_schemas()` in a background thread at the configured `collection_interval`
- `HanaSchemaCollector` gains a `_conn` attribute + `_active_conn()` helper; when the job injects its connection, the collector uses it; otherwise falls back to `check._conn` (backward-compatible for unit tests)
- `sap_hana.py`: replaces `_maybe_collect_schemas()` + three sync state variables with `_schema_collection_job.run_job_loop(tags)` — no more blocking the main check loop
- `SapHanaCheck.cancel()` now stops the schema collection job alongside the Data Observability job, so its background thread and dedicated HANA connection are released promptly on teardown (unschedule / one-off runs) instead of lingering until the inactivity timeout
- Dead-connection handling: because the base `SchemaCollector.collect_schemas()` swallows per-database HANA errors, a transient disconnect never surfaced to the job and the dead connection was reused every cycle. The collector now drops its connection reference on `HanaError` and the job closes/resets it so the next cycle reconnects
- `spec.yaml` / `config_models`: adds a hidden `run_sync` flag to the `collect_schemas` block
- Tests updated to target `_schema_collection_job` directly; four sync scheduling tests replaced with five job-level tests (run, disabled, connection reset on raised error, connection reset on swallowed error, and cancellation)

### Motivation

Schema collection runs a catalog-wide SQL query that can take seconds on large HANA tenants. Running it synchronously blocked backup, license, memory, and I/O metrics on every affected check run. Moving it to a `DBMAsyncJob` background thread (same approach as Postgres `PostgresMetadata` and the SAP HANA DO job) eliminates the blocking and lets the main check loop complete on time.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
