### PR TITLE
Add a Tokens value object to unify token accounting in the ddev AI framework

### DIFF
--- a/ddev/src/ddev/ai/accounting/__init__.py
+++ b/ddev/src/ddev/ai/accounting/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/ddev/src/ddev/ai/accounting/tokens.py
+++ b/ddev/src/ddev/ai/accounting/tokens.py
@@ -24,3 +24,8 @@ class Tokens(BaseModel):
             cache_read=self.cache_read + other.cache_read,
             cache_creation=self.cache_creation + other.cache_creation,
         )
+
+    def __radd__(self, other: Tokens | int) -> Tokens:
+        if other == 0:
+            return self
+        return NotImplemented

--- a/ddev/src/ddev/ai/accounting/tokens.py
+++ b/ddev/src/ddev/ai/accounting/tokens.py
@@ -1,0 +1,26 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Tokens(BaseModel):
+    """Accumulable input/output/cache token totals."""
+
+    model_config = ConfigDict(frozen=True)
+
+    input: int = 0
+    output: int = 0
+    cache_read: int = 0
+    cache_creation: int = 0
+
+    def __add__(self, other: Tokens) -> Tokens:
+        return Tokens(
+            input=self.input + other.input,
+            output=self.output + other.output,
+            cache_read=self.cache_read + other.cache_read,
+            cache_creation=self.cache_creation + other.cache_creation,
+        )

--- a/ddev/src/ddev/ai/agent/types.py
+++ b/ddev/src/ddev/ai/agent/types.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.tools.core.types import ToolResult
 
 
@@ -100,6 +101,15 @@ class TokenUsage:
     context_usage: ContextUsage | None = None  # None only for agents that don't provide context tracking
     web_search_requests: int = 0  # number of web search requests (billed separately from tokens)
     web_fetch_requests: int = 0  # number of web fetch requests (billed separately from tokens)
+
+    def to_tokens(self) -> Tokens:
+        """Project this per-call usage into accumulable token totals."""
+        return Tokens(
+            input=self.input_tokens,
+            output=self.output_tokens,
+            cache_read=self.cache_read_input_tokens,
+            cache_creation=self.cache_creation_input_tokens,
+        )
 
 
 @dataclass(frozen=True)

--- a/ddev/src/ddev/ai/flows/openmetrics/phases/inspect_endpoint.py
+++ b/ddev/src/ddev/ai/flows/openmetrics/phases/inspect_endpoint.py
@@ -236,8 +236,6 @@ class InspectEndpointPhase(Phase):
 
         return PhaseOutcome(
             memory_text=memory_text,
-            total_input_tokens=0,
-            total_output_tokens=0,
             extra_checkpoint={
                 "endpoint_url": endpoint_url,
                 "status_code": response.status_code,

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -16,7 +16,7 @@ from ddev.ai.phases.goal import GOAL_TASK_SUFFIX, GoalValidationError, render_go
 from ddev.ai.phases.messages import PhaseFailedMessage
 from ddev.ai.phases.template import render_inline, render_prompt
 from ddev.ai.react.process import ReActProcess
-from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointStatus, FailedCheckpoint, TokenUsage
+from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointStatus, CheckpointTokenInfo, FailedCheckpoint
 from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
 
 if TYPE_CHECKING:
@@ -356,7 +356,7 @@ class AgenticPhase(Phase):
                     started_at=self._started_at.isoformat() if self._started_at else None,
                     finished_at=datetime.now(UTC).isoformat(),
                     error=str(error.original_exception),
-                    tokens=TokenUsage(
+                    tokens=CheckpointTokenInfo(
                         total_input=self._total_input_tokens,
                         total_output=self._total_output_tokens,
                     ),

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -26,6 +26,35 @@ if TYPE_CHECKING:
     from ddev.ai.react.types import ReActResult
 
 
+RESUME_NOTICE = """
+
+---
+
+NOTE FROM THE HARNESS — RESUMED RUN
+
+This phase is being re-run because a previous execution of this flow failed or was \
+interrupted while this phase was the one in progress. You are picking up from where it stopped.
+
+Some of this phase's work may already be partially on disk from that earlier attempt — files \
+created or half-edited, assets generated, commands partially applied. Before doing new work, \
+inspect the current state of the files this phase is responsible for, reconcile anything that is \
+incomplete or inconsistent, and avoid blindly duplicating steps that were already finished. \
+Treat the on-disk state as the source of truth and bring it to a correct, complete result."""
+
+RESUME_NOTICE_ERROR = """
+
+The previous attempt recorded this error:
+
+{error}"""
+
+
+def build_resume_notice(error: str | None) -> str:
+    notice = RESUME_NOTICE
+    if error:
+        notice += RESUME_NOTICE_ERROR.format(error=error)
+    return notice
+
+
 def render_task_prompt(
     task: TaskConfig,
     config_dir: Path,
@@ -288,6 +317,9 @@ class AgenticPhase(Phase):
             context,
             self._resolver,
         )
+        if self._resume_frontier:
+            prior = context.get("checkpoints", {}).get(self._phase_id) or {}
+            system_prompt += build_resume_notice(prior.get("error"))
         try:
             process = self._process_factory.create(
                 scope=self._scope,

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.phases.base import FlowContext, Phase, PhaseOutcome
 from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError, PhaseConfig, TaskConfig
@@ -16,7 +17,7 @@ from ddev.ai.phases.goal import GOAL_TASK_SUFFIX, GoalValidationError, render_go
 from ddev.ai.phases.messages import PhaseFailedMessage
 from ddev.ai.phases.template import render_inline, render_prompt
 from ddev.ai.react.process import ReActProcess
-from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointStatus, CheckpointTokenInfo, FailedCheckpoint
+from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointStatus, FailedCheckpoint
 from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
 
 if TYPE_CHECKING:
@@ -107,8 +108,7 @@ class AgenticPhase(Phase):
         self._process_factory = process_factory
         self._scope = AgentScope(owner_id=phase_id, role=AgentRole.PHASE)
         self._goal_attempt_log: list[dict[str, Any]] = []
-        self._total_input_tokens: int = 0
-        self._total_output_tokens: int = 0
+        self._tokens: Tokens = Tokens()
 
     @classmethod
     def validate_config(
@@ -160,7 +160,7 @@ class AgenticPhase(Phase):
         process: ReActProcess,
         context: dict[str, Any],
     ) -> None:
-        """Run the task loop, accumulating tokens into self._total_input/output_tokens.
+        """Run the task loop, accumulating tokens into self._tokens.
 
         Override to customize task execution — e.g. add retries, change ordering, etc.
         Default implementation iterates through config.tasks sequentially.
@@ -200,22 +200,20 @@ class AgenticPhase(Phase):
             return
 
         if task.compact_context_before:
-            input_tokens, output_tokens = await process.compact()
-            self._add_tokens(input_tokens, output_tokens)
+            self._tokens += await process.compact()
             return
 
-        input_tokens, output_tokens = await self._compact_if_needed(process, last_result)
-        self._add_tokens(input_tokens, output_tokens)
+        self._tokens += await self._compact_if_needed(process, last_result)
 
     async def _compact_if_needed(
         self,
         process: ReActProcess,
         last_result: ReActResult | None,
-    ) -> tuple[int, int]:
+    ) -> Tokens:
         if last_result is None or last_result.context_usage is None:
-            return 0, 0
+            return Tokens()
         if last_result.context_usage.context_pct < self._config.context_compact_threshold_pct:
-            return 0, 0
+            return Tokens()
         return await process.compact()
 
     def _task_has_goal(self, task: TaskConfig) -> bool:
@@ -238,7 +236,7 @@ class AgenticPhase(Phase):
         prompt: str,
     ) -> ReActResult:
         result = await process.start(prompt)
-        self._add_tokens(result.total_input_tokens, result.total_output_tokens)
+        self._tokens += result.tokens
         return result
 
     async def _run_goal_validation(
@@ -265,11 +263,11 @@ class AgenticPhase(Phase):
             )
         except GoalValidationError as e:
             self._record_goal_attempt(task, e.attempts, final_valid=False)
-            self._add_tokens(e.input_tokens, e.output_tokens)
+            self._tokens += e.tokens
             raise
 
         self._record_goal_attempt(task, outcome.attempts, final_valid=True)
-        self._add_tokens(outcome.total_input_tokens, outcome.total_output_tokens)
+        self._tokens += outcome.tokens
         return outcome.final_result
 
     def _record_goal_attempt(
@@ -287,27 +285,19 @@ class AgenticPhase(Phase):
             }
         )
 
-    def _add_tokens(
-        self,
-        input_tokens: int,
-        output_tokens: int,
-    ) -> None:
-        self._total_input_tokens += input_tokens
-        self._total_output_tokens += output_tokens
-
     async def _run_memory_step(
         self,
         process: ReActProcess,
         context: dict[str, Any],
-    ) -> tuple[str, int, int]:
-        """Run the final summary turn. Returns (memory_text, input_tokens, output_tokens)."""
+    ) -> tuple[str, Tokens]:
+        """Run the final summary turn. Returns (memory_text, tokens)."""
         user_additions = None
         if self._config.checkpoint is not None:
             user_additions = render_memory_prompt(self._config.checkpoint, self._config_dir, context)
         memory_prompt = self._checkpoint_manager.build_memory_prompt(user_additions)
 
         response = await process.run_once(memory_prompt)
-        return response.text, response.usage.input_tokens, response.usage.output_tokens
+        return response.text, response.usage.to_tokens()
 
     async def execute(self, context: dict[str, Any]) -> PhaseOutcome:
         self.before_react()
@@ -334,7 +324,7 @@ class AgenticPhase(Phase):
 
         self.after_react()
 
-        memory_text, mem_in, mem_out = await self._run_memory_step(process, context)
+        memory_text, mem_tokens = await self._run_memory_step(process, context)
 
         extra: dict[str, Any] = {}
         if self._goal_attempt_log:
@@ -342,8 +332,7 @@ class AgenticPhase(Phase):
 
         return PhaseOutcome(
             memory_text=memory_text,
-            total_input_tokens=self._total_input_tokens + mem_in,
-            total_output_tokens=self._total_output_tokens + mem_out,
+            tokens=self._tokens + mem_tokens,
             extra_checkpoint=extra,
         )
 
@@ -356,10 +345,7 @@ class AgenticPhase(Phase):
                     started_at=self._started_at.isoformat() if self._started_at else None,
                     finished_at=datetime.now(UTC).isoformat(),
                     error=str(error.original_exception),
-                    tokens=CheckpointTokenInfo(
-                        total_input=self._total_input_tokens,
-                        total_output=self._total_output_tokens,
-                    ),
+                    tokens=self._tokens,
                     goal_validations=self._goal_attempt_log or None,
                 ),
             )

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -317,9 +317,10 @@ class AgenticPhase(Phase):
             context,
             self._resolver,
         )
-        if self._resume_frontier:
-            prior = context.get("checkpoints", {}).get(self._phase_id) or {}
-            system_prompt += build_resume_notice(prior.get("error"))
+        if self._is_resume_frontier:
+            prior = (context.get("checkpoints") or {}).get(self._phase_id) or {}
+            error = prior.get("error") if isinstance(prior, dict) else None
+            system_prompt += build_resume_notice(error)
         try:
             process = self._process_factory.create(
                 scope=self._scope,

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -32,13 +32,13 @@ RESUME_NOTICE = """
 
 NOTE FROM THE HARNESS — RESUMED RUN
 
-This phase is being re-run because a previous execution of this flow failed or was \
+This phase is being re-run because a previous execution of this flow failed or was
 interrupted while this phase was the one in progress. You are picking up from where it stopped.
 
-Some of this phase's work may already be partially on disk from that earlier attempt — files \
-created or half-edited, assets generated, commands partially applied. Before doing new work, \
-inspect the current state of the files this phase is responsible for, reconcile anything that is \
-incomplete or inconsistent, and avoid blindly duplicating steps that were already finished. \
+Some of this phase's work may already be partially on disk from that earlier attempt — files
+created or half-edited, assets generated, commands partially applied. Before doing new work,
+inspect the current state of the files this phase is responsible for, reconcile anything that is
+incomplete or inconsistent, and avoid blindly duplicating steps that were already finished.
 Treat the on-disk state as the source of truth and bring it to a correct, complete result."""
 
 RESUME_NOTICE_ERROR = """

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -16,7 +16,7 @@ from ddev.ai.phases.goal import GOAL_TASK_SUFFIX, GoalValidationError, render_go
 from ddev.ai.phases.messages import PhaseFailedMessage
 from ddev.ai.phases.template import render_inline, render_prompt
 from ddev.ai.react.process import ReActProcess
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointStatus, FailedCheckpoint, TokenUsage
 from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
 
 if TYPE_CHECKING:
@@ -318,8 +318,8 @@ class AgenticPhase(Phase):
             self._resolver,
         )
         if self._is_resume_frontier:
-            prior = (context.get("checkpoints") or {}).get(self._phase_id) or {}
-            error = prior.get("error") if isinstance(prior, dict) else None
+            prior = (context.get("checkpoints") or {}).get(self._phase_id)
+            error = prior.error if isinstance(prior, FailedCheckpoint) else None
             system_prompt += build_resume_notice(error)
         try:
             process = self._process_factory.create(
@@ -348,20 +348,21 @@ class AgenticPhase(Phase):
         )
 
     async def on_error(self, error: MessageProcessingError | ProcessorHookError) -> None:
-        payload: dict[str, Any] = {
-            "status": "failed",
-            "started_at": self._started_at.isoformat() if self._started_at else None,
-            "finished_at": datetime.now(UTC).isoformat(),
-            "error": str(error.original_exception),
-            "tokens": {
-                "total_input": self._total_input_tokens,
-                "total_output": self._total_output_tokens,
-            },
-        }
-        if self._goal_attempt_log:
-            payload["goal_validations"] = self._goal_attempt_log
         try:
-            self._checkpoint_manager.write_phase_checkpoint(self._phase_id, payload)
+            self._checkpoint_manager.write_phase_checkpoint(
+                self._phase_id,
+                FailedCheckpoint(
+                    status=CheckpointStatus.FAILED,
+                    started_at=self._started_at.isoformat() if self._started_at else None,
+                    finished_at=datetime.now(UTC).isoformat(),
+                    error=str(error.original_exception),
+                    tokens=TokenUsage(
+                        total_input=self._total_input_tokens,
+                        total_output=self._total_output_tokens,
+                    ),
+                    goal_validations=self._goal_attempt_log or None,
+                ),
+            )
         except Exception:
             self._logger.exception("Failed to write failure checkpoint for phase %s", self._phase_id)
         finally:

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.phases.config import AgentConfig, PhaseConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
@@ -19,7 +20,6 @@ from ddev.ai.runtime.checkpoints import (
     RESERVED_SUCCESS_KEYS,
     CheckpointManager,
     CheckpointStatus,
-    CheckpointTokenInfo,
     FailedCheckpoint,
     SuccessCheckpoint,
 )
@@ -45,8 +45,7 @@ class FlowContext:
 @dataclass
 class PhaseOutcome:
     memory_text: str
-    total_input_tokens: int = 0
-    total_output_tokens: int = 0
+    tokens: Tokens = field(default_factory=Tokens)
     extra_checkpoint: dict[str, Any] = field(default_factory=dict)
 
 
@@ -158,10 +157,7 @@ class Phase(AsyncProcessor[PhaseTrigger]):
             status=CheckpointStatus.SUCCESS,
             started_at=self._started_at.isoformat(),
             finished_at=datetime.now(UTC).isoformat(),
-            tokens=CheckpointTokenInfo(
-                total_input=outcome.total_input_tokens,
-                total_output=outcome.total_output_tokens,
-            ),
+            tokens=outcome.tokens,
             memory_path=str(self._checkpoint_manager.memory_path(self._phase_id)),
             **outcome.extra_checkpoint,
         )

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -19,9 +19,9 @@ from ddev.ai.runtime.checkpoints import (
     RESERVED_SUCCESS_KEYS,
     CheckpointManager,
     CheckpointStatus,
+    CheckpointTokenInfo,
     FailedCheckpoint,
     SuccessCheckpoint,
-    TokenUsage,
 )
 from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
 from ddev.event_bus.orchestrator import AsyncProcessor, BaseMessage
@@ -158,7 +158,7 @@ class Phase(AsyncProcessor[PhaseTrigger]):
             status=CheckpointStatus.SUCCESS,
             started_at=self._started_at.isoformat(),
             finished_at=datetime.now(UTC).isoformat(),
-            tokens=TokenUsage(
+            tokens=CheckpointTokenInfo(
                 total_input=outcome.total_input_tokens,
                 total_output=outcome.total_output_tokens,
             ),

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -32,6 +32,7 @@ class FlowContext:
     config_dir: Path
     callbacks: Callbacks = field(default_factory=Callbacks)
     logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
+    resume_frontier: frozenset[str] = frozenset()
 
 
 @dataclass
@@ -67,6 +68,7 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         self._config_dir = context.config_dir
         self._callbacks = context.callbacks
         self._logger = context.logger
+        self._resume_frontier = phase_id in context.resume_frontier
         self._started_at: datetime | None = None
         self._resolver: Callable[[str], str] | None = None
         self._executed = False

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -15,7 +15,14 @@ from typing import TYPE_CHECKING, Any
 from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.phases.config import AgentConfig, PhaseConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import (
+    RESERVED_SUCCESS_KEYS,
+    CheckpointManager,
+    CheckpointStatus,
+    FailedCheckpoint,
+    SuccessCheckpoint,
+    TokenUsage,
+)
 from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
 from ddev.event_bus.orchestrator import AsyncProcessor, BaseMessage
 
@@ -142,25 +149,25 @@ class Phase(AsyncProcessor[PhaseTrigger]):
 
         outcome = await self.execute(context)
 
-        checkpoint_payload: dict[str, Any] = {
-            "status": "success",
-            "started_at": self._started_at.isoformat(),
-            "finished_at": datetime.now(UTC).isoformat(),
-            "tokens": {
-                "total_input": outcome.total_input_tokens,
-                "total_output": outcome.total_output_tokens,
-            },
-            "memory_path": str(self._checkpoint_manager.memory_path(self._phase_id)),
-        }
-        reserved = set(checkpoint_payload) & set(outcome.extra_checkpoint)
-        if reserved:
+        conflicts = RESERVED_SUCCESS_KEYS & set(outcome.extra_checkpoint)
+        if conflicts:
             raise ValueError(
-                f"Phase {self._phase_id!r}: extra_checkpoint cannot override reserved keys: {sorted(reserved)}"
+                f"Phase {self._phase_id!r}: extra_checkpoint cannot override reserved keys: {sorted(conflicts)}"
             )
-        checkpoint_payload.update(outcome.extra_checkpoint)
+        checkpoint = SuccessCheckpoint(
+            status=CheckpointStatus.SUCCESS,
+            started_at=self._started_at.isoformat(),
+            finished_at=datetime.now(UTC).isoformat(),
+            tokens=TokenUsage(
+                total_input=outcome.total_input_tokens,
+                total_output=outcome.total_output_tokens,
+            ),
+            memory_path=str(self._checkpoint_manager.memory_path(self._phase_id)),
+            **outcome.extra_checkpoint,
+        )
 
         self._checkpoint_manager.write_memory(self._phase_id, outcome.memory_text)
-        self._checkpoint_manager.write_phase_checkpoint(self._phase_id, checkpoint_payload)
+        self._checkpoint_manager.write_phase_checkpoint(self._phase_id, checkpoint)
         await self._callbacks.fire_phase_finish(self._phase_id)
 
     async def on_success(self, message: PhaseTrigger) -> None:
@@ -177,12 +184,12 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         try:
             self._checkpoint_manager.write_phase_checkpoint(
                 self._phase_id,
-                {
-                    "status": "failed",
-                    "started_at": self._started_at.isoformat() if self._started_at else None,
-                    "finished_at": datetime.now(UTC).isoformat(),
-                    "error": str(error.original_exception),
-                },
+                FailedCheckpoint(
+                    status=CheckpointStatus.FAILED,
+                    started_at=self._started_at.isoformat() if self._started_at else None,
+                    finished_at=datetime.now(UTC).isoformat(),
+                    error=str(error.original_exception),
+                ),
             )
         except Exception:
             self._logger.exception("Failed to write failure checkpoint for phase %s", self._phase_id)

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -68,7 +68,7 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         self._config_dir = context.config_dir
         self._callbacks = context.callbacks
         self._logger = context.logger
-        self._resume_frontier = phase_id in context.resume_frontier
+        self._is_resume_frontier = phase_id in context.resume_frontier
         self._started_at: datetime | None = None
         self._resolver: Callable[[str], str] | None = None
         self._executed = False

--- a/ddev/src/ddev/ai/phases/config.py
+++ b/ddev/src/ddev/ai/phases/config.py
@@ -51,6 +51,24 @@ def _detect_cycles(
     return cycles, False
 
 
+def _topological_sort(flow: list[FlowEntry]) -> list[FlowEntry]:
+    """Stable topological sort of an acyclic flow: dependencies before dependents.
+
+    Phases with no ordering constraint between them keep their original
+    declaration order. The caller must guarantee the graph is acyclic.
+    """
+    remaining_deps = {entry.phase: set(entry.dependencies) for entry in flow}
+
+    ordered: list[FlowEntry] = []
+    emitted: set[str] = set()
+    while len(ordered) < len(flow):
+        # First phase in declaration order whose dependencies are all emitted.
+        nxt = next(entry for entry in flow if entry.phase not in emitted and remaining_deps[entry.phase] <= emitted)
+        ordered.append(nxt)
+        emitted.add(nxt.phase)
+    return ordered
+
+
 class TaskConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: str = Field(pattern=r"^[A-Za-z0-9._-]{1,64}$")
@@ -132,6 +150,8 @@ class FlowEntry(BaseModel):
 
 
 class FlowConfig(BaseModel):
+    """Validated flow entries, topologically sorted."""
+
     model_config = ConfigDict(extra="forbid")
     variables: dict[str, str] = {}
     agents: dict[str, AgentConfig]
@@ -166,6 +186,7 @@ class FlowConfig(BaseModel):
             suffix = f"\n  (showing first {len(cycles)}; more cycles exist)" if truncated else ""
             raise ValueError(f"Cycle(s) detected in flow:\n  {formatted}{suffix}")
 
+        self.flow = _topological_sort(self.flow)
         return self
 
     @classmethod

--- a/ddev/src/ddev/ai/phases/goal.py
+++ b/ddev/src/ddev/ai/phases/goal.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.phases.config import AgentConfig, TaskConfig
@@ -77,10 +78,9 @@ GOAL_PARSE_RETRY_PROMPT = (
 class GoalValidationError(Exception):
     """Base class for goal-validation failures. Carries the token cost and attempt count."""
 
-    def __init__(self, message: str, input_tokens: int = 0, output_tokens: int = 0) -> None:
+    def __init__(self, message: str, tokens: Tokens | None = None) -> None:
         super().__init__(message)
-        self.input_tokens = input_tokens
-        self.output_tokens = output_tokens
+        self.tokens = tokens or Tokens()
         self.attempts: int = 0
 
 
@@ -96,16 +96,14 @@ class GoalAttemptsExhausted(GoalValidationError):
 class GoalCheckResult:
     valid: bool
     reason: str
-    input_tokens: int
-    output_tokens: int
+    tokens: Tokens
 
 
 @dataclass(frozen=True)
 class GoalLoopOutcome:
     final_result: ReActResult
     attempts: int
-    total_input_tokens: int
-    total_output_tokens: int
+    tokens: Tokens
 
 
 def render_goal_text(
@@ -165,25 +163,22 @@ async def _run_reviewer_once(
     second response still does not parse, raise GoalParseError.
     """
     result = await reviewer_process.start(user_message)
-    in_tokens = result.total_input_tokens
-    out_tokens = result.total_output_tokens
+    tokens = result.tokens
 
     parsed = parse_reviewer_output(result.final_response.text or "")
     if parsed is None:
         retry_result = await reviewer_process.start(GOAL_PARSE_RETRY_PROMPT)
-        in_tokens += retry_result.total_input_tokens
-        out_tokens += retry_result.total_output_tokens
+        tokens += retry_result.tokens
         parsed = parse_reviewer_output(retry_result.final_response.text or "")
         if parsed is None:
             raise GoalParseError(
                 "Reviewer did not return valid JSON after one parse-retry. "
                 f"Last raw output: {retry_result.final_response.text!r}",
-                input_tokens=in_tokens,
-                output_tokens=out_tokens,
+                tokens=tokens,
             )
 
     valid, reason = parsed
-    return GoalCheckResult(valid=valid, reason=reason, input_tokens=in_tokens, output_tokens=out_tokens)
+    return GoalCheckResult(valid=valid, reason=reason, tokens=tokens)
 
 
 async def _drive_goal_loop(
@@ -195,9 +190,9 @@ async def _drive_goal_loop(
     initial_result: ReActResult,
     reviewer_process: ReActProcess,
     callbacks: Callbacks,
-    compact_if_needed: Callable[[ReActResult], Awaitable[tuple[int, int]]],
+    compact_if_needed: Callable[[ReActResult], Awaitable[Tokens]],
 ) -> GoalLoopOutcome:
-    total_in = total_out = 0
+    total = Tokens()
     attempts = 0
     worker_result = initial_result
 
@@ -216,8 +211,7 @@ async def _drive_goal_loop(
                 reviewer_process.reset()
 
             check = await _run_reviewer_once(reviewer_process, user_message)
-            total_in += check.input_tokens
-            total_out += check.output_tokens
+            total += check.tokens
 
             await callbacks.fire_after_goal_check(task.name, attempts, check.valid, check.reason)
 
@@ -225,8 +219,7 @@ async def _drive_goal_loop(
                 return GoalLoopOutcome(
                     final_result=worker_result,
                     attempts=attempts,
-                    total_input_tokens=total_in,
-                    total_output_tokens=total_out,
+                    tokens=total,
                 )
 
             if attempts >= task.max_goal_attempts:
@@ -235,17 +228,13 @@ async def _drive_goal_loop(
                     f"{attempts} attempts. Last reviewer reason: {check.reason}"
                 )
 
-            compact_in, compact_out = await compact_if_needed(worker_result)
-            total_in += compact_in
-            total_out += compact_out
+            total += await compact_if_needed(worker_result)
 
             retry_prompt = GOAL_RETRY_PROMPT_TEMPLATE.format(goal=goal_text, reason=check.reason)
             worker_result = await worker_process.start(retry_prompt)
-            total_in += worker_result.total_input_tokens
-            total_out += worker_result.total_output_tokens
+            total += worker_result.tokens
     except GoalValidationError as e:
-        e.input_tokens += total_in
-        e.output_tokens += total_out
+        e.tokens += total
         e.attempts = attempts
         raise
 
@@ -261,7 +250,7 @@ async def run_goal_loop(
     process_factory: ReActProcessFactory,
     callbacks: Callbacks,
     phase_id: str,
-    compact_if_needed: Callable[[ReActResult], Awaitable[tuple[int, int]]],
+    compact_if_needed: Callable[[ReActResult], Awaitable[Tokens]],
 ) -> GoalLoopOutcome:
     """Drive the reviewer + worker-retry loop for a single task with a goal.
 

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -4,6 +4,7 @@
 
 import asyncio
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.agent.build import AgentRuntime
 from ddev.ai.agent.exceptions import AgentError
 from ddev.ai.agent.scope import AgentScope
@@ -47,14 +48,14 @@ class ReActProcess:
         """Clear the agent's conversation history."""
         self._agent.reset()
 
-    async def compact(self, response: AgentResponse | None = None) -> tuple[int, int]:
+    async def compact(self, response: AgentResponse | None = None) -> Tokens:
         """Compact the agent's conversation history unconditionally.
 
         Args:
             response: The last agent response. If None, compaction is unconditional.
 
-        Returns (input_tokens, output_tokens) from the compaction API call.
-        Returns (0, 0) if history was already compact and no API call was made.
+        Returns the tokens spent on the compaction API call.
+        Returns ``Tokens()`` if history was already compact and no API call was made.
         """
         await self._callbacks.fire_before_compact(self._scope)
 
@@ -66,8 +67,8 @@ class ReActProcess:
 
         await self._callbacks.fire_after_compact(self._scope)
         if compact_response is None:
-            return 0, 0
-        return compact_response.usage.input_tokens, compact_response.usage.output_tokens
+            return Tokens()
+        return compact_response.usage.to_tokens()
 
     def _is_compact_needed(self, response: AgentResponse) -> bool:
         if self._compact_threshold_pct is None:
@@ -98,8 +99,7 @@ class ReActProcess:
 
             response = await self._agent.send(prompt, allowed_tools)
             iterations = 1
-            total_input = response.usage.input_tokens
-            total_output = response.usage.output_tokens
+            total: Tokens = response.usage.to_tokens()
 
             await self._callbacks.fire_agent_response(self._scope, response, iterations)
 
@@ -116,8 +116,7 @@ class ReActProcess:
                     r if isinstance(r, ToolResult) else ToolResult(success=False, error=f"{type(r).__name__}: {r}")
                     for r in raw_results
                 ]
-                total_input += sum(result.total_input_tokens for result in tool_results)
-                total_output += sum(result.total_output_tokens for result in tool_results)
+                total += sum((result.tokens for result in tool_results), Tokens())
 
                 tool_call_results = list(zip(response.tool_calls, tool_results, strict=True))
 
@@ -130,21 +129,17 @@ class ReActProcess:
 
                 response = await self._agent.send(messages, allowed_tools)
                 iterations += 1
-                total_input += response.usage.input_tokens
-                total_output += response.usage.output_tokens
+                total += response.usage.to_tokens()
 
                 await self._callbacks.fire_agent_response(self._scope, response, iterations)
 
                 if self._is_compact_needed(response):
-                    compact_in, compact_out = await self.compact(response)
-                    total_input += compact_in
-                    total_output += compact_out
+                    total += await self.compact(response)
 
             react_result = ReActResult(
                 final_response=response,
                 iterations=iterations,
-                total_input_tokens=total_input,
-                total_output_tokens=total_output,
+                tokens=total,
                 context_usage=response.usage.context_usage,
             )
 

--- a/ddev/src/ddev/ai/react/types.py
+++ b/ddev/src/ddev/ai/react/types.py
@@ -4,6 +4,7 @@
 
 from dataclasses import dataclass
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.agent.types import AgentResponse, ContextUsage
 
 
@@ -13,6 +14,5 @@ class ReActResult:
 
     final_response: AgentResponse
     iterations: int
-    total_input_tokens: int  # sum across all iterations
-    total_output_tokens: int  # sum across all iterations
+    tokens: Tokens  # sum across all iterations
     context_usage: ContextUsage | None  # promoted from final_response.usage.context_usage

--- a/ddev/src/ddev/ai/runtime/agent_log.py
+++ b/ddev/src/ddev/ai/runtime/agent_log.py
@@ -134,8 +134,10 @@ class AgentLogger:
                     "event": "finish",
                     "success": True,
                     "iterations": result.iterations,
-                    "total_input_tokens": result.total_input_tokens,
-                    "total_output_tokens": result.total_output_tokens,
+                    "total_input_tokens": result.tokens.input,
+                    "total_output_tokens": result.tokens.output,
+                    "total_cache_read_tokens": result.tokens.cache_read,
+                    "total_cache_creation_tokens": result.tokens.cache_creation,
                     "stop_reason": str(result.final_response.stop_reason),
                 },
             )

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -2,14 +2,59 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from __future__ import annotations
+
+from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any, Literal
 
 import yaml
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
 
 
 class CheckpointReadError(Exception):
     """Raised when checkpoints.yaml exists but cannot be read or parsed."""
+
+
+class CheckpointStatus(StrEnum):
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+class TokenUsage(BaseModel):
+    total_input: int
+    total_output: int
+
+
+class SuccessCheckpoint(BaseModel):
+    """Checkpoint written at the end of a successful phase execution."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: Literal[CheckpointStatus.SUCCESS]
+    started_at: str
+    finished_at: str
+    tokens: TokenUsage
+    memory_path: str
+
+
+class FailedCheckpoint(BaseModel):
+    """Checkpoint written when a phase terminates with an error."""
+
+    status: Literal[CheckpointStatus.FAILED]
+    started_at: str | None
+    finished_at: str
+    error: str
+    tokens: TokenUsage | None = None
+    goal_validations: list[dict[str, Any]] | None = None
+
+
+PhaseCheckpoint = Annotated[SuccessCheckpoint | FailedCheckpoint, Field(discriminator="status")]
+
+# TypeAdapter provides model_validate() for annotated union types that aren't BaseModel subclasses.
+_CHECKPOINT_ADAPTER: TypeAdapter[PhaseCheckpoint] = TypeAdapter(PhaseCheckpoint)
+
+RESERVED_SUCCESS_KEYS: frozenset[str] = frozenset(SuccessCheckpoint.model_fields)
 
 
 class CheckpointManager:
@@ -26,25 +71,33 @@ class CheckpointManager:
     def _ensure_dir(self) -> None:
         self.root.mkdir(parents=True, exist_ok=True)
 
-    def read(self) -> dict[str, Any]:
-        """Return full checkpoint data, keyed by phase_id. Empty dict if file absent."""
+    def read(self) -> dict[str, PhaseCheckpoint]:
+        """Return validated checkpoints keyed by phase_id. Skips malformed entries. Empty dict if file absent."""
         if not self._path.exists():
             return {}
         try:
-            return yaml.safe_load(self._path.read_text(encoding="utf-8")) or {}
+            raw = yaml.safe_load(self._path.read_text(encoding="utf-8")) or {}
         except (OSError, yaml.YAMLError) as e:
             raise CheckpointReadError(f"Failed to load checkpoints from {self._path}: {e}") from e
 
-    def write_phase_checkpoint(self, phase_id: str, data: dict[str, Any]) -> None:
+        result: dict[str, PhaseCheckpoint] = {}
+        for phase_id, data in raw.items():
+            try:
+                result[phase_id] = _CHECKPOINT_ADAPTER.validate_python(data)
+            except ValidationError as e:
+                raise CheckpointReadError(f"Checkpoint for phase {phase_id!r} in {self._path} is invalid: {e}") from e
+        return result
+
+    def write_phase_checkpoint(self, phase_id: str, data: PhaseCheckpoint) -> None:
         """Write or overwrite one phase's section in checkpoints.yaml."""
-        checkpoints = self.read()
-        checkpoints[phase_id] = data
+        all_checkpoints = {pid: cp.model_dump(mode="json") for pid, cp in self.read().items()}
+        all_checkpoints[phase_id] = data.model_dump(mode="json")
         self._ensure_dir()
-        self._path.write_text(yaml.dump(checkpoints, default_flow_style=False, sort_keys=False), encoding="utf-8")
+        self._path.write_text(yaml.dump(all_checkpoints, default_flow_style=False, sort_keys=False), encoding="utf-8")
 
     def successful_phases(self) -> set[str]:
         """Phase ids whose last recorded checkpoint reached 'success'."""
-        return {pid for pid, data in self.read().items() if isinstance(data, dict) and data.get("status") == "success"}
+        return {pid for pid, data in self.read().items() if data.status == CheckpointStatus.SUCCESS}
 
     def build_memory_prompt(self, user_additions: str | None) -> str:
         """Build the memory prompt to send to the agent at the end of a phase."""

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -42,6 +42,10 @@ class CheckpointManager:
         self._ensure_dir()
         self._path.write_text(yaml.dump(checkpoints, default_flow_style=False, sort_keys=False), encoding="utf-8")
 
+    def successful_phases(self) -> set[str]:
+        """Phase ids whose last recorded checkpoint reached 'success'."""
+        return {pid for pid, data in self.read().items() if isinstance(data, dict) and data.get("status") == "success"}
+
     def build_memory_prompt(self, user_additions: str | None) -> str:
         """Build the memory prompt to send to the agent at the end of a phase."""
         base_prompt = "Write a brief summary of what you accomplished in this phase."

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -11,6 +11,8 @@ from typing import Annotated, Any, Literal
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
 
+from ddev.ai.accounting.tokens import Tokens
+
 
 class CheckpointReadError(Exception):
     """Raised when checkpoints.yaml exists but cannot be read or parsed."""
@@ -21,11 +23,6 @@ class CheckpointStatus(StrEnum):
     FAILED = "failed"
 
 
-class CheckpointTokenInfo(BaseModel):
-    total_input: int
-    total_output: int
-
-
 class SuccessCheckpoint(BaseModel):
     """Checkpoint written at the end of a successful phase execution."""
 
@@ -34,7 +31,7 @@ class SuccessCheckpoint(BaseModel):
     status: Literal[CheckpointStatus.SUCCESS]
     started_at: str
     finished_at: str
-    tokens: CheckpointTokenInfo
+    tokens: Tokens
     memory_path: str
 
 
@@ -45,7 +42,7 @@ class FailedCheckpoint(BaseModel):
     started_at: str | None
     finished_at: str
     error: str
-    tokens: CheckpointTokenInfo | None = None
+    tokens: Tokens | None = None
     goal_validations: list[dict[str, Any]] | None = None
 
 

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -72,7 +72,9 @@ class CheckpointManager:
         self.root.mkdir(parents=True, exist_ok=True)
 
     def read(self) -> dict[str, PhaseCheckpoint]:
-        """Return validated checkpoints keyed by phase_id. Skips malformed entries. Empty dict if file absent."""
+        """Return validated checkpoints keyed by phase_id.
+        Raises CheckpointReadError if any entry fails validation.
+        Empty dict if file absent."""
         if not self._path.exists():
             return {}
         try:
@@ -89,7 +91,8 @@ class CheckpointManager:
         return result
 
     def write_phase_checkpoint(self, phase_id: str, data: PhaseCheckpoint) -> None:
-        """Write or overwrite one phase's section in checkpoints.yaml."""
+        """Write or overwrite one phase's section in checkpoints.yaml.
+        Raises CheckpointWriteError if the existing file is corrupted."""
         all_checkpoints = {pid: cp.model_dump(mode="json") for pid, cp in self.read().items()}
         all_checkpoints[phase_id] = data.model_dump(mode="json")
         self._ensure_dir()

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -21,7 +21,7 @@ class CheckpointStatus(StrEnum):
     FAILED = "failed"
 
 
-class TokenUsage(BaseModel):
+class CheckpointTokenInfo(BaseModel):
     total_input: int
     total_output: int
 
@@ -34,7 +34,7 @@ class SuccessCheckpoint(BaseModel):
     status: Literal[CheckpointStatus.SUCCESS]
     started_at: str
     finished_at: str
-    tokens: TokenUsage
+    tokens: CheckpointTokenInfo
     memory_path: str
 
 
@@ -45,7 +45,7 @@ class FailedCheckpoint(BaseModel):
     started_at: str | None
     finished_at: str
     error: str
-    tokens: TokenUsage | None = None
+    tokens: CheckpointTokenInfo | None = None
     goal_validations: list[dict[str, Any]] | None = None
 
 

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -12,7 +12,7 @@ from ddev.ai.phases.config import FlowConfig, FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.registry import PhaseRegistry, discover_and_register_phases
 from ddev.ai.runtime.agent_log import AgentLogger
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointReadError
 from ddev.ai.runtime.resources import RunResources
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.event_bus.exceptions import FatalProcessingError
@@ -105,6 +105,10 @@ class PhaseOrchestrator(EventBusOrchestrator):
         dependency_map: dict[str, list[str]] = {entry.phase: entry.dependencies for entry in config.flow}
 
         completed, frontier = self._resolve_resume_state(config, checkpoint_manager)
+        if self._resume:
+            self._logger.info(
+                "Resuming: %d phase(s) completed, re-running frontier %r", len(completed), sorted(frontier)
+            )
 
         self._agent_logger = AgentLogger(checkpoint_manager.root)
         run_callbacks = self._callbacks.with_set(self._agent_logger.as_callback_set())
@@ -143,8 +147,9 @@ class PhaseOrchestrator(EventBusOrchestrator):
             self.register_processor(phase, [PhaseTrigger])
 
         self.submit_message(PhaseTrigger(id="start", phase_id=None))
-        for phase_id in completed:
-            self.submit_message(PhaseTrigger(id=f"{phase_id}_resumed", phase_id=phase_id))
+        for entry in config.flow:
+            if entry.phase in completed:
+                self.submit_message(PhaseTrigger(id=f"{entry.phase}_resumed", phase_id=entry.phase))
 
     def _resolve_resume_state(
         self,
@@ -161,7 +166,12 @@ class PhaseOrchestrator(EventBusOrchestrator):
         if not self._resume:
             return set(), set()
 
-        succeeded = checkpoint_manager.successful_phases()
+        try:
+            succeeded = checkpoint_manager.successful_phases()
+        except CheckpointReadError as e:
+            raise FlowConfigError(
+                f"Cannot resume: checkpoints file is unreadable ({e}). Delete it and restart from scratch."
+            ) from e
         completed: set[str] = set()
         frontier: set[str] = set()
         for entry in config.flow:

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -28,6 +28,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
         agent_clients: dict[str, Any],
         file_access_policy: FileAccessPolicy,
         callbacks: Callbacks | None = None,
+        resume: bool = False,
         grace_period: float = 10,
         max_timeout: float = 600,
         logger: logging.Logger | None = None,
@@ -55,6 +56,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
         self._agent_clients = agent_clients
         self._file_access_policy = file_access_policy
         self._callbacks: Callbacks = callbacks or Callbacks()
+        self._resume = resume
         self._agent_logger: AgentLogger | None = None
         self._phase_registry = PhaseRegistry()
         self._failed_phase: str | None = None
@@ -102,6 +104,8 @@ class PhaseOrchestrator(EventBusOrchestrator):
         checkpoint_manager = CheckpointManager(self._checkpoint_path)
         dependency_map: dict[str, list[str]] = {entry.phase: entry.dependencies for entry in config.flow}
 
+        completed, frontier = self._resolve_resume_state(config, checkpoint_manager)
+
         self._agent_logger = AgentLogger(checkpoint_manager.root)
         run_callbacks = self._callbacks.with_set(self._agent_logger.as_callback_set())
 
@@ -117,10 +121,14 @@ class PhaseOrchestrator(EventBusOrchestrator):
             config_dir=config_dir,
             callbacks=run_callbacks,
             logger=self._logger,
+            resume_frontier=frozenset(frontier),
         )
 
         for entry in config.flow:
             phase_id = entry.phase
+            if phase_id in completed:
+                self._logger.info("Resuming: skipping already-completed phase %r", phase_id)
+                continue
             phase_config = config.phases[phase_id]
             deps = dependency_map[phase_id]
             phase_cls = self._phase_registry.get(phase_config.type)
@@ -135,6 +143,34 @@ class PhaseOrchestrator(EventBusOrchestrator):
             self.register_processor(phase, [PhaseTrigger])
 
         self.submit_message(PhaseTrigger(id="start", phase_id=None))
+        for phase_id in completed:
+            self.submit_message(PhaseTrigger(id=f"{phase_id}_resumed", phase_id=phase_id))
+
+    def _resolve_resume_state(
+        self,
+        config: FlowConfig,
+        checkpoint_manager: CheckpointManager,
+    ) -> tuple[set[str], set[str]]:
+        """Compute (completed, frontier) for a resumed run; both empty when not resuming.
+
+        ``completed`` is the dependency-closed set of phases that succeeded *and* whose every
+        transitive dependency also succeeded. ``frontier`` is the phases that will run first
+        on resume (not completed, but all their dependencies are): the ones that may be sitting
+        on partial work from the interrupted run.
+        """
+        if not self._resume:
+            return set(), set()
+
+        succeeded = checkpoint_manager.successful_phases()
+        completed: set[str] = set()
+        frontier: set[str] = set()
+        for entry in config.flow:
+            deps_done = all(dep in completed for dep in entry.dependencies)
+            if entry.phase in succeeded and deps_done:
+                completed.add(entry.phase)
+            elif deps_done:
+                frontier.add(entry.phase)
+        return completed, frontier
 
     async def on_message_received(self, message: BaseMessage) -> None:
         """Stop the entire pipeline immediately when any phase fails."""

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -158,10 +158,11 @@ class PhaseOrchestrator(EventBusOrchestrator):
     ) -> tuple[set[str], set[str]]:
         """Compute (completed, frontier) for a resumed run; both empty when not resuming.
 
-        ``completed`` is the dependency-closed set of phases that succeeded *and* whose every
+        ``completed`` is the dependency-closed set of phases that succeeded and whose every
         transitive dependency also succeeded. ``frontier`` is the phases that will run first
-        on resume (not completed, but all their dependencies are): the ones that may be sitting
-        on partial work from the interrupted run.
+        on resume (not completed, but all their dependencies are).
+
+        The single-pass closure relies on ``config.flow`` being topologically sorted.
         """
         if not self._resume:
             return set(), set()

--- a/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
+++ b/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
@@ -124,6 +124,5 @@ class SpawnSubagentTool(BaseTool[SpawnSubagentInput]):
         return ToolResult(
             success=True,
             data=data,
-            total_input_tokens=result.total_input_tokens,
-            total_output_tokens=result.total_output_tokens,
+            tokens=result.tokens,
         )

--- a/ddev/src/ddev/ai/tools/core/types.py
+++ b/ddev/src/ddev/ai/tools/core/types.py
@@ -2,7 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from ddev.ai.accounting.tokens import Tokens
 
 
 class ToolResult(BaseModel):
@@ -15,5 +17,4 @@ class ToolResult(BaseModel):
     total_size: int | None = None
     shown_size: int | None = None
     hint: str | None = None
-    total_input_tokens: int = 0
-    total_output_tokens: int = 0
+    tokens: Tokens = Field(default_factory=Tokens)

--- a/ddev/tests/ai/accounting/__init__.py
+++ b/ddev/tests/ai/accounting/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/ddev/tests/ai/accounting/test_tokens.py
+++ b/ddev/tests/ai/accounting/test_tokens.py
@@ -27,6 +27,14 @@ def test_addition_is_commutative_and_associative():
     assert (a + b) + c == a + (b + c)
 
 
+def test_sum_without_start_value():
+    parts = [
+        Tokens(input=1, output=2, cache_read=3, cache_creation=4),
+        Tokens(input=10, output=20, cache_read=30, cache_creation=40),
+    ]
+    assert sum(parts) == Tokens(input=11, output=22, cache_read=33, cache_creation=44)
+
+
 def test_is_frozen():
     a = Tokens(input=1)
     with pytest.raises(ValidationError):

--- a/ddev/tests/ai/accounting/test_tokens.py
+++ b/ddev/tests/ai/accounting/test_tokens.py
@@ -1,0 +1,43 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+from pydantic import ValidationError
+
+from ddev.ai.accounting.tokens import Tokens
+from ddev.ai.agent.types import TokenUsage
+
+
+def test_default_is_zero():
+    assert Tokens() == Tokens(input=0, output=0, cache_read=0, cache_creation=0)
+
+
+def test_add_sums_every_field():
+    a = Tokens(input=1, output=2, cache_read=3, cache_creation=4)
+    b = Tokens(input=10, output=20, cache_read=30, cache_creation=40)
+    assert a + b == Tokens(input=11, output=22, cache_read=33, cache_creation=44)
+
+
+def test_addition_is_commutative_and_associative():
+    a = Tokens(input=1, output=2, cache_read=3, cache_creation=4)
+    b = Tokens(input=5, output=6, cache_read=7, cache_creation=8)
+    c = Tokens(input=9, output=10, cache_read=11, cache_creation=12)
+    assert a + b == b + a
+    assert (a + b) + c == a + (b + c)
+
+
+def test_is_frozen():
+    a = Tokens(input=1)
+    with pytest.raises(ValidationError):
+        a.input = 2
+
+
+def test_from_usage_maps_all_four_fields():
+    usage = TokenUsage(
+        input_tokens=5,
+        output_tokens=6,
+        cache_read_input_tokens=7,
+        cache_creation_input_tokens=8,
+    )
+    assert usage.to_tokens() == Tokens(input=5, output=6, cache_read=7, cache_creation=8)

--- a/ddev/tests/ai/callbacks/test_callbacks.py
+++ b/ddev/tests/ai/callbacks/test_callbacks.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.agent.types import AgentResponse, StopReason, TokenUsage, ToolCall
 from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
@@ -40,8 +41,7 @@ def react_result(response: AgentResponse) -> ReActResult:
     return ReActResult(
         final_response=response,
         iterations=1,
-        total_input_tokens=10,
-        total_output_tokens=5,
+        tokens=Tokens(input=10, output=5),
         context_usage=None,
     )
 

--- a/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
+++ b/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
@@ -25,9 +25,9 @@ from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
     CheckpointStatus,
+    CheckpointTokenInfo,
     FailedCheckpoint,
     SuccessCheckpoint,
-    TokenUsage,
 )
 from ddev.event_bus.exceptions import MessageProcessingError
 
@@ -192,7 +192,7 @@ async def test_success_with_prometheus_body(flow_dir, message_queue, monkeypatch
     assert "sample_metric_names" not in checkpoint.model_extra
     assert checkpoint.status_code == 200
     assert checkpoint.endpoint_url == ENDPOINT_URL
-    assert checkpoint.tokens == TokenUsage(total_input=0, total_output=0)
+    assert checkpoint.tokens == CheckpointTokenInfo(total_input=0, total_output=0)
 
 
 async def test_success_with_openmetrics_body(flow_dir, message_queue, monkeypatch):

--- a/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
+++ b/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
@@ -11,6 +11,7 @@ import pytest
 from prometheus_client import Metric
 from prometheus_client.parser import text_string_to_metric_families as parse_prometheus
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.flows.openmetrics.phases import inspect_endpoint as inspect_endpoint_module
 from ddev.ai.flows.openmetrics.phases.inspect_endpoint import (
     EndpointInspectionError,
@@ -25,7 +26,6 @@ from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
     CheckpointStatus,
-    CheckpointTokenInfo,
     FailedCheckpoint,
     SuccessCheckpoint,
 )
@@ -192,7 +192,7 @@ async def test_success_with_prometheus_body(flow_dir, message_queue, monkeypatch
     assert "sample_metric_names" not in checkpoint.model_extra
     assert checkpoint.status_code == 200
     assert checkpoint.endpoint_url == ENDPOINT_URL
-    assert checkpoint.tokens == CheckpointTokenInfo(total_input=0, total_output=0)
+    assert checkpoint.tokens == Tokens(input=0, output=0)
 
 
 async def test_success_with_openmetrics_body(flow_dir, message_queue, monkeypatch):

--- a/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
+++ b/ddev/tests/ai/flows/openmetrics/phases/test_inspect_endpoint.py
@@ -22,7 +22,13 @@ from ddev.ai.flows.openmetrics.phases.inspect_endpoint import (
 from ddev.ai.phases.base import FlowContext
 from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError, PhaseConfig, TaskConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import (
+    CheckpointManager,
+    CheckpointStatus,
+    FailedCheckpoint,
+    SuccessCheckpoint,
+    TokenUsage,
+)
 from ddev.event_bus.exceptions import MessageProcessingError
 
 ENDPOINT_URL = "http://example.test:9100/metrics"
@@ -179,13 +185,14 @@ async def test_success_with_prometheus_body(flow_dir, message_queue, monkeypatch
     assert "HTTP status:** 200" in memory
 
     checkpoint = mgr.read()[PHASE_ID]
-    assert checkpoint["status"] == "success"
-    assert checkpoint["exposition_format"] == "prometheus"
-    assert checkpoint["metric_count"] == len(expected_families)
-    assert "sample_metric_names" not in checkpoint
-    assert checkpoint["status_code"] == 200
-    assert checkpoint["endpoint_url"] == ENDPOINT_URL
-    assert checkpoint["tokens"] == {"total_input": 0, "total_output": 0}
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    assert checkpoint.status == CheckpointStatus.SUCCESS
+    assert checkpoint.exposition_format == "prometheus"
+    assert checkpoint.metric_count == len(expected_families)
+    assert "sample_metric_names" not in checkpoint.model_extra
+    assert checkpoint.status_code == 200
+    assert checkpoint.endpoint_url == ENDPOINT_URL
+    assert checkpoint.tokens == TokenUsage(total_input=0, total_output=0)
 
 
 async def test_success_with_openmetrics_body(flow_dir, message_queue, monkeypatch):
@@ -196,10 +203,11 @@ async def test_success_with_openmetrics_body(flow_dir, message_queue, monkeypatc
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     checkpoint = mgr.read()[PHASE_ID]
-    assert checkpoint["status"] == "success"
-    assert checkpoint["exposition_format"] == "openmetrics"
-    assert checkpoint["content_type"] == content_type
-    assert checkpoint["metric_count"] >= 1
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    assert checkpoint.status == CheckpointStatus.SUCCESS
+    assert checkpoint.exposition_format == "openmetrics"
+    assert checkpoint.content_type == content_type
+    assert checkpoint.metric_count >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -216,8 +224,9 @@ async def _assert_phase_fails(phase, mgr, message_queue, *, error_contains: str)
         wrapped = MessageProcessingError(phase._phase_id, trigger, raised)
         await phase.on_error(wrapped)
         checkpoint = mgr.read()[phase._phase_id]
-        assert checkpoint["status"] == "failed"
-        assert error_contains.lower() in checkpoint["error"].lower()
+        assert isinstance(checkpoint, FailedCheckpoint)
+        assert checkpoint.status == CheckpointStatus.FAILED
+        assert error_contains.lower() in checkpoint.error.lower()
         msg = message_queue.get_nowait()
         assert isinstance(msg, PhaseFailedMessage)
         assert error_contains.lower() in msg.error.lower()
@@ -289,7 +298,8 @@ async def test_failure_missing_endpoint_url(flow_dir, message_queue):
     await phase.on_error(wrapped)
 
     checkpoint = mgr.read()[PHASE_ID]
-    assert checkpoint["status"] == "failed"
+    assert isinstance(checkpoint, FailedCheckpoint)
+    assert checkpoint.status == CheckpointStatus.FAILED
     msg = message_queue.get_nowait()
     assert isinstance(msg, PhaseFailedMessage)
 
@@ -391,7 +401,8 @@ async def test_jsonl_path_in_checkpoint(flow_dir, message_queue, monkeypatch):
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     checkpoint = mgr.read()[PHASE_ID]
-    path_str = checkpoint["metrics_jsonl_path"]
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    path_str = checkpoint.metrics_jsonl_path
     assert isinstance(path_str, str)
     assert os.path.isabs(path_str)
     assert os.path.exists(path_str)
@@ -404,9 +415,10 @@ async def test_jsonl_one_row_per_family(flow_dir, message_queue, monkeypatch):
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     checkpoint = mgr.read()[PHASE_ID]
+    assert isinstance(checkpoint, SuccessCheckpoint)
     rows = _read_jsonl(flow_dir / f"{PHASE_ID}_metrics.jsonl")
     expected_families = list(parse_prometheus(PROMETHEUS_BODY))
-    assert len(rows) == checkpoint["metric_count"] == len(expected_families)
+    assert len(rows) == checkpoint.metric_count == len(expected_families)
 
 
 async def test_jsonl_row_schema(flow_dir, message_queue, monkeypatch):
@@ -564,8 +576,9 @@ async def test_memory_text_includes_jsonl_path(flow_dir, message_queue, monkeypa
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     checkpoint = mgr.read()[PHASE_ID]
+    assert isinstance(checkpoint, SuccessCheckpoint)
     memory = mgr.memory_content(PHASE_ID)
-    assert checkpoint["metrics_jsonl_path"] in memory
+    assert checkpoint.metrics_jsonl_path in memory
 
 
 async def test_jsonl_sidecar_atomic_on_os_replace_failure(flow_dir, message_queue, monkeypatch):
@@ -605,7 +618,9 @@ async def test_exposition_path_in_checkpoint(flow_dir, message_queue, monkeypatc
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    path_str = mgr.read()[PHASE_ID]["exposition_path"]
+    checkpoint = mgr.read()[PHASE_ID]
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    path_str = checkpoint.exposition_path
     assert isinstance(path_str, str)
     assert os.path.isabs(path_str)
     assert os.path.exists(path_str)
@@ -627,7 +642,9 @@ async def test_memory_text_includes_exposition_path(flow_dir, message_queue, mon
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    assert mgr.read()[PHASE_ID]["exposition_path"] in mgr.memory_content(PHASE_ID)
+    checkpoint = mgr.read()[PHASE_ID]
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    assert checkpoint.exposition_path in mgr.memory_content(PHASE_ID)
 
 
 async def test_exposition_failure_propagates_as_phase_failure(flow_dir, message_queue, monkeypatch):

--- a/ddev/tests/ai/phases/conftest.py
+++ b/ddev/tests/ai/phases/conftest.py
@@ -149,6 +149,7 @@ def make_agent_phase(
     captured_worker_kwargs: dict[str, Any] | None = None,
     goal_runtime_builder: Callable[[str], AgentRuntime] | None = None,
     agent_config: AgentConfig | None = None,
+    resume_frontier: frozenset[str] = frozenset(),
 ) -> tuple[AgenticPhase, CheckpointManager]:
     """Build an AgenticPhase ready for process_message-driven tests.
 
@@ -172,6 +173,7 @@ def make_agent_phase(
         flow_variables=flow_variables or {},
         config_dir=flow_dir,
         callbacks=effective_callbacks,
+        resume_frontier=resume_frontier,
     )
 
     process_factory = MockProcessFactory(

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -852,3 +852,67 @@ async def test_goal_parse_error_logged_and_tokens_captured(flow_dir, monkeypatch
     assert phase._goal_attempt_log == [{"task": "t1", "attempts": 1, "final_valid": False}]
     assert phase._total_input_tokens == 10 + 8 + 6
     assert phase._total_output_tokens == 5 + 4 + 3
+
+
+# ---------------------------------------------------------------------------
+# process_message — resumed-run system-prompt injection
+# ---------------------------------------------------------------------------
+
+
+async def test_resume_frontier_phase_injects_notice_with_error(flow_dir, monkeypatch, message_queue):
+    """A frontier phase with a prior failed checkpoint gets the resume notice plus the error."""
+    mock_agent = MockAgent([make_response("done", 100, 50), make_response("summary", 10, 5)])
+    captured: dict = {}
+    phase, mgr = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        resume_frontier=frozenset({"p1"}),
+        captured_worker_kwargs=captured,
+    )
+    mgr.write_phase_checkpoint("p1", {"status": "failed", "error": "Error code: 500 - boom"})
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert "RESUMED RUN" in captured["system_prompt"]
+    assert "Error code: 500 - boom" in captured["system_prompt"]
+
+
+async def test_resume_frontier_phase_injects_notice_without_error(flow_dir, monkeypatch, message_queue):
+    """A frontier phase with no prior checkpoint (e.g. Ctrl+C) gets the notice but no error line."""
+    mock_agent = MockAgent([make_response("done", 100, 50), make_response("summary", 10, 5)])
+    captured: dict = {}
+    phase, _ = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        resume_frontier=frozenset({"p1"}),
+        captured_worker_kwargs=captured,
+    )
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert "RESUMED RUN" in captured["system_prompt"]
+    assert "previous attempt recorded this error" not in captured["system_prompt"]
+
+
+async def test_non_frontier_phase_gets_no_resume_notice(flow_dir, monkeypatch, message_queue):
+    """A phase outside the frontier never gets the notice, even with a stale failed checkpoint."""
+    mock_agent = MockAgent([make_response("done", 100, 50), make_response("summary", 10, 5)])
+    captured: dict = {}
+    phase, mgr = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        resume_frontier=frozenset(),
+        captured_worker_kwargs=captured,
+    )
+    mgr.write_phase_checkpoint("p1", {"status": "failed", "error": "stale"})
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert "RESUMED RUN" not in captured["system_prompt"]
+    assert "stale" not in captured["system_prompt"]

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -16,7 +16,8 @@ from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.runtime.agent_log import AgentLogger
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointStatus, FailedCheckpoint, SuccessCheckpoint
+from ddev.ai.runtime.checkpoints import TokenUsage as CheckpointTokenInfo
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.registry import ToolRegistry
 
@@ -125,12 +126,13 @@ async def test_happy_path_single_task(flow_dir, monkeypatch, message_queue):
 
     assert mgr.memory_content("p1") == "summary"
     checkpoint = mgr.read()["p1"]
-    assert checkpoint["status"] == "success"
-    assert checkpoint["tokens"] == {"total_input": 110, "total_output": 55}
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    assert checkpoint.status == CheckpointStatus.SUCCESS
+    assert checkpoint.tokens == CheckpointTokenInfo(total_input=110, total_output=55)
     assert mock_agent.send_calls[0] == "Do the work."
     assert "Write a brief summary" in mock_agent.send_calls[1]
     # checkpoint memory_path points to the written file
-    memory_path = Path(checkpoint["memory_path"])
+    memory_path = Path(checkpoint.memory_path)
     assert memory_path.is_absolute() and memory_path.exists() and memory_path.name == "p1_memory.md"
 
 
@@ -152,7 +154,9 @@ async def test_happy_path_two_tasks_accumulates_tokens(flow_dir, monkeypatch, me
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    assert mgr.read()["p1"]["tokens"] == {"total_input": 310, "total_output": 135}
+    checkpoint = mgr.read()["p1"]
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    assert checkpoint.tokens == CheckpointTokenInfo(total_input=310, total_output=135)
 
 
 # ---------------------------------------------------------------------------
@@ -481,11 +485,12 @@ async def test_phase_with_goal_passes_first_attempt(flow_dir, monkeypatch, messa
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     cp = mgr.read()["p1"]
-    assert cp["status"] == "success"
-    assert cp["goal_validations"] == [{"task": "t1", "attempts": 1, "final_valid": True}]
+    assert isinstance(cp, SuccessCheckpoint)
+    assert cp.status == CheckpointStatus.SUCCESS
+    assert cp.goal_validations == [{"task": "t1", "attempts": 1, "final_valid": True}]
     assert worker.send_calls[0].startswith("Do it.")
     assert "independent reviewer" in worker.send_calls[0]
-    assert cp["tokens"] == {"total_input": 100 + 7 + 10, "total_output": 50 + 3 + 5}
+    assert cp.tokens == CheckpointTokenInfo(total_input=100 + 7 + 10, total_output=50 + 3 + 5)
     assert captured_builder_calls == ["p1.goal.t1"]
 
     log_file = mgr.root / "goal_reviewer" / "p1.goal.t1.jsonl"
@@ -643,10 +648,11 @@ async def test_on_error_writes_tokens_and_goal_validations_to_checkpoint(flow_di
     await phase.on_error(err)
 
     cp = mgr.read()["p1"]
-    assert cp["status"] == "failed"
-    assert cp["tokens"] == {"total_input": 42, "total_output": 17}
-    assert cp["goal_validations"] == [{"task": "t1", "attempts": 2, "final_valid": False}]
-    assert cp["error"] == "something went wrong"
+    assert isinstance(cp, FailedCheckpoint)
+    assert cp.status == CheckpointStatus.FAILED
+    assert cp.tokens == CheckpointTokenInfo(total_input=42, total_output=17)
+    assert cp.goal_validations == [{"task": "t1", "attempts": 2, "final_valid": False}]
+    assert cp.error == "something went wrong"
 
 
 # ---------------------------------------------------------------------------
@@ -772,7 +778,7 @@ async def test_clear_context_before_on_first_task_is_harmless(flow_dir, monkeypa
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    assert mgr.read()["p1"]["status"] == "success"
+    assert mgr.read()["p1"].status == CheckpointStatus.SUCCESS
     assert mock_agent.reset_call_count == 1
 
 
@@ -793,8 +799,10 @@ async def test_compact_context_before_on_first_task_is_noop(flow_dir, monkeypatc
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    assert mgr.read()["p1"]["status"] == "success"
-    assert mgr.read()["p1"]["tokens"] == {"total_input": 110, "total_output": 55}
+    cp = mgr.read()["p1"]
+    assert isinstance(cp, SuccessCheckpoint)
+    assert cp.status == CheckpointStatus.SUCCESS
+    assert cp.tokens == CheckpointTokenInfo(total_input=110, total_output=55)
     assert mock_agent.compact_call_count == 1
 
 
@@ -871,7 +879,15 @@ async def test_resume_frontier_phase_injects_notice_with_error(flow_dir, monkeyp
         resume_frontier=frozenset({"p1"}),
         captured_worker_kwargs=captured,
     )
-    mgr.write_phase_checkpoint("p1", {"status": "failed", "error": "Error code: 500 - boom"})
+    mgr.write_phase_checkpoint(
+        "p1",
+        FailedCheckpoint(
+            status=CheckpointStatus.FAILED,
+            started_at=None,
+            finished_at="2026-01-01T00:00:00+00:00",
+            error="Error code: 500 - boom",
+        ),
+    )
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -910,7 +926,12 @@ async def test_non_frontier_phase_gets_no_resume_notice(flow_dir, monkeypatch, m
         resume_frontier=frozenset(),
         captured_worker_kwargs=captured,
     )
-    mgr.write_phase_checkpoint("p1", {"status": "failed", "error": "stale"})
+    mgr.write_phase_checkpoint(
+        "p1",
+        FailedCheckpoint(
+            status=CheckpointStatus.FAILED, started_at=None, finished_at="2026-01-01T00:00:00+00:00", error="stale"
+        ),
+    )
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.agent.build import AgentRuntime
 from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.agent.types import AgentResponse, StopReason, TokenUsage, ToolCall
@@ -19,7 +20,6 @@ from ddev.ai.runtime.agent_log import AgentLogger
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
     CheckpointStatus,
-    CheckpointTokenInfo,
     FailedCheckpoint,
     SuccessCheckpoint,
 )
@@ -133,7 +133,7 @@ async def test_happy_path_single_task(flow_dir, monkeypatch, message_queue):
     checkpoint = mgr.read()["p1"]
     assert isinstance(checkpoint, SuccessCheckpoint)
     assert checkpoint.status == CheckpointStatus.SUCCESS
-    assert checkpoint.tokens == CheckpointTokenInfo(total_input=110, total_output=55)
+    assert checkpoint.tokens == Tokens(input=110, output=55)
     assert mock_agent.send_calls[0] == "Do the work."
     assert "Write a brief summary" in mock_agent.send_calls[1]
     # checkpoint memory_path points to the written file
@@ -161,7 +161,7 @@ async def test_happy_path_two_tasks_accumulates_tokens(flow_dir, monkeypatch, me
 
     checkpoint = mgr.read()["p1"]
     assert isinstance(checkpoint, SuccessCheckpoint)
-    assert checkpoint.tokens == CheckpointTokenInfo(total_input=310, total_output=135)
+    assert checkpoint.tokens == Tokens(input=310, output=135)
 
 
 # ---------------------------------------------------------------------------
@@ -386,7 +386,7 @@ async def test_run_memory_step_returns_response_data(flow_dir, monkeypatch, mess
 
     result = await phase._run_memory_step(_memory_process(mock_agent), {})
 
-    assert result == ("summary text", 7, 3)
+    assert result == ("summary text", Tokens(input=7, output=3))
 
 
 # ---------------------------------------------------------------------------
@@ -495,7 +495,7 @@ async def test_phase_with_goal_passes_first_attempt(flow_dir, monkeypatch, messa
     assert cp.goal_validations == [{"task": "t1", "attempts": 1, "final_valid": True}]
     assert worker.send_calls[0].startswith("Do it.")
     assert "independent reviewer" in worker.send_calls[0]
-    assert cp.tokens == CheckpointTokenInfo(total_input=100 + 7 + 10, total_output=50 + 3 + 5)
+    assert cp.tokens == Tokens(input=100 + 7 + 10, output=50 + 3 + 5)
     assert captured_builder_calls == ["p1.goal.t1"]
 
     log_file = mgr.root / "goal_reviewer" / "p1.goal.t1.jsonl"
@@ -628,8 +628,8 @@ async def test_goal_exhaustion_tokens_captured_on_phase(flow_dir, monkeypatch, m
     with pytest.raises(GoalAttemptsExhausted):
         await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    assert phase._total_input_tokens == 10 + 8 + 10 + 8
-    assert phase._total_output_tokens == 5 + 4 + 5 + 4
+    assert phase._tokens.input == 10 + 8 + 10 + 8
+    assert phase._tokens.output == 5 + 4 + 5 + 4
 
 
 async def test_on_error_writes_tokens_and_goal_validations_to_checkpoint(flow_dir, monkeypatch, message_queue):
@@ -640,8 +640,7 @@ async def test_on_error_writes_tokens_and_goal_validations_to_checkpoint(flow_di
     worker = MockAgent([make_response("done", 0, 0)])
     phase, mgr = make_agent_phase(flow_dir, worker, monkeypatch, message_queue)
 
-    phase._total_input_tokens = 42
-    phase._total_output_tokens = 17
+    phase._tokens = Tokens(input=42, output=17)
     phase._goal_attempt_log = [{"task": "t1", "attempts": 2, "final_valid": False}]
     phase._started_at = None
 
@@ -655,7 +654,7 @@ async def test_on_error_writes_tokens_and_goal_validations_to_checkpoint(flow_di
     cp = mgr.read()["p1"]
     assert isinstance(cp, FailedCheckpoint)
     assert cp.status == CheckpointStatus.FAILED
-    assert cp.tokens == CheckpointTokenInfo(total_input=42, total_output=17)
+    assert cp.tokens == Tokens(input=42, output=17)
     assert cp.goal_validations == [{"task": "t1", "attempts": 2, "final_valid": False}]
     assert cp.error == "something went wrong"
 
@@ -807,7 +806,7 @@ async def test_compact_context_before_on_first_task_is_noop(flow_dir, monkeypatc
     cp = mgr.read()["p1"]
     assert isinstance(cp, SuccessCheckpoint)
     assert cp.status == CheckpointStatus.SUCCESS
-    assert cp.tokens == CheckpointTokenInfo(total_input=110, total_output=55)
+    assert cp.tokens == Tokens(input=110, output=55)
     assert mock_agent.compact_call_count == 1
 
 
@@ -863,8 +862,8 @@ async def test_goal_parse_error_logged_and_tokens_captured(flow_dir, monkeypatch
         await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     assert phase._goal_attempt_log == [{"task": "t1", "attempts": 1, "final_valid": False}]
-    assert phase._total_input_tokens == 10 + 8 + 6
-    assert phase._total_output_tokens == 5 + 4 + 3
+    assert phase._tokens.input == 10 + 8 + 6
+    assert phase._tokens.output == 5 + 4 + 3
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -16,8 +16,13 @@ from ddev.ai.phases.config import AgentConfig, CheckpointConfig, FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.runtime.agent_log import AgentLogger
-from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointStatus, FailedCheckpoint, SuccessCheckpoint
-from ddev.ai.runtime.checkpoints import TokenUsage as CheckpointTokenInfo
+from ddev.ai.runtime.checkpoints import (
+    CheckpointManager,
+    CheckpointStatus,
+    CheckpointTokenInfo,
+    FailedCheckpoint,
+    SuccessCheckpoint,
+)
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.registry import ToolRegistry
 

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -9,7 +9,13 @@ import pytest
 from ddev.ai.phases.base import FlowContext, Phase, PhaseOutcome
 from ddev.ai.phases.config import PhaseConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import (
+    CheckpointManager,
+    CheckpointStatus,
+    FailedCheckpoint,
+    SuccessCheckpoint,
+    TokenUsage,
+)
 from ddev.event_bus.exceptions import HookName, MessageProcessingError, ProcessorHookError
 
 
@@ -109,9 +115,10 @@ async def test_on_error_writes_failed_checkpoint(flow_context, message_queue):
     await phase.on_error(wrapped)
 
     checkpoint = mgr.read()["p1"]
-    assert checkpoint["status"] == "failed"
-    assert checkpoint["error"] == "boom"
-    assert checkpoint["started_at"] is None  # not started yet
+    assert isinstance(checkpoint, FailedCheckpoint)
+    assert checkpoint.status == CheckpointStatus.FAILED
+    assert checkpoint.error == "boom"
+    assert checkpoint.started_at is None  # not started yet
 
 
 async def test_on_error_emits_failed_message(flow_context, message_queue):
@@ -136,8 +143,9 @@ async def test_on_error_writes_failed_checkpoint_after_start(flow_context, messa
     await phase.on_error(wrapped)
 
     checkpoint = mgr.read()["p1"]
-    assert checkpoint["status"] == "failed"
-    assert checkpoint["started_at"] is not None
+    assert isinstance(checkpoint, FailedCheckpoint)
+    assert checkpoint.status == CheckpointStatus.FAILED
+    assert checkpoint.started_at is not None
 
 
 # ---------------------------------------------------------------------------
@@ -223,13 +231,14 @@ async def test_process_message_writes_memory_and_checkpoint(flow_context, messag
     assert mgr.memory_content("p1") == "stub-memory-body"
 
     checkpoint = mgr.read()["p1"]
-    assert checkpoint["status"] == "success"
-    assert checkpoint["tokens"] == {"total_input": 123, "total_output": 45}
-    assert checkpoint["memory_path"] == str(mgr.memory_path("p1"))
-    assert checkpoint["custom_field"] == "custom_value"
-    assert checkpoint["count"] == 7
-    assert checkpoint["started_at"]
-    assert checkpoint["finished_at"]
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    assert checkpoint.status == CheckpointStatus.SUCCESS
+    assert checkpoint.tokens == TokenUsage(total_input=123, total_output=45)
+    assert checkpoint.memory_path == str(mgr.memory_path("p1"))
+    assert checkpoint.custom_field == "custom_value"
+    assert checkpoint.count == 7
+    assert checkpoint.started_at
+    assert checkpoint.finished_at
 
 
 @pytest.mark.parametrize(

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -6,13 +6,13 @@ from datetime import UTC, datetime
 
 import pytest
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.phases.base import FlowContext, Phase, PhaseOutcome
 from ddev.ai.phases.config import PhaseConfig
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
     CheckpointStatus,
-    CheckpointTokenInfo,
     FailedCheckpoint,
     SuccessCheckpoint,
 )
@@ -220,8 +220,7 @@ async def test_process_message_writes_memory_and_checkpoint(flow_context, messag
     """
     outcome = PhaseOutcome(
         memory_text="stub-memory-body",
-        total_input_tokens=123,
-        total_output_tokens=45,
+        tokens=Tokens(input=123, output=45),
         extra_checkpoint={"custom_field": "custom_value", "count": 7},
     )
     phase, mgr = _make_stub_phase(flow_context, message_queue, outcome=outcome)
@@ -233,7 +232,7 @@ async def test_process_message_writes_memory_and_checkpoint(flow_context, messag
     checkpoint = mgr.read()["p1"]
     assert isinstance(checkpoint, SuccessCheckpoint)
     assert checkpoint.status == CheckpointStatus.SUCCESS
-    assert checkpoint.tokens == CheckpointTokenInfo(total_input=123, total_output=45)
+    assert checkpoint.tokens == Tokens(input=123, output=45)
     assert checkpoint.memory_path == str(mgr.memory_path("p1"))
     assert checkpoint.custom_field == "custom_value"
     assert checkpoint.count == 7

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -12,9 +12,9 @@ from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
     CheckpointStatus,
+    CheckpointTokenInfo,
     FailedCheckpoint,
     SuccessCheckpoint,
-    TokenUsage,
 )
 from ddev.event_bus.exceptions import HookName, MessageProcessingError, ProcessorHookError
 
@@ -233,7 +233,7 @@ async def test_process_message_writes_memory_and_checkpoint(flow_context, messag
     checkpoint = mgr.read()["p1"]
     assert isinstance(checkpoint, SuccessCheckpoint)
     assert checkpoint.status == CheckpointStatus.SUCCESS
-    assert checkpoint.tokens == TokenUsage(total_input=123, total_output=45)
+    assert checkpoint.tokens == CheckpointTokenInfo(total_input=123, total_output=45)
     assert checkpoint.memory_path == str(mgr.memory_path("p1"))
     assert checkpoint.custom_field == "custom_value"
     assert checkpoint.count == 7

--- a/ddev/tests/ai/phases/test_config.py
+++ b/ddev/tests/ai/phases/test_config.py
@@ -430,6 +430,31 @@ def test_flow_config_acyclic_chain_ok():
     assert len(config.flow) == 3
 
 
+def test_flow_config_sorts_dependencies_before_dependents():
+    """A dependent declared before its dependency is reordered so deps come first."""
+    raw = _three_phase_config()
+    raw["flow"] = [
+        {"phase": "p3", "dependencies": ["p2"]},
+        {"phase": "p2", "dependencies": ["p1"]},
+        {"phase": "p1"},
+    ]
+    config = FlowConfig.model_validate(raw)
+    assert [entry.phase for entry in config.flow] == ["p1", "p2", "p3"]
+
+
+def test_flow_config_topological_sort_is_stable():
+    """Independent phases keep their original declaration order; deps still come first."""
+    raw = _three_phase_config()
+    raw["flow"] = [
+        {"phase": "p2", "dependencies": ["p1"]},
+        {"phase": "p3"},
+        {"phase": "p1"},
+    ]
+    config = FlowConfig.model_validate(raw)
+    # p1 must precede p2; p3 has no constraints so it stays as early as its declaration allows.
+    assert [entry.phase for entry in config.flow] == ["p3", "p1", "p2"]
+
+
 def test_flow_disjoined_graphs_ok():
     agent = {"tools": []}
     task = {"name": "t", "prompt": "Do it."}

--- a/ddev/tests/ai/phases/test_goal.py
+++ b/ddev/tests/ai/phases/test_goal.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.agent.build import AgentRuntime
 from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
@@ -150,7 +151,7 @@ def _reviewer_factory(
 
 
 async def _noop_compact(_):
-    return 0, 0
+    return Tokens()
 
 
 # ---------------------------------------------------------------------------
@@ -163,8 +164,7 @@ async def test_run_goal_loop_passes_on_first_attempt(tmp_path):
     initial_result = ReActResult(
         final_response=make_response("did things"),
         iterations=1,
-        total_input_tokens=100,
-        total_output_tokens=50,
+        tokens=Tokens(input=100, output=50),
         context_usage=None,
     )
     run_logger = AgentLogger(tmp_path)
@@ -187,8 +187,8 @@ async def test_run_goal_loop_passes_on_first_attempt(tmp_path):
     )
 
     assert outcome.attempts == 1
-    assert outcome.total_input_tokens == 20
-    assert outcome.total_output_tokens == 10
+    assert outcome.tokens.input == 20
+    assert outcome.tokens.output == 10
     assert outcome.final_result is initial_result
     assert worker_agent.send_calls == []
     assert builder_calls[0]["owner_id"] == "p1.goal.t1"
@@ -205,8 +205,7 @@ async def test_run_goal_loop_derives_reviewer_runtime_policy(tmp_path):
     initial_result = ReActResult(
         final_response=make_response("did things"),
         iterations=1,
-        total_input_tokens=100,
-        total_output_tokens=50,
+        tokens=Tokens(input=100, output=50),
         context_usage=None,
     )
     factory, builder_calls, _ = _reviewer_factory([make_response('{"valid": true, "reason": ""}', 20, 10)])
@@ -244,8 +243,7 @@ async def test_run_goal_loop_one_retry_then_pass(tmp_path):
     initial_result = ReActResult(
         final_response=make_response("initial work"),
         iterations=1,
-        total_input_tokens=100,
-        total_output_tokens=50,
+        tokens=Tokens(input=100, output=50),
         context_usage=None,
     )
     factory, _, reviewer_agent = _reviewer_factory(
@@ -274,8 +272,8 @@ async def test_run_goal_loop_one_retry_then_pass(tmp_path):
     assert "missing X" in worker_agent.send_calls[0]
     assert "g" in worker_agent.send_calls[0]
     assert len(reviewer_agent.send_calls) == 2
-    assert outcome.total_input_tokens == 20 + 25 + 30
-    assert outcome.total_output_tokens == 10 + 12 + 15
+    assert outcome.tokens.input == 20 + 25 + 30
+    assert outcome.tokens.output == 10 + 12 + 15
 
 
 async def test_run_goal_loop_exhausts_attempts(tmp_path):
@@ -283,8 +281,7 @@ async def test_run_goal_loop_exhausts_attempts(tmp_path):
     initial_result = ReActResult(
         final_response=make_response("attempt 1"),
         iterations=1,
-        total_input_tokens=10,
-        total_output_tokens=5,
+        tokens=Tokens(input=10, output=5),
         context_usage=None,
     )
     factory, _, _ = _reviewer_factory(
@@ -309,8 +306,8 @@ async def test_run_goal_loop_exhausts_attempts(tmp_path):
         )
 
     err = exc_info.value
-    assert err.input_tokens == 5 + 10 + 7
-    assert err.output_tokens == 3 + 5 + 4
+    assert err.tokens.input == 5 + 10 + 7
+    assert err.tokens.output == 3 + 5 + 4
 
 
 async def test_run_goal_loop_parse_retry_succeeds(tmp_path):
@@ -318,8 +315,7 @@ async def test_run_goal_loop_parse_retry_succeeds(tmp_path):
     initial_result = ReActResult(
         final_response=make_response("done"),
         iterations=1,
-        total_input_tokens=0,
-        total_output_tokens=0,
+        tokens=Tokens(input=0, output=0),
         context_usage=None,
     )
     factory, _, reviewer_agent = _reviewer_factory(
@@ -343,8 +339,8 @@ async def test_run_goal_loop_parse_retry_succeeds(tmp_path):
     )
     assert outcome.attempts == 1
     assert len(reviewer_agent.send_calls) == 2
-    assert outcome.total_input_tokens == 5 + 7
-    assert outcome.total_output_tokens == 5 + 7
+    assert outcome.tokens.input == 5 + 7
+    assert outcome.tokens.output == 5 + 7
 
 
 async def test_run_goal_loop_parse_retry_fails_raises(tmp_path):
@@ -352,8 +348,7 @@ async def test_run_goal_loop_parse_retry_fails_raises(tmp_path):
     initial_result = ReActResult(
         final_response=make_response("done"),
         iterations=1,
-        total_input_tokens=0,
-        total_output_tokens=0,
+        tokens=Tokens(input=0, output=0),
         context_usage=None,
     )
     factory, _, _ = _reviewer_factory(
@@ -378,8 +373,8 @@ async def test_run_goal_loop_parse_retry_fails_raises(tmp_path):
         )
 
     err = exc_info.value
-    assert err.input_tokens == 5 + 7
-    assert err.output_tokens == 3 + 4
+    assert err.tokens.input == 5 + 7
+    assert err.tokens.output == 3 + 4
 
 
 async def test_run_goal_loop_fires_callbacks(tmp_path):
@@ -398,8 +393,7 @@ async def test_run_goal_loop_fires_callbacks(tmp_path):
     initial_result = ReActResult(
         final_response=make_response("attempt 1"),
         iterations=1,
-        total_input_tokens=0,
-        total_output_tokens=0,
+        tokens=Tokens(input=0, output=0),
         context_usage=None,
     )
     factory, _, _ = _reviewer_factory(

--- a/ddev/tests/ai/react/test_process.py
+++ b/ddev/tests/ai/react/test_process.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.agent.base import BaseAgent
 from ddev.ai.agent.build import AgentRuntime
 from ddev.ai.agent.exceptions import AgentConnectionError
@@ -569,8 +570,8 @@ async def test_total_tokens_summed_across_iterations() -> None:
 
     result = await make_process(agent).start("Task")
 
-    assert result.total_input_tokens == 300
-    assert result.total_output_tokens == 130
+    assert result.tokens.input == 300
+    assert result.tokens.output == 130
     assert result.iterations == 2
 
 
@@ -580,12 +581,12 @@ async def test_tool_result_tokens_included_in_total_tokens() -> None:
         make_response(StopReason.END_TURN, input_tokens=200, output_tokens=80),
     ]
     agent = MockAgent(responses)
-    registry = MockToolRegistry(ToolResult(success=True, data="ok", total_input_tokens=30, total_output_tokens=10))
+    registry = MockToolRegistry(ToolResult(success=True, data="ok", tokens=Tokens(input=30, output=10)))
 
     result = await make_process(agent, registry=registry).start("Task")
 
-    assert result.total_input_tokens == 330
-    assert result.total_output_tokens == 140
+    assert result.tokens.input == 330
+    assert result.tokens.output == 140
 
 
 # ---------------------------------------------------------------------------
@@ -623,18 +624,17 @@ async def test_reset_delegates_to_agent() -> None:
 
 async def test_compact_delegates_to_agent_returns_zero_when_no_op() -> None:
     agent = MockAgent([])  # compact_response is None — no compaction occurred
-    compact_in, compact_out = await make_process(agent).compact()
+    compact_tokens = await make_process(agent).compact()
     assert agent.compact_calls == 1
-    assert compact_in == 0
-    assert compact_out == 0
+    assert compact_tokens == Tokens()
 
 
 async def test_compact_returns_tokens_when_compaction_occurs() -> None:
     agent = MockAgent([])
     agent.compact_response = make_response(StopReason.END_TURN, input_tokens=40, output_tokens=15)
-    compact_in, compact_out = await make_process(agent).compact()
-    assert compact_in == 40
-    assert compact_out == 15
+    compact_tokens = await make_process(agent).compact()
+    assert compact_tokens.input == 40
+    assert compact_tokens.output == 15
 
 
 async def test_compact_fires_before_and_after_callbacks() -> None:
@@ -722,5 +722,5 @@ async def test_auto_compact_tokens_included_in_result() -> None:
 
     result = await make_process(agent, compact_threshold_pct=75.0).start("task")
 
-    assert result.total_input_tokens == 100 + 200 + 30
-    assert result.total_output_tokens == 50 + 80 + 10
+    assert result.tokens.input == 100 + 200 + 30
+    assert result.tokens.output == 50 + 80 + 10

--- a/ddev/tests/ai/runtime/conftest.py
+++ b/ddev/tests/ai/runtime/conftest.py
@@ -4,9 +4,9 @@
 
 from typing import Any
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.runtime.checkpoints import (
     CheckpointStatus,
-    CheckpointTokenInfo,
     FailedCheckpoint,
     SuccessCheckpoint,
 )
@@ -20,7 +20,7 @@ def make_success(**kwargs: Any) -> SuccessCheckpoint:
         status=CheckpointStatus.SUCCESS,
         started_at=STARTED,
         finished_at=FINISHED,
-        tokens=CheckpointTokenInfo(total_input=10, total_output=20),
+        tokens=Tokens(input=10, output=20),
         memory_path="/tmp/phase_memory.md",
         **kwargs,
     )
@@ -45,7 +45,7 @@ def make_checkpoint(data: dict) -> SuccessCheckpoint | FailedCheckpoint:
                 status=CheckpointStatus.SUCCESS,
                 started_at=ts,
                 finished_at=ts,
-                tokens=CheckpointTokenInfo(total_input=0, total_output=0),
+                tokens=Tokens(),
                 memory_path="/tmp/mem.md",
             )
         case "failed":

--- a/ddev/tests/ai/runtime/conftest.py
+++ b/ddev/tests/ai/runtime/conftest.py
@@ -1,0 +1,56 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from typing import Any
+
+from ddev.ai.runtime.checkpoints import (
+    CheckpointStatus,
+    CheckpointTokenInfo,
+    FailedCheckpoint,
+    SuccessCheckpoint,
+)
+
+STARTED = "2026-01-01T00:00:00+00:00"
+FINISHED = "2026-01-01T00:01:00+00:00"
+
+
+def make_success(**kwargs: Any) -> SuccessCheckpoint:
+    return SuccessCheckpoint(
+        status=CheckpointStatus.SUCCESS,
+        started_at=STARTED,
+        finished_at=FINISHED,
+        tokens=CheckpointTokenInfo(total_input=10, total_output=20),
+        memory_path="/tmp/phase_memory.md",
+        **kwargs,
+    )
+
+
+def make_failed(**kwargs: Any) -> FailedCheckpoint:
+    return FailedCheckpoint(
+        status=CheckpointStatus.FAILED,
+        started_at=STARTED,
+        finished_at=FINISHED,
+        error="something broke",
+        **kwargs,
+    )
+
+
+def make_checkpoint(data: dict) -> SuccessCheckpoint | FailedCheckpoint:
+    status = data.get("status")
+    ts = "2026-01-01T00:00:00+00:00"
+    match status:
+        case "success":
+            return SuccessCheckpoint(
+                status=CheckpointStatus.SUCCESS,
+                started_at=ts,
+                finished_at=ts,
+                tokens=CheckpointTokenInfo(total_input=0, total_output=0),
+                memory_path="/tmp/mem.md",
+            )
+        case "failed":
+            return FailedCheckpoint(
+                status=CheckpointStatus.FAILED, started_at=None, finished_at=ts, error=data.get("error", "")
+            )
+        case _:
+            raise ValueError(f"unexpected checkpoint status: {status!r}")

--- a/ddev/tests/ai/runtime/test_agent_log.py
+++ b/ddev/tests/ai/runtime/test_agent_log.py
@@ -82,6 +82,25 @@ async def test_full_sequence_writes_start_and_finish_with_timestamps(tmp_path):
     assert events[-1]["iterations"] == 2
 
 
+async def test_finish_event_carries_all_four_token_fields(tmp_path):
+    logger = AgentLogger(tmp_path)
+    cb = logger.as_callback_set()
+
+    result = ReActResult(
+        final_response=make_response(),
+        iterations=2,
+        tokens=Tokens(input=30, output=12, cache_read=7, cache_creation=3),
+        context_usage=None,
+    )
+    await cb.fire_agent_finish(PHASE, result)
+
+    finish = read_events(tmp_path / "phase" / "p1.jsonl")[-1]
+    assert finish["total_input_tokens"] == 30
+    assert finish["total_output_tokens"] == 12
+    assert finish["total_cache_read_tokens"] == 7
+    assert finish["total_cache_creation_tokens"] == 3
+
+
 async def test_error_emits_error_then_failed_finish(tmp_path):
     logger = AgentLogger(tmp_path)
     cb = logger.as_callback_set()

--- a/ddev/tests/ai/runtime/test_agent_log.py
+++ b/ddev/tests/ai/runtime/test_agent_log.py
@@ -5,6 +5,7 @@
 import json
 from pathlib import Path
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.agent.types import (
     AgentResponse,
@@ -35,8 +36,7 @@ def make_result(response: AgentResponse | None = None) -> ReActResult:
     return ReActResult(
         final_response=response,
         iterations=2,
-        total_input_tokens=30,
-        total_output_tokens=12,
+        tokens=Tokens(input=30, output=12),
         context_usage=None,
     )
 

--- a/ddev/tests/ai/runtime/test_checkpoints.py
+++ b/ddev/tests/ai/runtime/test_checkpoints.py
@@ -6,7 +6,38 @@ from pathlib import Path
 
 import pytest
 
-from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointReadError
+from ddev.ai.runtime.checkpoints import (
+    CheckpointManager,
+    CheckpointReadError,
+    CheckpointStatus,
+    FailedCheckpoint,
+    SuccessCheckpoint,
+    TokenUsage,
+)
+
+STARTED = "2026-01-01T00:00:00+00:00"
+FINISHED = "2026-01-01T00:01:00+00:00"
+
+
+def make_success(**kwargs) -> SuccessCheckpoint:
+    return SuccessCheckpoint(
+        status=CheckpointStatus.SUCCESS,
+        started_at=STARTED,
+        finished_at=FINISHED,
+        tokens=TokenUsage(total_input=10, total_output=20),
+        memory_path="/tmp/phase_memory.md",
+        **kwargs,
+    )
+
+
+def make_failed(**kwargs) -> FailedCheckpoint:
+    return FailedCheckpoint(
+        status=CheckpointStatus.FAILED,
+        started_at=STARTED,
+        finished_at=FINISHED,
+        error="something broke",
+        **kwargs,
+    )
 
 
 @pytest.fixture
@@ -35,10 +66,17 @@ def test_read_malformed_yaml_raises_checkpoint_read_error(manager):
 
 
 def test_read_unreadable_file_raises_checkpoint_read_error(manager, monkeypatch):
-    manager._path.write_text("phase1:\n  status: success\n")
+    manager.write_phase_checkpoint("phase1", make_success())
     monkeypatch.setattr("pathlib.Path.read_text", lambda *_, **__: (_ for _ in ()).throw(OSError("permission denied")))
     with pytest.raises(CheckpointReadError, match="checkpoints.yaml"):
         manager.read()
+
+
+def test_read_returns_validated_checkpoint(manager):
+    manager.write_phase_checkpoint("phase1", make_success())
+    data = manager.read()
+    assert isinstance(data["phase1"], SuccessCheckpoint)
+    assert data["phase1"].status == CheckpointStatus.SUCCESS
 
 
 # ---------------------------------------------------------------------------
@@ -47,30 +85,38 @@ def test_read_unreadable_file_raises_checkpoint_read_error(manager, monkeypatch)
 
 
 def test_write_and_read_back(manager):
-    manager.write_phase_checkpoint("phase1", {"status": "success", "tokens": 100})
+    manager.write_phase_checkpoint("phase1", make_success())
     data = manager.read()
-    assert data["phase1"]["status"] == "success"
-    assert data["phase1"]["tokens"] == 100
+    assert data["phase1"].status == CheckpointStatus.SUCCESS
+    assert data["phase1"].tokens.total_input == 10
+    assert data["phase1"].tokens.total_output == 20
+
+
+def test_write_preserves_extra_fields(manager):
+    manager.write_phase_checkpoint("phase1", make_success(endpoint_url="http://localhost:8080"))
+    data = manager.read()
+    assert isinstance(data["phase1"], SuccessCheckpoint)
+    assert data["phase1"].model_extra["endpoint_url"] == "http://localhost:8080"
 
 
 def test_write_creates_parent_dirs(tmp_path):
     manager = CheckpointManager(tmp_path / "nested" / "dir" / "checkpoints.yaml")
-    manager.write_phase_checkpoint("p", {"status": "success"})
-    assert manager.read()["p"]["status"] == "success"
+    manager.write_phase_checkpoint("p", make_success())
+    assert manager.read()["p"].status == CheckpointStatus.SUCCESS
 
 
 def test_write_multiple_phases(manager):
-    manager.write_phase_checkpoint("phase1", {"status": "success"})
-    manager.write_phase_checkpoint("phase2", {"status": "failed"})
+    manager.write_phase_checkpoint("phase1", make_success())
+    manager.write_phase_checkpoint("phase2", make_failed())
     data = manager.read()
-    assert data["phase1"]["status"] == "success"
-    assert data["phase2"]["status"] == "failed"
+    assert data["phase1"].status == CheckpointStatus.SUCCESS
+    assert data["phase2"].status == CheckpointStatus.FAILED
 
 
 def test_write_overwrites_existing_phase(manager):
-    manager.write_phase_checkpoint("phase1", {"status": "running"})
-    manager.write_phase_checkpoint("phase1", {"status": "success"})
-    assert manager.read()["phase1"]["status"] == "success"
+    manager.write_phase_checkpoint("phase1", make_failed())
+    manager.write_phase_checkpoint("phase1", make_success())
+    assert manager.read()["phase1"].status == CheckpointStatus.SUCCESS
 
 
 # ---------------------------------------------------------------------------
@@ -153,12 +199,52 @@ def test_successful_phases_empty_when_no_file(manager):
 
 
 def test_successful_phases_returns_only_succeeded(manager):
-    manager.write_phase_checkpoint("a", {"status": "success"})
-    manager.write_phase_checkpoint("b", {"status": "failed", "error": "boom"})
-    manager.write_phase_checkpoint("c", {"status": "success"})
+    manager.write_phase_checkpoint("a", make_success())
+    manager.write_phase_checkpoint("b", make_failed())
+    manager.write_phase_checkpoint("c", make_success())
     assert manager.successful_phases() == {"a", "c"}
 
 
-def test_successful_phases_ignores_malformed_entries(manager):
-    manager._path.write_text("a:\n  status: success\nb: not-a-dict\n")
-    assert manager.successful_phases() == {"a"}
+def test_read_raises_on_invalid_checkpoint_entry(manager):
+    manager.write_phase_checkpoint("a", make_success())
+    import yaml
+
+    raw = yaml.safe_load(manager._path.read_text())
+    raw["b"] = "not-a-dict"
+    manager._path.write_text(yaml.dump(raw))
+    with pytest.raises(CheckpointReadError, match="phase 'b'"):
+        manager.read()
+
+
+# ---------------------------------------------------------------------------
+# FailedCheckpoint fields
+# ---------------------------------------------------------------------------
+
+
+def test_failed_checkpoint_with_tokens(manager):
+    cp = make_failed(tokens=TokenUsage(total_input=5, total_output=15))
+    manager.write_phase_checkpoint("phase1", cp)
+    data = manager.read()
+    assert isinstance(data["phase1"], FailedCheckpoint)
+    assert data["phase1"].tokens is not None
+    assert data["phase1"].tokens.total_input == 5
+
+
+def test_failed_checkpoint_with_goal_validations(manager):
+    cp = make_failed(goal_validations=[{"attempt": 1, "result": "fail"}])
+    manager.write_phase_checkpoint("phase1", cp)
+    data = manager.read()
+    assert isinstance(data["phase1"], FailedCheckpoint)
+    assert data["phase1"].goal_validations == [{"attempt": 1, "result": "fail"}]
+
+
+def test_failed_checkpoint_started_at_none(manager):
+    cp = FailedCheckpoint(
+        status=CheckpointStatus.FAILED,
+        started_at=None,
+        finished_at=FINISHED,
+        error="crashed before start",
+    )
+    manager.write_phase_checkpoint("phase1", cp)
+    data = manager.read()
+    assert data["phase1"].started_at is None

--- a/ddev/tests/ai/runtime/test_checkpoints.py
+++ b/ddev/tests/ai/runtime/test_checkpoints.py
@@ -5,6 +5,7 @@
 from pathlib import Path
 
 import pytest
+import yaml
 
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
@@ -15,29 +16,7 @@ from ddev.ai.runtime.checkpoints import (
     SuccessCheckpoint,
 )
 
-STARTED = "2026-01-01T00:00:00+00:00"
-FINISHED = "2026-01-01T00:01:00+00:00"
-
-
-def make_success(**kwargs) -> SuccessCheckpoint:
-    return SuccessCheckpoint(
-        status=CheckpointStatus.SUCCESS,
-        started_at=STARTED,
-        finished_at=FINISHED,
-        tokens=CheckpointTokenInfo(total_input=10, total_output=20),
-        memory_path="/tmp/phase_memory.md",
-        **kwargs,
-    )
-
-
-def make_failed(**kwargs) -> FailedCheckpoint:
-    return FailedCheckpoint(
-        status=CheckpointStatus.FAILED,
-        started_at=STARTED,
-        finished_at=FINISHED,
-        error="something broke",
-        **kwargs,
-    )
+from .conftest import FINISHED, make_failed, make_success
 
 
 @pytest.fixture
@@ -207,8 +186,6 @@ def test_successful_phases_returns_only_succeeded(manager):
 
 def test_read_raises_on_invalid_checkpoint_entry(manager):
     manager.write_phase_checkpoint("a", make_success())
-    import yaml
-
     raw = yaml.safe_load(manager._path.read_text())
     raw["b"] = "not-a-dict"
     manager._path.write_text(yaml.dump(raw))

--- a/ddev/tests/ai/runtime/test_checkpoints.py
+++ b/ddev/tests/ai/runtime/test_checkpoints.py
@@ -7,11 +7,11 @@ from pathlib import Path
 import pytest
 import yaml
 
+from ddev.ai.accounting.tokens import Tokens
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
     CheckpointReadError,
     CheckpointStatus,
-    CheckpointTokenInfo,
     FailedCheckpoint,
     SuccessCheckpoint,
 )
@@ -67,8 +67,8 @@ def test_write_and_read_back(manager):
     manager.write_phase_checkpoint("phase1", make_success())
     data = manager.read()
     assert data["phase1"].status == CheckpointStatus.SUCCESS
-    assert data["phase1"].tokens.total_input == 10
-    assert data["phase1"].tokens.total_output == 20
+    assert data["phase1"].tokens.input == 10
+    assert data["phase1"].tokens.output == 20
 
 
 def test_write_preserves_extra_fields(manager):
@@ -199,12 +199,12 @@ def test_read_raises_on_invalid_checkpoint_entry(manager):
 
 
 def test_failed_checkpoint_with_tokens(manager):
-    cp = make_failed(tokens=CheckpointTokenInfo(total_input=5, total_output=15))
+    cp = make_failed(tokens=Tokens(input=5, output=15))
     manager.write_phase_checkpoint("phase1", cp)
     data = manager.read()
     assert isinstance(data["phase1"], FailedCheckpoint)
     assert data["phase1"].tokens is not None
-    assert data["phase1"].tokens.total_input == 5
+    assert data["phase1"].tokens.input == 5
 
 
 def test_failed_checkpoint_with_goal_validations(manager):

--- a/ddev/tests/ai/runtime/test_checkpoints.py
+++ b/ddev/tests/ai/runtime/test_checkpoints.py
@@ -10,9 +10,9 @@ from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
     CheckpointReadError,
     CheckpointStatus,
+    CheckpointTokenInfo,
     FailedCheckpoint,
     SuccessCheckpoint,
-    TokenUsage,
 )
 
 STARTED = "2026-01-01T00:00:00+00:00"
@@ -24,7 +24,7 @@ def make_success(**kwargs) -> SuccessCheckpoint:
         status=CheckpointStatus.SUCCESS,
         started_at=STARTED,
         finished_at=FINISHED,
-        tokens=TokenUsage(total_input=10, total_output=20),
+        tokens=CheckpointTokenInfo(total_input=10, total_output=20),
         memory_path="/tmp/phase_memory.md",
         **kwargs,
     )
@@ -222,7 +222,7 @@ def test_read_raises_on_invalid_checkpoint_entry(manager):
 
 
 def test_failed_checkpoint_with_tokens(manager):
-    cp = make_failed(tokens=TokenUsage(total_input=5, total_output=15))
+    cp = make_failed(tokens=CheckpointTokenInfo(total_input=5, total_output=15))
     manager.write_phase_checkpoint("phase1", cp)
     data = manager.read()
     assert isinstance(data["phase1"], FailedCheckpoint)

--- a/ddev/tests/ai/runtime/test_checkpoints.py
+++ b/ddev/tests/ai/runtime/test_checkpoints.py
@@ -141,3 +141,24 @@ def test_resolve_template_variable_memory_suffix(manager):
 
 def test_resolve_template_variable_non_memory_key(manager):
     assert manager.resolve_template_variable("some_variable") == "<VARIABLE UNDEFINED: some_variable>"
+
+
+# ---------------------------------------------------------------------------
+# successful_phases
+# ---------------------------------------------------------------------------
+
+
+def test_successful_phases_empty_when_no_file(manager):
+    assert manager.successful_phases() == set()
+
+
+def test_successful_phases_returns_only_succeeded(manager):
+    manager.write_phase_checkpoint("a", {"status": "success"})
+    manager.write_phase_checkpoint("b", {"status": "failed", "error": "boom"})
+    manager.write_phase_checkpoint("c", {"status": "success"})
+    assert manager.successful_phases() == {"a", "c"}
+
+
+def test_successful_phases_ignores_malformed_entries(manager):
+    manager._path.write_text("a:\n  status: success\nb: not-a-dict\n")
+    assert manager.successful_phases() == {"a"}

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -15,6 +15,7 @@ from ddev.ai.phases.base import Phase
 from ddev.ai.phases.config import FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.resources import ResourceUnavailableError
+from ddev.ai.runtime.checkpoints import CheckpointManager
 from ddev.ai.runtime.orchestrator import PhaseOrchestrator
 from ddev.ai.runtime.resources import RunResources
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
@@ -496,9 +497,9 @@ def linear_flow(tmp_path):
 
 
 def _write_checkpoints(flow_dir: Path, statuses: dict[str, dict]) -> None:
-    import yaml
-
-    (flow_dir / "checkpoints.yaml").write_text(yaml.dump(statuses), encoding="utf-8")
+    manager = CheckpointManager(flow_dir / "checkpoints.yaml")
+    for phase_id, data in statuses.items():
+        manager.write_phase_checkpoint(phase_id, data)
 
 
 def _drain_trigger_phase_ids(orchestrator) -> list:
@@ -527,7 +528,7 @@ async def test_resume_marks_only_frontier_phase(linear_flow, make_orchestrator):
     await orchestrator.on_initialize()
 
     phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
-    assert phases_by_name["c"]._resume_frontier is True
+    assert phases_by_name["c"]._is_resume_frontier is True
 
 
 async def test_resume_emits_triggers_for_completed_phases(linear_flow, make_orchestrator):
@@ -552,9 +553,9 @@ async def test_resume_dependency_closure_reruns_descendants_of_failure(linear_fl
 
     phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
     assert set(phases_by_name) == {"a", "b", "c"}  # nothing skipped
-    assert phases_by_name["a"]._resume_frontier is True
-    assert phases_by_name["b"]._resume_frontier is False
-    assert phases_by_name["c"]._resume_frontier is False
+    assert phases_by_name["a"]._is_resume_frontier is True
+    assert phases_by_name["b"]._is_resume_frontier is False
+    assert phases_by_name["c"]._is_resume_frontier is False
 
 
 async def test_resume_with_no_checkpoints_frontier_is_root(linear_flow, make_orchestrator):
@@ -564,9 +565,9 @@ async def test_resume_with_no_checkpoints_frontier_is_root(linear_flow, make_orc
 
     phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
     assert set(phases_by_name) == {"a", "b", "c"}
-    assert phases_by_name["a"]._resume_frontier is True
-    assert phases_by_name["b"]._resume_frontier is False
-    assert phases_by_name["c"]._resume_frontier is False
+    assert phases_by_name["a"]._is_resume_frontier is True
+    assert phases_by_name["b"]._is_resume_frontier is False
+    assert phases_by_name["c"]._is_resume_frontier is False
 
 
 async def test_no_resume_ignores_checkpoints(linear_flow, make_orchestrator):
@@ -577,6 +578,13 @@ async def test_no_resume_ignores_checkpoints(linear_flow, make_orchestrator):
 
     phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
     assert set(phases_by_name) == {"a", "b", "c"}
-    assert all(p._resume_frontier is False for p in phases_by_name.values())
+    assert all(p._is_resume_frontier is False for p in phases_by_name.values())
     ids = _drain_trigger_phase_ids(orchestrator)
     assert ids == [None]  # only the initial trigger, no resume triggers
+
+
+async def test_resume_corrupt_checkpoints_raises_flow_config_error(linear_flow, make_orchestrator):
+    (linear_flow / "checkpoints.yaml").write_text("{ not: valid: yaml", encoding="utf-8")
+    orchestrator = make_orchestrator(linear_flow, resume=True)
+    with pytest.raises(FlowConfigError, match="Cannot resume"):
+        await orchestrator.on_initialize()

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -451,3 +451,132 @@ def test_run_raises_runtime_error_when_phase_fails(tmp_path, make_orchestrator):
 
     with pytest.raises(FatalProcessingError, match="Phase 'failing' failed"):
         orchestrator.run()
+
+
+# ---------------------------------------------------------------------------
+# PhaseOrchestrator.on_initialize — resume
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def linear_flow(tmp_path):
+    """Three-phase linear flow: a -> b -> c."""
+    (tmp_path / "prompts").mkdir()
+    (tmp_path / "prompts" / "writer.md").write_text("system prompt")
+    (tmp_path / "flow.yaml").write_text(
+        dedent("""\
+        agents:
+          writer:
+            tools: []
+        phases:
+          a:
+            agent: writer
+            tasks:
+              - name: ta
+                prompt: a
+          b:
+            agent: writer
+            tasks:
+              - name: tb
+                prompt: b
+          c:
+            agent: writer
+            tasks:
+              - name: tc
+                prompt: c
+        flow:
+          - phase: a
+          - phase: b
+            dependencies: [a]
+          - phase: c
+            dependencies: [b]
+        """)
+    )
+    return tmp_path
+
+
+def _write_checkpoints(flow_dir: Path, statuses: dict[str, dict]) -> None:
+    import yaml
+
+    (flow_dir / "checkpoints.yaml").write_text(yaml.dump(statuses), encoding="utf-8")
+
+
+def _drain_trigger_phase_ids(orchestrator) -> list:
+    ids = []
+    while not orchestrator._queue.empty():
+        msg = orchestrator._queue.get_nowait()
+        if isinstance(msg, PhaseTrigger):
+            ids.append(msg.phase_id)
+    return ids
+
+
+async def test_resume_skips_completed_phases(linear_flow, make_orchestrator):
+    """With a,b succeeded, only c is registered to run."""
+    _write_checkpoints(linear_flow, {"a": {"status": "success"}, "b": {"status": "success"}})
+    orchestrator = make_orchestrator(linear_flow, resume=True)
+    await orchestrator.on_initialize()
+
+    processors = orchestrator._subscribers.get(PhaseTrigger, [])
+    assert {p.name for p in processors} == {"c"}
+
+
+async def test_resume_marks_only_frontier_phase(linear_flow, make_orchestrator):
+    """The first non-completed phase is the frontier; nothing else is."""
+    _write_checkpoints(linear_flow, {"a": {"status": "success"}, "b": {"status": "success"}})
+    orchestrator = make_orchestrator(linear_flow, resume=True)
+    await orchestrator.on_initialize()
+
+    phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
+    assert phases_by_name["c"]._resume_frontier is True
+
+
+async def test_resume_emits_triggers_for_completed_phases(linear_flow, make_orchestrator):
+    """Completed phases get their completion triggers emitted so dependents unblock."""
+    _write_checkpoints(linear_flow, {"a": {"status": "success"}, "b": {"status": "success"}})
+    orchestrator = make_orchestrator(linear_flow, resume=True)
+    await orchestrator.on_initialize()
+
+    ids = _drain_trigger_phase_ids(orchestrator)
+    assert None in ids  # initial trigger
+    assert {i for i in ids if i is not None} == {"a", "b"}
+
+
+async def test_resume_dependency_closure_reruns_descendants_of_failure(linear_flow, make_orchestrator):
+    """A succeeded phase whose ancestor failed is NOT skipped — it and its descendants re-run."""
+    _write_checkpoints(
+        linear_flow,
+        {"a": {"status": "failed", "error": "boom"}, "b": {"status": "success"}, "c": {"status": "success"}},
+    )
+    orchestrator = make_orchestrator(linear_flow, resume=True)
+    await orchestrator.on_initialize()
+
+    phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
+    assert set(phases_by_name) == {"a", "b", "c"}  # nothing skipped
+    assert phases_by_name["a"]._resume_frontier is True
+    assert phases_by_name["b"]._resume_frontier is False
+    assert phases_by_name["c"]._resume_frontier is False
+
+
+async def test_resume_with_no_checkpoints_frontier_is_root(linear_flow, make_orchestrator):
+    """Ctrl+C before any checkpoint: all phases run, the root is the frontier."""
+    orchestrator = make_orchestrator(linear_flow, resume=True)
+    await orchestrator.on_initialize()
+
+    phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
+    assert set(phases_by_name) == {"a", "b", "c"}
+    assert phases_by_name["a"]._resume_frontier is True
+    assert phases_by_name["b"]._resume_frontier is False
+    assert phases_by_name["c"]._resume_frontier is False
+
+
+async def test_no_resume_ignores_checkpoints(linear_flow, make_orchestrator):
+    """Without resume, every phase is registered and none is a frontier, despite checkpoints."""
+    _write_checkpoints(linear_flow, {"a": {"status": "success"}, "b": {"status": "success"}})
+    orchestrator = make_orchestrator(linear_flow, resume=False)
+    await orchestrator.on_initialize()
+
+    phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
+    assert set(phases_by_name) == {"a", "b", "c"}
+    assert all(p._resume_frontier is False for p in phases_by_name.values())
+    ids = _drain_trigger_phase_ids(orchestrator)
+    assert ids == [None]  # only the initial trigger, no resume triggers

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -588,3 +588,39 @@ async def test_resume_corrupt_checkpoints_raises_flow_config_error(linear_flow, 
     orchestrator = make_orchestrator(linear_flow, resume=True)
     with pytest.raises(FlowConfigError, match="Cannot resume"):
         await orchestrator.on_initialize()
+
+
+async def test_resume_closure_independent_of_flow_declaration_order(tmp_path, make_orchestrator):
+    """A flow declared dependents-first still resolves the resume closure correctly."""
+    (tmp_path / "prompts").mkdir()
+    (tmp_path / "prompts" / "writer.md").write_text("system prompt")
+    (tmp_path / "flow.yaml").write_text(
+        dedent("""\
+        agents:
+          writer:
+            tools: []
+        phases:
+          a:
+            agent: writer
+            tasks: [{name: ta, prompt: a}]
+          b:
+            agent: writer
+            tasks: [{name: tb, prompt: b}]
+          c:
+            agent: writer
+            tasks: [{name: tc, prompt: c}]
+        flow:
+          - phase: c
+            dependencies: [b]
+          - phase: b
+            dependencies: [a]
+          - phase: a
+        """)
+    )
+    _write_checkpoints(tmp_path, {"a": {"status": "success"}, "b": {"status": "success"}})
+    orchestrator = make_orchestrator(tmp_path, resume=True)
+    await orchestrator.on_initialize()
+
+    processors = orchestrator._subscribers.get(PhaseTrigger, [])
+    assert {p.name for p in processors} == {"c"}  # a and b skipped, c is the frontier
+    assert processors[0]._is_resume_frontier is True

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -18,9 +18,9 @@ from ddev.ai.phases.resources import ResourceUnavailableError
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
     CheckpointStatus,
+    CheckpointTokenInfo,
     FailedCheckpoint,
     SuccessCheckpoint,
-    TokenUsage,
 )
 from ddev.ai.runtime.orchestrator import PhaseOrchestrator
 from ddev.ai.runtime.resources import RunResources
@@ -510,7 +510,7 @@ def _make_checkpoint(data: dict) -> SuccessCheckpoint | FailedCheckpoint:
             status=CheckpointStatus.SUCCESS,
             started_at=ts,
             finished_at=ts,
-            tokens=TokenUsage(total_input=0, total_output=0),
+            tokens=CheckpointTokenInfo(total_input=0, total_output=0),
             memory_path="/tmp/mem.md",
         )
     return FailedCheckpoint(

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -15,7 +15,13 @@ from ddev.ai.phases.base import Phase
 from ddev.ai.phases.config import FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.resources import ResourceUnavailableError
-from ddev.ai.runtime.checkpoints import CheckpointManager
+from ddev.ai.runtime.checkpoints import (
+    CheckpointManager,
+    CheckpointStatus,
+    FailedCheckpoint,
+    SuccessCheckpoint,
+    TokenUsage,
+)
 from ddev.ai.runtime.orchestrator import PhaseOrchestrator
 from ddev.ai.runtime.resources import RunResources
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
@@ -496,10 +502,26 @@ def linear_flow(tmp_path):
     return tmp_path
 
 
+def _make_checkpoint(data: dict) -> SuccessCheckpoint | FailedCheckpoint:
+    status = data.get("status")
+    ts = "2026-01-01T00:00:00+00:00"
+    if status == "success":
+        return SuccessCheckpoint(
+            status=CheckpointStatus.SUCCESS,
+            started_at=ts,
+            finished_at=ts,
+            tokens=TokenUsage(total_input=0, total_output=0),
+            memory_path="/tmp/mem.md",
+        )
+    return FailedCheckpoint(
+        status=CheckpointStatus.FAILED, started_at=None, finished_at=ts, error=data.get("error", "")
+    )
+
+
 def _write_checkpoints(flow_dir: Path, statuses: dict[str, dict]) -> None:
     manager = CheckpointManager(flow_dir / "checkpoints.yaml")
     for phase_id, data in statuses.items():
-        manager.write_phase_checkpoint(phase_id, data)
+        manager.write_phase_checkpoint(phase_id, _make_checkpoint(data))
 
 
 def _drain_trigger_phase_ids(orchestrator) -> list:

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -15,17 +15,13 @@ from ddev.ai.phases.base import Phase
 from ddev.ai.phases.config import FlowConfigError
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.resources import ResourceUnavailableError
-from ddev.ai.runtime.checkpoints import (
-    CheckpointManager,
-    CheckpointStatus,
-    CheckpointTokenInfo,
-    FailedCheckpoint,
-    SuccessCheckpoint,
-)
+from ddev.ai.runtime.checkpoints import CheckpointManager
 from ddev.ai.runtime.orchestrator import PhaseOrchestrator
 from ddev.ai.runtime.resources import RunResources
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.event_bus.exceptions import FatalProcessingError
+
+from .conftest import make_checkpoint
 
 
 @pytest.fixture
@@ -502,26 +498,10 @@ def linear_flow(tmp_path):
     return tmp_path
 
 
-def _make_checkpoint(data: dict) -> SuccessCheckpoint | FailedCheckpoint:
-    status = data.get("status")
-    ts = "2026-01-01T00:00:00+00:00"
-    if status == "success":
-        return SuccessCheckpoint(
-            status=CheckpointStatus.SUCCESS,
-            started_at=ts,
-            finished_at=ts,
-            tokens=CheckpointTokenInfo(total_input=0, total_output=0),
-            memory_path="/tmp/mem.md",
-        )
-    return FailedCheckpoint(
-        status=CheckpointStatus.FAILED, started_at=None, finished_at=ts, error=data.get("error", "")
-    )
-
-
 def _write_checkpoints(flow_dir: Path, statuses: dict[str, dict]) -> None:
     manager = CheckpointManager(flow_dir / "checkpoints.yaml")
     for phase_id, data in statuses.items():
-        manager.write_phase_checkpoint(phase_id, _make_checkpoint(data))
+        manager.write_phase_checkpoint(phase_id, make_checkpoint(data))
 
 
 def _drain_trigger_phase_ids(orchestrator) -> list:

--- a/ddev/tests/ai/tools/agents/test_spawn_subagent.py
+++ b/ddev/tests/ai/tools/agents/test_spawn_subagent.py
@@ -197,8 +197,8 @@ async def test_happy_path(tmp_path: Path, name: str | None, expected_id: str) ->
 
     assert result.success is True
     assert result.data == "ok"
-    assert result.total_input_tokens == 10
-    assert result.total_output_tokens == 5
+    assert result.tokens.input == 10
+    assert result.tokens.output == 5
     assert factory.calls[0]["owner_id"] == expected_id
 
     events = read_events(subagent_log(tmp_path, expected_id))

--- a/ddev/tests/ai/tools/test_registry.py
+++ b/ddev/tests/ai/tools/test_registry.py
@@ -258,20 +258,23 @@ def test_available_tool_names_includes_web_fetch():
 def test_from_names_multiple_native(tmp_path):
     registry = from_names(["web_search", "web_fetch"], tmp_path)
     assert registry.definitions == []
-    assert registry.native_tool_names == ["web_search", "web_fetch"]
+    assert registry.native_tool_names == (
+        "web_search",
+        "web_fetch",
+    )
 
 
 def test_from_names_native_only(tmp_path):
     registry = from_names(["web_search"], tmp_path)
     assert registry.definitions == []
-    assert list(registry.native_tool_names) == ["web_search"]
+    assert registry.native_tool_names == ("web_search",)
 
 
 def test_from_names_client_and_native(tmp_path):
     registry = from_names(["read_file", "web_search"], tmp_path)
     assert len(registry.definitions) == 1
     assert registry.definitions[0]["name"] == "read_file"
-    assert list(registry.native_tool_names) == ["web_search"]
+    assert registry.native_tool_names == ("web_search",)
 
 
 def test_from_names_native_not_in_tools_dict(tmp_path):
@@ -288,7 +291,7 @@ def test_native_tool_names_not_affected_by_input_mutation():
     names = ["web_search"]
     registry = ToolRegistry([], native_tool_names=names)
     names.append("web_fetch")
-    assert list(registry.native_tool_names) == ["web_search"]
+    assert registry.native_tool_names == ("web_search",)
 
 
 def test_filter_read_only_includes_native_read_only():


### PR DESCRIPTION
### What does this PR do?

Introduces a `Tokens` value object (`ddev/ai/accounting/tokens.py`) and routes all token accounting in the `ddev` AI framework through it.

`Tokens` is a frozen Pydantic model carrying `input`, `output`, `cache_read`, and `cache_creation`, with `__add__` and an additive zero (`Tokens()`), so accumulation everywhere collapses to a single `total += result.tokens`.

Concretely:
- Replaces the `(input_tokens, output_tokens)` integer pairs that were threaded through `ReActResult`, `ToolResult`, `PhaseOutcome`, the goal-loop types (`GoalCheckResult`, `GoalLoopOutcome`, `GoalValidationError`), and `AgenticPhase`'s internal accumulator.
- Deletes `CheckpointTokenInfo`; checkpoints now persist a `Tokens` directly. The on-disk `tokens` shape changes from `{total_input, total_output}` to `{input, output, cache_read, cache_creation}`.
- Adds `TokenUsage.to_tokens()` to project a single-call usage snapshot into accumulable totals (the projection lives on `TokenUsage` to keep `ddev/ai/accounting` a dependency-free leaf and avoid an import cycle).
- `ReActProcess.compact()` now returns `Tokens` instead of a tuple.
- The `agent_log` finish event keeps its `total_input_tokens` / `total_output_tokens` keys (now sourced from `Tokens`) and additionally emits `total_cache_read_tokens` / `total_cache_creation_tokens`.

Most of the line count is in the tests: they touch a lot of lines but only to align with the new `Tokens` syntax (constructing `Tokens(input=..., output=...)` and reading `.tokens.input` instead of the old flat fields). There is no behavioral change to the tests — same scenarios, same expectations. A small focused `tests/ai/accounting/test_tokens.py` covers the value object itself.

### Motivation

Token accounting suffered from primitive obsession and shotgun surgery: the input/output pair was duplicated across ~8 files, every accumulation was two `+=` lines, and forgetting one silently undercounted. Two side effects of the old shape are also fixed here:

- **Silent cache drop:** cache read/write tokens were tracked per call but discarded at every accumulation site, so totals were not cost-accurate. They now accumulate.
- **Duplicate types:** `TokenUsage` (per-call) and `CheckpointTokenInfo` (persisted) were two more representations of the same pair; the latter is now gone.

The value object removes the duplication, makes accumulation a single operation, and gives cost/usage concerns a clear home to grow into.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
