### PR TITLE
[DBMON-6781] Implement agent_hostname in DatabaseCheck

### DIFF
--- a/datadog_checks_base/changelog.d/24243.added
+++ b/datadog_checks_base/changelog.d/24243.added
@@ -1,0 +1,1 @@
+Implement the ``agent_hostname`` property on the ``DatabaseCheck`` base class.

--- a/datadog_checks_base/datadog_checks/base/checks/db.py
+++ b/datadog_checks_base/datadog_checks/base/checks/db.py
@@ -4,10 +4,16 @@
 
 from abc import abstractmethod
 
+from datadog_checks.base.agent import datadog_agent
+
 from . import AgentCheck
 
 
 class DatabaseCheck(AgentCheck):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._agent_hostname = None
+
     def database_monitoring_query_sample(self, raw_event: str):
         self.event_platform_event(raw_event, "dbm-samples")
 
@@ -32,6 +38,12 @@ class DatabaseCheck(AgentCheck):
     @abstractmethod
     def database_identifier(self) -> str:
         pass
+
+    @property
+    def agent_hostname(self) -> str:
+        if self._agent_hostname is None:
+            self._agent_hostname = datadog_agent.get_hostname()
+        return self._agent_hostname
 
     @property
     def dbms(self) -> str:

--- a/datadog_checks_base/tests/base/checks/test_database_check.py
+++ b/datadog_checks_base/tests/base/checks/test_database_check.py
@@ -1,0 +1,38 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from unittest import mock
+
+from datadog_checks.base.checks.db import DatabaseCheck
+from datadog_checks.base.stubs.datadog_agent import datadog_agent
+
+
+class FakeDatabaseCheck(DatabaseCheck):
+    @property
+    def reported_hostname(self):
+        return None
+
+    @property
+    def database_identifier(self):
+        return "test-db"
+
+    @property
+    def dbms_version(self):
+        return "1.0.0"
+
+    @property
+    def tags(self):
+        return []
+
+    @property
+    def cloud_metadata(self):
+        return {}
+
+
+def test_agent_hostname_resolves_once_and_caches():
+    check = FakeDatabaseCheck("test", {}, [{}])
+    # The hostname comes from an FFI call, so it should only be resolved once and cached.
+    with mock.patch.object(datadog_agent, "get_hostname", return_value="my-agent-host") as get_hostname:
+        assert check.agent_hostname == "my-agent-host"
+        assert check.agent_hostname == "my-agent-host"
+        assert get_hostname.call_count == 1


### PR DESCRIPTION
### What does this PR do?
Implements the `agent_hostname` function that's currently duplicated in Clickhouse, Mysql, Postgres and SqlServer integrations on `DatabaseCheck` class. This is an additive change that implements existing logic. Once we bump `datadog_checks_base` package in the integrations we can then remove duplicated logic.

### Motivation
Support work for simplifying and unifying database check logic across DBM integrations

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
