### PR TITLE
Parameterize SQL Server agent history row limit

### DIFF
--- a/sqlserver/changelog.d/24206.fixed
+++ b/sqlserver/changelog.d/24206.fixed
@@ -1,0 +1,1 @@
+Parameterize the SQL Server Agent job history row limit.

--- a/sqlserver/datadog_checks/sqlserver/agent_history.py
+++ b/sqlserver/datadog_checks/sqlserver/agent_history.py
@@ -20,7 +20,7 @@ DEFAULT_ROW_LIMIT = 10000
 
 AGENT_HISTORY_QUERY = """\
 WITH BASE AS (
-    SELECT {history_row_limit_filter}
+    SELECT TOP (?)
         j.name AS job_name,
         CAST(sjh.job_id AS CHAR(36)) AS job_id,
         sjh.step_name,
@@ -136,12 +136,10 @@ class SqlserverAgentHistory(DBMAsyncJob):
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _get_new_agent_job_history(self, cursor):
-        history_row_limit_filter = "TOP {history_row_limit}".format(history_row_limit=self.history_row_limit)
-        query = AGENT_HISTORY_QUERY.format(history_row_limit_filter=history_row_limit_filter)
-        params = (self._last_collection_time,)
+        params = (self.history_row_limit, self._last_collection_time)
         self.log.debug("collecting sql server agent jobs history")
-        self.log.debug("Running query [%s] %s", query, params)
-        cursor.execute(query, params)
+        self.log.debug("Running query [%s] %s", AGENT_HISTORY_QUERY, params)
+        cursor.execute(AGENT_HISTORY_QUERY, params)
         columns = [i[0] for i in cursor.description]
         # construct row dicts manually as there's no DictCursor for pyodbc
         rows = [dict(zip(columns, row)) for row in cursor.fetchall()]

--- a/sqlserver/tests/test_agent_jobs.py
+++ b/sqlserver/tests/test_agent_jobs.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock
 import pytest
 
 from datadog_checks.sqlserver import SQLServer
-from datadog_checks.sqlserver.agent_history import SqlserverAgentHistory
+from datadog_checks.sqlserver.agent_history import AGENT_HISTORY_QUERY, SqlserverAgentHistory
 
 from .common import (
     CHECK_NAME,
@@ -21,165 +21,6 @@ logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.integration]
 
-
-AGENT_HISTORY_QUERY = """\
-WITH BASE AS (
-    SELECT {history_row_limit_filter}
-        j.name AS job_name,
-        CAST(sjh.job_id AS CHAR(36)) AS job_id,
-        sjh.step_name,
-        sjh.step_id,
-        sjh.instance_id AS step_instance_id,
-        DATEDIFF(SECOND, '19700101',
-            DATEADD(HOUR, sjh.run_time / 10000,
-                DATEADD(MINUTE, (sjh.run_time / 100) % 100,
-                    DATEADD(SECOND, sjh.run_time % 100,
-                        CAST(CAST(sjh.run_date AS CHAR(8)) AS DATETIME)
-                    )
-                )
-            )
-        ) - DATEPART(TZOFFSET, SYSDATETIMEOFFSET()) * 60 AS run_epoch_time,
-        (sjh.run_duration / 10000) * 3600
-        + ((sjh.run_duration % 10000) / 100) * 60
-        + (sjh.run_duration % 100) AS run_duration_seconds,
-        CASE sjh.run_status
-            WHEN 0 THEN 'Failed'
-            WHEN 1 THEN 'Succeeded'
-            WHEN 2 THEN 'Retry'
-            WHEN 3 THEN 'Canceled'
-            WHEN 4 THEN 'In Progress'
-            ELSE 'Unknown'
-        END AS step_run_status,
-        sjh.message
-    FROM msdb.dbo.sysjobhistory AS sjh
-    INNER JOIN msdb.dbo.sysjobs AS j ON j.job_id = sjh.job_id
-	ORDER BY step_instance_id DESC
-),
-COMPLETION_CTE AS (
-    SELECT
-        BASE.*,
-        MIN(CASE WHEN BASE.step_id = 0 THEN BASE.step_instance_id END) OVER (
-            PARTITION BY BASE.job_id
-            ORDER BY BASE.step_instance_id
-            ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
-        ) AS completion_instance_id
-    FROM BASE
-),
-HISTORY_ENTRIES AS (
-    SELECT
-        C.*,
-        DATEDIFF(SECOND, '19700101',
-            DATEADD(HOUR, c_sjh.run_time / 10000,
-                DATEADD(MINUTE, (c_sjh.run_time / 100) % 100,
-                    DATEADD(SECOND, c_sjh.run_time % 100,
-                        CAST(CAST(c_sjh.run_date AS CHAR(8)) AS DATETIME)
-                    )
-                )
-            )
-        ) - DATEPART(TZOFFSET, SYSDATETIMEOFFSET()) * 60
-        + (c_sjh.run_duration / 10000) * 3600
-        + ((c_sjh.run_duration % 10000) / 100) * 60
-        + (c_sjh.run_duration % 100) AS completion_epoch_time
-    FROM COMPLETION_CTE AS C
-    LEFT JOIN msdb.dbo.sysjobhistory AS c_sjh
-        ON c_sjh.instance_id = C.completion_instance_id
-		WHERE C.completion_instance_id IS NOT NULL
-)
-SELECT
-	job_name,
-	job_id,
-	step_name,
-	step_id,
-	step_instance_id,
-	completion_instance_id,
-	run_epoch_time,
-	run_duration_seconds,
-	step_run_status,
-	message
-FROM HISTORY_ENTRIES
-WHERE
-    completion_epoch_time > ?;
-"""
-
-
-FORMATTED_HISTORY_QUERY = """\
-WITH BASE AS (
-    SELECT TOP 10000
-        j.name AS job_name,
-        CAST(sjh.job_id AS CHAR(36)) AS job_id,
-        sjh.step_name,
-        sjh.step_id,
-        sjh.instance_id AS step_instance_id,
-        DATEDIFF(SECOND, '19700101',
-            DATEADD(HOUR, sjh.run_time / 10000,
-                DATEADD(MINUTE, (sjh.run_time / 100) % 100,
-                    DATEADD(SECOND, sjh.run_time % 100,
-                        CAST(CAST(sjh.run_date AS CHAR(8)) AS DATETIME)
-                    )
-                )
-            )
-        ) - DATEPART(TZOFFSET, SYSDATETIMEOFFSET()) * 60 AS run_epoch_time,
-        (sjh.run_duration / 10000) * 3600
-        + ((sjh.run_duration % 10000) / 100) * 60
-        + (sjh.run_duration % 100) AS run_duration_seconds,
-        CASE sjh.run_status
-            WHEN 0 THEN 'Failed'
-            WHEN 1 THEN 'Succeeded'
-            WHEN 2 THEN 'Retry'
-            WHEN 3 THEN 'Canceled'
-            WHEN 4 THEN 'In Progress'
-            ELSE 'Unknown'
-        END AS step_run_status,
-        sjh.message
-    FROM msdb.dbo.sysjobhistory AS sjh
-    INNER JOIN msdb.dbo.sysjobs AS j ON j.job_id = sjh.job_id
-	ORDER BY step_instance_id DESC
-),
-COMPLETION_CTE AS (
-    SELECT
-        BASE.*,
-        MIN(CASE WHEN BASE.step_id = 0 THEN BASE.step_instance_id END) OVER (
-            PARTITION BY BASE.job_id
-            ORDER BY BASE.step_instance_id
-            ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
-        ) AS completion_instance_id
-    FROM BASE
-),
-HISTORY_ENTRIES AS (
-    SELECT
-        C.*,
-        DATEDIFF(SECOND, '19700101',
-            DATEADD(HOUR, c_sjh.run_time / 10000,
-                DATEADD(MINUTE, (c_sjh.run_time / 100) % 100,
-                    DATEADD(SECOND, c_sjh.run_time % 100,
-                        CAST(CAST(c_sjh.run_date AS CHAR(8)) AS DATETIME)
-                    )
-                )
-            )
-        ) - DATEPART(TZOFFSET, SYSDATETIMEOFFSET()) * 60
-        + (c_sjh.run_duration / 10000) * 3600
-        + ((c_sjh.run_duration % 10000) / 100) * 60
-        + (c_sjh.run_duration % 100) AS completion_epoch_time
-    FROM COMPLETION_CTE AS C
-    LEFT JOIN msdb.dbo.sysjobhistory AS c_sjh
-        ON c_sjh.instance_id = C.completion_instance_id
-		WHERE C.completion_instance_id IS NOT NULL
-)
-SELECT
-	job_name,
-	job_id,
-	step_name,
-	step_id,
-	step_instance_id,
-	completion_instance_id,
-	run_epoch_time,
-	run_duration_seconds,
-	step_run_status,
-	message
-FROM HISTORY_ENTRIES
-WHERE
-    completion_epoch_time > ?;
-"""
 
 AGENT_ACTIVITY_DURATION_QUERY = """\
     SELECT
@@ -406,10 +247,7 @@ def test_connection_with_agent_history(instance_docker):
 
     with check.connection.open_managed_default_connection(KEY_PREFIX):
         with check.connection.get_managed_cursor(KEY_PREFIX) as cursor:
-            history_row_limit_filter = "TOP {history_row_limit}".format(history_row_limit=10000)
-            query = AGENT_HISTORY_QUERY.format(history_row_limit_filter=history_row_limit_filter)
-            cursor.execute(query, (10000,))
-            assert query == FORMATTED_HISTORY_QUERY
+            cursor.execute(AGENT_HISTORY_QUERY, (10000, 10000))
 
 
 class AgentHistoryCursor:
@@ -447,9 +285,11 @@ def test_agent_history_query_parameterizes_last_collection_time() -> None:
     agent_history._get_new_agent_job_history(cursor)
 
     query, params = cursor.executions[0]
+    assert "SELECT TOP (?)" in query
     assert "completion_epoch_time > ?;" in query
+    assert "SELECT TOP 10000" not in query
     assert "completion_epoch_time > 10000;" not in query
-    assert params == (10000,)
+    assert params == (10000, 10000)
 
 
 @pytest.mark.usefixtures('dd_environment')
@@ -504,15 +344,11 @@ def test_history_output(instance_docker, sa_conn):
     check.initialize_connection()
     with check.connection.open_managed_default_connection(KEY_PREFIX):
         with check.connection.get_managed_cursor(KEY_PREFIX) as cursor:
-            history_row_limit_filter = "TOP {history_row_limit}".format(history_row_limit=10000)
-            query = AGENT_HISTORY_QUERY.format(history_row_limit_filter=history_row_limit_filter)
-            cursor.execute(query, (now - 1,))
+            cursor.execute(AGENT_HISTORY_QUERY, (10000, now - 1))
             results = cursor.fetchall()
             assert len(results) == 7, "should have 7 steps associated with completed jobs"
             assert len(results[0]) == 10, "should have 10 columns per step"
-            history_row_limit_filter = "TOP {history_row_limit}".format(history_row_limit=10000)
-            query = AGENT_HISTORY_QUERY.format(history_row_limit_filter=history_row_limit_filter)
-            cursor.execute(query, (now + 1,))
+            cursor.execute(AGENT_HISTORY_QUERY, (10000, now + 1))
             results = cursor.fetchall()
             assert len(results) == 4, (
                 "should only have 4 steps associated with completed jobs when filtering with last collection time"


### PR DESCRIPTION
### What does this PR do?

Parameterizes the SQL Server Agent job history row limit by changing the query to use `SELECT TOP (?)` and executing it with `(history_row_limit, last_collection_time)`. It also removes duplicated test SQL so the tests execute the production `AGENT_HISTORY_QUERY` directly.

### Motivation

Follow-up to #24203. That PR stabilized the changing `completion_epoch_time` filter; this removes the remaining query text formatting for the configurable `history_row_limit` so both dynamic query inputs are bound parameters.

Validation so far:

- `ddev --no-interactive test -fs sqlserver`
- `ddev --no-interactive test sqlserver:py3.13-linux-odbc-2022-single -- -k test_agent_history_query_parameterizes_last_collection_time`

I also attempted `test_connection_with_agent_history` locally to exercise `TOP (?)` against SQL Server, but the local Docker SQL Server container failed before query execution with `initerrlog: Could not open error log file '/var/opt/mssql/log/errorlog'. Operating system error = 5(Access is denied.)`.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
