### PR TITLE
Add ddev ai openmetrics CLI command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,9 @@ benchmark_*.svg
 ## Local overrides for ddev
 .ddev.toml
 
+## AI flow run artifacts (ddev ai)
+.ddev/ai-runs/
+
 ## Size metrics
 size-uncompressed.txt
 size-compressed.txt

--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final, overload
 
@@ -34,6 +35,12 @@ if TYPE_CHECKING:
         ToolParam,
         ToolResultBlockParam,
     )
+
+# The pinned anthropic SDK lags the live API's enum values (e.g. the web_fetch error code
+# ``url_not_in_prior_context`` is absent from older ``WebFetchToolResultErrorCode`` literals),
+# so serializing a raw ``Message`` makes Pydantic emit a noisy ``UserWarning``. The value still
+# round-trips fine as a string; silence only this serializer warning to keep the console clean.
+warnings.filterwarnings("ignore", message="^Pydantic serializer warnings", module=r"pydantic\.main")
 
 DEFAULT_MODEL: Final[str] = "claude-sonnet-4-6"
 DEFAULT_MAX_TOKENS: Final[int] = 8192  # max tokens per response

--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final, overload
 
@@ -35,12 +34,6 @@ if TYPE_CHECKING:
         ToolParam,
         ToolResultBlockParam,
     )
-
-# The pinned anthropic SDK lags the live API's enum values (e.g. the web_fetch error code
-# ``url_not_in_prior_context`` is absent from older ``WebFetchToolResultErrorCode`` literals),
-# so serializing a raw ``Message`` makes Pydantic emit a noisy ``UserWarning``. The value still
-# round-trips fine as a string; silence only this serializer warning to keep the console clean.
-warnings.filterwarnings("ignore", message="^Pydantic serializer warnings", module=r"pydantic\.main")
 
 DEFAULT_MODEL: Final[str] = "claude-sonnet-4-6"
 DEFAULT_MAX_TOKENS: Final[int] = 8192  # max tokens per response

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -62,6 +62,10 @@ class PhaseOrchestrator(EventBusOrchestrator):
         self._failed_phase: str | None = None
         self._failed_error: str | None = None
 
+    @property
+    def failed_phase(self) -> str | None:
+        return self._failed_phase
+
     async def on_initialize(self) -> None:
         """Discover custom phases, parse flow.yaml, construct phases, submit PhaseTrigger."""
         config_dir = self._flow_yaml_path.parent

--- a/ddev/src/ddev/cli/ai/__init__.py
+++ b/ddev/src/ddev/cli/ai/__init__.py
@@ -4,10 +4,7 @@
 """
 ``ddev ai`` command group.
 
-Scaffolds integrations with an AI agent flow. Kept light at import time: only
-``click`` and the subcommand modules load up-front. The heavy machinery
-(``anthropic``, the phase orchestrator) is imported inside the command bodies so
-``ddev ai --help`` stays fast.
+Scaffolds integrations with an AI agent flow.
 """
 
 from __future__ import annotations
@@ -18,7 +15,7 @@ from ddev.cli.ai.openmetrics import openmetrics
 
 
 @click.group(short_help='Build integrations with AI agents')
-def ai() -> None:
+def ai():
     """Build integrations with AI agents."""
 
 

--- a/ddev/src/ddev/cli/ai/__init__.py
+++ b/ddev/src/ddev/cli/ai/__init__.py
@@ -1,0 +1,25 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""
+``ddev ai`` command group.
+
+Scaffolds integrations with an AI agent flow. Kept light at import time: only
+``click`` and the subcommand modules load up-front. The heavy machinery
+(``anthropic``, the phase orchestrator) is imported inside the command bodies so
+``ddev ai --help`` stays fast.
+"""
+
+from __future__ import annotations
+
+import click
+
+from ddev.cli.ai.openmetrics import openmetrics
+
+
+@click.group(short_help='Build integrations with AI agents')
+def ai() -> None:
+    """Build integrations with AI agents."""
+
+
+ai.add_command(openmetrics)

--- a/ddev/src/ddev/cli/ai/openmetrics.py
+++ b/ddev/src/ddev/cli/ai/openmetrics.py
@@ -1,0 +1,237 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ddev.cli.application import Application
+
+# Wall-clock budget for the whole flow.
+DEFAULT_TIMEOUT = 3600.0
+
+# Files the flow is expected to produce, relative to the integration directory.
+# Used only for the final summary so the user can see at a glance what landed.
+EXPECTED_ARTIFACTS = (
+    'datadog_checks/{name}/metrics.yaml',
+    'metadata.csv',
+    'datadog_checks/{name}/check.py',
+    'assets/configuration/spec.yaml',
+    'datadog_checks/{name}/data/conf.yaml.example',
+    'tests/conftest.py',
+    'tests/test_unit.py',
+    'tests/test_integration.py',
+    'tests/test_e2e.py',
+    'tests/docker',
+    'tests/fixtures/metrics.txt',
+)
+
+
+def _normalize(display_name: str) -> str:
+    """Derive the snake_case integration name from the display name."""
+    return re.sub(r'[^a-z0-9]+', '_', display_name.lower()).strip('_')
+
+
+def _flow_phase_ids(flow_yaml: Path) -> list[str]:
+    """The phases the flow schedules, in order."""
+    import yaml
+
+    flow = yaml.safe_load(flow_yaml.read_text(encoding='utf-8'))
+    return [entry['phase'] for entry in flow.get('flow', [])]
+
+
+def _incomplete_phases(checkpoint_path: Path, flow_yaml: Path) -> list[str]:
+    """Scheduled phases that did not reach 'success' (e.g. on timeout)."""
+    from ddev.ai.runtime.checkpoints import CheckpointManager
+
+    phase_ids = _flow_phase_ids(flow_yaml)
+    if not checkpoint_path.exists():
+        return phase_ids
+    successful = CheckpointManager(checkpoint_path).successful_phases()
+    return [pid for pid in phase_ids if pid not in successful]
+
+
+def _report_artifacts(app: Application, integration_dir: Path) -> None:
+    """Print which expected artifacts the flow produced."""
+    name = integration_dir.name
+    app.display_header('Generated artifacts')
+    for rel in EXPECTED_ARTIFACTS:
+        path = integration_dir / rel.format(name=name)
+        marker = '✓' if path.exists() else '✗'
+        app.display_info(f'  {marker} {path.relative_to(integration_dir.parent)}')
+
+
+@click.command('openmetrics', short_help='Scaffold an OpenMetrics integration with AI')
+@click.argument('display_name')
+@click.option(
+    '--endpoint',
+    required=True,
+    help='OpenMetrics endpoint URL to inspect, e.g. `http://localhost:9090/metrics`.',
+)
+@click.option(
+    '--docker-path',
+    required=True,
+    help='Path to a `tests/docker` directory copied into the generated integration for E2E tests.',
+)
+@click.option(
+    '--prd',
+    required=True,
+    help='Path to a product requirements document (.md) with the team-specific requirements the '
+    'integration must satisfy (e.g. metrics to drop, forced config defaults).',
+)
+@click.option('--force', is_flag=True, help='Overwrite the integration directory if it already exists.')
+@click.option(
+    '--resume',
+    is_flag=True,
+    help='Resume the previous run for this integration, skipping phases that already completed '
+    'successfully. Requires an existing run and is mutually exclusive with `--force`.',
+)
+@click.option(
+    '--timeout',
+    type=float,
+    default=DEFAULT_TIMEOUT,
+    show_default=True,
+    help='Maximum wall-clock seconds for the whole flow.',
+)
+@click.pass_obj
+def openmetrics(
+    app: Application,
+    *,
+    display_name: str,
+    endpoint: str,
+    docker_path: str,
+    prd: str,
+    force: bool,
+    resume: bool,
+    timeout: float,
+) -> None:
+    """Scaffold an OpenMetrics integration for DISPLAY_NAME using an AI agent flow.
+
+    DISPLAY_NAME is the technology's display name (e.g. `KrakenD`); the agent
+    derives the snake_case package name and metric prefix from it.
+    """
+    import os
+    import shutil
+    from pathlib import Path
+
+    import ddev.ai
+
+    if timeout <= 0:
+        app.abort('`--timeout` must be greater than 0.')
+
+    api_key = app.config.ai.anthropic_api_key
+    if not api_key:
+        app.abort(
+            'No Anthropic API key found. Set `ai.anthropic_api_key` in your ddev config '
+            '(see `ddev config`), or export `DD_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`.'
+        )
+
+    docker_source = Path(docker_path).expanduser().resolve()
+    if not docker_source.is_dir():
+        app.abort(f'`--docker-path` {docker_source} is not a directory. Point it at a `tests/docker` directory.')
+
+    prd_path = Path(prd).expanduser().resolve()
+    if not prd_path.is_file():
+        app.abort(f'`--prd` file {prd_path} does not exist. Provide a product requirements document.')
+    prd_content = prd_path.read_text(encoding='utf-8').strip()
+    if not prd_content:
+        app.abort(
+            f'`--prd` file {prd_path} is empty. Write the requirements in it; if there are genuinely '
+            'none, state that explicitly.'
+        )
+
+    integration_name = _normalize(display_name)
+    if not integration_name:
+        app.abort(f'Could not derive an integration name from {display_name!r}.')
+
+    if resume and force:
+        app.abort('`--resume` and `--force` are mutually exclusive: resume keeps prior work, force deletes it.')
+
+    repo_path = Path(app.repo.path)
+    integration_dir = repo_path / integration_name
+    flow_yaml = Path(ddev.ai.__file__).resolve().parent / 'flows' / 'openmetrics' / 'flow.yaml'
+
+    run_dir = repo_path / '.ddev' / 'ai-runs' / integration_name
+    checkpoint_path = run_dir / 'checkpoints.yaml'
+
+    if resume:
+        if not checkpoint_path.exists():
+            app.abort(
+                f"No previous run found for '{integration_name}' at {run_dir}. "
+                'Run without `--resume` to start a fresh build.'
+            )
+        app.display_warning(
+            'Resuming the previous run: phases that already completed are skipped, and the '
+            'interrupted phase restarts — it will reconcile any partially written files.'
+        )
+    else:
+        if integration_dir.exists():
+            if not force:
+                app.abort(
+                    f"Integration '{integration_name}' already exists at {integration_dir}. "
+                    'Pass `--force` to overwrite it.'
+                )
+            shutil.rmtree(integration_dir)
+            app.display_warning(f'Removed existing {integration_dir} (--force).')
+        if run_dir.exists():
+            shutil.rmtree(run_dir)
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+    app.display_info(f'Technology:    {display_name}  (-> integration: {integration_name})')
+    app.display_info(f'Endpoint:      {endpoint}')
+    app.display_info(f'Docker source: {docker_source}')
+    app.display_info(f'PRD:           {prd_path}')
+    app.display_info(f'Timeout:       {timeout:.0f}s')
+    app.display_info(f'Output repo:   {repo_path}')
+    app.display_info(f'Run artifacts: {run_dir}')
+
+    import anthropic
+
+    from ddev.ai.runtime.orchestrator import PhaseOrchestrator
+    from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
+
+    # Run from the repo root.
+    os.chdir(repo_path)
+
+    orchestrator = PhaseOrchestrator(
+        flow_yaml_path=flow_yaml,
+        checkpoint_path=checkpoint_path,
+        runtime_variables={
+            'endpoint_url': endpoint,
+            'integration': display_name,
+            'docker_source_path': str(docker_source),
+            'prd': prd_content,
+        },
+        agent_clients={'anthropic': anthropic.AsyncAnthropic(api_key=api_key)},
+        file_access_policy=FileAccessPolicy(write_root=repo_path),
+        callbacks=None,
+        resume=resume,
+        max_timeout=timeout,
+    )
+
+    try:
+        orchestrator.run()
+    except Exception as e:
+        app.display_error(f'Pipeline failed: {type(e).__name__}: {e}')
+        if orchestrator._failed_phase:
+            app.display_error(f'  failed phase: {orchestrator._failed_phase}')
+        app.display_warning('Re-run with `--resume` to retry from the failed phase; completed phases are skipped.')
+        app.abort(f'Run artifacts saved at {run_dir}.')
+
+    incomplete = _incomplete_phases(checkpoint_path, flow_yaml)
+    if incomplete:
+        app.display_error(f"Pipeline incomplete — these phases did not reach 'success': {', '.join(incomplete)}")
+        app.display_warning(
+            f'The run likely hit the {timeout:.0f}s budget; raise `--timeout` and re-run with `--resume`.'
+        )
+        _report_artifacts(app, integration_dir)
+        app.abort(f'Run artifacts saved at {run_dir}.')
+
+    app.display_success(f"Integration '{integration_name}' generated.")
+    _report_artifacts(app, integration_dir)

--- a/ddev/src/ddev/cli/ai/openmetrics.py
+++ b/ddev/src/ddev/cli/ai/openmetrics.py
@@ -110,14 +110,14 @@ def openmetrics(
     force: bool,
     resume: bool,
     timeout: float,
-) -> None:
+):
     """Scaffold an OpenMetrics integration for DISPLAY_NAME using an AI agent flow.
 
     DISPLAY_NAME is the technology's display name (e.g. `KrakenD`); the agent
     derives the snake_case package name and metric prefix from it.
     """
-    import os
     import shutil
+    import warnings
     from pathlib import Path
 
     import ddev.ai
@@ -155,7 +155,11 @@ def openmetrics(
 
     repo_path = Path(app.repo.path)
     integration_dir = repo_path / integration_name
+
+    # TODO: discover the existing flow.yaml
     flow_yaml = Path(ddev.ai.__file__).resolve().parent / 'flows' / 'openmetrics' / 'flow.yaml'
+    if not flow_yaml.is_file():
+        app.abort(f'Flow definition not found: {flow_yaml}')
 
     run_dir = repo_path / '.ddev' / 'ai-runs' / integration_name
     checkpoint_path = run_dir / 'checkpoints.yaml'
@@ -196,9 +200,6 @@ def openmetrics(
     from ddev.ai.runtime.orchestrator import PhaseOrchestrator
     from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 
-    # Run from the repo root.
-    os.chdir(repo_path)
-
     orchestrator = PhaseOrchestrator(
         flow_yaml_path=flow_yaml,
         checkpoint_path=checkpoint_path,
@@ -216,11 +217,18 @@ def openmetrics(
     )
 
     try:
-        orchestrator.run()
+        # Run from the repo root.
+        with app.repo.path.as_cwd(), warnings.catch_warnings():
+            warnings.filterwarnings('ignore', message='^Pydantic serializer warnings', module=r'pydantic\.main')
+            orchestrator.run()
     except Exception as e:
         app.display_error(f'Pipeline failed: {type(e).__name__}: {e}')
-        if orchestrator._failed_phase:
-            app.display_error(f'  failed phase: {orchestrator._failed_phase}')
+        if app.verbosity > 0:
+            import traceback
+
+            app.display_error(traceback.format_exc())
+        if orchestrator.failed_phase:
+            app.display_error(f'  failed phase: {orchestrator.failed_phase}')
         app.display_warning('Re-run with `--resume` to retry from the failed phase; completed phases are skipped.')
         app.abort(f'Run artifacts saved at {run_dir}.')
 

--- a/ddev/src/ddev/cli/meta/__init__.py
+++ b/ddev/src/ddev/cli/meta/__init__.py
@@ -12,6 +12,7 @@ from datadog_checks.dev.tooling.commands.meta.prometheus import prom
 from datadog_checks.dev.tooling.commands.meta.snmp import snmp
 from datadog_checks.dev.tooling.commands.meta.windows import windows
 
+from ddev.cli.ai import ai
 from ddev.cli.meta.scripts import scripts
 
 
@@ -24,6 +25,7 @@ def meta():
     """
 
 
+meta.add_command(ai)
 meta.add_command(catalog)
 meta.add_command(changes)
 meta.add_command(create_example_commits)

--- a/ddev/tests/cli/ai/__init__.py
+++ b/ddev/tests/cli/ai/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/ddev/tests/cli/ai/conftest.py
+++ b/ddev/tests/cli/ai/conftest.py
@@ -1,0 +1,57 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def no_anthropic_env(monkeypatch):
+    """Keep the developer's real keys out of the test so the no-key path is reachable."""
+    monkeypatch.delenv('DD_ANTHROPIC_API_KEY', raising=False)
+    monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+
+
+@pytest.fixture(autouse=True)
+def restore_cwd():
+    """The command chdirs into the repo root on the orchestrator path; undo it for the next test."""
+    cwd = os.getcwd()
+    yield
+    os.chdir(cwd)
+
+
+@pytest.fixture
+def docker_dir(tmp_path):
+    """A valid `--docker-path` directory."""
+    path = tmp_path / 'docker'
+    path.mkdir()
+    (path / 'docker-compose.yaml').write_text('services: {}\n')
+    return path
+
+
+@pytest.fixture
+def prd_file(tmp_path):
+    """A valid, non-empty `--prd` file."""
+    path = tmp_path / 'prd.md'
+    path.write_text('Drop the foo_total metric.\n')
+    return path
+
+
+@pytest.fixture
+def ai_repo(tmp_path_factory, config_file):
+    """An empty repo that `app.repo.path` resolves to, isolated from the real checkout."""
+    repo_path = tmp_path_factory.mktemp('ai-repo')
+    config_file.model.repos['core'] = str(repo_path)
+    config_file.save()
+    return repo_path
+
+
+@pytest.fixture
+def with_api_key(config_file):
+    """Set an Anthropic key in config so validation gets past the key check."""
+    config_file.model.ai.anthropic_api_key = 'sk-test'
+    config_file.save()
+    return config_file

--- a/ddev/tests/cli/ai/test_openmetrics.py
+++ b/ddev/tests/cli/ai/test_openmetrics.py
@@ -31,7 +31,7 @@ def mock_orchestrator(mocker):
     mocker.patch('anthropic.AsyncAnthropic')
     mocker.patch('ddev.ai.tools.fs.file_access_policy.FileAccessPolicy')
     orchestrator_cls = mocker.patch('ddev.ai.runtime.orchestrator.PhaseOrchestrator')
-    orchestrator_cls.return_value._failed_phase = None
+    orchestrator_cls.return_value.failed_phase = None
     mocker.patch('ddev.cli.ai.openmetrics._incomplete_phases', return_value=[])
     return orchestrator_cls
 
@@ -208,7 +208,7 @@ def test_custom_timeout_passed_through(ddev, docker_dir, prd_file, with_api_key,
 
 def test_run_failure_aborts(ddev, docker_dir, prd_file, with_api_key, ai_repo, mock_orchestrator):
     mock_orchestrator.return_value.run.side_effect = RuntimeError('boom')
-    mock_orchestrator.return_value._failed_phase = 'inspect_endpoint'
+    mock_orchestrator.return_value.failed_phase = 'inspect_endpoint'
 
     result = invoke(ddev, 'KrakenD', docker_dir, prd_file)
 

--- a/ddev/tests/cli/ai/test_openmetrics.py
+++ b/ddev/tests/cli/ai/test_openmetrics.py
@@ -1,0 +1,288 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import pytest
+
+from ddev.cli.ai.openmetrics import _flow_phase_ids, _incomplete_phases, _normalize
+
+
+def invoke(ddev, display_name, docker_dir, prd_file, *extra):
+    """Run the command with all required options filled in, plus any extras."""
+    return ddev(
+        'meta',
+        'ai',
+        'openmetrics',
+        display_name,
+        '--endpoint',
+        'http://localhost:9090/metrics',
+        '--docker-path',
+        str(docker_dir),
+        '--prd',
+        str(prd_file),
+        *extra,
+    )
+
+
+@pytest.fixture
+def mock_orchestrator(mocker):
+    """Replace the heavy run machinery with a mock that succeeds and produces no phases gap."""
+    mocker.patch('anthropic.AsyncAnthropic')
+    mocker.patch('ddev.ai.tools.fs.file_access_policy.FileAccessPolicy')
+    orchestrator_cls = mocker.patch('ddev.ai.runtime.orchestrator.PhaseOrchestrator')
+    orchestrator_cls.return_value._failed_phase = None
+    mocker.patch('ddev.cli.ai.openmetrics._incomplete_phases', return_value=[])
+    return orchestrator_cls
+
+
+# --- registration & help ----------------------------------------------------
+
+
+def test_registered_under_meta_ai(ddev):
+    result = ddev('meta', 'ai', '--help')
+
+    assert result.exit_code == 0, result.output
+    assert 'openmetrics' in result.output
+
+
+def test_help_lists_options(ddev):
+    result = ddev('meta', 'ai', 'openmetrics', '--help')
+
+    assert result.exit_code == 0, result.output
+    assert 'DISPLAY_NAME' in result.output
+    for option in ('--endpoint', '--docker-path', '--prd', '--force', '--resume', '--timeout'):
+        assert option in result.output
+
+
+# --- argument parsing (click) ------------------------------------------------
+
+
+def test_missing_display_name(ddev):
+    result = ddev('meta', 'ai', 'openmetrics')
+
+    assert result.exit_code == 2
+
+
+@pytest.mark.parametrize('option', ['--endpoint', '--docker-path', '--prd'])
+def test_required_options(ddev, docker_dir, prd_file, option):
+    args = {
+        '--endpoint': 'http://localhost:9090/metrics',
+        '--docker-path': str(docker_dir),
+        '--prd': str(prd_file),
+    }
+    del args[option]
+    flat = [item for pair in args.items() for item in pair]
+
+    result = ddev('meta', 'ai', 'openmetrics', 'KrakenD', *flat)
+
+    assert result.exit_code == 2
+    assert option in result.output
+
+
+# --- validation aborts -------------------------------------------------------
+
+
+@pytest.mark.parametrize('value', ['0', '-5'])
+def test_timeout_must_be_positive(ddev, docker_dir, prd_file, value):
+    result = invoke(ddev, 'KrakenD', docker_dir, prd_file, '--timeout', value)
+
+    assert result.exit_code == 1
+    assert '`--timeout` must be greater than 0.' in result.output
+
+
+def test_missing_api_key(ddev, docker_dir, prd_file):
+    result = invoke(ddev, 'KrakenD', docker_dir, prd_file)
+
+    assert result.exit_code == 1
+    assert 'No Anthropic API key found' in result.output
+
+
+def test_docker_path_not_a_directory(ddev, prd_file, with_api_key):
+    result = ddev(
+        'meta',
+        'ai',
+        'openmetrics',
+        'KrakenD',
+        '--endpoint',
+        'http://localhost:9090/metrics',
+        '--docker-path',
+        str(prd_file),  # a file, not a directory
+        '--prd',
+        str(prd_file),
+    )
+
+    assert result.exit_code == 1
+    assert 'is not a directory' in result.output
+
+
+def test_prd_file_missing(ddev, docker_dir, tmp_path, with_api_key):
+    missing = tmp_path / 'nope.md'
+
+    result = invoke(ddev, 'KrakenD', docker_dir, missing)
+
+    assert result.exit_code == 1
+    assert 'does not exist' in result.output
+
+
+def test_prd_file_empty(ddev, docker_dir, tmp_path, with_api_key):
+    empty = tmp_path / 'empty.md'
+    empty.write_text('   \n')
+
+    result = invoke(ddev, 'KrakenD', docker_dir, empty)
+
+    assert result.exit_code == 1
+    assert 'is empty' in result.output
+
+
+def test_display_name_not_normalizable(ddev, docker_dir, prd_file, with_api_key):
+    result = invoke(ddev, '@@@', docker_dir, prd_file)
+
+    assert result.exit_code == 1
+    assert 'Could not derive an integration name' in result.output
+
+
+def test_resume_and_force_mutually_exclusive(ddev, docker_dir, prd_file, with_api_key):
+    result = invoke(ddev, 'KrakenD', docker_dir, prd_file, '--resume', '--force')
+
+    assert result.exit_code == 1
+    assert 'mutually exclusive' in result.output
+
+
+def test_resume_without_previous_run(ddev, docker_dir, prd_file, with_api_key, ai_repo):
+    result = invoke(ddev, 'KrakenD', docker_dir, prd_file, '--resume')
+
+    assert result.exit_code == 1
+    assert 'No previous run found' in result.output
+
+
+def test_existing_integration_without_force(ddev, docker_dir, prd_file, with_api_key, ai_repo):
+    (ai_repo / 'krakend').mkdir()
+
+    result = invoke(ddev, 'KrakenD', docker_dir, prd_file)
+
+    assert result.exit_code == 1
+    assert 'already exists' in result.output
+
+
+# --- orchestrator path (mocked) ----------------------------------------------
+
+
+def test_force_removes_existing_integration(ddev, docker_dir, prd_file, with_api_key, ai_repo, mock_orchestrator):
+    integration_dir = ai_repo / 'krakend'
+    integration_dir.mkdir()
+    (integration_dir / 'leftover.txt').write_text('stale')
+
+    result = invoke(ddev, 'KrakenD', docker_dir, prd_file, '--force')
+
+    assert result.exit_code == 0, result.output
+    assert 'Removed existing' in result.output
+    assert not integration_dir.exists()
+
+
+def test_successful_run_wires_runtime_variables(ddev, docker_dir, prd_file, with_api_key, ai_repo, mock_orchestrator):
+    result = invoke(ddev, 'KrakenD', docker_dir, prd_file)
+
+    assert result.exit_code == 0, result.output
+    assert "Integration 'krakend' generated." in result.output
+    assert 'Generated artifacts' in result.output
+
+    mock_orchestrator.return_value.run.assert_called_once()
+    kwargs = mock_orchestrator.call_args.kwargs
+    assert kwargs['resume'] is False
+    assert kwargs['max_timeout'] == pytest.approx(3600.0)
+    assert kwargs['runtime_variables'] == {
+        'endpoint_url': 'http://localhost:9090/metrics',
+        'integration': 'KrakenD',
+        'docker_source_path': str(docker_dir.resolve()),
+        'prd': 'Drop the foo_total metric.',
+    }
+
+
+def test_custom_timeout_passed_through(ddev, docker_dir, prd_file, with_api_key, ai_repo, mock_orchestrator):
+    result = invoke(ddev, 'KrakenD', docker_dir, prd_file, '--timeout', '120')
+
+    assert result.exit_code == 0, result.output
+    assert mock_orchestrator.call_args.kwargs['max_timeout'] == pytest.approx(120.0)
+
+
+def test_run_failure_aborts(ddev, docker_dir, prd_file, with_api_key, ai_repo, mock_orchestrator):
+    mock_orchestrator.return_value.run.side_effect = RuntimeError('boom')
+    mock_orchestrator.return_value._failed_phase = 'inspect_endpoint'
+
+    result = invoke(ddev, 'KrakenD', docker_dir, prd_file)
+
+    assert result.exit_code == 1
+    assert 'Pipeline failed: RuntimeError: boom' in result.output
+    assert 'failed phase: inspect_endpoint' in result.output
+    assert 'Re-run with `--resume`' in result.output
+
+
+def test_incomplete_phases_aborts(ddev, docker_dir, prd_file, with_api_key, ai_repo, mocker, mock_orchestrator):
+    mocker.patch('ddev.cli.ai.openmetrics._incomplete_phases', return_value=['write_tests', 'write_readme'])
+
+    result = invoke(ddev, 'KrakenD', docker_dir, prd_file)
+
+    assert result.exit_code == 1
+    assert "did not reach 'success': write_tests, write_readme" in result.output
+    assert 'Generated artifacts' in result.output
+
+
+def test_resume_run_skips_when_checkpoint_exists(ddev, docker_dir, prd_file, with_api_key, ai_repo, mock_orchestrator):
+    checkpoint = ai_repo / '.ddev' / 'ai-runs' / 'krakend' / 'checkpoints.yaml'
+    checkpoint.parent.mkdir(parents=True)
+    checkpoint.write_text('inspect_endpoint:\n  status: success\n')
+
+    result = invoke(ddev, 'KrakenD', docker_dir, prd_file, '--resume')
+
+    assert result.exit_code == 0, result.output
+    assert 'Resuming the previous run' in result.output
+    assert mock_orchestrator.call_args.kwargs['resume'] is True
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'display_name, expected',
+    [
+        ('KrakenD', 'krakend'),
+        ('My Cool App', 'my_cool_app'),
+        ('foo-bar.baz', 'foo_bar_baz'),
+        ('  Spaced  ', 'spaced'),
+        ('Multi___Score', 'multi_score'),
+        ('123 Numbers', '123_numbers'),
+        ('!!!', ''),
+    ],
+)
+def test_normalize(display_name, expected):
+    assert _normalize(display_name) == expected
+
+
+def test_flow_phase_ids_preserves_order(tmp_path):
+    flow_yaml = tmp_path / 'flow.yaml'
+    flow_yaml.write_text(
+        'flow:\n  - phase: inspect_endpoint\n  - phase: rename_metrics\n  - phase: build_integration\n'
+    )
+
+    assert _flow_phase_ids(flow_yaml) == ['inspect_endpoint', 'rename_metrics', 'build_integration']
+
+
+def test_incomplete_phases_returns_all_when_no_checkpoint(tmp_path):
+    flow_yaml = tmp_path / 'flow.yaml'
+    flow_yaml.write_text('flow:\n  - phase: a\n  - phase: b\n')
+
+    assert _incomplete_phases(tmp_path / 'absent.yaml', flow_yaml) == ['a', 'b']
+
+
+def test_incomplete_phases_filters_successful(tmp_path, mocker):
+    flow_yaml = tmp_path / 'flow.yaml'
+    flow_yaml.write_text('flow:\n  - phase: a\n  - phase: b\n  - phase: c\n')
+    checkpoint = tmp_path / 'checkpoints.yaml'
+    checkpoint.write_text('placeholder: {}\n')
+    mocker.patch(
+        'ddev.ai.runtime.checkpoints.CheckpointManager.successful_phases',
+        return_value={'a', 'c'},
+    )
+
+    assert _incomplete_phases(checkpoint, flow_yaml) == ['b']


### PR DESCRIPTION
### What does this PR do?

Adds the `ddev ai openmetrics` CLI command, which scaffolds an OpenMetrics integration from a running endpoint using the AI agent flow.

- Registers a new `ai` command group under `ddev meta` (kept light at import time — heavy dependencies like `anthropic` and the phase orchestrator are imported inside the command body).
- Implements `openmetrics DISPLAY_NAME` with `--endpoint`, `--docker-path`, `--prd`, `--force`, `--resume`, and `--timeout` options, including up-front validation (API key, paths, mutually exclusive flags, resume preconditions) and a post-run report of the expected artifacts.
- Adds unit/CLI tests covering option parsing, every validation/abort branch, and the orchestrator success/failure/resume paths (with the run machinery mocked).
- Ignores `.ddev/ai-runs/` (per-run artifacts) in `.gitignore`.
- Silences a noisy Pydantic serializer `UserWarning` raised when the pinned `anthropic` SDK lags the live API's enum values.

### Motivation

Give integration developers a single command to bootstrap an OpenMetrics integration end to end (metrics, config spec, check, tests) from an endpoint and a PRD, on top of the AI framework.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
