### PR TITLE
Fix MySQL query metric digest baselining

### DIFF
--- a/mysql/changelog.d/24194.fixed
+++ b/mysql/changelog.d/24194.fixed
@@ -1,0 +1,1 @@
+Fix MySQL query metrics inflation when new digest variants share a normalized query signature.

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -74,8 +74,6 @@ def _row_state_key(row):
     :param row: a normalized row from a MySQL statement metrics source
     :return: a tuple uniquely identifying the cumulative database counter
     """
-    # Prepared-statement rows carry a non-null `object_instance_begin` as `_dd_statement_id`;
-    # digest rows leave it null. That presence check is what tells the two sources apart.
     if row.get('_dd_statement_id') is not None:
         # `object_instance_begin` is a memory address that MySQL can reuse for a
         # different prepared statement once the old one is deallocated. Include

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -56,7 +56,7 @@ METRICS_COLUMNS = {
     'sum_select_range_check',
 }
 
-INTERNAL_COLUMNS = {'_dd_statement_id', '_dd_statement_source'}
+INTERNAL_COLUMNS = {'_dd_statement_id'}
 DIGEST_STATEMENT_SOURCE = 'events_statements_summary_by_digest'
 PREPARED_STATEMENT_SOURCE = 'prepared_statements_instances'
 
@@ -74,15 +74,16 @@ def _row_state_key(row):
     :param row: a normalized row from a MySQL statement metrics source
     :return: a tuple uniquely identifying the cumulative database counter
     """
-    statement_source = row.get('_dd_statement_source', DIGEST_STATEMENT_SOURCE)
-    if statement_source == PREPARED_STATEMENT_SOURCE:
+    # Prepared-statement rows carry a non-null `object_instance_begin` as `_dd_statement_id`;
+    # digest rows leave it null. That presence check is what tells the two sources apart.
+    if row.get('_dd_statement_id') is not None:
         # `object_instance_begin` is a memory address that MySQL can reuse for a
         # different prepared statement once the old one is deallocated. Include
         # the query_signature so a reused address doesn't merge two different
         # statements' cumulative counters before diffing.
-        return statement_source, row['schema_name'], row['_dd_statement_id'], row['query_signature']
+        return PREPARED_STATEMENT_SOURCE, row['schema_name'], row['_dd_statement_id'], row['query_signature']
 
-    return statement_source, row['schema_name'], row['digest']
+    return DIGEST_STATEMENT_SOURCE, row['schema_name'], row['digest']
 
 
 def _strip_internal_columns(row):
@@ -268,12 +269,11 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
         condition = (
             "WHERE `last_seen` >= %s"
             if only_query_recent_statements
-            else "WHERE `digest_text` NOT LIKE 'EXPLAIN %%' OR `digest_text` IS NULL"
+            else "WHERE `digest_text` NOT LIKE 'EXPLAIN %' OR `digest_text` IS NULL"
         )
 
         sql_statement_summary = """\
-            SELECT %s AS `_dd_statement_source`,
-                   NULL AS `_dd_statement_id`,
+            SELECT NULL AS `_dd_statement_id`,
                    `schema_name`,
                    `digest`,
                    `digest_text`,
@@ -307,8 +307,7 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
             # MySQL documents `object_instance_begin` as the table's primary key:
             # https://dev.mysql.com/doc/refman/8.4/en/performance-schema-prepared-statements-instances-table.html
             prepared_sql_statement_summary = """\
-                SELECT  %s AS `_dd_statement_source`,
-                        `object_instance_begin` AS `_dd_statement_id`,
+                SELECT  `object_instance_begin` AS `_dd_statement_id`,
                         `owner_object_schema` AS `schema_name`,
                         NULL AS `digest`,
                         `sql_text` AS `digest_text`,
@@ -334,7 +333,7 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
                         `sum_select_range_check` AS `sum_select_range_check`,
                         NOW() AS `last_seen`
                 FROM performance_schema.prepared_statements_instances
-                WHERE `sql_text` NOT LIKE 'EXPLAIN %%' OR `sql_text` IS NULL
+                WHERE `sql_text` NOT LIKE 'EXPLAIN %' OR `sql_text` IS NULL
                 """
 
             sql_statement_summary = f"""\
@@ -350,12 +349,7 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
                 """
 
         with closing(self._get_db_connection().cursor(CommenterDictCursor)) as cursor:
-            if only_query_recent_statements:
-                args = [DIGEST_STATEMENT_SOURCE, self._last_seen]
-            elif collect_prepared_statements:
-                args = [DIGEST_STATEMENT_SOURCE, PREPARED_STATEMENT_SOURCE]
-            else:
-                args = [DIGEST_STATEMENT_SOURCE]
+            args = [self._last_seen] if only_query_recent_statements else None
             cursor.execute(sql_statement_summary, args)
 
             rows = cursor.fetchall() or []  # type: ignore

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -300,6 +300,8 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
 
         if collect_prepared_statements:
             # Every prepared statement object has a row in `performance_schema.prepared_statements_instances`.
+            # MySQL documents `object_instance_begin` as the table's primary key:
+            # https://dev.mysql.com/doc/refman/8.4/en/performance-schema-prepared-statements-instances-table.html
             prepared_sql_statement_summary = """\
                 SELECT  %s AS `_dd_statement_source`,
                         `object_instance_begin` AS `_dd_statement_id`,

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -76,7 +76,11 @@ def _row_state_key(row):
     """
     statement_source = row.get('_dd_statement_source', DIGEST_STATEMENT_SOURCE)
     if statement_source == PREPARED_STATEMENT_SOURCE:
-        return statement_source, row['schema_name'], row['_dd_statement_id']
+        # `object_instance_begin` is a memory address that MySQL can reuse for a
+        # different prepared statement once the old one is deallocated. Include
+        # the query_signature so a reused address doesn't merge two different
+        # statements' cumulative counters before diffing.
+        return statement_source, row['schema_name'], row['_dd_statement_id'], row['query_signature']
 
     return statement_source, row['schema_name'], row['digest']
 

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -56,7 +56,7 @@ METRICS_COLUMNS = {
     'sum_select_range_check',
 }
 
-INTERNAL_COLUMNS = {'_dd_digest_text', '_dd_statement_source'}
+INTERNAL_COLUMNS = {'_dd_statement_id', '_dd_statement_source'}
 DIGEST_STATEMENT_SOURCE = 'events_statements_summary_by_digest'
 PREPARED_STATEMENT_SOURCE = 'prepared_statements_instances'
 
@@ -75,10 +75,10 @@ def _row_state_key(row):
     :return: a tuple uniquely identifying the cumulative database counter
     """
     statement_source = row.get('_dd_statement_source', DIGEST_STATEMENT_SOURCE)
-    if row['digest'] is not None:
-        return statement_source, row['schema_name'], row['digest']
+    if statement_source == PREPARED_STATEMENT_SOURCE:
+        return statement_source, row['schema_name'], row['_dd_statement_id']
 
-    return statement_source, row['schema_name'], row.get('_dd_digest_text', row['digest_text'])
+    return statement_source, row['schema_name'], row['digest']
 
 
 def _strip_internal_columns(row):
@@ -269,6 +269,7 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
 
         sql_statement_summary = """\
             SELECT %s AS `_dd_statement_source`,
+                   NULL AS `_dd_statement_id`,
                    `schema_name`,
                    `digest`,
                    `digest_text`,
@@ -299,36 +300,35 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
 
         if collect_prepared_statements:
             # Every prepared statement object has a row in `performance_schema.prepared_statements_instances`.
-            # Group by `schema_name` and `digest_text` to get the totals for each statement.
             prepared_sql_statement_summary = """\
                 SELECT  %s AS `_dd_statement_source`,
+                        `object_instance_begin` AS `_dd_statement_id`,
                         `owner_object_schema` AS `schema_name`,
                         NULL AS `digest`,
                         `sql_text` AS `digest_text`,
-                        sum(`count_execute`) AS `count_star`,
-                        sum(`sum_timer_execute`) AS `sum_timer_wait`,
-                        sum(`sum_lock_time`) AS `sum_lock_time`,
-                        sum(`sum_errors`) AS `sum_errors`,
-                        sum(`sum_rows_affected`) AS `sum_rows_affected`,
-                        sum(`sum_rows_sent`) AS `sum_rows_sent`,
-                        sum(`sum_rows_examined`) AS `sum_rows_examined`,
-                        sum(`sum_select_scan`) AS `sum_select_scan`,
-                        sum(`sum_select_full_join`) AS `sum_select_full_join`,
-                        sum(`sum_no_index_used`) AS `sum_no_index_used`,
-                        sum(`sum_no_good_index_used`) AS `sum_no_good_index_used`,
-                        sum(`sum_sort_rows`) AS `sum_sort_rows`,
-                        sum(`sum_sort_merge_passes`) AS `sum_sort_merge_passes`,
-                        sum(`sum_sort_range`) AS `sum_sort_range`,
-                        sum(`sum_sort_scan`) AS `sum_sort_scan`,
-                        sum(`sum_created_tmp_tables`) AS `sum_created_tmp_tables`,
-                        sum(`sum_created_tmp_disk_tables`) AS `sum_created_tmp_disk_tables`,
-                        sum(`sum_select_full_range_join`) AS `sum_select_full_range_join`,
-                        sum(`sum_select_range`) AS `sum_select_range`,
-                        sum(`sum_select_range_check`) AS `sum_select_range_check`,
+                        `count_execute` AS `count_star`,
+                        `sum_timer_execute` AS `sum_timer_wait`,
+                        `sum_lock_time` AS `sum_lock_time`,
+                        `sum_errors` AS `sum_errors`,
+                        `sum_rows_affected` AS `sum_rows_affected`,
+                        `sum_rows_sent` AS `sum_rows_sent`,
+                        `sum_rows_examined` AS `sum_rows_examined`,
+                        `sum_select_scan` AS `sum_select_scan`,
+                        `sum_select_full_join` AS `sum_select_full_join`,
+                        `sum_no_index_used` AS `sum_no_index_used`,
+                        `sum_no_good_index_used` AS `sum_no_good_index_used`,
+                        `sum_sort_rows` AS `sum_sort_rows`,
+                        `sum_sort_merge_passes` AS `sum_sort_merge_passes`,
+                        `sum_sort_range` AS `sum_sort_range`,
+                        `sum_sort_scan` AS `sum_sort_scan`,
+                        `sum_created_tmp_tables` AS `sum_created_tmp_tables`,
+                        `sum_created_tmp_disk_tables` AS `sum_created_tmp_disk_tables`,
+                        `sum_select_full_range_join` AS `sum_select_full_range_join`,
+                        `sum_select_range` AS `sum_select_range`,
+                        `sum_select_range_check` AS `sum_select_range_check`,
                         NOW() AS `last_seen`
                 FROM performance_schema.prepared_statements_instances
                 WHERE `sql_text` NOT LIKE 'EXPLAIN %%' OR `sql_text` IS NULL
-                GROUP BY `owner_object_schema`, `sql_text`
                 """
 
             sql_statement_summary = f"""\
@@ -380,7 +380,6 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
                 continue
 
             normalized_row['digest_text'] = obfuscated_statement
-            normalized_row['_dd_digest_text'] = row['digest_text']
             normalized_row['query_signature'] = compute_sql_signature(obfuscated_statement)
             metadata = statement['metadata']
             normalized_row['dd_tables'] = metadata.get('tables', None)

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -56,6 +56,10 @@ METRICS_COLUMNS = {
     'sum_select_range_check',
 }
 
+INTERNAL_COLUMNS = {'_dd_digest_text', '_dd_statement_source'}
+DIGEST_STATEMENT_SOURCE = 'events_statements_summary_by_digest'
+PREPARED_STATEMENT_SOURCE = 'prepared_statements_instances'
+
 
 def _row_key(row):
     """
@@ -63,6 +67,36 @@ def _row_key(row):
     :return: a tuple uniquely identifying this row
     """
     return row['schema_name'], row['query_signature']
+
+
+def _row_state_key(row):
+    """
+    :param row: a normalized row from a MySQL statement metrics source
+    :return: a tuple uniquely identifying the cumulative database counter
+    """
+    statement_source = row.get('_dd_statement_source', DIGEST_STATEMENT_SOURCE)
+    if row['digest'] is not None:
+        return statement_source, row['schema_name'], row['digest']
+
+    return statement_source, row['schema_name'], row.get('_dd_digest_text', row['digest_text'])
+
+
+def _strip_internal_columns(row):
+    return {k: v for k, v in row.items() if k not in INTERNAL_COLUMNS}
+
+
+def _merge_rows_by_query_signature(rows):
+    merged_rows = {}
+    for row in rows:
+        query_key = _row_key(row)
+        if query_key in merged_rows:
+            for metric in METRICS_COLUMNS:
+                if metric in row:
+                    merged_rows[query_key][metric] = merged_rows[query_key].get(metric, 0) + row[metric]
+        else:
+            merged_rows[query_key] = _strip_internal_columns(row)
+
+    return list(merged_rows.values())
 
 
 class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
@@ -197,7 +231,8 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
         monotonic_rows = self._filter_query_rows(monotonic_rows)
         monotonic_rows = self._normalize_queries(monotonic_rows)
         monotonic_rows = self._add_associated_rows(monotonic_rows)
-        rows = self._state.compute_derivative_rows(monotonic_rows, METRICS_COLUMNS, key=_row_key)
+        rows = self._state.compute_derivative_rows(monotonic_rows, METRICS_COLUMNS, key=_row_state_key)
+        rows = _merge_rows_by_query_signature(rows)
         return rows
 
     def _get_statement_count(self, tags):
@@ -229,11 +264,12 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
         condition = (
             "WHERE `last_seen` >= %s"
             if only_query_recent_statements
-            else "WHERE `digest_text` NOT LIKE 'EXPLAIN %' OR `digest_text` IS NULL"
+            else "WHERE `digest_text` NOT LIKE 'EXPLAIN %%' OR `digest_text` IS NULL"
         )
 
         sql_statement_summary = """\
-            SELECT `schema_name`,
+            SELECT %s AS `_dd_statement_source`,
+                   `schema_name`,
                    `digest`,
                    `digest_text`,
                    `count_star`,
@@ -265,7 +301,8 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
             # Every prepared statement object has a row in `performance_schema.prepared_statements_instances`.
             # Group by `schema_name` and `digest_text` to get the totals for each statement.
             prepared_sql_statement_summary = """\
-                SELECT  `owner_object_schema` AS `schema_name`,
+                SELECT  %s AS `_dd_statement_source`,
+                        `owner_object_schema` AS `schema_name`,
                         NULL AS `digest`,
                         `sql_text` AS `digest_text`,
                         sum(`count_execute`) AS `count_star`,
@@ -290,7 +327,7 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
                         sum(`sum_select_range_check`) AS `sum_select_range_check`,
                         NOW() AS `last_seen`
                 FROM performance_schema.prepared_statements_instances
-                WHERE `sql_text` NOT LIKE 'EXPLAIN %' OR `sql_text` IS NULL
+                WHERE `sql_text` NOT LIKE 'EXPLAIN %%' OR `sql_text` IS NULL
                 GROUP BY `owner_object_schema`, `sql_text`
                 """
 
@@ -307,7 +344,12 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
                 """
 
         with closing(self._get_db_connection().cursor(CommenterDictCursor)) as cursor:
-            args = [self._last_seen] if only_query_recent_statements else None
+            if only_query_recent_statements:
+                args = [DIGEST_STATEMENT_SOURCE, self._last_seen]
+            elif collect_prepared_statements:
+                args = [DIGEST_STATEMENT_SOURCE, PREPARED_STATEMENT_SOURCE]
+            else:
+                args = [DIGEST_STATEMENT_SOURCE]
             cursor.execute(sql_statement_summary, args)
 
             rows = cursor.fetchall() or []  # type: ignore
@@ -338,6 +380,7 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
                 continue
 
             normalized_row['digest_text'] = obfuscated_statement
+            normalized_row['_dd_digest_text'] = row['digest_text']
             normalized_row['query_signature'] = compute_sql_signature(obfuscated_statement)
             metadata = statement['metadata']
             normalized_row['dd_tables'] = metadata.get('tables', None)
@@ -359,7 +402,7 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
         for row in rows:
             key = (row['schema_name'], row['query_signature'])
             digest_rows = self._statement_rows.get(key, {})
-            digest_rows[row['digest']] = row
+            digest_rows[_row_state_key(row)] = row
             self._statement_rows[key] = digest_rows
 
         return [row for statement_row in self._statement_rows.values() for row in statement_row.values()]

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -75,10 +75,7 @@ def _row_state_key(row):
     :return: a tuple uniquely identifying the cumulative database counter
     """
     if row.get('_dd_statement_id') is not None:
-        # `object_instance_begin` is a memory address that MySQL can reuse for a
-        # different prepared statement once the old one is deallocated. Include
-        # the query_signature so a reused address doesn't merge two different
-        # statements' cumulative counters before diffing.
+        # `object_instance_begin` is a reusable address, so key on the signature too.
         return PREPARED_STATEMENT_SOURCE, row['schema_name'], row['_dd_statement_id'], row['query_signature']
 
     return DIGEST_STATEMENT_SOURCE, row['schema_name'], row['digest']

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -285,10 +285,8 @@ def test_statement_metrics_with_duplicates(aggregator, dd_run_check, dbm_instanc
 @pytest.mark.usefixtures('dd_environment')
 @mock.patch.dict('os.environ', {'DDEV_SKIP_GENERIC_TAGS_CHECK': 'true'})
 def test_statement_metrics_new_digest_does_not_inflate(aggregator, dd_run_check, dbm_instance, datadog_agent):
-    # Two structurally distinct queries (different WHERE columns -> two distinct MySQL digests on every version)
-    # are forced by obfuscation to the same normalized query, so DBM aggregates them under one query_signature.
-    # A digest first seen AFTER the signature is already baselined must be baselined itself (contribute 0), not
-    # have its full first-seen count dumped into a single interval. Exercises the real per-statement SQL end to end.
+    # Two distinct queries obfuscated to the same signature => two digests under one signature. A digest first
+    # seen after the signature is baselined must itself be baselined, not have its full count dumped in one interval.
     query_one = "select * from information_schema.processlist where state = 'starting'"
     query_two = "select * from information_schema.processlist where command = 'Sleep'"
     normalized_query = 'SELECT * FROM `information_schema` . `processlist`'
@@ -308,20 +306,17 @@ def test_statement_metrics_new_digest_does_not_inflate(aggregator, dd_run_check,
 
     with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
         mock_agent.side_effect = obfuscate_sql
-        # Baseline: only query_one exists, so its digest baselines the shared signature.
-        run_query(query_one)
+        run_query(query_one)  # baseline the signature with query_one's digest
         dd_run_check(mysql_check)
-        # query_one runs once more (a real +1 delta); query_two appears for the first time (5 executions).
-        run_query(query_one)
+        run_query(query_one)  # +1 real delta
         for _ in range(5):
-            run_query(query_two)
+            run_query(query_two)  # query_two: a new digest for the same signature
         dd_run_check(mysql_check)
 
     events = aggregator.get_event_platform_events("dbm-metrics")
     matching_rows = [r for e in events for r in e['mysql_rows'] if r['query_signature'] == query_signature]
     assert len(matching_rows) == 1
-    # Only query_one's incremental execution (1) is counted; query_two is a newly-seen digest that gets
-    # baselined, so its 5 first-seen executions are not dumped. The pre-fix code reported 6.
+    # only query_one's +1 is counted; query_two is baselined, not dumped (pre-fix: 6)
     assert matching_rows[0]['count_star'] == 1
 
 
@@ -340,15 +335,13 @@ def test_statement_metrics_new_prepared_statement_instance_does_not_inflate(
     prepared_sql = DEFAULT_FQ_SUCCESS_QUERY
     query_signature = compute_sql_signature(prepared_sql)
 
-    # Keep the session open so both prepared-statement instances persist across the two checks.
+    # one session so both instances stay live across the checks
     with closing(bob_conn.cursor()) as cursor:
-        # Baseline: one instance (ps1) exists and executes once.
         cursor.execute("PREPARE ps1 FROM '{}'".format(prepared_sql))
         cursor.execute("EXECUTE ps1")
-        dd_run_check(mysql_check)
-        # A second instance of the same statement text (ps2, distinct object_instance_begin) appears and
-        # executes several times; ps1 executes once more.
-        cursor.execute("EXECUTE ps1")
+        dd_run_check(mysql_check)  # baseline the signature with ps1
+        cursor.execute("EXECUTE ps1")  # +1 real delta
+        # ps2: second instance, same sql_text, distinct object_instance_begin
         cursor.execute("PREPARE ps2 FROM '{}'".format(prepared_sql))
         for _ in range(5):
             cursor.execute("EXECUTE ps2")
@@ -359,8 +352,7 @@ def test_statement_metrics_new_prepared_statement_instance_does_not_inflate(
     events = aggregator.get_event_platform_events("dbm-metrics")
     matching_rows = [r for e in events for r in e['mysql_rows'] if r['query_signature'] == query_signature]
     assert len(matching_rows) == 1
-    # ps1 contributed 1 execution this interval; ps2 is a newly-seen instance -> baselined, not dumped.
-    # The pre-fix SUM(count_execute) GROUP BY sql_text would have reported 6.
+    # only ps1's +1 is counted; ps2 is baselined, not dumped (pre-fix SUM-by-sql_text: 6)
     assert matching_rows[0]['count_star'] == 1
 
 
@@ -413,10 +405,8 @@ def test_statement_metrics_baselines_new_digest_before_merging_query_signature(d
 def test_statement_metrics_baselines_new_prepared_statement_instance_before_merging_query_signature(
     dbm_instance, datadog_agent
 ):
-    # Two prepared-statement instances (distinct object_instance_begin) share the same sql_text and therefore
-    # the same query_signature. `prepared_statements_instances` rows have a NULL digest, so they must be baselined
-    # and diffed by their instance identity (object_instance_begin) rather than merged by signature before diffing.
-    # Otherwise a newly-prepared instance dumps its full count_execute into a single interval.
+    # Two instances (distinct object_instance_begin), same sql_text => same signature. Prepared rows have a NULL
+    # digest, so they must be diffed per instance; a newly-seen instance is baselined, not dumped.
     normalized_query = 'SELECT `id` FROM `dbm_order` WHERE `id` = ?'
     query_signature = compute_sql_signature(normalized_query)
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
@@ -456,17 +446,15 @@ def test_statement_metrics_baselines_new_prepared_statement_instance_before_merg
 
     assert len(rows) == 1
     assert rows[0]['query_signature'] == query_signature
-    # Only instance 1001's delta (10) is counted; the newly-seen instance 2002 is baselined, not dumped.
+    # only 1001's delta (10) is counted; new instance 2002 is baselined, not dumped
     assert rows[0]['count_star'] == 10
     assert '_dd_statement_id' not in rows[0]
 
 
 @pytest.mark.unit
 def test_statement_metrics_reused_prepared_statement_instance_id_is_not_merged(dbm_instance, datadog_agent):
-    # object_instance_begin is a memory address MySQL can reuse for a different prepared statement once the
-    # previous one is deallocated. The deallocated row lingers in the _statement_rows cache until its TTL, so a
-    # reused id must not collapse the stale row and the new statement onto the same state key; otherwise the new
-    # statement's first execution is reported as a delta for the old query.
+    # object_instance_begin is a reusable memory address: after a statement is deallocated its id can be handed to
+    # a different one. A recycled id (different sql_text/signature) must not merge with the stale cached row.
     normalized_a = 'SELECT `id` FROM `dbm_order` WHERE `id` = ?'
     normalized_b = 'SELECT `name` FROM `dbm_user` WHERE `id` = ?'
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
@@ -484,7 +472,7 @@ def test_statement_metrics_reused_prepared_statement_instance_id_is_not_merged(d
     rows_by_run = iter(
         [
             [row(1001, 'SELECT id FROM dbm_order WHERE id = ?', 100)],
-            # id 1001 was deallocated; a different statement reuses the same object_instance_begin
+            # 1001 deallocated, then reused by a different statement
             [row(1001, 'SELECT name FROM dbm_user WHERE id = ?', 5000)],
         ]
     )
@@ -503,8 +491,7 @@ def test_statement_metrics_reused_prepared_statement_instance_id_is_not_merged(d
         assert mysql_check._statement_metrics._collect_per_statement_metrics([]) == []
         rows = mysql_check._statement_metrics._collect_per_statement_metrics([])
 
-    # The reused id belongs to a different statement, so it is baselined instead of being merged with the stale
-    # row. Without keying on the SQL identity the two rows would merge and emit a spurious 5000 delta.
+    # the reused id is a different statement => baselined, not merged with the stale row (pre-fix: spurious 5000)
     assert rows == []
 
 

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -281,6 +281,89 @@ def test_statement_metrics_with_duplicates(aggregator, dd_run_check, dbm_instanc
     assert row['count_star'] == 2
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@mock.patch.dict('os.environ', {'DDEV_SKIP_GENERIC_TAGS_CHECK': 'true'})
+def test_statement_metrics_new_digest_does_not_inflate(aggregator, dd_run_check, dbm_instance, datadog_agent):
+    # Two structurally distinct queries (different WHERE columns -> two distinct MySQL digests on every version)
+    # are forced by obfuscation to the same normalized query, so DBM aggregates them under one query_signature.
+    # A digest first seen AFTER the signature is already baselined must be baselined itself (contribute 0), not
+    # have its full first-seen count dumped into a single interval. Exercises the real per-statement SQL end to end.
+    query_one = "select * from information_schema.processlist where state = 'starting'"
+    query_two = "select * from information_schema.processlist where command = 'Sleep'"
+    normalized_query = 'SELECT * FROM `information_schema` . `processlist`'
+    query_signature = compute_sql_signature(normalized_query)
+
+    mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
+
+    def obfuscate_sql(query, options=None):
+        if 'processlist' in query:
+            return normalized_query
+        return query
+
+    def run_query(q):
+        with mysql_check._connect() as db:
+            with closing(db.cursor()) as cursor:
+                cursor.execute(q)
+
+    with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
+        mock_agent.side_effect = obfuscate_sql
+        # Baseline: only query_one exists, so its digest baselines the shared signature.
+        run_query(query_one)
+        dd_run_check(mysql_check)
+        # query_one runs once more (a real +1 delta); query_two appears for the first time (5 executions).
+        run_query(query_one)
+        for _ in range(5):
+            run_query(query_two)
+        dd_run_check(mysql_check)
+
+    events = aggregator.get_event_platform_events("dbm-metrics")
+    matching_rows = [r for e in events for r in e['mysql_rows'] if r['query_signature'] == query_signature]
+    assert len(matching_rows) == 1
+    # Only query_one's incremental execution (1) is counted; query_two is a newly-seen digest that gets
+    # baselined, so its 5 first-seen executions are not dumped. The pre-fix code reported 6.
+    assert matching_rows[0]['count_star'] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_statement_metrics_new_prepared_statement_instance_does_not_inflate(
+    aggregator, dd_run_check, dbm_instance, bob_conn, datadog_agent
+):
+    if MYSQL_FLAVOR == 'mariadb' and MYSQL_VERSION_PARSED < parse_version('10.5.0'):
+        pytest.skip("prepared_statements_instances is unavailable on MariaDB < 10.5")
+
+    dbm_instance['query_metrics']['only_query_recent_statements'] = False
+    dbm_instance['query_metrics']['collect_prepared_statements'] = True
+    mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
+
+    prepared_sql = DEFAULT_FQ_SUCCESS_QUERY
+    query_signature = compute_sql_signature(prepared_sql)
+
+    # Keep the session open so both prepared-statement instances persist across the two checks.
+    with closing(bob_conn.cursor()) as cursor:
+        # Baseline: one instance (ps1) exists and executes once.
+        cursor.execute("PREPARE ps1 FROM '{}'".format(prepared_sql))
+        cursor.execute("EXECUTE ps1")
+        dd_run_check(mysql_check)
+        # A second instance of the same statement text (ps2, distinct object_instance_begin) appears and
+        # executes several times; ps1 executes once more.
+        cursor.execute("EXECUTE ps1")
+        cursor.execute("PREPARE ps2 FROM '{}'".format(prepared_sql))
+        for _ in range(5):
+            cursor.execute("EXECUTE ps2")
+        dd_run_check(mysql_check)
+        cursor.execute("DEALLOCATE PREPARE ps1")
+        cursor.execute("DEALLOCATE PREPARE ps2")
+
+    events = aggregator.get_event_platform_events("dbm-metrics")
+    matching_rows = [r for e in events for r in e['mysql_rows'] if r['query_signature'] == query_signature]
+    assert len(matching_rows) == 1
+    # ps1 contributed 1 execution this interval; ps2 is a newly-seen instance -> baselined, not dumped.
+    # The pre-fix SUM(count_execute) GROUP BY sql_text would have reported 6.
+    assert matching_rows[0]['count_star'] == 1
+
+
 @pytest.mark.unit
 def test_statement_metrics_baselines_new_digest_before_merging_query_signature(dbm_instance, datadog_agent):
     normalized_query = 'SELECT * FROM `employees` WHERE `id` = ?'

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -285,17 +285,18 @@ def test_statement_metrics_with_duplicates(aggregator, dd_run_check, dbm_instanc
 @pytest.mark.usefixtures('dd_environment')
 @mock.patch.dict('os.environ', {'DDEV_SKIP_GENERIC_TAGS_CHECK': 'true'})
 def test_statement_metrics_new_digest_does_not_inflate(aggregator, dd_run_check, dbm_instance, datadog_agent):
-    # Two distinct queries obfuscated to the same signature => two digests under one signature. A digest first
-    # seen after the signature is baselined must itself be baselined, not have its full count dumped in one interval.
+    # Two processlist queries with distinct WHERE `state` shapes (=> two digests on every version) obfuscated to
+    # one signature. A digest first seen after the signature is baselined must itself be baselined, not dumped.
+    # Matching only `WHERE `state`` keeps the collapse off the check's own processlist queries.
     query_one = "select * from information_schema.processlist where state = 'starting'"
-    query_two = "select * from information_schema.processlist where command = 'Sleep'"
-    normalized_query = 'SELECT * FROM `information_schema` . `processlist`'
+    query_two = "select * from information_schema.processlist where state = 'starting' or state = 'suspended'"
+    normalized_query = 'SELECT * FROM `information_schema` . `processlist` WHERE `state` = ?'
     query_signature = compute_sql_signature(normalized_query)
 
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
     def obfuscate_sql(query, options=None):
-        if 'processlist' in query:
+        if 'WHERE `state`' in query:
             return normalized_query
         return query
 
@@ -306,17 +307,17 @@ def test_statement_metrics_new_digest_does_not_inflate(aggregator, dd_run_check,
 
     with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
         mock_agent.side_effect = obfuscate_sql
-        run_query(query_one)  # baseline the signature with query_one's digest
+        run_query(query_one)  # digest A -> baseline the signature
         dd_run_check(mysql_check)
         run_query(query_one)  # +1 real delta
         for _ in range(5):
-            run_query(query_two)  # query_two: a new digest for the same signature
+            run_query(query_two)  # digest B: new, same signature
         dd_run_check(mysql_check)
 
     events = aggregator.get_event_platform_events("dbm-metrics")
     matching_rows = [r for e in events for r in e['mysql_rows'] if r['query_signature'] == query_signature]
     assert len(matching_rows) == 1
-    # only query_one's +1 is counted; query_two is baselined, not dumped (pre-fix: 6)
+    # only digest A's +1 is counted; digest B is baselined, not dumped (pre-fix: 6)
     assert matching_rows[0]['count_star'] == 1
 
 

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -289,7 +289,6 @@ def test_statement_metrics_baselines_new_digest_before_merging_query_signature(d
 
     def row(digest, digest_text, count_star):
         return {
-            '_dd_statement_source': statements.DIGEST_STATEMENT_SOURCE,
             '_dd_statement_id': None,
             'schema_name': 'personio',
             'digest': digest,
@@ -325,7 +324,6 @@ def test_statement_metrics_baselines_new_digest_before_merging_query_signature(d
     assert rows[0]['query_signature'] == query_signature
     assert rows[0]['count_star'] == 10
     assert '_dd_statement_id' not in rows[0]
-    assert '_dd_statement_source' not in rows[0]
 
 
 @pytest.mark.unit
@@ -342,7 +340,6 @@ def test_statement_metrics_baselines_new_prepared_statement_instance_before_merg
 
     def row(object_instance_begin, count_star):
         return {
-            '_dd_statement_source': statements.PREPARED_STATEMENT_SOURCE,
             '_dd_statement_id': object_instance_begin,
             'schema_name': 'personio',
             'digest': None,
@@ -379,7 +376,6 @@ def test_statement_metrics_baselines_new_prepared_statement_instance_before_merg
     # Only instance 1001's delta (10) is counted; the newly-seen instance 2002 is baselined, not dumped.
     assert rows[0]['count_star'] == 10
     assert '_dd_statement_id' not in rows[0]
-    assert '_dd_statement_source' not in rows[0]
 
 
 @pytest.mark.unit
@@ -394,7 +390,6 @@ def test_statement_metrics_reused_prepared_statement_instance_id_is_not_merged(d
 
     def row(object_instance_begin, digest_text, count_star):
         return {
-            '_dd_statement_source': statements.PREPARED_STATEMENT_SOURCE,
             '_dd_statement_id': object_instance_begin,
             'schema_name': 'personio',
             'digest': None,

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -290,6 +290,7 @@ def test_statement_metrics_baselines_new_digest_before_merging_query_signature(d
     def row(digest, digest_text, count_star):
         return {
             '_dd_statement_source': statements.DIGEST_STATEMENT_SOURCE,
+            '_dd_statement_id': None,
             'schema_name': 'personio',
             'digest': digest,
             'digest_text': digest_text,
@@ -323,7 +324,7 @@ def test_statement_metrics_baselines_new_digest_before_merging_query_signature(d
     assert len(rows) == 1
     assert rows[0]['query_signature'] == query_signature
     assert rows[0]['count_star'] == 10
-    assert '_dd_digest_text' not in rows[0]
+    assert '_dd_statement_id' not in rows[0]
     assert '_dd_statement_source' not in rows[0]
 
 
@@ -1110,7 +1111,6 @@ def test_normalize_queries(dbm_instance):
             'digest': '44e35cee979ba420eb49a8471f852bbe15b403c89742704817dfbaace0d99dbb',
             'schema': 'network',
             'digest_text': 'SELECT * from table where name = ?',
-            '_dd_digest_text': 'SELECT * from table where name = ?',
             'query_signature': '761498b7d5f04d11',
             'dd_commands': None,
             'dd_comments': None,
@@ -1139,7 +1139,6 @@ def test_normalize_queries(dbm_instance):
             'digest': None,
             'schema': None,
             'digest_text': None,
-            '_dd_digest_text': None,
             'query_signature': None,
             'dd_commands': None,
             'dd_comments': None,

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -328,6 +328,60 @@ def test_statement_metrics_baselines_new_digest_before_merging_query_signature(d
     assert '_dd_statement_source' not in rows[0]
 
 
+@pytest.mark.unit
+def test_statement_metrics_baselines_new_prepared_statement_instance_before_merging_query_signature(
+    dbm_instance, datadog_agent
+):
+    # Two prepared-statement instances (distinct object_instance_begin) share the same sql_text and therefore
+    # the same query_signature. `prepared_statements_instances` rows have a NULL digest, so they must be baselined
+    # and diffed by their instance identity (object_instance_begin) rather than merged by signature before diffing.
+    # Otherwise a newly-prepared instance dumps its full count_execute into a single interval.
+    normalized_query = 'SELECT `id` FROM `dbm_order` WHERE `id` = ?'
+    query_signature = compute_sql_signature(normalized_query)
+    mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
+
+    def row(object_instance_begin, count_star):
+        return {
+            '_dd_statement_source': statements.PREPARED_STATEMENT_SOURCE,
+            '_dd_statement_id': object_instance_begin,
+            'schema_name': 'personio',
+            'digest': None,
+            'digest_text': 'SELECT id FROM dbm_order WHERE id = ?',
+            'count_star': count_star,
+            'last_seen': time.time(),
+        }
+
+    rows_by_run = iter(
+        [
+            [row(1001, 100)],
+            [
+                row(1001, 110),
+                row(2002, 5000),  # a newly-prepared instance of the same statement
+            ],
+        ]
+    )
+
+    def obfuscate_sql(query, options=None):
+        return json.dumps({'query': normalized_query, 'metadata': {}})
+
+    with (
+        mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent,
+        mock.patch.object(mysql_check._statement_metrics, '_get_statement_count'),
+        mock.patch.object(mysql_check._statement_metrics, '_query_summary_per_statement', side_effect=rows_by_run),
+    ):
+        mock_agent.side_effect = obfuscate_sql
+
+        assert mysql_check._statement_metrics._collect_per_statement_metrics([]) == []
+        rows = mysql_check._statement_metrics._collect_per_statement_metrics([])
+
+    assert len(rows) == 1
+    assert rows[0]['query_signature'] == query_signature
+    # Only instance 1001's delta (10) is counted; the newly-seen instance 2002 is baselined, not dumped.
+    assert rows[0]['count_star'] == 10
+    assert '_dd_statement_id' not in rows[0]
+    assert '_dd_statement_source' not in rows[0]
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -281,6 +281,52 @@ def test_statement_metrics_with_duplicates(aggregator, dd_run_check, dbm_instanc
     assert row['count_star'] == 2
 
 
+@pytest.mark.unit
+def test_statement_metrics_baselines_new_digest_before_merging_query_signature(dbm_instance, datadog_agent):
+    normalized_query = 'SELECT * FROM `employees` WHERE `id` = ?'
+    query_signature = compute_sql_signature(normalized_query)
+    mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
+
+    def row(digest, digest_text, count_star):
+        return {
+            '_dd_statement_source': statements.DIGEST_STATEMENT_SOURCE,
+            'schema_name': 'personio',
+            'digest': digest,
+            'digest_text': digest_text,
+            'count_star': count_star,
+            'last_seen': time.time(),
+        }
+
+    rows_by_run = iter(
+        [
+            [row('digest-a', 'SELECT * FROM employees WHERE id = ?', 100)],
+            [
+                row('digest-a', 'SELECT * FROM employees WHERE id = ?', 110),
+                row('digest-b', 'SELECT * FROM employees WHERE id IN (?)', 5000),
+            ],
+        ]
+    )
+
+    def obfuscate_sql(query, options=None):
+        return json.dumps({'query': normalized_query, 'metadata': {}})
+
+    with (
+        mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent,
+        mock.patch.object(mysql_check._statement_metrics, '_get_statement_count'),
+        mock.patch.object(mysql_check._statement_metrics, '_query_summary_per_statement', side_effect=rows_by_run),
+    ):
+        mock_agent.side_effect = obfuscate_sql
+
+        assert mysql_check._statement_metrics._collect_per_statement_metrics([]) == []
+        rows = mysql_check._statement_metrics._collect_per_statement_metrics([])
+
+    assert len(rows) == 1
+    assert rows[0]['query_signature'] == query_signature
+    assert rows[0]['count_star'] == 10
+    assert '_dd_digest_text' not in rows[0]
+    assert '_dd_statement_source' not in rows[0]
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
@@ -1064,6 +1110,7 @@ def test_normalize_queries(dbm_instance):
             'digest': '44e35cee979ba420eb49a8471f852bbe15b403c89742704817dfbaace0d99dbb',
             'schema': 'network',
             'digest_text': 'SELECT * from table where name = ?',
+            '_dd_digest_text': 'SELECT * from table where name = ?',
             'query_signature': '761498b7d5f04d11',
             'dd_commands': None,
             'dd_comments': None,
@@ -1092,6 +1139,7 @@ def test_normalize_queries(dbm_instance):
             'digest': None,
             'schema': None,
             'digest_text': None,
+            '_dd_digest_text': None,
             'query_signature': None,
             'dd_commands': None,
             'dd_comments': None,

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -382,6 +382,54 @@ def test_statement_metrics_baselines_new_prepared_statement_instance_before_merg
     assert '_dd_statement_source' not in rows[0]
 
 
+@pytest.mark.unit
+def test_statement_metrics_reused_prepared_statement_instance_id_is_not_merged(dbm_instance, datadog_agent):
+    # object_instance_begin is a memory address MySQL can reuse for a different prepared statement once the
+    # previous one is deallocated. The deallocated row lingers in the _statement_rows cache until its TTL, so a
+    # reused id must not collapse the stale row and the new statement onto the same state key; otherwise the new
+    # statement's first execution is reported as a delta for the old query.
+    normalized_a = 'SELECT `id` FROM `dbm_order` WHERE `id` = ?'
+    normalized_b = 'SELECT `name` FROM `dbm_user` WHERE `id` = ?'
+    mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
+
+    def row(object_instance_begin, digest_text, count_star):
+        return {
+            '_dd_statement_source': statements.PREPARED_STATEMENT_SOURCE,
+            '_dd_statement_id': object_instance_begin,
+            'schema_name': 'personio',
+            'digest': None,
+            'digest_text': digest_text,
+            'count_star': count_star,
+            'last_seen': time.time(),
+        }
+
+    rows_by_run = iter(
+        [
+            [row(1001, 'SELECT id FROM dbm_order WHERE id = ?', 100)],
+            # id 1001 was deallocated; a different statement reuses the same object_instance_begin
+            [row(1001, 'SELECT name FROM dbm_user WHERE id = ?', 5000)],
+        ]
+    )
+
+    def obfuscate_sql(query, options=None):
+        normalized = normalized_a if 'dbm_order' in query else normalized_b
+        return json.dumps({'query': normalized, 'metadata': {}})
+
+    with (
+        mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent,
+        mock.patch.object(mysql_check._statement_metrics, '_get_statement_count'),
+        mock.patch.object(mysql_check._statement_metrics, '_query_summary_per_statement', side_effect=rows_by_run),
+    ):
+        mock_agent.side_effect = obfuscate_sql
+
+        assert mysql_check._statement_metrics._collect_per_statement_metrics([]) == []
+        rows = mysql_check._statement_metrics._collect_per_statement_metrics([])
+
+    # The reused id belongs to a different statement, so it is baselined instead of being merged with the stale
+    # row. Without keying on the SQL identity the two rows would merge and emit a spurious 5000 delta.
+    assert rows == []
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -283,46 +283,6 @@ def test_statement_metrics_with_duplicates(aggregator, dd_run_check, dbm_instanc
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-@mock.patch.dict('os.environ', {'DDEV_SKIP_GENERIC_TAGS_CHECK': 'true'})
-def test_statement_metrics_new_digest_does_not_inflate(aggregator, dd_run_check, dbm_instance, datadog_agent):
-    # Two processlist queries with distinct WHERE `state` shapes (=> two digests on every version) obfuscated to
-    # one signature. A digest first seen after the signature is baselined must itself be baselined, not dumped.
-    # Matching only `WHERE `state`` keeps the collapse off the check's own processlist queries.
-    query_one = "select * from information_schema.processlist where state = 'starting'"
-    query_two = "select * from information_schema.processlist where state = 'starting' or state = 'suspended'"
-    normalized_query = 'SELECT * FROM `information_schema` . `processlist` WHERE `state` = ?'
-    query_signature = compute_sql_signature(normalized_query)
-
-    mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
-
-    def obfuscate_sql(query, options=None):
-        if 'WHERE `state`' in query:
-            return normalized_query
-        return query
-
-    def run_query(q):
-        with mysql_check._connect() as db:
-            with closing(db.cursor()) as cursor:
-                cursor.execute(q)
-
-    with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
-        mock_agent.side_effect = obfuscate_sql
-        run_query(query_one)  # digest A -> baseline the signature
-        dd_run_check(mysql_check)
-        run_query(query_one)  # +1 real delta
-        for _ in range(5):
-            run_query(query_two)  # digest B: new, same signature
-        dd_run_check(mysql_check)
-
-    events = aggregator.get_event_platform_events("dbm-metrics")
-    matching_rows = [r for e in events for r in e['mysql_rows'] if r['query_signature'] == query_signature]
-    assert len(matching_rows) == 1
-    # only digest A's +1 is counted; digest B is baselined, not dumped (pre-fix: 6)
-    assert matching_rows[0]['count_star'] == 1
-
-
-@pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
 def test_statement_metrics_new_prepared_statement_instance_does_not_inflate(
     aggregator, dd_run_check, dbm_instance, bob_conn, datadog_agent
 ):
@@ -353,7 +313,7 @@ def test_statement_metrics_new_prepared_statement_instance_does_not_inflate(
     events = aggregator.get_event_platform_events("dbm-metrics")
     matching_rows = [r for e in events for r in e['mysql_rows'] if r['query_signature'] == query_signature]
     assert len(matching_rows) == 1
-    # only ps1's +1 is counted; ps2 is baselined, not dumped (pre-fix SUM-by-sql_text: 6)
+    # only ps1's +1 is counted; ps2 is baselined, not dumped
     assert matching_rows[0]['count_star'] == 1
 
 
@@ -492,7 +452,7 @@ def test_statement_metrics_reused_prepared_statement_instance_id_is_not_merged(d
         assert mysql_check._statement_metrics._collect_per_statement_metrics([]) == []
         rows = mysql_check._statement_metrics._collect_per_statement_metrics([])
 
-    # the reused id is a different statement => baselined, not merged with the stale row (pre-fix: spurious 5000)
+    # the reused id is a different statement => baselined, not merged with the stale row
     assert rows == []
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes MySQL DBM query metrics so cumulative statement counters are diffed by their native statement row identity before the resulting deltas are merged back into normalized query rows.

This keeps the existing `query_signature` aggregation behavior while preventing a first-seen digest variant from contributing its full lifetime `count_star` value to `mysql.queries.count` in a single collection interval.

### Motivation

SDBM-2685 reported inflated MySQL query metrics after a MariaDB 11.4 upgrade. The affected instances have multiple MariaDB digest rows that normalize to the same Datadog `query_signature`. The previous collection path merged those cumulative digest rows by `query_signature` before calculating derivatives, so a newly observed digest could make the merged total jump by its full cumulative count.

This change follows the same separation used by Postgres V2 query metrics: baseline and diff using the database-native row identity, then aggregate derivative rows by Datadog's normalized output identity.

Validation:

- `ddev --no-interactive test mysql -- -k test_statement_metrics_baselines_new_digest_before_merging_query_signature`
- `PATH="/opt/homebrew/Cellar/docker/29.6.0/bin:$PATH" ddev --no-interactive test mysql -- -k "test_statement_metrics_with_duplicates or test_normalize_queries"`
- `ddev test -fs mysql`

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged