### PR TITLE
Add OAuth account_config.json for docusign and hubspot-content-hub

### DIFF
--- a/docusign/assets/account_config.json
+++ b/docusign/assets/account_config.json
@@ -1,0 +1,23 @@
+{
+  "supported_auth_methods": [
+    {
+      "auth_name": "oauth",
+      "oauth2_authorization_code": {
+        "authorization_server": {
+          "authorization_endpoint": "https://account.docusign.com/oauth/auth"
+        },
+        "authorization_request": {
+          "scopes": ["signature", "impersonation"]
+        }
+      }
+    }
+  ],
+  "additional_config_fields": [
+    {
+      "key": "tags",
+      "label": "Tags",
+      "editable": true,
+      "tags": {}
+    }
+  ]
+}

--- a/hubspot_content_hub/assets/account_config.json
+++ b/hubspot_content_hub/assets/account_config.json
@@ -1,0 +1,53 @@
+{
+  "supported_auth_methods": [
+    {
+      "auth_name": "oauth",
+      "oauth2_authorization_code": {
+        "authorization_server": {
+          "authorization_endpoint": "https://app.hubspot.com/oauth/authorize"
+        },
+        "authorization_request": {
+          "scopes": [
+            "account-info.security.read",
+            "business-intelligence",
+            "content",
+            "crm.objects.companies.read",
+            "crm.schemas.companies.read"
+          ]
+        }
+      }
+    }
+  ],
+  "additional_config_fields": [
+    {
+      "key": "tags",
+      "label": "Tags",
+      "editable": true,
+      "tags": {}
+    },
+    {
+      "key": "metrics_enabled",
+      "label": "Metrics",
+      "editable": true,
+      "checkbox": {
+        "default": true
+      }
+    },
+    {
+      "key": "logs_enabled",
+      "label": "Logs",
+      "editable": true,
+      "checkbox": {
+        "default": true
+      }
+    },
+    {
+      "key": "companies_reference_table_enabled",
+      "label": "Companies Reference Table",
+      "editable": true,
+      "checkbox": {
+        "default": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds `assets/account_config.json` for two OAuth integrations that were missing one:

- `docusign`
- `hubspot_content_hub`

## Source

Account configs are sourced from the canonical definitions in [dd-source](https://github.com/DataDog/dd-source):
- `domains/web-integrations/libs/go/oauthstaticconfig/integrations.json` (auth endpoint + scopes)
- `domains/web-integrations/shared/libs/go/schemas/account-config/*.json` (full account-config shape, including `additional_config_fields`)

Each uses the OAuth authorization-code flow and follows the same structure as the existing `klaviyo` / `ringcentral` configs in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)