### PR TITLE
Document ddev worktree override and running lint through ddev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,23 @@ ddev -x validate config -s <INTEGRATION_NAME>
 ddev -x validate models -s <INTEGRATION_NAME>
 ```
 
+## Worktrees
+
+When working in a git worktree (anything other than the primary checkout), run `ddev config override` as the first step after entering the directory. This writes a gitignored `.ddev.toml` that points the `core` repo at the current worktree.
+
+Without this override, `ddev` resolves `core` to whatever the global configuration points at, which is usually a different worktree. Every `ddev test`, `ddev test --lint`, and `ddev env` command would then run against the wrong checkout and produce misleading results.
+
+Verify the override took effect with `ddev config show`: the `[repos]` `core` entry should point at the current directory and be marked as an override.
+
+If `ddev config override` cannot write the file in your environment, create `.ddev.toml` by hand at the worktree root:
+
+```toml
+repo = "core"
+
+[repos]
+core = "<absolute-path-to-this-worktree>"
+```
+
 ## Testing
 
 Run unit and integration tests with `ddev --no-interactive test <INTEGRATION>`. For example, for the pgbouncer integration, run `ddev --no-interactive test pgbouncer`.
@@ -128,6 +145,8 @@ For E2E tests, `--recreate` performs `docker compose down --volumes` followed by
 ## Code Formatting
 
 Format code with `ddev test -fs <INTEGRATION>`. For example, for the pgbouncer integration, run `ddev test -fs pgbouncer`.
+
+Always run linting and formatting through `ddev`: use `ddev test -fs <INTEGRATION>` to fix issues and `ddev test --lint <INTEGRATION>` (or `-s`) to check them. Do not invoke `ruff`, `black`, or `mypy` directly. CI runs them inside `ddev`'s pinned hatch lint environment, and a different locally installed version can report different results, passing locally while failing CI or the other way around.
 
 ## Changelog Management
 


### PR DESCRIPTION
### What does this PR do?

Adds two guidelines to `AGENTS.md`:

- A new **Worktrees** section instructing contributors to run `ddev config override` as the first step in any git worktree, so `ddev` targets the current checkout instead of whatever the global configuration points at. It also documents how to verify the override and how to create `.ddev.toml` by hand if the command cannot write the file.
- An addition to **Code Formatting** that linting and formatting must always run through `ddev` (`ddev test -fs` / `ddev test --lint`) rather than invoking `ruff`, `black`, or `mypy` directly, because CI uses `ddev`'s pinned hatch lint environment and a different local tool version can disagree with CI.

### Motivation

While fixing merge conflicts in a worktree, `ddev` resolved the `core` repo to a different worktree (the global default), and lint was run with a locally installed `ruff` whose version differed from the one CI pins. That combination produced misleading local results and a lint failure that only surfaced in CI. These guidelines prevent both issues.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
