### PR TITLE
[DBMON-6783] Implement DatabaseChecks.tags property to use tag_manager

### DIFF
--- a/datadog_checks_base/changelog.d/24244.added
+++ b/datadog_checks_base/changelog.d/24244.added
@@ -1,0 +1,1 @@
+Implement the `DatabaseCheck.tags` property backed by a shared `TagManager` so DBM integrations can consolidate tag handling.

--- a/datadog_checks_base/datadog_checks/base/checks/db.py
+++ b/datadog_checks_base/datadog_checks/base/checks/db.py
@@ -4,10 +4,16 @@
 
 from abc import abstractmethod
 
+from datadog_checks.base.utils.db.utils import TagManager
+
 from . import AgentCheck
 
 
 class DatabaseCheck(AgentCheck):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.tag_manager = TagManager()
+
     def database_monitoring_query_sample(self, raw_event: str):
         self.event_platform_event(raw_event, "dbm-samples")
 
@@ -43,9 +49,8 @@ class DatabaseCheck(AgentCheck):
         pass
 
     @property
-    @abstractmethod
     def tags(self) -> list[str]:
-        pass
+        return self.tag_manager.get_tags()
 
     @property
     @abstractmethod


### PR DESCRIPTION
### What does this PR do?
Implements the tags property on DatabaseChecks class to wire up TagManager. This plumbs through logic that already exists in Clickhouse, Mysql and SqlServer integrations in an additive way that will allow us to consolidate this logic into our base class. All writes to TagManager are still handled within each integration currently. Postgres still overrides this function for it's current manual tag handling (which has a [draft PR](https://github.com/DataDog/integrations-core/compare/eric.weaver/DBMON-6715-postgres) to switch this to TagManager once base package is released with pending support changes)

Existing integration tests should be capturing that this is working correctly and not introducing unexpected side effects. Testing around tags itself will be brought into this base class once any write logic is moved over

### Motivation
Support work for simplifying and unifying database check logic across DBM integrations

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
