### PR TITLE
Add resume support to the AI flow orchestrator

### DIFF
--- a/ddev/src/ddev/ai/flows/openmetrics/phases/inspect_endpoint.py
+++ b/ddev/src/ddev/ai/flows/openmetrics/phases/inspect_endpoint.py
@@ -238,7 +238,7 @@ class InspectEndpointPhase(Phase):
             memory_text=memory_text,
             total_input_tokens=0,
             total_output_tokens=0,
-            extra_checkpoint={
+            checkpoint_data={
                 "endpoint_url": endpoint_url,
                 "status_code": response.status_code,
                 "content_type": content_type,

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -26,6 +26,35 @@ if TYPE_CHECKING:
     from ddev.ai.react.types import ReActResult
 
 
+RESUME_NOTICE = """
+
+---
+
+NOTE FROM THE HARNESS — RESUMED RUN
+
+This phase is being re-run because a previous execution of this flow failed or was \
+interrupted while this phase was the one in progress. You are picking up from where it stopped.
+
+Some of this phase's work may already be partially on disk from that earlier attempt — files \
+created or half-edited, assets generated, commands partially applied. Before doing new work, \
+inspect the current state of the files this phase is responsible for, reconcile anything that is \
+incomplete or inconsistent, and avoid blindly duplicating steps that were already finished. \
+Treat the on-disk state as the source of truth and bring it to a correct, complete result."""
+
+RESUME_NOTICE_ERROR = """
+
+The previous attempt recorded this error:
+
+{error}"""
+
+
+def build_resume_notice(error: str | None) -> str:
+    notice = RESUME_NOTICE
+    if error:
+        notice += RESUME_NOTICE_ERROR.format(error=error)
+    return notice
+
+
 def render_task_prompt(
     task: TaskConfig,
     config_dir: Path,
@@ -288,6 +317,9 @@ class AgenticPhase(Phase):
             context,
             self._resolver,
         )
+        if self._resume_frontier:
+            prior = context.get("checkpoints", {}).get(self._phase_id) or {}
+            system_prompt += build_resume_notice(prior.get("error"))
         try:
             process = self._process_factory.create(
                 scope=self._scope,

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -16,7 +16,13 @@ from ddev.ai.phases.goal import GOAL_TASK_SUFFIX, GoalValidationError, render_go
 from ddev.ai.phases.messages import PhaseFailedMessage
 from ddev.ai.phases.template import render_inline, render_prompt
 from ddev.ai.react.process import ReActProcess
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import (
+    CheckpointManager,
+    CheckpointStatus,
+    CheckpointTokenInfo,
+    FailedCheckpoint,
+    GoalValidationRecord,
+)
 from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
 
 if TYPE_CHECKING:
@@ -106,7 +112,7 @@ class AgenticPhase(Phase):
         self._agent_config = agent_config
         self._process_factory = process_factory
         self._scope = AgentScope(owner_id=phase_id, role=AgentRole.PHASE)
-        self._goal_attempt_log: list[dict[str, Any]] = []
+        self._goal_attempt_log: list[GoalValidationRecord] = []
         self._total_input_tokens: int = 0
         self._total_output_tokens: int = 0
 
@@ -280,11 +286,11 @@ class AgenticPhase(Phase):
         final_valid: bool,
     ) -> None:
         self._goal_attempt_log.append(
-            {
-                "task": task.name,
-                "attempts": attempts,
-                "final_valid": final_valid,
-            }
+            GoalValidationRecord(
+                task=task.name,
+                attempts=attempts,
+                final_valid=final_valid,
+            )
         )
 
     def _add_tokens(
@@ -318,8 +324,8 @@ class AgenticPhase(Phase):
             self._resolver,
         )
         if self._is_resume_frontier:
-            prior = (context.get("checkpoints") or {}).get(self._phase_id) or {}
-            error = prior.get("error") if isinstance(prior, dict) else None
+            prior = (context.get("checkpoints") or {}).get(self._phase_id)
+            error = prior.error if prior is not None and prior.status == CheckpointStatus.FAILED else None
             system_prompt += build_resume_notice(error)
         try:
             process = self._process_factory.create(
@@ -336,32 +342,29 @@ class AgenticPhase(Phase):
 
         memory_text, mem_in, mem_out = await self._run_memory_step(process, context)
 
-        extra: dict[str, Any] = {}
-        if self._goal_attempt_log:
-            extra["goal_validations"] = self._goal_attempt_log
-
         return PhaseOutcome(
             memory_text=memory_text,
             total_input_tokens=self._total_input_tokens + mem_in,
             total_output_tokens=self._total_output_tokens + mem_out,
-            extra_checkpoint=extra,
+            goal_validations=self._goal_attempt_log or None,
         )
 
     async def on_error(self, error: MessageProcessingError | ProcessorHookError) -> None:
-        payload: dict[str, Any] = {
-            "status": "failed",
-            "started_at": self._started_at.isoformat() if self._started_at else None,
-            "finished_at": datetime.now(UTC).isoformat(),
-            "error": str(error.original_exception),
-            "tokens": {
-                "total_input": self._total_input_tokens,
-                "total_output": self._total_output_tokens,
-            },
-        }
-        if self._goal_attempt_log:
-            payload["goal_validations"] = self._goal_attempt_log
         try:
-            self._checkpoint_manager.write_phase_checkpoint(self._phase_id, payload)
+            self._checkpoint_manager.write_phase_checkpoint(
+                self._phase_id,
+                FailedCheckpoint(
+                    status=CheckpointStatus.FAILED,
+                    started_at=self._started_at.isoformat() if self._started_at else None,
+                    finished_at=datetime.now(UTC).isoformat(),
+                    error=str(error.original_exception),
+                    tokens=CheckpointTokenInfo(
+                        total_input=self._total_input_tokens,
+                        total_output=self._total_output_tokens,
+                    ),
+                    goal_validations=self._goal_attempt_log or None,
+                ),
+            )
         except Exception:
             self._logger.exception("Failed to write failure checkpoint for phase %s", self._phase_id)
         finally:

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -354,7 +354,6 @@ class AgenticPhase(Phase):
             self._checkpoint_manager.write_phase_checkpoint(
                 self._phase_id,
                 FailedCheckpoint(
-                    status=CheckpointStatus.FAILED,
                     started_at=self._started_at.isoformat() if self._started_at else None,
                     finished_at=datetime.now(UTC).isoformat(),
                     error=str(error.original_exception),

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -317,9 +317,10 @@ class AgenticPhase(Phase):
             context,
             self._resolver,
         )
-        if self._resume_frontier:
-            prior = context.get("checkpoints", {}).get(self._phase_id) or {}
-            system_prompt += build_resume_notice(prior.get("error"))
+        if self._is_resume_frontier:
+            prior = (context.get("checkpoints") or {}).get(self._phase_id) or {}
+            error = prior.get("error") if isinstance(prior, dict) else None
+            system_prompt += build_resume_notice(error)
         try:
             process = self._process_factory.create(
                 scope=self._scope,

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -32,13 +32,13 @@ RESUME_NOTICE = """
 
 NOTE FROM THE HARNESS — RESUMED RUN
 
-This phase is being re-run because a previous execution of this flow failed or was \
+This phase is being re-run because a previous execution of this flow failed or was
 interrupted while this phase was the one in progress. You are picking up from where it stopped.
 
-Some of this phase's work may already be partially on disk from that earlier attempt — files \
-created or half-edited, assets generated, commands partially applied. Before doing new work, \
-inspect the current state of the files this phase is responsible for, reconcile anything that is \
-incomplete or inconsistent, and avoid blindly duplicating steps that were already finished. \
+Some of this phase's work may already be partially on disk from that earlier attempt — files
+created or half-edited, assets generated, commands partially applied. Before doing new work,
+inspect the current state of the files this phase is responsible for, reconcile anything that is
+incomplete or inconsistent, and avoid blindly duplicating steps that were already finished.
 Treat the on-disk state as the source of truth and bring it to a correct, complete result."""
 
 RESUME_NOTICE_ERROR = """

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -15,7 +15,14 @@ from typing import TYPE_CHECKING, Any
 from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.phases.config import AgentConfig, PhaseConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import (
+    CheckpointManager,
+    CheckpointStatus,
+    CheckpointTokenInfo,
+    FailedCheckpoint,
+    GoalValidationRecord,
+    SuccessCheckpoint,
+)
 from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
 from ddev.event_bus.orchestrator import AsyncProcessor, BaseMessage
 
@@ -40,7 +47,8 @@ class PhaseOutcome:
     memory_text: str
     total_input_tokens: int = 0
     total_output_tokens: int = 0
-    extra_checkpoint: dict[str, Any] = field(default_factory=dict)
+    goal_validations: list[GoalValidationRecord] | None = None
+    checkpoint_data: dict[str, Any] = field(default_factory=dict)
 
 
 class Phase(AsyncProcessor[PhaseTrigger]):
@@ -142,25 +150,21 @@ class Phase(AsyncProcessor[PhaseTrigger]):
 
         outcome = await self.execute(context)
 
-        checkpoint_payload: dict[str, Any] = {
-            "status": "success",
-            "started_at": self._started_at.isoformat(),
-            "finished_at": datetime.now(UTC).isoformat(),
-            "tokens": {
-                "total_input": outcome.total_input_tokens,
-                "total_output": outcome.total_output_tokens,
-            },
-            "memory_path": str(self._checkpoint_manager.memory_path(self._phase_id)),
-        }
-        reserved = set(checkpoint_payload) & set(outcome.extra_checkpoint)
-        if reserved:
-            raise ValueError(
-                f"Phase {self._phase_id!r}: extra_checkpoint cannot override reserved keys: {sorted(reserved)}"
-            )
-        checkpoint_payload.update(outcome.extra_checkpoint)
+        checkpoint = SuccessCheckpoint(
+            status=CheckpointStatus.SUCCESS,
+            started_at=self._started_at.isoformat(),
+            finished_at=datetime.now(UTC).isoformat(),
+            tokens=CheckpointTokenInfo(
+                total_input=outcome.total_input_tokens,
+                total_output=outcome.total_output_tokens,
+            ),
+            memory_path=str(self._checkpoint_manager.memory_path(self._phase_id)),
+            goal_validations=outcome.goal_validations,
+            phase_data=outcome.checkpoint_data,
+        )
 
         self._checkpoint_manager.write_memory(self._phase_id, outcome.memory_text)
-        self._checkpoint_manager.write_phase_checkpoint(self._phase_id, checkpoint_payload)
+        self._checkpoint_manager.write_phase_checkpoint(self._phase_id, checkpoint)
         await self._callbacks.fire_phase_finish(self._phase_id)
 
     async def on_success(self, message: PhaseTrigger) -> None:
@@ -177,12 +181,13 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         try:
             self._checkpoint_manager.write_phase_checkpoint(
                 self._phase_id,
-                {
-                    "status": "failed",
-                    "started_at": self._started_at.isoformat() if self._started_at else None,
-                    "finished_at": datetime.now(UTC).isoformat(),
-                    "error": str(error.original_exception),
-                },
+                FailedCheckpoint(
+                    status=CheckpointStatus.FAILED,
+                    started_at=self._started_at.isoformat() if self._started_at else None,
+                    finished_at=datetime.now(UTC).isoformat(),
+                    error=str(error.original_exception),
+                    tokens=CheckpointTokenInfo(total_input=0, total_output=0),
+                ),
             )
         except Exception:
             self._logger.exception("Failed to write failure checkpoint for phase %s", self._phase_id)

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -32,6 +32,7 @@ class FlowContext:
     config_dir: Path
     callbacks: Callbacks = field(default_factory=Callbacks)
     logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
+    resume_frontier: frozenset[str] = frozenset()
 
 
 @dataclass
@@ -67,6 +68,7 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         self._config_dir = context.config_dir
         self._callbacks = context.callbacks
         self._logger = context.logger
+        self._resume_frontier = phase_id in context.resume_frontier
         self._started_at: datetime | None = None
         self._resolver: Callable[[str], str] | None = None
         self._executed = False

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -68,7 +68,7 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         self._config_dir = context.config_dir
         self._callbacks = context.callbacks
         self._logger = context.logger
-        self._resume_frontier = phase_id in context.resume_frontier
+        self._is_resume_frontier = phase_id in context.resume_frontier
         self._started_at: datetime | None = None
         self._resolver: Callable[[str], str] | None = None
         self._executed = False

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -17,7 +17,6 @@ from ddev.ai.phases.config import AgentConfig, PhaseConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
-    CheckpointStatus,
     CheckpointTokenInfo,
     FailedCheckpoint,
     GoalValidationRecord,
@@ -151,7 +150,6 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         outcome = await self.execute(context)
 
         checkpoint = SuccessCheckpoint(
-            status=CheckpointStatus.SUCCESS,
             started_at=self._started_at.isoformat(),
             finished_at=datetime.now(UTC).isoformat(),
             tokens=CheckpointTokenInfo(
@@ -182,7 +180,6 @@ class Phase(AsyncProcessor[PhaseTrigger]):
             self._checkpoint_manager.write_phase_checkpoint(
                 self._phase_id,
                 FailedCheckpoint(
-                    status=CheckpointStatus.FAILED,
                     started_at=self._started_at.isoformat() if self._started_at else None,
                     finished_at=datetime.now(UTC).isoformat(),
                     error=str(error.original_exception),

--- a/ddev/src/ddev/ai/phases/config.py
+++ b/ddev/src/ddev/ai/phases/config.py
@@ -51,6 +51,24 @@ def _detect_cycles(
     return cycles, False
 
 
+def _topological_sort(flow: list[FlowEntry]) -> list[FlowEntry]:
+    """Stable topological sort of an acyclic flow: dependencies before dependents.
+
+    Phases with no ordering constraint between them keep their original
+    declaration order. The caller must guarantee the graph is acyclic.
+    """
+    remaining_deps = {entry.phase: set(entry.dependencies) for entry in flow}
+
+    ordered: list[FlowEntry] = []
+    emitted: set[str] = set()
+    while len(ordered) < len(flow):
+        # First phase in declaration order whose dependencies are all emitted.
+        nxt = next(entry for entry in flow if entry.phase not in emitted and remaining_deps[entry.phase] <= emitted)
+        ordered.append(nxt)
+        emitted.add(nxt.phase)
+    return ordered
+
+
 class TaskConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: str = Field(pattern=r"^[A-Za-z0-9._-]{1,64}$")
@@ -132,6 +150,8 @@ class FlowEntry(BaseModel):
 
 
 class FlowConfig(BaseModel):
+    """Validated flow entries, topologically sorted."""
+
     model_config = ConfigDict(extra="forbid")
     variables: dict[str, str] = {}
     agents: dict[str, AgentConfig]
@@ -166,6 +186,7 @@ class FlowConfig(BaseModel):
             suffix = f"\n  (showing first {len(cycles)}; more cycles exist)" if truncated else ""
             raise ValueError(f"Cycle(s) detected in flow:\n  {formatted}{suffix}")
 
+        self.flow = _topological_sort(self.flow)
         return self
 
     @classmethod

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -35,7 +35,7 @@ class GoalValidationRecord(BaseModel):
 class SuccessCheckpoint(BaseModel):
     """Checkpoint written at the end of a successful phase execution."""
 
-    status: Literal[CheckpointStatus.SUCCESS]
+    status: Literal[CheckpointStatus.SUCCESS] = CheckpointStatus.SUCCESS
     started_at: str
     finished_at: str
     tokens: CheckpointTokenInfo
@@ -47,7 +47,7 @@ class SuccessCheckpoint(BaseModel):
 class FailedCheckpoint(BaseModel):
     """Checkpoint written when a phase terminates with an error."""
 
-    status: Literal[CheckpointStatus.FAILED]
+    status: Literal[CheckpointStatus.FAILED] = CheckpointStatus.FAILED
     started_at: str | None
     finished_at: str
     error: str
@@ -96,7 +96,7 @@ class CheckpointManager:
 
     def write_phase_checkpoint(self, phase_id: str, data: PhaseCheckpoint) -> None:
         """Write or overwrite one phase's section in checkpoints.yaml.
-        Raises CheckpointWriteError if the existing file is corrupted."""
+        Raises CheckpointReadError if the existing file is corrupted."""
         all_checkpoints = {pid: cp.model_dump(mode="json") for pid, cp in self.read().items()}
         all_checkpoints[phase_id] = data.model_dump(mode="json")
         self._ensure_dir()

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -2,14 +2,63 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from __future__ import annotations
+
+from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any, Literal
 
 import yaml
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
 
 class CheckpointReadError(Exception):
     """Raised when checkpoints.yaml exists but cannot be read or parsed."""
+
+
+class CheckpointStatus(StrEnum):
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+class CheckpointTokenInfo(BaseModel):
+    total_input: int
+    total_output: int
+
+
+class GoalValidationRecord(BaseModel):
+    task: str
+    attempts: int
+    final_valid: bool
+
+
+class SuccessCheckpoint(BaseModel):
+    """Checkpoint written at the end of a successful phase execution."""
+
+    status: Literal[CheckpointStatus.SUCCESS]
+    started_at: str
+    finished_at: str
+    tokens: CheckpointTokenInfo
+    memory_path: str
+    goal_validations: list[GoalValidationRecord] | None = None
+    phase_data: dict[str, Any] = {}
+
+
+class FailedCheckpoint(BaseModel):
+    """Checkpoint written when a phase terminates with an error."""
+
+    status: Literal[CheckpointStatus.FAILED]
+    started_at: str | None
+    finished_at: str
+    error: str
+    tokens: CheckpointTokenInfo
+    goal_validations: list[GoalValidationRecord] | None = None
+
+
+PhaseCheckpoint = Annotated[SuccessCheckpoint | FailedCheckpoint, Field(discriminator="status")]
+
+# TypeAdapter provides model_validate() for annotated union types that aren't BaseModel subclasses.
+CheckpointAdapter: TypeAdapter[PhaseCheckpoint] = TypeAdapter(PhaseCheckpoint)
 
 
 class CheckpointManager:
@@ -26,25 +75,36 @@ class CheckpointManager:
     def _ensure_dir(self) -> None:
         self.root.mkdir(parents=True, exist_ok=True)
 
-    def read(self) -> dict[str, Any]:
-        """Return full checkpoint data, keyed by phase_id. Empty dict if file absent."""
+    def read(self) -> dict[str, PhaseCheckpoint]:
+        """Return validated checkpoints keyed by phase_id.
+        Raises CheckpointReadError if any entry fails validation.
+        Empty dict if file absent."""
         if not self._path.exists():
             return {}
         try:
-            return yaml.safe_load(self._path.read_text(encoding="utf-8")) or {}
+            raw = yaml.safe_load(self._path.read_text(encoding="utf-8")) or {}
         except (OSError, yaml.YAMLError) as e:
             raise CheckpointReadError(f"Failed to load checkpoints from {self._path}: {e}") from e
 
-    def write_phase_checkpoint(self, phase_id: str, data: dict[str, Any]) -> None:
-        """Write or overwrite one phase's section in checkpoints.yaml."""
-        checkpoints = self.read()
-        checkpoints[phase_id] = data
+        result: dict[str, PhaseCheckpoint] = {}
+        for phase_id, data in raw.items():
+            try:
+                result[phase_id] = CheckpointAdapter.validate_python(data)
+            except ValidationError as e:
+                raise CheckpointReadError(f"Checkpoint for phase {phase_id!r} in {self._path} is invalid: {e}") from e
+        return result
+
+    def write_phase_checkpoint(self, phase_id: str, data: PhaseCheckpoint) -> None:
+        """Write or overwrite one phase's section in checkpoints.yaml.
+        Raises CheckpointWriteError if the existing file is corrupted."""
+        all_checkpoints = {pid: cp.model_dump(mode="json") for pid, cp in self.read().items()}
+        all_checkpoints[phase_id] = data.model_dump(mode="json")
         self._ensure_dir()
-        self._path.write_text(yaml.dump(checkpoints, default_flow_style=False, sort_keys=False), encoding="utf-8")
+        self._path.write_text(yaml.dump(all_checkpoints, default_flow_style=False, sort_keys=False), encoding="utf-8")
 
     def successful_phases(self) -> set[str]:
         """Phase ids whose last recorded checkpoint reached 'success'."""
-        return {pid for pid, data in self.read().items() if isinstance(data, dict) and data.get("status") == "success"}
+        return {pid for pid, data in self.read().items() if data.status == CheckpointStatus.SUCCESS}
 
     def build_memory_prompt(self, user_additions: str | None) -> str:
         """Build the memory prompt to send to the agent at the end of a phase."""

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -42,6 +42,10 @@ class CheckpointManager:
         self._ensure_dir()
         self._path.write_text(yaml.dump(checkpoints, default_flow_style=False, sort_keys=False), encoding="utf-8")
 
+    def successful_phases(self) -> set[str]:
+        """Phase ids whose last recorded checkpoint reached 'success'."""
+        return {pid for pid, data in self.read().items() if isinstance(data, dict) and data.get("status") == "success"}
+
     def build_memory_prompt(self, user_additions: str | None) -> str:
         """Build the memory prompt to send to the agent at the end of a phase."""
         base_prompt = "Write a brief summary of what you accomplished in this phase."

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -6,10 +6,15 @@ from __future__ import annotations
 
 from enum import StrEnum
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 import yaml
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError
+
+from ddev.ai.phases.config import FlowConfigError
+
+if TYPE_CHECKING:
+    from ddev.ai.phases.config import FlowConfig
 
 
 class CheckpointReadError(Exception):
@@ -135,3 +140,29 @@ class CheckpointManager:
         if key.endswith("_memory"):
             return self.memory_content(key.removesuffix("_memory"))
         return f"<VARIABLE UNDEFINED: {key}>"
+
+
+def resolve_resume_state(config: FlowConfig, checkpoint_manager: CheckpointManager) -> tuple[set[str], set[str]]:
+    """Compute (completed, frontier) for resuming a flow from its checkpoints.
+
+    ``completed`` is the dependency-closed set of phases that succeeded and whose every
+    transitive dependency also succeeded. ``frontier`` is the phases that will run first
+    on resume (not completed, but all their dependencies are).
+
+    The single-pass closure relies on ``config.flow`` being topologically sorted.
+    """
+    try:
+        succeeded = checkpoint_manager.successful_phases()
+    except CheckpointReadError as e:
+        raise FlowConfigError(
+            f"Cannot resume: checkpoints file is unreadable ({e}). Delete it and restart from scratch."
+        ) from e
+    completed: set[str] = set()
+    frontier: set[str] = set()
+    for entry in config.flow:
+        deps_done = all(dep in completed for dep in entry.dependencies)
+        if entry.phase in succeeded and deps_done:
+            completed.add(entry.phase)
+        elif deps_done:
+            frontier.add(entry.phase)
+    return completed, frontier

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -12,7 +12,7 @@ from ddev.ai.phases.config import FlowConfig, FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.registry import PhaseRegistry, discover_and_register_phases
 from ddev.ai.runtime.agent_log import AgentLogger
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointReadError
 from ddev.ai.runtime.resources import RunResources
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.event_bus.exceptions import FatalProcessingError
@@ -105,6 +105,10 @@ class PhaseOrchestrator(EventBusOrchestrator):
         dependency_map: dict[str, list[str]] = {entry.phase: entry.dependencies for entry in config.flow}
 
         completed, frontier = self._resolve_resume_state(config, checkpoint_manager)
+        if self._resume:
+            self._logger.info(
+                "Resuming: %d phase(s) completed, re-running frontier %r", len(completed), sorted(frontier)
+            )
 
         self._agent_logger = AgentLogger(checkpoint_manager.root)
         run_callbacks = self._callbacks.with_set(self._agent_logger.as_callback_set())
@@ -143,8 +147,9 @@ class PhaseOrchestrator(EventBusOrchestrator):
             self.register_processor(phase, [PhaseTrigger])
 
         self.submit_message(PhaseTrigger(id="start", phase_id=None))
-        for phase_id in completed:
-            self.submit_message(PhaseTrigger(id=f"{phase_id}_resumed", phase_id=phase_id))
+        for entry in config.flow:
+            if entry.phase in completed:
+                self.submit_message(PhaseTrigger(id=f"{entry.phase}_resumed", phase_id=entry.phase))
 
     def _resolve_resume_state(
         self,
@@ -161,7 +166,12 @@ class PhaseOrchestrator(EventBusOrchestrator):
         if not self._resume:
             return set(), set()
 
-        succeeded = checkpoint_manager.successful_phases()
+        try:
+            succeeded = checkpoint_manager.successful_phases()
+        except CheckpointReadError as e:
+            raise FlowConfigError(
+                f"Cannot resume: checkpoints file is unreadable ({e}). Delete it and restart from scratch."
+            ) from e
         completed: set[str] = set()
         frontier: set[str] = set()
         for entry in config.flow:

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -28,6 +28,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
         agent_clients: dict[str, Any],
         file_access_policy: FileAccessPolicy,
         callbacks: Callbacks | None = None,
+        resume: bool = False,
         grace_period: float = 10,
         max_timeout: float = 600,
         logger: logging.Logger | None = None,
@@ -55,6 +56,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
         self._agent_clients = agent_clients
         self._file_access_policy = file_access_policy
         self._callbacks: Callbacks = callbacks or Callbacks()
+        self._resume = resume
         self._agent_logger: AgentLogger | None = None
         self._phase_registry = PhaseRegistry()
         self._failed_phase: str | None = None
@@ -102,6 +104,8 @@ class PhaseOrchestrator(EventBusOrchestrator):
         checkpoint_manager = CheckpointManager(self._checkpoint_path)
         dependency_map: dict[str, list[str]] = {entry.phase: entry.dependencies for entry in config.flow}
 
+        completed, frontier = self._resolve_resume_state(config, checkpoint_manager)
+
         self._agent_logger = AgentLogger(checkpoint_manager.root)
         run_callbacks = self._callbacks.with_set(self._agent_logger.as_callback_set())
 
@@ -117,10 +121,14 @@ class PhaseOrchestrator(EventBusOrchestrator):
             config_dir=config_dir,
             callbacks=run_callbacks,
             logger=self._logger,
+            resume_frontier=frozenset(frontier),
         )
 
         for entry in config.flow:
             phase_id = entry.phase
+            if phase_id in completed:
+                self._logger.info("Resuming: skipping already-completed phase %r", phase_id)
+                continue
             phase_config = config.phases[phase_id]
             deps = dependency_map[phase_id]
             phase_cls = self._phase_registry.get(phase_config.type)
@@ -135,6 +143,34 @@ class PhaseOrchestrator(EventBusOrchestrator):
             self.register_processor(phase, [PhaseTrigger])
 
         self.submit_message(PhaseTrigger(id="start", phase_id=None))
+        for phase_id in completed:
+            self.submit_message(PhaseTrigger(id=f"{phase_id}_resumed", phase_id=phase_id))
+
+    def _resolve_resume_state(
+        self,
+        config: FlowConfig,
+        checkpoint_manager: CheckpointManager,
+    ) -> tuple[set[str], set[str]]:
+        """Compute (completed, frontier) for a resumed run; both empty when not resuming.
+
+        ``completed`` is the dependency-closed set of phases that succeeded *and* whose every
+        transitive dependency also succeeded. ``frontier`` is the phases that will run first
+        on resume (not completed, but all their dependencies are): the ones that may be sitting
+        on partial work from the interrupted run.
+        """
+        if not self._resume:
+            return set(), set()
+
+        succeeded = checkpoint_manager.successful_phases()
+        completed: set[str] = set()
+        frontier: set[str] = set()
+        for entry in config.flow:
+            deps_done = all(dep in completed for dep in entry.dependencies)
+            if entry.phase in succeeded and deps_done:
+                completed.add(entry.phase)
+            elif deps_done:
+                frontier.add(entry.phase)
+        return completed, frontier
 
     async def on_message_received(self, message: BaseMessage) -> None:
         """Stop the entire pipeline immediately when any phase fails."""

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -12,7 +12,7 @@ from ddev.ai.phases.config import FlowConfig, FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.registry import PhaseRegistry, discover_and_register_phases
 from ddev.ai.runtime.agent_log import AgentLogger
-from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointReadError
+from ddev.ai.runtime.checkpoints import CheckpointManager, resolve_resume_state
 from ddev.ai.runtime.resources import RunResources
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.event_bus.exceptions import FatalProcessingError
@@ -104,7 +104,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
         checkpoint_manager = CheckpointManager(self._checkpoint_path)
         dependency_map: dict[str, list[str]] = {entry.phase: entry.dependencies for entry in config.flow}
 
-        completed, frontier = self._resolve_resume_state(config, checkpoint_manager)
+        completed, frontier = resolve_resume_state(config, checkpoint_manager) if self._resume else (set(), set())
         if self._resume:
             self._logger.info(
                 "Resuming: %d phase(s) completed, re-running frontier %r", len(completed), sorted(frontier)
@@ -150,38 +150,6 @@ class PhaseOrchestrator(EventBusOrchestrator):
         for entry in config.flow:
             if entry.phase in completed:
                 self.submit_message(PhaseTrigger(id=f"{entry.phase}_resumed", phase_id=entry.phase))
-
-    def _resolve_resume_state(
-        self,
-        config: FlowConfig,
-        checkpoint_manager: CheckpointManager,
-    ) -> tuple[set[str], set[str]]:
-        """Compute (completed, frontier) for a resumed run; both empty when not resuming.
-
-        ``completed`` is the dependency-closed set of phases that succeeded and whose every
-        transitive dependency also succeeded. ``frontier`` is the phases that will run first
-        on resume (not completed, but all their dependencies are).
-
-        The single-pass closure relies on ``config.flow`` being topologically sorted.
-        """
-        if not self._resume:
-            return set(), set()
-
-        try:
-            succeeded = checkpoint_manager.successful_phases()
-        except CheckpointReadError as e:
-            raise FlowConfigError(
-                f"Cannot resume: checkpoints file is unreadable ({e}). Delete it and restart from scratch."
-            ) from e
-        completed: set[str] = set()
-        frontier: set[str] = set()
-        for entry in config.flow:
-            deps_done = all(dep in completed for dep in entry.dependencies)
-            if entry.phase in succeeded and deps_done:
-                completed.add(entry.phase)
-            elif deps_done:
-                frontier.add(entry.phase)
-        return completed, frontier
 
     async def on_message_received(self, message: BaseMessage) -> None:
         """Stop the entire pipeline immediately when any phase fails."""

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -158,10 +158,11 @@ class PhaseOrchestrator(EventBusOrchestrator):
     ) -> tuple[set[str], set[str]]:
         """Compute (completed, frontier) for a resumed run; both empty when not resuming.
 
-        ``completed`` is the dependency-closed set of phases that succeeded *and* whose every
+        ``completed`` is the dependency-closed set of phases that succeeded and whose every
         transitive dependency also succeeded. ``frontier`` is the phases that will run first
-        on resume (not completed, but all their dependencies are): the ones that may be sitting
-        on partial work from the interrupted run.
+        on resume (not completed, but all their dependencies are).
+
+        The single-pass closure relies on ``config.flow`` being topologically sorted.
         """
         if not self._resume:
             return set(), set()

--- a/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
+++ b/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
@@ -22,7 +22,13 @@ from ddev.ai.flows.openmetrics.phases.inspect_endpoint import (
 from ddev.ai.phases.base import FlowContext
 from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError, PhaseConfig, TaskConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import (
+    CheckpointManager,
+    CheckpointStatus,
+    CheckpointTokenInfo,
+    FailedCheckpoint,
+    SuccessCheckpoint,
+)
 from ddev.event_bus.exceptions import MessageProcessingError
 
 ENDPOINT_URL = "http://example.test:9100/metrics"
@@ -179,13 +185,14 @@ async def test_success_with_prometheus_body(flow_dir, message_queue, monkeypatch
     assert "HTTP status:** 200" in memory
 
     checkpoint = mgr.read()[PHASE_ID]
-    assert checkpoint["status"] == "success"
-    assert checkpoint["exposition_format"] == "prometheus"
-    assert checkpoint["metric_count"] == len(expected_families)
-    assert "sample_metric_names" not in checkpoint
-    assert checkpoint["status_code"] == 200
-    assert checkpoint["endpoint_url"] == ENDPOINT_URL
-    assert checkpoint["tokens"] == {"total_input": 0, "total_output": 0}
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    assert checkpoint.status == CheckpointStatus.SUCCESS
+    assert checkpoint.phase_data["exposition_format"] == "prometheus"
+    assert checkpoint.phase_data["metric_count"] == len(expected_families)
+    assert "sample_metric_names" not in checkpoint.phase_data
+    assert checkpoint.phase_data["status_code"] == 200
+    assert checkpoint.phase_data["endpoint_url"] == ENDPOINT_URL
+    assert checkpoint.tokens == CheckpointTokenInfo(total_input=0, total_output=0)
 
 
 async def test_success_with_openmetrics_body(flow_dir, message_queue, monkeypatch):
@@ -196,10 +203,11 @@ async def test_success_with_openmetrics_body(flow_dir, message_queue, monkeypatc
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     checkpoint = mgr.read()[PHASE_ID]
-    assert checkpoint["status"] == "success"
-    assert checkpoint["exposition_format"] == "openmetrics"
-    assert checkpoint["content_type"] == content_type
-    assert checkpoint["metric_count"] >= 1
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    assert checkpoint.status == CheckpointStatus.SUCCESS
+    assert checkpoint.phase_data["exposition_format"] == "openmetrics"
+    assert checkpoint.phase_data["content_type"] == content_type
+    assert checkpoint.phase_data["metric_count"] >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -216,8 +224,9 @@ async def _assert_phase_fails(phase, mgr, message_queue, *, error_contains: str)
         wrapped = MessageProcessingError(phase._phase_id, trigger, raised)
         await phase.on_error(wrapped)
         checkpoint = mgr.read()[phase._phase_id]
-        assert checkpoint["status"] == "failed"
-        assert error_contains.lower() in checkpoint["error"].lower()
+        assert isinstance(checkpoint, FailedCheckpoint)
+        assert checkpoint.status == CheckpointStatus.FAILED
+        assert error_contains.lower() in checkpoint.error.lower()
         msg = message_queue.get_nowait()
         assert isinstance(msg, PhaseFailedMessage)
         assert error_contains.lower() in msg.error.lower()
@@ -289,7 +298,8 @@ async def test_failure_missing_endpoint_url(flow_dir, message_queue):
     await phase.on_error(wrapped)
 
     checkpoint = mgr.read()[PHASE_ID]
-    assert checkpoint["status"] == "failed"
+    assert isinstance(checkpoint, FailedCheckpoint)
+    assert checkpoint.status == CheckpointStatus.FAILED
     msg = message_queue.get_nowait()
     assert isinstance(msg, PhaseFailedMessage)
 
@@ -391,7 +401,8 @@ async def test_jsonl_path_in_checkpoint(flow_dir, message_queue, monkeypatch):
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     checkpoint = mgr.read()[PHASE_ID]
-    path_str = checkpoint["metrics_jsonl_path"]
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    path_str = checkpoint.phase_data["metrics_jsonl_path"]
     assert isinstance(path_str, str)
     assert os.path.isabs(path_str)
     assert os.path.exists(path_str)
@@ -404,9 +415,10 @@ async def test_jsonl_one_row_per_family(flow_dir, message_queue, monkeypatch):
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     checkpoint = mgr.read()[PHASE_ID]
+    assert isinstance(checkpoint, SuccessCheckpoint)
     rows = _read_jsonl(flow_dir / f"{PHASE_ID}_metrics.jsonl")
     expected_families = list(parse_prometheus(PROMETHEUS_BODY))
-    assert len(rows) == checkpoint["metric_count"] == len(expected_families)
+    assert len(rows) == checkpoint.phase_data["metric_count"] == len(expected_families)
 
 
 async def test_jsonl_row_schema(flow_dir, message_queue, monkeypatch):
@@ -564,8 +576,9 @@ async def test_memory_text_includes_jsonl_path(flow_dir, message_queue, monkeypa
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     checkpoint = mgr.read()[PHASE_ID]
+    assert isinstance(checkpoint, SuccessCheckpoint)
     memory = mgr.memory_content(PHASE_ID)
-    assert checkpoint["metrics_jsonl_path"] in memory
+    assert checkpoint.phase_data["metrics_jsonl_path"] in memory
 
 
 async def test_jsonl_sidecar_atomic_on_os_replace_failure(flow_dir, message_queue, monkeypatch):
@@ -605,7 +618,9 @@ async def test_exposition_path_in_checkpoint(flow_dir, message_queue, monkeypatc
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    path_str = mgr.read()[PHASE_ID]["exposition_path"]
+    checkpoint = mgr.read()[PHASE_ID]
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    path_str = checkpoint.phase_data["exposition_path"]
     assert isinstance(path_str, str)
     assert os.path.isabs(path_str)
     assert os.path.exists(path_str)
@@ -627,7 +642,9 @@ async def test_memory_text_includes_exposition_path(flow_dir, message_queue, mon
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    assert mgr.read()[PHASE_ID]["exposition_path"] in mgr.memory_content(PHASE_ID)
+    checkpoint = mgr.read()[PHASE_ID]
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    assert checkpoint.phase_data["exposition_path"] in mgr.memory_content(PHASE_ID)
 
 
 async def test_exposition_failure_propagates_as_phase_failure(flow_dir, message_queue, monkeypatch):

--- a/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
+++ b/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
@@ -24,7 +24,6 @@ from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
-    CheckpointStatus,
     CheckpointTokenInfo,
     FailedCheckpoint,
     SuccessCheckpoint,
@@ -186,7 +185,6 @@ async def test_success_with_prometheus_body(flow_dir, message_queue, monkeypatch
 
     checkpoint = mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
-    assert checkpoint.status == CheckpointStatus.SUCCESS
     assert checkpoint.phase_data["exposition_format"] == "prometheus"
     assert checkpoint.phase_data["metric_count"] == len(expected_families)
     assert "sample_metric_names" not in checkpoint.phase_data
@@ -204,7 +202,6 @@ async def test_success_with_openmetrics_body(flow_dir, message_queue, monkeypatc
 
     checkpoint = mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
-    assert checkpoint.status == CheckpointStatus.SUCCESS
     assert checkpoint.phase_data["exposition_format"] == "openmetrics"
     assert checkpoint.phase_data["content_type"] == content_type
     assert checkpoint.phase_data["metric_count"] >= 1
@@ -225,7 +222,6 @@ async def _assert_phase_fails(phase, mgr, message_queue, *, error_contains: str)
         await phase.on_error(wrapped)
         checkpoint = mgr.read()[phase._phase_id]
         assert isinstance(checkpoint, FailedCheckpoint)
-        assert checkpoint.status == CheckpointStatus.FAILED
         assert error_contains.lower() in checkpoint.error.lower()
         msg = message_queue.get_nowait()
         assert isinstance(msg, PhaseFailedMessage)
@@ -299,7 +295,6 @@ async def test_failure_missing_endpoint_url(flow_dir, message_queue):
 
     checkpoint = mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, FailedCheckpoint)
-    assert checkpoint.status == CheckpointStatus.FAILED
     msg = message_queue.get_nowait()
     assert isinstance(msg, PhaseFailedMessage)
 

--- a/ddev/tests/ai/phases/conftest.py
+++ b/ddev/tests/ai/phases/conftest.py
@@ -149,6 +149,7 @@ def make_agent_phase(
     captured_worker_kwargs: dict[str, Any] | None = None,
     goal_runtime_builder: Callable[[str], AgentRuntime] | None = None,
     agent_config: AgentConfig | None = None,
+    resume_frontier: frozenset[str] = frozenset(),
 ) -> tuple[AgenticPhase, CheckpointManager]:
     """Build an AgenticPhase ready for process_message-driven tests.
 
@@ -172,6 +173,7 @@ def make_agent_phase(
         flow_variables=flow_variables or {},
         config_dir=flow_dir,
         callbacks=effective_callbacks,
+        resume_frontier=resume_frontier,
     )
 
     process_factory = MockProcessFactory(

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -18,7 +18,6 @@ from ddev.ai.react.process import ReActProcess
 from ddev.ai.runtime.agent_log import AgentLogger
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
-    CheckpointStatus,
     CheckpointTokenInfo,
     FailedCheckpoint,
     GoalValidationRecord,
@@ -133,7 +132,6 @@ async def test_happy_path_single_task(flow_dir, monkeypatch, message_queue):
     assert mgr.memory_content("p1") == "summary"
     checkpoint = mgr.read()["p1"]
     assert isinstance(checkpoint, SuccessCheckpoint)
-    assert checkpoint.status == CheckpointStatus.SUCCESS
     assert checkpoint.tokens == CheckpointTokenInfo(total_input=110, total_output=55)
     assert mock_agent.send_calls[0] == "Do the work."
     assert "Write a brief summary" in mock_agent.send_calls[1]
@@ -492,7 +490,6 @@ async def test_phase_with_goal_passes_first_attempt(flow_dir, monkeypatch, messa
 
     cp = mgr.read()["p1"]
     assert isinstance(cp, SuccessCheckpoint)
-    assert cp.status == CheckpointStatus.SUCCESS
     assert cp.goal_validations == [GoalValidationRecord(task="t1", attempts=1, final_valid=True)]
     assert worker.send_calls[0].startswith("Do it.")
     assert "independent reviewer" in worker.send_calls[0]
@@ -655,7 +652,6 @@ async def test_on_error_writes_tokens_and_goal_validations_to_checkpoint(flow_di
 
     cp = mgr.read()["p1"]
     assert isinstance(cp, FailedCheckpoint)
-    assert cp.status == CheckpointStatus.FAILED
     assert cp.tokens == CheckpointTokenInfo(total_input=42, total_output=17)
     assert cp.goal_validations == [GoalValidationRecord(task="t1", attempts=2, final_valid=False)]
     assert cp.error == "something went wrong"
@@ -784,7 +780,7 @@ async def test_clear_context_before_on_first_task_is_harmless(flow_dir, monkeypa
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    assert mgr.read()["p1"].status == CheckpointStatus.SUCCESS
+    assert isinstance(mgr.read()["p1"], SuccessCheckpoint)
     assert mock_agent.reset_call_count == 1
 
 
@@ -807,7 +803,6 @@ async def test_compact_context_before_on_first_task_is_noop(flow_dir, monkeypatc
 
     cp = mgr.read()["p1"]
     assert isinstance(cp, SuccessCheckpoint)
-    assert cp.status == CheckpointStatus.SUCCESS
     assert cp.tokens == CheckpointTokenInfo(total_input=110, total_output=55)
     assert mock_agent.compact_call_count == 1
 

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -16,7 +16,14 @@ from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.runtime.agent_log import AgentLogger
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import (
+    CheckpointManager,
+    CheckpointStatus,
+    CheckpointTokenInfo,
+    FailedCheckpoint,
+    GoalValidationRecord,
+    SuccessCheckpoint,
+)
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.registry import ToolRegistry
 
@@ -125,12 +132,13 @@ async def test_happy_path_single_task(flow_dir, monkeypatch, message_queue):
 
     assert mgr.memory_content("p1") == "summary"
     checkpoint = mgr.read()["p1"]
-    assert checkpoint["status"] == "success"
-    assert checkpoint["tokens"] == {"total_input": 110, "total_output": 55}
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    assert checkpoint.status == CheckpointStatus.SUCCESS
+    assert checkpoint.tokens == CheckpointTokenInfo(total_input=110, total_output=55)
     assert mock_agent.send_calls[0] == "Do the work."
     assert "Write a brief summary" in mock_agent.send_calls[1]
     # checkpoint memory_path points to the written file
-    memory_path = Path(checkpoint["memory_path"])
+    memory_path = Path(checkpoint.memory_path)
     assert memory_path.is_absolute() and memory_path.exists() and memory_path.name == "p1_memory.md"
 
 
@@ -152,7 +160,9 @@ async def test_happy_path_two_tasks_accumulates_tokens(flow_dir, monkeypatch, me
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    assert mgr.read()["p1"]["tokens"] == {"total_input": 310, "total_output": 135}
+    checkpoint = mgr.read()["p1"]
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    assert checkpoint.tokens == CheckpointTokenInfo(total_input=310, total_output=135)
 
 
 # ---------------------------------------------------------------------------
@@ -481,11 +491,12 @@ async def test_phase_with_goal_passes_first_attempt(flow_dir, monkeypatch, messa
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     cp = mgr.read()["p1"]
-    assert cp["status"] == "success"
-    assert cp["goal_validations"] == [{"task": "t1", "attempts": 1, "final_valid": True}]
+    assert isinstance(cp, SuccessCheckpoint)
+    assert cp.status == CheckpointStatus.SUCCESS
+    assert cp.goal_validations == [GoalValidationRecord(task="t1", attempts=1, final_valid=True)]
     assert worker.send_calls[0].startswith("Do it.")
     assert "independent reviewer" in worker.send_calls[0]
-    assert cp["tokens"] == {"total_input": 100 + 7 + 10, "total_output": 50 + 3 + 5}
+    assert cp.tokens == CheckpointTokenInfo(total_input=100 + 7 + 10, total_output=50 + 3 + 5)
     assert captured_builder_calls == ["p1.goal.t1"]
 
     log_file = mgr.root / "goal_reviewer" / "p1.goal.t1.jsonl"
@@ -526,7 +537,7 @@ async def test_phase_with_goal_exhausts_attempts_fails_phase(flow_dir, monkeypat
         await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     assert mgr.read() == {}
-    assert phase._goal_attempt_log == [{"task": "t1", "attempts": 2, "final_valid": False}]
+    assert phase._goal_attempt_log == [GoalValidationRecord(task="t1", attempts=2, final_valid=False)]
 
     # The reviewer ran (and succeeded as an agent) on each attempt; its per-run
     # log exists. The goal-loop verdict itself lives in the phase checkpoint.
@@ -579,8 +590,8 @@ async def test_phase_goal_partial_progress_preserved_on_exhaustion(flow_dir, mon
         await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     assert phase._goal_attempt_log == [
-        {"task": "t1", "attempts": 1, "final_valid": True},
-        {"task": "t2", "attempts": 2, "final_valid": False},
+        GoalValidationRecord(task="t1", attempts=1, final_valid=True),
+        GoalValidationRecord(task="t2", attempts=2, final_valid=False),
     ]
 
 
@@ -632,7 +643,7 @@ async def test_on_error_writes_tokens_and_goal_validations_to_checkpoint(flow_di
 
     phase._total_input_tokens = 42
     phase._total_output_tokens = 17
-    phase._goal_attempt_log = [{"task": "t1", "attempts": 2, "final_valid": False}]
+    phase._goal_attempt_log = [GoalValidationRecord(task="t1", attempts=2, final_valid=False)]
     phase._started_at = None
 
     err = MessageProcessingError(
@@ -643,10 +654,11 @@ async def test_on_error_writes_tokens_and_goal_validations_to_checkpoint(flow_di
     await phase.on_error(err)
 
     cp = mgr.read()["p1"]
-    assert cp["status"] == "failed"
-    assert cp["tokens"] == {"total_input": 42, "total_output": 17}
-    assert cp["goal_validations"] == [{"task": "t1", "attempts": 2, "final_valid": False}]
-    assert cp["error"] == "something went wrong"
+    assert isinstance(cp, FailedCheckpoint)
+    assert cp.status == CheckpointStatus.FAILED
+    assert cp.tokens == CheckpointTokenInfo(total_input=42, total_output=17)
+    assert cp.goal_validations == [GoalValidationRecord(task="t1", attempts=2, final_valid=False)]
+    assert cp.error == "something went wrong"
 
 
 # ---------------------------------------------------------------------------
@@ -772,7 +784,7 @@ async def test_clear_context_before_on_first_task_is_harmless(flow_dir, monkeypa
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    assert mgr.read()["p1"]["status"] == "success"
+    assert mgr.read()["p1"].status == CheckpointStatus.SUCCESS
     assert mock_agent.reset_call_count == 1
 
 
@@ -793,8 +805,10 @@ async def test_compact_context_before_on_first_task_is_noop(flow_dir, monkeypatc
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    assert mgr.read()["p1"]["status"] == "success"
-    assert mgr.read()["p1"]["tokens"] == {"total_input": 110, "total_output": 55}
+    cp = mgr.read()["p1"]
+    assert isinstance(cp, SuccessCheckpoint)
+    assert cp.status == CheckpointStatus.SUCCESS
+    assert cp.tokens == CheckpointTokenInfo(total_input=110, total_output=55)
     assert mock_agent.compact_call_count == 1
 
 
@@ -849,7 +863,7 @@ async def test_goal_parse_error_logged_and_tokens_captured(flow_dir, monkeypatch
     with pytest.raises(GoalParseError):
         await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    assert phase._goal_attempt_log == [{"task": "t1", "attempts": 1, "final_valid": False}]
+    assert phase._goal_attempt_log == [GoalValidationRecord(task="t1", attempts=1, final_valid=False)]
     assert phase._total_input_tokens == 10 + 8 + 6
     assert phase._total_output_tokens == 5 + 4 + 3
 
@@ -871,7 +885,16 @@ async def test_resume_frontier_phase_injects_notice_with_error(flow_dir, monkeyp
         resume_frontier=frozenset({"p1"}),
         captured_worker_kwargs=captured,
     )
-    mgr.write_phase_checkpoint("p1", {"status": "failed", "error": "Error code: 500 - boom"})
+    mgr.write_phase_checkpoint(
+        "p1",
+        FailedCheckpoint(
+            status=CheckpointStatus.FAILED,
+            started_at=None,
+            finished_at="2026-01-01T00:00:00+00:00",
+            error="Error code: 500 - boom",
+            tokens=CheckpointTokenInfo(total_input=0, total_output=0),
+        ),
+    )
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -910,7 +933,16 @@ async def test_non_frontier_phase_gets_no_resume_notice(flow_dir, monkeypatch, m
         resume_frontier=frozenset(),
         captured_worker_kwargs=captured,
     )
-    mgr.write_phase_checkpoint("p1", {"status": "failed", "error": "stale"})
+    mgr.write_phase_checkpoint(
+        "p1",
+        FailedCheckpoint(
+            status=CheckpointStatus.FAILED,
+            started_at=None,
+            finished_at="2026-01-01T00:00:00+00:00",
+            error="stale",
+            tokens=CheckpointTokenInfo(total_input=0, total_output=0),
+        ),
+    )
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -852,3 +852,67 @@ async def test_goal_parse_error_logged_and_tokens_captured(flow_dir, monkeypatch
     assert phase._goal_attempt_log == [{"task": "t1", "attempts": 1, "final_valid": False}]
     assert phase._total_input_tokens == 10 + 8 + 6
     assert phase._total_output_tokens == 5 + 4 + 3
+
+
+# ---------------------------------------------------------------------------
+# process_message — resumed-run system-prompt injection
+# ---------------------------------------------------------------------------
+
+
+async def test_resume_frontier_phase_injects_notice_with_error(flow_dir, monkeypatch, message_queue):
+    """A frontier phase with a prior failed checkpoint gets the resume notice plus the error."""
+    mock_agent = MockAgent([make_response("done", 100, 50), make_response("summary", 10, 5)])
+    captured: dict = {}
+    phase, mgr = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        resume_frontier=frozenset({"p1"}),
+        captured_worker_kwargs=captured,
+    )
+    mgr.write_phase_checkpoint("p1", {"status": "failed", "error": "Error code: 500 - boom"})
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert "RESUMED RUN" in captured["system_prompt"]
+    assert "Error code: 500 - boom" in captured["system_prompt"]
+
+
+async def test_resume_frontier_phase_injects_notice_without_error(flow_dir, monkeypatch, message_queue):
+    """A frontier phase with no prior checkpoint (e.g. Ctrl+C) gets the notice but no error line."""
+    mock_agent = MockAgent([make_response("done", 100, 50), make_response("summary", 10, 5)])
+    captured: dict = {}
+    phase, _ = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        resume_frontier=frozenset({"p1"}),
+        captured_worker_kwargs=captured,
+    )
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert "RESUMED RUN" in captured["system_prompt"]
+    assert "previous attempt recorded this error" not in captured["system_prompt"]
+
+
+async def test_non_frontier_phase_gets_no_resume_notice(flow_dir, monkeypatch, message_queue):
+    """A phase outside the frontier never gets the notice, even with a stale failed checkpoint."""
+    mock_agent = MockAgent([make_response("done", 100, 50), make_response("summary", 10, 5)])
+    captured: dict = {}
+    phase, mgr = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        resume_frontier=frozenset(),
+        captured_worker_kwargs=captured,
+    )
+    mgr.write_phase_checkpoint("p1", {"status": "failed", "error": "stale"})
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert "RESUMED RUN" not in captured["system_prompt"]
+    assert "stale" not in captured["system_prompt"]

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -888,7 +888,6 @@ async def test_resume_frontier_phase_injects_notice_with_error(flow_dir, monkeyp
     mgr.write_phase_checkpoint(
         "p1",
         FailedCheckpoint(
-            status=CheckpointStatus.FAILED,
             started_at=None,
             finished_at="2026-01-01T00:00:00+00:00",
             error="Error code: 500 - boom",
@@ -936,7 +935,6 @@ async def test_non_frontier_phase_gets_no_resume_notice(flow_dir, monkeypatch, m
     mgr.write_phase_checkpoint(
         "p1",
         FailedCheckpoint(
-            status=CheckpointStatus.FAILED,
             started_at=None,
             finished_at="2026-01-01T00:00:00+00:00",
             error="stale",

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -9,7 +9,6 @@ from ddev.ai.phases.config import PhaseConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
-    CheckpointStatus,
     CheckpointTokenInfo,
     FailedCheckpoint,
     GoalValidationRecord,
@@ -115,7 +114,6 @@ async def test_on_error_writes_failed_checkpoint(flow_context, message_queue):
 
     checkpoint = mgr.read()["p1"]
     assert isinstance(checkpoint, FailedCheckpoint)
-    assert checkpoint.status == CheckpointStatus.FAILED
     assert checkpoint.error == "boom"
     assert checkpoint.started_at is None  # not started yet
 
@@ -143,7 +141,6 @@ async def test_on_error_writes_failed_checkpoint_after_start(flow_context, messa
 
     checkpoint = mgr.read()["p1"]
     assert isinstance(checkpoint, FailedCheckpoint)
-    assert checkpoint.status == CheckpointStatus.FAILED
     assert checkpoint.started_at is not None
 
 
@@ -232,7 +229,6 @@ async def test_process_message_writes_memory_and_checkpoint(flow_context, messag
 
     checkpoint = mgr.read()["p1"]
     assert isinstance(checkpoint, SuccessCheckpoint)
-    assert checkpoint.status == CheckpointStatus.SUCCESS
     assert checkpoint.tokens == CheckpointTokenInfo(total_input=123, total_output=45)
     assert checkpoint.memory_path == str(mgr.memory_path("p1"))
     assert checkpoint.phase_data == {"custom_field": "custom_value", "count": 7}

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -4,12 +4,17 @@
 
 from datetime import UTC, datetime
 
-import pytest
-
 from ddev.ai.phases.base import FlowContext, Phase, PhaseOutcome
 from ddev.ai.phases.config import PhaseConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import (
+    CheckpointManager,
+    CheckpointStatus,
+    CheckpointTokenInfo,
+    FailedCheckpoint,
+    GoalValidationRecord,
+    SuccessCheckpoint,
+)
 from ddev.event_bus.exceptions import HookName, MessageProcessingError, ProcessorHookError
 
 
@@ -109,9 +114,10 @@ async def test_on_error_writes_failed_checkpoint(flow_context, message_queue):
     await phase.on_error(wrapped)
 
     checkpoint = mgr.read()["p1"]
-    assert checkpoint["status"] == "failed"
-    assert checkpoint["error"] == "boom"
-    assert checkpoint["started_at"] is None  # not started yet
+    assert isinstance(checkpoint, FailedCheckpoint)
+    assert checkpoint.status == CheckpointStatus.FAILED
+    assert checkpoint.error == "boom"
+    assert checkpoint.started_at is None  # not started yet
 
 
 async def test_on_error_emits_failed_message(flow_context, message_queue):
@@ -136,8 +142,9 @@ async def test_on_error_writes_failed_checkpoint_after_start(flow_context, messa
     await phase.on_error(wrapped)
 
     checkpoint = mgr.read()["p1"]
-    assert checkpoint["status"] == "failed"
-    assert checkpoint["started_at"] is not None
+    assert isinstance(checkpoint, FailedCheckpoint)
+    assert checkpoint.status == CheckpointStatus.FAILED
+    assert checkpoint.started_at is not None
 
 
 # ---------------------------------------------------------------------------
@@ -207,14 +214,15 @@ def test_should_process_returns_false_after_already_executed(flow_context, messa
 
 
 async def test_process_message_writes_memory_and_checkpoint(flow_context, message_queue):
-    """End-to-end Phase contract: memory_text is persisted, extra_checkpoint merges,
+    """End-to-end Phase contract: memory_text is persisted, phase_data is recorded,
     token totals land in the checkpoint, and the success metadata is recorded.
     """
     outcome = PhaseOutcome(
         memory_text="stub-memory-body",
         total_input_tokens=123,
         total_output_tokens=45,
-        extra_checkpoint={"custom_field": "custom_value", "count": 7},
+        goal_validations=[GoalValidationRecord(task="t1", attempts=1, final_valid=True)],
+        checkpoint_data={"custom_field": "custom_value", "count": 7},
     )
     phase, mgr = _make_stub_phase(flow_context, message_queue, outcome=outcome)
 
@@ -223,35 +231,11 @@ async def test_process_message_writes_memory_and_checkpoint(flow_context, messag
     assert mgr.memory_content("p1") == "stub-memory-body"
 
     checkpoint = mgr.read()["p1"]
-    assert checkpoint["status"] == "success"
-    assert checkpoint["tokens"] == {"total_input": 123, "total_output": 45}
-    assert checkpoint["memory_path"] == str(mgr.memory_path("p1"))
-    assert checkpoint["custom_field"] == "custom_value"
-    assert checkpoint["count"] == 7
-    assert checkpoint["started_at"]
-    assert checkpoint["finished_at"]
-
-
-@pytest.mark.parametrize(
-    "reserved_key",
-    ["status", "started_at", "finished_at", "tokens", "memory_path"],
-)
-async def test_extra_checkpoint_cannot_override_reserved_keys(flow_context, message_queue, reserved_key):
-    outcome = PhaseOutcome(memory_text="m", extra_checkpoint={reserved_key: "evil"})
-    phase, mgr = _make_stub_phase(flow_context, message_queue, outcome=outcome)
-
-    with pytest.raises(ValueError, match=f"reserved keys.*{reserved_key}"):
-        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
-
-    assert mgr.read() == {}
-    assert not mgr.memory_path("p1").exists()
-
-
-async def test_failed_phase_omits_memory_path(flow_context, message_queue):
-    phase, mgr = _make_stub_phase(flow_context, message_queue)
-
-    wrapped = MessageProcessingError("p1", PhaseTrigger(id="start", phase_id=None), RuntimeError("boom"))
-    await phase.on_error(wrapped)
-
-    checkpoint = mgr.read()["p1"]
-    assert "memory_path" not in checkpoint
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    assert checkpoint.status == CheckpointStatus.SUCCESS
+    assert checkpoint.tokens == CheckpointTokenInfo(total_input=123, total_output=45)
+    assert checkpoint.memory_path == str(mgr.memory_path("p1"))
+    assert checkpoint.phase_data == {"custom_field": "custom_value", "count": 7}
+    assert checkpoint.goal_validations == [GoalValidationRecord(task="t1", attempts=1, final_valid=True)]
+    assert checkpoint.started_at
+    assert checkpoint.finished_at

--- a/ddev/tests/ai/phases/test_config.py
+++ b/ddev/tests/ai/phases/test_config.py
@@ -430,6 +430,31 @@ def test_flow_config_acyclic_chain_ok():
     assert len(config.flow) == 3
 
 
+def test_flow_config_sorts_dependencies_before_dependents():
+    """A dependent declared before its dependency is reordered so deps come first."""
+    raw = _three_phase_config()
+    raw["flow"] = [
+        {"phase": "p3", "dependencies": ["p2"]},
+        {"phase": "p2", "dependencies": ["p1"]},
+        {"phase": "p1"},
+    ]
+    config = FlowConfig.model_validate(raw)
+    assert [entry.phase for entry in config.flow] == ["p1", "p2", "p3"]
+
+
+def test_flow_config_topological_sort_is_stable():
+    """Independent phases keep their original declaration order; deps still come first."""
+    raw = _three_phase_config()
+    raw["flow"] = [
+        {"phase": "p2", "dependencies": ["p1"]},
+        {"phase": "p3"},
+        {"phase": "p1"},
+    ]
+    config = FlowConfig.model_validate(raw)
+    # p1 must precede p2; p3 has no constraints so it stays as early as its declaration allows.
+    assert [entry.phase for entry in config.flow] == ["p3", "p1", "p2"]
+
+
 def test_flow_disjoined_graphs_ok():
     agent = {"tools": []}
     task = {"name": "t", "prompt": "Do it."}

--- a/ddev/tests/ai/runtime/helpers.py
+++ b/ddev/tests/ai/runtime/helpers.py
@@ -1,0 +1,40 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from typing import Any
+
+from ddev.ai.runtime.checkpoints import (
+    CheckpointAdapter,
+    CheckpointStatus,
+    CheckpointTokenInfo,
+    FailedCheckpoint,
+    PhaseCheckpoint,
+    SuccessCheckpoint,
+)
+
+STARTED = "2026-01-01T00:00:00+00:00"
+FINISHED = "2026-01-01T00:01:00+00:00"
+DEFAULT_TOKENS = CheckpointTokenInfo(total_input=10, total_output=20)
+
+
+def make_checkpoint(status: CheckpointStatus, data: dict[str, Any] | None = None) -> PhaseCheckpoint:
+    """Build a checkpoint of the given status, validated through the discriminated union adapter."""
+    payload = {
+        "started_at": STARTED,
+        "finished_at": FINISHED,
+        "tokens": DEFAULT_TOKENS,
+        "memory_path": "/tmp/phase_memory.md",
+        "error": "something broke",
+        **(data or {}),
+        "status": status,
+    }
+    return CheckpointAdapter.validate_python(payload)
+
+
+def make_success_checkpoint(**kwargs: Any) -> SuccessCheckpoint:
+    return make_checkpoint(CheckpointStatus.SUCCESS, kwargs)
+
+
+def make_failed_checkpoint(**kwargs: Any) -> FailedCheckpoint:
+    return make_checkpoint(CheckpointStatus.FAILED, kwargs)

--- a/ddev/tests/ai/runtime/test_checkpoints.py
+++ b/ddev/tests/ai/runtime/test_checkpoints.py
@@ -10,7 +10,7 @@ import yaml
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
     CheckpointReadError,
-    CheckpointStatus,
+    FailedCheckpoint,
     SuccessCheckpoint,
 )
 
@@ -53,7 +53,6 @@ def test_read_returns_validated_checkpoint(manager: CheckpointManager):
     manager.write_phase_checkpoint("phase1", make_success_checkpoint())
     data = manager.read()
     assert isinstance(data["phase1"], SuccessCheckpoint)
-    assert data["phase1"].status == CheckpointStatus.SUCCESS
 
 
 # ---------------------------------------------------------------------------
@@ -64,7 +63,7 @@ def test_read_returns_validated_checkpoint(manager: CheckpointManager):
 def test_write_and_read_back(manager: CheckpointManager):
     manager.write_phase_checkpoint("phase1", make_success_checkpoint())
     data = manager.read()
-    assert data["phase1"].status == CheckpointStatus.SUCCESS
+    assert isinstance(data["phase1"], SuccessCheckpoint)
     assert data["phase1"].tokens.total_input == 10
     assert data["phase1"].tokens.total_output == 20
 
@@ -81,21 +80,21 @@ def test_write_preserves_phase_data(manager: CheckpointManager):
 def test_write_creates_parent_dirs(tmp_path: Path):
     manager = CheckpointManager(tmp_path / "nested" / "dir" / "checkpoints.yaml")
     manager.write_phase_checkpoint("p", make_success_checkpoint())
-    assert manager.read()["p"].status == CheckpointStatus.SUCCESS
+    assert isinstance(manager.read()["p"], SuccessCheckpoint)
 
 
 def test_write_multiple_phases(manager: CheckpointManager):
     manager.write_phase_checkpoint("phase1", make_success_checkpoint())
     manager.write_phase_checkpoint("phase2", make_failed_checkpoint())
     data = manager.read()
-    assert data["phase1"].status == CheckpointStatus.SUCCESS
-    assert data["phase2"].status == CheckpointStatus.FAILED
+    assert isinstance(data["phase1"], SuccessCheckpoint)
+    assert isinstance(data["phase2"], FailedCheckpoint)
 
 
 def test_write_overwrites_existing_phase(manager: CheckpointManager):
     manager.write_phase_checkpoint("phase1", make_failed_checkpoint())
     manager.write_phase_checkpoint("phase1", make_success_checkpoint())
-    assert manager.read()["phase1"].status == CheckpointStatus.SUCCESS
+    assert isinstance(manager.read()["phase1"], SuccessCheckpoint)
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/runtime/test_checkpoints.py
+++ b/ddev/tests/ai/runtime/test_checkpoints.py
@@ -141,3 +141,24 @@ def test_resolve_template_variable_memory_suffix(manager):
 
 def test_resolve_template_variable_non_memory_key(manager):
     assert manager.resolve_template_variable("some_variable") == "<VARIABLE UNDEFINED: some_variable>"
+
+
+# ---------------------------------------------------------------------------
+# successful_phases
+# ---------------------------------------------------------------------------
+
+
+def test_successful_phases_empty_when_no_file(manager):
+    assert manager.successful_phases() == set()
+
+
+def test_successful_phases_returns_only_succeeded(manager):
+    manager.write_phase_checkpoint("a", {"status": "success"})
+    manager.write_phase_checkpoint("b", {"status": "failed", "error": "boom"})
+    manager.write_phase_checkpoint("c", {"status": "success"})
+    assert manager.successful_phases() == {"a", "c"}
+
+
+def test_successful_phases_ignores_malformed_entries(manager):
+    manager._path.write_text("a:\n  status: success\nb: not-a-dict\n")
+    assert manager.successful_phases() == {"a"}

--- a/ddev/tests/ai/runtime/test_checkpoints.py
+++ b/ddev/tests/ai/runtime/test_checkpoints.py
@@ -5,12 +5,20 @@
 from pathlib import Path
 
 import pytest
+import yaml
 
-from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointReadError
+from ddev.ai.runtime.checkpoints import (
+    CheckpointManager,
+    CheckpointReadError,
+    CheckpointStatus,
+    SuccessCheckpoint,
+)
+
+from .helpers import make_failed_checkpoint, make_success_checkpoint
 
 
 @pytest.fixture
-def manager(tmp_path) -> CheckpointManager:
+def manager(tmp_path: Path) -> CheckpointManager:
     return CheckpointManager(tmp_path / "checkpoints.yaml")
 
 
@@ -19,26 +27,33 @@ def manager(tmp_path) -> CheckpointManager:
 # ---------------------------------------------------------------------------
 
 
-def test_read_returns_empty_when_file_absent(manager):
+def test_read_returns_empty_when_file_absent(manager: CheckpointManager):
     assert manager.read() == {}
 
 
-def test_read_returns_empty_when_file_is_empty(manager):
+def test_read_returns_empty_when_file_is_empty(manager: CheckpointManager):
     manager._path.write_text("")
     assert manager.read() == {}
 
 
-def test_read_malformed_yaml_raises_checkpoint_read_error(manager):
+def test_read_malformed_yaml_raises_checkpoint_read_error(manager: CheckpointManager):
     manager._path.write_text(": :\n -[")
     with pytest.raises(CheckpointReadError, match="checkpoints.yaml"):
         manager.read()
 
 
-def test_read_unreadable_file_raises_checkpoint_read_error(manager, monkeypatch):
-    manager._path.write_text("phase1:\n  status: success\n")
+def test_read_unreadable_file_raises_checkpoint_read_error(manager: CheckpointManager, monkeypatch: pytest.MonkeyPatch):
+    manager.write_phase_checkpoint("phase1", make_success_checkpoint())
     monkeypatch.setattr("pathlib.Path.read_text", lambda *_, **__: (_ for _ in ()).throw(OSError("permission denied")))
     with pytest.raises(CheckpointReadError, match="checkpoints.yaml"):
         manager.read()
+
+
+def test_read_returns_validated_checkpoint(manager: CheckpointManager):
+    manager.write_phase_checkpoint("phase1", make_success_checkpoint())
+    data = manager.read()
+    assert isinstance(data["phase1"], SuccessCheckpoint)
+    assert data["phase1"].status == CheckpointStatus.SUCCESS
 
 
 # ---------------------------------------------------------------------------
@@ -46,31 +61,41 @@ def test_read_unreadable_file_raises_checkpoint_read_error(manager, monkeypatch)
 # ---------------------------------------------------------------------------
 
 
-def test_write_and_read_back(manager):
-    manager.write_phase_checkpoint("phase1", {"status": "success", "tokens": 100})
+def test_write_and_read_back(manager: CheckpointManager):
+    manager.write_phase_checkpoint("phase1", make_success_checkpoint())
     data = manager.read()
-    assert data["phase1"]["status"] == "success"
-    assert data["phase1"]["tokens"] == 100
+    assert data["phase1"].status == CheckpointStatus.SUCCESS
+    assert data["phase1"].tokens.total_input == 10
+    assert data["phase1"].tokens.total_output == 20
 
 
-def test_write_creates_parent_dirs(tmp_path):
+def test_write_preserves_phase_data(manager: CheckpointManager):
+    manager.write_phase_checkpoint(
+        "phase1", make_success_checkpoint(phase_data={"endpoint_url": "http://localhost:8080"})
+    )
+    data = manager.read()
+    assert isinstance(data["phase1"], SuccessCheckpoint)
+    assert data["phase1"].phase_data["endpoint_url"] == "http://localhost:8080"
+
+
+def test_write_creates_parent_dirs(tmp_path: Path):
     manager = CheckpointManager(tmp_path / "nested" / "dir" / "checkpoints.yaml")
-    manager.write_phase_checkpoint("p", {"status": "success"})
-    assert manager.read()["p"]["status"] == "success"
+    manager.write_phase_checkpoint("p", make_success_checkpoint())
+    assert manager.read()["p"].status == CheckpointStatus.SUCCESS
 
 
-def test_write_multiple_phases(manager):
-    manager.write_phase_checkpoint("phase1", {"status": "success"})
-    manager.write_phase_checkpoint("phase2", {"status": "failed"})
+def test_write_multiple_phases(manager: CheckpointManager):
+    manager.write_phase_checkpoint("phase1", make_success_checkpoint())
+    manager.write_phase_checkpoint("phase2", make_failed_checkpoint())
     data = manager.read()
-    assert data["phase1"]["status"] == "success"
-    assert data["phase2"]["status"] == "failed"
+    assert data["phase1"].status == CheckpointStatus.SUCCESS
+    assert data["phase2"].status == CheckpointStatus.FAILED
 
 
-def test_write_overwrites_existing_phase(manager):
-    manager.write_phase_checkpoint("phase1", {"status": "running"})
-    manager.write_phase_checkpoint("phase1", {"status": "success"})
-    assert manager.read()["phase1"]["status"] == "success"
+def test_write_overwrites_existing_phase(manager: CheckpointManager):
+    manager.write_phase_checkpoint("phase1", make_failed_checkpoint())
+    manager.write_phase_checkpoint("phase1", make_success_checkpoint())
+    assert manager.read()["phase1"].status == CheckpointStatus.SUCCESS
 
 
 # ---------------------------------------------------------------------------
@@ -78,12 +103,12 @@ def test_write_overwrites_existing_phase(manager):
 # ---------------------------------------------------------------------------
 
 
-def test_build_memory_prompt_no_additions(manager):
+def test_build_memory_prompt_no_additions(manager: CheckpointManager):
     result = manager.build_memory_prompt(None)
     assert result == "Write a brief summary of what you accomplished in this phase."
 
 
-def test_build_memory_prompt_with_additions(manager):
+def test_build_memory_prompt_with_additions(manager: CheckpointManager):
     result = manager.build_memory_prompt("Also list the files you created.")
     assert result.startswith("Also list the files you created.")
     assert "Write a brief summary" in result
@@ -94,34 +119,34 @@ def test_build_memory_prompt_with_additions(manager):
 # ---------------------------------------------------------------------------
 
 
-def test_write_memory_and_read_back(manager):
+def test_write_memory_and_read_back(manager: CheckpointManager):
     manager.write_memory("draft", "Created integration.py and tests.")
     assert manager.memory_content("draft") == "Created integration.py and tests."
 
 
-def test_write_memory_overwrites(manager):
+def test_write_memory_overwrites(manager: CheckpointManager):
     manager.write_memory("draft", "first version")
     manager.write_memory("draft", "second version")
     assert manager.memory_content("draft") == "second version"
 
 
-def test_memory_content_absent_returns_placeholder(manager):
+def test_memory_content_absent_returns_placeholder(manager: CheckpointManager):
     assert manager.memory_content("nonexistent") == "<MEMORY NOT FOUND: nonexistent>"
 
 
-def test_memory_path_returns_absolute_path(manager):
+def test_memory_path_returns_absolute_path(manager: CheckpointManager):
     path = manager.memory_path("phase1")
     assert isinstance(path, Path)
     assert path.is_absolute()
     assert path.name == "phase1_memory.md"
 
 
-def test_memory_path_before_write(manager):
+def test_memory_path_before_write(manager: CheckpointManager):
     path = manager.memory_path("phase1")
     assert not path.exists()
 
 
-def test_memory_file_location(manager):
+def test_memory_file_location(manager: CheckpointManager):
     manager.write_memory("phase1", "content")
     expected_path = manager._path.parent / "phase1_memory.md"
     assert expected_path.exists()
@@ -134,12 +159,12 @@ def test_memory_file_location(manager):
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_template_variable_memory_suffix(manager):
+def test_resolve_template_variable_memory_suffix(manager: CheckpointManager):
     manager.write_memory("draft", "Draft memory content.")
     assert manager.resolve_template_variable("draft_memory") == "Draft memory content."
 
 
-def test_resolve_template_variable_non_memory_key(manager):
+def test_resolve_template_variable_non_memory_key(manager: CheckpointManager):
     assert manager.resolve_template_variable("some_variable") == "<VARIABLE UNDEFINED: some_variable>"
 
 
@@ -148,17 +173,21 @@ def test_resolve_template_variable_non_memory_key(manager):
 # ---------------------------------------------------------------------------
 
 
-def test_successful_phases_empty_when_no_file(manager):
+def test_successful_phases_empty_when_no_file(manager: CheckpointManager):
     assert manager.successful_phases() == set()
 
 
-def test_successful_phases_returns_only_succeeded(manager):
-    manager.write_phase_checkpoint("a", {"status": "success"})
-    manager.write_phase_checkpoint("b", {"status": "failed", "error": "boom"})
-    manager.write_phase_checkpoint("c", {"status": "success"})
+def test_successful_phases_returns_only_succeeded(manager: CheckpointManager):
+    manager.write_phase_checkpoint("a", make_success_checkpoint())
+    manager.write_phase_checkpoint("b", make_failed_checkpoint())
+    manager.write_phase_checkpoint("c", make_success_checkpoint())
     assert manager.successful_phases() == {"a", "c"}
 
 
-def test_successful_phases_ignores_malformed_entries(manager):
-    manager._path.write_text("a:\n  status: success\nb: not-a-dict\n")
-    assert manager.successful_phases() == {"a"}
+def test_read_raises_on_invalid_checkpoint_entry(manager: CheckpointManager):
+    manager.write_phase_checkpoint("a", make_success_checkpoint())
+    raw = yaml.safe_load(manager._path.read_text())
+    raw["b"] = "not-a-dict"
+    manager._path.write_text(yaml.dump(raw))
+    with pytest.raises(CheckpointReadError, match="phase 'b'"):
+        manager.read()

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -15,6 +15,7 @@ from ddev.ai.phases.base import Phase
 from ddev.ai.phases.config import FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.resources import ResourceUnavailableError
+from ddev.ai.runtime.checkpoints import CheckpointManager
 from ddev.ai.runtime.orchestrator import PhaseOrchestrator
 from ddev.ai.runtime.resources import RunResources
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
@@ -496,9 +497,9 @@ def linear_flow(tmp_path):
 
 
 def _write_checkpoints(flow_dir: Path, statuses: dict[str, dict]) -> None:
-    import yaml
-
-    (flow_dir / "checkpoints.yaml").write_text(yaml.dump(statuses), encoding="utf-8")
+    manager = CheckpointManager(flow_dir / "checkpoints.yaml")
+    for phase_id, data in statuses.items():
+        manager.write_phase_checkpoint(phase_id, data)
 
 
 def _drain_trigger_phase_ids(orchestrator) -> list:
@@ -527,7 +528,7 @@ async def test_resume_marks_only_frontier_phase(linear_flow, make_orchestrator):
     await orchestrator.on_initialize()
 
     phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
-    assert phases_by_name["c"]._resume_frontier is True
+    assert phases_by_name["c"]._is_resume_frontier is True
 
 
 async def test_resume_emits_triggers_for_completed_phases(linear_flow, make_orchestrator):
@@ -552,9 +553,9 @@ async def test_resume_dependency_closure_reruns_descendants_of_failure(linear_fl
 
     phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
     assert set(phases_by_name) == {"a", "b", "c"}  # nothing skipped
-    assert phases_by_name["a"]._resume_frontier is True
-    assert phases_by_name["b"]._resume_frontier is False
-    assert phases_by_name["c"]._resume_frontier is False
+    assert phases_by_name["a"]._is_resume_frontier is True
+    assert phases_by_name["b"]._is_resume_frontier is False
+    assert phases_by_name["c"]._is_resume_frontier is False
 
 
 async def test_resume_with_no_checkpoints_frontier_is_root(linear_flow, make_orchestrator):
@@ -564,9 +565,9 @@ async def test_resume_with_no_checkpoints_frontier_is_root(linear_flow, make_orc
 
     phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
     assert set(phases_by_name) == {"a", "b", "c"}
-    assert phases_by_name["a"]._resume_frontier is True
-    assert phases_by_name["b"]._resume_frontier is False
-    assert phases_by_name["c"]._resume_frontier is False
+    assert phases_by_name["a"]._is_resume_frontier is True
+    assert phases_by_name["b"]._is_resume_frontier is False
+    assert phases_by_name["c"]._is_resume_frontier is False
 
 
 async def test_no_resume_ignores_checkpoints(linear_flow, make_orchestrator):
@@ -577,6 +578,13 @@ async def test_no_resume_ignores_checkpoints(linear_flow, make_orchestrator):
 
     phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
     assert set(phases_by_name) == {"a", "b", "c"}
-    assert all(p._resume_frontier is False for p in phases_by_name.values())
+    assert all(p._is_resume_frontier is False for p in phases_by_name.values())
     ids = _drain_trigger_phase_ids(orchestrator)
     assert ids == [None]  # only the initial trigger, no resume triggers
+
+
+async def test_resume_corrupt_checkpoints_raises_flow_config_error(linear_flow, make_orchestrator):
+    (linear_flow / "checkpoints.yaml").write_text("{ not: valid: yaml", encoding="utf-8")
+    orchestrator = make_orchestrator(linear_flow, resume=True)
+    with pytest.raises(FlowConfigError, match="Cannot resume"):
+        await orchestrator.on_initialize()

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -15,11 +15,13 @@ from ddev.ai.phases.base import Phase
 from ddev.ai.phases.config import FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.resources import ResourceUnavailableError
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointStatus
 from ddev.ai.runtime.orchestrator import PhaseOrchestrator
 from ddev.ai.runtime.resources import RunResources
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.event_bus.exceptions import FatalProcessingError
+
+from .helpers import make_checkpoint
 
 
 @pytest.fixture
@@ -499,7 +501,7 @@ def linear_flow(tmp_path):
 def _write_checkpoints(flow_dir: Path, statuses: dict[str, dict]) -> None:
     manager = CheckpointManager(flow_dir / "checkpoints.yaml")
     for phase_id, data in statuses.items():
-        manager.write_phase_checkpoint(phase_id, data)
+        manager.write_phase_checkpoint(phase_id, make_checkpoint(CheckpointStatus(data["status"]), data))
 
 
 def _drain_trigger_phase_ids(orchestrator) -> list:

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -451,3 +451,132 @@ def test_run_raises_runtime_error_when_phase_fails(tmp_path, make_orchestrator):
 
     with pytest.raises(FatalProcessingError, match="Phase 'failing' failed"):
         orchestrator.run()
+
+
+# ---------------------------------------------------------------------------
+# PhaseOrchestrator.on_initialize — resume
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def linear_flow(tmp_path):
+    """Three-phase linear flow: a -> b -> c."""
+    (tmp_path / "prompts").mkdir()
+    (tmp_path / "prompts" / "writer.md").write_text("system prompt")
+    (tmp_path / "flow.yaml").write_text(
+        dedent("""\
+        agents:
+          writer:
+            tools: []
+        phases:
+          a:
+            agent: writer
+            tasks:
+              - name: ta
+                prompt: a
+          b:
+            agent: writer
+            tasks:
+              - name: tb
+                prompt: b
+          c:
+            agent: writer
+            tasks:
+              - name: tc
+                prompt: c
+        flow:
+          - phase: a
+          - phase: b
+            dependencies: [a]
+          - phase: c
+            dependencies: [b]
+        """)
+    )
+    return tmp_path
+
+
+def _write_checkpoints(flow_dir: Path, statuses: dict[str, dict]) -> None:
+    import yaml
+
+    (flow_dir / "checkpoints.yaml").write_text(yaml.dump(statuses), encoding="utf-8")
+
+
+def _drain_trigger_phase_ids(orchestrator) -> list:
+    ids = []
+    while not orchestrator._queue.empty():
+        msg = orchestrator._queue.get_nowait()
+        if isinstance(msg, PhaseTrigger):
+            ids.append(msg.phase_id)
+    return ids
+
+
+async def test_resume_skips_completed_phases(linear_flow, make_orchestrator):
+    """With a,b succeeded, only c is registered to run."""
+    _write_checkpoints(linear_flow, {"a": {"status": "success"}, "b": {"status": "success"}})
+    orchestrator = make_orchestrator(linear_flow, resume=True)
+    await orchestrator.on_initialize()
+
+    processors = orchestrator._subscribers.get(PhaseTrigger, [])
+    assert {p.name for p in processors} == {"c"}
+
+
+async def test_resume_marks_only_frontier_phase(linear_flow, make_orchestrator):
+    """The first non-completed phase is the frontier; nothing else is."""
+    _write_checkpoints(linear_flow, {"a": {"status": "success"}, "b": {"status": "success"}})
+    orchestrator = make_orchestrator(linear_flow, resume=True)
+    await orchestrator.on_initialize()
+
+    phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
+    assert phases_by_name["c"]._resume_frontier is True
+
+
+async def test_resume_emits_triggers_for_completed_phases(linear_flow, make_orchestrator):
+    """Completed phases get their completion triggers emitted so dependents unblock."""
+    _write_checkpoints(linear_flow, {"a": {"status": "success"}, "b": {"status": "success"}})
+    orchestrator = make_orchestrator(linear_flow, resume=True)
+    await orchestrator.on_initialize()
+
+    ids = _drain_trigger_phase_ids(orchestrator)
+    assert None in ids  # initial trigger
+    assert {i for i in ids if i is not None} == {"a", "b"}
+
+
+async def test_resume_dependency_closure_reruns_descendants_of_failure(linear_flow, make_orchestrator):
+    """A succeeded phase whose ancestor failed is NOT skipped — it and its descendants re-run."""
+    _write_checkpoints(
+        linear_flow,
+        {"a": {"status": "failed", "error": "boom"}, "b": {"status": "success"}, "c": {"status": "success"}},
+    )
+    orchestrator = make_orchestrator(linear_flow, resume=True)
+    await orchestrator.on_initialize()
+
+    phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
+    assert set(phases_by_name) == {"a", "b", "c"}  # nothing skipped
+    assert phases_by_name["a"]._resume_frontier is True
+    assert phases_by_name["b"]._resume_frontier is False
+    assert phases_by_name["c"]._resume_frontier is False
+
+
+async def test_resume_with_no_checkpoints_frontier_is_root(linear_flow, make_orchestrator):
+    """Ctrl+C before any checkpoint: all phases run, the root is the frontier."""
+    orchestrator = make_orchestrator(linear_flow, resume=True)
+    await orchestrator.on_initialize()
+
+    phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
+    assert set(phases_by_name) == {"a", "b", "c"}
+    assert phases_by_name["a"]._resume_frontier is True
+    assert phases_by_name["b"]._resume_frontier is False
+    assert phases_by_name["c"]._resume_frontier is False
+
+
+async def test_no_resume_ignores_checkpoints(linear_flow, make_orchestrator):
+    """Without resume, every phase is registered and none is a frontier, despite checkpoints."""
+    _write_checkpoints(linear_flow, {"a": {"status": "success"}, "b": {"status": "success"}})
+    orchestrator = make_orchestrator(linear_flow, resume=False)
+    await orchestrator.on_initialize()
+
+    phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
+    assert set(phases_by_name) == {"a", "b", "c"}
+    assert all(p._resume_frontier is False for p in phases_by_name.values())
+    ids = _drain_trigger_phase_ids(orchestrator)
+    assert ids == [None]  # only the initial trigger, no resume triggers

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -588,3 +588,39 @@ async def test_resume_corrupt_checkpoints_raises_flow_config_error(linear_flow, 
     orchestrator = make_orchestrator(linear_flow, resume=True)
     with pytest.raises(FlowConfigError, match="Cannot resume"):
         await orchestrator.on_initialize()
+
+
+async def test_resume_closure_independent_of_flow_declaration_order(tmp_path, make_orchestrator):
+    """A flow declared dependents-first still resolves the resume closure correctly."""
+    (tmp_path / "prompts").mkdir()
+    (tmp_path / "prompts" / "writer.md").write_text("system prompt")
+    (tmp_path / "flow.yaml").write_text(
+        dedent("""\
+        agents:
+          writer:
+            tools: []
+        phases:
+          a:
+            agent: writer
+            tasks: [{name: ta, prompt: a}]
+          b:
+            agent: writer
+            tasks: [{name: tb, prompt: b}]
+          c:
+            agent: writer
+            tasks: [{name: tc, prompt: c}]
+        flow:
+          - phase: c
+            dependencies: [b]
+          - phase: b
+            dependencies: [a]
+          - phase: a
+        """)
+    )
+    _write_checkpoints(tmp_path, {"a": {"status": "success"}, "b": {"status": "success"}})
+    orchestrator = make_orchestrator(tmp_path, resume=True)
+    await orchestrator.on_initialize()
+
+    processors = orchestrator._subscribers.get(PhaseTrigger, [])
+    assert {p.name for p in processors} == {"c"}  # a and b skipped, c is the frontier
+    assert processors[0]._is_resume_frontier is True

--- a/ddev/tests/ai/tools/test_registry.py
+++ b/ddev/tests/ai/tools/test_registry.py
@@ -260,14 +260,14 @@ def test_from_names_multiple_native(tmp_path):
 def test_from_names_native_only(tmp_path):
     registry = from_names(["web_search"], tmp_path)
     assert registry.definitions == []
-    assert list(registry.native_tool_names) == ["web_search"]
+    assert registry.native_tool_names == ("web_search",)
 
 
 def test_from_names_client_and_native(tmp_path):
     registry = from_names(["read_file", "web_search"], tmp_path)
     assert len(registry.definitions) == 1
     assert registry.definitions[0]["name"] == "read_file"
-    assert list(registry.native_tool_names) == ["web_search"]
+    assert registry.native_tool_names == ("web_search",)
 
 
 def test_from_names_native_not_in_tools_dict(tmp_path):
@@ -284,7 +284,7 @@ def test_native_tool_names_not_affected_by_input_mutation():
     names = ["web_search"]
     registry = ToolRegistry([], native_tool_names=names)
     names.append("web_fetch")
-    assert list(registry.native_tool_names) == ["web_search"]
+    assert registry.native_tool_names == ("web_search",)
 
 
 def test_filter_read_only_includes_native_read_only():


### PR DESCRIPTION
### What does this PR do?

Adds **resume** support to the AI flow orchestrator (framework only — no CLI yet).

When the orchestrator is constructed with `resume=True`, it reads the run's `checkpoints.yaml` and continues a previously failed or interrupted run instead of starting over:

- **`CheckpointManager.successful_phases()`** reports which phases reached `success`.
- The orchestrator computes a **dependency-closed** completed set: a phase counts as done only if it *and all of its transitive dependencies* succeeded. It then **skips registering** those phases (their `execute()` is never called) and emits a completion `PhaseTrigger` for each so dependent phases unblock through the normal trigger chain. No resume-specific logic leaks into the phases.
- The **frontier** (the phases that run first on resume — the ones that may be sitting on partial work) is carried via `FlowContext.resume_frontier`. An `AgenticPhase` in the frontier gets a short **resumed-run notice** appended to its system prompt, telling the agent this is a re-run, to reconcile any partially-written files, and including the previous error when one was recorded. Interrupted runs that never wrote a checkpoint (e.g. `Ctrl+C`) still get the notice, just without an error string.

The dependency-closure guard matters when the flow definition changes between a run and its resume (e.g. inserting a phase in the middle): a previously-succeeded phase that gains a new, un-run ancestor is correctly re-run instead of skipped with stale inputs.

The dependency-closure computation walks `config.flow` in a single pass, which requires dependencies to be classified before the phases that depend on them. To guarantee that without assuming the author wrote `flow.yaml` in any particular order, **`FlowConfig` now topologically sorts the flow at parse time** (a stable sort applied after cycle detection, so phases with no ordering constraint keep their declaration order). Every consumer that iterates `config.flow` — registration, trigger emission, and the resume closure — can now rely on dependencies appearing before their dependents.

Resume is phase-granular: a failed/interrupted phase re-runs from scratch; completed phases are not re-executed.

**Next step:** a follow-up PR will add the `--resume` flag (and the one-folder-per-integration run directory) to the `ddev ai openmetrics` CLI command, wiring `resume=` through to this orchestrator.

### Tests

- `successful_phases()` behavior, including malformed entries.
- Orchestrator resume: completed phases are skipped; only the frontier is marked; completion triggers are emitted; the dependency-closure re-runs descendants of a failed ancestor; an interrupted run with no checkpoints makes the root the frontier; without `resume` checkpoints are ignored; a corrupt `checkpoints.yaml` surfaces as an actionable `FlowConfigError`; and the closure resolves correctly even when the flow is declared dependents-first.
- `FlowConfig` topological sort: dependents declared before their dependencies are reordered, and the sort is stable for unconstrained phases.
- `AgenticPhase` system-prompt injection: frontier phase with/without a recorded error; non-frontier phase gets no notice.

### Unrelated drive-by fix

Also fixed a small bug in two existing `test_registry` tests that were asserting against a `list` while the value is a `tuple` (`native_tool_names`). This is leftover from a previous PR and is unrelated to resume — included only so the suite passes.

### Motivation

A single transient failure (e.g. an API 500) or a `Ctrl+C` would abort an entire multi-phase AI run and force re-running everything from scratch, including the expensive completed phases. Resume lets a run pick up from the last successful checkpoint.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required. — `qa/skip-qa` (developer-only `ddev` tooling, nothing shipped with the Agent)
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
