### PR TITLE
kafka_consumer: always fetch highwater offsets when cluster monitoring is enabled

### DIFF
--- a/kafka_consumer/changelog.d/24149.fixed
+++ b/kafka_consumer/changelog.d/24149.fixed
@@ -1,0 +1,1 @@
+Fix kafka.broker_offset and kafka.topic.message_rate not being collected when enable_cluster_monitoring is true and the consumer context count exceeds max_partition_contexts.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -102,7 +102,10 @@ class KafkaCheck(AgentCheck):
             consumer_offsets,
             highwater_offsets,
         )
-        if total_contexts >= self._context_limit:
+        # When cluster monitoring is enabled, all offsets and lag metrics are reported regardless
+        # of context count so that the full cluster picture is always available.
+        reporting_limit = float('inf') if self.config._cluster_monitoring_enabled else self._context_limit
+        if total_contexts >= self._context_limit and not self.config._cluster_monitoring_enabled:
             self.warning(
                 """Discovered %s metric contexts - this exceeds the maximum number of %s contexts permitted by the
                 check. Please narrow your target by specifying in your kafka_consumer.yaml the consumer groups, topics
@@ -115,11 +118,11 @@ class KafkaCheck(AgentCheck):
         if self.config._kafka_cluster_id_override:
             cluster_id = self.config._kafka_cluster_id_override
 
-        self.report_highwater_offsets(highwater_offsets, self._context_limit, cluster_id)
+        self.report_highwater_offsets(highwater_offsets, reporting_limit, cluster_id)
         self.report_consumer_offsets_and_lag(
             consumer_offsets,
             highwater_offsets,
-            self._context_limit - len(highwater_offsets),
+            reporting_limit - len(highwater_offsets),
             broker_timestamps,
             cluster_id,
         )

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -67,7 +67,9 @@ class KafkaCheck(AgentCheck):
         persistent_cache_key = "broker_timestamps_"
         consumer_contexts_count = self.count_consumer_contexts(consumer_offsets)
         try:
-            if consumer_contexts_count < self._context_limit:
+            # Cluster monitoring always requires highwater offsets (for topic.message_rate and other
+            # cluster metadata metrics), so bypass the consumer context limit in that case.
+            if consumer_contexts_count < self._context_limit or self.config._cluster_monitoring_enabled:
                 # Fetch highwater offsets
                 # Build partitions list or use all if configured
                 # If cluster monitoring is enabled, always fetch all broker highwater marks


### PR DESCRIPTION
### What does this PR do?

When `enable_cluster_monitoring: true`, bypass the `max_partition_contexts` guard in two places:

1. **Highwater offset collection** — the context count no longer gates whether highwater offsets are fetched at all.
2. **Metric reporting** — `kafka.broker_offset`, `kafka.consumer_offset`, and `kafka.consumer_lag` are reported for all partitions without a cap.

Also suppresses the misleading "narrow your target" warning in cluster monitoring mode.

### Motivation

**Bug 1: `kafka.topic.message_rate` always 0, `kafka.broker_offset` missing**

With `enable_cluster_monitoring: true` the check forces `monitor_unlisted_consumer_groups: true`, which causes the consumer context count to exceed the default limit of 500 (customer's clusters had 959 and 1,570 contexts). The existing guard:

```python
if consumer_contexts_count < self._context_limit:
    highwater_offsets, cluster_id = self.get_highwater_offsets(partitions)
else:
    self.warning("Context limit reached. Skipping highwater offset collection.")
```

skipped highwater offset collection entirely, leaving `highwater_offsets = {}`. This caused:

- `kafka.broker_offset` — `report_highwater_offsets({}, ...)` iterates an empty dict and emits nothing.
- `kafka.topic.message_rate` — `_collect_topic_metadata` receives `highwater_offsets = {}`, every partition gets `current_offset = -1`, `sum_latest` and `sum_previous` stay 0, and the rate is emitted as 0.

Fix: bypass the guard when `_cluster_monitoring_enabled` is true.

**Bug 2: `kafka.consumer_lag` silently capped**

Even after fixing the fetch, the reporting functions were still capped at `_context_limit`. In cluster monitoring mode the user wants full cluster visibility by design — all consumer lag for all partitions should be reported. Fix: use `float('inf')` as the reporting limit when cluster monitoring is enabled (`int == inf` is `False`, `int >= inf` is `False`, `int < inf` is `True` — no changes to the report functions needed).

Confirmed from customer flares: status log shows `"Context limit reached. Skipping highwater offset collection."` on both instances with `enable_cluster_monitoring: true`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged