### PR TITLE
Escape SQL Server passwords in connection strings

### DIFF
--- a/sqlserver/changelog.d/24138.fixed
+++ b/sqlserver/changelog.d/24138.fixed
@@ -1,0 +1,1 @@
+Escape SQL Server passwords when building connection strings.

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -153,7 +153,7 @@ def _escape_odbc_connection_string_value(value: str) -> str:
 def _escape_legacy_freetds_odbc_connection_string_value(value: str) -> str:
     """Return a value escaped for legacy FreeTDS ODBC connection strings."""
     # FreeTDS 1.3.6 does not decode "}}" inside braced values. It treats "}" as
-    # part of the password unless the next character is ";", so the legacy retry
+    # part of the password unless the next character is ";", so the FreeTDS path
     # keeps the brace raw.
     # Password: pa;ss}word
     # Connection string: Driver=FreeTDS;Server=host;UID=datadog;PWD={pa;ss}word};
@@ -301,7 +301,17 @@ class Connection(object):
                 # autocommit: true disables implicit transaction
                 rawconn = adodbapi.connect(cs, {'timeout': self.timeout, 'autocommit': True})
             else:
-                rawconn = self._open_odbc_connection(cs, db_key, db_name=db_name)
+                cs += self._conn_string_odbc(db_key, db_name=db_name)
+                if self.managed_auth_enabled:
+                    token_struct = generate_managed_identity_token(
+                        self.managed_identity_client_id, self.managed_identity_scope
+                    )
+                    rawconn = pyodbc.connect(
+                        cs, timeout=self.timeout, autocommit=True, attrs_before={SQL_COPT_SS_ACCESS_TOKEN: token_struct}
+                    )
+                else:
+                    rawconn = pyodbc.connect(cs, timeout=self.timeout, autocommit=True)
+                rawconn.timeout = self.timeout
 
             self.service_check_handler(AgentCheck.OK, host, database, is_default=is_default)
             if conn_key not in self._conns:
@@ -349,33 +359,6 @@ class Connection(object):
                 # if not the default db, we should still log this exception
                 # to give the customer an opportunity to fix the issue
                 self.log.debug(check_err_message)
-
-    def _open_odbc_connection(self, connection_string_prefix: str, db_key: str, db_name: str | None = None) -> object:
-        """Open an ODBC connection, retrying legacy FreeTDS brace parsing when needed."""
-        conn_str = connection_string_prefix + self._conn_string_odbc(db_key, db_name=db_name)
-        try:
-            return self._pyodbc_connect(conn_str)
-        except Exception:
-            _, _, _, password, _, driver = self._get_access_info(db_key, db_name)
-            if not password or '}' not in password or not _is_freetds_driver(driver):
-                raise
-
-            conn_str = connection_string_prefix + self._conn_string_odbc(
-                db_key, db_name=db_name, escape_func=_escape_legacy_freetds_odbc_connection_string_value
-            )
-            return self._pyodbc_connect(conn_str)
-
-    def _pyodbc_connect(self, conn_str: str) -> object:
-        """Open a pyodbc connection with the configured authentication mode."""
-        if self.managed_auth_enabled:
-            token_struct = generate_managed_identity_token(self.managed_identity_client_id, self.managed_identity_scope)
-            rawconn = pyodbc.connect(
-                conn_str, timeout=self.timeout, autocommit=True, attrs_before={SQL_COPT_SS_ACCESS_TOKEN: token_struct}
-            )
-        else:
-            rawconn = pyodbc.connect(conn_str, timeout=self.timeout, autocommit=True)
-        rawconn.timeout = self.timeout
-        return rawconn
 
     def _setup_new_connection(self, rawconn):
         with rawconn.cursor() as cursor:
@@ -665,12 +648,16 @@ class Connection(object):
                     " however %s has been selected" % (key, other_connector, self.connector)
                 )
 
-    def _conn_string_odbc(self, db_key, conn_key=None, db_name=None, escape_func=_escape_odbc_connection_string_value):
+    def _conn_string_odbc(self, db_key, conn_key=None, db_name=None):
         """Return a connection string to use with odbc"""
         if conn_key:
             dsn, host, username, password, database, driver = conn_key.split(":")
         else:
             dsn, host, username, password, database, driver = self._get_access_info(db_key, db_name)
+
+        escape_func = _escape_odbc_connection_string_value
+        if _is_freetds_driver(driver):
+            escape_func = _escape_legacy_freetds_odbc_connection_string_value
 
         if self.managed_auth_enabled:
             # if managed_identity authentication is configured,

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -656,7 +656,8 @@ class Connection(object):
             dsn, host, username, password, database, driver = self._get_access_info(db_key, db_name)
 
         escape_func = _escape_odbc_connection_string_value
-        if driver and _is_freetds_driver(driver):
+        is_freetds_driver = driver and _is_freetds_driver(driver)
+        if is_freetds_driver:
             escape_func = _escape_legacy_freetds_odbc_connection_string_value
 
         if self.managed_auth_enabled:
@@ -683,6 +684,11 @@ class Connection(object):
             conn_str += 'UID={};'.format(username)
         self.log.debug("Connection string (before password) %s", conn_str)
         if password:
+            if is_freetds_driver and '};' in password:
+                raise ConfigurationError(
+                    "SQL Server passwords containing the sequence '};' cannot be represented in FreeTDS ODBC "
+                    "connection strings. Use Microsoft ODBC Driver for SQL Server or change the password."
+                )
             conn_str += 'PWD={};'.format(escape_func(password))
         return conn_str
 

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -139,11 +139,13 @@ def parse_connection_string_properties(cs):
 
 def _escape_odbc_connection_string_value(value: str) -> str:
     """Return a value escaped for an ODBC connection string."""
+    # MS Learn "Strong Passwords": brace special-character passwords and double right braces.
     return '{{{}}}'.format(value.replace('}', '}}'))
 
 
 def _escape_adodbapi_connection_string_value(value: str) -> str:
     """Return a value escaped for an adodbapi connection string."""
+    # MS Learn OLE DB Driver keywords: quote string values and double the enclosing quote.
     return '"{}"'.format(value.replace('"', '""'))
 
 

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -137,6 +137,16 @@ def parse_connection_string_properties(cs):
     return params
 
 
+def _escape_odbc_connection_string_value(value: str) -> str:
+    """Return a value escaped for an ODBC connection string."""
+    return '{{{}}}'.format(value.replace('}', '}}'))
+
+
+def _escape_adodbapi_connection_string_value(value: str) -> str:
+    """Return a value escaped for an adodbapi connection string."""
+    return '"{}"'.format(value.replace('"', '""'))
+
+
 class Connection(object):
     """Manages the connection to a SQL Server instance."""
 
@@ -638,7 +648,7 @@ class Connection(object):
             conn_str += 'UID={};'.format(username)
         self.log.debug("Connection string (before password) %s", conn_str)
         if password:
-            conn_str += 'PWD={};'.format(password)
+            conn_str += 'PWD={};'.format(_escape_odbc_connection_string_value(password))
         return conn_str
 
     def _conn_string_adodbapi(self, db_key, conn_key=None, db_name=None):
@@ -659,7 +669,7 @@ class Connection(object):
             conn_str += 'User ID={};'.format(username)
         self.log.debug("Connection string (before password) %s", conn_str)
         if password:
-            conn_str += 'Password={};'.format(password)
+            conn_str += 'Password={};'.format(_escape_adodbapi_connection_string_value(password))
         if not username and not password:
             conn_str += 'Integrated Security=SSPI;'
         return conn_str

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -139,13 +139,25 @@ def parse_connection_string_properties(cs):
 
 def _escape_odbc_connection_string_value(value: str) -> str:
     """Return a value escaped for an ODBC connection string."""
-    # MS Learn "Strong Passwords": brace special-character passwords and double right braces.
+    # SQL Server passwords may contain symbols, but ODBC connection strings use
+    # semicolons to separate key/value pairs. Microsoft documents wrapping
+    # special-character passwords in braces and escaping a literal right brace as
+    # "}}"; the outer braces are delimiters, not part of the password.
+    # Password: pa;ss}word
+    # Connection string: Server=host;UID=datadog;PWD={pa;ss}}word};
+    # Docs: https://learn.microsoft.com/en-us/sql/relational-databases/security/strong-passwords
     return '{{{}}}'.format(value.replace('}', '}}'))
 
 
 def _escape_adodbapi_connection_string_value(value: str) -> str:
     """Return a value escaped for an adodbapi connection string."""
-    # MS Learn OLE DB Driver keywords: quote string values and double the enclosing quote.
+    # adodbapi uses an ADO/OLE DB connection string, where semicolons separate
+    # key/value pairs. Quoting keeps semicolons inside the password value; a
+    # literal quote inside that value is escaped by doubling it. The outer quotes
+    # are delimiters, not part of the password.
+    # Password: pa;ss"word
+    # Connection string: Provider=MSOLEDBSQL;User ID=datadog;Password="pa;ss""word";
+    # Docs: https://learn.microsoft.com/en-us/sql/connect/oledb/applications/using-connection-string-keywords-with-oledb-driver-for-sql-server
     return '"{}"'.format(value.replace('"', '""'))
 
 

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -161,9 +161,9 @@ def _escape_legacy_freetds_odbc_connection_string_value(value: str) -> str:
     return '{{{}}}'.format(value)
 
 
-def _is_freetds_driver(driver: str | None) -> bool:
+def _is_freetds_driver(driver: str) -> bool:
     """Return whether an ODBC driver value points to FreeTDS."""
-    return bool(driver and ('freetds' in driver.lower() or 'libtdsodbc' in driver.lower()))
+    return 'freetds' in driver.lower() or 'libtdsodbc' in driver.lower()
 
 
 def _escape_adodbapi_connection_string_value(value: str) -> str:
@@ -656,7 +656,7 @@ class Connection(object):
             dsn, host, username, password, database, driver = self._get_access_info(db_key, db_name)
 
         escape_func = _escape_odbc_connection_string_value
-        if _is_freetds_driver(driver):
+        if driver and _is_freetds_driver(driver):
             escape_func = _escape_legacy_freetds_odbc_connection_string_value
 
         if self.managed_auth_enabled:

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -140,13 +140,30 @@ def parse_connection_string_properties(cs):
 def _escape_odbc_connection_string_value(value: str) -> str:
     """Return a value escaped for an ODBC connection string."""
     # SQL Server passwords may contain symbols, but ODBC connection strings use
-    # semicolons to separate key/value pairs. Microsoft documents wrapping
-    # special-character passwords in braces and escaping a literal right brace as
-    # "}}"; the outer braces are delimiters, not part of the password.
+    # semicolons to separate key/value pairs. The ODBC string spec wraps such
+    # values in braces and escapes a literal right brace as "}}"; the outer
+    # braces are delimiters, not part of the password.
     # Password: pa;ss}word
     # Connection string: Server=host;UID=datadog;PWD={pa;ss}}word};
-    # Docs: https://learn.microsoft.com/en-us/sql/relational-databases/security/strong-passwords
+    # Sources: https://learn.microsoft.com/en-us/sql/relational-databases/security/strong-passwords
+    # https://sqlprotocoldoc.z19.web.core.windows.net/MS-ODBCSTR/%5BMS-ODBCSTR%5D-100604.pdf
     return '{{{}}}'.format(value.replace('}', '}}'))
+
+
+def _escape_legacy_freetds_odbc_connection_string_value(value: str) -> str:
+    """Return a value escaped for legacy FreeTDS ODBC connection strings."""
+    # FreeTDS 1.3.6 does not decode "}}" inside braced values. It treats "}" as
+    # part of the password unless the next character is ";", so the legacy retry
+    # keeps the brace raw.
+    # Password: pa;ss}word
+    # Connection string: Driver=FreeTDS;Server=host;UID=datadog;PWD={pa;ss}word};
+    # Source: https://github.com/FreeTDS/freetds/blob/v1.3.6/src/odbc/connectparams.c
+    return '{{{}}}'.format(value)
+
+
+def _is_freetds_driver(driver: str | None) -> bool:
+    """Return whether an ODBC driver value points to FreeTDS."""
+    return bool(driver and ('freetds' in driver.lower() or 'libtdsodbc' in driver.lower()))
 
 
 def _escape_adodbapi_connection_string_value(value: str) -> str:
@@ -284,17 +301,7 @@ class Connection(object):
                 # autocommit: true disables implicit transaction
                 rawconn = adodbapi.connect(cs, {'timeout': self.timeout, 'autocommit': True})
             else:
-                cs += self._conn_string_odbc(db_key, db_name=db_name)
-                if self.managed_auth_enabled:
-                    token_struct = generate_managed_identity_token(
-                        self.managed_identity_client_id, self.managed_identity_scope
-                    )
-                    rawconn = pyodbc.connect(
-                        cs, timeout=self.timeout, autocommit=True, attrs_before={SQL_COPT_SS_ACCESS_TOKEN: token_struct}
-                    )
-                else:
-                    rawconn = pyodbc.connect(cs, timeout=self.timeout, autocommit=True)
-                rawconn.timeout = self.timeout
+                rawconn = self._open_odbc_connection(cs, db_key, db_name=db_name)
 
             self.service_check_handler(AgentCheck.OK, host, database, is_default=is_default)
             if conn_key not in self._conns:
@@ -342,6 +349,33 @@ class Connection(object):
                 # if not the default db, we should still log this exception
                 # to give the customer an opportunity to fix the issue
                 self.log.debug(check_err_message)
+
+    def _open_odbc_connection(self, connection_string_prefix: str, db_key: str, db_name: str | None = None) -> object:
+        """Open an ODBC connection, retrying legacy FreeTDS brace parsing when needed."""
+        conn_str = connection_string_prefix + self._conn_string_odbc(db_key, db_name=db_name)
+        try:
+            return self._pyodbc_connect(conn_str)
+        except Exception:
+            _, _, _, password, _, driver = self._get_access_info(db_key, db_name)
+            if not password or '}' not in password or not _is_freetds_driver(driver):
+                raise
+
+            conn_str = connection_string_prefix + self._conn_string_odbc(
+                db_key, db_name=db_name, escape_func=_escape_legacy_freetds_odbc_connection_string_value
+            )
+            return self._pyodbc_connect(conn_str)
+
+    def _pyodbc_connect(self, conn_str: str) -> object:
+        """Open a pyodbc connection with the configured authentication mode."""
+        if self.managed_auth_enabled:
+            token_struct = generate_managed_identity_token(self.managed_identity_client_id, self.managed_identity_scope)
+            rawconn = pyodbc.connect(
+                conn_str, timeout=self.timeout, autocommit=True, attrs_before={SQL_COPT_SS_ACCESS_TOKEN: token_struct}
+            )
+        else:
+            rawconn = pyodbc.connect(conn_str, timeout=self.timeout, autocommit=True)
+        rawconn.timeout = self.timeout
+        return rawconn
 
     def _setup_new_connection(self, rawconn):
         with rawconn.cursor() as cursor:
@@ -631,7 +665,7 @@ class Connection(object):
                     " however %s has been selected" % (key, other_connector, self.connector)
                 )
 
-    def _conn_string_odbc(self, db_key, conn_key=None, db_name=None):
+    def _conn_string_odbc(self, db_key, conn_key=None, db_name=None, escape_func=_escape_odbc_connection_string_value):
         """Return a connection string to use with odbc"""
         if conn_key:
             dsn, host, username, password, database, driver = conn_key.split(":")
@@ -662,7 +696,7 @@ class Connection(object):
             conn_str += 'UID={};'.format(username)
         self.log.debug("Connection string (before password) %s", conn_str)
         if password:
-            conn_str += 'PWD={};'.format(_escape_odbc_connection_string_value(password))
+            conn_str += 'PWD={};'.format(escape_func(password))
         return conn_str
 
     def _conn_string_adodbapi(self, db_key, conn_key=None, db_name=None):

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -317,6 +317,24 @@ def test_connection_string_escapes_password_special_characters(
     assert expected_password_parameter in conn_str
 
 
+@pytest.mark.unit
+def test_freetds_password_with_closing_brace_semicolon_raises_limitation(
+    instance_minimal_defaults: dict[str, object],
+) -> None:
+    password = 'pass};word'
+    instance_minimal_defaults.update({'connector': 'odbc', 'driver': 'FreeTDS', 'password': password})
+    connection = Connection({}, instance_minimal_defaults, None)
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        connection._conn_string_odbc('database')
+
+    error_message = str(exc_info.value)
+    assert "'};'" in error_message
+    assert 'FreeTDS' in error_message
+    assert 'Microsoft ODBC Driver for SQL Server' in error_message
+    assert password not in error_message
+
+
 @pytest.fixture
 def special_characters_password_login(sa_conn: object) -> tuple[str, str]:
     with sa_conn.cursor() as cursor:

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -308,15 +308,34 @@ def test_connection_string_escapes_password_with_semicolon(
     assert expected_password_parameter in conn_str
 
 
+def drop_semicolon_password_login(sa_conn: object) -> None:
+    with sa_conn.cursor() as cursor:
+        cursor.execute(
+            """
+            IF EXISTS (
+                SELECT 1 FROM sys.database_principals WHERE name = N'datadog_semicolon_password'
+            )
+                DROP USER [datadog_semicolon_password]
+            """
+        )
+        cursor.execute(
+            """
+            IF EXISTS (
+                SELECT 1 FROM sys.server_principals WHERE name = N'datadog_semicolon_password'
+            )
+                DROP LOGIN [datadog_semicolon_password]
+            """
+        )
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_connection_with_semicolon_in_password(instance_docker: dict[str, object], sa_conn: object) -> None:
     login_name = 'datadog_semicolon_password'
     password = 'Pa;ssword123!'
 
+    drop_semicolon_password_login(sa_conn)
     with sa_conn.cursor() as cursor:
-        cursor.execute("DROP USER IF EXISTS [datadog_semicolon_password]")
-        cursor.execute("DROP LOGIN IF EXISTS [datadog_semicolon_password]")
         cursor.execute("CREATE LOGIN [datadog_semicolon_password] WITH PASSWORD = 'Pa;ssword123!', CHECK_POLICY = OFF")
         cursor.execute("CREATE USER [datadog_semicolon_password] FOR LOGIN [datadog_semicolon_password]")
 
@@ -331,9 +350,7 @@ def test_connection_with_semicolon_in_password(instance_docker: dict[str, object
                 cursor.execute("select 1")
                 assert cursor.fetchall()
     finally:
-        with sa_conn.cursor() as cursor:
-            cursor.execute("DROP USER IF EXISTS [datadog_semicolon_password]")
-            cursor.execute("DROP LOGIN IF EXISTS [datadog_semicolon_password]")
+        drop_semicolon_password_login(sa_conn)
 
 
 @pytest.mark.flaky

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -26,12 +26,8 @@ from datadog_checks.sqlserver.connection_errors import (
 from .common import CHECK_NAME, SQLSERVER_YEAR
 
 KEY_PREFIX = "dbm-test-"
-FREETDS_SPECIAL_CHARACTERS_PASSWORD_LOGIN = 'datadog_freetds_special_characters_password'
-FREETDS_SPECIAL_CHARACTERS_PASSWORD = 'Pa;ssword123!'
-ODBC_SPECIAL_CHARACTERS_PASSWORD_LOGIN = 'datadog_odbc_special_characters_password'
-ODBC_SPECIAL_CHARACTERS_PASSWORD = 'Pa;ss}word123!'
-ADODBAPI_SPECIAL_CHARACTERS_PASSWORD_LOGIN = 'datadog_adodbapi_special_characters_password'
-ADODBAPI_SPECIAL_CHARACTERS_PASSWORD = 'Pa;ss"word123!'
+SPECIAL_CHARACTERS_PASSWORD_LOGIN = 'datadog_special_characters_password'
+SPECIAL_CHARACTERS_PASSWORD = 'Pa;ss}"word123!'
 
 
 @pytest.mark.unit
@@ -296,8 +292,8 @@ def test_config_with_and_without_port(instance_minimal_defaults, host, port, exp
 @pytest.mark.parametrize(
     'connector,password,expected_password_parameter',
     [
-        pytest.param('odbc', 'pa;ss}word', 'PWD={pa;ss}}word};', id='odbc'),
-        pytest.param('adodbapi', 'pa;ss"word', 'Password="pa;ss""word";', id='adodbapi'),
+        pytest.param('odbc', SPECIAL_CHARACTERS_PASSWORD, 'PWD={Pa;ss}}"word123!};', id='odbc'),
+        pytest.param('adodbapi', SPECIAL_CHARACTERS_PASSWORD, 'Password="Pa;ss}""word123!";', id='adodbapi'),
     ],
 )
 def test_connection_string_escapes_password_special_characters(
@@ -314,46 +310,8 @@ def test_connection_string_escapes_password_special_characters(
     assert expected_password_parameter in conn_str
 
 
-def special_characters_password_credentials(instance: dict[str, object]) -> tuple[str, str]:
-    if instance.get('connector') == 'adodbapi':
-        return ADODBAPI_SPECIAL_CHARACTERS_PASSWORD_LOGIN, ADODBAPI_SPECIAL_CHARACTERS_PASSWORD
-    driver = str(instance.get('driver', '')).lower()
-    if 'freetds' in driver or 'tdsodbc' in driver:
-        return FREETDS_SPECIAL_CHARACTERS_PASSWORD_LOGIN, FREETDS_SPECIAL_CHARACTERS_PASSWORD
-    return ODBC_SPECIAL_CHARACTERS_PASSWORD_LOGIN, ODBC_SPECIAL_CHARACTERS_PASSWORD
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize(
-    'instance,expected_password',
-    [
-        pytest.param({'connector': 'odbc', 'driver': 'FreeTDS'}, FREETDS_SPECIAL_CHARACTERS_PASSWORD, id='freetds'),
-        pytest.param(
-            {'connector': 'odbc', 'driver': '/opt/homebrew/lib/libtdsodbc.so'},
-            FREETDS_SPECIAL_CHARACTERS_PASSWORD,
-            id='freetds-path',
-        ),
-        pytest.param(
-            {'connector': 'odbc', 'driver': '{ODBC Driver 18 for SQL Server}'},
-            ODBC_SPECIAL_CHARACTERS_PASSWORD,
-            id='microsoft-odbc',
-        ),
-        pytest.param(
-            {'connector': 'adodbapi', 'adoprovider': 'MSOLEDBSQL'},
-            ADODBAPI_SPECIAL_CHARACTERS_PASSWORD,
-            id='adodbapi',
-        ),
-    ],
-)
-def test_special_characters_password_credentials(instance: dict[str, object], expected_password: str) -> None:
-    _, password = special_characters_password_credentials(instance)
-
-    assert password == expected_password
-
-
 @pytest.fixture
-def special_characters_password_login(instance_docker: dict[str, object], sa_conn: object) -> tuple[str, str]:
-    login, password = special_characters_password_credentials(instance_docker)
+def special_characters_password_login(sa_conn: object) -> tuple[str, str]:
     with sa_conn.cursor() as cursor:
         cursor.execute(
             """
@@ -363,7 +321,7 @@ def special_characters_password_login(instance_docker: dict[str, object], sa_con
                 CREATE LOGIN [{login}] WITH PASSWORD = '{password}', CHECK_POLICY = OFF
             ELSE
                 ALTER LOGIN [{login}] WITH PASSWORD = '{password}', CHECK_POLICY = OFF
-            """.format(login=login, password=password)
+            """.format(login=SPECIAL_CHARACTERS_PASSWORD_LOGIN, password=SPECIAL_CHARACTERS_PASSWORD)
         )
         cursor.execute(
             """
@@ -371,9 +329,9 @@ def special_characters_password_login(instance_docker: dict[str, object], sa_con
                 SELECT 1 FROM sys.database_principals WHERE name = N'{login}'
             )
                 CREATE USER [{login}] FOR LOGIN [{login}]
-            """.format(login=login)
+            """.format(login=SPECIAL_CHARACTERS_PASSWORD_LOGIN)
         )
-    return login, password
+    return SPECIAL_CHARACTERS_PASSWORD_LOGIN, SPECIAL_CHARACTERS_PASSWORD
 
 
 @pytest.mark.integration

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -288,16 +288,16 @@ def test_config_with_and_without_port(instance_minimal_defaults, host, port, exp
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    'connector,expected_password_parameter',
+    'connector,password,expected_password_parameter',
     [
-        pytest.param('odbc', 'PWD={pa;ss}}word};', id='odbc'),
-        pytest.param('adodbapi', 'Password="pa;ss}word";', id='adodbapi'),
+        pytest.param('odbc', 'pa;ss}word', 'PWD={pa;ss}}word};', id='odbc'),
+        pytest.param('adodbapi', 'pa;ss"word', 'Password="pa;ss""word";', id='adodbapi'),
     ],
 )
-def test_connection_string_escapes_password_with_semicolon(
-    instance_minimal_defaults: dict[str, object], connector: str, expected_password_parameter: str
+def test_connection_string_escapes_password_special_characters(
+    instance_minimal_defaults: dict[str, object], connector: str, password: str, expected_password_parameter: str
 ) -> None:
-    instance_minimal_defaults.update({'connector': connector, 'password': 'pa;ss}word'})
+    instance_minimal_defaults.update({'connector': connector, 'password': password})
     connection = Connection({}, instance_minimal_defaults, None)
 
     if connector == 'odbc':

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -26,8 +26,12 @@ from datadog_checks.sqlserver.connection_errors import (
 from .common import CHECK_NAME, SQLSERVER_YEAR
 
 KEY_PREFIX = "dbm-test-"
-SPECIAL_CHARACTERS_PASSWORD_LOGIN = 'datadog_special_characters_password'
-SPECIAL_CHARACTERS_PASSWORD = 'Pa;ss}"word123!'
+FREETDS_SPECIAL_CHARACTERS_PASSWORD_LOGIN = 'datadog_freetds_special_characters_password'
+FREETDS_SPECIAL_CHARACTERS_PASSWORD = 'Pa;ssword123!'
+ODBC_SPECIAL_CHARACTERS_PASSWORD_LOGIN = 'datadog_odbc_special_characters_password'
+ODBC_SPECIAL_CHARACTERS_PASSWORD = 'Pa;ss}word123!'
+ADODBAPI_SPECIAL_CHARACTERS_PASSWORD_LOGIN = 'datadog_adodbapi_special_characters_password'
+ADODBAPI_SPECIAL_CHARACTERS_PASSWORD = 'Pa;ss"word123!'
 
 
 @pytest.mark.unit
@@ -310,8 +314,46 @@ def test_connection_string_escapes_password_special_characters(
     assert expected_password_parameter in conn_str
 
 
+def special_characters_password_credentials(instance: dict[str, object]) -> tuple[str, str]:
+    if instance.get('connector') == 'adodbapi':
+        return ADODBAPI_SPECIAL_CHARACTERS_PASSWORD_LOGIN, ADODBAPI_SPECIAL_CHARACTERS_PASSWORD
+    driver = str(instance.get('driver', '')).lower()
+    if 'freetds' in driver or 'tdsodbc' in driver:
+        return FREETDS_SPECIAL_CHARACTERS_PASSWORD_LOGIN, FREETDS_SPECIAL_CHARACTERS_PASSWORD
+    return ODBC_SPECIAL_CHARACTERS_PASSWORD_LOGIN, ODBC_SPECIAL_CHARACTERS_PASSWORD
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'instance,expected_password',
+    [
+        pytest.param({'connector': 'odbc', 'driver': 'FreeTDS'}, FREETDS_SPECIAL_CHARACTERS_PASSWORD, id='freetds'),
+        pytest.param(
+            {'connector': 'odbc', 'driver': '/opt/homebrew/lib/libtdsodbc.so'},
+            FREETDS_SPECIAL_CHARACTERS_PASSWORD,
+            id='freetds-path',
+        ),
+        pytest.param(
+            {'connector': 'odbc', 'driver': '{ODBC Driver 18 for SQL Server}'},
+            ODBC_SPECIAL_CHARACTERS_PASSWORD,
+            id='microsoft-odbc',
+        ),
+        pytest.param(
+            {'connector': 'adodbapi', 'adoprovider': 'MSOLEDBSQL'},
+            ADODBAPI_SPECIAL_CHARACTERS_PASSWORD,
+            id='adodbapi',
+        ),
+    ],
+)
+def test_special_characters_password_credentials(instance: dict[str, object], expected_password: str) -> None:
+    _, password = special_characters_password_credentials(instance)
+
+    assert password == expected_password
+
+
 @pytest.fixture
-def special_characters_password_login(sa_conn: object) -> tuple[str, str]:
+def special_characters_password_login(instance_docker: dict[str, object], sa_conn: object) -> tuple[str, str]:
+    login, password = special_characters_password_credentials(instance_docker)
     with sa_conn.cursor() as cursor:
         cursor.execute(
             """
@@ -319,7 +361,9 @@ def special_characters_password_login(sa_conn: object) -> tuple[str, str]:
                 SELECT 1 FROM sys.server_principals WHERE name = N'{login}'
             )
                 CREATE LOGIN [{login}] WITH PASSWORD = '{password}', CHECK_POLICY = OFF
-            """.format(login=SPECIAL_CHARACTERS_PASSWORD_LOGIN, password=SPECIAL_CHARACTERS_PASSWORD)
+            ELSE
+                ALTER LOGIN [{login}] WITH PASSWORD = '{password}', CHECK_POLICY = OFF
+            """.format(login=login, password=password)
         )
         cursor.execute(
             """
@@ -327,9 +371,9 @@ def special_characters_password_login(sa_conn: object) -> tuple[str, str]:
                 SELECT 1 FROM sys.database_principals WHERE name = N'{login}'
             )
                 CREATE USER [{login}] FOR LOGIN [{login}]
-            """.format(login=SPECIAL_CHARACTERS_PASSWORD_LOGIN)
+            """.format(login=login)
         )
-    return SPECIAL_CHARACTERS_PASSWORD_LOGIN, SPECIAL_CHARACTERS_PASSWORD
+    return login, password
 
 
 @pytest.mark.integration

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -286,6 +286,56 @@ def test_config_with_and_without_port(instance_minimal_defaults, host, port, exp
     assert result_host == expected_host
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'connector,expected_password_parameter',
+    [
+        pytest.param('odbc', 'PWD={pa;ss}}word};', id='odbc'),
+        pytest.param('adodbapi', 'Password="pa;ss}word";', id='adodbapi'),
+    ],
+)
+def test_connection_string_escapes_password_with_semicolon(
+    instance_minimal_defaults: dict[str, object], connector: str, expected_password_parameter: str
+) -> None:
+    instance_minimal_defaults.update({'connector': connector, 'password': 'pa;ss}word'})
+    connection = Connection({}, instance_minimal_defaults, None)
+
+    if connector == 'odbc':
+        conn_str = connection._conn_string_odbc('database')
+    else:
+        conn_str = connection._conn_string_adodbapi('database')
+
+    assert expected_password_parameter in conn_str
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_connection_with_semicolon_in_password(instance_docker: dict[str, object], sa_conn: object) -> None:
+    login_name = 'datadog_semicolon_password'
+    password = 'Pa;ssword123!'
+
+    with sa_conn.cursor() as cursor:
+        cursor.execute("DROP USER IF EXISTS [datadog_semicolon_password]")
+        cursor.execute("DROP LOGIN IF EXISTS [datadog_semicolon_password]")
+        cursor.execute("CREATE LOGIN [datadog_semicolon_password] WITH PASSWORD = 'Pa;ssword123!', CHECK_POLICY = OFF")
+        cursor.execute("CREATE USER [datadog_semicolon_password] FOR LOGIN [datadog_semicolon_password]")
+
+    try:
+        instance_docker['username'] = login_name
+        instance_docker['password'] = password
+        check = SQLServer(CHECK_NAME, {}, [instance_docker])
+        check.initialize_connection()
+
+        with check.connection.open_managed_default_connection(KEY_PREFIX):
+            with check.connection.get_managed_cursor(KEY_PREFIX) as cursor:
+                cursor.execute("select 1")
+                assert cursor.fetchall()
+    finally:
+        with sa_conn.cursor() as cursor:
+            cursor.execute("DROP USER IF EXISTS [datadog_semicolon_password]")
+            cursor.execute("DROP LOGIN IF EXISTS [datadog_semicolon_password]")
+
+
 @pytest.mark.flaky
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -312,6 +312,13 @@ def drop_semicolon_password_login(sa_conn: object) -> None:
     with sa_conn.cursor() as cursor:
         cursor.execute(
             """
+            SELECT session_id FROM sys.dm_exec_sessions WHERE login_name = N'datadog_semicolon_password'
+            """
+        )
+        for row in cursor.fetchall():
+            cursor.execute('KILL {}'.format(row[0]))
+        cursor.execute(
+            """
             IF EXISTS (
                 SELECT 1 FROM sys.database_principals WHERE name = N'datadog_semicolon_password'
             )

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -310,6 +310,41 @@ def test_connection_string_escapes_password_special_characters(
     assert expected_password_parameter in conn_str
 
 
+@pytest.mark.unit
+def test_odbc_connection_retries_legacy_freetds_password_brace_escape(
+    instance_minimal_defaults: dict[str, object],
+) -> None:
+    instance_minimal_defaults.update(
+        {'connector': 'odbc', 'driver': 'FreeTDS', 'password': SPECIAL_CHARACTERS_PASSWORD}
+    )
+    connection = Connection({}, instance_minimal_defaults, None)
+    rawconn = mock.MagicMock()
+    connection._pyodbc_connect = mock.MagicMock(side_effect=[Exception("login failed"), rawconn])
+
+    assert connection._open_odbc_connection('', 'database') is rawconn
+
+    first_conn_str = connection._pyodbc_connect.call_args_list[0].args[0]
+    retry_conn_str = connection._pyodbc_connect.call_args_list[1].args[0]
+    assert 'PWD={Pa;ss}}"word123!};' in first_conn_str
+    assert 'PWD={Pa;ss}"word123!};' in retry_conn_str
+
+
+@pytest.mark.unit
+def test_odbc_connection_does_not_retry_legacy_escape_for_non_freetds(
+    instance_minimal_defaults: dict[str, object],
+) -> None:
+    instance_minimal_defaults.update(
+        {'connector': 'odbc', 'driver': '{ODBC Driver 18 for SQL Server}', 'password': SPECIAL_CHARACTERS_PASSWORD}
+    )
+    connection = Connection({}, instance_minimal_defaults, None)
+    connection._pyodbc_connect = mock.MagicMock(side_effect=Exception("login failed"))
+
+    with pytest.raises(Exception, match="login failed"):
+        connection._open_odbc_connection('', 'database')
+
+    connection._pyodbc_connect.assert_called_once()
+
+
 @pytest.fixture
 def special_characters_password_login(sa_conn: object) -> tuple[str, str]:
     with sa_conn.cursor() as cursor:

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -26,8 +26,8 @@ from datadog_checks.sqlserver.connection_errors import (
 from .common import CHECK_NAME, SQLSERVER_YEAR
 
 KEY_PREFIX = "dbm-test-"
-SEMICOLON_PASSWORD_LOGIN = 'datadog_semicolon_password'
-SEMICOLON_PASSWORD = 'Pa;ssword123!'
+SPECIAL_CHARACTERS_PASSWORD_LOGIN = 'datadog_special_characters_password'
+SPECIAL_CHARACTERS_PASSWORD = 'Pa;ss}"word123!'
 
 
 @pytest.mark.unit
@@ -311,7 +311,7 @@ def test_connection_string_escapes_password_special_characters(
 
 
 @pytest.fixture
-def semicolon_password_login(sa_conn: object) -> tuple[str, str]:
+def special_characters_password_login(sa_conn: object) -> tuple[str, str]:
     with sa_conn.cursor() as cursor:
         cursor.execute(
             """
@@ -319,7 +319,7 @@ def semicolon_password_login(sa_conn: object) -> tuple[str, str]:
                 SELECT 1 FROM sys.server_principals WHERE name = N'{login}'
             )
                 CREATE LOGIN [{login}] WITH PASSWORD = '{password}', CHECK_POLICY = OFF
-            """.format(login=SEMICOLON_PASSWORD_LOGIN, password=SEMICOLON_PASSWORD)
+            """.format(login=SPECIAL_CHARACTERS_PASSWORD_LOGIN, password=SPECIAL_CHARACTERS_PASSWORD)
         )
         cursor.execute(
             """
@@ -327,17 +327,17 @@ def semicolon_password_login(sa_conn: object) -> tuple[str, str]:
                 SELECT 1 FROM sys.database_principals WHERE name = N'{login}'
             )
                 CREATE USER [{login}] FOR LOGIN [{login}]
-            """.format(login=SEMICOLON_PASSWORD_LOGIN)
+            """.format(login=SPECIAL_CHARACTERS_PASSWORD_LOGIN)
         )
-    return SEMICOLON_PASSWORD_LOGIN, SEMICOLON_PASSWORD
+    return SPECIAL_CHARACTERS_PASSWORD_LOGIN, SPECIAL_CHARACTERS_PASSWORD
 
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_connection_with_semicolon_in_password(
-    instance_docker: dict[str, object], semicolon_password_login: tuple[str, str]
+def test_connection_with_special_characters_in_password(
+    instance_docker: dict[str, object], special_characters_password_login: tuple[str, str]
 ) -> None:
-    login_name, password = semicolon_password_login
+    login_name, password = special_characters_password_login
     instance_docker['username'] = login_name
     instance_docker['password'] = password
     check = SQLServer(CHECK_NAME, {}, [instance_docker])

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -290,16 +290,23 @@ def test_config_with_and_without_port(instance_minimal_defaults, host, port, exp
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    'connector,password,expected_password_parameter',
+    'connector,driver,password,expected_password_parameter',
     [
-        pytest.param('odbc', SPECIAL_CHARACTERS_PASSWORD, 'PWD={Pa;ss}}"word123!};', id='odbc'),
-        pytest.param('adodbapi', SPECIAL_CHARACTERS_PASSWORD, 'Password="Pa;ss}""word123!";', id='adodbapi'),
+        pytest.param('odbc', None, SPECIAL_CHARACTERS_PASSWORD, 'PWD={Pa;ss}}"word123!};', id='odbc'),
+        pytest.param('odbc', 'FreeTDS', SPECIAL_CHARACTERS_PASSWORD, 'PWD={Pa;ss}"word123!};', id='odbc-freetds'),
+        pytest.param('adodbapi', None, SPECIAL_CHARACTERS_PASSWORD, 'Password="Pa;ss}""word123!";', id='adodbapi'),
     ],
 )
 def test_connection_string_escapes_password_special_characters(
-    instance_minimal_defaults: dict[str, object], connector: str, password: str, expected_password_parameter: str
+    instance_minimal_defaults: dict[str, object],
+    connector: str,
+    driver: str | None,
+    password: str,
+    expected_password_parameter: str,
 ) -> None:
     instance_minimal_defaults.update({'connector': connector, 'password': password})
+    if driver:
+        instance_minimal_defaults['driver'] = driver
     connection = Connection({}, instance_minimal_defaults, None)
 
     if connector == 'odbc':
@@ -308,41 +315,6 @@ def test_connection_string_escapes_password_special_characters(
         conn_str = connection._conn_string_adodbapi('database')
 
     assert expected_password_parameter in conn_str
-
-
-@pytest.mark.unit
-def test_odbc_connection_retries_legacy_freetds_password_brace_escape(
-    instance_minimal_defaults: dict[str, object],
-) -> None:
-    instance_minimal_defaults.update(
-        {'connector': 'odbc', 'driver': 'FreeTDS', 'password': SPECIAL_CHARACTERS_PASSWORD}
-    )
-    connection = Connection({}, instance_minimal_defaults, None)
-    rawconn = mock.MagicMock()
-    connection._pyodbc_connect = mock.MagicMock(side_effect=[Exception("login failed"), rawconn])
-
-    assert connection._open_odbc_connection('', 'database') is rawconn
-
-    first_conn_str = connection._pyodbc_connect.call_args_list[0].args[0]
-    retry_conn_str = connection._pyodbc_connect.call_args_list[1].args[0]
-    assert 'PWD={Pa;ss}}"word123!};' in first_conn_str
-    assert 'PWD={Pa;ss}"word123!};' in retry_conn_str
-
-
-@pytest.mark.unit
-def test_odbc_connection_does_not_retry_legacy_escape_for_non_freetds(
-    instance_minimal_defaults: dict[str, object],
-) -> None:
-    instance_minimal_defaults.update(
-        {'connector': 'odbc', 'driver': '{ODBC Driver 18 for SQL Server}', 'password': SPECIAL_CHARACTERS_PASSWORD}
-    )
-    connection = Connection({}, instance_minimal_defaults, None)
-    connection._pyodbc_connect = mock.MagicMock(side_effect=Exception("login failed"))
-
-    with pytest.raises(Exception, match="login failed"):
-        connection._open_odbc_connection('', 'database')
-
-    connection._pyodbc_connect.assert_called_once()
 
 
 @pytest.fixture

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -26,6 +26,8 @@ from datadog_checks.sqlserver.connection_errors import (
 from .common import CHECK_NAME, SQLSERVER_YEAR
 
 KEY_PREFIX = "dbm-test-"
+SEMICOLON_PASSWORD_LOGIN = 'datadog_semicolon_password'
+SEMICOLON_PASSWORD = 'Pa;ssword123!'
 
 
 @pytest.mark.unit
@@ -308,56 +310,43 @@ def test_connection_string_escapes_password_special_characters(
     assert expected_password_parameter in conn_str
 
 
-def drop_semicolon_password_login(sa_conn: object) -> None:
+@pytest.fixture
+def semicolon_password_login(sa_conn: object) -> tuple[str, str]:
     with sa_conn.cursor() as cursor:
         cursor.execute(
             """
-            SELECT session_id FROM sys.dm_exec_sessions WHERE login_name = N'datadog_semicolon_password'
-            """
-        )
-        for row in cursor.fetchall():
-            cursor.execute('KILL {}'.format(row[0]))
-        cursor.execute(
-            """
-            IF EXISTS (
-                SELECT 1 FROM sys.database_principals WHERE name = N'datadog_semicolon_password'
+            IF NOT EXISTS (
+                SELECT 1 FROM sys.server_principals WHERE name = N'{login}'
             )
-                DROP USER [datadog_semicolon_password]
-            """
+                CREATE LOGIN [{login}] WITH PASSWORD = '{password}', CHECK_POLICY = OFF
+            """.format(login=SEMICOLON_PASSWORD_LOGIN, password=SEMICOLON_PASSWORD)
         )
         cursor.execute(
             """
-            IF EXISTS (
-                SELECT 1 FROM sys.server_principals WHERE name = N'datadog_semicolon_password'
+            IF NOT EXISTS (
+                SELECT 1 FROM sys.database_principals WHERE name = N'{login}'
             )
-                DROP LOGIN [datadog_semicolon_password]
-            """
+                CREATE USER [{login}] FOR LOGIN [{login}]
+            """.format(login=SEMICOLON_PASSWORD_LOGIN)
         )
+    return SEMICOLON_PASSWORD_LOGIN, SEMICOLON_PASSWORD
 
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_connection_with_semicolon_in_password(instance_docker: dict[str, object], sa_conn: object) -> None:
-    login_name = 'datadog_semicolon_password'
-    password = 'Pa;ssword123!'
+def test_connection_with_semicolon_in_password(
+    instance_docker: dict[str, object], semicolon_password_login: tuple[str, str]
+) -> None:
+    login_name, password = semicolon_password_login
+    instance_docker['username'] = login_name
+    instance_docker['password'] = password
+    check = SQLServer(CHECK_NAME, {}, [instance_docker])
+    check.initialize_connection()
 
-    drop_semicolon_password_login(sa_conn)
-    with sa_conn.cursor() as cursor:
-        cursor.execute("CREATE LOGIN [datadog_semicolon_password] WITH PASSWORD = 'Pa;ssword123!', CHECK_POLICY = OFF")
-        cursor.execute("CREATE USER [datadog_semicolon_password] FOR LOGIN [datadog_semicolon_password]")
-
-    try:
-        instance_docker['username'] = login_name
-        instance_docker['password'] = password
-        check = SQLServer(CHECK_NAME, {}, [instance_docker])
-        check.initialize_connection()
-
-        with check.connection.open_managed_default_connection(KEY_PREFIX):
-            with check.connection.get_managed_cursor(KEY_PREFIX) as cursor:
-                cursor.execute("select 1")
-                assert cursor.fetchall()
-    finally:
-        drop_semicolon_password_login(sa_conn)
+    with check.connection.open_managed_default_connection(KEY_PREFIX):
+        with check.connection.get_managed_cursor(KEY_PREFIX) as cursor:
+            cursor.execute("select 1")
+            assert cursor.fetchall()
 
 
 @pytest.mark.flaky


### PR DESCRIPTION
### What does this PR do?
Escapes SQL Server passwords when the integration builds connection strings from the `password` config field. ODBC connection strings now wrap passwords in braces and escape closing braces, while adodbapi connection strings now quote passwords and escape embedded quotes.

### Motivation
[DBMON-737](https://datadoghq.atlassian.net/browse/DBMON-737) reports that SQL Server logins fail when passwords contain special connection-string delimiters such as semicolons. The integration previously appended configured passwords directly as `PWD=<password>;` or `Password=<password>;`, so a semicolon inside the password was parsed as the end of the password value.

Validation:
- `ddev test -fs sqlserver`
- `ddev --no-interactive test sqlserver:py3.13-linux-FreeTDS-2022-single -- -k "test_parse_connection_string_properties or test_connection_string_escapes_password_with_semicolon" -q`
- Attempted `ddev --no-interactive test sqlserver:py3.13-linux-FreeTDS-2022-single -- -k test_connection_with_semicolon_in_password -q`; the SQL Server Docker container exited during environment setup on this aarch64 host before the test body ran.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[DBMON-737]: https://datadoghq.atlassian.net/browse/DBMON-737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ