### PR TITLE
Fix mysql.queries.count inflation when new digest variants appear mid-stream

### DIFF
--- a/mysql/changelog.d/24188.fixed
+++ b/mysql/changelog.d/24188.fixed
@@ -1,0 +1,1 @@
+Fix `mysql.queries.count` being inflated when multiple query digest variants map to the same normalized query signature, causing reported query counts to be hundreds to thousands of times higher than actual execution rates after a database restart.

--- a/mysql/changelog.d/24188.fixed
+++ b/mysql/changelog.d/24188.fixed
@@ -1,1 +1,1 @@
-Fix `mysql.queries.count` being inflated when multiple query digest variants map to the same normalized query signature, causing reported query counts to be hundreds to thousands of times higher than actual execution rates after a database restart.
+Fix `mysql.queries.count` inflation when multiple digest variants share the same query signature.

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -62,7 +62,7 @@ def _row_key(row):
     :param row: a normalized row from events_statements_summary_by_digest
     :return: a tuple uniquely identifying this row
     """
-    return row['schema_name'], row['query_signature']
+    return row['schema_name'], row['query_signature'], row['digest']
 
 
 class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):


### PR DESCRIPTION
### What does this PR do?

Fixes `mysql.queries.count` inflating by hundreds to thousands of times the actual query execution rate after a database restart.

Change: include `digest` in `_row_key` so each digest variant gets its own state slot in `compute_derivative_rows`.

### Motivation

When a database restarts, `performance_schema.events_statements_summary_by_digest` resets to zero. As the database warms up, new digest variants for already-tracked `query_signature` groups appear one by one with their full accumulated `count_star`. Because `_row_key` was keyed only on `(schema_name, query_signature)`, `_merge_duplicate_rows` would sum the new digest's full `count_star` into the merged total and `compute_derivative_rows` would emit that entire sum as a delta spike, rather than treating the first appearance as a baseline.

The inflation grows over time as more digest variants are first encountered, producing an accelerating curve in dashboards. Observed ~300x inflation on a production MariaDB 11.4 instance with up to 13 digest variants for a single query (max `count_star` 1,435,642 vs min 14). Reproduction test: buggy version emits 2,001x the expected count; fixed version emits exactly the expected count.

With the fix, each digest has its own `_previous_statements` entry. A new digest appearing for the first time has `prev is None` and is correctly skipped — its `count_star` becomes the new baseline. From the next collection onward only the actual per-interval increment is emitted.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged