### PR TITLE
Wait for Tekton metrics  in E2E Test

### DIFF
--- a/tekton/tests/conftest.py
+++ b/tekton/tests/conftest.py
@@ -3,10 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 from contextlib import ExitStack
+from urllib.request import urlopen
 
 import pytest
 
 from datadog_checks.dev import get_here, run_command
+from datadog_checks.dev.conditions import WaitFor
 from datadog_checks.dev.kind import kind_run
 from datadog_checks.dev.kube_port_forward import port_forward
 
@@ -19,6 +21,15 @@ def _wait_for_resource(*, kind, name, condition, namespace=None, timeout="300s")
     if namespace:
         command.extend(["-n", namespace])
     run_command(command)
+
+
+def wait_for_metric_families(endpoint, families):
+    with urlopen(endpoint, timeout=5) as response:
+        metrics = response.read().decode("utf-8")
+
+    missing = [family for family in families if family not in metrics]
+    if missing:
+        raise AssertionError("Tekton metric families are not available yet: {}".format(", ".join(missing)))
 
 
 def setup_tekton():
@@ -76,6 +87,22 @@ def dd_environment():
             port_forward(kubeconfig, 'tekton-pipelines', 9000, 'service', 'tekton-triggers-controller')
         )
         instances['triggers_controller_endpoint'] = f'http://{trigger_host}:{trigger_port}/metrics'
+
+        WaitFor(
+            wait_for_metric_families,
+            attempts=60,
+            wait=2,
+            args=(
+                instances['triggers_controller_endpoint'],
+                [
+                    'controller_clusterinterceptor_count',
+                    'controller_clustertriggerbinding_count',
+                    'controller_eventlistener_count',
+                    'controller_triggerbinding_count',
+                    'controller_triggertemplate_count',
+                ],
+            ),
+        )()
 
         yield {'instances': [instances]}
 

--- a/tekton/tests/conftest.py
+++ b/tekton/tests/conftest.py
@@ -23,7 +23,7 @@ def _wait_for_resource(*, kind, name, condition, namespace=None, timeout="300s")
     run_command(command)
 
 
-def wait_for_metric_families(endpoint, families):
+def wait_for_metric_families(endpoint: str, families: list[str]) -> None:
     with urlopen(endpoint, timeout=5) as response:
         metrics = response.read().decode("utf-8")
 


### PR DESCRIPTION
Adds a readiness wait for Tekton trigger metric families before running the E2E Agent check.

This is intended to address the repeated Tekton flake where `tekton.triggers_controller.clusterinterceptor` is missing on the first scrape.

Recent failures:
- https://github.com/DataDog/integrations-core/actions/runs/28026005702/job/83141035488
- https://github.com/DataDog/integrations-core/actions/runs/28033363038/job/83141042093

Validation on this fix branch:
- Test Agent release run: https://github.com/DataDog/integrations-core/actions/runs/28088592447
- Tekton passed 6/6 attempts, including reruns:
  - https://github.com/DataDog/integrations-core/actions/runs/28088592447/job/83160672642
  - https://github.com/DataDog/integrations-core/actions/runs/28088592447/job/83165747621
  - https://github.com/DataDog/integrations-core/actions/runs/28088592447/job/83168466440
  - https://github.com/DataDog/integrations-core/actions/runs/28088592447/job/83169416516
  - https://github.com/DataDog/integrations-core/actions/runs/28088592447/job/83170348735
  - https://github.com/DataDog/integrations-core/actions/runs/28088592447/job/83171218750