### PR TITLE
Properly ignore autodiscovery tags 

### DIFF
--- a/dcgm/changelog.d/24171.added
+++ b/dcgm/changelog.d/24171.added
@@ -1,0 +1,1 @@
+Bump minimum version of datadog-checks-base to 37.35.0.

--- a/dcgm/changelog.d/24171.changed
+++ b/dcgm/changelog.d/24171.changed
@@ -1,0 +1,1 @@
+Filter autodiscovery ``kube_namespace``, ``pod_name``, and ``kube_container_name`` tags from the exporter pod so only the GPU workload tags are submitted.

--- a/dcgm/changelog.d/24171.fixed
+++ b/dcgm/changelog.d/24171.fixed
@@ -1,0 +1,1 @@
+Fix ``ignore_tags`` not filtering autodiscovery tags from the exporter pod.

--- a/dcgm/changelog.d/24171.fixed
+++ b/dcgm/changelog.d/24171.fixed
@@ -1,1 +1,0 @@
-Fix ``ignore_tags`` not filtering autodiscovery tags from the exporter pod.

--- a/dcgm/datadog_checks/dcgm/check.py
+++ b/dcgm/datadog_checks/dcgm/check.py
@@ -14,7 +14,7 @@ class DcgmCheck(OpenMetricsBaseCheckV2):
         return {
             "metrics": [METRIC_MAP],
             "rename_labels": RENAME_LABELS_MAP,
-            "ignored_tags": IGNORED_TAGS,
+            "ignore_tags": IGNORED_TAGS,
         }
 
     def configure_scrapers(self):

--- a/dcgm/pyproject.toml
+++ b/dcgm/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.35.0",
 ]
 dynamic = [
     "version",

--- a/dcgm/tests/test_unit.py
+++ b/dcgm/tests/test_unit.py
@@ -25,14 +25,39 @@ def test_critical_service_check(dd_run_check, aggregator, mock_http_response, ch
 @pytest.mark.usefixtures("mock_label_remap")
 def test_label_remap(dd_run_check, aggregator, check):
     """
-    Test that the labels are remapped correctly.
+    Test that Prometheus labels are remapped and autodiscovery tags for the
+    exporter pod's namespace/pod/container are filtered out via ignore_tags.
     """
+    # First run to initialize scrapers
     dd_run_check(check)
+    aggregator.reset()
+
+    # Simulate autodiscovery adding tags for the exporter pod itself
+    check.set_dynamic_tags(
+        'kube_namespace:gpu-operator',
+        'pod_name:nvidia-dcgm-exporter-abc',
+        'kube_container_name:nvidia-dcgm-exporter',
+    )
+    dd_run_check(check)
+
     aggregator.assert_service_check('dcgm.openmetrics.health', DcgmCheck.OK)
-    relabeled_tags = ['kube_namespace:foo', 'pod_name:bar', 'kube_container_name:baz']
-    aggregator.assert_metric('dcgm.gpu_utilization')
-    for tag in relabeled_tags:
-        aggregator.assert_metric_has_tag('dcgm.gpu_utilization', tag)
+
+    aggregator.assert_metric(
+        'dcgm.gpu_utilization',
+        tags=[
+            'DCGM_FI_DRIVER_VERSION:460.106.00',
+            'DCGM_FI_PROCESS_NAME:/usr/bin/dcgm-exporter',
+            'Hostname:424773df46e0',
+            'UUID:GPU-20c56d28-0da5-6d26-a36a-e7af1ce2586e',
+            'device:nvidia0',
+            'endpoint:http://localhost:9400/metrics',
+            'gpu:0',
+            'kube_container_name:baz',
+            'kube_namespace:foo',
+            'modelName:Tesla T4',
+            'pod_name:bar',
+        ],
+    )
 
 
 @pytest.mark.usefixtures("mock_metrics")


### PR DESCRIPTION
### What does this PR do?
Properly ignore autodiscovery-added tags 

Also bumps the minimum base check to include this [PR](https://github.com/DataDog/integrations-core/issues/23328) which fixes filtering for external tags
### Motivation
This issue was reported and identified in https://github.com/DataDog/integrations-core/issues/19570, thanks @nwilliams-bdai 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
