### PR TITLE
[CONTP-1783] Surface DatadogInstrumentation CRD for integration kubernetes setup

### DIFF
--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -79,7 +79,7 @@ For containerized environments, see [Configure integrations with Autodiscovery o
 
 Apply the following annotation to your pod, where `<CONTAINER_NAME>` is the Aerospike container name or a [custom identifier][15]:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: aerospike`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: aerospike`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][16].
 
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.checks: |
@@ -157,3 +157,4 @@ Need help? Contact [Datadog support][9].
 [13]: https://github.com/DataDog/integrations-core/blob/7.36.x/aerospike/datadog_checks/aerospike/data/conf.yaml.example
 [14]: https://docs.datadoghq.com/containers/docker/integrations/
 [15]: https://docs.datadoghq.com/containers/guide/ad_identifiers/
+[16]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -106,8 +106,6 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 Apply the following annotation to your pod, where `<CONTAINER_NAME>` is the Aerospike container name or a [custom identifier][15]:
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.logs: |
   [

--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -79,6 +79,8 @@ For containerized environments, see [Configure integrations with Autodiscovery o
 
 Apply the following annotation to your pod, where `<CONTAINER_NAME>` is the Aerospike container name or a [custom identifier][15]:
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: aerospike`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.checks: |
   {
@@ -103,6 +105,8 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 **Example**
 
 Apply the following annotation to your pod, where `<CONTAINER_NAME>` is the Aerospike container name or a [custom identifier][15]:
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.logs: |

--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -79,8 +79,6 @@ For containerized environments, see [Configure integrations with Autodiscovery o
 
 Apply the following annotation to your pod, where `<CONTAINER_NAME>` is the Aerospike container name or a [custom identifier][15]:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: aerospike`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][16].
-
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.checks: |
   {
@@ -90,6 +88,8 @@ ad.datadoghq.com/<CONTAINER_NAME>.checks: |
     }
   } 
 ```
+
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: aerospike`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][16].
 
 
 ##### Log collection

--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -89,7 +89,7 @@ ad.datadoghq.com/<CONTAINER_NAME>.checks: |
   } 
 ```
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: aerospike`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][16].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: aerospike`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][16].
 
 
 ##### Log collection

--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -79,8 +79,7 @@ For containerized environments, see [Configure integrations with Autodiscovery o
 
 Choose a Kubernetes Autodiscovery configuration, where `<CONTAINER_NAME>` is the Aerospike container name:
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.checks: |
@@ -91,8 +90,7 @@ ad.datadoghq.com/<CONTAINER_NAME>.checks: |
     }
   } 
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -115,9 +113,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][16].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 
 ##### Log collection

--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -77,7 +77,10 @@ For containerized environments, see [Configure integrations with Autodiscovery o
 
 **Example**
 
-Apply the following annotation to your pod, where `<CONTAINER_NAME>` is the Aerospike container name or a [custom identifier][15]:
+Choose a Kubernetes Autodiscovery configuration, where `<CONTAINER_NAME>` is the Aerospike container name:
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.checks: |
@@ -88,8 +91,33 @@ ad.datadoghq.com/<CONTAINER_NAME>.checks: |
     }
   } 
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: aerospike`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][16].
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet # Or another target kind, if applicable.
+    name: <AEROSPIKE_WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: aerospike
+        containerName: <CONTAINER_NAME>
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:9145/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][16].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 
 ##### Log collection

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -445,7 +445,7 @@ Ensure that `url` matches your Airflow [webserver `base_url`][19], the URL used 
 
 If you are using the [official Airflow Helm chart][24], this should be applied on the `webserver` pod and its `webserver` container. For example, with the [`webserver.podAnnotations`][22], your Autodiscovery Annotations may look like the following:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: airflow`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: airflow`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][28].
 
 ```yaml
 webserver:
@@ -610,3 +610,4 @@ Need help? Contact [Datadog support][11].
 [25]: https://airflow.apache.org/docs/apache-airflow-providers-datadog/stable/index.html
 [26]: https://airflow.apache.org/docs/docker-stack/entrypoint.html#installing-additional-requirements
 [27]: https://docs.datadoghq.com/developers/dogstatsd/?tab=cgroups#origin-detection
+[28]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -445,6 +445,8 @@ Ensure that `url` matches your Airflow [webserver `base_url`][19], the URL used 
 
 If you are using the [official Airflow Helm chart][24], this should be applied on the `webserver` pod and its `webserver` container. For example, with the [`webserver.podAnnotations`][22], your Autodiscovery Annotations may look like the following:
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: airflow`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 ```yaml
 webserver:
   podAnnotations:

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -460,7 +460,7 @@ webserver:
       }
 ```
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: airflow`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][28].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: airflow`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][28].
 
 Adjust the `ad.datadoghq.com/<CONTAINER_NAME>.checks` annotation accordingly if your container name differs.
 

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -445,8 +445,6 @@ Ensure that `url` matches your Airflow [webserver `base_url`][19], the URL used 
 
 If you are using the [official Airflow Helm chart][24], this should be applied on the `webserver` pod and its `webserver` container. For example, with the [`webserver.podAnnotations`][22], your Autodiscovery Annotations may look like the following:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: airflow`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][28].
-
 ```yaml
 webserver:
   podAnnotations:
@@ -461,6 +459,8 @@ webserver:
         }
       }
 ```
+
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: airflow`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][28].
 
 Adjust the `ad.datadoghq.com/<CONTAINER_NAME>.checks` annotation accordingly if your container name differs.
 

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -445,8 +445,7 @@ Ensure that `url` matches your Airflow [webserver `base_url`][19], the URL used 
 
 If you are using the [official Airflow Helm chart][24], target the `webserver` pod and its `webserver` container. Choose one of the following Autodiscovery configurations:
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 ```yaml
 webserver:
@@ -462,8 +461,7 @@ webserver:
         }
       }
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 The official Airflow Helm chart runs the webserver in a Deployment named `<RELEASE_NAME>-webserver`:
 
@@ -488,9 +486,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][28].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 Adjust the `ad.datadoghq.com/<CONTAINER_NAME>.checks` annotation accordingly if your container name differs.
 

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -443,7 +443,10 @@ For containerized environments, see the [Autodiscovery Integration Templates][8]
 
 Ensure that `url` matches your Airflow [webserver `base_url`][19], the URL used to connect to your Airflow instance. Replace `localhost` with the template variable `%%host%%`.
 
-If you are using the [official Airflow Helm chart][24], this should be applied on the `webserver` pod and its `webserver` container. For example, with the [`webserver.podAnnotations`][22], your Autodiscovery Annotations may look like the following:
+If you are using the [official Airflow Helm chart][24], target the `webserver` pod and its `webserver` container. Choose one of the following Autodiscovery configurations:
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 webserver:
@@ -459,8 +462,35 @@ webserver:
         }
       }
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: airflow`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][28].
+The official Airflow Helm chart runs the webserver in a Deployment named `<RELEASE_NAME>-webserver`:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: <RELEASE_NAME>-webserver
+  config:
+    checks:
+      - integration: airflow
+        containerName: webserver
+        initConfig: {}
+        instances:
+          - url: "http://%%host%%:8080"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][28].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 Adjust the `ad.datadoghq.com/<CONTAINER_NAME>.checks` annotation accordingly if your container name differs.
 

--- a/apache/README.md
+++ b/apache/README.md
@@ -113,6 +113,8 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][10] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][11].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: apache`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 **Annotations v1** (for Datadog Agent < v7.36)
 
 ```yaml
@@ -164,6 +166,8 @@ spec:
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes Log Collection][12].
 
 Then, set [Log Integrations][9] as pod annotations. This can also be configured with [a file, a configmap, or a key-value store][13].
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 **Annotations v1/v2**
 

--- a/apache/README.md
+++ b/apache/README.md
@@ -113,7 +113,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][10] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][11].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: apache`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: apache`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][23].
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -286,3 +286,4 @@ Additional helpful documentation, links, and articles:
 [20]: https://www.datadoghq.com/blog/monitoring-apache-web-server-performance
 [21]: https://www.datadoghq.com/blog/collect-apache-performance-metrics
 [22]: https://www.datadoghq.com/blog/monitor-apache-web-server-datadog
+[23]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/apache/README.md
+++ b/apache/README.md
@@ -167,8 +167,6 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 Then, set [Log Integrations][9] as pod annotations. This can also be configured with [a file, a configmap, or a key-value store][13].
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 **Annotations v1/v2**
 
 ```yaml

--- a/apache/README.md
+++ b/apache/README.md
@@ -113,7 +113,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][10] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][11].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: apache`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][23].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: apache`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][23].
 
 **Annotations v1** (for Datadog Agent < v7.36)
 

--- a/apache/README.md
+++ b/apache/README.md
@@ -111,9 +111,10 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-Set [Autodiscovery Integrations Templates][10] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][11].
+Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with [a file, a configmap, or a key-value store][11].
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: apache`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][23].
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -159,6 +160,33 @@ spec:
   containers:
     - name: apache
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment # Or another target kind, if applicable.
+    name: <APACHE_WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: apache
+        containerName: apache
+        initConfig: {}
+        instances:
+          - apache_status_url: "http://%%host%%/server-status?auto"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][23].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 ##### Log collection
 

--- a/apache/README.md
+++ b/apache/README.md
@@ -113,8 +113,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with [a file, a configmap, or a key-value store][11].
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -160,8 +159,7 @@ spec:
   containers:
     - name: apache
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -184,9 +182,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][23].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 ##### Log collection
 

--- a/argo_rollouts/README.md
+++ b/argo_rollouts/README.md
@@ -20,7 +20,7 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 The Argo Rollouts controller has Prometheus-formatted metrics readily available at `/metrics` on port `8090`. For the Agent to start collecting metrics, the Argo Rollouts pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample argo_rollouts.d/conf.yaml][4].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: argo_rollouts`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: argo_rollouts`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `argo_rollouts.info.replicas.updated` metric is exposed only after a replica is updated.
 

--- a/argo_rollouts/README.md
+++ b/argo_rollouts/README.md
@@ -20,7 +20,7 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 The Argo Rollouts controller has Prometheus-formatted metrics readily available at `/metrics` on port `8090`. For the Agent to start collecting metrics, the Argo Rollouts pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample argo_rollouts.d/conf.yaml][4].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: argo_rollouts`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: argo_rollouts`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `argo_rollouts.info.replicas.updated` metric is exposed only after a replica is updated.
 
@@ -103,3 +103,4 @@ Additional helpful documentation, links, and articles:
 [9]: https://docs.datadoghq.com/help/
 [10]: https://docs.datadoghq.com/agent/kubernetes/log/
 [11]: https://www.datadoghq.com/blog/container-native-ci-cd-integrations/
+[12]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/argo_rollouts/README.md
+++ b/argo_rollouts/README.md
@@ -20,6 +20,8 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 The Argo Rollouts controller has Prometheus-formatted metrics readily available at `/metrics` on port `8090`. For the Agent to start collecting metrics, the Argo Rollouts pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample argo_rollouts.d/conf.yaml][4].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: argo_rollouts`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `argo_rollouts.info.replicas.updated` metric is exposed only after a replica is updated.
 
 The only parameter required for configuring the Argo Rollouts check is:

--- a/argo_rollouts/README.md
+++ b/argo_rollouts/README.md
@@ -18,14 +18,15 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 ### Configuration
 
-The Argo Rollouts controller has Prometheus-formatted metrics readily available at `/metrics` on port `8090`. For the Agent to start collecting metrics, the Argo Rollouts pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample argo_rollouts.d/conf.yaml][4].
-
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: argo_rollouts`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
+The Argo Rollouts controller has Prometheus-formatted metrics readily available at `/metrics` on port `8090`. Configure the check with one of the Kubernetes Autodiscovery options below. You can find additional configuration options by reviewing the [sample argo_rollouts.d/conf.yaml][4].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `argo_rollouts.info.replicas.updated` metric is exposed only after a replica is updated.
 
 The only parameter required for configuring the Argo Rollouts check is:
 - `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `8090`. In containerized environments, `%%host%%` should be used for [host autodetection][3]. 
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 apiVersion: v1
@@ -51,6 +52,35 @@ spec:
     - name: 'argo-rollouts'
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+This example targets the Argo Rollouts controller Deployment:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: argo-rollouts
+  config:
+    checks:
+      - integration: argo_rollouts
+        containerName: argo-rollouts
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:8090/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 #### Log collection
 

--- a/argo_workflows/README.md
+++ b/argo_workflows/README.md
@@ -20,7 +20,7 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 The Argo Workflows Workflow Controller has [Prometheus-formatted metrics][11] available at `/metrics` on port `9090`. For the Agent to start collecting metrics, the Workflow Controller pod needs to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample argo_workflows.d/conf.yaml][4].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: argo_workflows`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: argo_workflows`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
 
 The only parameter required for configuring the Argo Workflows check is:
 - `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `9090`. In containerized environments, `%%host%%` should be used for [host autodetection][3].

--- a/argo_workflows/README.md
+++ b/argo_workflows/README.md
@@ -20,6 +20,8 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 The Argo Workflows Workflow Controller has [Prometheus-formatted metrics][11] available at `/metrics` on port `9090`. For the Agent to start collecting metrics, the Workflow Controller pod needs to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample argo_workflows.d/conf.yaml][4].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: argo_workflows`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 The only parameter required for configuring the Argo Workflows check is:
 - `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `9090`. In containerized environments, `%%host%%` should be used for [host autodetection][3].
 

--- a/argo_workflows/README.md
+++ b/argo_workflows/README.md
@@ -20,7 +20,7 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 The Argo Workflows Workflow Controller has [Prometheus-formatted metrics][11] available at `/metrics` on port `9090`. For the Agent to start collecting metrics, the Workflow Controller pod needs to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample argo_workflows.d/conf.yaml][4].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: argo_workflows`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: argo_workflows`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
 
 The only parameter required for configuring the Argo Workflows check is:
 - `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `9090`. In containerized environments, `%%host%%` should be used for [host autodetection][3].
@@ -102,3 +102,4 @@ Additional helpful documentation, links, and articles:
 [10]: https://docs.datadoghq.com/agent/kubernetes/log/
 [11]: https://argo-workflows.readthedocs.io/en/stable/metrics/
 [12]: https://www.datadoghq.com/blog/container-native-ci-cd-integrations/
+[13]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/argo_workflows/README.md
+++ b/argo_workflows/README.md
@@ -18,12 +18,13 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 ### Configuration
 
-The Argo Workflows Workflow Controller has [Prometheus-formatted metrics][11] available at `/metrics` on port `9090`. For the Agent to start collecting metrics, the Workflow Controller pod needs to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample argo_workflows.d/conf.yaml][4].
-
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: argo_workflows`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
+The Argo Workflows Workflow Controller has [Prometheus-formatted metrics][11] available at `/metrics` on port `9090`. Configure the check with one of the Kubernetes Autodiscovery options below. You can find additional configuration options by reviewing the [sample argo_workflows.d/conf.yaml][4].
 
 The only parameter required for configuring the Argo Workflows check is:
 - `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `9090`. In containerized environments, `%%host%%` should be used for [host autodetection][3].
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 apiVersion: v1
@@ -32,7 +33,7 @@ kind: Pod
 metadata:
   name: '<POD_NAME>'
   annotations:
-    ad.datadoghq.com/argo-workflows.checks: |
+    ad.datadoghq.com/workflow-controller.checks: |
       {
         "argo_workflows": {
           "init_config": {},
@@ -46,9 +47,38 @@ metadata:
     # (...)
 spec:
   containers:
-    - name: 'argo-workflows'
+    - name: 'workflow-controller'
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+This example targets the Argo Workflows controller Deployment:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: workflow-controller
+  config:
+    checks:
+      - integration: argo_workflows
+        containerName: workflow-controller
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:9090/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 #### Log collection
 

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -31,6 +31,8 @@ The Datadog Agent can collect the exposed metrics using this integration. Follow
 
 Ensure that the Prometheus-formatted metrics are exposed in your Argo CD cluster. This is enabled by default if using Argo CD's [default manifests][10]. For the Agent to gather all metrics, each of the three aforementioned components needs to be annotated. For more information about annotations, see the [Autodiscovery Integration Templates][4] for guidance. Additional configuration options are available by reviewing the [sample argocd.d/conf.yaml][12].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: argocd`, and set `containerImage` to match each component image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 There are use cases where Argo CD Applications contain labels that need to be exposed as Prometheus metrics. These labels are available using the `argocd_app_labels` metric, which is disabled on the Application Controller by default. Refer to the [ArgoCD Documentation][14] for instructions on how to enable it.
 
 Example configurations:
@@ -206,4 +208,3 @@ Additional helpful documentation, links, and articles:
 [14]: https://argo-cd.readthedocs.io/en/stable/operator-manual/metrics/#exposing-application-labels-as-prometheus-metrics
 [15]: https://github.com/DataDog/integrations-core/blob/master/argocd/datadog_checks/argocd/data/conf.yaml.example#L45-L72
 [16]: https://www.datadoghq.com/blog/container-native-ci-cd-integrations/
-

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -31,7 +31,7 @@ The Datadog Agent can collect the exposed metrics using this integration. Follow
 
 Ensure that the Prometheus-formatted metrics are exposed in your Argo CD cluster. This is enabled by default if using Argo CD's [default manifests][10]. For the Agent to gather all metrics, each of the three aforementioned components needs to be annotated. For more information about annotations, see the [Autodiscovery Integration Templates][4] for guidance. Additional configuration options are available by reviewing the [sample argocd.d/conf.yaml][12].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: argocd`, and set `containerImage` to match each component image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: argocd`, and set `containerImage` to match each component image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
 
 There are use cases where Argo CD Applications contain labels that need to be exposed as Prometheus metrics. These labels are available using the `argocd_app_labels` metric, which is disabled on the Application Controller by default. Refer to the [ArgoCD Documentation][14] for instructions on how to enable it.
 
@@ -208,3 +208,4 @@ Additional helpful documentation, links, and articles:
 [14]: https://argo-cd.readthedocs.io/en/stable/operator-manual/metrics/#exposing-application-labels-as-prometheus-metrics
 [15]: https://github.com/DataDog/integrations-core/blob/master/argocd/datadog_checks/argocd/data/conf.yaml.example#L45-L72
 [16]: https://www.datadoghq.com/blog/container-native-ci-cd-integrations/
+[17]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -31,7 +31,7 @@ The Datadog Agent can collect the exposed metrics using this integration. Follow
 
 Ensure that the Prometheus-formatted metrics are exposed in your Argo CD cluster. This is enabled by default if using Argo CD's [default manifests][10]. For the Agent to gather all metrics, each of the three aforementioned components needs to be annotated. For more information about annotations, see the [Autodiscovery Integration Templates][4] for guidance. Additional configuration options are available by reviewing the [sample argocd.d/conf.yaml][12].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: argocd`, and set `containerImage` to match each component image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: argocd`, and set `containerName` to match each component's container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
 
 There are use cases where Argo CD Applications contain labels that need to be exposed as Prometheus metrics. These labels are available using the `argocd_app_labels` metric, which is disabled on the Application Controller by default. Refer to the [ArgoCD Documentation][14] for instructions on how to enable it.
 

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -29,13 +29,14 @@ The Datadog Agent can collect the exposed metrics using this integration. Follow
 #### Containerized
 ##### Metric collection
 
-Ensure that the Prometheus-formatted metrics are exposed in your Argo CD cluster. This is enabled by default if using Argo CD's [default manifests][10]. For the Agent to gather all metrics, each of the three aforementioned components needs to be annotated. For more information about annotations, see the [Autodiscovery Integration Templates][4] for guidance. Additional configuration options are available by reviewing the [sample argocd.d/conf.yaml][12].
-
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: argocd`, and set `containerName` to match each component's container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
+Ensure that the Prometheus-formatted metrics are exposed in your Argo CD cluster. This is enabled by default if using Argo CD's [default manifests][10]. Configure each of the three components with one of the Kubernetes Autodiscovery options below. Additional configuration options are available by reviewing the [sample argocd.d/conf.yaml][12].
 
 There are use cases where Argo CD Applications contain labels that need to be exposed as Prometheus metrics. These labels are available using the `argocd_app_labels` metric, which is disabled on the Application Controller by default. Refer to the [ArgoCD Documentation][14] for instructions on how to enable it.
 
 Example configurations:
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 **Application Controller**:
 ```yaml
@@ -114,6 +115,71 @@ spec:
     - name: 'argocd-repo-server'
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+Create one resource per target workload. These resources mirror the annotation configurations:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: argocd-application-controller-instrumentation
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: argocd-application-controller
+  config:
+    checks:
+      - integration: argocd
+        containerName: argocd-application-controller
+        initConfig: {}
+        instances:
+          - app_controller_endpoint: "http://%%host%%:8082/metrics"
+---
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: argocd-server-instrumentation
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: argocd-server
+  config:
+    checks:
+      - integration: argocd
+        containerName: argocd-server
+        initConfig: {}
+        instances:
+          - api_server_endpoint: "http://%%host%%:8083/metrics"
+---
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: argocd-repo-server-instrumentation
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: argocd-repo-server
+  config:
+    checks:
+      - integration: argocd
+        containerName: argocd-repo-server
+        initConfig: {}
+        instances:
+          - repo_server_endpoint: "http://%%host%%:8084/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 **Note**: For the full list of supported endpoints, see the [conf.yaml example file][15].
 
@@ -121,6 +187,9 @@ spec:
 
 **Clashing Tag Names**:
 The Argo CD integration attaches a name tag derived from the application name OpenMetrics label when available. This could sometimes lead to querying issues if a name tag is already attached to a host, as seen in the example `name: host_a, app_a`. To prevent any unwanted behavior when querying, it is advisable to [remap the name label][13] to something more unique, such as `argocd_app_name` if the host happens to already have a name tag. Below is an example configuration:
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 **Application Controller**:
 ```yaml
@@ -150,6 +219,37 @@ spec:
     - name: 'argocd-application-controller'
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+Target the Application Controller StatefulSet:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: argocd-application-controller
+  config:
+    checks:
+      - integration: argocd
+        containerName: argocd-application-controller
+        initConfig: {}
+        instances:
+          - app_controller_endpoint: "http://%%host%%:8082/metrics"
+            rename_labels:
+              name: "argocd_app_name"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 ##### Log collection
 

--- a/calico/README.md
+++ b/calico/README.md
@@ -45,7 +45,7 @@ Using annotations:
        [....]
    ```
 
-   For a Prometheus pod managed by a supported Kubernetes workload, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: openmetrics`, and set `containerImage` to match the Prometheus pod image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][16].
+   You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: openmetrics`, and set `containerName` to match the Prometheus container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][16].
 
 You can find values for `<FELIX-SERVICE-IP>` and `<FELIX-SERVICE-PORT>` by running `kubectl get all -all-namespaces`.
 

--- a/calico/README.md
+++ b/calico/README.md
@@ -25,6 +25,8 @@ Using annotations:
 
 3. To use Autodiscovery, modify `prometheus-pod`. Add the following snippet to your Prometheus YAML configuration file:
 
+   For a Prometheus pod managed by a supported Kubernetes workload, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: openmetrics`, and set `containerImage` to match the Prometheus pod image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
    ```
    metadata:
      [...]

--- a/calico/README.md
+++ b/calico/README.md
@@ -25,8 +25,6 @@ Using annotations:
 
 3. To use Autodiscovery, modify `prometheus-pod`. Add the following snippet to your Prometheus YAML configuration file:
 
-   For a Prometheus pod managed by a supported Kubernetes workload, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: openmetrics`, and set `containerImage` to match the Prometheus pod image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
    ```
    metadata:
      [...]
@@ -46,6 +44,8 @@ Using annotations:
      spec:
        [....]
    ```
+
+   For a Prometheus pod managed by a supported Kubernetes workload, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: openmetrics`, and set `containerImage` to match the Prometheus pod image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][16].
 
 You can find values for `<FELIX-SERVICE-IP>` and `<FELIX-SERVICE-PORT>` by running `kubectl get all -all-namespaces`.
 
@@ -164,3 +164,4 @@ Additional helpful documentation, links, and articles:
 [13]: https://docs.datadoghq.com/agent/docker/integrations/?tab=docker
 [14]: https://docs.datadoghq.com/agent/kubernetes/log/?tab=containerinstallation#setup
 [15]: https://www.datadoghq.com/blog/monitor-calico-with-datadog/
+[16]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/calico/README.md
+++ b/calico/README.md
@@ -16,14 +16,17 @@ The Calico check is included in the [Datadog Agent][2] package.
 
 #### Installation with a Kubernetes cluster-based Agent
 
-Using annotations:
+Using a Kubernetes cluster-based Agent:
 
 1. Set up Calico on your cluster.
 
 2. Enable Prometheus metrics using the instructions in [Monitor Calico component metrics][9].
    Once enabled, you should have a `felix-metrics-svc` service running in your cluster, as well as a `prometheus-pod`.
 
-3. To use Autodiscovery, modify `prometheus-pod`. Add the following snippet to your Prometheus YAML configuration file:
+3. Configure `prometheus-pod` with one of the following Autodiscovery options:
+
+   <!-- xxx tabs xxx -->
+   <!-- xxx tab "Kubernetes annotations" xxx -->
 
    ```
    metadata:
@@ -44,8 +47,38 @@ Using annotations:
      spec:
        [....]
    ```
+   <!-- xxz tab xxx -->
+   <!-- xxx tab "DatadogInstrumentation CRD" xxx -->
 
-   You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: openmetrics`, and set `containerName` to match the Prometheus container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][16].
+   The standalone `prometheus-pod` from the Calico guide cannot be targeted directly.
+
+   ```yaml
+   apiVersion: datadoghq.com/v1alpha1
+   kind: DatadogInstrumentation
+   metadata:
+     name: <CR_NAME>
+     namespace: <WORKLOAD_NAMESPACE>
+   spec:
+     targetRef:
+       apiVersion: apps/v1
+       kind: Deployment # Or another target kind, if applicable.
+       name: <PROMETHEUS_WORKLOAD_NAME>
+     config:
+       checks:
+         - integration: openmetrics
+           containerName: prometheus-pod
+           initConfig: {}
+           instances:
+             - prometheus_url: "http://<FELIX-SERVICE-IP>:<FELIX-SERVICE-PORT>/metrics"
+               namespace: "calico"
+               metrics:
+                 - "*"
+   ```
+
+   For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][16].
+
+   <!-- xxz tab xxx -->
+   <!-- xxz tabs xxx -->
 
 You can find values for `<FELIX-SERVICE-IP>` and `<FELIX-SERVICE-PORT>` by running `kubectl get all -all-namespaces`.
 

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -69,7 +69,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][5] as pod annotations on your application container. Alternatively, you can configure templates with a [file, configmap, or key-value store][6].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: coredns`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: coredns`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][25].
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -284,3 +284,4 @@ Additional helpful documentation, links, and articles:
 [22]: https://www.datadoghq.com/blog/coredns-monitoring-tools/
 [23]: https://www.datadoghq.com/blog/monitoring-coredns-with-datadog/
 [24]: https://docs.datadoghq.com/integrations/guide/versions-for-openmetrics-based-integrations
+[25]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -159,8 +159,6 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 Then, set [Log Integrations][8] as pod annotations. Alternatively, you can configure this with a [file, configmap, or key-value store][9].
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 **Annotations v1/v2**
 
 ```yaml

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -69,6 +69,8 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][5] as pod annotations on your application container. Alternatively, you can configure templates with a [file, configmap, or key-value store][6].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: coredns`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 **Annotations v1** (for Datadog Agent < v7.36)
 
 ```yaml
@@ -156,6 +158,8 @@ To enable the legacy mode of this OpenMetrics-based check, replace `openmetrics_
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes Log Collection][7].
 
 Then, set [Log Integrations][8] as pod annotations. Alternatively, you can configure this with a [file, configmap, or key-value store][9].
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 **Annotations v1/v2**
 

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -69,7 +69,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][5] as pod annotations on your application container. Alternatively, you can configure templates with a [file, configmap, or key-value store][6].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: coredns`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][25].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: coredns`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][25].
 
 **Annotations v1** (for Datadog Agent < v7.36)
 

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -67,9 +67,10 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-Set [Autodiscovery Integrations Templates][5] as pod annotations on your application container. Alternatively, you can configure templates with a [file, configmap, or key-value store][6].
+Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with a [file, configmap, or key-value store][6].
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: coredns`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][25].
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -121,6 +122,37 @@ spec:
   containers:
     - name: coredns
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+This example targets the CoreDNS Deployment:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: coredns
+  config:
+    checks:
+      - integration: coredns
+        containerName: coredns
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:9153/metrics"
+            tags:
+              - "dns-pod:%%host%%"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][25].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 To enable the legacy mode of this OpenMetrics-based check, replace `openmetrics_endpoint` with `prometheus_url`:
 

--- a/coredns/README.md
+++ b/coredns/README.md
@@ -69,8 +69,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with a [file, configmap, or key-value store][6].
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -122,8 +121,7 @@ spec:
   containers:
     - name: coredns
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 This example targets the CoreDNS Deployment:
 
@@ -150,9 +148,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][25].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 To enable the legacy mode of this OpenMetrics-based check, replace `openmetrics_endpoint` with `prometheus_url`:
 

--- a/dcgm/README.md
+++ b/dcgm/README.md
@@ -289,7 +289,7 @@ LABEL "com.datadoghq.ad.instances"='[{"openmetrics_endpoint": "http://%%host%%:9
 
 Set [Autodiscovery Integrations Templates][12] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][11].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: dcgm`, and set `containerImage` to match each exporter image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: dcgm`, and set `containerImage` to match each exporter image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][20].
 
 **Annotations v2** (for Datadog Agent v7.47+)
 
@@ -414,3 +414,4 @@ Additional helpful documentation, links, and articles:
 [17]: https://docs.datadoghq.com/integrations/nvml/#metrics
 [18]: https://docs.datadoghq.com/gpu_monitoring/
 [19]: https://docs.datadoghq.com/gpu_monitoring/setup/?tab=datadogoperator
+[20]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/dcgm/README.md
+++ b/dcgm/README.md
@@ -289,7 +289,7 @@ LABEL "com.datadoghq.ad.instances"='[{"openmetrics_endpoint": "http://%%host%%:9
 
 Set [Autodiscovery Integrations Templates][12] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][11].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: dcgm`, and set `containerImage` to match each exporter image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][20].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: dcgm`, and set `containerName` to match each exporter's container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][20].
 
 **Annotations v2** (for Datadog Agent v7.47+)
 

--- a/dcgm/README.md
+++ b/dcgm/README.md
@@ -289,6 +289,8 @@ LABEL "com.datadoghq.ad.instances"='[{"openmetrics_endpoint": "http://%%host%%:9
 
 Set [Autodiscovery Integrations Templates][12] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][11].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: dcgm`, and set `containerImage` to match each exporter image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 **Annotations v2** (for Datadog Agent v7.47+)
 
 ```yaml

--- a/dcgm/README.md
+++ b/dcgm/README.md
@@ -155,8 +155,7 @@ The DCGM exporter can quickly be installed in a Kubernetes environment using the
          # Copy the content from the Installation section.
    ```
 3. Create your DCGM Exporter Helm chart `dcgm-values.yaml` with the following content : 
-   <!-- xxx tabs xxx -->
-   <!-- xxx tab "Kubernetes annotations" xxx -->
+   **Kubernetes annotations**
 
    ```yaml
    # Exposing more metrics than the default for additional monitoring - this requires the use of a dedicated ConfigMap for which the Kubernetes ServiceAccount used by the exporter has access thanks to step 1.
@@ -179,8 +178,7 @@ The DCGM exporter can quickly be installed in a Kubernetes environment using the
    serviceMonitor:
      enabled: false
    ```
-   <!-- xxz tab xxx -->
-   <!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+   **DatadogInstrumentation CRD**
 
    Keep the other Helm values in this step, omit `podAnnotations`, and apply this resource after installing the chart:
 
@@ -206,8 +204,6 @@ The DCGM exporter can quickly be installed in a Kubernetes environment using the
 
    For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][20].
 
-   <!-- xxz tab xxx -->
-   <!-- xxz tabs xxx -->
 4. Install the DCGM Exporter Helm chart in the `default` namespace with the following command, while being in the directory with your `dcgm-values.yaml` :
    ```shell
    helm install dcgm-datadog gpu-helm-charts/dcgm-exporter -n default -f dcgm-values.yaml
@@ -232,8 +228,7 @@ The DCGM exporter can be installed in a Kubernetes environment by using NVIDIA G
     * Create a namespace `gpu-operator` if one is not already present: `kubectl create namespace gpu-operator`.
     * Create a ConfigMap using the file edited above: `kubectl create configmap metrics-config -n gpu-operator --from-file=dcgm-metrics.csv`
 3. Create your GPU Operator Helm chart `dcgm-values.yaml` with the following content: 
-   <!-- xxx tabs xxx -->
-   <!-- xxx tab "Kubernetes annotations" xxx -->
+   **Kubernetes annotations**
 
    ```yaml
    # Refer to NVIDIA documentation for the driver and toolkit for your GPU-enabled nodes - example below for Amazon Linux 2 g5.xlarge
@@ -263,8 +258,7 @@ The DCGM exporter can be installed in a Kubernetes environment by using NVIDIA G
            }
          }
    ```
-   <!-- xxz tab xxx -->
-   <!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+   **DatadogInstrumentation CRD**
 
    Keep the other Helm values in this step, omit `daemonsets.annotations`, and apply this resource after installing the chart:
 
@@ -290,8 +284,6 @@ The DCGM exporter can be installed in a Kubernetes environment by using NVIDIA G
 
    For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][20].
 
-   <!-- xxz tab xxx -->
-   <!-- xxz tabs xxx -->
 4. Install the DCGM Exporter Helm chart in the `default` namespace with the following command, while being in the directory with your `dcgm-values.yaml`:
    ```bash
    helm install datadog-dcgm-gpu-operator -n gpu-operator nvidia/gpu-operator -f dcgm-values.yaml
@@ -353,8 +345,7 @@ LABEL "com.datadoghq.ad.instances"='[{"openmetrics_endpoint": "http://%%host%%:9
 
 Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with [a file, a configmap, or a key-value store][11].
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 **Annotations v2** (for Datadog Agent v7.47+)
 
@@ -379,8 +370,7 @@ spec:
   containers:
     - name: dcgm
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 This example targets a DCGM exporter DaemonSet named `dcgm`:
 
@@ -405,9 +395,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][20].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/dcgm/README.md
+++ b/dcgm/README.md
@@ -155,6 +155,9 @@ The DCGM exporter can quickly be installed in a Kubernetes environment using the
          # Copy the content from the Installation section.
    ```
 3. Create your DCGM Exporter Helm chart `dcgm-values.yaml` with the following content : 
+   <!-- xxx tabs xxx -->
+   <!-- xxx tab "Kubernetes annotations" xxx -->
+
    ```yaml
    # Exposing more metrics than the default for additional monitoring - this requires the use of a dedicated ConfigMap for which the Kubernetes ServiceAccount used by the exporter has access thanks to step 1.
    # Ref: https://github.com/NVIDIA/dcgm-exporter/blob/e55ec750def325f9f1fdbd0a6f98c932672002e4/deployment/values.yaml#L38
@@ -176,6 +179,35 @@ The DCGM exporter can quickly be installed in a Kubernetes environment using the
    serviceMonitor:
      enabled: false
    ```
+   <!-- xxz tab xxx -->
+   <!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+   Keep the other Helm values in this step, omit `podAnnotations`, and apply this resource after installing the chart:
+
+   ```yaml
+   apiVersion: datadoghq.com/v1alpha1
+   kind: DatadogInstrumentation
+   metadata:
+     name: <CR_NAME>
+     namespace: <WORKLOAD_NAMESPACE>
+   spec:
+     targetRef:
+       apiVersion: apps/v1
+       kind: DaemonSet
+       name: dcgm-datadog-dcgm-exporter
+     config:
+       checks:
+         - integration: dcgm
+           containerName: exporter
+           initConfig: {}
+           instances:
+             - openmetrics_endpoint: "http://%%host%%:9400/metrics"
+   ```
+
+   For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][20].
+
+   <!-- xxz tab xxx -->
+   <!-- xxz tabs xxx -->
 4. Install the DCGM Exporter Helm chart in the `default` namespace with the following command, while being in the directory with your `dcgm-values.yaml` :
    ```shell
    helm install dcgm-datadog gpu-helm-charts/dcgm-exporter -n default -f dcgm-values.yaml
@@ -200,6 +232,9 @@ The DCGM exporter can be installed in a Kubernetes environment by using NVIDIA G
     * Create a namespace `gpu-operator` if one is not already present: `kubectl create namespace gpu-operator`.
     * Create a ConfigMap using the file edited above: `kubectl create configmap metrics-config -n gpu-operator --from-file=dcgm-metrics.csv`
 3. Create your GPU Operator Helm chart `dcgm-values.yaml` with the following content: 
+   <!-- xxx tabs xxx -->
+   <!-- xxx tab "Kubernetes annotations" xxx -->
+
    ```yaml
    # Refer to NVIDIA documentation for the driver and toolkit for your GPU-enabled nodes - example below for Amazon Linux 2 g5.xlarge
    driver:
@@ -228,6 +263,35 @@ The DCGM exporter can be installed in a Kubernetes environment by using NVIDIA G
            }
          }
    ```
+   <!-- xxz tab xxx -->
+   <!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+   Keep the other Helm values in this step, omit `daemonsets.annotations`, and apply this resource after installing the chart:
+
+   ```yaml
+   apiVersion: datadoghq.com/v1alpha1
+   kind: DatadogInstrumentation
+   metadata:
+     name: <CR_NAME>
+     namespace: <WORKLOAD_NAMESPACE>
+   spec:
+     targetRef:
+       apiVersion: apps/v1
+       kind: DaemonSet
+       name: nvidia-dcgm-exporter
+     config:
+       checks:
+         - integration: dcgm
+           containerName: nvidia-dcgm-exporter
+           initConfig: {}
+           instances:
+             - openmetrics_endpoint: "http://%%host%%:9400/metrics"
+   ```
+
+   For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][20].
+
+   <!-- xxz tab xxx -->
+   <!-- xxz tabs xxx -->
 4. Install the DCGM Exporter Helm chart in the `default` namespace with the following command, while being in the directory with your `dcgm-values.yaml`:
    ```bash
    helm install datadog-dcgm-gpu-operator -n gpu-operator nvidia/gpu-operator -f dcgm-values.yaml
@@ -287,9 +351,10 @@ LABEL "com.datadoghq.ad.instances"='[{"openmetrics_endpoint": "http://%%host%%:9
 
 ##### Metric collection
 
-Set [Autodiscovery Integrations Templates][12] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][11].
+Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with [a file, a configmap, or a key-value store][11].
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: dcgm`, and set `containerName` to match each exporter's container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][20].
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 **Annotations v2** (for Datadog Agent v7.47+)
 
@@ -314,6 +379,35 @@ spec:
   containers:
     - name: dcgm
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+This example targets a DCGM exporter DaemonSet named `dcgm`:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: DaemonSet
+    name: dcgm
+  config:
+    checks:
+      - integration: dcgm
+        containerName: dcgm
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:9400/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][20].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -277,7 +277,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][17] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][18].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: elastic`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: elastic`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -490,3 +490,4 @@ See [service_checks.json][26] for a list of service checks provided by this inte
 [28]: https://www.datadoghq.com/blog/monitor-elasticsearch-performance-metrics
 [29]: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html
 [30]: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html
+[31]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -277,6 +277,8 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][17] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][18].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: elastic`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 **Annotations v1** (for Datadog Agent < v7.36)
 
 ```yaml
@@ -328,6 +330,8 @@ spec:
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see the [Kubernetes Log Collection][19].
 
 Then, set [Log Integrations][14] as pod annotations. This can also be configured with [a file, a configmap, or a key-value store][20].
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 **Annotations v1/v2**
 

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -331,8 +331,6 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see t
 
 Then, set [Log Integrations][14] as pod annotations. This can also be configured with [a file, a configmap, or a key-value store][20].
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 **Annotations v1/v2**
 
 ```yaml

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -277,7 +277,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][17] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][18].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: elastic`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: elastic`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
 
 **Annotations v1** (for Datadog Agent < v7.36)
 

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -275,9 +275,10 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-Set [Autodiscovery Integrations Templates][17] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][18].
+Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with [a file, a configmap, or a key-value store][18].
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: elastic`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -323,6 +324,33 @@ spec:
   containers:
     - name: elasticsearch
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet # Or another target kind, if applicable.
+    name: <ELASTICSEARCH_WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: elastic
+        containerName: elasticsearch
+        initConfig: {}
+        instances:
+          - url: "http://%%host%%:9200"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 ##### Log collection
 

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -277,8 +277,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with [a file, a configmap, or a key-value store][18].
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -324,8 +323,7 @@ spec:
   containers:
     - name: elasticsearch
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -348,9 +346,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 ##### Log collection
 

--- a/external_dns/README.md
+++ b/external_dns/README.md
@@ -22,7 +22,7 @@ Edit the `external_dns.d/conf.yaml` file, in the `conf.d/` folder at the root of
 
 If you are using one Datadog Agent pod per Kubernetes worker node, use these example annotations on your external-dns pod to retrieve the data automatically:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: external_dns`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: external_dns`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][9].
 
 ```yaml
 apiVersion: v1
@@ -67,3 +67,4 @@ Need help? Contact [Datadog support][8].
 [6]: https://github.com/DataDog/integrations-core/blob/master/external_dns/metadata.csv
 [7]: https://github.com/DataDog/integrations-core/blob/master/external_dns/assets/service_checks.json
 [8]: https://docs.datadoghq.com/help/
+[9]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/external_dns/README.md
+++ b/external_dns/README.md
@@ -32,7 +32,7 @@ metadata:
     ad.datadoghq.com/external-dns.instances: '[{"prometheus_url":"http://%%host%%:7979/metrics", "tags":["externaldns-pod:%%host%%"]}]'
 ```
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: external_dns`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][9].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: external_dns`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][9].
 
 - The `externaldns-pod` tag keeps track of the target DNS pod IP. The other tags are related to the Datadog Agent that is polling the information using the autodiscovery.
 - The autodiscovery annotations are done on the pod. To deploy, add the annotations to the metadata of the template's specification.

--- a/external_dns/README.md
+++ b/external_dns/README.md
@@ -22,6 +22,8 @@ Edit the `external_dns.d/conf.yaml` file, in the `conf.d/` folder at the root of
 
 If you are using one Datadog Agent pod per Kubernetes worker node, use these example annotations on your external-dns pod to retrieve the data automatically:
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: external_dns`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 ```yaml
 apiVersion: v1
 kind: Pod

--- a/external_dns/README.md
+++ b/external_dns/README.md
@@ -22,8 +22,6 @@ Edit the `external_dns.d/conf.yaml` file, in the `conf.d/` folder at the root of
 
 If you are using one Datadog Agent pod per Kubernetes worker node, use these example annotations on your external-dns pod to retrieve the data automatically:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: external_dns`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][9].
-
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -33,6 +31,8 @@ metadata:
     ad.datadoghq.com/external-dns.init_configs: '[{}]'
     ad.datadoghq.com/external-dns.instances: '[{"prometheus_url":"http://%%host%%:7979/metrics", "tags":["externaldns-pod:%%host%%"]}]'
 ```
+
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: external_dns`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][9].
 
 - The `externaldns-pod` tag keeps track of the target DNS pod IP. The other tags are related to the Datadog Agent that is polling the information using the autodiscovery.
 - The autodiscovery annotations are done on the pod. To deploy, add the annotations to the metadata of the template's specification.

--- a/external_dns/README.md
+++ b/external_dns/README.md
@@ -20,7 +20,10 @@ Edit the `external_dns.d/conf.yaml` file, in the `conf.d/` folder at the root of
 
 #### Using with service discovery
 
-If you are using one Datadog Agent pod per Kubernetes worker node, use these example annotations on your external-dns pod to retrieve the data automatically:
+If you are using one Datadog Agent pod per Kubernetes worker node, choose one of the following Autodiscovery configurations for external-dns:
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 apiVersion: v1
@@ -31,11 +34,40 @@ metadata:
     ad.datadoghq.com/external-dns.init_configs: '[{}]'
     ad.datadoghq.com/external-dns.instances: '[{"prometheus_url":"http://%%host%%:7979/metrics", "tags":["externaldns-pod:%%host%%"]}]'
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: external_dns`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][9].
+This example targets the ExternalDNS Deployment:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: external-dns
+  config:
+    checks:
+      - integration: external_dns
+        containerName: external-dns
+        initConfig: {}
+        instances:
+          - prometheus_url: "http://%%host%%:7979/metrics"
+            tags:
+              - "externaldns-pod:%%host%%"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][9].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 - The `externaldns-pod` tag keeps track of the target DNS pod IP. The other tags are related to the Datadog Agent that is polling the information using the autodiscovery.
-- The autodiscovery annotations are done on the pod. To deploy, add the annotations to the metadata of the template's specification.
+- When using pod annotations, add them to the metadata of the template's specification.
 
 ### Validation
 

--- a/fluxcd/README.md
+++ b/fluxcd/README.md
@@ -55,7 +55,7 @@ spec:
 # (...)
 ```
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: fluxcd`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: fluxcd`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
 
 #### Log collection
 

--- a/fluxcd/README.md
+++ b/fluxcd/README.md
@@ -32,6 +32,8 @@ You can pick and choose which services you monitor depending on your needs.
 
 This is an example configuration with Kubernetes annotations on your Flux pods. See the [sample configuration file][4] for all available configuration options.
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: fluxcd`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 ```yaml
 apiVersion: v1
 kind: Pod

--- a/fluxcd/README.md
+++ b/fluxcd/README.md
@@ -32,7 +32,7 @@ You can pick and choose which services you monitor depending on your needs.
 
 This is an example configuration with Kubernetes annotations on your Flux pods. See the [sample configuration file][4] for all available configuration options.
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: fluxcd`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: fluxcd`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
 
 ```yaml
 apiVersion: v1
@@ -112,3 +112,4 @@ Additional helpful documentation, links, and articles:
 [11]: https://www.datadoghq.com/blog/container-native-integrations/#cicd-with-flux
 [12]: https://docs.datadoghq.com/agent/kubernetes/log/
 [13]: https://www.datadoghq.com/blog/container-native-ci-cd-integrations/
+[14]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/fluxcd/README.md
+++ b/fluxcd/README.md
@@ -32,8 +32,6 @@ You can pick and choose which services you monitor depending on your needs.
 
 This is an example configuration with Kubernetes annotations on your Flux pods. See the [sample configuration file][4] for all available configuration options.
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: fluxcd`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
-
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -56,6 +54,8 @@ spec:
     - name: 'manager'
 # (...)
 ```
+
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: fluxcd`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
 
 #### Log collection
 

--- a/fluxcd/README.md
+++ b/fluxcd/README.md
@@ -30,7 +30,10 @@ You can pick and choose which services you monitor depending on your needs.
 
 #### Metric collection
 
-This is an example configuration with Kubernetes annotations on your Flux pods. See the [sample configuration file][4] for all available configuration options.
+Choose one of the following Kubernetes Autodiscovery configurations. See the [sample configuration file][4] for all available configuration options.
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 apiVersion: v1
@@ -54,8 +57,35 @@ spec:
     - name: 'manager'
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: fluxcd`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
+This example targets the `source-controller` Deployment. Create a separate resource for each additional Flux controller that you monitor:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: source-controller
+  config:
+    checks:
+      - integration: fluxcd
+        containerName: manager
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:8080/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 #### Log collection
 

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -98,7 +98,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 
 Add pod annotations under `.spec.template.metadata` for a Deployment:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: haproxy`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: haproxy`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
 
 ```yaml
 apiVersion: apps/v1
@@ -437,3 +437,4 @@ Need help? Contact [Datadog support][20].
 [28]: https://github.com/DataDog/integrations-core/blob/0e34b3309cc1371095762bfcaf121b0b45a4e263/haproxy/datadog_checks/haproxy/data/conf.yaml.example#L631
 [29]: https://docs.datadoghq.com/integrations/guide/versions-for-openmetrics-based-integrations
 [30]: https://docs.datadoghq.com/integrations/guide/prometheus-host-collection/
+[31]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -98,8 +98,6 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 
 Add pod annotations under `.spec.template.metadata` for a Deployment:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: haproxy`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
-
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -123,6 +121,8 @@ spec:
       containers:
         - name: haproxy
 ```
+
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: haproxy`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -122,7 +122,7 @@ spec:
         - name: haproxy
 ```
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: haproxy`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: haproxy`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -98,6 +98,8 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 
 Add pod annotations under `.spec.template.metadata` for a Deployment:
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: haproxy`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -308,6 +310,8 @@ _Available for Agent versions >6.0_
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes Log Collection][14].
 
 Then, set [Log Integrations][11] as pod annotations. This can also be configured with [a file, a configmap, or a key-value store][15].
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 **Annotations v1/v2**
 

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -311,8 +311,6 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 Then, set [Log Integrations][11] as pod annotations. This can also be configured with [a file, a configmap, or a key-value store][15].
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 **Annotations v1/v2**
 
 ```yaml

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -98,8 +98,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 
 Choose one of the following Kubernetes Autodiscovery configurations for the Deployment:
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 ```yaml
 apiVersion: apps/v1
@@ -124,8 +123,7 @@ spec:
       containers:
         - name: haproxy
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 Target the HAProxy Deployment shown in the annotation example:
 
@@ -151,9 +149,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
@@ -289,8 +284,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with [a file, a configmap, or a key-value store][13].
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 **Annotations v1** (for Datadog Agent v7.36 or earlier)
 
@@ -336,8 +330,7 @@ spec:
   containers:
     - name: haproxy
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -360,9 +353,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 ##### Log collection
 

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -96,7 +96,10 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 
 ##### Kubernetes Deployment example
 
-Add pod annotations under `.spec.template.metadata` for a Deployment:
+Choose one of the following Kubernetes Autodiscovery configurations for the Deployment:
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 apiVersion: apps/v1
@@ -121,8 +124,36 @@ spec:
       containers:
         - name: haproxy
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: haproxy`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
+Target the HAProxy Deployment shown in the annotation example:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: haproxy
+  config:
+    checks:
+      - integration: haproxy
+        containerName: haproxy
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:<PORT>/metrics"
+            use_openmetrics: "true"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
@@ -256,7 +287,10 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-Set [Autodiscovery Integrations Templates][12] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][13].
+Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with [a file, a configmap, or a key-value store][13].
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 **Annotations v1** (for Datadog Agent v7.36 or earlier)
 
@@ -302,6 +336,33 @@ spec:
   containers:
     - name: haproxy
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment # Or another target kind, if applicable.
+    name: haproxy
+  config:
+    checks:
+      - integration: haproxy
+        containerName: haproxy
+        initConfig: {}
+        instances:
+          - url: "https://%%host%%/admin?stats"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 ##### Log collection
 

--- a/istio/README.md
+++ b/istio/README.md
@@ -90,7 +90,7 @@ This annotation specifies the container `discovery` to match the default contain
 
 The method for applying these annotations varies depending on the [Istio deployment strategy (Istioctl, Helm, Operator)][22] used. Consult the Istio documentation for the proper method to apply these pod annotations. See the [sample istio.d/conf.yaml][8] for all available configuration options.
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: istio`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][33].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: istio`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][33].
 
 ##### Ambient mode configuration
 

--- a/istio/README.md
+++ b/istio/README.md
@@ -90,7 +90,7 @@ This annotation specifies the container `discovery` to match the default contain
 
 The method for applying these annotations varies depending on the [Istio deployment strategy (Istioctl, Helm, Operator)][22] used. Consult the Istio documentation for the proper method to apply these pod annotations. See the [sample istio.d/conf.yaml][8] for all available configuration options.
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: istio`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: istio`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][33].
 
 ##### Ambient mode configuration
 
@@ -312,3 +312,4 @@ Additional helpful documentation, links, and articles:
 [30]: https://docs.datadoghq.com/security/application_security/?source=istio-tile-overview
 [31]: https://docs.datadoghq.com/security/application_security/setup/istio/?source=istio-tile-setup
 [32]: https://www.datadoghq.com/blog/app-api-protection-envoy-istio-nginx-haproxy/
+[33]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/istio/README.md
+++ b/istio/README.md
@@ -161,8 +161,6 @@ _Available for Agent versions >6.0_
 
 First, enable the Datadog Agent to perform log collection in Kubernetes. See [Kubernetes Log Collection][13].
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; create one `DatadogInstrumentation` resource per target workload and use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 #### Istio logs
 
 To collect Istio logs from your control plane (`istiod`), apply the following pod annotations for the deployment `istiod` in the `istio-system` namespace:

--- a/istio/README.md
+++ b/istio/README.md
@@ -90,6 +90,8 @@ This annotation specifies the container `discovery` to match the default contain
 
 The method for applying these annotations varies depending on the [Istio deployment strategy (Istioctl, Helm, Operator)][22] used. Consult the Istio documentation for the proper method to apply these pod annotations. See the [sample istio.d/conf.yaml][8] for all available configuration options.
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: istio`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 ##### Ambient mode configuration
 
 Istio ambient mode, generally available in Istio v1.24, replaces sidecar injection with two shared components: the `ztunnel` DaemonSet (L4 zero-trust tunneling) and optional `waypoint` proxies (L7 HTTP/gRPC processing). Set `istio_mode: ambient` and configure one or more of `ztunnel_endpoint`, `waypoint_endpoint`, and `istiod_endpoint` on the same instance. The check scrapes each endpoint that is set. Adjust the URLs in the example below to match your cluster's hostnames and ports.
@@ -158,6 +160,8 @@ kubectl patch daemonset datadog-agent -p '{"spec":{"template":{"metadata":{"anno
 _Available for Agent versions >6.0_
 
 First, enable the Datadog Agent to perform log collection in Kubernetes. See [Kubernetes Log Collection][13].
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; create one `DatadogInstrumentation` resource per target workload and use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 #### Istio logs
 

--- a/istio/README.md
+++ b/istio/README.md
@@ -69,7 +69,10 @@ instances:
 Customize this file with any additional configurations. See the [sample istio.d/conf.yaml][8] for all available configuration options.
 
 ##### Control plane configuration
-To monitor the Istio control plane and report the `mixer`, `galley`, `pilot`, and `citadel` metrics, you must configure the Agent to monitor the `istiod` deployment. In Istio v1.5 or later, apply the following pod annotations for the deployment `istiod` in the `istio-system` namespace:
+To monitor the Istio control plane and report the `mixer`, `galley`, `pilot`, and `citadel` metrics, configure the Agent to monitor the `istiod` deployment with one of the following Autodiscovery options:
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 ad.datadoghq.com/discovery.checks: |
@@ -84,13 +87,41 @@ ad.datadoghq.com/discovery.checks: |
     }
   }
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+Target the `istiod` Deployment:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: istiod
+  config:
+    checks:
+      - integration: istio
+        containerName: discovery
+        initConfig: {}
+        instances:
+          - istiod_endpoint: "http://%%host%%:15014/metrics"
+            use_openmetrics: "true"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][33].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 **Note**: The Autodiscovery Annotations v2 syntax is supported for Agent v7.36+.
 
 This annotation specifies the container `discovery` to match the default container name of the Istio container in this pod. Replace this annotation `ad.datadoghq.com/<CONTAINER_NAME>.checks` with the name (`.spec.containers[i].name`) of your Istio container if yours differs.
 
-The method for applying these annotations varies depending on the [Istio deployment strategy (Istioctl, Helm, Operator)][22] used. Consult the Istio documentation for the proper method to apply these pod annotations. See the [sample istio.d/conf.yaml][8] for all available configuration options.
-
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: istio`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][33].
+When using annotations, the method for applying them varies depending on the [Istio deployment strategy (Istioctl, Helm, Operator)][22] used. Consult the Istio documentation for the proper method. See the [sample istio.d/conf.yaml][8] for all available configuration options.
 
 ##### Ambient mode configuration
 

--- a/karpenter/README.md
+++ b/karpenter/README.md
@@ -22,7 +22,7 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 Make sure that the Prometheus-formatted metrics are exposed in your Karpenter cluster and on which port. You can configure the port by following the instructions on the [Metrics][10] page in the Karpenter documentation. For the Agent to start collecting metrics, the Karpenter pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample karpenter.d/conf.yaml][4].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: karpenter`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: karpenter`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `karpenter.nodes.terminated` metric is exposed only after a node is terminated.
 
@@ -107,3 +107,4 @@ Additional helpful documentation, links, and articles:
 [10]: https://karpenter.sh/docs/reference/metrics/
 [11]: https://docs.datadoghq.com/agent/kubernetes/log/
 [12]: https://www.datadoghq.com/blog/container-native-integrations/#autoscaling-and-resource-utilization-with-karpenter
+[13]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/karpenter/README.md
+++ b/karpenter/README.md
@@ -22,6 +22,8 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 Make sure that the Prometheus-formatted metrics are exposed in your Karpenter cluster and on which port. You can configure the port by following the instructions on the [Metrics][10] page in the Karpenter documentation. For the Agent to start collecting metrics, the Karpenter pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample karpenter.d/conf.yaml][4].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: karpenter`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `karpenter.nodes.terminated` metric is exposed only after a node is terminated.
 
 The only parameter required for configuring the Karpenter check is:

--- a/karpenter/README.md
+++ b/karpenter/README.md
@@ -22,7 +22,7 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 Make sure that the Prometheus-formatted metrics are exposed in your Karpenter cluster and on which port. You can configure the port by following the instructions on the [Metrics][10] page in the Karpenter documentation. For the Agent to start collecting metrics, the Karpenter pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample karpenter.d/conf.yaml][4].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: karpenter`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: karpenter`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `karpenter.nodes.terminated` metric is exposed only after a node is terminated.
 

--- a/karpenter/README.md
+++ b/karpenter/README.md
@@ -20,14 +20,15 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 #### Metric collection
 
-Make sure that the Prometheus-formatted metrics are exposed in your Karpenter cluster and on which port. You can configure the port by following the instructions on the [Metrics][10] page in the Karpenter documentation. For the Agent to start collecting metrics, the Karpenter pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample karpenter.d/conf.yaml][4].
-
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: karpenter`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
+Make sure that the Prometheus-formatted metrics are exposed in your Karpenter cluster and on which port. You can configure the port by following the instructions on the [Metrics][10] page in the Karpenter documentation. Configure the check with one of the Kubernetes Autodiscovery options below. You can find additional configuration options by reviewing the [sample karpenter.d/conf.yaml][4].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `karpenter.nodes.terminated` metric is exposed only after a node is terminated.
 
 The only parameter required for configuring the Karpenter check is:
 - `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `8080`, but it can be configured using the `METRICS_PORT` [environment variable][10]. In containerized environments, `%%host%%` should be used for [host autodetection][3]. 
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 apiVersion: v1
@@ -53,6 +54,35 @@ spec:
     - name: 'controller'
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+Target the Karpenter controller Deployment:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: karpenter
+  config:
+    checks:
+      - integration: karpenter
+        containerName: controller
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:8080/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 #### Log collection
 

--- a/keda/README.md
+++ b/keda/README.md
@@ -37,6 +37,8 @@ prometheus:
 
 For the Agent to start collecting metrics, the KEDA controller pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample keda.d/conf.yaml][4]. 
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: keda`, and set `containerImage` to match each component image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `keda.scaler.detail_errors.count` metric is exposed only after a scaler encountered an error.
 
 The only parameter required for configuring the KEDA check is:

--- a/keda/README.md
+++ b/keda/README.md
@@ -37,7 +37,7 @@ prometheus:
 
 For the Agent to start collecting metrics, the KEDA controller pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample keda.d/conf.yaml][4]. 
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: keda`, and set `containerImage` to match each component image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: keda`, and set `containerImage` to match each component image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `keda.scaler.detail_errors.count` metric is exposed only after a scaler encountered an error.
 
@@ -144,3 +144,4 @@ Need help? Contact [Datadog support][9].
 [9]: https://docs.datadoghq.com/help/
 [10]: https://keda.sh/docs/2.16/integrations/prometheus/
 [11]: https://github.com/kedacore/charts/blob/main/keda/README.md#operations
+[12]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/keda/README.md
+++ b/keda/README.md
@@ -37,7 +37,7 @@ prometheus:
 
 For the Agent to start collecting metrics, the KEDA controller pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample keda.d/conf.yaml][4]. 
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: keda`, and set `containerImage` to match each component image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: keda`, and set `containerName` to match each component's container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `keda.scaler.detail_errors.count` metric is exposed only after a scaler encountered an error.
 

--- a/keda/README.md
+++ b/keda/README.md
@@ -35,14 +35,15 @@ prometheus:
     enabled: true
 ```
 
-For the Agent to start collecting metrics, the KEDA controller pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample keda.d/conf.yaml][4]. 
-
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: keda`, and set `containerName` to match each component's container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
+Configure each KEDA controller with one of the Kubernetes Autodiscovery options below. You can find additional configuration options by reviewing the [sample keda.d/conf.yaml][4].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `keda.scaler.detail_errors.count` metric is exposed only after a scaler encountered an error.
 
 The only parameter required for configuring the KEDA check is:
 - `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `8080`. In containerized environments, `%%host%%` should be used for [host autodetection][3]. 
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 apiVersion: v1
@@ -96,6 +97,35 @@ spec:
     - name: keda-operator
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+This example targets the KEDA Operator Deployment. Create a separate resource for each additional KEDA controller that you monitor:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: keda-operator
+  config:
+    checks:
+      - integration: keda
+        containerName: keda-operator
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:8080/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 #### Log collection
 
 _Available for Agent versions >6.0_

--- a/kube_apiserver_metrics/README.md
+++ b/kube_apiserver_metrics/README.md
@@ -24,7 +24,7 @@ In this case, you can setup the integration against the `kubernetes` Service in 
 
 - The main use case to run the `kube_apiserver_metrics` check is as a [Cluster Level Check][4]. 
 - You can do this with [annotations on your service](#annotate-service), or by using a [local file](#local-file) through the Datadog Operator, Helm Chart or manually. 
-- To configure the same endpoint check without annotating the Service, use a `DatadogInstrumentation` resource that targets the Service. Service targets omit `containerImage`. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+- To configure the same endpoint check without annotating the Service, use a `DatadogInstrumentation` resource that targets the Service. Service targets omit `containerImage`. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][15].
 - To collect metrics, set the following parameters and values in an [Autodiscovery][8] template. 
 
 | Parameter         | Value                                                                 |
@@ -162,3 +162,4 @@ Need help? Contact [Datadog support][11].
 [12]: https://docs.datadoghq.com/containers/kubernetes/integrations/?tab=annotations
 [13]: https://docs.datadoghq.com/containers/cluster_agent/clusterchecks/?tab=helm#configuration-from-configuration-files
 [14]: https:docs.datadoghq.com//containers/cluster_agent/clusterchecks/?tab=datadogoperator#setting-up-check-configurations
+[15]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/kube_apiserver_metrics/README.md
+++ b/kube_apiserver_metrics/README.md
@@ -24,7 +24,7 @@ In this case, you can setup the integration against the `kubernetes` Service in 
 
 - The main use case to run the `kube_apiserver_metrics` check is as a [Cluster Level Check][4]. 
 - You can do this with [annotations on your service](#annotate-service), or by using a [local file](#local-file) through the Datadog Operator, Helm Chart or manually. 
-- To configure the same endpoint check without annotating the Service, use a `DatadogInstrumentation` resource that targets the Service. Service targets omit `containerImage`. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][15].
+- To configure the same endpoint check without annotating the Service, use a `DatadogInstrumentation` resource that targets the Service. Service targets omit `containerName`. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][15].
 - To collect metrics, set the following parameters and values in an [Autodiscovery][8] template. 
 
 | Parameter         | Value                                                                 |

--- a/kube_apiserver_metrics/README.md
+++ b/kube_apiserver_metrics/README.md
@@ -24,6 +24,7 @@ In this case, you can setup the integration against the `kubernetes` Service in 
 
 - The main use case to run the `kube_apiserver_metrics` check is as a [Cluster Level Check][4]. 
 - You can do this with [annotations on your service](#annotate-service), or by using a [local file](#local-file) through the Datadog Operator, Helm Chart or manually. 
+- To configure the same endpoint check without annotating the Service, use a `DatadogInstrumentation` resource that targets the Service. Service targets omit `containerImage`. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 - To collect metrics, set the following parameters and values in an [Autodiscovery][8] template. 
 
 | Parameter         | Value                                                                 |

--- a/kube_apiserver_metrics/README.md
+++ b/kube_apiserver_metrics/README.md
@@ -23,8 +23,7 @@ However, if you are using a managed Kubernetes distribution like GKE, EKS, or AK
 In this case, you can setup the integration against the `kubernetes` Service in the `default` namespace.
 
 - The main use case to run the `kube_apiserver_metrics` check is as a [Cluster Level Check][4]. 
-- You can do this with [annotations on your service](#annotate-service), or by using a [local file](#local-file) through the Datadog Operator, Helm Chart or manually. 
-- To configure the same endpoint check without annotating the Service, use a `DatadogInstrumentation` resource that targets the Service. Service targets omit `containerName`. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][15].
+- You can do this with [annotations or a `DatadogInstrumentation` resource](#annotate-service), or by using a [local file](#local-file) through the Datadog Operator, Helm Chart or manually.
 - To collect metrics, set the following parameters and values in an [Autodiscovery][8] template. 
 
 | Parameter         | Value                                                                 |
@@ -37,10 +36,12 @@ You can review all available configuration options in the [kube_apiserver_metric
 
 #### Annotate service
 
-You can annotate the kubernetes service in your `default` namespace with the following:
+Choose one of the following Autodiscovery configurations for the `kubernetes` Service in the `default` namespace:
 
 <!-- xxx tabs xxx -->
-<!-- xxx tab "Annotations v2 (for Datadog Agent v7.36)" xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
+
+**Annotations v2** (for Datadog Agent v7.36+)
 
 ```yaml
 ad.datadoghq.com/endpoints.checks: |
@@ -55,9 +56,7 @@ ad.datadoghq.com/endpoints.checks: |
   }
 ```
 
-<!-- xxz tab xxx -->
-
-<!-- xxx tab "Annotations v1 (for Datadog Agent < v7.36)" xxx -->
+**Annotations v1** (for Datadog Agent < v7.36)
 
 ```yaml
 annotations:
@@ -66,6 +65,31 @@ annotations:
   ad.datadoghq.com/endpoints.instances:
     '[{ "prometheus_url": "https://%%host%%:%%port%%/metrics"}]'
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+This resource targets the Service and omits `containerName`:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: kubernetes-api-server-metrics
+  namespace: default
+spec:
+  targetRef:
+    apiVersion: v1
+    kind: Service
+    name: kubernetes
+  config:
+    checks:
+      - integration: kube_apiserver_metrics
+        initConfig: {}
+        instances:
+          - prometheus_url: "https://%%host%%:%%port%%/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][15].
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/kubeflow/README.md
+++ b/kubeflow/README.md
@@ -31,6 +31,8 @@ No additional installation is needed on your server.
 Make sure that the Prometheus-formatted metrics are exposed for your `kubeflow` componenet. 
 For the Agent to start collecting metrics, the `kubeflow` pods need to be annotated.
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: kubeflow`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 Kubeflow has metrics endpoints that can be accessed on port `9090`. 
 
 To enable metrics exposure in kubeflow through prometheus, you might need to enable the prometheus service monitoring for the component in question.

--- a/kubeflow/README.md
+++ b/kubeflow/README.md
@@ -31,7 +31,7 @@ No additional installation is needed on your server.
 Make sure that the Prometheus-formatted metrics are exposed for your `kubeflow` componenet. 
 For the Agent to start collecting metrics, the `kubeflow` pods need to be annotated.
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: kubeflow`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: kubeflow`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][10].
 
 Kubeflow has metrics endpoints that can be accessed on port `9090`. 
 
@@ -142,3 +142,4 @@ Need help? Contact [Datadog support][9].
 [7]: https://github.com/DataDog/integrations-core/blob/master/kubeflow/metadata.csv
 [8]: https://github.com/DataDog/integrations-core/blob/master/kubeflow/assets/service_checks.json
 [9]: https://docs.datadoghq.com/help/
+[10]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/kubeflow/README.md
+++ b/kubeflow/README.md
@@ -31,7 +31,7 @@ No additional installation is needed on your server.
 Make sure that the Prometheus-formatted metrics are exposed for your `kubeflow` componenet. 
 For the Agent to start collecting metrics, the `kubeflow` pods need to be annotated.
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: kubeflow`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][10].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: kubeflow`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][10].
 
 Kubeflow has metrics endpoints that can be accessed on port `9090`. 
 

--- a/kubeflow/README.md
+++ b/kubeflow/README.md
@@ -29,9 +29,7 @@ No additional installation is needed on your server.
 #### Metric collection
 
 Make sure that the Prometheus-formatted metrics are exposed for your `kubeflow` componenet. 
-For the Agent to start collecting metrics, the `kubeflow` pods need to be annotated.
-
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: kubeflow`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][10].
+Configure the `kubeflow` workload with one of the Kubernetes Autodiscovery options below.
 
 Kubeflow has metrics endpoints that can be accessed on port `9090`. 
 
@@ -85,6 +83,9 @@ Where `<kubeflow-component>` is to be replaced by `pipelines`, `kserve` or `kati
 
 The only parameter required for configuring the `kubeflow` check is `openmetrics_endpoint`. This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `9090`. In containerized environments, `%%host%%` should be used for [host autodetection][3]. 
 
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
+
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -109,6 +110,35 @@ spec:
     - name: 'controller'
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+Target the Deployment for the Kubeflow component that exposes the metrics endpoint:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: <KUBEFLOW_COMPONENT_NAME>
+  config:
+    checks:
+      - integration: kubeflow
+        containerName: controller
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:9090/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][10].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 ### Validation
 

--- a/kubernetes_cluster_autoscaler/README.md
+++ b/kubernetes_cluster_autoscaler/README.md
@@ -26,6 +26,8 @@ No additional installation is needed on your server.
 Make sure that the Prometheus-formatted metrics are exposed in your `kubernetes_cluster_autoscaler` cluster. 
 For the Agent to start collecting metrics, the `kubernetes_cluster_autoscaler` pods need to be annotated.
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: kubernetes_cluster_autoscaler`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 [Kubernetes Cluster Autoscaler][11] has metrics and livenessProbe endpoints that can be accessed on port `8085`. These endpoints are located under `/metrics` and `/health-check` and provide valuable information about the state of your cluster during scaling operations.
 
 **Note**: To change the default port, use the `--address` flag.

--- a/kubernetes_cluster_autoscaler/README.md
+++ b/kubernetes_cluster_autoscaler/README.md
@@ -26,7 +26,7 @@ No additional installation is needed on your server.
 Make sure that the Prometheus-formatted metrics are exposed in your `kubernetes_cluster_autoscaler` cluster. 
 For the Agent to start collecting metrics, the `kubernetes_cluster_autoscaler` pods need to be annotated.
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: kubernetes_cluster_autoscaler`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: kubernetes_cluster_autoscaler`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
 
 [Kubernetes Cluster Autoscaler][11] has metrics and livenessProbe endpoints that can be accessed on port `8085`. These endpoints are located under `/metrics` and `/health-check` and provide valuable information about the state of your cluster during scaling operations.
 

--- a/kubernetes_cluster_autoscaler/README.md
+++ b/kubernetes_cluster_autoscaler/README.md
@@ -26,7 +26,7 @@ No additional installation is needed on your server.
 Make sure that the Prometheus-formatted metrics are exposed in your `kubernetes_cluster_autoscaler` cluster. 
 For the Agent to start collecting metrics, the `kubernetes_cluster_autoscaler` pods need to be annotated.
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: kubernetes_cluster_autoscaler`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: kubernetes_cluster_autoscaler`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
 
 [Kubernetes Cluster Autoscaler][11] has metrics and livenessProbe endpoints that can be accessed on port `8085`. These endpoints are located under `/metrics` and `/health-check` and provide valuable information about the state of your cluster during scaling operations.
 
@@ -118,3 +118,4 @@ Need help? Contact [Datadog support][9].
 [9]: https://docs.datadoghq.com/help/
 [10]: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
 [11]: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-monitor-cluster-autoscaler
+[12]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/kubernetes_cluster_autoscaler/README.md
+++ b/kubernetes_cluster_autoscaler/README.md
@@ -24,9 +24,7 @@ No additional installation is needed on your server.
 #### Metric collection
 
 Make sure that the Prometheus-formatted metrics are exposed in your `kubernetes_cluster_autoscaler` cluster. 
-For the Agent to start collecting metrics, the `kubernetes_cluster_autoscaler` pods need to be annotated.
-
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: kubernetes_cluster_autoscaler`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
+Configure the `kubernetes_cluster_autoscaler` workload with one of the Kubernetes Autodiscovery options below.
 
 [Kubernetes Cluster Autoscaler][11] has metrics and livenessProbe endpoints that can be accessed on port `8085`. These endpoints are located under `/metrics` and `/health-check` and provide valuable information about the state of your cluster during scaling operations.
 
@@ -56,6 +54,9 @@ The only parameters required for configuring the `kubernetes_cluster_autoscaler`
 * `openmetrics_endpoint`
   This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `8085`. To configure a different port, use the `METRICS_PORT` [environment variable][10]. In containerized environments, `%%host%%` should be used for [host autodetection][3]. 
 
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
+
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -80,6 +81,35 @@ spec:
     - name: '<CONTAINER_NAME>'
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+Target the Cluster Autoscaler Deployment:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cluster-autoscaler
+  config:
+    checks:
+      - integration: kubernetes_cluster_autoscaler
+        containerName: cluster-autoscaler
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:8085/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][12].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 
 ### Validation

--- a/kuma/README.md
+++ b/kuma/README.md
@@ -31,6 +31,8 @@ Metrics are collected from the Kuma control plane and the Envoy data planes.
 
 To configure the Agent to collect metrics from the Kuma control plane using autodiscovery, apply the following pod annotations to your `kuma-control-plane` deployment. This example assumes you installed Kuma using Helm. For more information about autodiscovery, see [Autodiscovery Integration Templates][4].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kuma` for the control plane or `integration: envoy` for data plane sidecars, and set `containerImage` to match each target image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 ```yaml
 # values.yaml
 controlPlane:
@@ -113,6 +115,8 @@ Enable log collection in your `datadog.yaml` file:
 ```yaml
 logs_enabled: true
 ```
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; create one `DatadogInstrumentation` resource per target workload and use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 ##### Control Plane Logs
 

--- a/kuma/README.md
+++ b/kuma/README.md
@@ -31,8 +31,6 @@ Metrics are collected from the Kuma control plane and the Envoy data planes.
 
 To configure the Agent to collect metrics from the Kuma control plane using autodiscovery, apply the following pod annotations to your `kuma-control-plane` deployment. This example assumes you installed Kuma using Helm. For more information about autodiscovery, see [Autodiscovery Integration Templates][4].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kuma` for the control plane or `integration: envoy` for data plane sidecars, and set `containerImage` to match each target image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
-
 ```yaml
 # values.yaml
 controlPlane:
@@ -50,6 +48,8 @@ controlPlane:
         }
       }
 ```
+
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kuma` for the control plane or `integration: envoy` for data plane sidecars, and set `containerImage` to match each target image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
 
 **Note:** The autodiscovery annotation for Kuma has the format `ad.datadoghq.com/<CONTAINER_NAME>.checks:`. 
 If your control plane has a different name, change the line accordingly. For more information, see the [Datadog documentation][18].

--- a/kuma/README.md
+++ b/kuma/README.md
@@ -116,8 +116,6 @@ Enable log collection in your `datadog.yaml` file:
 logs_enabled: true
 ```
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; create one `DatadogInstrumentation` resource per target workload and use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 ##### Control Plane Logs
 
 To collect logs from the Kuma control plane, apply the following annotations to your `kuma-control-plane` deployment:

--- a/kuma/README.md
+++ b/kuma/README.md
@@ -31,7 +31,7 @@ Metrics are collected from the Kuma control plane and the Envoy data planes.
 
 To configure the Agent to collect metrics from the Kuma control plane using autodiscovery, apply the following pod annotations to your `kuma-control-plane` deployment. This example assumes you installed Kuma using Helm. For more information about autodiscovery, see [Autodiscovery Integration Templates][4].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kuma` for the control plane or `integration: envoy` for data plane sidecars, and set `containerImage` to match each target image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kuma` for the control plane or `integration: envoy` for data plane sidecars, and set `containerImage` to match each target image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
 
 ```yaml
 # values.yaml
@@ -237,3 +237,4 @@ Need help? Contact [Datadog support][9].
 [16]: https://kuma.io/docs/latest/policies/meshtrafficpermission/
 [17]: https://docs.datadoghq.com/containers/guide/auto_conf/?tab=datadogoperator#disable-auto-configuration
 [18]: https://docs.datadoghq.com/containers/kubernetes/integrations/?tab=annotations
+[19]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/kuma/README.md
+++ b/kuma/README.md
@@ -49,7 +49,7 @@ controlPlane:
       }
 ```
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kuma` for the control plane or `integration: envoy` for data plane sidecars, and set `containerImage` to match each target image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kuma` for the control plane or `integration: envoy` for data plane sidecars, and set `containerName` to match each target container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
 
 **Note:** The autodiscovery annotation for Kuma has the format `ad.datadoghq.com/<CONTAINER_NAME>.checks:`. 
 If your control plane has a different name, change the line accordingly. For more information, see the [Datadog documentation][18].

--- a/kuma/README.md
+++ b/kuma/README.md
@@ -29,7 +29,10 @@ Metrics are collected from the Kuma control plane and the Envoy data planes.
 
 **Autodiscovery (Kubernetes)**
 
-To configure the Agent to collect metrics from the Kuma control plane using autodiscovery, apply the following pod annotations to your `kuma-control-plane` deployment. This example assumes you installed Kuma using Helm. For more information about autodiscovery, see [Autodiscovery Integration Templates][4].
+To configure the Agent to collect metrics from the Kuma control plane, choose one of the following Autodiscovery options. This example assumes you installed Kuma using Helm.
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 # values.yaml
@@ -48,8 +51,36 @@ controlPlane:
         }
       }
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kuma` for the control plane or `integration: envoy` for data plane sidecars, and set `containerName` to match each target container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
+Target the Kuma control plane Deployment:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kuma-control-plane
+  config:
+    checks:
+      - integration: kuma
+        containerName: control-plane
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:5680/metrics"
+            service: "kuma-control-plane"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 **Note:** The autodiscovery annotation for Kuma has the format `ad.datadoghq.com/<CONTAINER_NAME>.checks:`. 
 If your control plane has a different name, change the line accordingly. For more information, see the [Datadog documentation][18].
@@ -89,7 +120,10 @@ Metrics from the data planes are collected using the [Envoy integration][10].
             path: "/metrics"
     ```
 
-2.  Next, configure the Datadog Agent to collect these metrics by applying the following annotations to your application pods. For guidance on applying annotations, see [Autodiscovery Integration Templates][4].
+2.  Next, configure the Datadog Agent to collect these metrics with one of the following Autodiscovery options.
+
+    <!-- xxx tabs xxx -->
+    <!-- xxx tab "Kubernetes annotations" xxx -->
 
     ```yaml
     ad.datadoghq.com/kuma-sidecar.checks: |
@@ -104,6 +138,36 @@ Metrics from the data planes are collected using the [Envoy integration][10].
         }
       }
     ```
+    <!-- xxz tab xxx -->
+    <!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+    Create one resource for each application workload that Kuma injects with the Envoy sidecar:
+
+    ```yaml
+    apiVersion: datadoghq.com/v1alpha1
+    kind: DatadogInstrumentation
+    metadata:
+      name: <CR_NAME>
+      namespace: <WORKLOAD_NAMESPACE>
+    spec:
+      targetRef:
+        apiVersion: apps/v1
+        kind: Deployment # Or another target kind, if applicable.
+        name: <APPLICATION_WORKLOAD_NAME>
+      config:
+        checks:
+          - integration: envoy
+            containerName: kuma-sidecar
+            initConfig: {}
+            instances:
+              - openmetrics_endpoint: "http://%%host%%:5670/metrics"
+                collect_server_info: false
+    ```
+
+    For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
+
+    <!-- xxz tab xxx -->
+    <!-- xxz tabs xxx -->
 
     **Note:** The autodiscovery annotation for Kuma has the format `ad.datadoghq.com/<CONTAINER_NAME>.checks:`. 
     If your sidecar has a different name, change the line accordingly. For more information, see the [Datadog documentation][18].

--- a/kyverno/README.md
+++ b/kyverno/README.md
@@ -20,7 +20,7 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 Kyverno consists of multiple controllers such as Backup, Admissions, Cleanup, and Reports controllers. Each of these controllers can be monitored. Each Kyverno controller has Prometheus-formatted metrics readily available at `/metrics` on port `8000`. For the Agent to start collecting metrics, the Kyverno controller pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample kyverno.d/conf.yaml][4]. 
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kyverno`, and set `containerImage` to match each controller image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kyverno`, and set `containerImage` to match each controller image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][11].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `kyverno.controller.drop.count` metric is exposed only after an object is dropped by a controller.
 
@@ -127,3 +127,4 @@ Need help? Contact [Datadog support][9].
 [8]: https://github.com/DataDog/integrations-core/blob/master/kyverno/assets/service_checks.json
 [9]: https://docs.datadoghq.com/help/
 [10]: https://docs.datadoghq.com/agent/kubernetes/log/
+[11]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/kyverno/README.md
+++ b/kyverno/README.md
@@ -20,6 +20,8 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 Kyverno consists of multiple controllers such as Backup, Admissions, Cleanup, and Reports controllers. Each of these controllers can be monitored. Each Kyverno controller has Prometheus-formatted metrics readily available at `/metrics` on port `8000`. For the Agent to start collecting metrics, the Kyverno controller pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample kyverno.d/conf.yaml][4]. 
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kyverno`, and set `containerImage` to match each controller image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `kyverno.controller.drop.count` metric is exposed only after an object is dropped by a controller.
 
 The only parameter required for configuring the Kyverno check is:

--- a/kyverno/README.md
+++ b/kyverno/README.md
@@ -20,7 +20,7 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 Kyverno consists of multiple controllers such as Backup, Admissions, Cleanup, and Reports controllers. Each of these controllers can be monitored. Each Kyverno controller has Prometheus-formatted metrics readily available at `/metrics` on port `8000`. For the Agent to start collecting metrics, the Kyverno controller pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample kyverno.d/conf.yaml][4]. 
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kyverno`, and set `containerImage` to match each controller image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][11].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kyverno`, and set `containerName` to match each controller's container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][11].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `kyverno.controller.drop.count` metric is exposed only after an object is dropped by a controller.
 

--- a/kyverno/README.md
+++ b/kyverno/README.md
@@ -18,14 +18,15 @@ This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoin
 
 ### Configuration
 
-Kyverno consists of multiple controllers such as Backup, Admissions, Cleanup, and Reports controllers. Each of these controllers can be monitored. Each Kyverno controller has Prometheus-formatted metrics readily available at `/metrics` on port `8000`. For the Agent to start collecting metrics, the Kyverno controller pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample kyverno.d/conf.yaml][4]. 
-
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: kyverno`, and set `containerName` to match each controller's container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][11].
+Kyverno consists of multiple controllers such as Backup, Admissions, Cleanup, and Reports controllers. Each of these controllers can be monitored. Each Kyverno controller has Prometheus-formatted metrics readily available at `/metrics` on port `8000`. Configure each controller with one of the Kubernetes Autodiscovery options below. You can find additional configuration options by reviewing the [sample kyverno.d/conf.yaml][4].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `kyverno.controller.drop.count` metric is exposed only after an object is dropped by a controller.
 
 The only parameter required for configuring the Kyverno check is:
 - `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `8000`. In containerized environments, `%%host%%` should be used for [host autodetection][3]. 
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 apiVersion: v1
@@ -79,6 +80,35 @@ spec:
     - name: controller
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+This example targets the Reports Controller Deployment. Create a separate resource for each additional Kyverno controller that you monitor:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kyverno-reports-controller
+  config:
+    checks:
+      - integration: kyverno
+        containerName: controller
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:8000/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][11].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 #### Log collection
 

--- a/litellm/README.md
+++ b/litellm/README.md
@@ -95,7 +95,7 @@ spec:
 # (...)
 ```
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: litellm`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: litellm`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
 
 For more information and alternative ways to configure the check in Kubernetes-based environments, see the [Kubernetes Integration Setup documentation][3].
 

--- a/litellm/README.md
+++ b/litellm/README.md
@@ -70,7 +70,7 @@ Note: The listed metrics can only be collected if they are available. Some metri
 
 For LiteLLM Proxy running on Kubernetes, configuration can be easily done via pod annotations. See the example below:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: litellm`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: litellm`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
 
 ```yaml
 apiVersion: v1
@@ -142,3 +142,4 @@ Need help? Contact [Datadog support][9].
 [11]: https://docs.litellm.ai/docs/proxy/logging
 [12]: https://docs.datadoghq.com/llm_observability/quickstart/
 [13]: https://docs.datadoghq.com/llm_observability/instrumentation/auto_instrumentation?tab=python#litellm
+[14]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/litellm/README.md
+++ b/litellm/README.md
@@ -70,8 +70,6 @@ Note: The listed metrics can only be collected if they are available. Some metri
 
 For LiteLLM Proxy running on Kubernetes, configuration can be easily done via pod annotations. See the example below:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: litellm`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
-
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -96,6 +94,8 @@ spec:
     - name: <CONTAINER_NAME>
 # (...)
 ```
+
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: litellm`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
 
 For more information and alternative ways to configure the check in Kubernetes-based environments, see the [Kubernetes Integration Setup documentation][3].
 

--- a/litellm/README.md
+++ b/litellm/README.md
@@ -70,6 +70,8 @@ Note: The listed metrics can only be collected if they are available. Some metri
 
 For LiteLLM Proxy running on Kubernetes, configuration can be easily done via pod annotations. See the example below:
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: litellm`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 ```yaml
 apiVersion: v1
 kind: Pod

--- a/litellm/README.md
+++ b/litellm/README.md
@@ -70,8 +70,7 @@ Note: The listed metrics can only be collected if they are available. Some metri
 
 For LiteLLM Proxy running on Kubernetes, choose one of the following Autodiscovery configurations:
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+##### Kubernetes annotations
 
 ```yaml
 apiVersion: v1
@@ -97,8 +96,7 @@ spec:
     - name: <CONTAINER_NAME>
 # (...)
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+##### DatadogInstrumentation CRD
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -121,9 +119,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 For more information and alternative ways to configure the check in Kubernetes-based environments, see the [Kubernetes Integration Setup documentation][3].
 

--- a/litellm/README.md
+++ b/litellm/README.md
@@ -68,7 +68,10 @@ Note: The listed metrics can only be collected if they are available. Some metri
 
 #### Kubernetes-based
 
-For LiteLLM Proxy running on Kubernetes, configuration can be easily done via pod annotations. See the example below:
+For LiteLLM Proxy running on Kubernetes, choose one of the following Autodiscovery configurations:
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 apiVersion: v1
@@ -94,8 +97,33 @@ spec:
     - name: <CONTAINER_NAME>
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: litellm`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment # Or another target kind, if applicable.
+    name: <LITELLM_WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: litellm
+        containerName: litellm
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:4000/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 For more information and alternative ways to configure the check in Kubernetes-based environments, see the [Kubernetes Integration Setup documentation][3].
 

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -377,7 +377,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][13] as pod annotations on your application container. Aside from this, templates can also be configure with a [file, configmap, or key-value store][14].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: mongo`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: mongo`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][30].
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -617,3 +617,4 @@ Additional helpful documentation, links, and articles:
 [27]: https://www.datadoghq.com/blog/monitoring-mongodb-performance-metrics-mmap
 [28]: https://docs.datadoghq.com/database_monitoring/setup_mongodb/
 [29]: https://docs.datadoghq.com/database_monitoring/#mongodb
+[30]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -377,7 +377,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][13] as pod annotations on your application container. Aside from this, templates can also be configure with a [file, configmap, or key-value store][14].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: mongo`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][30].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: mongo`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][30].
 
 **Annotations v1** (for Datadog Agent < v7.36)
 

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -377,6 +377,8 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][13] as pod annotations on your application container. Aside from this, templates can also be configure with a [file, configmap, or key-value store][14].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: mongo`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 **Annotations v1** (for Datadog Agent < v7.36)
 
 ```yaml
@@ -433,6 +435,8 @@ spec:
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes Log Collection][15].
 
 Then, set [Log Integrations][11] as pod annotations. This can also be configured with [a file, a configmap, or a key-value store][16].
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 **Annotations v1/v2**
 

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -436,8 +436,6 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 Then, set [Log Integrations][11] as pod annotations. This can also be configured with [a file, a configmap, or a key-value store][16].
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 **Annotations v1/v2**
 
 ```yaml

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -375,9 +375,10 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-Set [Autodiscovery Integrations Templates][13] as pod annotations on your application container. Aside from this, templates can also be configure with a [file, configmap, or key-value store][14].
+Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with a [file, configmap, or key-value store][14].
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: mongo`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][30].
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -429,6 +430,37 @@ spec:
   containers:
     - name: mongo
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet # Or another target kind, if applicable.
+    name: <MONGODB_WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: mongo
+        containerName: mongo
+        initConfig: {}
+        instances:
+          - hosts:
+              - "%%host%%:%%port%%"
+            username: "datadog"
+            password: "<UNIQUEPASSWORD>"
+            database: "<DATABASE>"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][30].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 ##### Log collection
 

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -377,8 +377,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with a [file, configmap, or key-value store][14].
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -430,8 +429,7 @@ spec:
   containers:
     - name: mongo
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -458,9 +456,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][30].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 ##### Log collection
 

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -278,6 +278,8 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][15] as pod annotations on your application container. Alternatively, you can configure templates with a [file, configmap, or key-value store][16].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: mysql`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 **Annotations v1** (for Datadog Agent < v7.36)
 
 ```yaml
@@ -338,6 +340,8 @@ See [Autodiscovery template variables][12] for details on using `<UNIQUEPASSWORD
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes Log Collection][17].
 
 Then, set [Log Integrations][14] as pod annotations. Alternatively, you can configure this with a [file, configmap, or key-value store][18].
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 **Annotations v1/v2**
 

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -278,7 +278,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][15] as pod annotations on your application container. Alternatively, you can configure templates with a [file, configmap, or key-value store][16].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: mysql`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][34].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: mysql`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][34].
 
 **Annotations v1** (for Datadog Agent < v7.36)
 

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -341,8 +341,6 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 Then, set [Log Integrations][14] as pod annotations. Alternatively, you can configure this with a [file, configmap, or key-value store][18].
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 **Annotations v1/v2**
 
 ```yaml

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -276,9 +276,10 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-Set [Autodiscovery Integrations Templates][15] as pod annotations on your application container. Alternatively, you can configure templates with a [file, configmap, or key-value store][16].
+Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with a [file, configmap, or key-value store][16].
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: mysql`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][34].
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -331,6 +332,35 @@ spec:
   containers:
     - name: mysql
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet # Or another target kind, if applicable.
+    name: <MYSQL_WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: mysql
+        containerName: mysql
+        initConfig: {}
+        instances:
+          - server: "%%host%%"
+            username: "datadog"
+            password: "<UNIQUEPASSWORD>"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][34].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 See [Autodiscovery template variables][12] for details on using `<UNIQUEPASSWORD>` as an environment variable instead of a label.
 

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -278,7 +278,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][15] as pod annotations on your application container. Alternatively, you can configure templates with a [file, configmap, or key-value store][16].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: mysql`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: mysql`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][34].
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -603,3 +603,4 @@ Additional helpful documentation, links, and articles:
 [31]: https://www.datadoghq.com/blog/monitoring-mysql-performance-metrics
 [32]: https://docs.datadoghq.com/database_monitoring/setup_mysql/
 [33]: https://docs.datadoghq.com/database_monitoring/#mysql
+[34]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -278,8 +278,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with a [file, configmap, or key-value store][16].
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -332,8 +331,7 @@ spec:
   containers:
     - name: mysql
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -358,9 +356,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][34].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 See [Autodiscovery template variables][12] for details on using `<UNIQUEPASSWORD>` as an environment variable instead of a label.
 

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -264,7 +264,7 @@ To configure this check for an Agent running on Kubernetes:
 
 To collect metrics, set the following parameters and values in an [Autodiscovery template][11]. You can do this with Kubernetes Annotations (shown below) on your NGINX pod(s), or with a [local file, ConfigMap, key-value store, Datadog Operator manifest, or Helm chart][12].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: nginx`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: nginx`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][24].
 
 | Parameter            | Value                                                                      |
 | -------------------- | -------------------------------------------------------------------------- |
@@ -469,3 +469,4 @@ Additional helpful documentation, links, and articles:
 [21]: https://www.datadoghq.com/blog/how-to-monitor-nginx
 [22]: https://www.datadoghq.com/blog/how-to-collect-nginx-metrics/index.html
 [23]: https://www.datadoghq.com/blog/how-to-monitor-nginx-with-datadog/index.html
+[24]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -264,7 +264,7 @@ To configure this check for an Agent running on Kubernetes:
 
 To collect metrics, set the following parameters and values in an [Autodiscovery template][11]. You can do this with Kubernetes Annotations (shown below) on your NGINX pod(s), or with a [local file, ConfigMap, key-value store, Datadog Operator manifest, or Helm chart][12].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: nginx`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][24].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: nginx`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][24].
 
 | Parameter            | Value                                                                      |
 | -------------------- | -------------------------------------------------------------------------- |

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -264,6 +264,8 @@ To configure this check for an Agent running on Kubernetes:
 
 To collect metrics, set the following parameters and values in an [Autodiscovery template][11]. You can do this with Kubernetes Annotations (shown below) on your NGINX pod(s), or with a [local file, ConfigMap, key-value store, Datadog Operator manifest, or Helm chart][12].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: nginx`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 | Parameter            | Value                                                                      |
 | -------------------- | -------------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `["nginx"]`                                                                |
@@ -325,6 +327,8 @@ Then, set the following parameter in an [Autodiscovery template][11]. You can do
 | Parameter            | Value                                                                      |
 | -------------------- | -------------------------------------------------------------------------- |
 | `<LOG_CONFIG>`       | `[{"source":"nginx","service":"nginx"}]`                                   |
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 **Annotations v1/v2**
 

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -328,8 +328,6 @@ Then, set the following parameter in an [Autodiscovery template][11]. You can do
 | -------------------- | -------------------------------------------------------------------------- |
 | `<LOG_CONFIG>`       | `[{"source":"nginx","service":"nginx"}]`                                   |
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 **Annotations v1/v2**
 
 ```yaml

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -262,15 +262,16 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-To collect metrics, set the following parameters and values in an [Autodiscovery template][11]. You can do this with Kubernetes Annotations (shown below) on your NGINX pod(s), or with a [local file, ConfigMap, key-value store, Datadog Operator manifest, or Helm chart][12].
-
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: nginx`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][24].
+To collect metrics, set the following parameters and values with one of the Kubernetes Autodiscovery options below. You can also use a [local file, ConfigMap, key-value store, Datadog Operator manifest, or Helm chart][12].
 
 | Parameter            | Value                                                                      |
 | -------------------- | -------------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `["nginx"]`                                                                |
 | `<INIT_CONFIG>`      | `[{}]`                                                                     |
 | `<INSTANCE_CONFIG>`  | `[{"nginx_status_url": "http://%%host%%:18080/nginx_status"}]`             |
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -314,6 +315,33 @@ metadata:
   labels:
     name: nginx
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment # Or another target kind, if applicable.
+    name: <NGINX_WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: nginx
+        containerName: nginx
+        initConfig: {}
+        instances:
+          - nginx_status_url: "http://%%host%%:81/nginx_status/"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][24].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 **Note**: This instance configuration works only with NGINX Open Source. If you are using NGINX Plus, inline the corresponding instance configuration.
 

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -270,8 +270,7 @@ To collect metrics, set the following parameters and values with one of the Kube
 | `<INIT_CONFIG>`      | `[{}]`                                                                     |
 | `<INSTANCE_CONFIG>`  | `[{"nginx_status_url": "http://%%host%%:18080/nginx_status"}]`             |
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -315,8 +314,7 @@ metadata:
   labels:
     name: nginx
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -339,9 +337,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][24].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 **Note**: This instance configuration works only with NGINX Open Source. If you are using NGINX Plus, inline the corresponding instance configuration.
 

--- a/nvidia_triton/README.md
+++ b/nvidia_triton/README.md
@@ -106,9 +106,6 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 Then, set Log Integrations as pod annotations. This can also be configured with a file, a configmap, or a key-value store. For more information, see the configuration section of [Kubernetes Log Collection][14].
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
-
 **Annotations v1/v2**
 
 ```yaml

--- a/nvidia_triton/README.md
+++ b/nvidia_triton/README.md
@@ -106,6 +106,8 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 Then, set Log Integrations as pod annotations. This can also be configured with a file, a configmap, or a key-value store. For more information, see the configuration section of [Kubernetes Log Collection][14].
 
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 
 **Annotations v1/v2**
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -286,7 +286,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][13] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][14].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: postgres`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: postgres`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -526,3 +526,4 @@ Additional helpful documentation, links, and articles:
 [28]: https://docs.datadoghq.com/database_monitoring/setup_postgres/
 [29]: https://docs.datadoghq.com/database_monitoring/#postgres
 [30]: https://docs.datadoghq.com/integrations/postgres/?tab=host#faq
+[31]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -346,8 +346,6 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 Then, set [Log Integrations][11] as pod annotations. This can also be configured with [a file, a configmap, or a key-value store][16].
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 **Annotations v1/v2**
 
 ```yaml

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -286,7 +286,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][13] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][14].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: postgres`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: postgres`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
 
 **Annotations v1** (for Datadog Agent < v7.36)
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -286,6 +286,8 @@ To configure this check for an Agent running on Kubernetes:
 
 Set [Autodiscovery Integrations Templates][13] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][14].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: postgres`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 **Annotations v1** (for Datadog Agent < v7.36)
 
 ```yaml
@@ -343,6 +345,8 @@ spec:
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes Log Collection][15].
 
 Then, set [Log Integrations][11] as pod annotations. This can also be configured with [a file, a configmap, or a key-value store][16].
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 **Annotations v1/v2**
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -284,9 +284,10 @@ To configure this check for an Agent running on Kubernetes:
 ##### Metric collection
 **Note**: The `<container-name>.check_names` must match the container name where the integration needs to collect metrics. In the example, we are using `postgres.check_names` because the container name is postgres.
 
-Set [Autodiscovery Integrations Templates][13] as pod annotations on your application container. Aside from this, templates can also be configured with [a file, a configmap, or a key-value store][14].
+Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with [a file, a configmap, or a key-value store][14].
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: postgres`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -338,6 +339,36 @@ spec:
   containers:
     - name: postgres
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet # Or another target kind, if applicable.
+    name: <POSTGRESQL_WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: postgres
+        containerName: postgres
+        initConfig: {}
+        instances:
+          - host: "%%host%%"
+            port: "5432"
+            username: "datadog"
+            password: "<PASSWORD>"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 ##### Log collection
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -286,8 +286,7 @@ To configure this check for an Agent running on Kubernetes:
 
 Choose one of the following Kubernetes Autodiscovery configurations. You can also configure templates with [a file, a configmap, or a key-value store][14].
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -339,8 +338,7 @@ spec:
   containers:
     - name: postgres
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -366,9 +364,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][31].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 ##### Log collection
 

--- a/ray/README.md
+++ b/ray/README.md
@@ -61,7 +61,7 @@ labels:
 
 This example demonstrates the configuration as Kubernetes annotations on your Ray pods. See the [sample configuration file][4] for all available configuration options.
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: ray`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: ray`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][15].
 
 ```yaml
 apiVersion: v1
@@ -196,3 +196,4 @@ Need help? Contact [Datadog support][9].
 [12]: https://docs.ray.io/en/latest/ray-observability/user-guides/configure-logging.html
 [13]: https://docs.datadoghq.com/agent/kubernetes/log/#setup
 [14]: https://docs.datadoghq.com/agent/kubernetes/log/#configuration
+[15]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/ray/README.md
+++ b/ray/README.md
@@ -61,6 +61,8 @@ labels:
 
 This example demonstrates the configuration as Kubernetes annotations on your Ray pods. See the [sample configuration file][4] for all available configuration options.
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: ray`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -156,6 +158,8 @@ The Ray integration can collect logs from the Ray service and forward them to Da
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes Log Collection][13].
 
 Then, set Log Integrations as pod annotations. This can also be configured with a file, a configmap, or a key-value store. For more information, see the configuration section of [Kubernetes Log Collection][14].
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 
 **Annotations v1/v2**

--- a/ray/README.md
+++ b/ray/README.md
@@ -61,8 +61,6 @@ labels:
 
 This example demonstrates the configuration as Kubernetes annotations on your Ray pods. See the [sample configuration file][4] for all available configuration options.
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: ray`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][15].
-
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -85,6 +83,8 @@ spec:
     - name: 'ray'
 # (...)
 ```
+
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: ray`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][15].
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/ray/README.md
+++ b/ray/README.md
@@ -84,7 +84,7 @@ spec:
 # (...)
 ```
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: ray`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][15].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: ray`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][15].
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/ray/README.md
+++ b/ray/README.md
@@ -159,9 +159,6 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 Then, set Log Integrations as pod annotations. This can also be configured with a file, a configmap, or a key-value store. For more information, see the configuration section of [Kubernetes Log Collection][14].
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
-
 **Annotations v1/v2**
 
 ```yaml

--- a/ray/README.md
+++ b/ray/README.md
@@ -59,7 +59,10 @@ labels:
 
 ##### Metric collection
 
-This example demonstrates the configuration as Kubernetes annotations on your Ray pods. See the [sample configuration file][4] for all available configuration options.
+Choose one of the following Kubernetes Autodiscovery configurations. See the [sample configuration file][4] for all available configuration options.
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 apiVersion: v1
@@ -83,8 +86,33 @@ spec:
     - name: 'ray'
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: ray`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][15].
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment # Or another target kind, if applicable.
+    name: <RAY_WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: ray
+        containerName: ray
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:8080"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][15].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/ray/README.md
+++ b/ray/README.md
@@ -61,8 +61,7 @@ labels:
 
 Choose one of the following Kubernetes Autodiscovery configurations. See the [sample configuration file][4] for all available configuration options.
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 ```yaml
 apiVersion: v1
@@ -86,8 +85,7 @@ spec:
     - name: 'ray'
 # (...)
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -110,9 +108,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][15].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -151,6 +151,8 @@ To configure this check for an Agent running on Kubernetes:
 
 To collect metrics, set the following parameters and values in an [Autodiscovery template][14]. You can do this with Kubernetes Annotations (shown below) on your Redis pod(s), or with a [local file, ConfigMap, key-value store, Datadog Operator manifest, or Helm chart][15].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: redisdb`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 | Parameter            | Value                                                                      |
 | -------------------- | -------------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `["redisdb"]`                                                              |
@@ -231,6 +233,8 @@ Then, set the following parameter in an [Autodiscovery template][14]. You can do
 | Parameter            | Value                                                                      |
 | -------------------- | -------------------------------------------------------------------------- |
 | `<LOG_CONFIG>`       | `[{"source":"redis","service":"<YOUR_APP_NAME>"}]`                         |
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 **Annotations v1/v2**
 

--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -157,8 +157,7 @@ To collect metrics, set the following parameters and values with one of the Kube
 | `<INIT_CONFIG>`      | `[{}]`                                                                     |
 | `<INSTANCE_CONFIG>`  | `[{"host": "%%host%%","port":"6379","password":"%%env_REDIS_PASSWORD%%"}]` |
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -218,8 +217,7 @@ spec:
       ports:
         - containerPort: 6379
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -244,9 +242,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][27].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 **Note**: 
 - If no user is specified in the configuration, the Redis integration authenticates with the `default` user. The password specified in the configuration therefore applies to `default` user.

--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -234,8 +234,6 @@ Then, set the following parameter in an [Autodiscovery template][14]. You can do
 | -------------------- | -------------------------------------------------------------------------- |
 | `<LOG_CONFIG>`       | `[{"source":"redis","service":"<YOUR_APP_NAME>"}]`                         |
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 **Annotations v1/v2**
 
 ```yaml

--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -149,15 +149,16 @@ To configure this check for an Agent running on Kubernetes:
 
 ##### Metric collection
 
-To collect metrics, set the following parameters and values in an [Autodiscovery template][14]. You can do this with Kubernetes Annotations (shown below) on your Redis pod(s), or with a [local file, ConfigMap, key-value store, Datadog Operator manifest, or Helm chart][15].
-
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: redisdb`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][27].
+To collect metrics, set the following parameters and values with one of the Kubernetes Autodiscovery options below. You can also use a [local file, ConfigMap, key-value store, Datadog Operator manifest, or Helm chart][15].
 
 | Parameter            | Value                                                                      |
 | -------------------- | -------------------------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `["redisdb"]`                                                              |
 | `<INIT_CONFIG>`      | `[{}]`                                                                     |
 | `<INSTANCE_CONFIG>`  | `[{"host": "%%host%%","port":"6379","password":"%%env_REDIS_PASSWORD%%"}]` |
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 **Annotations v1** (for Datadog Agent < v7.36)
 
@@ -217,6 +218,35 @@ spec:
       ports:
         - containerPort: 6379
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet # Or another target kind, if applicable.
+    name: <REDIS_WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: redisdb
+        containerName: redis
+        initConfig: {}
+        instances:
+          - host: "%%host%%"
+            port: "6379"
+            password: "%%env_REDIS_PASSWORD%%"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][27].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 **Note**: 
 - If no user is specified in the configuration, the Redis integration authenticates with the `default` user. The password specified in the configuration therefore applies to `default` user.

--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -151,7 +151,7 @@ To configure this check for an Agent running on Kubernetes:
 
 To collect metrics, set the following parameters and values in an [Autodiscovery template][14]. You can do this with Kubernetes Annotations (shown below) on your Redis pod(s), or with a [local file, ConfigMap, key-value store, Datadog Operator manifest, or Helm chart][15].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: redisdb`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][27].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: redisdb`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][27].
 
 | Parameter            | Value                                                                      |
 | -------------------- | -------------------------------------------------------------------------- |

--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -151,7 +151,7 @@ To configure this check for an Agent running on Kubernetes:
 
 To collect metrics, set the following parameters and values in an [Autodiscovery template][14]. You can do this with Kubernetes Annotations (shown below) on your Redis pod(s), or with a [local file, ConfigMap, key-value store, Datadog Operator manifest, or Helm chart][15].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: redisdb`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: redisdb`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][27].
 
 | Parameter            | Value                                                                      |
 | -------------------- | -------------------------------------------------------------------------- |
@@ -408,3 +408,4 @@ Additional helpful documentation, links, and articles:
 [23]: https://github.com/DataDog/integrations-core/blob/master/redisdb/metadata.csv
 [24]: https://github.com/DataDog/integrations-core/blob/master/redisdb/assets/service_checks.json
 [26]: https://www.datadoghq.com/blog/how-to-monitor-redis-performance-metrics
+[27]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/strimzi/README.md
+++ b/strimzi/README.md
@@ -36,6 +36,8 @@ Follow the instructions below to enable and configure this check for an Agent.
 
 For containerized environments, refer to the [Autodiscovery Integration Templates][3] for guidance on applying these instructions. Here's an example of how to configure this on the different Operator manifests using pod annotations:
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration` to the check used by each target workload (`strimzi`, `kafka`, `kafka_consumer`, or `zk` in these examples), and set `containerImage` to match each target image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 ##### Cluster Operator:
 ```yaml
 apiVersion: apps/v1

--- a/strimzi/README.md
+++ b/strimzi/README.md
@@ -114,7 +114,7 @@ spec:
 ```
 **Note**: The template used as for this example can be found [here][14].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration` to the check used by each target workload (`strimzi`, `kafka`, `kafka_consumer`, or `zk` in these examples), and set `containerImage` to match each target image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration` to the check used by each target workload (`strimzi`, `kafka`, `kafka_consumer`, or `zk` in these examples), and set `containerName` to match each target container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
 
 See the [sample strimzi.d/conf.yaml][4] for all available configuration options.
 

--- a/strimzi/README.md
+++ b/strimzi/README.md
@@ -36,8 +36,6 @@ Follow the instructions below to enable and configure this check for an Agent.
 
 For containerized environments, refer to the [Autodiscovery Integration Templates][3] for guidance on applying these instructions. Here's an example of how to configure this on the different Operator manifests using pod annotations:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration` to the check used by each target workload (`strimzi`, `kafka`, `kafka_consumer`, or `zk` in these examples), and set `containerImage` to match each target image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
-
 ##### Cluster Operator:
 ```yaml
 apiVersion: apps/v1
@@ -115,6 +113,8 @@ spec:
 ...
 ```
 **Note**: The template used as for this example can be found [here][14].
+
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration` to the check used by each target workload (`strimzi`, `kafka`, `kafka_consumer`, or `zk` in these examples), and set `containerImage` to match each target image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
 
 See the [sample strimzi.d/conf.yaml][4] for all available configuration options.
 

--- a/strimzi/README.md
+++ b/strimzi/README.md
@@ -36,7 +36,7 @@ Follow the instructions below to enable and configure this check for an Agent.
 
 For containerized environments, refer to the [Autodiscovery Integration Templates][3] for guidance on applying these instructions. Here's an example of how to configure this on the different Operator manifests using pod annotations:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration` to the check used by each target workload (`strimzi`, `kafka`, `kafka_consumer`, or `zk` in these examples), and set `containerImage` to match each target image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration` to the check used by each target workload (`strimzi`, `kafka`, `kafka_consumer`, or `zk` in these examples), and set `containerImage` to match each target image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
 
 ##### Cluster Operator:
 ```yaml
@@ -252,3 +252,4 @@ Additional helpful documentation, links, and articles:
 [16]: https://docs.datadoghq.com/agent/kubernetes/log/
 [17]: https://docs.datadoghq.com/integrations/kafka/?tab=host#kafka-consumer-integration
 [18]: https://www.datadoghq.com/blog/container-native-integrations/#messaging-and-streaming-with-strimzi
+[19]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/strimzi/README.md
+++ b/strimzi/README.md
@@ -34,12 +34,9 @@ Follow the instructions below to enable and configure this check for an Agent.
 
 #### Containerized
 
-For containerized environments, choose one of the following Autodiscovery configurations for each Operator workload:
+For containerized environments, refer to the [Autodiscovery Integration Templates][3] for guidance on applying these instructions. Here's an example of how to configure this on the different Operator manifests using pod annotations:
 
 ##### Cluster Operator:
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
-
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -75,42 +72,10 @@ spec:
         - name: strimzi-cluster-operator
 ...
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
-
-Target the Cluster Operator Deployment shown in the annotation example:
-
-```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogInstrumentation
-metadata:
-  name: <CR_NAME>
-  namespace: <WORKLOAD_NAMESPACE>
-spec:
-  targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: strimzi-cluster-operator
-  config:
-    checks:
-      - integration: strimzi
-        containerName: strimzi-cluster-operator
-        initConfig: {}
-        instances:
-          - cluster_operator_endpoint: "http://%%host%%:8080/metrics"
-```
-
-For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 **Note**: The template used for this example can be found [here][13].
 
 
 ##### Topic and User Operators:
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
-
 ```yaml
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
@@ -147,50 +112,13 @@ spec:
               } 
 ...
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
-
-The Topic and User Operators run in the same Entity Operator Deployment:
-
-```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogInstrumentation
-metadata:
-  name: <CR_NAME>
-  namespace: <WORKLOAD_NAMESPACE>
-spec:
-  targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: my-cluster-entity-operator
-  config:
-    checks:
-      - integration: strimzi
-        containerName: topic-operator
-        initConfig: {}
-        instances:
-          - topic_operator_endpoint: "http://%%host%%:8080/metrics"
-      - integration: strimzi
-        containerName: user-operator
-        initConfig: {}
-        instances:
-          - user_operator_endpoint: "http://%%host%%:8081/metrics"
-```
-
-For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 **Note**: The template used as for this example can be found [here][14].
 
 See the [sample strimzi.d/conf.yaml][4] for all available configuration options.
 
 #### Kafka and Zookeeper
 
-The Kafka and Zookeeper components of Strimzi can be monitored using the [Kafka][11], [Kafka Consumer][17] and [Zookeeper][12] checks. Kafka metrics are collected through JMX. For more information on enabling JMX, see the [Strimzi documentation on JMX options][15]. Choose one of the following Autodiscovery configurations for each component:
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
-
+The Kafka and Zookeeper components of Strimzi can be monitored using the [Kafka][11], [Kafka Consumer][17] and [Zookeeper][12] checks. Kafka metrics are collected through JMX. For more information on enabling JMX, see the [Strimzi documentation on JMX options][15]. Here's an example of how to configure the Kafka, Kafka Consumer and Zookeeper checks using Pod annotations:
 ```yaml
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
@@ -261,64 +189,6 @@ spec:
                 }
               } 
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
-
-Create one resource per target workload. These resources mirror the annotation configurations:
-
-```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogInstrumentation
-metadata:
-  name: kafka-instrumentation
-  namespace: <WORKLOAD_NAMESPACE>
-spec:
-  targetRef:
-    apiVersion: apps/v1
-    kind: StatefulSet
-    name: my-cluster-kafka
-  config:
-    checks:
-      - integration: kafka
-        containerName: kafka
-        initConfig:
-          is_jmx: true
-          collect_default_metrics: true
-          new_gc_metrics: true
-        instances:
-          - host: "%%host%%"
-            port: "9999"
-      - integration: kafka_consumer
-        containerName: kafka
-        initConfig: {}
-        instances:
-          - kafka_connect_str: "%%host%%:9092"
-            monitor_unlisted_consumer_groups: "true"
----
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogInstrumentation
-metadata:
-  name: zookeeper-instrumentation
-  namespace: <WORKLOAD_NAMESPACE>
-spec:
-  targetRef:
-    apiVersion: apps/v1
-    kind: StatefulSet
-    name: my-cluster-zookeeper
-  config:
-    checks:
-      - integration: zk
-        containerName: zookeeper
-        initConfig: {}
-        instances:
-          - host: "%%host%%"
-            port: "2181"
-```
-
-For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 **Note**: The template used for this example can be found [here][14].
 
 #### Log collection
@@ -380,4 +250,3 @@ Additional helpful documentation, links, and articles:
 [16]: https://docs.datadoghq.com/agent/kubernetes/log/
 [17]: https://docs.datadoghq.com/integrations/kafka/?tab=host#kafka-consumer-integration
 [18]: https://www.datadoghq.com/blog/container-native-integrations/#messaging-and-streaming-with-strimzi
-[19]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/strimzi/README.md
+++ b/strimzi/README.md
@@ -34,9 +34,12 @@ Follow the instructions below to enable and configure this check for an Agent.
 
 #### Containerized
 
-For containerized environments, refer to the [Autodiscovery Integration Templates][3] for guidance on applying these instructions. Here's an example of how to configure this on the different Operator manifests using pod annotations:
+For containerized environments, choose one of the following Autodiscovery configurations for each Operator workload:
 
 ##### Cluster Operator:
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -72,10 +75,42 @@ spec:
         - name: strimzi-cluster-operator
 ...
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+Target the Cluster Operator Deployment shown in the annotation example:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: strimzi-cluster-operator
+  config:
+    checks:
+      - integration: strimzi
+        containerName: strimzi-cluster-operator
+        initConfig: {}
+        instances:
+          - cluster_operator_endpoint: "http://%%host%%:8080/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 **Note**: The template used for this example can be found [here][13].
 
 
 ##### Topic and User Operators:
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
+
 ```yaml
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
@@ -112,15 +147,50 @@ spec:
               } 
 ...
 ```
-**Note**: The template used as for this example can be found [here][14].
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration` to the check used by each target workload (`strimzi`, `kafka`, `kafka_consumer`, or `zk` in these examples), and set `containerName` to match each target container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
+The Topic and User Operators run in the same Entity Operator Deployment:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-cluster-entity-operator
+  config:
+    checks:
+      - integration: strimzi
+        containerName: topic-operator
+        initConfig: {}
+        instances:
+          - topic_operator_endpoint: "http://%%host%%:8080/metrics"
+      - integration: strimzi
+        containerName: user-operator
+        initConfig: {}
+        instances:
+          - user_operator_endpoint: "http://%%host%%:8081/metrics"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
+**Note**: The template used as for this example can be found [here][14].
 
 See the [sample strimzi.d/conf.yaml][4] for all available configuration options.
 
 #### Kafka and Zookeeper
 
-The Kafka and Zookeeper components of Strimzi can be monitored using the [Kafka][11], [Kafka Consumer][17] and [Zookeeper][12] checks. Kafka metrics are collected through JMX. For more information on enabling JMX, see the [Strimzi documentation on JMX options][15]. Here's an example of how to configure the Kafka, Kafka Consumer and Zookeeper checks using Pod annotations:
+The Kafka and Zookeeper components of Strimzi can be monitored using the [Kafka][11], [Kafka Consumer][17] and [Zookeeper][12] checks. Kafka metrics are collected through JMX. For more information on enabling JMX, see the [Strimzi documentation on JMX options][15]. Choose one of the following Autodiscovery configurations for each component:
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
+
 ```yaml
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
@@ -191,6 +261,64 @@ spec:
                 }
               } 
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+Create one resource per target workload. These resources mirror the annotation configurations:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: kafka-instrumentation
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: my-cluster-kafka
+  config:
+    checks:
+      - integration: kafka
+        containerName: kafka
+        initConfig:
+          is_jmx: true
+          collect_default_metrics: true
+          new_gc_metrics: true
+        instances:
+          - host: "%%host%%"
+            port: "9999"
+      - integration: kafka_consumer
+        containerName: kafka
+        initConfig: {}
+        instances:
+          - kafka_connect_str: "%%host%%:9092"
+            monitor_unlisted_consumer_groups: "true"
+---
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: zookeeper-instrumentation
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: my-cluster-zookeeper
+  config:
+    checks:
+      - integration: zk
+        containerName: zookeeper
+        initConfig: {}
+        instances:
+          - host: "%%host%%"
+            port: "2181"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 **Note**: The template used for this example can be found [here][14].
 
 #### Log collection

--- a/temporal/README.md
+++ b/temporal/README.md
@@ -109,8 +109,6 @@ Apply the following configuration parameter to `logs`:
 
 The following Kubernetes annotation is applied to a pod under `metadata`, where `<CONTAINER_NAME>` is the name of your Temporal container (or a [custom identifier][16]):
 
-For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.logs: |
   [

--- a/temporal/README.md
+++ b/temporal/README.md
@@ -83,8 +83,6 @@ Note that when Temporal services in a cluster are deployed independently, every 
 
 The following Kubernetes annotation is applied to a pod under `metadata`, where `<CONTAINER_NAME>` is the name of your Temporal container (or a [custom identifier][16]):
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: temporal`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
-
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.checks: |
   {
@@ -94,6 +92,8 @@ ad.datadoghq.com/<CONTAINER_NAME>.checks: |
     }
   } 
 ```
+
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: temporal`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
 
 ##### Log collection
 

--- a/temporal/README.md
+++ b/temporal/README.md
@@ -83,7 +83,7 @@ Note that when Temporal services in a cluster are deployed independently, every 
 
 The following Kubernetes annotation is applied to a pod under `metadata`, where `<CONTAINER_NAME>` is the name of your Temporal container (or a [custom identifier][16]):
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: temporal`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: temporal`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
 
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.checks: |
@@ -176,3 +176,4 @@ Additional helpful documentation, links, and articles:
 [16]: https://docs.datadoghq.com/containers/guide/ad_identifiers/
 [17]: https://docs.datadoghq.com/agent/kubernetes/log/
 [18]: https://docs.datadoghq.com/containers/docker/log/
+[19]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/temporal/README.md
+++ b/temporal/README.md
@@ -83,6 +83,8 @@ Note that when Temporal services in a cluster are deployed independently, every 
 
 The following Kubernetes annotation is applied to a pod under `metadata`, where `<CONTAINER_NAME>` is the name of your Temporal container (or a [custom identifier][16]):
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: temporal`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.checks: |
   {
@@ -106,6 +108,8 @@ Apply the following configuration parameter to `logs`:
 **Example**
 
 The following Kubernetes annotation is applied to a pod under `metadata`, where `<CONTAINER_NAME>` is the name of your Temporal container (or a [custom identifier][16]):
+
+For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.logs: |

--- a/temporal/README.md
+++ b/temporal/README.md
@@ -93,7 +93,7 @@ ad.datadoghq.com/<CONTAINER_NAME>.checks: |
   } 
 ```
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: temporal`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: temporal`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
 
 ##### Log collection
 

--- a/temporal/README.md
+++ b/temporal/README.md
@@ -83,8 +83,7 @@ Note that when Temporal services in a cluster are deployed independently, every 
 
 Choose one of the following Kubernetes Autodiscovery configurations, where `<CONTAINER_NAME>` is the name of your Temporal container:
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+###### Kubernetes annotations
 
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.checks: |
@@ -95,8 +94,7 @@ ad.datadoghq.com/<CONTAINER_NAME>.checks: |
     }
   } 
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+###### DatadogInstrumentation CRD
 
 Temporal services are commonly deployed separately. Create one resource for each service workload that you monitor:
 
@@ -121,9 +119,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 ##### Log collection
 

--- a/temporal/README.md
+++ b/temporal/README.md
@@ -81,7 +81,10 @@ Note that when Temporal services in a cluster are deployed independently, every 
 
 **Example**
 
-The following Kubernetes annotation is applied to a pod under `metadata`, where `<CONTAINER_NAME>` is the name of your Temporal container (or a [custom identifier][16]):
+Choose one of the following Kubernetes Autodiscovery configurations, where `<CONTAINER_NAME>` is the name of your Temporal container:
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```
 ad.datadoghq.com/<CONTAINER_NAME>.checks: |
@@ -92,8 +95,35 @@ ad.datadoghq.com/<CONTAINER_NAME>.checks: |
     }
   } 
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: temporal`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
+Temporal services are commonly deployed separately. Create one resource for each service workload that you monitor:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment # Or another target kind, if applicable.
+    name: <TEMPORAL_SERVICE_NAME>
+  config:
+    checks:
+      - integration: temporal
+        containerName: <CONTAINER_NAME>
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "<LISTEN_ADDRESS>/<HANDLER_PATH>"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][19].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 ##### Log collection
 

--- a/torchserve/README.md
+++ b/torchserve/README.md
@@ -226,7 +226,7 @@ spec:
 # (...)
 ```
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: torchserve`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: torchserve`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/torchserve/README.md
+++ b/torchserve/README.md
@@ -187,8 +187,6 @@ labels:
 
 This example demonstrates the complete configuration leveraging the three different APIs described in the previous sections as Kubernetes annotations on your Torchserve pods:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: torchserve`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
-
 ```yaml
 apiVersion: v1
 kind: Pod
@@ -227,6 +225,8 @@ spec:
     - name: 'torchserve'
 # (...)
 ```
+
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: torchserve`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/torchserve/README.md
+++ b/torchserve/README.md
@@ -187,6 +187,8 @@ labels:
 
 This example demonstrates the complete configuration leveraging the three different APIs described in the previous sections as Kubernetes annotations on your Torchserve pods:
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: torchserve`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 ```yaml
 apiVersion: v1
 kind: Pod

--- a/torchserve/README.md
+++ b/torchserve/README.md
@@ -187,7 +187,7 @@ labels:
 
 This example demonstrates the complete configuration leveraging the three different APIs described in the previous sections as Kubernetes annotations on your Torchserve pods:
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: torchserve`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: torchserve`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
 
 ```yaml
 apiVersion: v1
@@ -310,3 +310,4 @@ Need help? Contact [Datadog support][9].
 [14]: https://pytorch.org/serve/inference_api.html
 [15]: https://pytorch.org/serve/metrics_api.html
 [16]: https://pytorch.org/serve/logging.html?highlight=logs
+[17]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/torchserve/README.md
+++ b/torchserve/README.md
@@ -187,8 +187,7 @@ labels:
 
 Choose one of the following Kubernetes Autodiscovery configurations. The example uses the three APIs described in the previous sections:
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Kubernetes annotations" xxx -->
+##### Kubernetes annotations
 
 ```yaml
 apiVersion: v1
@@ -228,8 +227,7 @@ spec:
     - name: 'torchserve'
 # (...)
 ```
-<!-- xxz tab xxx -->
-<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+##### DatadogInstrumentation CRD
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -261,9 +259,6 @@ spec:
 ```
 
 For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/torchserve/README.md
+++ b/torchserve/README.md
@@ -185,7 +185,10 @@ labels:
 <!-- xxz tab xxx -->
 <!-- xxx tab "Kubernetes" xxx -->
 
-This example demonstrates the complete configuration leveraging the three different APIs described in the previous sections as Kubernetes annotations on your Torchserve pods:
+Choose one of the following Kubernetes Autodiscovery configurations. The example uses the three APIs described in the previous sections:
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 apiVersion: v1
@@ -225,8 +228,42 @@ spec:
     - name: 'torchserve'
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: torchserve`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment # Or another target kind, if applicable.
+    name: <TORCHSERVE_WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: torchserve
+        containerName: torchserve
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:8082/metrics"
+            extra_metrics:
+              - "my_custom_torchserve_metric"
+          - inference_api_url: "http://%%host%%:8080"
+          - management_api_url: "http://%%host%%:8081"
+            include:
+              - ".*"
+            exclude:
+              - ".*-test"
+            interval: 3600
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/traefik_mesh/README.md
+++ b/traefik_mesh/README.md
@@ -37,6 +37,8 @@ In addition, a small subset of metrics can be collected by communicating with di
 
 Make sure that the Prometheus-formatted metrics are exposed in your Traefik Mesh cluster. You can configure and customize this by following the instructions on the [Observability page in the official Traefik Mesh documentation][10]. In order for the Agent to start collecting metrics, the Traefik Mesh pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [`traefik_mesh.d/conf.yaml` sample][4].
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: traefik_mesh`, and set `containerImage` to match each component image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 **Note**: The following metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed.
 
 When configuring the Traefik Mesh check, you can use the following parameters:

--- a/traefik_mesh/README.md
+++ b/traefik_mesh/README.md
@@ -37,7 +37,7 @@ In addition, a small subset of metrics can be collected by communicating with di
 
 Make sure that the Prometheus-formatted metrics are exposed in your Traefik Mesh cluster. You can configure and customize this by following the instructions on the [Observability page in the official Traefik Mesh documentation][10]. In order for the Agent to start collecting metrics, the Traefik Mesh pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [`traefik_mesh.d/conf.yaml` sample][4].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: traefik_mesh`, and set `containerImage` to match each component image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: traefik_mesh`, and set `containerName` to match each component's container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
 
 **Note**: The following metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed.
 

--- a/traefik_mesh/README.md
+++ b/traefik_mesh/README.md
@@ -37,7 +37,7 @@ In addition, a small subset of metrics can be collected by communicating with di
 
 Make sure that the Prometheus-formatted metrics are exposed in your Traefik Mesh cluster. You can configure and customize this by following the instructions on the [Observability page in the official Traefik Mesh documentation][10]. In order for the Agent to start collecting metrics, the Traefik Mesh pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [`traefik_mesh.d/conf.yaml` sample][4].
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: traefik_mesh`, and set `containerImage` to match each component image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: traefik_mesh`, and set `containerImage` to match each component image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
 
 **Note**: The following metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed.
 
@@ -144,3 +144,4 @@ Need help? Contact [Datadog support][9].
 [10]: https://doc.traefik.io/traefik/observability/metrics/overview/
 [11]: https://docs.datadoghq.com/integrations/openmetrics/
 [12]: https://docs.datadoghq.com/containers/kubernetes/log/
+[13]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/traefik_mesh/README.md
+++ b/traefik_mesh/README.md
@@ -35,9 +35,7 @@ In addition, a small subset of metrics can be collected by communicating with di
 #### Containerized
 ##### Metric collection
 
-Make sure that the Prometheus-formatted metrics are exposed in your Traefik Mesh cluster. You can configure and customize this by following the instructions on the [Observability page in the official Traefik Mesh documentation][10]. In order for the Agent to start collecting metrics, the Traefik Mesh pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [`traefik_mesh.d/conf.yaml` sample][4].
-
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Create one `DatadogInstrumentation` resource per target workload, use the same check instance configuration in `spec.config.checks`, set `integration: traefik_mesh`, and set `containerName` to match each component's container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
+Make sure that the Prometheus-formatted metrics are exposed in your Traefik Mesh cluster. You can configure and customize this by following the instructions on the [Observability page in the official Traefik Mesh documentation][10]. Configure each component with one of the Kubernetes Autodiscovery options below. You can find additional configuration options by reviewing the [`traefik_mesh.d/conf.yaml` sample][4].
 
 **Note**: The following metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed.
 
@@ -47,6 +45,9 @@ When configuring the Traefik Mesh check, you can use the following parameters:
 - `traefik_controller_api_endpoint`: This parameter is optional. The default port is set to `9000`.
 
 #### Traefik Proxy
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
+
 ```yaml
 # (...)
 metadata:
@@ -70,8 +71,41 @@ spec:
     - name: <CONTAINER_NAME>
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+Target the Traefik Mesh proxy DaemonSet:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: DaemonSet
+    name: traefik-mesh-proxy
+  config:
+    checks:
+      - integration: traefik_mesh
+        containerName: traefik-mesh-proxy
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:8082/metrics"
+            traefik_proxy_api_endpoint: "http://%%host%%:8080"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 #### Traefik Controller
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
+
 ```yaml
 # (...)
 metadata:
@@ -94,6 +128,35 @@ spec:
     - name: <CONTAINER_NAME>
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+Target the Traefik Mesh controller Deployment:
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: traefik-mesh-controller
+  config:
+    checks:
+      - integration: traefik_mesh
+        containerName: traefik-mesh-controller
+        initConfig: {}
+        instances:
+          - traefik_controller_api_endpoint: "http://%%host%%:9000"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][13].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 See the [sample traefik_mesh.d/conf.yaml][4] for all available configuration options.
 

--- a/twistlock/README.md
+++ b/twistlock/README.md
@@ -46,6 +46,8 @@ For containerized environments, see the [Autodiscovery Integration Templates][5]
 
 If you're using Kubernetes, add the config to replication controller section of twistlock_console.yaml before deploying:
 
+If you deploy Twistlock Console on a supported Kubernetes workload, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: twistlock`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 ```yaml
 apiVersion: v1
 kind: ReplicationController
@@ -103,6 +105,8 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 2. Mount the Docker socket to the Datadog Agent. See the Datadog Kubernetes [example manifests][8].
 
 3. Make sure the log section is included in the Pod annotation for the defender, where the container name can be found just below in the pod spec:
+
+   For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
 
    ```yaml
    ad.datadoghq.com/<container-name>.logs: '[{"source": "twistlock", "service": "twistlock"}]'

--- a/twistlock/README.md
+++ b/twistlock/README.md
@@ -106,8 +106,6 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 
 3. Make sure the log section is included in the Pod annotation for the defender, where the container name can be found just below in the pod spec:
 
-   For log-only configuration, `DatadogInstrumentation` also supports `logs`; use `integration: logs` for log-only resources. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
-
    ```yaml
    ad.datadoghq.com/<container-name>.logs: '[{"source": "twistlock", "service": "twistlock"}]'
    ```

--- a/twistlock/README.md
+++ b/twistlock/README.md
@@ -46,7 +46,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][5]
 
 If you're using Kubernetes, add the config to replication controller section of twistlock_console.yaml before deploying:
 
-If you deploy Twistlock Console on a supported Kubernetes workload, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: twistlock`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+If you deploy Twistlock Console on a supported Kubernetes workload, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: twistlock`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
 
 ```yaml
 apiVersion: v1
@@ -169,3 +169,4 @@ Need help? Contact [Datadog support][13].
 [11]: https://github.com/DataDog/integrations-core/blob/master/twistlock/metadata.csv
 [12]: https://github.com/DataDog/integrations-core/blob/master/twistlock/assets/service_checks.json
 [13]: https://docs.datadoghq.com/help/
+[14]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/twistlock/README.md
+++ b/twistlock/README.md
@@ -46,8 +46,6 @@ For containerized environments, see the [Autodiscovery Integration Templates][5]
 
 If you're using Kubernetes, add the config to replication controller section of twistlock_console.yaml before deploying:
 
-If you deploy Twistlock Console on a supported Kubernetes workload, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: twistlock`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
-
 ```yaml
 apiVersion: v1
 kind: ReplicationController
@@ -70,6 +68,8 @@ spec:
       labels:
         name: twistlock-console
 ```
+
+If you deploy Twistlock Console on a supported Kubernetes workload, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: twistlock`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
 
 ##### Log collection
 

--- a/twistlock/README.md
+++ b/twistlock/README.md
@@ -69,7 +69,7 @@ spec:
         name: twistlock-console
 ```
 
-If you deploy Twistlock Console on a supported Kubernetes workload, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: twistlock`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: twistlock`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
 
 ##### Log collection
 

--- a/twistlock/README.md
+++ b/twistlock/README.md
@@ -69,8 +69,6 @@ spec:
         name: twistlock-console
 ```
 
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: twistlock`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][14].
-
 ##### Log collection
 
 <!-- partial
@@ -169,4 +167,3 @@ Need help? Contact [Datadog support][13].
 [11]: https://github.com/DataDog/integrations-core/blob/master/twistlock/metadata.csv
 [12]: https://github.com/DataDog/integrations-core/blob/master/twistlock/assets/service_checks.json
 [13]: https://docs.datadoghq.com/help/
-[14]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -41,7 +41,7 @@ In addition, a small subset of metrics can be collected by communicating with di
 
 Make sure that the Prometheus-formatted metrics are exposed in your Weaviate cluster. You can configure and customize this by following the instructions on the [Monitoring][10] page in the Weaviate documentation. For the Agent to start collecting metrics, the Weaviate pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample weaviate.d/conf.yaml][4]
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: weaviate`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
+You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: weaviate`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the object deletion metric is exposed only when an object is deleted.
 

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -41,7 +41,7 @@ In addition, a small subset of metrics can be collected by communicating with di
 
 Make sure that the Prometheus-formatted metrics are exposed in your Weaviate cluster. You can configure and customize this by following the instructions on the [Monitoring][10] page in the Weaviate documentation. For the Agent to start collecting metrics, the Weaviate pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample weaviate.d/conf.yaml][4]
 
-For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: weaviate`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: weaviate`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the object deletion metric is exposed only when an object is deleted.
 
@@ -126,3 +126,4 @@ Additional helpful documentation, links, and articles:
 [14]: https://github.com/weaviate/weaviate-helm/blob/576f613bad3f8e25015c61a7143800123ab378d3/weaviate/values.yaml#L1196
 [15]: https://www.datadoghq.com/blog/ai-integrations/
 [16]: https://raw.githubusercontent.com/DataDog/integrations-core/master/weaviate/images/weaviate_dashboard.png
+[17]: https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -41,6 +41,8 @@ In addition, a small subset of metrics can be collected by communicating with di
 
 Make sure that the Prometheus-formatted metrics are exposed in your Weaviate cluster. You can configure and customize this by following the instructions on the [Monitoring][10] page in the Weaviate documentation. For the Agent to start collecting metrics, the Weaviate pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample weaviate.d/conf.yaml][4]
 
+For supported Kubernetes workloads, you can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: weaviate`, and set `containerImage` to match the application image. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD](https://docs.datadoghq.com/containers/guide/configure-autodiscovery-with-the-datadoginstrumentation-crd/).
+
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the object deletion metric is exposed only when an object is deleted.
 
 The two most important parameters for configuring the Weaviate check are as follows:

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -39,9 +39,7 @@ In addition, a small subset of metrics can be collected by communicating with di
 #### Containerized
 ##### Metric collection
 
-Make sure that the Prometheus-formatted metrics are exposed in your Weaviate cluster. You can configure and customize this by following the instructions on the [Monitoring][10] page in the Weaviate documentation. For the Agent to start collecting metrics, the Weaviate pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample weaviate.d/conf.yaml][4]
-
-You can use a `DatadogInstrumentation` resource instead of pod annotations. Use the same check instance configuration in `spec.config.checks`, set `integration: weaviate`, and set `containerName` to match the application container name. For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
+Make sure that the Prometheus-formatted metrics are exposed in your Weaviate cluster. You can configure and customize this by following the instructions on the [Monitoring][10] page in the Weaviate documentation. Configure the check with one of the Kubernetes Autodiscovery options below. You can find additional configuration options by reviewing the [sample weaviate.d/conf.yaml][4].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the object deletion metric is exposed only when an object is deleted.
 
@@ -51,6 +49,9 @@ The two most important parameters for configuring the Weaviate check are as foll
 
 If authentication is required for the RESTful API endpoints, the check can be configured to provide an API key as part of the [request header][13].
 
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Kubernetes annotations" xxx -->
 
 ```yaml
 apiVersion: v1
@@ -78,6 +79,36 @@ spec:
     - name: 'weaviate'
 # (...)
 ```
+<!-- xxz tab xxx -->
+<!-- xxx tab "DatadogInstrumentation CRD" xxx -->
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogInstrumentation
+metadata:
+  name: <CR_NAME>
+  namespace: <WORKLOAD_NAMESPACE>
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet # Or another target kind, if applicable.
+    name: <WEAVIATE_WORKLOAD_NAME>
+  config:
+    checks:
+      - integration: weaviate
+        containerName: weaviate
+        initConfig: {}
+        instances:
+          - openmetrics_endpoint: "http://%%host%%:2112/metrics"
+            weaviate_api_endpoint: "http://%%host%%:8080"
+            headers:
+              Authorization: "Bearer if_needed_for_auth"
+```
+
+For setup details, see [Configure Autodiscovery with the DatadogInstrumentation CRD][17].
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 **Note**: You can set these annotations directly in your [Weaviate Helm chart][14] using `annotations` key.
 


### PR DESCRIPTION
## Summary
- Add DatadogInstrumentation guidance to multiple integration READMEs as an alternative to pod annotations.
- Cover both metrics and log-only setups where applicable, including notes for service targets and workloads with multiple components.
- Link each section to the Autodiscovery with DatadogInstrumentation CRD guide for setup details.

Related to:
- https://github.com/DataDog/documentation/pull/37532
- https://datadoghq.atlassian.net/wiki/x/mIPAmgE (internal blog post)