### PR TITLE
Remove Mongo queryStats server-side sort

### DIFF
--- a/mongo/changelog.d/24140.fixed
+++ b/mongo/changelog.d/24140.fixed
@@ -1,0 +1,1 @@
+Remove server-side sort from MongoDB query metrics collection to avoid queryStats sort memory failures.

--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -254,10 +254,7 @@ class MongoApi(object):
         - metrics: execution statistics (execCount, totalExecMicros, etc.)
         - asOf: timestamp of the statistics
         """
-        pipeline = [
-            {'$queryStats': {}},
-            {'$sort': {'metrics.execCount': -1}},
-        ]
+        pipeline = [{'$queryStats': {}}]
         return self['admin'].aggregate(pipeline, session=session, maxTimeMS=self._timeout)
 
     @property

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -670,7 +670,7 @@ def test_parse_mongo_version_with_suffix(check, instance, dd_run_check, datadog_
     datadog_agent.assert_metadata('test:123', {'version.scheme': 'semver', 'version.major': '3', 'version.minor': '6'})
 
 
-def test_query_stats_does_not_use_server_side_sort_or_allow_disk_use():
+def test_query_stats_does_not_use_server_side_sort_or_allow_disk_use() -> None:
     api = MongoApi.__new__(MongoApi)
     api._timeout = 123
     admin_db = mock.MagicMock()

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -11,8 +11,6 @@ from urllib.parse import quote_plus
 import mock
 import pytest
 from bson import json_util
-from pymongo.errors import ConnectionFailure, OperationFailure
-
 from datadog_checks.base import ConfigurationError
 from datadog_checks.base.utils.db.sql import compute_exec_plan_signature
 from datadog_checks.mongo.api import CRITICAL_FAILURE, MongoApi
@@ -21,6 +19,7 @@ from datadog_checks.mongo.common import MongosDeployment, ReplicaSetDeployment, 
 from datadog_checks.mongo.dbm.utils import get_explain_plan, should_explain_operation
 from datadog_checks.mongo.mongo import HostingType, MongoDb, metrics
 from datadog_checks.mongo.utils import parse_mongo_uri
+from pymongo.errors import ConnectionFailure, OperationFailure
 
 from . import common
 from .conftest import mock_pymongo
@@ -668,6 +667,19 @@ def test_parse_mongo_version_with_suffix(check, instance, dd_run_check, datadog_
         mocked_client.server_info = mock.MagicMock(return_value={'version': '3.6.23-13.0'})
         dd_run_check(check)
     datadog_agent.assert_metadata('test:123', {'version.scheme': 'semver', 'version.major': '3', 'version.minor': '6'})
+
+
+def test_query_stats_does_not_use_server_side_sort_or_allow_disk_use():
+    api = MongoApi.__new__(MongoApi)
+    api._timeout = 123
+    admin_db = mock.MagicMock()
+    api._cli = {'admin': admin_db}
+
+    cursor = object()
+    admin_db.aggregate.return_value = cursor
+
+    assert api.query_stats(session='session') is cursor
+    admin_db.aggregate.assert_called_once_with([{'$queryStats': {}}], session='session', maxTimeMS=123)
 
 
 @mock.patch(

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -11,6 +11,8 @@ from urllib.parse import quote_plus
 import mock
 import pytest
 from bson import json_util
+from pymongo.errors import ConnectionFailure, OperationFailure
+
 from datadog_checks.base import ConfigurationError
 from datadog_checks.base.utils.db.sql import compute_exec_plan_signature
 from datadog_checks.mongo.api import CRITICAL_FAILURE, MongoApi
@@ -19,7 +21,6 @@ from datadog_checks.mongo.common import MongosDeployment, ReplicaSetDeployment, 
 from datadog_checks.mongo.dbm.utils import get_explain_plan, should_explain_operation
 from datadog_checks.mongo.mongo import HostingType, MongoDb, metrics
 from datadog_checks.mongo.utils import parse_mongo_uri
-from pymongo.errors import ConnectionFailure, OperationFailure
 
 from . import common
 from .conftest import mock_pymongo


### PR DESCRIPTION
### What does this PR do?
Remove the server-side `$sort` stage from the MongoDB `$queryStats` aggregation used for DBM query metrics. The agent now requests the `$queryStats` cursor directly, avoiding MongoDB's blocking sort memory limit and the `mongos` restriction where `$queryStats` cannot be combined with a spillable `$sort` when `allowDiskUse` is enabled.

### Motivation
A customer on an Atlas sharded cluster hit `QueryExceededMemoryLimitNoDiskUseAllowed` while collecting query metrics. Local MongoDB 7/8 reproductions showed the existing `$queryStats + $sort` pipeline can exceed the 100 MB sort limit. Testing also showed that adding `allowDiskUse=True` fixes standalone deployments but fails on sharded `mongos` with `IllegalOperation`, so removing the unnecessary server-side sort is the safer fix.

Validated with unit tests, DBM query metrics tests, local Docker MongoDB 7/8 standalone and sharded repros, and Atlas 7/8 sanity checks.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged