### PR TITLE
[kafka_actions] Bound message reads to a start-of-check snapshot

### DIFF
--- a/kafka_actions/assets/configuration/spec.yaml
+++ b/kafka_actions/assets/configuration/spec.yaml
@@ -205,8 +205,10 @@ files:
     - name: read_messages
       description: |
         Configuration for reading messages from Kafka topics.
-        Messages are streamed in real-time and sent to Datadog as they arrive.
-        The check has a 20-second timeout for the entire operation.
+        Only messages already present in the log when the check starts are read; the
+        per-partition high watermark is captured up front and consumption stops once every
+        partition is drained, so messages produced after the check began are never returned.
+        A 5-second timeout bounds the entire operation as a safety net.
         Supports JSON, BSON, Protobuf, and Avro with optional Schema Registry integration.
         Filtering is applied after deserialization using jq-style expressions.
       fleet_configurable: true

--- a/kafka_actions/changelog.d/24162.fixed
+++ b/kafka_actions/changelog.d/24162.fixed
@@ -1,0 +1,1 @@
+Fix `read_messages` hanging until the global timeout when a filter matched fewer messages than `n_messages_retrieved`. Consumption is now bounded to a snapshot of the log taken when the check starts (per-partition high watermark + `enable.partition.eof`), the default timeout is reduced from 20s to 5s, and a `hit_timeout` stat distinguishes a truncated read from a complete one.

--- a/kafka_actions/datadog_checks/kafka_actions/check.py
+++ b/kafka_actions/datadog_checks/kafka_actions/check.py
@@ -267,7 +267,7 @@ class KafkaActionsCheck(AgentCheck):
         start_timestamp = config.get('start_timestamp')
         n_messages_retrieved = config.get('n_messages_retrieved', 10)
         max_scanned_messages = config.get('max_scanned_messages', 1000)
-        timeout_ms = config.get('timeout_ms', 20000)
+        timeout_ms = config.get('timeout_ms', 5000)
         filter_expression = config.get('filter', '')
         consumer_group_id = config.get('consumer_group_id') or f"datadog-agent-{self.remote_config_id}"
 
@@ -326,6 +326,8 @@ class KafkaActionsCheck(AgentCheck):
         if scanned_count >= max_scanned_messages and sent_count < n_messages_retrieved:
             hit_scan_limit = True
 
+        hit_timeout = self.kafka_client.hit_timeout and not hit_retrieved_limit and not hit_scan_limit
+
         elapsed_time = time.time() - start_time
 
         stats = {
@@ -337,6 +339,7 @@ class KafkaActionsCheck(AgentCheck):
             'messages_filtered_out': filtered_out_count,
             'hit_scan_limit': hit_scan_limit,
             'hit_retrieved_limit': hit_retrieved_limit,
+            'hit_timeout': hit_timeout,
             'elapsed_time_seconds': round(elapsed_time, 3),
             'n_messages_retrieved': n_messages_retrieved,
             'max_scanned_messages': max_scanned_messages,
@@ -355,6 +358,14 @@ class KafkaActionsCheck(AgentCheck):
                 "Hit max_scanned_messages limit (%d) before retrieving %d messages. Only found %d matching messages.",
                 max_scanned_messages,
                 n_messages_retrieved,
+                sent_count,
+            )
+
+        if hit_timeout:
+            self.log.warning(
+                "Hit the %dms timeout after scanning %d messages and retrieving %d. Result may be incomplete.",
+                timeout_ms,
+                scanned_count,
                 sent_count,
             )
 

--- a/kafka_actions/datadog_checks/kafka_actions/data/conf.yaml.example
+++ b/kafka_actions/datadog_checks/kafka_actions/data/conf.yaml.example
@@ -197,8 +197,10 @@ instances:
 
     ## @param read_messages - mapping - optional
     ## Configuration for reading messages from Kafka topics.
-    ## Messages are streamed in real-time and sent to Datadog as they arrive.
-    ## The check has a 20-second timeout for the entire operation.
+    ## Only messages already present in the log when the check starts are read; the
+    ## per-partition high watermark is captured up front and consumption stops once every
+    ## partition is drained, so messages produced after the check began are never returned.
+    ## A 5-second timeout bounds the entire operation as a safety net.
     ## Supports JSON, BSON, Protobuf, and Avro with optional Schema Registry integration.
     ## Filtering is applied after deserialization using jq-style expressions.
     #

--- a/kafka_actions/datadog_checks/kafka_actions/kafka_client.py
+++ b/kafka_actions/datadog_checks/kafka_actions/kafka_client.py
@@ -32,6 +32,8 @@ class KafkaActionsClient:
         self.consumer = None
         self.producer = None
         self.admin_client = None
+        # True when consume_messages stopped on the timeout rather than draining all partitions.
+        self.hit_timeout = False
 
     def _get_authentication_config(self) -> dict[str, Any]:
         """Build authentication configuration for librdkafka."""
@@ -134,6 +136,8 @@ class KafkaActionsClient:
                     'group.id': group_id,
                     'auto.offset.reset': 'earliest',
                     'enable.auto.commit': False,
+                    # Signal end-of-partition via a _PARTITION_EOF event so we stop once drained.
+                    'enable.partition.eof': True,
                 }
             )
             self.consumer = Consumer(config)
@@ -193,13 +197,16 @@ class KafkaActionsClient:
         start_offset: int = -2,
         start_timestamp: int | None = None,
         max_messages: int = 1000,
-        timeout_ms: int = 30000,
+        timeout_ms: int = 5000,
         group_id: str = 'kafka_actions',
     ):
-        """Consume messages from a Kafka topic, yielding them as they arrive.
+        """Consume the messages already present in a topic, yielding them as they are read.
 
-        This is a generator that yields messages in real-time as they're consumed,
-        allowing for immediate processing and sending to Datadog.
+        The per-partition high watermark is captured before consumption begins and no message
+        at or beyond it is yielded, so messages produced after the check starts are never
+        returned and the generator can't tail a live topic. A partition stops on EOF or when its
+        captured watermark is reached; the generator returns once all are drained. ``timeout_ms``
+        is only a safety net.
 
         Args:
             topic: Topic name
@@ -207,15 +214,17 @@ class KafkaActionsClient:
             start_offset: Starting offset (-1 for latest, -2 for earliest)
             start_timestamp: Starting timestamp in milliseconds since epoch. When set, start_offset is ignored.
             max_messages: Maximum messages to consume
-            timeout_ms: Global timeout in milliseconds for the entire consumption
+            timeout_ms: Safety-net timeout in milliseconds for the entire consumption
             group_id: Consumer group ID
 
         Yields:
-            Kafka messages as they arrive
+            Kafka messages that existed in the log when consumption began
         """
         consumer = self.get_consumer(group_id)
+        admin = self.get_admin_client()
         start_time = time.time()
         global_timeout_s = timeout_ms / 1000.0
+        self.hit_timeout = False
 
         try:
             if partition == -1:
@@ -227,44 +236,42 @@ class KafkaActionsClient:
             else:
                 partition_ids = [partition]
 
-            if start_timestamp is not None:
-                # Resolve timestamp to per-partition offsets using offsets_for_times.
-                timestamp_partitions = [TopicPartition(topic, p, start_timestamp) for p in partition_ids]
-                partitions = consumer.offsets_for_times(timestamp_partitions, timeout=10)
-                for tp in partitions:
-                    if tp.offset != -1:
-                        self.log.debug(
-                            "Partition %d: timestamp %d resolved to offset %d",
-                            tp.partition,
-                            start_timestamp,
-                            tp.offset,
-                        )
-            elif start_offset == -1:
-                # For "latest" offset, seek back from the high watermark to read the last N existing messages.
-                # Use AdminClient.list_offsets to fetch all high watermarks in a single batched call.
-                admin = self.get_admin_client()
-                offset_request = {TopicPartition(topic, p): OffsetSpec.latest() for p in partition_ids}
-                futures = admin.list_offsets(offset_request, request_timeout=10)
+            # Snapshot each partition's high watermark; we never read at or beyond it.
+            end_request = {TopicPartition(topic, p): OffsetSpec.latest() for p in partition_ids}
+            end_futures = admin.list_offsets(end_request, request_timeout=10)
+            end_offsets = {tp.partition: future.result().offset for tp, future in end_futures.items()}
 
-                partitions = []
-                for tp, future in futures.items():
-                    result = future.result()
-                    seek_offset = max(0, result.offset - max_messages)
-                    partitions.append(TopicPartition(topic, tp.partition, seek_offset))
-                    self.log.debug("Partition %d: high=%d, seeking to %d", tp.partition, result.offset, seek_offset)
-            else:
-                partitions = [TopicPartition(topic, p, start_offset) for p in partition_ids]
+            start_offsets = self._resolve_start_offsets(
+                consumer, admin, topic, partition_ids, start_offset, start_timestamp, max_messages, end_offsets
+            )
 
-            self.log.debug("Assigning partitions: %s", partitions)
+            # Assign only partitions that have messages in [start, high_watermark).
+            partitions = []
+            active = set()
+            for p in partition_ids:
+                start = start_offsets.get(p, 0)
+                end = end_offsets.get(p, 0)
+                if start < end:
+                    partitions.append(TopicPartition(topic, p, start))
+                    active.add(p)
+                else:
+                    self.log.debug("Partition %d: nothing to read (start=%d, high=%d)", p, start, end)
+
+            if not partitions:
+                self.log.debug("No messages to read for topic %s in [start, high-watermark)", topic)
+                return
+
+            self.log.debug("Assigning partitions: %s (high watermarks: %s)", partitions, end_offsets)
             consumer.assign(partitions)
 
             consumed = 0
 
-            while consumed < max_messages:
+            while consumed < max_messages and active:
                 elapsed = time.time() - start_time
                 remaining_timeout = global_timeout_s - elapsed
 
                 if remaining_timeout <= 0:
+                    self.hit_timeout = True
                     self.log.debug("Global timeout reached after %d messages", consumed)
                     break
 
@@ -272,18 +279,27 @@ class KafkaActionsClient:
                 msg = consumer.poll(timeout=poll_timeout)
 
                 if msg is None:
-                    self.log.debug("Poll returned None (no more messages available), stopping consumption")
-                    break
+                    # End-of-data arrives as an EOF event, not None; keep polling until drained.
+                    continue
 
                 if msg.error():
                     if msg.error().code() == KafkaError._PARTITION_EOF:
-                        self.log.debug("Reached end of partition")
+                        active.discard(msg.partition())
                         continue
                     else:
                         raise KafkaException(msg.error())
 
+                p = msg.partition()
+                # Never surface a message at or beyond the captured high watermark.
+                if p not in active or msg.offset() >= end_offsets.get(p, 0):
+                    active.discard(p)
+                    continue
+
                 yield msg
                 consumed += 1
+
+                if msg.offset() >= end_offsets[p] - 1:
+                    active.discard(p)
 
             self.log.debug("Consumed %d messages from topic %s in %.2fs", consumed, topic, time.time() - start_time)
 
@@ -291,6 +307,41 @@ class KafkaActionsClient:
             if consumer:
                 consumer.close()
                 self.consumer = None
+
+    def _resolve_start_offsets(
+        self,
+        consumer,
+        admin,
+        topic: str,
+        partition_ids: list[int],
+        start_offset: int,
+        start_timestamp: int | None,
+        max_messages: int,
+        end_offsets: dict[int, int],
+    ) -> dict[int, int]:
+        """Return a {partition: start_offset} map. A start at or beyond the high watermark
+        means there is nothing to read for that partition."""
+        if start_timestamp is not None:
+            # An offset < 0 means the timestamp is past the end of the log: nothing to read.
+            timestamp_partitions = [TopicPartition(topic, p, start_timestamp) for p in partition_ids]
+            resolved = consumer.offsets_for_times(timestamp_partitions, timeout=10)
+            start_offsets = {}
+            for tp in resolved:
+                end = end_offsets.get(tp.partition, 0)
+                start_offsets[tp.partition] = tp.offset if tp.offset is not None and tp.offset >= 0 else end
+            return start_offsets
+
+        if start_offset == -1:
+            # "latest": seek back from the high watermark to read the last N existing messages.
+            return {p: max(0, end_offsets.get(p, 0) - max_messages) for p in partition_ids}
+
+        if start_offset == -2:
+            # "earliest": use the low watermark as the numeric start.
+            low_request = {TopicPartition(topic, p): OffsetSpec.earliest() for p in partition_ids}
+            low_futures = admin.list_offsets(low_request, request_timeout=10)
+            return {tp.partition: future.result().offset for tp, future in low_futures.items()}
+
+        return dict.fromkeys(partition_ids, start_offset)
 
     def produce_message(
         self,

--- a/kafka_actions/tests/test_unit.py
+++ b/kafka_actions/tests/test_unit.py
@@ -4,13 +4,37 @@
 
 import base64
 import json
-from unittest.mock import patch
+import logging
+from unittest.mock import MagicMock, patch
 
 import pytest
-
+from confluent_kafka import KafkaError
 from datadog_checks.kafka_actions import KafkaActionsCheck
+from datadog_checks.kafka_actions.kafka_client import KafkaActionsClient
 
 pytestmark = [pytest.mark.unit]
+
+
+def _futures(offsets):
+    """Build a {topic-partition: future} map mimicking AdminClient.list_offsets results."""
+    out = {}
+    for p, off in offsets.items():
+        fut = MagicMock()
+        fut.result.return_value = MagicMock(offset=off)
+        out[MagicMock(partition=p)] = fut
+    return out
+
+
+def _eof(partition):
+    """A mock poll() result representing a _PARTITION_EOF event."""
+    msg = MagicMock()
+    msg.error.return_value = MagicMock(code=MagicMock(return_value=KafkaError._PARTITION_EOF))
+    msg.partition.return_value = partition
+    return msg
+
+
+def _client():
+    return KafkaActionsClient({'kafka_connect_str': 'localhost:9092'}, logging.getLogger('test'))
 
 
 class MockKafkaMessage:
@@ -385,107 +409,113 @@ class TestReadMessagesAdvancedFiltering:
 
 
 class TestConsumeMessagesLatestOffset:
-    """Test that start_offset=-1 seeks back from high watermark instead of waiting at end."""
+    """Test that start_offset=-1 seeks back from the captured high watermark."""
 
     def test_latest_offset_seeks_back_from_high_watermark(self):
-        from unittest.mock import MagicMock
-
         consumer = MagicMock()
-        consumer.poll.return_value = None
-
         metadata = MagicMock()
         metadata.topics = {'t': MagicMock(partitions={0: MagicMock(), 1: MagicMock()})}
         consumer.list_topics.return_value = metadata
+        consumer.poll.side_effect = [_eof(0), _eof(1)]
 
         mock_admin = MagicMock()
-        tp0, tp1 = MagicMock(partition=0), MagicMock(partition=1)
-        f0, f1 = MagicMock(), MagicMock()
-        f0.result.return_value = MagicMock(offset=100)
-        f1.result.return_value = MagicMock(offset=200)
-        mock_admin.list_offsets.return_value = {tp0: f0, tp1: f1}
+        mock_admin.list_offsets.return_value = _futures({0: 100, 1: 200})
 
-        import logging
-
-        from datadog_checks.kafka_actions.kafka_client import KafkaActionsClient
-
-        client = KafkaActionsClient({'kafka_connect_str': 'localhost:9092'}, logging.getLogger('test'))
-
+        client = _client()
         with (
             patch.object(client, 'get_consumer', return_value=consumer),
             patch.object(client, 'get_admin_client', return_value=mock_admin),
         ):
             list(client.consume_messages(topic='t', start_offset=-1, max_messages=10, timeout_ms=500))
 
-        mock_admin.list_offsets.assert_called_once()
         assigned = {tp.partition: tp.offset for tp in consumer.assign.call_args[0][0]}
         assert assigned[0] == 90  # max(0, 100 - 10)
         assert assigned[1] == 190  # max(0, 200 - 10)
+
+
+class TestConsumeMessagesSnapshotBound:
+    """Test that consumption never crosses the high watermark captured at the start."""
+
+    def test_does_not_yield_messages_at_or_beyond_high_watermark(self):
+        consumer = MagicMock()
+        metadata = MagicMock()
+        metadata.topics = {'t': MagicMock(partitions={0: MagicMock()})}
+        consumer.list_topics.return_value = metadata
+        # High watermark is 5; a message at offset 5 arrives after the snapshot and must be dropped.
+        consumer.poll.side_effect = [
+            MockKafkaMessage(key=b'k', value=b'v', partition=0, offset=0),
+            MockKafkaMessage(key=b'k', value=b'v', partition=0, offset=1),
+            MockKafkaMessage(key=b'k', value=b'v', partition=0, offset=5),
+        ]
+
+        mock_admin = MagicMock()
+        mock_admin.list_offsets.return_value = _futures({0: 5})
+
+        client = _client()
+        with (
+            patch.object(client, 'get_consumer', return_value=consumer),
+            patch.object(client, 'get_admin_client', return_value=mock_admin),
+        ):
+            result = list(client.consume_messages(topic='t', start_offset=0, max_messages=1000, timeout_ms=500))
+
+        assert [m.offset() for m in result] == [0, 1]
 
 
 class TestConsumeMessagesStartTimestamp:
     """Test that start_timestamp resolves to per-partition offsets via offsets_for_times."""
 
     def test_start_timestamp_resolves_offsets(self):
-        from unittest.mock import MagicMock
-
         consumer = MagicMock()
-        consumer.poll.return_value = None
-
         metadata = MagicMock()
         metadata.topics = {'t': MagicMock(partitions={0: MagicMock(), 1: MagicMock()})}
         consumer.list_topics.return_value = metadata
+        consumer.offsets_for_times.return_value = [
+            MagicMock(partition=0, offset=50),
+            MagicMock(partition=1, offset=120),
+        ]
+        consumer.poll.side_effect = [_eof(0), _eof(1)]
 
-        # offsets_for_times returns TopicPartitions with resolved offsets
-        resolved_tp0 = MagicMock(partition=0, offset=50)
-        resolved_tp1 = MagicMock(partition=1, offset=120)
-        consumer.offsets_for_times.return_value = [resolved_tp0, resolved_tp1]
+        mock_admin = MagicMock()
+        mock_admin.list_offsets.return_value = _futures({0: 100, 1: 200})
 
-        import logging
-
-        from datadog_checks.kafka_actions.kafka_client import KafkaActionsClient
-
-        client = KafkaActionsClient({'kafka_connect_str': 'localhost:9092'}, logging.getLogger('test'))
-
-        with patch.object(client, 'get_consumer', return_value=consumer):
+        client = _client()
+        with (
+            patch.object(client, 'get_consumer', return_value=consumer),
+            patch.object(client, 'get_admin_client', return_value=mock_admin),
+        ):
             list(client.consume_messages(topic='t', start_timestamp=1700000000000, max_messages=10, timeout_ms=500))
 
         consumer.offsets_for_times.assert_called_once()
-        call_args = consumer.offsets_for_times.call_args[0][0]
-        assert len(call_args) == 2
-        # Verify each TopicPartition was created with the timestamp
-        for tp in call_args:
+        for tp in consumer.offsets_for_times.call_args[0][0]:
             assert tp.offset == 1700000000000
+        assigned = {tp.partition: tp.offset for tp in consumer.assign.call_args[0][0]}
+        assert assigned == {0: 50, 1: 120}
 
-        assigned = consumer.assign.call_args[0][0]
-        assert len(assigned) == 2
-
-    def test_start_timestamp_includes_partitions_at_end(self):
-        from unittest.mock import MagicMock
-
+    def test_start_timestamp_skips_partitions_past_end(self):
         consumer = MagicMock()
-        consumer.poll.return_value = None
-
         metadata = MagicMock()
         metadata.topics = {'t': MagicMock(partitions={0: MagicMock(), 1: MagicMock()})}
         consumer.list_topics.return_value = metadata
+        # Partition 0 has no message at/after the timestamp (offset=-1); it must not be assigned.
+        consumer.offsets_for_times.return_value = [
+            MagicMock(partition=0, offset=-1),
+            MagicMock(partition=1, offset=120),
+        ]
+        consumer.poll.side_effect = [_eof(1)]
 
-        # Partition 0 has no messages at the timestamp (offset=-1 = OFFSET_END), partition 1 does
-        resolved_tp0 = MagicMock(partition=0, offset=-1)
-        resolved_tp1 = MagicMock(partition=1, offset=120)
-        consumer.offsets_for_times.return_value = [resolved_tp0, resolved_tp1]
+        mock_admin = MagicMock()
+        mock_admin.list_offsets.return_value = _futures({0: 100, 1: 200})
 
-        import logging
-
-        from datadog_checks.kafka_actions.kafka_client import KafkaActionsClient
-
-        client = KafkaActionsClient({'kafka_connect_str': 'localhost:9092'}, logging.getLogger('test'))
-
-        with patch.object(client, 'get_consumer', return_value=consumer):
+        client = _client()
+        with (
+            patch.object(client, 'get_consumer', return_value=consumer),
+            patch.object(client, 'get_admin_client', return_value=mock_admin),
+        ):
             list(client.consume_messages(topic='t', start_timestamp=1700000000000, max_messages=10, timeout_ms=500))
 
-        # Both partitions should be assigned; partition 0 waits at end for new messages
         assigned = consumer.assign.call_args[0][0]
-        assert len(assigned) == 2
+        assert len(assigned) == 1
+        assert assigned[0].partition == 1
 
     def test_start_timestamp_overrides_start_offset(self, dd_run_check, aggregator):
         """Test that start_timestamp is passed through from check config."""
@@ -525,27 +555,53 @@ class TestConsumeMessagesStartTimestamp:
 
 
 class TestConsumeMessagesEarlyReturn:
-    """Test that consume_messages returns early on None poll or partition EOF."""
+    """Test that consume_messages stops when all partitions are drained (EOF), not on None."""
 
-    def test_none_poll_breaks_immediately(self):
-        from unittest.mock import MagicMock
-
+    def test_eof_drains_and_stops(self):
         consumer = MagicMock()
         metadata = MagicMock()
         metadata.topics = {'t': MagicMock(partitions={0: MagicMock()})}
         consumer.list_topics.return_value = metadata
-        consumer.poll.side_effect = [MockKafkaMessage(key=b'k', value=b'v', partition=0, offset=0), None]
+        # A None poll must NOT end consumption; only EOF (or the watermark) does.
+        consumer.poll.side_effect = [
+            MockKafkaMessage(key=b'k', value=b'v', partition=0, offset=0),
+            None,
+            _eof(0),
+        ]
 
-        import logging
+        mock_admin = MagicMock()
+        mock_admin.list_offsets.return_value = _futures({0: 100})
 
-        from datadog_checks.kafka_actions.kafka_client import KafkaActionsClient
-
-        client = KafkaActionsClient({'kafka_connect_str': 'localhost:9092'}, logging.getLogger('test'))
-        with patch.object(client, 'get_consumer', return_value=consumer):
-            result = list(client.consume_messages(topic='t', start_offset=0, max_messages=1000, timeout_ms=30000))
+        client = _client()
+        with (
+            patch.object(client, 'get_consumer', return_value=consumer),
+            patch.object(client, 'get_admin_client', return_value=mock_admin),
+        ):
+            result = list(client.consume_messages(topic='t', start_offset=0, max_messages=1000, timeout_ms=500))
 
         assert len(result) == 1
-        assert consumer.poll.call_count == 2
+        assert consumer.poll.call_count == 3
+
+    def test_empty_range_returns_without_polling(self):
+        consumer = MagicMock()
+        metadata = MagicMock()
+        metadata.topics = {'t': MagicMock(partitions={0: MagicMock()})}
+        consumer.list_topics.return_value = metadata
+
+        mock_admin = MagicMock()
+        # start (10) is already at the high watermark (10): nothing to read.
+        mock_admin.list_offsets.return_value = _futures({0: 10})
+
+        client = _client()
+        with (
+            patch.object(client, 'get_consumer', return_value=consumer),
+            patch.object(client, 'get_admin_client', return_value=mock_admin),
+        ):
+            result = list(client.consume_messages(topic='t', start_offset=10, max_messages=1000, timeout_ms=500))
+
+        assert result == []
+        consumer.assign.assert_not_called()
+        consumer.poll.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/kafka_actions/tests/test_unit.py
+++ b/kafka_actions/tests/test_unit.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from confluent_kafka import KafkaError
+
 from datadog_checks.kafka_actions import KafkaActionsCheck
 from datadog_checks.kafka_actions.kafka_client import KafkaActionsClient
 


### PR DESCRIPTION
### What does this PR do?

Fixes `read_messages` hanging until its global timeout when a selective filter matches fewer messages than `n_messages_retrieved`.

Once the consumer drained the messages already in the log, it kept polling the live head of the topic. Because a continuously-produced topic almost always delivers a new message within the poll window, the "no more messages" (`poll() == None`) exit never fired, so the read blocked for the full timeout (20s) and returned a partial, silently-truncated result.

### Motivation

Observed on a live 10-partition topic: a `.value.country == "..."` filter that matched ~85 of the ~780 retained messages (fewer than the requested `n_messages_retrieved=100`) consistently took the full 20s. Profiling showed the time was entirely in `consumer.poll()` tailing the live head — schema-registry fetches (0.08s) and deserialization (0.12s) were negligible. The historical scan itself runs at ~4,900 msg/s.

### Approach

Bound consumption to a snapshot of the log taken when the check starts:

- Capture each partition's high watermark (log-end offset) up front and never yield a message at or beyond it, so messages produced after the check began are excluded and live-tailing is impossible.
- Enable `enable.partition.eof` and stop a partition on its `_PARTITION_EOF` event or when its captured watermark is reached; return as soon as every partition is drained (an empty range returns immediately).
- Reduce the default timeout from 20s to 5s — now only a safety net.
- Surface a `hit_timeout` stat so a timeout-truncated read is distinguishable from a complete one.

### Testing

- Updated/added unit tests for the snapshot bound, EOF-based termination, empty-range short-circuit, and per-partition start-offset resolution.
- Verified against a live 10-partition Kafka cluster: the previously-hanging filtered read now returns in ~0.3s instead of 20s, no-filter reads remain fast, and a future-dated `start_timestamp` (nothing to read) returns in ~0.09s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)