### PR TITLE
Ignore non-package tags when auto-detecting release packages

### DIFF
--- a/.github/workflows/scripts/_release/packages.py
+++ b/.github/workflows/scripts/_release/packages.py
@@ -39,27 +39,32 @@ def resolve_packages(
     """Resolve the list of packages to release.
 
     Resolution order:
-    - JSON array   → use the provided list verbatim
-    - empty string → auto-detect from git tags at HEAD
+    - JSON array   → use the provided list verbatim; unknown names are an error
+    - empty string → auto-detect from git tags at HEAD; tags that do not map to a
+      real package (e.g. ``*-bootstrap-*`` sentinel tags used to bootstrap a
+      release branch) are ignored
 
     Returns ``(packages, mode_description)``.
-    Raises ``ValueError`` on invalid input or unknown package names.
+    Raises ``ValueError`` on invalid input or unknown manually selected packages.
     """
     selected = selected.strip()
+    known = set(all_packages)
 
     if selected:
         try:
             packages = json.loads(selected)
         except json.JSONDecodeError as e:
             raise ValueError(f"SELECTED_PACKAGES is not valid JSON: {e}") from e
-        mode = f"manual ({selected})"
-    else:
-        tags = head_tags if head_tags is not None else get_tags_at_head()
-        packages = detect_from_tags(tags)
-        mode = "auto-detect from tags at HEAD"
+        unknown = sorted(set(packages) - known)
+        if unknown:
+            raise ValueError(f"Unknown packages: {', '.join(unknown)}")
+        return packages, f"manual ({selected})"
 
-    unknown = sorted(set(packages) - set(all_packages))
-    if unknown:
-        raise ValueError(f"Unknown packages: {', '.join(unknown)}")
+    tags = head_tags if head_tags is not None else get_tags_at_head()
+    detected = detect_from_tags(tags)
+    packages = [name for name in detected if name in known]
+    ignored = sorted(set(detected) - known)
+    if ignored:
+        print(f"Ignoring tag(s) at HEAD with no matching package: {', '.join(ignored)}")
 
-    return packages, mode
+    return packages, "auto-detect from tags at HEAD"

--- a/.github/workflows/scripts/_release/packages.py
+++ b/.github/workflows/scripts/_release/packages.py
@@ -36,7 +36,10 @@ def resolve_packages(
     all_packages: list[str],
     head_tags: list[str] | None = None,
 ) -> tuple[list[str], str]:
-    """Resolve packages to release from a JSON list (errors on unknown names) or, when empty, from tags at HEAD (ignoring tags with no matching package)."""
+    """Resolve packages to release from a JSON list, or from tags at HEAD when empty.
+
+    A JSON list errors on unknown names; tag detection ignores tags with no matching package.
+    """
     selected = selected.strip()
     known = set(all_packages)
 

--- a/.github/workflows/scripts/_release/packages.py
+++ b/.github/workflows/scripts/_release/packages.py
@@ -36,17 +36,7 @@ def resolve_packages(
     all_packages: list[str],
     head_tags: list[str] | None = None,
 ) -> tuple[list[str], str]:
-    """Resolve the list of packages to release.
-
-    Resolution order:
-    - JSON array   → use the provided list verbatim; unknown names are an error
-    - empty string → auto-detect from git tags at HEAD; tags that do not map to a
-      real package (e.g. ``*-bootstrap-*`` sentinel tags used to bootstrap a
-      release branch) are ignored
-
-    Returns ``(packages, mode_description)``.
-    Raises ``ValueError`` on invalid input or unknown manually selected packages.
-    """
+    """Resolve packages to release from a JSON list (errors on unknown names) or, when empty, from tags at HEAD (ignoring tags with no matching package)."""
     selected = selected.strip()
     known = set(all_packages)
 

--- a/.github/workflows/scripts/tests/test_packages.py
+++ b/.github/workflows/scripts/tests/test_packages.py
@@ -65,7 +65,20 @@ class TestResolvePackages:
         with pytest.raises(ValueError, match="SELECTED_PACKAGES is not valid JSON"):
             resolve_packages(selected="not-json", all_packages=self.all_packages)
 
-    def test_unknown_in_auto_detect_raises(self):
+    def test_auto_detect_ignores_unknown_tags(self):
+        # Sentinel/bootstrap tags at HEAD (e.g. dk-bootstrap-7.78.0) do not map to
+        # real packages and must be ignored rather than aborting the release.
+        tags = ["rabbitmq-8.5.1", "dk-bootstrap-7.78.0"]
+        packages, mode = resolve_packages(
+            selected="", all_packages=self.all_packages + ["rabbitmq"], head_tags=tags
+        )
+        assert packages == ["rabbitmq"]
+        assert mode == "auto-detect from tags at HEAD"
+
+    def test_auto_detect_all_unknown_returns_empty(self):
         tags = ["not-a-package-1.0.0"]
-        with pytest.raises(ValueError, match="Unknown packages"):
-            resolve_packages(selected="", all_packages=self.all_packages, head_tags=tags)
+        packages, mode = resolve_packages(
+            selected="", all_packages=self.all_packages, head_tags=tags
+        )
+        assert packages == []
+        assert mode == "auto-detect from tags at HEAD"


### PR DESCRIPTION
### What does this PR do?

Fixes recurring failures in the release workflow (`Trigger Wheel Builds` → `release-dispatch.yml`) at the **Prepare dispatch** step, which aborted with `Unknown packages: dk-bootstrap` and exit code 1.

When `SELECTED_PACKAGES` is empty, `resolve_packages()` auto-detects packages from every git tag pointing at HEAD. Release branches carry sentinel `*-bootstrap-*` tags (e.g. `dk-bootstrap-7.78.0`, annotated "Bootstrap integration release for 7.78.x") that do not correspond to a real package. The previous code treated any detected name absent from `get_all_packages()` as a fatal error, even in auto-detect mode, so any release whose HEAD carried such a tag failed.

This change makes `resolve_packages()` mode-aware:

- Auto-detect from tags at HEAD: tags with no matching package are ignored (and logged), instead of aborting the release.
- Manual selection (explicit JSON list in `SELECTED_PACKAGES`): unknown names remain a hard error to catch typos.

### Motivation

The release workflow failed repeatedly whenever a bootstrap/sentinel tag was present at HEAD alongside the real package tag (for example `dk-bootstrap-7.78.0` together with `rabbitmq-8.5.1`). These sentinel tags are an established pattern in the repo (`az-bootstrap-*`, `aarakke-bootstrap-release-*`, `coignetpbootstrap-*`, `dk-bootstrap-*`, ...), so the failure recurs on every affected release. No security-relevant behavior (signing, provenance, permissions, dispatch flow) is changed; only non-package tags no longer abort the run.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
