### PR TITLE
Remove pull_request trigger from flaky-tests workflow

### DIFF
--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -1,9 +1,6 @@
 name: Daily Flaky Tests (every 8 hours)
 
 on:
-  pull_request:
-    paths:
-    - .github/workflows/test-results-master.yml
   workflow_dispatch:
     inputs:
       dry_run:
@@ -56,5 +53,5 @@ jobs:
 
     uses: ./.github/workflows/test-results-master.yml
     with:
-      dry_run: ${{ github.event_name == 'pull_request' || inputs.dry_run || false }}
+      dry_run: ${{ inputs.dry_run || false }}
     secrets: inherit


### PR DESCRIPTION
### What does this PR do?

Removes the `pull_request` trigger from `.github/workflows/flaky-tests.yml` that fired when `.github/workflows/test-results-master.yml` was changed.

Also simplifies the `dry_run` expression in the `publish-test-results` job, which previously included a `github.event_name == 'pull_request'` check that is no longer relevant.

### Motivation

https://datadoghq.atlassian.net/browse/AI-6933

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged