### PR TITLE
Add Anthropic web fetch as a provider-native server tool

### DIFF
--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -19,9 +19,10 @@ from ddev.ai.agent.types import (
     TokenUsage,
     ToolCall,
     ToolResultMessage,
-    WebSearchActivity,
+    WebActivity,
+    WebCitation,
+    WebFetchCall,
     WebSearchCall,
-    WebSearchCitation,
 )
 from ddev.ai.tools.registry import ToolRegistry
 
@@ -38,12 +39,19 @@ DEFAULT_MODEL: Final[str] = "claude-sonnet-4-6"
 DEFAULT_MAX_TOKENS: Final[int] = 8192  # max tokens per response
 MAX_CONTINUATIONS: Final[int] = 10
 
-# Pinned to the ZDR-eligible version; web_search_20260209 is not ZDR-eligible by default.
+# Pinned to the ZDR-eligible versions; the _20260209 variants are not ZDR-eligible by default.
 WEB_SEARCH_VERSION: Final[str] = "web_search_20250305"
+WEB_FETCH_VERSION: Final[str] = "web_fetch_20250910"
 
 NATIVE_TOOL_DEFINITIONS: Final[dict[str, ToolParam]] = {
     # max_uses stays below MAX_CONTINUATIONS so a turn is always left to receive the final response.
     "web_search": {"type": WEB_SEARCH_VERSION, "name": "web_search", "max_uses": MAX_CONTINUATIONS - 1},
+    "web_fetch": {
+        "type": WEB_FETCH_VERSION,
+        "name": "web_fetch",
+        "max_uses": MAX_CONTINUATIONS - 1,
+        "citations": {"enabled": True},
+    },
 }
 
 # 1h TTL for the static prefix (system + tools): paid once, read for the whole session.
@@ -68,7 +76,7 @@ class ResponseContent:
 
     text: str
     tool_calls: list[ToolCall]
-    citations: list[WebSearchCitation]
+    citations: list[WebCitation]
 
 
 class AnthropicAgent(BaseAgent[MessageParam]):
@@ -149,10 +157,10 @@ class AnthropicAgent(BaseAgent[MessageParam]):
         return [NATIVE_TOOL_DEFINITIONS[name] for name in names]
 
     @staticmethod
-    def _web_search_requests(response: Message) -> int:
-        """Web search request count from one response (0 if absent). Robust to fakes/providers."""
+    def _server_tool_requests(response: Message, attr: str) -> int:
+        """Server tool request count from one response (0 if absent). Robust to fakes/providers."""
         server_use = getattr(response.usage, "server_tool_use", None)
-        return getattr(server_use, "web_search_requests", 0)
+        return getattr(server_use, attr, 0)
 
     @staticmethod
     def _extract_web_searches(responses: list[Message]) -> list[WebSearchCall]:
@@ -181,6 +189,34 @@ class AnthropicAgent(BaseAgent[MessageParam]):
             count, error = results.get(use_id, (0, None))
             searches.append(WebSearchCall(query=query, result_count=count, error=error))
         return searches
+
+    @staticmethod
+    def _extract_web_fetches(responses: list[Message]) -> list[WebFetchCall]:
+        """Collect server-side web fetches (url + retrieved_at/error) across all responses.
+
+        Like web searches, fetches are server tools: the model emits a ``ServerToolUseBlock``
+        (the url) and Anthropic answers inline with a ``WebFetchToolResultBlock``. They never
+        become client ``ToolCall``s, so we surface them here for logging.
+        """
+        urls: dict[str, str] = {}
+        results: dict[str, tuple[str | None, str | None]] = {}
+        for response in responses:
+            for block in response.content:
+                if isinstance(block, anthropic.types.ServerToolUseBlock) and block.name == "web_fetch":
+                    url = block.input.get("url", "")
+                    urls[block.id] = str(url)
+                elif isinstance(block, anthropic.types.WebFetchToolResultBlock):
+                    content = block.content
+                    if isinstance(content, anthropic.types.WebFetchToolResultErrorBlock):
+                        results[block.tool_use_id] = (None, content.error_code)
+                    else:
+                        results[block.tool_use_id] = (content.retrieved_at, None)
+
+        fetches: list[WebFetchCall] = []
+        for use_id, url in urls.items():
+            retrieved_at, error = results.get(use_id, (None, None))
+            fetches.append(WebFetchCall(url=url, retrieved_at=retrieved_at, error=error))
+        return fetches
 
     async def _create_until_complete(
         self,
@@ -287,20 +323,29 @@ class AnthropicAgent(BaseAgent[MessageParam]):
 
     @staticmethod
     def _parse_response_content(response: Message) -> ResponseContent:
-        """Extract text, client tool calls, and web-search citations from response blocks.
+        """Extract text, client tool calls, and web-search/fetch citations from response blocks.
 
         Server tool blocks are intentionally skipped: they stay verbatim in history so
         Anthropic can resolve encrypted_content / encrypted_index for citations.
         """
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
-        citations: list[WebSearchCitation] = []
+        citations: list[WebCitation] = []
         for block in response.content:
             if isinstance(block, anthropic.types.TextBlock):
                 text_parts.append(block.text)
                 for c in block.citations or []:
                     if isinstance(c, anthropic.types.CitationsWebSearchResultLocation):
-                        citations.append(WebSearchCitation(url=c.url, title=c.title, cited_text=c.cited_text))
+                        citations.append(WebCitation(url=c.url, title=c.title, cited_text=c.cited_text))
+                    elif isinstance(
+                        c,
+                        (
+                            anthropic.types.CitationCharLocation,
+                            anthropic.types.CitationPageLocation,
+                            anthropic.types.CitationContentBlockLocation,
+                        ),
+                    ):
+                        citations.append(WebCitation(cited_text=c.cited_text, title=c.document_title))
             elif isinstance(block, anthropic.types.ToolUseBlock):
                 tool_calls.append(ToolCall(id=block.id, name=block.name, input=dict(block.input)))
         return ResponseContent(text="\n".join(text_parts), tool_calls=tool_calls, citations=citations)
@@ -320,7 +365,8 @@ class AnthropicAgent(BaseAgent[MessageParam]):
                 window_size=await self._get_context_window(),
                 used_tokens=final.usage.input_tokens + final_cache_read + final_cache_creation,
             ),
-            web_search_requests=sum(self._web_search_requests(r) for r in all_responses),
+            web_search_requests=sum(self._server_tool_requests(r, "web_search_requests") for r in all_responses),
+            web_fetch_requests=sum(self._server_tool_requests(r, "web_fetch_requests") for r in all_responses),
         )
 
     def _append_history(
@@ -374,8 +420,9 @@ class AnthropicAgent(BaseAgent[MessageParam]):
             text=parsed.text,
             tool_calls=parsed.tool_calls,
             usage=await self._build_usage(completion),
-            web_activity=WebSearchActivity(
+            web_activity=WebActivity(
                 searches=self._extract_web_searches(completion.all_responses),
+                fetches=self._extract_web_fetches(completion.all_responses),
                 citations=parsed.citations,
             ),
         )

--- a/ddev/src/ddev/ai/agent/types.py
+++ b/ddev/src/ddev/ai/agent/types.py
@@ -39,20 +39,30 @@ class WebSearchCall:
 
 
 @dataclass(frozen=True)
-class WebSearchCitation:
-    """A source cited by the model in a web-search-enabled response."""
+class WebFetchCall:
+    """A server-side web fetch the model performed."""
 
     url: str
+    retrieved_at: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class WebCitation:
+    """A source cited by the model (web search result or fetched document)."""
+
     cited_text: str
+    url: str | None = None
     title: str | None = None
 
 
 @dataclass(frozen=True)
-class WebSearchActivity:
-    """All web search activity from a single agent turn: queries made and sources cited."""
+class WebActivity:
+    """All web activity from a single agent turn: searches, fetches, and cited sources."""
 
     searches: list[WebSearchCall] = field(default_factory=list)
-    citations: list[WebSearchCitation] = field(default_factory=list)
+    fetches: list[WebFetchCall] = field(default_factory=list)
+    citations: list[WebCitation] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -89,6 +99,7 @@ class TokenUsage:
     cache_creation_input_tokens: int  # tokens written to prompt cache
     context_usage: ContextUsage | None = None  # None only for agents that don't provide context tracking
     web_search_requests: int = 0  # number of web search requests (billed separately from tokens)
+    web_fetch_requests: int = 0  # number of web fetch requests (billed separately from tokens)
 
 
 @dataclass(frozen=True)
@@ -100,4 +111,4 @@ class AgentResponse:
     text: str
     tool_calls: list[ToolCall]
     usage: TokenUsage
-    web_activity: WebSearchActivity = field(default_factory=WebSearchActivity)
+    web_activity: WebActivity = field(default_factory=WebActivity)

--- a/ddev/src/ddev/ai/runtime/agent_log.py
+++ b/ddev/src/ddev/ai/runtime/agent_log.py
@@ -82,10 +82,15 @@ class AgentLogger:
                         "cache_read": response.usage.cache_read_input_tokens,
                         "cache_creation": response.usage.cache_creation_input_tokens,
                         "web_search_requests": response.usage.web_search_requests,
+                        "web_fetch_requests": response.usage.web_fetch_requests,
                     },
                     "web_searches": [
                         {"query": ws.query, "result_count": ws.result_count, "error": ws.error}
                         for ws in response.web_activity.searches
+                    ],
+                    "web_fetches": [
+                        {"url": wf.url, "retrieved_at": wf.retrieved_at, "error": wf.error}
+                        for wf in response.web_activity.fetches
                     ],
                     "web_citations": [
                         {"url": c.url, "title": c.title, "cited_text": c.cited_text}

--- a/ddev/src/ddev/ai/tools/registry.py
+++ b/ddev/src/ddev/ai/tools/registry.py
@@ -74,6 +74,7 @@ class ToolSpec:
 # Server (provider-executed) tools.
 NATIVE_TOOL_READ_ONLY: dict[str, bool] = {
     "web_search": True,
+    "web_fetch": True,
 }
 NATIVE_TOOL_NAMES: list[str] = list(NATIVE_TOOL_READ_ONLY)
 

--- a/ddev/tests/ai/agent/test_anthropic_client.py
+++ b/ddev/tests/ai/agent/test_anthropic_client.py
@@ -11,6 +11,7 @@ import pytest
 from ddev.ai.agent.anthropic_client import (
     MAX_CONTINUATIONS,
     NATIVE_TOOL_DEFINITIONS,
+    WEB_FETCH_VERSION,
     WEB_SEARCH_VERSION,
     AnthropicAgent,
     CompletionResult,
@@ -31,8 +32,9 @@ def make_usage(
     cache_read: int | None = None,
     cache_creation: int | None = None,
     web_search_requests: int = 0,
+    web_fetch_requests: int = 0,
 ) -> SimpleNamespace:
-    server_tool_use = SimpleNamespace(web_search_requests=web_search_requests)
+    server_tool_use = SimpleNamespace(web_search_requests=web_search_requests, web_fetch_requests=web_fetch_requests)
     return SimpleNamespace(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
@@ -462,6 +464,34 @@ async def test_web_search_max_uses_stays_below_continuation_budget() -> None:
     assert web_search["max_uses"] == MAX_CONTINUATIONS - 1
 
 
+async def test_web_fetch_injected_with_citations_enabled() -> None:
+    registry = ToolRegistry([], native_tool_names=["web_fetch"])
+    resp = make_response("end_turn", [make_text_block("ok")])
+    agent, create_mock = make_agent(tools=registry, mock_response=resp)
+
+    await agent.send("Fetch a page")
+
+    web_fetch = next(t for t in create_mock.call_args.kwargs["tools"] if t.get("name") == "web_fetch")
+    assert web_fetch["type"] == WEB_FETCH_VERSION
+    assert web_fetch["citations"] == {"enabled": True}
+    assert web_fetch["max_uses"] == MAX_CONTINUATIONS - 1
+
+
+async def test_both_native_tools_injected_together() -> None:
+    registry = ToolRegistry([FakeTool("read_file")], native_tool_names=["web_search", "web_fetch"])
+    resp = make_response("end_turn", [make_text_block("ok")])
+    agent, create_mock = make_agent(tools=registry, mock_response=resp)
+
+    await agent.send("Hi")
+
+    sent_tools = create_mock.call_args.kwargs["tools"]
+    sent_names = [t["name"] for t in sent_tools]
+    assert sent_names == ["read_file", "web_search", "web_fetch"]
+    # Static cache breakpoint only on the last entry.
+    assert sent_tools[-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert all("cache_control" not in t for t in sent_tools[:-1])
+
+
 async def test_create_until_complete_returns_completion_result() -> None:
     final = make_response("end_turn", [make_text_block("done")])
     agent, _ = make_agent(mock_response=final)
@@ -602,7 +632,85 @@ async def test_no_web_searches_yields_empty_activity() -> None:
     result = await agent.send("Hi")
 
     assert result.web_activity.searches == []
+    assert result.web_activity.fetches == []
     assert result.web_activity.citations == []
+
+
+def make_server_fetch_use(id: str, url: str) -> anthropic.types.ServerToolUseBlock:
+    return anthropic.types.ServerToolUseBlock(type="server_tool_use", id=id, name="web_fetch", input={"url": url})
+
+
+def make_web_fetch_result(tool_use_id: str, url: str, retrieved_at: str) -> anthropic.types.WebFetchToolResultBlock:
+    doc = anthropic.types.DocumentBlock(
+        type="document",
+        source=anthropic.types.PlainTextSource(type="text", media_type="text/plain", data="page body"),
+    )
+    fetched = anthropic.types.WebFetchBlock(type="web_fetch_result", url=url, retrieved_at=retrieved_at, content=doc)
+    return anthropic.types.WebFetchToolResultBlock(
+        type="web_fetch_tool_result", tool_use_id=tool_use_id, content=fetched
+    )
+
+
+async def test_web_fetches_surfaced_with_url_and_retrieved_at() -> None:
+    content = [
+        make_text_block("Fetching..."),
+        make_server_fetch_use("srv1", "https://example.com/doc"),
+        make_web_fetch_result("srv1", "https://example.com/doc", "2026-01-01T00:00:00Z"),
+        make_text_block("Here is the content."),
+    ]
+    resp = make_response("end_turn", content)
+    agent, _ = make_agent(mock_response=resp)
+
+    result = await agent.send("Fetch the doc")
+
+    assert result.tool_calls == []
+    assert len(result.web_activity.fetches) == 1
+    fetch = result.web_activity.fetches[0]
+    assert fetch.url == "https://example.com/doc"
+    assert fetch.retrieved_at == "2026-01-01T00:00:00Z"
+    assert fetch.error is None
+
+
+async def test_web_fetch_error_surfaced() -> None:
+    error = anthropic.types.WebFetchToolResultErrorBlock(
+        type="web_fetch_tool_result_error", error_code="url_not_accessible"
+    )
+    content = [
+        make_server_fetch_use("srv1", "https://example.com/missing"),
+        anthropic.types.WebFetchToolResultBlock(type="web_fetch_tool_result", tool_use_id="srv1", content=error),
+    ]
+    agent, _ = make_agent(mock_response=make_response("end_turn", content))
+
+    result = await agent.send("Fetch")
+
+    assert len(result.web_activity.fetches) == 1
+    assert result.web_activity.fetches[0].error == "url_not_accessible"
+    assert result.web_activity.fetches[0].retrieved_at is None
+
+
+async def test_web_fetch_requests_summed_into_usage() -> None:
+    resp = make_response("end_turn", [make_text_block("done")], usage=make_usage(web_fetch_requests=2))
+    agent, _ = make_agent(mock_response=resp)
+
+    result = await agent.send("Fetch")
+
+    assert result.usage.web_fetch_requests == 2
+
+
+async def test_web_fetch_result_preserved_in_history_not_parsed() -> None:
+    content = [
+        make_text_block("Fetching..."),
+        make_server_fetch_use("srv1", "https://example.com/doc"),
+        make_web_fetch_result("srv1", "https://example.com/doc", "2026-01-01T00:00:00Z"),
+        make_text_block("Done."),
+    ]
+    resp = make_response("end_turn", content)
+    agent, _ = make_agent(mock_response=resp)
+
+    result = await agent.send("Fetch")
+
+    assert result.tool_calls == []
+    assert agent.history[-1] == {"role": "assistant", "content": content}
 
 
 async def test_web_search_citations_extracted_from_text_block() -> None:
@@ -626,12 +734,12 @@ async def test_web_search_citations_extracted_from_text_block() -> None:
     assert c.cited_text == "some cited excerpt"
 
 
-async def test_non_web_search_citations_are_ignored() -> None:
+async def test_web_fetch_char_citation_surfaced() -> None:
     char_citation = anthropic.types.CitationCharLocation(
         type="char_location",
-        cited_text="some text",
+        cited_text="some cited text",
         document_index=0,
-        document_title=None,
+        document_title="Fetched Doc",
         end_char_index=10,
         start_char_index=0,
     )
@@ -641,7 +749,11 @@ async def test_non_web_search_citations_are_ignored() -> None:
 
     result = await agent.send("Hi")
 
-    assert result.web_activity.citations == []
+    assert len(result.web_activity.citations) == 1
+    c = result.web_activity.citations[0]
+    assert c.url is None
+    assert c.title == "Fetched Doc"
+    assert c.cited_text == "some cited text"
 
 
 async def test_citations_across_multiple_text_blocks() -> None:

--- a/ddev/tests/ai/phases/test_config.py
+++ b/ddev/tests/ai/phases/test_config.py
@@ -115,6 +115,11 @@ def test_agent_config_web_search_validates():
     assert "web_search" in ac.tools
 
 
+def test_agent_config_web_fetch_validates():
+    ac = AgentConfig(tools=["read_file", "web_fetch"])
+    assert "web_fetch" in ac.tools
+
+
 def test_agent_config_unknown_tool_raises():
     with pytest.raises(ValidationError, match="Unknown tool names"):
         AgentConfig(tools=["read_file", "teleport"])

--- a/ddev/tests/ai/runtime/test_agent_log.py
+++ b/ddev/tests/ai/runtime/test_agent_log.py
@@ -11,9 +11,10 @@ from ddev.ai.agent.types import (
     StopReason,
     TokenUsage,
     ToolCall,
-    WebSearchActivity,
+    WebActivity,
+    WebCitation,
+    WebFetchCall,
     WebSearchCall,
-    WebSearchCitation,
 )
 from ddev.ai.react.types import ReActResult
 from ddev.ai.runtime.agent_log import AgentLogger
@@ -136,9 +137,9 @@ async def test_emit_after_close_is_silently_dropped(tmp_path):
 
 
 async def test_agent_response_logs_web_searches_and_citations(tmp_path):
-    activity = WebSearchActivity(
+    activity = WebActivity(
         searches=[WebSearchCall(query="python typing", result_count=5)],
-        citations=[WebSearchCitation(url="https://docs.python.org", cited_text="PEP 484", title="PEP 484")],
+        citations=[WebCitation(url="https://docs.python.org", cited_text="PEP 484", title="PEP 484")],
     )
     response = AgentResponse(
         stop_reason=StopReason.END_TURN,
@@ -158,6 +159,35 @@ async def test_agent_response_logs_web_searches_and_citations(tmp_path):
     assert ev["web_citations"] == [{"url": "https://docs.python.org", "title": "PEP 484", "cited_text": "PEP 484"}]
 
 
+async def test_agent_response_logs_web_fetches(tmp_path):
+    activity = WebActivity(
+        fetches=[WebFetchCall(url="https://example.com/doc", retrieved_at="2026-01-01T00:00:00Z")],
+    )
+    response = AgentResponse(
+        stop_reason=StopReason.END_TURN,
+        text="here",
+        tool_calls=[],
+        usage=TokenUsage(
+            input_tokens=10,
+            output_tokens=5,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+            web_fetch_requests=1,
+        ),
+        web_activity=activity,
+    )
+    logger = AgentLogger(tmp_path)
+    cb = logger.as_callback_set()
+
+    await cb.fire_agent_response(PHASE, response, 1)
+
+    ev = read_events(tmp_path / "phase" / "p1.jsonl")[0]
+    assert ev["web_fetches"] == [
+        {"url": "https://example.com/doc", "retrieved_at": "2026-01-01T00:00:00Z", "error": None}
+    ]
+    assert ev["tokens"]["web_fetch_requests"] == 1
+
+
 async def test_agent_response_logs_empty_web_activity(tmp_path):
     logger = AgentLogger(tmp_path)
     cb = logger.as_callback_set()
@@ -166,6 +196,7 @@ async def test_agent_response_logs_empty_web_activity(tmp_path):
 
     events = read_events(tmp_path / "phase" / "p1.jsonl")
     assert events[0]["web_searches"] == []
+    assert events[0]["web_fetches"] == []
     assert events[0]["web_citations"] == []
 
 

--- a/ddev/tests/ai/tools/test_registry.py
+++ b/ddev/tests/ai/tools/test_registry.py
@@ -251,6 +251,16 @@ def test_available_tool_names_includes_web_search():
     assert "web_search" in ToolRegistry.available_tool_names()
 
 
+def test_available_tool_names_includes_web_fetch():
+    assert "web_fetch" in ToolRegistry.available_tool_names()
+
+
+def test_from_names_multiple_native(tmp_path):
+    registry = from_names(["web_search", "web_fetch"], tmp_path)
+    assert registry.definitions == []
+    assert registry.native_tool_names == ["web_search", "web_fetch"]
+
+
 def test_from_names_native_only(tmp_path):
     registry = from_names(["web_search"], tmp_path)
     assert registry.definitions == []
@@ -282,8 +292,8 @@ def test_native_tool_names_not_affected_by_input_mutation():
 
 
 def test_filter_read_only_includes_native_read_only():
-    result = filter_read_only(["read_file", "web_search", "create_file"])
-    assert result == ["read_file", "web_search"]
+    result = filter_read_only(["read_file", "web_search", "web_fetch", "create_file"])
+    assert result == ["read_file", "web_search", "web_fetch"]
 
 
 def test_filter_read_only_unknown_still_raises():


### PR DESCRIPTION
### What does this PR do?

Adds Anthropic's built-in **web fetch** server tool (`web_fetch_20250910`) as a configurable native tool for the `ddev` AI framework. Agents can now list `web_fetch` in the same flat `tools:` list as any other tool to retrieve a specific page and reason over its content with citations, rather than dumping raw HTML into the context window.

This **mirrors the web search tool** added in #24115 and reuses its entire server-tool rail unchanged — native-name recognition in `ToolRegistry`, native-definition injection in `AnthropicAgent.send()`, the `pause_turn` continuation loop, and verbatim history preservation of server-tool result blocks. Web fetch needs none of that plumbing rebuilt; it plugs into it.

What this PR actually adds:

- **Capability registration:** `web_fetch` in `NATIVE_TOOL_READ_ONLY` (read-only), so it is automatically valid in `tools:`, `available_tool_names()`, `from_names` partitioning, and `filter_read_only`.
- **Native definition:** `WEB_FETCH_VERSION` + a `NATIVE_TOOL_DEFINITIONS` entry pinned to the ZDR-eligible `web_fetch_20250910`, with `max_uses` capped below the `pause_turn` continuation budget (same as web search) and `citations: {enabled: true}` so fetched-page citations are returned.
- **Observability parity (generalized to be provider-neutral):** the `WebSearch*` types are renamed to neutral `WebActivity` / `WebCitation` and a `WebFetchCall` is added; `AnthropicAgent` now extracts fetched URLs (`_extract_web_fetches`), parses web-fetch citation locations (`CitationCharLocation` / `CitationPageLocation` / `CitationContentBlockLocation`), and surfaces a separate `web_fetch_requests` billing counter on `TokenUsage`. These flow into the JSONL agent log alongside the existing web-search fields.

### Motivation

Web search (#24115) returns titles, URLs, and short snippets — it cannot return a specific page's body. `http_get` returns raw, truncated HTML with no citations and still consumes context. Web fetch is executed by Anthropic, returns cited content, and bounds what reaches the context window, making it the right tool when an agent needs to read and cite a specific document.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
