### PR TITLE
Swap mesos_master and control_m test exceptions to agnostic http_exceptions hierarchy

### DIFF
--- a/control_m/tests/common.py
+++ b/control_m/tests/common.py
@@ -8,8 +8,8 @@ from typing import Any
 from unittest.mock import Mock
 
 from pytest import MonkeyPatch
-from requests.exceptions import HTTPError
 
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.control_m import ControlMCheck
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
@@ -26,7 +26,7 @@ def _respond(data: Any, status_code: int = 200) -> Mock:
         resp.raise_for_status = Mock()
     else:
         resp.text = f"Error {status_code}"
-        resp.raise_for_status = Mock(side_effect=HTTPError(f"{status_code} Server Error", response=resp))
+        resp.raise_for_status = Mock(side_effect=HTTPStatusError(f"{status_code} Server Error", response=resp))
     return resp
 
 

--- a/control_m/tests/test_unit.py
+++ b/control_m/tests/test_unit.py
@@ -8,9 +8,9 @@ from typing import Any
 
 import pytest
 from pytest import MonkeyPatch
-from requests.exceptions import HTTPError
 
 from datadog_checks.base.stubs.aggregator import AggregatorStub
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.dev.utils import get_metadata_metrics
 
 from .common import BASE_TAGS, FIXTURE_DIR, _load_job, _make_check, _mock_api, _run_check
@@ -45,7 +45,7 @@ def test_connect_server_error_emits_critical(
     check = _make_check(instance)
     _mock_api(check, monkeypatch, server_status=500)
 
-    with pytest.raises(HTTPError, match="500"):
+    with pytest.raises(HTTPStatusError, match="500"):
         _run_check(check)
 
     aggregator.assert_metric("control_m.can_connect", value=0, count=1)
@@ -71,7 +71,7 @@ def test_connect_session_login_failure_emits_critical(
     check = _make_check(session_instance)
     _mock_api(check, monkeypatch, login_status=401)
 
-    with pytest.raises(HTTPError, match="401"):
+    with pytest.raises(HTTPStatusError, match="401"):
         _run_check(check)
 
     aggregator.assert_metric("control_m.can_login", value=0, count=1)

--- a/mesos_master/changelog.d/22676.changed
+++ b/mesos_master/changelog.d/22676.changed
@@ -1,0 +1,1 @@
+Catch the backend-agnostic ``HTTPTimeoutError`` on request timeout so the check keeps working after the httpx migration.

--- a/mesos_master/datadog_checks/mesos_master/mesos_master.py
+++ b/mesos_master/datadog_checks/mesos_master/mesos_master.py
@@ -185,7 +185,8 @@ class MesosMaster(AgentCheck):
                 status = AgentCheck.OK
                 msg = "Mesos master instance detected at {} ".format(url)
         except (requests.exceptions.Timeout, HTTPTimeoutError):
-            # If there's a timeout
+            # On timeout. requests.exceptions.Timeout is a transition shim for the
+            # httpx2 migration. Drop it once requests is gone.
             msg = "{} seconds timeout when hitting {}".format(self.http.options['timeout'], url)
             status = AgentCheck.CRITICAL
         except Exception as e:

--- a/mesos_master/tests/test_check.py
+++ b/mesos_master/tests/test_check.py
@@ -4,10 +4,10 @@
 from unittest.mock import MagicMock
 
 import pytest
-import requests
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.errors import CheckException
+from datadog_checks.base.utils.http_exceptions import HTTPTimeoutError
 from datadog_checks.mesos_master import MesosMaster
 
 
@@ -99,21 +99,21 @@ def test_instance_timeout(check, instance):
         ),
         (
             'OK case with failing /state due to Timeout and fallback on /state.json',
-            [requests.exceptions.Timeout, MagicMock(status_code=200, content='{}')],
+            [HTTPTimeoutError("timeout"), MagicMock(status_code=200, content='{}')],
             AgentCheck.OK,
             ['my:tag', 'url:http://hello.com/state.json'],
             False,
         ),
         (
             'OK case with failing /state due to Exception and fallback on /state.json',
-            [Exception, MagicMock(status_code=200, content='{}')],
+            [Exception("unexpected error"), MagicMock(status_code=200, content='{}')],
             AgentCheck.OK,
             ['my:tag', 'url:http://hello.com/state.json'],
             False,
         ),
         (
             'NOK case with failing /state and /state.json due to timeout',
-            [requests.exceptions.Timeout, requests.exceptions.Timeout],
+            [HTTPTimeoutError("timeout"), HTTPTimeoutError("timeout")],
             AgentCheck.CRITICAL,
             ['my:tag', 'url:http://hello.com/state.json'],
             True,


### PR DESCRIPTION
### What does this PR do?

Moves the `mesos_master` and `control_m` test suites off `requests.exceptions` and onto the backend-agnostic `http_exceptions` hierarchy, so their assertions no longer name a backend-specific exception type and stay green once these integrations move to `httpx2`.

requests' `HTTPError` is a status error, so it maps to `HTTPStatusError` (the leaf), not the agnostic `HTTPError` root. Both integrations are safe to swap now because each injects the exception through a mock and production already catches the agnostic type (`mesos_master.py:187`) or catches `Exception` and re-raises (`control_m/check.py`).

### Motivation

Part of the `requests` to `httpx2` migration. Decoupling these assertions from `requests.exceptions` lets the suites pass under either backend, ahead of the per-integration flip.

### Verification

- `ddev --no-interactive test mesos_master`: 17 passed, 1 e2e skipped.
- `ddev --no-interactive test control_m`: 28 passed.
- `ddev test -fs mesos_master control_m`: clean.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
