### PR TITLE
Fix typos in Argo CD overview dashboard

### DIFF
--- a/argocd/assets/dashboards/argo_cd_overview.json
+++ b/argocd/assets/dashboards/argo_cd_overview.json
@@ -524,7 +524,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Number of Non Successful Application Syncs",
+                            "title": "Number of Unsuccessful Application Syncs",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries"
@@ -1830,7 +1830,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Count of of Redis Requests",
+                            "title": "Count of Redis Requests",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries"


### PR DESCRIPTION
### What does this PR do?

Fixes two typos in the Argo CD overview dashboard widget titles in `argocd/assets/dashboards/argo_cd_overview.json`:

- `Count of of Redis Requests` → `Count of Redis Requests`
- `Number of Non Successful Application Syncs` → `Number of Unsuccessful Application Syncs`

### Motivation

These misspellings are visible in the shipped Argo CD dashboard template and reduce readability. Closes #24214.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)