### PR TITLE
Catch ProcessLookupError on environment teardown

### DIFF
--- a/datadog_checks_dev/changelog.d/24174.fixed
+++ b/datadog_checks_dev/changelog.d/24174.fixed
@@ -1,0 +1,1 @@
+Catch `ProcessLookupError` when killing port-forward processes during E2E teardown to handle already-exited processes gracefully.

--- a/datadog_checks_dev/datadog_checks/dev/ssh_tunnel.py
+++ b/datadog_checks_dev/datadog_checks/dev/ssh_tunnel.py
@@ -140,5 +140,8 @@ class KillProcess(LazyFunction):
         with TempDir(self.temp_name) as temp_dir:
             with open(os.path.join(temp_dir, self.pid_file)) as pid_file:
                 pid = int(pid_file.read())
-                os.kill(pid, signal.SIGKILL if os.name == 'posix' else signal.SIGTERM)
+                try:
+                    os.kill(pid, signal.SIGKILL if os.name == 'posix' else signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
                 return 0


### PR DESCRIPTION
### What does this PR do?
Catches ProcessLookupError when ddev tears down environments.

```
self = <datadog_checks.dev.ssh_tunnel.KillProcess object at 0x7f310ad87230>

    def __call__(self):
        with TempDir(self.temp_name) as temp_dir:
            with open(os.path.join(temp_dir, self.pid_file)) as pid_file:
                pid = int(pid_file.read())
>               os.kill(pid, signal.SIGKILL if os.name == 'posix' else signal.SIGTERM)
E               ProcessLookupError: [Errno 3] No such process

../datadog_checks_dev/datadog_checks/dev/ssh_tunnel.py:143: ProcessLookupError
```
### Motivation
Strimzi flakes with this error: https://github.com/DataDog/integrations-core/actions/runs/27966488205/job/82761676780

I believe the main issue is that Strimzi only has one E2E test and it's marked as flakey so it doesn't run in CI, but ddev still spins up and down the environment. 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
