### PR TITLE
Catch agnostic HTTPStatusError in arangodb and swap to agnostic tests

### DIFF
--- a/arangodb/changelog.d/22676.changed
+++ b/arangodb/changelog.d/22676.changed
@@ -1,0 +1,1 @@
+Catch the backend-agnostic ``HTTPStatusError`` when fetching server tags so the check keeps working after the httpx migration.

--- a/arangodb/datadog_checks/arangodb/check.py
+++ b/arangodb/datadog_checks/arangodb/check.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from requests import HTTPError
 
 from datadog_checks.base import OpenMetricsBaseCheckV2
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 
 from .config_models import ConfigMixin
 from .metrics import METRIC_MAP
@@ -56,7 +57,7 @@ class ArangodbCheck(OpenMetricsBaseCheckV2, ConfigMixin):
 
             return 'server_{}:{}'.format(tag_name, response.json()[tag_name])
 
-        except HTTPError:
+        except (HTTPError, HTTPStatusError):
             self.log.debug("Unable to get server %s, skipping `server_%s` tag.", tag_name, tag_name)
         except Exception as e:
             self.log.debug(

--- a/arangodb/tests/test_arangodb.py
+++ b/arangodb/tests/test_arangodb.py
@@ -6,9 +6,9 @@ import os
 
 import mock
 import pytest
-from requests import HTTPError
 
 from datadog_checks.arangodb import ArangodbCheck
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.base.utils.http_testing import MockHTTPResponse
 from datadog_checks.dev.utils import get_metadata_metrics
 
@@ -78,7 +78,9 @@ def test_check(instance, dd_run_check, aggregator, tag_condition, base_tags, moc
     'side_effect, log_message',
     [
         pytest.param(
-            HTTPError, "Unable to get server foo, skipping `server_foo` tag.", id="HTTPError getting server tag"
+            HTTPStatusError("error"),
+            "Unable to get server foo, skipping `server_foo` tag.",
+            id="HTTPStatusError getting server tag",
         ),
         pytest.param(
             Exception,
@@ -87,12 +89,12 @@ def test_check(instance, dd_run_check, aggregator, tag_condition, base_tags, moc
         ),
     ],
 )
-def test_get_server_tag(instance, caplog, side_effect, log_message):
+def test_get_server_tag(instance, caplog, side_effect, log_message, mock_http):
     caplog.clear()
     check = ArangodbCheck('arangodb', {}, [instance])
-    with mock.patch("datadog_checks.base.utils.http.RequestsWrapper.get", side_effect=side_effect):
-        caplog.set_level(logging.DEBUG)
-        check.get_server_tag('foo', '/test_endpoint/foo')
+    mock_http.get.side_effect = side_effect
+    caplog.set_level(logging.DEBUG)
+    check.get_server_tag('foo', '/test_endpoint/foo')
 
     assert log_message in caplog.text
 


### PR DESCRIPTION
### What does this PR do?

Widen the `get_server_tag` exception handler to catch the backend-agnostic `HTTPStatusError` alongside requests' `HTTPError`, and swap the matching unit test to inject the agnostic type through the `mock_http` fixture instead of patching `RequestsWrapper.get` directly.

### Motivation

The Agent's HTTP layer is migrating from `requests` to `httpx2`. On the `httpx2` backend, HTTP errors surface as backend-agnostic `http_exceptions` types instead of `requests` exceptions, so a handler that only catches `requests.HTTPError` would stop catching the server-tag error after the switch and let it fall through to the generic handler, logging the wrong message. Catching `HTTPStatusError` as well is purely additive. Nothing changes under today's `requests` backend. Rerouting the test to the `mock_http` fixture makes it independent of which backend the check uses, so it stays green across the switch.

### Verification

Red-then-green: applying the test swap alone makes the `HTTPStatusError` case fail on the assertion (the agnostic exception escapes the requests-only clause and logs the wrong message via `except Exception`). With the production widening, the full suite is green (9 passed, 1 e2e skipped). `ddev test -fs arangodb` is clean.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required. (`qa/skip-qa`: no observable change under the shipped `requests` backend.)
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged