### PR TITLE
Add Agent version requirement to SAP HANA schema collection docs

### DIFF
--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -81,7 +81,7 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
    GRANT SELECT ON SYS_DATABASES.M_VOLUME_IO_TOTAL_STATISTICS TO DD_MONITOR;
    ```
 
-<!-- To collect schema metadata for Data Quality features in Data Observability, grant select on the catalog and monitoring views that store schema, table, and column definitions. These are already covered by the `GRANT CATALOG READ` in step 2, so this is only needed if you skipped that grant:
+   To collect schema metadata for Data Quality features in Data Observability (requires Agent 7.82.0+), grant select on the catalog and monitoring views that store schema, table, and column definitions. These are already covered by the `GRANT CATALOG READ` in step 2, so this is only needed if you skipped that grant:
 
    ```shell
    GRANT SELECT ON SYS.SCHEMAS TO DD_MONITOR;
@@ -91,7 +91,6 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
    GRANT SELECT ON SYS.VIEW_COLUMNS TO DD_MONITOR;
    GRANT SELECT ON SYS.M_TABLE_STATISTICS TO DD_MONITOR;
    ```
--->
 
 4. Finally, run the following command to assign the monitoring role to the desired user:
 
@@ -133,7 +132,9 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
 
 3. [Restart the Agent][5].
 
-<!-- #### Schema collection
+#### Schema collection
+
+**Requires Agent 7.82.0+.**
 
 The Agent can collect SAP HANA catalog metadata (schemas, tables, views, and columns) for Data Quality features in Data Observability. When the monitoring user has access to `SYS.M_TABLE_STATISTICS`, the Agent also collects row counts and last modification times for tables. Collection is disabled by default. To enable schema collection, ensure that the monitoring user can read the required views (see [Granting privileges](#granting-privileges)) and add the following block to your `sap_hana.d/conf.yaml` file:
 
@@ -147,7 +148,6 @@ The Agent can collect SAP HANA catalog metadata (schemas, tables, views, and col
 ```
 
 See the [sample sap_hana.d/conf.yaml][4] for all available schema collection options, including `include_schemas` and `exclude_schemas`.
--->
 
 ### Validation
 

--- a/sap_hana/README.md
+++ b/sap_hana/README.md
@@ -81,7 +81,7 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
    GRANT SELECT ON SYS_DATABASES.M_VOLUME_IO_TOTAL_STATISTICS TO DD_MONITOR;
    ```
 
-   To collect schema metadata for Data Quality features in Data Observability, grant select on the catalog and monitoring views that store schema, table, and column definitions. These are already covered by the `GRANT CATALOG READ` in step 2, so this is only needed if you skipped that grant:
+<!-- To collect schema metadata for Data Quality features in Data Observability, grant select on the catalog and monitoring views that store schema, table, and column definitions. These are already covered by the `GRANT CATALOG READ` in step 2, so this is only needed if you skipped that grant:
 
    ```shell
    GRANT SELECT ON SYS.SCHEMAS TO DD_MONITOR;
@@ -91,6 +91,7 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
    GRANT SELECT ON SYS.VIEW_COLUMNS TO DD_MONITOR;
    GRANT SELECT ON SYS.M_TABLE_STATISTICS TO DD_MONITOR;
    ```
+-->
 
 4. Finally, run the following command to assign the monitoring role to the desired user:
 
@@ -132,7 +133,7 @@ To learn how to set the port number for HANA tenant, single-tenant, and system d
 
 3. [Restart the Agent][5].
 
-#### Schema collection
+<!-- #### Schema collection
 
 The Agent can collect SAP HANA catalog metadata (schemas, tables, views, and columns) for Data Quality features in Data Observability. When the monitoring user has access to `SYS.M_TABLE_STATISTICS`, the Agent also collects row counts and last modification times for tables. Collection is disabled by default. To enable schema collection, ensure that the monitoring user can read the required views (see [Granting privileges](#granting-privileges)) and add the following block to your `sap_hana.d/conf.yaml` file:
 
@@ -146,6 +147,7 @@ The Agent can collect SAP HANA catalog metadata (schemas, tables, views, and col
 ```
 
 See the [sample sap_hana.d/conf.yaml][4] for all available schema collection options, including `include_schemas` and `exclude_schemas`.
+-->
 
 ### Validation
 


### PR DESCRIPTION
### What does this PR do?

Updates the SAP HANA schema collection documentation added in #23934 to indicate that the feature requires Agent 7.82.0+.

The agent-side changes from #23934 are not expected to ship until Agent 7.82.0. This PR adds a `**Requires Agent 7.82.0+.**` note to:

- The additional `GRANT SELECT ON SYS.*` statements for schema metadata collection in the "Granting privileges" section
- The `#### Schema collection` configuration subsection

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Replaces the HTML comment approach from the first commit on this branch.