### PR TITLE
mongo: auto-enable TLS for MongoDB Atlas hosts

### DIFF
--- a/mongo/changelog.d/24152.fixed
+++ b/mongo/changelog.d/24152.fixed
@@ -1,0 +1,1 @@
+Auto-enable TLS when connecting to MongoDB Atlas hosts to avoid a misleading connection error.

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -18,15 +18,27 @@ class MongoConfig(object):
 
         # x.509 authentication
 
+        # Auto-enable TLS for MongoDB Atlas: Atlas mandates TLS and the driver surfaces a
+        # misleading "connection closed" error when tls is omitted rather than a TLS error.
+        tls = instance.get('tls')
+        if tls is None:
+            raw_hosts = instance.get('hosts', [])
+            if isinstance(raw_hosts, str):
+                raw_hosts = [raw_hosts]
+            server = instance.get('server', '') or ''
+            if any('mongodb.net' in str(h) for h in raw_hosts) or 'mongodb.net' in server:
+                tls = True
+                log.debug('Auto-enabling TLS: detected MongoDB Atlas host (mongodb.net)')
+
         cacert_cert_dir = instance.get('tls_ca_file')
         if cacert_cert_dir is None and (
-            is_affirmative(instance.get('options', {}).get("tls")) or is_affirmative(instance.get('tls'))
+            is_affirmative(instance.get('options', {}).get("tls")) or is_affirmative(tls)
         ):
             cacert_cert_dir = certifi.where()
 
         self.tls_params = exclude_undefined_keys(
             {
-                'tls': instance.get('tls'),
+                'tls': tls,
                 'tlsCertificateKeyFile': instance.get('tls_certificate_key_file'),
                 'tlsCAFile': cacert_cert_dir,
                 'tlsAllowInvalidHostnames': instance.get('tls_allow_invalid_hostnames'),

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -3,12 +3,36 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import certifi
+from urllib.parse import urlparse
 
 from datadog_checks.base import ConfigurationError, is_affirmative
 from datadog_checks.base.utils.common import exclude_undefined_keys
 from datadog_checks.base.utils.db.utils import get_agent_host_tags
 from datadog_checks.mongo.common import DEFAULT_TIMEOUT
 from datadog_checks.mongo.utils import build_connection_string, parse_mongo_uri
+
+_ATLAS_SUFFIX = '.mongodb.net'
+
+
+def _is_atlas_host(host):
+    """Return True if the host is a MongoDB Atlas endpoint (ends with .mongodb.net).
+
+    Accepts either a bare host[:port] string or a full MongoDB URI. A substring
+    check ('mongodb.net' in host) would match attacker-controlled hostnames like
+    'evil.mongodb.net.attacker.com', so we anchor to the domain suffix.
+    """
+    host_str = str(host).lower()
+    if '://' in host_str:
+        try:
+            netloc = urlparse(host_str).netloc
+            if '@' in netloc:
+                netloc = netloc.split('@', 1)[1]
+            hostnames = [h.split(':')[0] for h in netloc.split(',')]
+        except Exception:
+            return False
+    else:
+        hostnames = [host_str.split(':')[0].rstrip('/')]
+    return any(h == 'mongodb.net' or h.endswith(_ATLAS_SUFFIX) for h in hostnames)
 
 
 class MongoConfig(object):
@@ -26,7 +50,8 @@ class MongoConfig(object):
             if isinstance(raw_hosts, str):
                 raw_hosts = [raw_hosts]
             server = instance.get('server', '') or ''
-            if any('mongodb.net' in str(h) for h in raw_hosts) or 'mongodb.net' in server:
+            all_hosts = list(raw_hosts) + ([server] if server else [])
+            if any(_is_atlas_host(h) for h in all_hosts):
                 tls = True
                 log.debug('Auto-enabling TLS: detected MongoDB Atlas host (mongodb.net)')
 

--- a/mongo/tests/test_unit_config.py
+++ b/mongo/tests/test_unit_config.py
@@ -72,6 +72,32 @@ def test_default_tls_params():
     assert config.tls_params == {}
 
 
+def test_atlas_host_auto_enables_tls():
+    instance = {'hosts': ['mycluster-shard-00-00.abc123.mongodb.net']}
+    config = MongoConfig(instance, mock.Mock(), {})
+    assert config.tls_params.get('tls') is True
+    assert 'tlsCAFile' in config.tls_params  # certifi CA set automatically
+
+
+def test_atlas_host_explicit_tls_false_respected():
+    # Explicit tls: false must not be overridden by auto-detection
+    instance = {'hosts': ['mycluster-shard-00-00.abc123.mongodb.net'], 'tls': False}
+    config = MongoConfig(instance, mock.Mock(), {})
+    assert config.tls_params.get('tls') is False
+
+
+def test_non_atlas_host_tls_not_auto_enabled():
+    instance = {'hosts': ['self-hosted.internal:27017']}
+    config = MongoConfig(instance, mock.Mock(), {})
+    assert config.tls_params == {}
+
+
+def test_atlas_server_uri_auto_enables_tls():
+    instance = {'server': 'mongodb://user:pass@mycluster-shard-00-00.abc123.mongodb.net:27017/admin'}
+    config = MongoConfig(instance, mock.Mock(), {})
+    assert config.tls_params.get('tls') is True
+
+
 def test_default_scheme(instance):
     instance['hosts'] = ['test.mongodb.com']
     with mock.patch('pymongo.uri_parser.parse_uri', return_value={'nodelist': ["test.mongodb.com"]}) as mock_parse_uri:

--- a/mongo/tests/test_unit_config.py
+++ b/mongo/tests/test_unit_config.py
@@ -92,6 +92,13 @@ def test_non_atlas_host_tls_not_auto_enabled():
     assert config.tls_params == {}
 
 
+def test_spoofed_atlas_hostname_not_auto_enabled():
+    # 'mongodb.net' appears mid-string — must not trigger auto-TLS
+    instance = {'hosts': ['evil.mongodb.net.attacker.com:27017']}
+    config = MongoConfig(instance, mock.Mock(), {})
+    assert config.tls_params == {}
+
+
 def test_atlas_server_uri_auto_enables_tls():
     instance = {'server': 'mongodb://user:pass@mycluster-shard-00-00.abc123.mongodb.net:27017/admin'}
     config = MongoConfig(instance, mock.Mock(), {})


### PR DESCRIPTION
### What does this PR do?

Auto-enables TLS in `MongoConfig` when any configured host contains `mongodb.net`, without requiring the user to set `tls: true` explicitly.

### Motivation

MongoDB Atlas mandates TLS on all connections. When `tls` is omitted the driver raises a generic `ServerSelectionTimeoutError: connection closed` — a misleading error that gives no indication TLS is the problem. Users connecting to Atlas for the first time reliably hit this (see #19236).

The check already detects Atlas post-connection via `_is_hosting_type_atlas()` (checks `mongodb.net` in the resolved server hostname). This PR applies the same heuristic pre-connection in `config.py` so the TLS parameter is set correctly before the first connection attempt.

Explicit `tls: false` is still respected — auto-detection only fires when `tls` is not set at all.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged