### PR TITLE
Validate appliance IP addresses from Orchestrator response in HPE Aruba EdgeConnect

### DIFF
--- a/hpe_aruba_edgeconnect/README.md
+++ b/hpe_aruba_edgeconnect/README.md
@@ -35,6 +35,8 @@ No additional installation is needed on your server.
 
    **Note**: Monitor permissions are enough to collect most metrics. Admin permissions are required to collect the `hpe_aruba_edgeconnect.device.cpu.usage` metric on the appliances. If the configured credentials do not have admin access, the Agent skips this metric, but collects the rest of the metrics.
 
+   It is recommended to configure `appliance_ips` with an explicit include list that matches your known appliance IP ranges. This helps ensure that the check only connects to expected appliances.
+
 2. [Restart the Agent][5].
 
 ### Validation

--- a/hpe_aruba_edgeconnect/changelog.d/24130.fixed
+++ b/hpe_aruba_edgeconnect/changelog.d/24130.fixed
@@ -1,0 +1,1 @@
+Validate appliance IP addresses from Orchestrator response before connecting to appliances.

--- a/hpe_aruba_edgeconnect/datadog_checks/hpe_aruba_edgeconnect/check.py
+++ b/hpe_aruba_edgeconnect/datadog_checks/hpe_aruba_edgeconnect/check.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
+import ipaddress
 import json
 import threading
 from collections.abc import Callable
@@ -117,7 +118,19 @@ class HpeArubaEdgeconnectCheck(AgentCheck, ConfigMixin):
             self.log.warning("No appliances returned from orchestrator %s", self.config.orchestrator_ip)
             return Appliances([], self.log)
         self.log.debug("Found %d appliances from orchestrator before filtering", len(raw_appliances))
-        all_appliances = [Appliance(a) for a in raw_appliances]
+        all_appliances = []
+        for raw in raw_appliances:
+            raw_ip = raw.get('ip', '')
+            try:
+                ipaddress.ip_address(raw_ip)
+            except ValueError:
+                self.log.warning(
+                    "Skipping appliance with non-IP address %r from orchestrator %s",
+                    raw_ip,
+                    self.config.orchestrator_ip,
+                )
+                continue
+            all_appliances.append(Appliance(raw))
         self._peer_lookup = {ap.host_name: (ap.ip, ap.site or 'unknown') for ap in all_appliances if ap.host_name}
         appliances = Appliances(all_appliances, self.log)
         appliances.filter(self.config.appliance_ips)

--- a/hpe_aruba_edgeconnect/datadog_checks/hpe_aruba_edgeconnect/check.py
+++ b/hpe_aruba_edgeconnect/datadog_checks/hpe_aruba_edgeconnect/check.py
@@ -112,13 +112,8 @@ class HpeArubaEdgeconnectCheck(AgentCheck, ConfigMixin):
                 "network-devices-metadata",
             )
 
-    def _collect_appliances_from_orch(self, client: OrchestratorClient) -> Appliances:
-        raw_appliances = client.get_appliances()
-        if not raw_appliances:
-            self.log.warning("No appliances returned from orchestrator %s", self.config.orchestrator_ip)
-            return Appliances([], self.log)
-        self.log.debug("Found %d appliances from orchestrator before filtering", len(raw_appliances))
-        all_appliances = []
+    def _parse_appliances(self, raw_appliances: list[dict]) -> list[Appliance]:
+        appliances = []
         for raw in raw_appliances:
             raw_ip = raw.get('ip', '')
             try:
@@ -130,7 +125,16 @@ class HpeArubaEdgeconnectCheck(AgentCheck, ConfigMixin):
                     self.config.orchestrator_ip,
                 )
                 continue
-            all_appliances.append(Appliance(raw))
+            appliances.append(Appliance(raw))
+        return appliances
+
+    def _collect_appliances_from_orch(self, client: OrchestratorClient) -> Appliances:
+        raw_appliances = client.get_appliances()
+        if not raw_appliances:
+            self.log.warning("No appliances returned from orchestrator %s", self.config.orchestrator_ip)
+            return Appliances([], self.log)
+        self.log.debug("Found %d appliances from orchestrator before filtering", len(raw_appliances))
+        all_appliances = self._parse_appliances(raw_appliances)
         self._peer_lookup = {ap.host_name: (ap.ip, ap.site or 'unknown') for ap in all_appliances if ap.host_name}
         appliances = Appliances(all_appliances, self.log)
         appliances.filter(self.config.appliance_ips)

--- a/hpe_aruba_edgeconnect/tests/conftest.py
+++ b/hpe_aruba_edgeconnect/tests/conftest.py
@@ -62,14 +62,14 @@ def dd_environment(instance, dd_save_state):
         orch_port = find_free_port(HOST)
         appliance_port = find_free_port(HOST)
         orch_ip = f'{HOST}:{orch_port}'
-        appliance_ip = f'{HOST}:{appliance_port}'
+        appliance_ip = '192.168.200.10'
 
         def _ready():
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
             urlopen(f'https://{orch_ip}/health', timeout=2, context=ctx)
-            urlopen(f'https://{appliance_ip}/health', timeout=2, context=ctx)
+            urlopen(f'https://{HOST}:{appliance_port}/health', timeout=2, context=ctx)
 
         inst = instance(
             orch_ip,

--- a/hpe_aruba_edgeconnect/tests/conftest.py
+++ b/hpe_aruba_edgeconnect/tests/conftest.py
@@ -62,7 +62,6 @@ def dd_environment(instance, dd_save_state):
         orch_port = find_free_port(HOST)
         appliance_port = find_free_port(HOST)
         orch_ip = f'{HOST}:{orch_port}'
-        appliance_ip = '192.168.200.10'
 
         def _ready():
             ctx = ssl.create_default_context()
@@ -88,7 +87,6 @@ def dd_environment(instance, dd_save_state):
                 'ORCH_PASSWORD': '',
                 'APPLIANCE_USERNAME': 'admin',
                 'APPLIANCE_PASSWORD': '',
-                'APPLIANCE_IP': appliance_ip,
             },
         ):
             yield {'instances': [inst]}

--- a/hpe_aruba_edgeconnect/tests/conftest.py
+++ b/hpe_aruba_edgeconnect/tests/conftest.py
@@ -8,6 +8,7 @@ from urllib.request import urlopen
 import pytest
 
 from datadog_checks.dev import WaitFor, docker_run, get_docker_hostname, get_here
+from datadog_checks.dev.docker import get_container_ip
 from datadog_checks.dev.utils import find_free_port
 from datadog_checks.hpe_aruba_edgeconnect import HpeArubaEdgeconnectCheck
 
@@ -63,12 +64,17 @@ def dd_environment(instance, dd_save_state):
         appliance_port = find_free_port(HOST)
         orch_ip = f'{HOST}:{orch_port}'
 
+        def _appliance_ready():
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            urlopen(f'https://{HOST}:{appliance_port}/health', timeout=2, context=ctx)
+
         def _ready():
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
             urlopen(f'https://{orch_ip}/health', timeout=2, context=ctx)
-            urlopen(f'https://{HOST}:{appliance_port}/health', timeout=2, context=ctx)
 
         inst = instance(
             orch_ip,
@@ -79,7 +85,8 @@ def dd_environment(instance, dd_save_state):
         with docker_run(
             compose_file=COMPOSE_FILE,
             build=True,
-            conditions=[WaitFor(_ready, attempts=60, wait=1)],
+            service_name='appliance',
+            conditions=[WaitFor(_appliance_ready, attempts=60, wait=1)],
             env_vars={
                 'HOST_PORT': str(orch_port),
                 'APPLIANCE_PORT': str(appliance_port),
@@ -89,7 +96,22 @@ def dd_environment(instance, dd_save_state):
                 'APPLIANCE_PASSWORD': '',
             },
         ):
-            yield {'instances': [inst]}
+            appliance_ip = get_container_ip('dd-appliance')
+            with docker_run(
+                compose_file=COMPOSE_FILE,
+                build=True,
+                conditions=[WaitFor(_ready, attempts=60, wait=1)],
+                env_vars={
+                    'HOST_PORT': str(orch_port),
+                    'APPLIANCE_PORT': str(appliance_port),
+                    'ORCH_USERNAME': 'admin',
+                    'ORCH_PASSWORD': '',
+                    'APPLIANCE_USERNAME': 'admin',
+                    'APPLIANCE_PASSWORD': '',
+                    'APPLIANCE_IP': appliance_ip,
+                },
+            ):
+                yield {'instances': [inst]}
 
 
 @pytest.fixture(scope='session')

--- a/hpe_aruba_edgeconnect/tests/conftest.py
+++ b/hpe_aruba_edgeconnect/tests/conftest.py
@@ -8,7 +8,6 @@ from urllib.request import urlopen
 import pytest
 
 from datadog_checks.dev import WaitFor, docker_run, get_docker_hostname, get_here
-from datadog_checks.dev.docker import get_container_ip
 from datadog_checks.dev.utils import find_free_port
 from datadog_checks.hpe_aruba_edgeconnect import HpeArubaEdgeconnectCheck
 
@@ -64,17 +63,12 @@ def dd_environment(instance, dd_save_state):
         appliance_port = find_free_port(HOST)
         orch_ip = f'{HOST}:{orch_port}'
 
-        def _appliance_ready():
-            ctx = ssl.create_default_context()
-            ctx.check_hostname = False
-            ctx.verify_mode = ssl.CERT_NONE
-            urlopen(f'https://{HOST}:{appliance_port}/health', timeout=2, context=ctx)
-
         def _ready():
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
             urlopen(f'https://{orch_ip}/health', timeout=2, context=ctx)
+            urlopen(f'https://{HOST}:{appliance_port}/health', timeout=2, context=ctx)
 
         inst = instance(
             orch_ip,
@@ -85,8 +79,7 @@ def dd_environment(instance, dd_save_state):
         with docker_run(
             compose_file=COMPOSE_FILE,
             build=True,
-            service_name='appliance',
-            conditions=[WaitFor(_appliance_ready, attempts=60, wait=1)],
+            conditions=[WaitFor(_ready, attempts=60, wait=1)],
             env_vars={
                 'HOST_PORT': str(orch_port),
                 'APPLIANCE_PORT': str(appliance_port),
@@ -96,22 +89,7 @@ def dd_environment(instance, dd_save_state):
                 'APPLIANCE_PASSWORD': '',
             },
         ):
-            appliance_ip = get_container_ip('dd-appliance')
-            with docker_run(
-                compose_file=COMPOSE_FILE,
-                build=True,
-                conditions=[WaitFor(_ready, attempts=60, wait=1)],
-                env_vars={
-                    'HOST_PORT': str(orch_port),
-                    'APPLIANCE_PORT': str(appliance_port),
-                    'ORCH_USERNAME': 'admin',
-                    'ORCH_PASSWORD': '',
-                    'APPLIANCE_USERNAME': 'admin',
-                    'APPLIANCE_PASSWORD': '',
-                    'APPLIANCE_IP': appliance_ip,
-                },
-            ):
-                yield {'instances': [inst]}
+            yield {'instances': [inst]}
 
 
 @pytest.fixture(scope='session')

--- a/hpe_aruba_edgeconnect/tests/docker/docker-compose.yaml
+++ b/hpe_aruba_edgeconnect/tests/docker/docker-compose.yaml
@@ -1,3 +1,9 @@
+networks:
+  default:
+    ipam:
+      config:
+        - subnet: "192.168.200.0/24"
+
 services:
   orch:
     build:
@@ -18,7 +24,10 @@ services:
       dockerfile: tests/docker/fake_appliance/Dockerfile
     container_name: dd-appliance
     ports:
-      - "${APPLIANCE_PORT}:8444"
+      - "${APPLIANCE_PORT}:443"
+    networks:
+      default:
+        ipv4_address: "192.168.200.10"
     environment:
       APPLIANCE_USERNAME: "${APPLIANCE_USERNAME}"
       APPLIANCE_PASSWORD: "${APPLIANCE_PASSWORD}"

--- a/hpe_aruba_edgeconnect/tests/docker/docker-compose.yaml
+++ b/hpe_aruba_edgeconnect/tests/docker/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
     environment:
       ORCH_USERNAME: "${ORCH_USERNAME}"
       ORCH_PASSWORD: "${ORCH_PASSWORD}"
+      APPLIANCE_IP: "${APPLIANCE_IP:-}"
     restart: "no"
 
   appliance:

--- a/hpe_aruba_edgeconnect/tests/docker/docker-compose.yaml
+++ b/hpe_aruba_edgeconnect/tests/docker/docker-compose.yaml
@@ -1,9 +1,3 @@
-networks:
-  default:
-    ipam:
-      config:
-        - subnet: "192.168.200.0/24"
-
 services:
   orch:
     build:
@@ -15,7 +9,6 @@ services:
     environment:
       ORCH_USERNAME: "${ORCH_USERNAME}"
       ORCH_PASSWORD: "${ORCH_PASSWORD}"
-      APPLIANCE_IP: "${APPLIANCE_IP}"
     restart: "no"
 
   appliance:
@@ -25,9 +18,6 @@ services:
     container_name: dd-appliance
     ports:
       - "${APPLIANCE_PORT}:443"
-    networks:
-      default:
-        ipv4_address: "192.168.200.10"
     environment:
       APPLIANCE_USERNAME: "${APPLIANCE_USERNAME}"
       APPLIANCE_PASSWORD: "${APPLIANCE_PASSWORD}"

--- a/hpe_aruba_edgeconnect/tests/docker/docker-compose.yaml
+++ b/hpe_aruba_edgeconnect/tests/docker/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
     environment:
       ORCH_USERNAME: "${ORCH_USERNAME}"
       ORCH_PASSWORD: "${ORCH_PASSWORD}"
-      APPLIANCE_IP: "${APPLIANCE_IP:-}"
     restart: "no"
 
   appliance:

--- a/hpe_aruba_edgeconnect/tests/docker/fake_appliance/Dockerfile
+++ b/hpe_aruba_edgeconnect/tests/docker/fake_appliance/Dockerfile
@@ -23,6 +23,6 @@ RUN mkdir -p /app/certs \
 
 COPY tests/docker/fake_appliance/app.py app.py
 
-EXPOSE 8444
+EXPOSE 443
 
 CMD ["python", "app.py"]

--- a/hpe_aruba_edgeconnect/tests/docker/fake_appliance/app.py
+++ b/hpe_aruba_edgeconnect/tests/docker/fake_appliance/app.py
@@ -190,4 +190,4 @@ if __name__ == "__main__":
     app.config["start_time"] = time.time()
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ctx.load_cert_chain(CERT_FILE, KEY_FILE)
-    app.run(host="0.0.0.0", port=8444, ssl_context=ctx)
+    app.run(host="0.0.0.0", port=443, ssl_context=ctx)

--- a/hpe_aruba_edgeconnect/tests/docker/fake_orch/app.py
+++ b/hpe_aruba_edgeconnect/tests/docker/fake_orch/app.py
@@ -77,11 +77,13 @@ def login():
 
 @app.route("/gms/rest/appliance")
 def appliances():
-    return jsonify([
-        _appliance(_appliance_ip(), "1.NE", "SydneySP01", "SYD", startup_time=86400),
-        _appliance(PEER_NEWYORK_IP, "4.NE", "NewYorkSP01", "NYC"),
-        _appliance(PEER_SANFRAN_IP, "5.NE", "SanFranSP02", "SFO"),
-    ])
+    return jsonify(
+        [
+            _appliance(_appliance_ip(), "1.NE", "SydneySP01", "SYD", startup_time=86400),
+            _appliance(PEER_NEWYORK_IP, "4.NE", "NewYorkSP01", "NYC"),
+            _appliance(PEER_SANFRAN_IP, "5.NE", "SanFranSP02", "SFO"),
+        ]
+    )
 
 
 @app.route("/gms/rest/gms/overlays/config")

--- a/hpe_aruba_edgeconnect/tests/docker/fake_orch/app.py
+++ b/hpe_aruba_edgeconnect/tests/docker/fake_orch/app.py
@@ -4,6 +4,7 @@
 """Fake HPE Aruba EdgeConnect orchestrator for E2E tests."""
 
 import os
+import socket
 import ssl
 
 from flask import Flask, jsonify, request
@@ -21,7 +22,7 @@ PEER_SANFRAN_IP = "10.0.0.3"
 
 
 def _appliance_ip():
-    return os.environ["APPLIANCE_IP"]
+    return socket.gethostbyname("dd-appliance")
 
 
 def _appliance(ip, ne_pk, host_name, site, startup_time=None):

--- a/hpe_aruba_edgeconnect/tests/docker/fake_orch/app.py
+++ b/hpe_aruba_edgeconnect/tests/docker/fake_orch/app.py
@@ -4,7 +4,6 @@
 """Fake HPE Aruba EdgeConnect orchestrator for E2E tests."""
 
 import os
-import socket
 import ssl
 
 from flask import Flask, jsonify, request
@@ -22,10 +21,7 @@ PEER_SANFRAN_IP = "10.0.0.3"
 
 
 def _appliance_ip():
-    explicit = os.environ.get("APPLIANCE_IP")
-    if explicit:
-        return explicit
-    return socket.gethostbyname("dd-appliance")
+    return os.environ["APPLIANCE_IP"]
 
 
 def _appliance(ip, ne_pk, host_name, site, startup_time=None):

--- a/hpe_aruba_edgeconnect/tests/docker/fake_orch/app.py
+++ b/hpe_aruba_edgeconnect/tests/docker/fake_orch/app.py
@@ -4,6 +4,7 @@
 """Fake HPE Aruba EdgeConnect orchestrator for E2E tests."""
 
 import os
+import socket
 import ssl
 
 from flask import Flask, jsonify, request
@@ -16,9 +17,15 @@ KEY_FILE = "/app/certs/key.pem"
 ORCH_USERNAME = os.environ.get("ORCH_USERNAME", "admin")
 ORCH_PASSWORD = os.environ.get("ORCH_PASSWORD", "")
 
-APPLIANCE_IP = os.environ.get("APPLIANCE_IP", "172.16.3.21")
 PEER_NEWYORK_IP = "10.0.0.2"
 PEER_SANFRAN_IP = "10.0.0.3"
+
+
+def _appliance_ip():
+    explicit = os.environ.get("APPLIANCE_IP")
+    if explicit:
+        return explicit
+    return socket.gethostbyname("dd-appliance")
 
 
 def _appliance(ip, ne_pk, host_name, site, startup_time=None):
@@ -60,13 +67,6 @@ def _appliance(ip, ne_pk, host_name, site, startup_time=None):
     }
 
 
-APPLIANCE_LIST = [
-    _appliance(APPLIANCE_IP, "1.NE", "SydneySP01", "SYD", startup_time=86400),
-    _appliance(PEER_NEWYORK_IP, "4.NE", "NewYorkSP01", "NYC"),
-    _appliance(PEER_SANFRAN_IP, "5.NE", "SanFranSP02", "SFO"),
-]
-
-
 @app.route("/gms/rest/authentication/login", methods=["POST"])
 def login():
     data = request.get_json(silent=True) or {}
@@ -77,7 +77,11 @@ def login():
 
 @app.route("/gms/rest/appliance")
 def appliances():
-    return jsonify(APPLIANCE_LIST)
+    return jsonify([
+        _appliance(_appliance_ip(), "1.NE", "SydneySP01", "SYD", startup_time=86400),
+        _appliance(PEER_NEWYORK_IP, "4.NE", "NewYorkSP01", "NYC"),
+        _appliance(PEER_SANFRAN_IP, "5.NE", "SanFranSP02", "SFO"),
+    ])
 
 
 @app.route("/gms/rest/gms/overlays/config")

--- a/hpe_aruba_edgeconnect/tests/test_unit.py
+++ b/hpe_aruba_edgeconnect/tests/test_unit.py
@@ -113,8 +113,8 @@ def test_appliances_filter(dd_run_check, aggregator, mocker, instance, ips, filt
 @pytest.mark.parametrize(
     'bad_ip',
     [
-        pytest.param('attacker.example.com', id='hostname'),
-        pytest.param('attacker.example.com:8443', id='host_port'),
+        pytest.param('appliance.example.com', id='hostname'),
+        pytest.param('appliance.example.com:8443', id='host_port'),
         pytest.param('localhost:9999', id='localhost_port'),
         pytest.param('', id='empty'),
     ],
@@ -125,7 +125,7 @@ def test_appliances_with_non_ip_address_are_skipped(dd_run_check, aggregator, mo
 
     payload = [
         {**APPLIANCE_PAYLOAD[0], 'ip': '10.0.0.1'},
-        {**APPLIANCE_PAYLOAD[0], 'ip': bad_ip, 'hostName': 'malicious'},
+        {**APPLIANCE_PAYLOAD[0], 'ip': bad_ip, 'hostName': 'invalid-appliance'},
     ]
     _setup_mocks(mocker, check, payload, appliance_client=_mock_appliance_client(TGZ_DATA))
 

--- a/hpe_aruba_edgeconnect/tests/test_unit.py
+++ b/hpe_aruba_edgeconnect/tests/test_unit.py
@@ -111,6 +111,36 @@ def test_appliances_filter(dd_run_check, aggregator, mocker, instance, ips, filt
 
 
 @pytest.mark.parametrize(
+    'bad_ip',
+    [
+        pytest.param('attacker.example.com', id='hostname'),
+        pytest.param('attacker.example.com:8443', id='host_port'),
+        pytest.param('localhost:9999', id='localhost_port'),
+        pytest.param('', id='empty'),
+    ],
+)
+def test_appliances_with_non_ip_address_are_skipped(dd_run_check, aggregator, mocker, instance, bad_ip):
+    inst = instance('localhost:8443', max_backfill_minutes=10)
+    check = HpeArubaEdgeconnectCheck('hpe_aruba_edgeconnect', {}, [inst])
+
+    payload = [
+        {**APPLIANCE_PAYLOAD[0], 'ip': '10.0.0.1'},
+        {**APPLIANCE_PAYLOAD[0], 'ip': bad_ip, 'hostName': 'malicious'},
+    ]
+    _setup_mocks(mocker, check, payload, appliance_client=_mock_appliance_client(TGZ_DATA))
+
+    dd_run_check(check)
+
+    monitored_ips = [
+        tag.split(':', 1)[1]
+        for metric in aggregator.metrics(f'{NS}.device.reachability')
+        for tag in metric.tags
+        if tag.startswith('device_ip:')
+    ]
+    assert monitored_ips == ['10.0.0.1']
+
+
+@pytest.mark.parametrize(
     'value, expected',
     [
         pytest.param('1000Mb/s (auto)', 1_000_000_000, id='1000mbps_auto'),


### PR DESCRIPTION
### What does this PR do?

Before creating an `Appliance` object from Orchestrator response data, validate
that the `ip` field is a well-formed IP address (IPv4 or IPv6) using
`ipaddress.ip_address()`. Records with non-IP values (hostnames, host:port
strings, empty strings) are skipped with a warning log and never reach
`ApplianceClient`.

### Motivation
https://datadoghq.atlassian.net/browse/AI-6934

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged