### PR TITLE
Add process autodiscovery infrastructure and support to krakend

### DIFF
--- a/datadog_checks_dev/changelog.d/24238.added
+++ b/datadog_checks_dev/changelog.d/24238.added
@@ -1,0 +1,1 @@
+Add process autodiscovery E2E testing helpers.

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -229,27 +229,44 @@ def _assert_no_log_patterns(logs: str, patterns: Sequence[str], candidate_index:
             )
 
 
+def _get_auto_conf_volume(check_root: str | os.PathLike[str] | None = None) -> str:
+    check_root = os.fspath(check_root or find_check_root(depth=2))
+    check_name = os.path.basename(check_root)
+    check_pkg = os.path.join(check_root, 'datadog_checks', check_name)
+    return f'{check_pkg}/data/auto_conf.yaml:/etc/datadog-agent/conf.d/{check_name}.d/auto_conf.yaml:ro'
+
+
 def get_e2e_discovery_metadata(
     check_root: str | os.PathLike[str] | None = None,
-) -> dict[str, list[str]]:
-    """Return Docker volume metadata for an e2e discovery run.
+) -> dict[str, list[str] | dict[str, str]]:
+    """Return metadata for an e2e discovery run.
 
-    Mounts the integration's ``auto_conf.yaml`` into the agent container.
+    Mounts the integration's ``auto_conf.yaml`` into the agent container, and grants
+    the capabilities needed for process-based autodiscovery to see processes running
+    in sibling containers (on top of the container-based autodiscovery already
+    enabled via the Docker socket mount).
 
     Use ``dd_agent_check_discovery`` alongside this metadata so that the static
     per-env config is temporarily replaced with an empty-instances file, leaving
     ``auto_conf.yaml`` as the sole AD template driving config-discovery.
     """
-    check_root = os.fspath(check_root or find_check_root(depth=1))
-    check_name = os.path.basename(check_root)
-    check_pkg = os.path.join(check_root, 'datadog_checks', check_name)
-    auto_conf = os.path.join(check_pkg, 'data', 'auto_conf.yaml')
-
     return {
         'docker_volumes': [
-            f'{auto_conf}:/etc/datadog-agent/conf.d/{check_name}.d/auto_conf.yaml:ro',
+            _get_auto_conf_volume(check_root),
             '/var/run/docker.sock:/var/run/docker.sock:ro',
         ],
+        'env_vars': {
+            # Reduce the default service collection interval from 60s to speed
+            # up tests. This needs to be set on the container instead of being
+            # passed in to `agent check` since it's read by the
+            # system-probe(-lite) daemon.
+            'DD_DISCOVERY_SERVICE_COLLECTION_INTERVAL': '10s',
+        },
+        # system-probe(-lite) needs these capabilities to read /proc entries of
+        # other processes for service discovery. Without them it falls back to
+        # only scanning the agent's own PID namespace, which finds no host
+        # processes.
+        'cap_add': ['SYS_PTRACE', 'DAC_READ_SEARCH'],
     }
 
 

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -238,37 +238,43 @@ def _get_auto_conf_volume(check_root: str | os.PathLike[str] | None = None) -> s
 
 def get_e2e_discovery_metadata(
     check_root: str | os.PathLike[str] | None = None,
+    *,
+    process: bool = False,
 ) -> dict[str, list[str] | dict[str, str]]:
     """Return metadata for an e2e discovery run.
 
-    Mounts the integration's ``auto_conf.yaml`` into the agent container, and grants
-    the capabilities needed for process-based autodiscovery to see processes running
-    in sibling containers (on top of the container-based autodiscovery already
-    enabled via the Docker socket mount).
+    Mounts the integration's ``auto_conf.yaml`` into the agent container. Pass
+    ``process=True`` to also grant the capabilities needed for process-based
+    autodiscovery to see processes running in sibling containers (on top of the
+    container-based autodiscovery already enabled via the Docker socket mount).
 
     Use ``dd_agent_check_discovery`` alongside this metadata so that the static
     per-env config is temporarily replaced with an empty-instances file, leaving
     ``auto_conf.yaml`` as the sole AD template driving config-discovery.
     """
-    return {
+    metadata: dict[str, list[str] | dict[str, str]] = {
         'docker_volumes': [
             _get_auto_conf_volume(check_root),
             '/var/run/docker.sock:/var/run/docker.sock:ro',
         ],
-        'env_vars': {
+    }
+
+    if process:
+        metadata['env_vars'] = {
             # Reduce the default service collection interval and minimum process
             # age to speed up tests. This needs to be set on the container
             # instead of being passed in to `agent check` since it's read by the
             # system-probe(-lite) daemon.
             'DD_DISCOVERY_SERVICE_COLLECTION_INTERVAL': '5s',
             'DD_DISCOVERY_SERVICE_COLLECTION_MIN_PROCESS_AGE': '1s',
-        },
+        }
         # system-probe(-lite) needs these capabilities to read /proc entries of
         # other processes for service discovery. Without them it falls back to
         # only scanning the agent's own PID namespace, which finds no host
         # processes.
-        'cap_add': ['SYS_PTRACE', 'DAC_READ_SEARCH'],
-    }
+        metadata['cap_add'] = ['SYS_PTRACE', 'DAC_READ_SEARCH']
+
+    return metadata
 
 
 def compose_file_active(compose_file):

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -256,11 +256,12 @@ def get_e2e_discovery_metadata(
             '/var/run/docker.sock:/var/run/docker.sock:ro',
         ],
         'env_vars': {
-            # Reduce the default service collection interval from 60s to speed
-            # up tests. This needs to be set on the container instead of being
-            # passed in to `agent check` since it's read by the
+            # Reduce the default service collection interval and minimum process
+            # age to speed up tests. This needs to be set on the container
+            # instead of being passed in to `agent check` since it's read by the
             # system-probe(-lite) daemon.
-            'DD_DISCOVERY_SERVICE_COLLECTION_INTERVAL': '10s',
+            'DD_DISCOVERY_SERVICE_COLLECTION_INTERVAL': '5s',
+            'DD_DISCOVERY_SERVICE_COLLECTION_MIN_PROCESS_AGE': '1s',
         },
         # system-probe(-lite) needs these capabilities to read /proc entries of
         # other processes for service discovery. Without them it falls back to

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -203,6 +203,9 @@ def dd_agent_check(request, aggregator, datadog_agent):
         if 'times' in kwargs:
             kwargs['check_times'] = kwargs.pop('times')
 
+        for env_key, env_value in (kwargs.pop('env_vars', None) or {}).items():
+            check_command.extend(['--env', '{}={}'.format(env_key, env_value)])
+
         for key, value in kwargs.items():
             if value is not False:
                 check_command.append('--{}'.format(key.replace('_', '-')))
@@ -244,11 +247,30 @@ def dd_agent_check_discovery(dd_agent_check):
     Passes the empty-instances config required to let ``auto_conf.yaml`` drive
     autodiscovery, and sets sensible defaults for ``discovery_min_instances`` and
     ``discovery_timeout`` — all of which can be overridden per call.
+
+    Pass ``process=True`` to exercise process-based (rather than container-based)
+    autodiscovery for a process that is otherwise container-bound: this excludes
+    the ``docker`` feature for this invocation only (so this run's autodiscovery
+    never learns about any containers) and, unless overridden, extends the
+    default timeout to account for the minimum process age that process-based
+    autodiscovery requires before it recognizes a process as a service.
     """
     if not e2e_testing():
         pytest.skip('Not running E2E tests')
 
-    def run(*, discovery_min_instances=1, discovery_timeout=30, **kwargs):
+    def run(*, discovery_min_instances=1, discovery_timeout=None, process=False, **kwargs):
+        if discovery_timeout is None:
+            # Process autodiscovery needs to wait for the agent to recognize the
+            # process as a service which happens after a minimum process age of 1
+            # minute. This time can be reduced significantly once agent-side
+            # support for reducing the minimum age via configuration is available.
+            discovery_timeout = 90 if process else 30
+
+        if process:
+            env_vars = kwargs.pop('env_vars', None) or {}
+            env_vars.setdefault('DD_AUTOCONFIG_EXCLUDE_FEATURES', 'docker')
+            kwargs['env_vars'] = env_vars
+
         return dd_agent_check(
             {'init_config': {}, 'instances': []},
             discovery_min_instances=discovery_min_instances,

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -9,7 +9,7 @@ import re
 from base64 import urlsafe_b64encode
 from collections import namedtuple  # Not using dataclasses for Py2 compatibility
 from io import open
-from typing import Dict, List, Literal, Optional, Tuple, overload  # noqa: F401
+from typing import Any, Dict, List, Literal, Optional, Tuple, overload  # noqa: F401
 
 import pytest
 
@@ -240,6 +240,45 @@ def dd_agent_check(request, aggregator, datadog_agent):
         yield run_check
 
 
+CONTAINER_ORIGIN_TAG_PREFIXES = ('docker_image:', 'image_id:', 'image_name:', 'image_tag:', 'short_image:')
+
+
+def _assert_discovery_used_expected_mechanism(aggregator: Any, *, process: bool) -> None:
+    """Assert that a ``dd_agent_check_discovery`` run actually used the mechanism it claims to.
+
+    Container-based Autodiscovery has its instances tagged by the Agent's tagger with container-origin
+    tags (``docker_image``, ``image_name``, etc.); process-based Autodiscovery does not. Without this
+    check, a bug that fails to exclude the ``docker`` feature during a ``process=True`` run can go
+    unnoticed: the container-based path silently produces a working instance, leaving the process CEL
+    selector completely untested even though the test still passes.
+    """
+    tags = set()
+    has_metrics = False
+    for name in aggregator.metric_names:
+        for metric in aggregator.metrics(name):
+            has_metrics = True
+            tags.update(metric.tags)
+
+    # If no data was submitted, don't assert anything here, let the test fail
+    # due to other assertions in the main test function.
+    if not has_metrics:
+        return
+
+    discovered_via_container = any(tag.startswith(prefix) for tag in tags for prefix in CONTAINER_ORIGIN_TAG_PREFIXES)
+
+    if process:
+        assert not discovered_via_container, (
+            'Process-based discovery was requested, but the submitted metrics carry container-origin '
+            'tags. Autodiscovery actually matched the container instead of the process, so the process '
+            'CEL selector was never exercised.'
+        )
+    else:
+        assert discovered_via_container, (
+            'Container-based discovery was requested, but the submitted metrics carry no container-origin '
+            'tags, so it is unclear that Autodiscovery actually matched via the container path.'
+        )
+
+
 @pytest.fixture
 def dd_agent_check_discovery(dd_agent_check):
     """Wrapper around ``dd_agent_check`` for config-discovery e2e tests.
@@ -271,12 +310,16 @@ def dd_agent_check_discovery(dd_agent_check):
             env_vars.setdefault('DD_AUTOCONFIG_EXCLUDE_FEATURES', 'docker')
             kwargs['env_vars'] = env_vars
 
-        return dd_agent_check(
+        aggregator = dd_agent_check(
             {'init_config': {}, 'instances': []},
             discovery_min_instances=discovery_min_instances,
             discovery_timeout=discovery_timeout,
             **kwargs,
         )
+
+        _assert_discovery_used_expected_mechanism(aggregator, process=process)
+
+        return aggregator
 
     return run
 

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -243,7 +243,7 @@ def dd_agent_check(request, aggregator, datadog_agent):
 CONTAINER_ORIGIN_TAG_PREFIXES = ('docker_image:', 'image_id:', 'image_name:', 'image_tag:', 'short_image:')
 
 
-def _assert_discovery_used_expected_mechanism(aggregator: Any, *, process: bool) -> None:
+def assert_discovery_used_expected_mechanism(aggregator: Any, *, process: bool) -> None:
     """Assert that a ``dd_agent_check_discovery`` run actually used the mechanism it claims to.
 
     Container-based Autodiscovery has its instances tagged by the Agent's tagger with container-origin
@@ -310,7 +310,7 @@ def dd_agent_check_discovery(dd_agent_check):
             **kwargs,
         )
 
-        _assert_discovery_used_expected_mechanism(aggregator, process=process)
+        assert_discovery_used_expected_mechanism(aggregator, process=process)
 
         return aggregator
 

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -288,11 +288,7 @@ def dd_agent_check_discovery(dd_agent_check):
     ``discovery_timeout`` — all of which can be overridden per call.
 
     Pass ``process=True`` to exercise process-based (rather than container-based)
-    autodiscovery for a process that is otherwise container-bound: this excludes
-    the ``docker`` feature for this invocation only (so this run's autodiscovery
-    never learns about any containers) and, unless overridden, extends the
-    default timeout to account for the minimum process age that process-based
-    autodiscovery requires before it recognizes a process as a service.
+    autodiscovery for a process that is otherwise container-bound.
     """
     if not e2e_testing():
         pytest.skip('Not running E2E tests')
@@ -307,6 +303,10 @@ def dd_agent_check_discovery(dd_agent_check):
 
         if process:
             env_vars = kwargs.pop('env_vars', None) or {}
+            # Exclude the `docker` feature so this run's autodiscovery never
+            # learns about any containers. This is because process-based
+            # autodiscovery normally ignores processes if it knows that they are
+            # inside containers, and we need to override this behavior.
             env_vars.setdefault('DD_AUTOCONFIG_EXCLUDE_FEATURES', 'docker')
             kwargs['env_vars'] = env_vars
 

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -293,14 +293,7 @@ def dd_agent_check_discovery(dd_agent_check):
     if not e2e_testing():
         pytest.skip('Not running E2E tests')
 
-    def run(*, discovery_min_instances=1, discovery_timeout=None, process=False, **kwargs):
-        if discovery_timeout is None:
-            # Process autodiscovery needs to wait for the agent to recognize the
-            # process as a service which happens after a minimum process age of 1
-            # minute. This time can be reduced significantly once agent-side
-            # support for reducing the minimum age via configuration is available.
-            discovery_timeout = 90 if process else 30
-
+    def run(*, discovery_min_instances=1, discovery_timeout=30, process=False, **kwargs):
         if process:
             env_vars = kwargs.pop('env_vars', None) or {}
             # Exclude the `docker` feature so this run's autodiscovery never

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/auto_conf/cel_selector.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/auto_conf/cel_selector.yaml
@@ -1,0 +1,4 @@
+- name: cel_selector
+  description: CEL selector for autodiscovery.
+  enabled: true
+  example: {}

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -16,7 +16,6 @@ from datadog_checks.dev.docker import (
     assert_all_discovery_candidates_stable,
     compose_file_active,
     docker_run,
-    get_e2e_discovery_metadata,
 )
 from datadog_checks.dev.subprocess import run_command
 
@@ -47,31 +46,6 @@ def _container_inspect(*, restart_count=0, running=True, health='healthy', ports
         },
         'RestartCount': restart_count,
         'State': state,
-    }
-
-
-def test_get_e2e_discovery_metadata(tmp_path):
-    check_root = tmp_path / 'test_check'
-    check_package_root = check_root / 'datadog_checks' / 'test_check'
-    data_dir = check_package_root / 'data'
-    data_dir.mkdir(parents=True)
-    (data_dir / 'auto_conf.yaml').write_text(
-        'ad_identifiers:\n  - test\ndiscovery: {}\ninit_config:\ninstances: []\n',
-        encoding='utf-8',
-    )
-
-    metadata = get_e2e_discovery_metadata(check_root)
-
-    assert metadata == {
-        'docker_volumes': [
-            f'{check_package_root}/data/auto_conf.yaml:/etc/datadog-agent/conf.d/test_check.d/auto_conf.yaml:ro',
-            '/var/run/docker.sock:/var/run/docker.sock:ro',
-        ],
-        'env_vars': {
-            'DD_DISCOVERY_SERVICE_COLLECTION_INTERVAL': '10s',
-            'DD_DISCOVERY_SERVICE_COLLECTION_MIN_PROCESS_AGE': '1s',
-        },
-        'cap_add': ['SYS_PTRACE', 'DAC_READ_SEARCH'],
     }
 
 

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -67,6 +67,10 @@ def test_get_e2e_discovery_metadata(tmp_path):
             f'{check_package_root}/data/auto_conf.yaml:/etc/datadog-agent/conf.d/test_check.d/auto_conf.yaml:ro',
             '/var/run/docker.sock:/var/run/docker.sock:ro',
         ],
+        'env_vars': {
+            'DD_DISCOVERY_SERVICE_COLLECTION_INTERVAL': '10s',
+        },
+        'cap_add': ['SYS_PTRACE', 'DAC_READ_SEARCH'],
     }
 
 

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -69,6 +69,7 @@ def test_get_e2e_discovery_metadata(tmp_path):
         ],
         'env_vars': {
             'DD_DISCOVERY_SERVICE_COLLECTION_INTERVAL': '10s',
+            'DD_DISCOVERY_SERVICE_COLLECTION_MIN_PROCESS_AGE': '1s',
         },
         'cap_add': ['SYS_PTRACE', 'DAC_READ_SEARCH'],
     }

--- a/ddev/changelog.d/24238.added
+++ b/ddev/changelog.d/24238.added
@@ -1,0 +1,1 @@
+Pass capabilities from e2e metadata to the Agent container.

--- a/ddev/src/ddev/e2e/agent/docker.py
+++ b/ddev/src/ddev/e2e/agent/docker.py
@@ -277,6 +277,9 @@ class DockerAgent(AgentInterface):
         for key, value in sorted(env_vars.items()):
             command.extend(['-e', f'{key}={value}'])
 
+        for cap in self.metadata.get('cap_add', []):
+            command.extend(['--cap-add', cap])
+
         # The docker `--add-host` command will reliably create entries in the `/etc/hosts` file,
         # otherwise, edits to that file will be overwritten on container restarts
         for host, ip in self.metadata.get('custom_hosts', []):

--- a/krakend/assets/configuration/spec.yaml
+++ b/krakend/assets/configuration/spec.yaml
@@ -80,4 +80,9 @@ files:
     overrides:
       value.example:
       - krakend
+  - template: auto_conf/cel_selector
+    overrides:
+      cel_selector.example:
+        processes:
+          - "process.name == 'krakend'"
   - template: auto_conf/discovery

--- a/krakend/changelog.d/24238.added
+++ b/krakend/changelog.d/24238.added
@@ -1,0 +1,1 @@
+Add process autodiscovery support.

--- a/krakend/datadog_checks/krakend/data/auto_conf.yaml
+++ b/krakend/datadog_checks/krakend/data/auto_conf.yaml
@@ -6,6 +6,12 @@
 ad_identifiers:
   - krakend
 
+## CEL selector for autodiscovery.
+#
+cel_selector:
+  processes:
+  - process.name == 'krakend'
+
 ## Enables configuration discovery
 #
 discovery: {}

--- a/krakend/tests/conftest.py
+++ b/krakend/tests/conftest.py
@@ -56,7 +56,7 @@ def run_docker_e2e(env_vars: dict[str, str], conditions: list[LazyFunction]):
             {
                 "instances": [{"openmetrics_endpoint": OPEN_METRICS_ENDPOINT}],
             },
-            get_e2e_discovery_metadata(),
+            get_e2e_discovery_metadata(process=True),
         )
 
 

--- a/krakend/tests/test_e2e.py
+++ b/krakend/tests/test_e2e.py
@@ -25,14 +25,15 @@ def test_e2e(dd_agent_check, instance: InstanceBuilder):
 
 
 @pytest.mark.e2e
-def test_e2e_discovery(dd_agent_check_discovery, is_lab):
+@pytest.mark.parametrize('process', [False, True], ids=['container', 'process'])
+def test_e2e_discovery(dd_agent_check_discovery, is_lab, process):
     # In the lab environment we currently do not mount auto_conf.yaml into the
     # Agent container, so the Agent has no Autodiscovery template to trigger
     # config discovery.
     if is_lab:
         pytest.skip('lab does not currently support configuration discovery')
 
-    aggregator = dd_agent_check_discovery(check_rate=True)
+    aggregator = dd_agent_check_discovery(check_rate=True, process=process)
 
     metadata_metrics = get_metrics_from_metadata()
 


### PR DESCRIPTION
### What does this PR do?

Adds process autodiscovery infrastructure, and support to the krakend integration. When krakend runs as a process in environments without containers, the agent's process autodiscovery listener matches it via a CEL expression and the existing configuration discovery flow finds the metrics endpoint and schedules the check automatically.

The essential change to add the support to krakend is the change to `auto_conf.yaml` (regenerated from `spec.yaml`). The other changes are infrastructure to allow process autodiscovery support to be added to integrations and to be E2E tested while keeping the amount of changes required in each integration relatively small.

The main challenge is cleanly re-using the existing container-based E2E infrastructure for process autodiscovery testing without running krakend as a true host process (since that would require a lot of extra work in each integration's tests to set up the respective services without using containers).

The chosen approach is to keep the existing Docker Compose setup unchanged and instead hide the containers from the agent by setting `DD_AUTOCONFIG_EXCLUDE_FEATURES=docker`, which makes the agent's process autodiscovery component handle the processes as normal host processes. This environment variable is pass to the `agent check` invocation. The Docker environment for the agent also needs a few extra caps and config options for the processes tests, but these options should not affect the container-based tests.

Note that the PR drops the mostly useless `test_get_e2e_discovery_metadata` test which doesn't add much value since it needs 1:1 update every time some metadata is added to `get_e2e_discovery_metadata` (like in this PR), and it also can't even call `get_e2e_discovery_metadata`  in the way that tests actually do (auto `check_root` computation), so it doesn't catch any bugs either.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-493

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged