### PR TITLE
Mark slurm seff_path as require_trusted_provider

### DIFF
--- a/slurm/assets/configuration/spec.yaml
+++ b/slurm/assets/configuration/spec.yaml
@@ -119,6 +119,13 @@ files:
         type: string
         require_trusted_provider: true
         example: /usr/bin/scontrol
+    - name: seff_path
+      description: Full path to the seff binary.
+      fleet_configurable: true
+      value:
+        type: string
+        require_trusted_provider: true
+        example: /usr/bin/seff
     - name: debug_sinfo_stats
       description: |
         Whether or not to enable debug logging for the sinfo command. This logs the output of the sinfo command

--- a/slurm/changelog.d/24235.security
+++ b/slurm/changelog.d/24235.security
@@ -1,0 +1,1 @@
+Require a trusted provider for the ``seff_path`` config option.

--- a/slurm/datadog_checks/slurm/config_models/defaults.py
+++ b/slurm/datadog_checks/slurm/config_models/defaults.py
@@ -96,6 +96,10 @@ def instance_sdiag_path():
     return '/usr/bin/sdiag'
 
 
+def instance_seff_path():
+    return '/usr/bin/seff'
+
+
 def instance_sinfo_collection_level():
     return 1
 

--- a/slurm/datadog_checks/slurm/config_models/instance.py
+++ b/slurm/datadog_checks/slurm/config_models/instance.py
@@ -20,15 +20,7 @@ from . import defaults, validators
 
 
 SECURE_FIELD_NAMES = frozenset(
-    [
-        'sacct_path',
-        'scontrol_path',
-        'sdiag_path',
-        'seff_path',
-        'sinfo_path',
-        'squeue_path',
-        'sshare_path',
-    ]
+    ['sacct_path', 'scontrol_path', 'sdiag_path', 'seff_path', 'sinfo_path', 'squeue_path', 'sshare_path']
 )
 
 
@@ -79,18 +71,14 @@ class InstanceConfig(BaseModel):
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):
-        return validation.core.initialize_config(
-            getattr(validators, 'initialize_instance', identity)(values)
-        )
+        return validation.core.initialize_config(getattr(validators, 'initialize_instance', identity)(values))
 
     @field_validator('*', mode='before')
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
-            value = getattr(validators, f'instance_{info.field_name}', identity)(
-                value, field=field
-            )
+            value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
 
             if info.field_name in SECURE_FIELD_NAMES:
                 validation.security.check_field_trusted_provider(
@@ -103,6 +91,4 @@ class InstanceConfig(BaseModel):
 
     @model_validator(mode='after')
     def _final_validation(cls, model):
-        return validation.core.check_model(
-            getattr(validators, 'check_instance', identity)(model)
-        )
+        return validation.core.check_model(getattr(validators, 'check_instance', identity)(model))

--- a/slurm/datadog_checks/slurm/config_models/instance.py
+++ b/slurm/datadog_checks/slurm/config_models/instance.py
@@ -20,7 +20,15 @@ from . import defaults, validators
 
 
 SECURE_FIELD_NAMES = frozenset(
-    ['sacct_path', 'scontrol_path', 'sdiag_path', 'sinfo_path', 'squeue_path', 'sshare_path']
+    [
+        'sacct_path',
+        'scontrol_path',
+        'sdiag_path',
+        'seff_path',
+        'sinfo_path',
+        'squeue_path',
+        'sshare_path',
+    ]
 )
 
 
@@ -61,6 +69,7 @@ class InstanceConfig(BaseModel):
     sacct_path: Optional[str] = None
     scontrol_path: Optional[str] = None
     sdiag_path: Optional[str] = None
+    seff_path: Optional[str] = None
     service: Optional[str] = None
     sinfo_collection_level: Optional[int] = None
     sinfo_path: Optional[str] = None
@@ -70,14 +79,18 @@ class InstanceConfig(BaseModel):
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):
-        return validation.core.initialize_config(getattr(validators, 'initialize_instance', identity)(values))
+        return validation.core.initialize_config(
+            getattr(validators, 'initialize_instance', identity)(values)
+        )
 
     @field_validator('*', mode='before')
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
-            value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+            value = getattr(validators, f'instance_{info.field_name}', identity)(
+                value, field=field
+            )
 
             if info.field_name in SECURE_FIELD_NAMES:
                 validation.security.check_field_trusted_provider(
@@ -90,4 +103,6 @@ class InstanceConfig(BaseModel):
 
     @model_validator(mode='after')
     def _final_validation(cls, model):
-        return validation.core.check_model(getattr(validators, 'check_instance', identity)(model))
+        return validation.core.check_model(
+            getattr(validators, 'check_instance', identity)(model)
+        )

--- a/slurm/datadog_checks/slurm/config_models/shared.py
+++ b/slurm/datadog_checks/slurm/config_models/shared.py
@@ -33,14 +33,18 @@ class SharedConfig(BaseModel):
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):
-        return validation.core.initialize_config(getattr(validators, 'initialize_shared', identity)(values))
+        return validation.core.initialize_config(
+            getattr(validators, 'initialize_shared', identity)(values)
+        )
 
     @field_validator('*', mode='before')
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
-            value = getattr(validators, f'shared_{info.field_name}', identity)(value, field=field)
+            value = getattr(validators, f'shared_{info.field_name}', identity)(
+                value, field=field
+            )
 
             if info.field_name in SECURE_FIELD_NAMES:
                 validation.security.check_field_trusted_provider(
@@ -53,4 +57,6 @@ class SharedConfig(BaseModel):
 
     @model_validator(mode='after')
     def _final_validation(cls, model):
-        return validation.core.check_model(getattr(validators, 'check_shared', identity)(model))
+        return validation.core.check_model(
+            getattr(validators, 'check_shared', identity)(model)
+        )

--- a/slurm/datadog_checks/slurm/config_models/shared.py
+++ b/slurm/datadog_checks/slurm/config_models/shared.py
@@ -33,18 +33,14 @@ class SharedConfig(BaseModel):
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):
-        return validation.core.initialize_config(
-            getattr(validators, 'initialize_shared', identity)(values)
-        )
+        return validation.core.initialize_config(getattr(validators, 'initialize_shared', identity)(values))
 
     @field_validator('*', mode='before')
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
-            value = getattr(validators, f'shared_{info.field_name}', identity)(
-                value, field=field
-            )
+            value = getattr(validators, f'shared_{info.field_name}', identity)(value, field=field)
 
             if info.field_name in SECURE_FIELD_NAMES:
                 validation.security.check_field_trusted_provider(
@@ -57,6 +53,4 @@ class SharedConfig(BaseModel):
 
     @model_validator(mode='after')
     def _final_validation(cls, model):
-        return validation.core.check_model(
-            getattr(validators, 'check_shared', identity)(model)
-        )
+        return validation.core.check_model(getattr(validators, 'check_shared', identity)(model))

--- a/slurm/datadog_checks/slurm/data/conf.yaml.example
+++ b/slurm/datadog_checks/slurm/data/conf.yaml.example
@@ -99,6 +99,11 @@ instances:
     #
     # scontrol_path: /usr/bin/scontrol
 
+    ## @param seff_path - string - optional - default: /usr/bin/seff
+    ## Full path to the seff binary.
+    #
+    # seff_path: /usr/bin/seff
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##


### PR DESCRIPTION
### What does this PR do?

Adds the `seff_path` instance config field to the Slurm integration spec and marks it with `require_trusted_provider: true`, matching the other binary path fields (`sinfo_path`, `sacct_path`, `sdiag_path`, `sshare_path`, `squeue_path`, `scontrol_path`) and the `slurm_binaries_dir` init_config field.

### Motivation
https://datadoghq.atlassian.net/browse/VULN-81302

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged