### PR TITLE
Fix typos in Kubernetes Cluster Autoscaler overview dashboard

### DIFF
--- a/kubernetes_cluster_autoscaler/assets/dashboards/kubernetes_cluster_autoscaler_overview.json
+++ b/kubernetes_cluster_autoscaler/assets/dashboards/kubernetes_cluster_autoscaler_overview.json
@@ -1,7 +1,7 @@
 {
     "author_name": "Datadog",
     "title": "Kubernetes Cluster Autoscaler Overview",
-    "description": "This dashboard provides insights into your Kubernetes Cluster Autoscaler.\nYou can use this dashbaord to check the cluster autoscaler state and resource consumption.\nYou can also use it to check for downsacaling and upscaling.",
+    "description": "This dashboard provides insights into your Kubernetes Cluster Autoscaler.\nYou can use this dashboard to check the cluster autoscaler state and resource consumption.\nYou can also use it to check for downscaling and upscaling.",
     "widgets": [
         {
             "id": 3375620455700908,


### PR DESCRIPTION
### What does this PR do?

Fixes typos in the Kubernetes Cluster Autoscaler overview dashboard (`kubernetes_cluster_autoscaler/assets/dashboards/kubernetes_cluster_autoscaler_overview.json`):

- `dashbaord` → `dashboard`
- `downsacaling` → `downscaling`

### Motivation

These misspellings are visible in the shipped Kubernetes Cluster Autoscaler dashboard template. Closes #24220.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)