### PR TITLE
[fluentd] Add the in_tail tracked_file_count metric

### DIFF
--- a/fluentd/changelog.d/24159.added
+++ b/fluentd/changelog.d/24159.added
@@ -1,0 +1,1 @@
+Add the ``fluentd.tracked_file_count`` gauge from the in_tail plugin.

--- a/fluentd/datadog_checks/fluentd/fluentd.py
+++ b/fluentd/datadog_checks/fluentd/fluentd.py
@@ -27,6 +27,7 @@ class Fluentd(AgentCheck):
         'buffer_stage_byte_size',
         'buffer_queue_byte_size',
         'buffer_available_buffer_space_ratios',
+        'tracked_file_count',
     ]
     _AVAILABLE_TAGS = frozenset(['plugin_id', 'type'])
     VERSION_PATTERN = r'.* (?P<version>[0-9\.]+)'

--- a/fluentd/metadata.csv
+++ b/fluentd/metadata.csv
@@ -11,4 +11,5 @@ fluentd.flush_time_count,gauge,,millisecond,,The total time of buffer flush in m
 fluentd.retry_count,gauge,,time,,The number of retries for this plugin.,-1,fluentd,retry count,
 fluentd.rollback_count,gauge,,unit,,The total number of rollback. rollback happens when write/try_write failed,-1,fluentd,rollback count,
 fluentd.slow_flush_count,gauge,,unit,,The total number of slow flush. This count will be incremented when buffer flush is longer than slow_flush_log_threshold,-1,fluentd,slow flush,cpu|memory
+fluentd.tracked_file_count,gauge,,file,,Number of files currently being tracked by the in_tail plugin,0,fluentd,tracked files,
 fluentd.write_count,gauge,,unit,,The total number of write/try_write call in output plugin,0,fluentd,write count,


### PR DESCRIPTION
### What does this PR do?

Adds the `fluentd.tracked_file_count` gauge to the fluentd check. The check previously collected only output-plugin gauges; this also reads the in_tail plugin's count of currently-tracked files from the monitor_agent (`/api/plugins.json`).

### Motivation

A fluentd that is running but tailing no files — e.g. its source `path` is missing or matches nothing — is a silent failure today: the process is up, `fluentd.is_ok` reports OK, and the output-plugin gauges look normal. `tracked_file_count` dropping to 0 is the only signal that in_tail has stopped picking up files, which makes it the metric needed to alert on that gap.

in_tail's monitor_agent also exposes three related stats that this PR deliberately leaves out, to keep it to the one metric that closes the gap. Happy to add them if you'd like them in the integration — but note they are monotonic totals, not gauges, so they'd belong as `monotonic_count` rather than in the check's `GAUGES` list:

- `opened_file_count` — cumulative files opened (`fluentd_input_files_opened_total`)
- `closed_file_count` — cumulative files closed (`fluentd_input_files_closed_total`)
- `rotated_file_count` — cumulative rotations detected (`fluentd_input_files_rotated_total`)

(in_tail defines those three as counters and `tracked_file_count` as a gauge via `prefer_gauge: true`, since it can decrease — `lib/fluent/plugin/in_tail.rb`.)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

---
Claude (Anthropic) assisted in researching the in_tail file-tracking metrics and drafting this change.
