### PR TITLE
Fix typo in Nvidia Triton overview dashboard

### DIFF
--- a/istio/assets/dashboards/overview.json
+++ b/istio/assets/dashboards/overview.json
@@ -2014,7 +2014,7 @@
                                 }
                             ],
                             "show_legend": true,
-                            "title": "Succesful Injection Requests",
+                            "title": "Successful Injection Requests",
                             "title_align": "left",
                             "title_size": "16",
                             "type": "timeseries"

--- a/nvidia_triton/assets/dashboards/nvidia_triton_overview.json
+++ b/nvidia_triton/assets/dashboards/nvidia_triton_overview.json
@@ -1,6 +1,6 @@
 {
     "author_name": "Datadog",
-    "description": "**Nvidia Triton**\n\nThis dashboard provides insights into your Nvidia Triton Server. You can use this dashbaord to check resource consumption in GPU and CPU. You can also use it to get in depth look at your inference requests per model and cache stats(if enabled).\n\n**Useful Links**\n\n* [Integration Docs]()",
+    "description": "**Nvidia Triton**\n\nThis dashboard provides insights into your Nvidia Triton Server. You can use this dashboard to check resource consumption in GPU and CPU. You can also use it to get in depth look at your inference requests per model and cache stats(if enabled).\n\n**Useful Links**\n\n* [Integration Docs]()",
     "layout_type": "ordered",
     "template_variables": [
         {


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in the Nvidia Triton overview dashboard (`nvidia_triton/assets/dashboards/nvidia_triton_overview.json`):

- `dashbaord` → `dashboard`

### Motivation

This misspelling is visible in the shipped Nvidia Triton dashboard template. Closes #24221.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)