### PR TITLE
Fix mypy type error in ddev _scaffold.py

### DIFF
--- a/ddev/changelog.d/24246.fixed
+++ b/ddev/changelog.d/24246.fixed
@@ -1,0 +1,1 @@
+Fix mypy type error in `_scaffold.py` where a `pathlib.Path` was assigned to a variable typed as `ddev.utils.fs.Path`.

--- a/ddev/src/ddev/cli/create/_scaffold.py
+++ b/ddev/src/ddev/cli/create/_scaffold.py
@@ -455,7 +455,7 @@ def _display_tree(app: Application, root: Path, files: list[TemplateFile]) -> No
         try:
             rel = f.target_path.relative_to(root)
         except ValueError:
-            rel = _StdPath(str(f.target_path))
+            rel = Path(str(f.target_path))
         branch: dict = tree
         for part in rel.parts:
             branch = branch.setdefault(part, {})


### PR DESCRIPTION
### What does this PR do?

Fixes a mypy type error in `ddev/src/ddev/cli/create/_scaffold.py`. In `_display_tree`, the `except` branch assigned a `pathlib.Path` to `rel`, but the variable is typed as `ddev.utils.fs.Path` from the `try` branch. Changed `_StdPath(...)` to `Path(...)` for consistency.

### Motivation

The mypy lint step in CI was failing with:

```
src/ddev/cli/create/_scaffold.py:458:19: error: Incompatible types in assignment
  (expression has type "pathlib.Path", variable has type "ddev.utils.fs.Path")
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged