### PR TITLE
MariaDB: use SHOW ALL REPLICAS STATUS for multi-channel replication

### DIFF
--- a/mysql/changelog.d/24178.fixed
+++ b/mysql/changelog.d/24178.fixed
@@ -1,0 +1,1 @@
+Fix MariaDB multi-channel replication reporting 0 channels by using SHOW ALL REPLICAS STATUS when no specific channel is configured.

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -1170,7 +1170,12 @@ class MySql(DatabaseCheck):
             for replica in replica_status:
                 # MySQL <5.7 does not have Channel_Name.
                 # For MySQL >=5.7 'Channel_Name' is set to an empty string by default
-                channel = self._config.replication_channel or replica.get('Channel_Name') or 'default'
+                channel = (
+                    self._config.replication_channel
+                    or replica.get('Channel_Name')
+                    or replica.get('Connection_name')
+                    or 'default'
+                )
                 for key, value in replica.items():
                     if value is not None:
                         replica_results[key]['channel:{0}'.format(channel)] = value

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -293,6 +293,10 @@ def show_replica_status_query(version, is_mariadb: bool, channel: str = '') -> t
         base_query = "SHOW SLAVE STATUS"
     if channel and not is_mariadb:
         return ("{0} FOR CHANNEL %s".format(base_query), (channel,))
+    elif is_mariadb and not channel:
+        # Without a specific channel, use ALL to return every replication channel.
+        # MariaDB uses Connection_name (not Channel_Name) to identify channels.
+        return ("SHOW ALL {0}S STATUS".format(base_query.split()[1]), ())
     else:
         return ("{0}".format(base_query), ())
 

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -288,17 +288,17 @@ QUERY_WAIT_EVENT_SUMMARY = {
 
 def show_replica_status_query(version, is_mariadb: bool, channel: str = '') -> tuple[str, tuple[str, ...]]:
     if version.version_compatible((10, 5, 1)) or not is_mariadb and version.version_compatible((8, 0, 22)):
-        base_query = "SHOW REPLICA STATUS"
+        replica_keyword = "REPLICA"
     else:
-        base_query = "SHOW SLAVE STATUS"
+        replica_keyword = "SLAVE"
+    base_query = "SHOW {0} STATUS".format(replica_keyword)
     if channel and not is_mariadb:
         return ("{0} FOR CHANNEL %s".format(base_query), (channel,))
     elif is_mariadb and not channel:
-        # Without a specific channel, use ALL to return every replication channel.
         # MariaDB uses Connection_name (not Channel_Name) to identify channels.
-        return ("SHOW ALL {0}S STATUS".format(base_query.split()[1]), ())
+        return ("SHOW ALL {0}S STATUS".format(replica_keyword), ())
     else:
-        return ("{0}".format(base_query), ())
+        return (base_query, ())
 
 
 def get_indexes_query(version, is_mariadb, placeholders):

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -777,10 +777,28 @@ class TestShowReplicaStatusQuery:
                 'my-channel',
                 'SHOW REPLICA STATUS',
                 (),
-                id='mariadb_ignores_channel',
+                id='mariadb_modern_with_channel',
             ),
             pytest.param(
-                '10.4.0-MariaDB', 'MariaDB', True, '', 'SHOW SLAVE STATUS', (), id='mariadb_legacy_no_channel'
+                '10.5.1-MariaDB',
+                'MariaDB',
+                True,
+                '',
+                'SHOW ALL REPLICAS STATUS',
+                (),
+                id='mariadb_modern_no_channel',
+            ),
+            pytest.param(
+                '10.4.0-MariaDB', 'MariaDB', True, '', 'SHOW ALL SLAVES STATUS', (), id='mariadb_legacy_no_channel'
+            ),
+            pytest.param(
+                '10.4.0-MariaDB',
+                'MariaDB',
+                True,
+                'my-channel',
+                'SHOW SLAVE STATUS',
+                (),
+                id='mariadb_legacy_with_channel',
             ),
         ],
     )

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -704,6 +704,20 @@ def test_collect_replication_metrics_returns_vars_when_has_replicas_connected():
     assert results.get('Replicas_connected') == 2
 
 
+def test_get_replica_stats_tags_each_mariadb_connection():
+    """Each MariaDB Connection_name maps to its own channel tag in _get_replica_stats."""
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[{'server': 'localhost', 'user': 'datadog'}])
+    mysql_check._config.replication_enabled = True
+    mysql_check._get_replica_replication_status = mock.MagicMock(
+        return_value=[
+            {'Connection_name': 'conn_a', 'Seconds_Behind_Master': 1},
+            {'Connection_name': 'conn_b', 'Seconds_Behind_Master': 2},
+        ]
+    )
+    results = mysql_check._get_replica_stats(mock.MagicMock())
+    assert results['Seconds_Behind_Master'] == {'channel:conn_a': 1, 'channel:conn_b': 2}
+
+
 def test_source_with_zero_replicas_emits_warning_service_check(aggregator, instance_basic):
     """Test that a source with 0 connected replicas emits WARNING for replica-loss detection."""
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[instance_basic])


### PR DESCRIPTION
### What does this PR do?

When `replication_channel` is not set on a MariaDB instance, use `SHOW ALL REPLICAS STATUS` (≥10.5.1) or `SHOW ALL SLAVES STATUS` (<10.5.1) instead of `SHOW REPLICA STATUS`. This returns all channels in a multi-source setup rather than just the default connection.

Also handle MariaDB's `Connection_name` field alongside MySQL's `Channel_Name` when tagging channel metrics.

### Motivation

MariaDB multi-channel replication was reporting 0 channels. The root cause was that `SHOW REPLICA STATUS` on MariaDB only returns the default connection — `SHOW ALL REPLICAS STATUS` is required to list all channels. Reported in https://github.com/DataDog/integrations-core/issues/16766.

MariaDB docs: https://mariadb.com/kb/en/show-replica-status/

Existing behavior (unchanged): when `replication_channel` is explicitly configured, the check still uses `SET @@default_master_connection` + `SHOW REPLICA STATUS` to monitor that specific channel.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged