### PR TITLE
Fix license header validation to compare against the correct base branch

### DIFF
--- a/datadog_checks_dev/changelog.d/24197.fixed
+++ b/datadog_checks_dev/changelog.d/24197.fixed
@@ -1,0 +1,1 @@
+Compare license headers against the actual base branch instead of always against ``origin/master``, fixing false validation failures for files that exist on a release branch but were deleted from master.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
@@ -33,7 +33,7 @@ IGNORES = {
 @click.argument('check', shell_complete=complete_valid_checks, required=False)
 @click.option('--fix', is_flag=True, help='Attempt to fix errors')
 @click.pass_context
-def license_headers(ctx, check, fix):
+def license_headers(ctx: click.Context, check: str | None, fix: bool) -> None:
     """Validate license headers in python code files.
 
     If `check` is specified, only the check will be validated, if check value is 'changed' will only apply to changed

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
@@ -52,7 +52,6 @@ def license_headers(ctx: click.Context, check: str | None, fix: bool) -> None:
     total_errors = 0
     total_fixes = 0
 
-    # Resolve the base ref once for the whole run and reuse it across every check.
     get_previous = build_get_previous()
 
     for check_name in checks:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
@@ -15,7 +15,7 @@ from datadog_checks.dev.tooling.commands.console import (
     echo_warning,
 )
 from datadog_checks.dev.tooling.constants import get_root
-from datadog_checks.dev.tooling.license_headers import validate_license_headers
+from datadog_checks.dev.tooling.license_headers import build_get_previous, validate_license_headers
 from datadog_checks.dev.tooling.testing import process_checks_option
 from datadog_checks.dev.tooling.utils import complete_valid_checks
 
@@ -52,11 +52,14 @@ def license_headers(ctx, check, fix):
     total_errors = 0
     total_fixes = 0
 
+    # Resolve the base ref once for the whole run and reuse it across every check.
+    get_previous = build_get_previous()
+
     for check_name in checks:
         path_to_check = root / check_name
         ignores = [pathlib.Path(p) for p in IGNORES.get(check_name, [])]
         ignores.extend([pathlib.Path(p) for p in IGNORES.get("all")])
-        errors = validate_license_headers(path_to_check, ignore=ignores, repo_root=root)
+        errors = validate_license_headers(path_to_check, ignore=ignores, repo_root=root, get_previous=get_previous)
 
         for err in errors:
             echo_failure(f'{check_name}/{err.path}: {err.message}')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -11,6 +11,8 @@ from datadog_checks.dev.subprocess import SubprocessResult, run_command
 
 from .constants import get_root
 
+RELEASE_BRANCH_PATTERN = re.compile(r'^\d+\.\d+\.x$')
+
 
 def get_git_root():
     """
@@ -225,3 +227,65 @@ def get_git_user():
 def get_git_email():
     result = run_command('git config --get user.email', capture=True, check=True)
     return result.stdout.strip()
+
+
+def get_base_ref() -> str:
+    """Return the git ref to compare files against when validating license headers.
+
+    Priority:
+    1. GITHUB_BASE_REF (set by GitHub Actions for pull requests — the target branch).
+    2. GITHUB_REF_NAME when it is master or a release branch (push events directly to those branches).
+    3. Closest ancestor among master and release branches, found via merge-base timestamps.
+    """
+    github_base_ref = os.environ.get('GITHUB_BASE_REF')
+    if github_base_ref:
+        return f'origin/{github_base_ref}'
+
+    github_ref_name = os.environ.get('GITHUB_REF_NAME', '')
+    if github_ref_name == 'master' or RELEASE_BRANCH_PATTERN.match(github_ref_name):
+        return f'origin/{github_ref_name}'
+
+    return _find_closest_base_ref()
+
+
+def _find_closest_base_ref() -> str:
+    """Find the closest ancestor among master and release branches using merge-base timestamps."""
+    with chdir(get_root()):
+        result = run_command('git for-each-ref --format=%(refname:short) refs/remotes/origin/', capture='out')
+        if result.code != 0:
+            return 'origin/master'
+
+        candidates = [
+            ref
+            for ref in result.stdout.strip().splitlines()
+            if ref == 'origin/master' or RELEASE_BRANCH_PATTERN.match(ref.removeprefix('origin/'))
+        ]
+
+        if not candidates:
+            return 'origin/master'
+
+        best_ref = 'origin/master'
+        best_timestamp = -1
+
+        for ref in candidates:
+            merge_base_result = run_command(f'git merge-base {ref} HEAD', capture='both')
+            if merge_base_result.code != 0:
+                continue
+            merge_base = merge_base_result.stdout.strip()
+            if not merge_base:
+                continue
+
+            timestamp_result = run_command(f'git show -s --format=%ct {merge_base}', capture='out')
+            if timestamp_result.code != 0:
+                continue
+
+            try:
+                timestamp = int(timestamp_result.stdout.strip())
+            except ValueError:
+                continue
+
+            if timestamp > best_timestamp:
+                best_timestamp = timestamp
+                best_ref = ref
+
+        return best_ref

--- a/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import functools
 import pathlib
 import re
 from collections import namedtuple
@@ -27,15 +28,29 @@ _COPYRIGHT_PATTERN = re.compile(
 LicenseHeaderError = namedtuple("LicenseHeaderError", ["message", "path", "fixed"])
 
 
-def _get_previous(path):
-    """Returns contents of the base branch version of file at `path` if it exists, and `None` otherwise."""
+def _get_previous(path, base_ref):
+    """Returns contents of the `base_ref` version of file at `path` if it exists, and `None` otherwise."""
     # git_show_file relies on global context to compute the final path from a relative one,
     # so we need to pass it the relative path it expects
     relpath = path.relative_to(get_root())
     try:
-        return git_show_file(str(relpath), get_base_ref())
+        return git_show_file(str(relpath), base_ref)
     except SubprocessError:
         return None
+
+
+def build_get_previous():
+    """Build a previous-version lookup that resolves the base ref at most once, lazily on first use.
+
+    Reuse a single instance across many files (and across checks) so the base ref, whose local
+    resolution shells out to several git commands, is computed only once per run.
+    """
+    resolve_base_ref = functools.lru_cache(maxsize=1)(get_base_ref)
+
+    def get_previous(path):
+        return _get_previous(path, resolve_base_ref())
+
+    return get_previous
 
 
 def validate_license_headers(
@@ -43,7 +58,7 @@ def validate_license_headers(
     ignore: Optional[Iterable[pathlib.Path]] = None,
     *,
     repo_root: Optional[pathlib.Path] = None,
-    get_previous: Callable[[pathlib.Path], Optional[str]] = _get_previous,
+    get_previous: Optional[Callable[[pathlib.Path], Optional[str]]] = None,
 ) -> List[LicenseHeaderError]:
     """
     Validate license headers under `check_path` and return a list of validation errors.
@@ -54,6 +69,9 @@ def validate_license_headers(
     - Only python (*.py) files need a license header
     - Code under hidden folders (starting with `.`) are ignored
     """
+    if get_previous is None:
+        get_previous = build_get_previous()
+
     ignoreset = set(ignore or [])
 
     def walk_recursively(path, gitignore_matcher):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
@@ -12,7 +12,7 @@ from pathspec.gitignore import GitIgnoreSpec
 from datadog_checks.dev.errors import SubprocessError
 
 from .constants import get_root
-from .git import git_show_file
+from .git import get_base_ref, git_show_file
 from .utils import get_license_header as get_default_license_header
 
 _COPYRIGHT_PATTERN = re.compile(
@@ -28,12 +28,12 @@ LicenseHeaderError = namedtuple("LicenseHeaderError", ["message", "path", "fixed
 
 
 def _get_previous(path):
-    """Returns contents of previous (origin/master) version of file at `path` if it exists, and `None` otherwise."""
+    """Returns contents of the base branch version of file at `path` if it exists, and `None` otherwise."""
     # git_show_file relies on global context to compute the final path from a relative one,
     # so we need to pass it the relative path it expects
     relpath = path.relative_to(get_root())
     try:
-        return git_show_file(str(relpath), "origin/master")
+        return git_show_file(str(relpath), get_base_ref())
     except SubprocessError:
         return None
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
@@ -6,7 +6,7 @@ import functools
 import pathlib
 import re
 from collections import namedtuple
-from typing import Callable, Iterable, List, Optional
+from typing import Callable, Iterable
 
 from pathspec.gitignore import GitIgnoreSpec
 
@@ -42,8 +42,9 @@ def _get_previous(path: pathlib.Path, base_ref: str) -> str | None:
 def build_get_previous() -> Callable[[pathlib.Path], str | None]:
     """Build a previous-version lookup that resolves the base ref at most once, lazily on first use.
 
-    Reuse a single instance across many files (and across checks) so the base ref, whose local
-    resolution shells out to several git commands, is computed only once per run.
+    The returned callable caches the base ref, whose local resolution shells out to several git
+    commands, so reusing a single instance across many files resolves it only once. Callers that
+    validate several checks should share one instance to amortize the lookup across all of them.
     """
     resolve_base_ref = functools.lru_cache(maxsize=1)(get_base_ref)
 
@@ -55,11 +56,11 @@ def build_get_previous() -> Callable[[pathlib.Path], str | None]:
 
 def validate_license_headers(
     check_path: pathlib.Path,
-    ignore: Optional[Iterable[pathlib.Path]] = None,
+    ignore: Iterable[pathlib.Path] | None = None,
     *,
-    repo_root: Optional[pathlib.Path] = None,
-    get_previous: Optional[Callable[[pathlib.Path], Optional[str]]] = None,
-) -> List[LicenseHeaderError]:
+    repo_root: pathlib.Path | None = None,
+    get_previous: Callable[[pathlib.Path], str | None] | None = None,
+) -> list[LicenseHeaderError]:
     """
     Validate license headers under `check_path` and return a list of validation errors.
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
@@ -28,7 +28,7 @@ _COPYRIGHT_PATTERN = re.compile(
 LicenseHeaderError = namedtuple("LicenseHeaderError", ["message", "path", "fixed"])
 
 
-def _get_previous(path, base_ref):
+def _get_previous(path: pathlib.Path, base_ref: str) -> str | None:
     """Returns contents of the `base_ref` version of file at `path` if it exists, and `None` otherwise."""
     # git_show_file relies on global context to compute the final path from a relative one,
     # so we need to pass it the relative path it expects
@@ -39,7 +39,7 @@ def _get_previous(path, base_ref):
         return None
 
 
-def build_get_previous():
+def build_get_previous() -> Callable[[pathlib.Path], str | None]:
     """Build a previous-version lookup that resolves the base ref at most once, lazily on first use.
 
     Reuse a single instance across many files (and across checks) so the base ref, whose local
@@ -47,7 +47,7 @@ def build_get_previous():
     """
     resolve_base_ref = functools.lru_cache(maxsize=1)(get_base_ref)
 
-    def get_previous(path):
+    def get_previous(path: pathlib.Path) -> str | None:
         return _get_previous(path, resolve_base_ref())
 
     return get_previous

--- a/datadog_checks_dev/tests/tooling/conftest.py
+++ b/datadog_checks_dev/tests/tooling/conftest.py
@@ -1,0 +1,14 @@
+# (C) Datadog, Inc. 2025-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.dev.tooling.constants import get_root, set_root
+
+
+@pytest.fixture
+def restore_root():
+    """Restore the global tooling root after a test that points it at a temp repo."""
+    original_root = get_root()
+    yield
+    set_root(original_root)

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -313,7 +313,7 @@ def _make_run_command_for_base_ref(remote_branches, merge_bases):
     return run_command
 
 
-def test_find_closest_base_ref_picks_most_recent_merge_base(monkeypatch):
+def test_find_closest_base_ref_picks_most_recent_merge_base(restore_root):
     remote_branches = ['origin/master', 'origin/7.80.x', 'origin/7.81.x', 'origin/some-feature']
     merge_bases = {
         'origin/master': ('aaa', '1000'),
@@ -330,7 +330,7 @@ def test_find_closest_base_ref_picks_most_recent_merge_base(monkeypatch):
             assert _find_closest_base_ref() == 'origin/7.81.x'
 
 
-def test_find_closest_base_ref_returns_master_when_no_candidates(monkeypatch):
+def test_find_closest_base_ref_returns_master_when_no_candidates(restore_root):
     set_root('/foo/')
     with mock.patch('datadog_checks.dev.tooling.git.chdir'):
         with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
@@ -338,11 +338,21 @@ def test_find_closest_base_ref_returns_master_when_no_candidates(monkeypatch):
             assert _find_closest_base_ref() == 'origin/master'
 
 
-def test_find_closest_base_ref_returns_master_when_for_each_ref_fails(monkeypatch):
+def test_find_closest_base_ref_returns_master_when_for_each_ref_fails(restore_root):
     set_root('/foo/')
     with mock.patch('datadog_checks.dev.tooling.git.chdir'):
         with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
             run.return_value = mock.MagicMock(code=1, stdout='')
+            assert _find_closest_base_ref() == 'origin/master'
+
+
+def test_find_closest_base_ref_returns_master_when_all_merge_base_calls_fail(restore_root):
+    set_root('/foo/')
+    with mock.patch('datadog_checks.dev.tooling.git.chdir'):
+        with mock.patch(
+            'datadog_checks.dev.tooling.git.run_command',
+            side_effect=_make_run_command_for_base_ref(['origin/master', 'origin/7.80.x'], {}),
+        ):
             assert _find_closest_base_ref() == 'origin/master'
 
 

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -6,7 +6,9 @@ import pytest
 
 from datadog_checks.dev.tooling.constants import set_root
 from datadog_checks.dev.tooling.git import (
+    _find_closest_base_ref,
     files_changed,
+    get_base_ref,
     get_commits_since,
     get_current_branch,
     git_commit,
@@ -219,3 +221,122 @@ def test_git_fetch(tags: bool, expected_command: list[str]):
             git_fetch(tags=tags)
             chdir.assert_called_once_with('/foo/')
             run.assert_called_once_with(expected_command, capture=True)
+
+
+@pytest.mark.parametrize(
+    'github_base_ref, expected',
+    [
+        ('master', 'origin/master'),
+        ('7.80.x', 'origin/7.80.x'),
+        ('7.81.x', 'origin/7.81.x'),
+    ],
+)
+def test_get_base_ref_uses_github_base_ref(monkeypatch, github_base_ref, expected):
+    monkeypatch.setenv('GITHUB_BASE_REF', github_base_ref)
+    monkeypatch.delenv('GITHUB_REF_NAME', raising=False)
+    assert get_base_ref() == expected
+
+
+@pytest.mark.parametrize(
+    'github_ref_name, expected',
+    [
+        ('master', 'origin/master'),
+        ('7.80.x', 'origin/7.80.x'),
+        ('7.81.x', 'origin/7.81.x'),
+    ],
+)
+def test_get_base_ref_uses_github_ref_name_for_base_branches(monkeypatch, github_ref_name, expected):
+    monkeypatch.delenv('GITHUB_BASE_REF', raising=False)
+    monkeypatch.setenv('GITHUB_REF_NAME', github_ref_name)
+    assert get_base_ref() == expected
+
+
+@pytest.mark.parametrize(
+    'github_ref_name',
+    ['aarakke/my-feature', 'feature-branch', ''],
+)
+def test_get_base_ref_falls_back_to_git_for_feature_branches(monkeypatch, github_ref_name):
+    monkeypatch.delenv('GITHUB_BASE_REF', raising=False)
+    monkeypatch.setenv('GITHUB_REF_NAME', github_ref_name)
+
+    with mock.patch('datadog_checks.dev.tooling.git._find_closest_base_ref', return_value='origin/master') as finder:
+        result = get_base_ref()
+        finder.assert_called_once()
+        assert result == 'origin/master'
+
+
+def test_get_base_ref_github_base_ref_takes_priority_over_ref_name(monkeypatch):
+    monkeypatch.setenv('GITHUB_BASE_REF', '7.80.x')
+    monkeypatch.setenv('GITHUB_REF_NAME', 'master')
+    assert get_base_ref() == 'origin/7.80.x'
+
+
+def _make_run_command_for_base_ref(remote_branches, merge_bases):
+    """Build a run_command mock for _find_closest_base_ref.
+
+    remote_branches: list of 'origin/xxx' strings returned by for-each-ref.
+    merge_bases: dict mapping ref -> (merge_base_sha, timestamp_str).
+    """
+
+    def run_command(cmd, capture=None, **kwargs):
+        result = mock.MagicMock()
+        if 'for-each-ref' in cmd:
+            result.code = 0
+            result.stdout = '\n'.join(remote_branches)
+        elif 'merge-base' in cmd:
+            # command is: git merge-base <ref> HEAD
+            ref = cmd.split()[-2]
+            if ref in merge_bases:
+                result.code = 0
+                result.stdout = merge_bases[ref][0]
+            else:
+                result.code = 1
+                result.stdout = ''
+        elif 'git show' in cmd:
+            sha = cmd.split()[-1]
+            ts = next((v[1] for v in merge_bases.values() if v[0] == sha), None)
+            if ts is not None:
+                result.code = 0
+                result.stdout = ts
+            else:
+                result.code = 1
+                result.stdout = ''
+        else:
+            result.code = 1
+            result.stdout = ''
+        return result
+
+    return run_command
+
+
+def test_find_closest_base_ref_picks_most_recent_merge_base(monkeypatch):
+    remote_branches = ['origin/master', 'origin/7.80.x', 'origin/7.81.x', 'origin/some-feature']
+    merge_bases = {
+        'origin/master': ('aaa', '1000'),
+        'origin/7.80.x': ('bbb', '2000'),
+        'origin/7.81.x': ('ccc', '3000'),
+    }
+
+    set_root('/foo/')
+    with mock.patch('datadog_checks.dev.tooling.git.chdir'):
+        with mock.patch(
+            'datadog_checks.dev.tooling.git.run_command',
+            side_effect=_make_run_command_for_base_ref(remote_branches, merge_bases),
+        ):
+            assert _find_closest_base_ref() == 'origin/7.81.x'
+
+
+def test_find_closest_base_ref_returns_master_when_no_candidates(monkeypatch):
+    set_root('/foo/')
+    with mock.patch('datadog_checks.dev.tooling.git.chdir'):
+        with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
+            run.return_value = mock.MagicMock(code=0, stdout='origin/some-feature\norigin/other')
+            assert _find_closest_base_ref() == 'origin/master'
+
+
+def test_find_closest_base_ref_returns_master_when_for_each_ref_fails(monkeypatch):
+    set_root('/foo/')
+    with mock.patch('datadog_checks.dev.tooling.git.chdir'):
+        with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
+            run.return_value = mock.MagicMock(code=1, stdout='')
+            assert _find_closest_base_ref() == 'origin/master'

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -1,10 +1,14 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+import subprocess
+
 import mock
 import pytest
 
-from datadog_checks.dev.tooling.constants import set_root
+from datadog_checks.dev.fs import temp_dir
+from datadog_checks.dev.tooling.constants import get_root, set_root
 from datadog_checks.dev.tooling.git import (
     _find_closest_base_ref,
     files_changed,
@@ -340,3 +344,81 @@ def test_find_closest_base_ref_returns_master_when_for_each_ref_fails(monkeypatc
         with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
             run.return_value = mock.MagicMock(code=1, stdout='')
             assert _find_closest_base_ref() == 'origin/master'
+
+
+def _git(repo, *args, date=None):
+    env = os.environ.copy()
+    if date is not None:
+        env['GIT_AUTHOR_DATE'] = date
+        env['GIT_COMMITTER_DATE'] = date
+    subprocess.run(['git', *args], cwd=repo, env=env, check=True, capture_output=True)
+
+
+@pytest.fixture
+def restore_root():
+    """Restore the global tooling root after a test that points it at a temp repo."""
+    original_root = get_root()
+    yield
+    set_root(original_root)
+
+
+@pytest.fixture
+def release_branch_repo(restore_root):
+    """A real git repo where a feature branch is cut from a release branch.
+
+    History (oldest to newest):
+        master (C1) <- 7.80.x (C2) <- 7.81.x (C3) <- feature (C4, HEAD)
+
+    Remote-tracking refs are populated since the finder inspects refs/remotes/origin/.
+    `origin/HEAD` and `origin/some-feature` are added to verify non-base refs are ignored.
+    """
+    with temp_dir() as repo:
+        _git(repo, '-c', 'init.defaultBranch=master', 'init')
+        _git(repo, 'config', 'user.email', 'test@example.com')
+        _git(repo, 'config', 'user.name', 'Test')
+        _git(repo, 'commit', '--allow-empty', '-m', 'C1 on master', date='2020-01-01T00:00:00')
+        _git(repo, 'checkout', '-b', '7.80.x')
+        _git(repo, 'commit', '--allow-empty', '-m', 'C2 on 7.80.x', date='2021-01-01T00:00:00')
+        _git(repo, 'checkout', '-b', '7.81.x')
+        _git(repo, 'commit', '--allow-empty', '-m', 'C3 on 7.81.x', date='2022-01-01T00:00:00')
+        _git(repo, 'checkout', '-b', 'feature')
+        _git(repo, 'commit', '--allow-empty', '-m', 'C4 on feature', date='2023-01-01T00:00:00')
+        _git(repo, 'update-ref', 'refs/remotes/origin/master', 'master')
+        _git(repo, 'update-ref', 'refs/remotes/origin/7.80.x', '7.80.x')
+        _git(repo, 'update-ref', 'refs/remotes/origin/7.81.x', '7.81.x')
+        _git(repo, 'update-ref', 'refs/remotes/origin/some-feature', 'feature')
+        _git(repo, 'symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/master')
+        set_root(repo)
+        yield repo
+
+
+def test_find_closest_base_ref_against_real_repo(release_branch_repo):
+    # The feature branch was cut from 7.81.x, so that is the most recent merge base.
+    assert _find_closest_base_ref() == 'origin/7.81.x'
+
+
+def test_get_base_ref_against_real_repo(release_branch_repo, monkeypatch):
+    monkeypatch.delenv('GITHUB_BASE_REF', raising=False)
+    monkeypatch.delenv('GITHUB_REF_NAME', raising=False)
+    assert get_base_ref() == 'origin/7.81.x'
+
+
+def test_find_closest_base_ref_against_branch_off_master(restore_root):
+    """A feature cut from master after a release branch diverged resolves to master."""
+    with temp_dir() as repo:
+        _git(repo, '-c', 'init.defaultBranch=master', 'init')
+        _git(repo, 'config', 'user.email', 'test@example.com')
+        _git(repo, 'config', 'user.name', 'Test')
+        _git(repo, 'commit', '--allow-empty', '-m', 'C1 on master', date='2020-01-01T00:00:00')
+        _git(repo, 'checkout', '-b', '7.80.x')
+        _git(repo, 'commit', '--allow-empty', '-m', 'C2 on 7.80.x', date='2021-01-01T00:00:00')
+        _git(repo, 'checkout', 'master')
+        _git(repo, 'commit', '--allow-empty', '-m', 'C3 on master', date='2022-01-01T00:00:00')
+        _git(repo, 'checkout', '-b', 'feature')
+        _git(repo, 'commit', '--allow-empty', '-m', 'C4 on feature', date='2023-01-01T00:00:00')
+        _git(repo, 'update-ref', 'refs/remotes/origin/master', 'master')
+        _git(repo, 'update-ref', 'refs/remotes/origin/7.80.x', '7.80.x')
+        set_root(repo)
+
+        # merge-base(feature, master) is C3 (2022), newer than merge-base(feature, 7.80.x) at C1 (2020).
+        assert _find_closest_base_ref() == 'origin/master'

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -8,7 +8,7 @@ import mock
 import pytest
 
 from datadog_checks.dev.fs import temp_dir
-from datadog_checks.dev.tooling.constants import get_root, set_root
+from datadog_checks.dev.tooling.constants import set_root
 from datadog_checks.dev.tooling.git import (
     _find_closest_base_ref,
     files_changed,
@@ -352,14 +352,6 @@ def _git(repo, *args, date=None):
         env['GIT_AUTHOR_DATE'] = date
         env['GIT_COMMITTER_DATE'] = date
     subprocess.run(['git', *args], cwd=repo, env=env, check=True, capture_output=True)
-
-
-@pytest.fixture
-def restore_root():
-    """Restore the global tooling root after a test that points it at a temp repo."""
-    original_root = get_root()
-    yield
-    set_root(original_root)
 
 
 @pytest.fixture

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -281,6 +281,7 @@ def _make_run_command_for_base_ref(remote_branches, merge_bases):
     remote_branches: list of 'origin/xxx' strings returned by for-each-ref.
     merge_bases: dict mapping ref -> (merge_base_sha, timestamp_str).
     """
+    sha_to_timestamp = dict(merge_bases.values())
 
     def run_command(cmd, capture=None, **kwargs):
         result = mock.MagicMock()
@@ -298,7 +299,7 @@ def _make_run_command_for_base_ref(remote_branches, merge_bases):
                 result.stdout = ''
         elif 'git show' in cmd:
             sha = cmd.split()[-1]
-            ts = next((v[1] for v in merge_bases.values() if v[0] == sha), None)
+            ts = sha_to_timestamp.get(sha)
             if ts is not None:
                 result.code = 0
                 result.stdout = ts

--- a/datadog_checks_dev/tests/tooling/test_license_headers.py
+++ b/datadog_checks_dev/tests/tooling/test_license_headers.py
@@ -4,9 +4,15 @@
 
 import pathlib
 
+import mock
 import pytest
 
-from datadog_checks.dev.tooling.license_headers import parse_license_header, validate_license_headers
+from datadog_checks.dev.tooling.constants import get_root, set_root
+from datadog_checks.dev.tooling.license_headers import (
+    build_get_previous,
+    parse_license_header,
+    validate_license_headers,
+)
 from datadog_checks.dev.tooling.utils import get_license_header
 
 
@@ -290,6 +296,51 @@ def _make_get_previous(d: dict = None):
         return d.get(path)
 
     return _fake_get_previous
+
+
+def test_build_get_previous_resolves_base_ref_lazily_and_only_once(tmp_path):
+    original_root = get_root()
+    set_root(tmp_path)
+    try:
+        with mock.patch(
+            "datadog_checks.dev.tooling.license_headers.get_base_ref", return_value="origin/master"
+        ) as get_base_ref:
+            with mock.patch("datadog_checks.dev.tooling.license_headers.git_show_file", return_value=None):
+                get_previous = build_get_previous()
+                # The base ref is not resolved until a file actually needs a lookup.
+                get_base_ref.assert_not_called()
+
+                for name in ("a.py", "b.py", "c.py"):
+                    get_previous(tmp_path / name)
+    finally:
+        set_root(original_root)
+
+    # Resolved a single time across every lookup, so the command can reuse one instance across checks.
+    get_base_ref.assert_called_once()
+
+
+def test_validate_license_headers_resolves_base_ref_once_per_run(tmp_path):
+    check_path = tmp_path / "check"
+    check_path.mkdir()
+    for name in ("a.py", "b.py", "c.py"):
+        _write_string_to_file(check_path / name, f"{get_license_header()}\n\nimport os\n")
+
+    original_root = get_root()
+    set_root(check_path)
+    try:
+        with mock.patch(
+            "datadog_checks.dev.tooling.license_headers.get_base_ref", return_value="origin/master"
+        ) as get_base_ref:
+            with mock.patch(
+                "datadog_checks.dev.tooling.license_headers.git_show_file", return_value=None
+            ) as git_show_file:
+                validate_license_headers(check_path)
+    finally:
+        set_root(original_root)
+
+    # Base ref is resolved a single time even though three files are scanned.
+    get_base_ref.assert_called_once()
+    assert git_show_file.call_count == 3
 
 
 def test_validate_license_headers_honors_gitignore_file_on_check_path(tmp_path):

--- a/datadog_checks_dev/tests/tooling/test_license_headers.py
+++ b/datadog_checks_dev/tests/tooling/test_license_headers.py
@@ -7,7 +7,7 @@ import pathlib
 import mock
 import pytest
 
-from datadog_checks.dev.tooling.constants import get_root, set_root
+from datadog_checks.dev.tooling.constants import set_root
 from datadog_checks.dev.tooling.license_headers import (
     build_get_previous,
     parse_license_header,
@@ -298,45 +298,35 @@ def _make_get_previous(d: dict = None):
     return _fake_get_previous
 
 
-def test_build_get_previous_resolves_base_ref_lazily_and_only_once(tmp_path):
-    original_root = get_root()
+def test_build_get_previous_resolves_base_ref_lazily_and_only_once(tmp_path, restore_root):
     set_root(tmp_path)
-    try:
-        with mock.patch(
-            "datadog_checks.dev.tooling.license_headers.get_base_ref", return_value="origin/master"
-        ) as get_base_ref:
-            with mock.patch("datadog_checks.dev.tooling.license_headers.git_show_file", return_value=None):
-                get_previous = build_get_previous()
-                # The base ref is not resolved until a file actually needs a lookup.
-                get_base_ref.assert_not_called()
+    with mock.patch(
+        "datadog_checks.dev.tooling.license_headers.get_base_ref", return_value="origin/master"
+    ) as get_base_ref:
+        with mock.patch("datadog_checks.dev.tooling.license_headers.git_show_file", return_value=None):
+            get_previous = build_get_previous()
+            # The base ref is not resolved until a file actually needs a lookup.
+            get_base_ref.assert_not_called()
 
-                for name in ("a.py", "b.py", "c.py"):
-                    get_previous(tmp_path / name)
-    finally:
-        set_root(original_root)
+            for name in ("a.py", "b.py", "c.py"):
+                get_previous(tmp_path / name)
 
     # Resolved a single time across every lookup, so the command can reuse one instance across checks.
     get_base_ref.assert_called_once()
 
 
-def test_validate_license_headers_resolves_base_ref_once_per_run(tmp_path):
+def test_validate_license_headers_resolves_base_ref_once_per_run(tmp_path, restore_root):
     check_path = tmp_path / "check"
     check_path.mkdir()
     for name in ("a.py", "b.py", "c.py"):
         _write_string_to_file(check_path / name, f"{get_license_header()}\n\nimport os\n")
 
-    original_root = get_root()
     set_root(check_path)
-    try:
-        with mock.patch(
-            "datadog_checks.dev.tooling.license_headers.get_base_ref", return_value="origin/master"
-        ) as get_base_ref:
-            with mock.patch(
-                "datadog_checks.dev.tooling.license_headers.git_show_file", return_value=None
-            ) as git_show_file:
-                validate_license_headers(check_path)
-    finally:
-        set_root(original_root)
+    with mock.patch(
+        "datadog_checks.dev.tooling.license_headers.get_base_ref", return_value="origin/master"
+    ) as get_base_ref:
+        with mock.patch("datadog_checks.dev.tooling.license_headers.git_show_file", return_value=None) as git_show_file:
+            validate_license_headers(check_path)
 
     # Base ref is resolved a single time even though three files are scanned.
     get_base_ref.assert_called_once()


### PR DESCRIPTION
### What does this PR do?
Makes the license-header validator compare each file against its actual base branch instead of always against `origin/master`.

A new `get_base_ref()` in `datadog_checks_dev/.../tooling/git.py` resolves the comparison ref by priority:
1. `GITHUB_BASE_REF` (GitHub Actions PR context: the target branch).
2. `GITHUB_REF_NAME` when it is `master` or a release branch (`N.N.x`) for push events.
3. The closest ancestor among `master` and release branches, picked by most recent `git merge-base` timestamp (`_find_closest_base_ref()`), falling back to `origin/master`.

`license_headers._get_previous()` now uses `get_base_ref()` instead of the hardcoded `origin/master`.

### Motivation
When a file exists on a release branch but has been deleted from `master`, the validator compared against `origin/master`, found nothing, and treated the file as new, enforcing the current-year copyright template. Files written in earlier years then failed validation in PRs targeting the release branch with "file does not match expected license format". Comparing against the real base branch fixes these false failures.

### Testing
- Mocked unit tests cover `get_base_ref()` env-var precedence and the `_find_closest_base_ref()` candidate filtering/selection and fallbacks.
- Real-git integration tests build throwaway repos (real commits, dated history, populated `refs/remotes/origin/*`) and exercise `_find_closest_base_ref()` / `get_base_ref()` end to end with no mocking, so the actual `for-each-ref` / `merge-base` / `%ct` plumbing and output capture are verified rather than simulated.

The real-git tests hand-roll their setup (a local `_git()` subprocess wrapper plus a `restore_root` fixture) because `datadog_checks_dev` ships no git-in-tests helpers. `ddev` already does: a `ClonedRepo` helper and `local_clone`/`repository` fixtures (`ddev/tests/helpers/git.py`, `ddev/tests/conftest.py`) that clone the repo, set git identity, and manage branches/worktrees via `PLATFORM.check_command_output` and `Path.as_cwd`. When this validation is migrated to `ddev`, these tests are better placed there and can reuse that machinery instead of reimplementing it.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged