### PR TITLE
Fix typo in Kubernetes control plane dashboard

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_control_plane.json
+++ b/kubernetes/assets/dashboards/kubernetes_control_plane.json
@@ -2655,7 +2655,7 @@
                     {
                         "id": 7350980922272526,
                         "definition": {
-                            "title": "Nodes unealthy",
+                            "title": "Nodes unhealthy",
                             "title_size": "16",
                             "title_align": "left",
                             "type": "query_value",


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in the Kubernetes control plane dashboard widget title in `kubernetes/assets/dashboards/kubernetes_control_plane.json`:

- `Nodes unealthy` → `Nodes unhealthy`

### Motivation

This misspelling is visible in the shipped Kubernetes control plane dashboard template. The other 11 dashboards under `kubernetes/assets/dashboards/` were reviewed and no additional typos were found. Closes #24216.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)