### PR TITLE
Catch agnostic HTTPError in sonarqube intg and swap the test

### DIFF
--- a/sonarqube/changelog.d/22676.changed
+++ b/sonarqube/changelog.d/22676.changed
@@ -1,0 +1,1 @@
+Catch the backend-agnostic ``HTTPError`` when collecting metadata and metrics so the check keeps working after the httpx migration.

--- a/sonarqube/datadog_checks/sonarqube/check.py
+++ b/sonarqube/datadog_checks/sonarqube/check.py
@@ -6,6 +6,7 @@ import re
 from requests.exceptions import RequestException
 
 from datadog_checks.base import AgentCheck, ConfigurationError
+from datadog_checks.base.utils.http_exceptions import HTTPError
 
 from .constants import CATEGORIES, MAX_PAGES, NUMERIC_TYPES
 
@@ -31,8 +32,8 @@ class SonarqubeCheck(AgentCheck):
         try:
             self.collect_metadata()
             self.collect_metrics()
-        except RequestException as e:
-            self.log.error('RequestException: %s', e)
+        except (RequestException, HTTPError) as e:
+            self.log.error('Error querying the SonarQube API: %s', e)
             self.service_check(self.SERVICE_CHECK_CONNECT, self.CRITICAL, tags=self._tags, message=str(e))
         else:
             self.service_check(self.SERVICE_CHECK_CONNECT, self.OK, tags=self._tags)

--- a/sonarqube/tests/test_unit.py
+++ b/sonarqube/tests/test_unit.py
@@ -4,8 +4,8 @@
 import os
 
 import mock
-import requests
 
+from datadog_checks.base.utils.http_exceptions import HTTPError
 from datadog_checks.base.utils.http_testing import MockHTTPResponse
 
 from .common import HERE
@@ -14,7 +14,7 @@ from .metrics import WEB_METRICS
 
 def test_service_check_critical(aggregator, dd_run_check, sonarqube_check, web_instance):
     with mock.patch('datadog_checks.sonarqube.check.SonarqubeCheck.http') as mock_http:
-        mock_http.get.side_effect = requests.exceptions.RequestException('Req Exception')
+        mock_http.get.side_effect = HTTPError('HTTP error')
         check = sonarqube_check(web_instance)
         global_tags = ['endpoint:{}'.format(web_instance['web_endpoint'])]
         global_tags.extend(web_instance['tags'])


### PR DESCRIPTION
### What does this PR do?
Widens the `except` clause in `SonarqubeCheck.check()` to catch the backend-agnostic `HTTPError` base alongside `requests`' `RequestException`, and swaps the injected exception in `test_service_check_critical` to that same agnostic base.

### Motivation
Part of the httpx migration. Once the HTTP layer moves off `requests`, transport failures surface as the agent's backend-agnostic `http_exceptions` rather than `requests.exceptions`. Catching the agnostic `HTTPError` base keeps the `sonarqube.api_access` service check reporting CRITICAL on HTTP failures under either backend, with no behavior change on the current `requests` backend. 

### Verification
Verified red-then-green: with the agnostic exception injected but the clause un-widened, it escapes `check()` and the test fails. Widening the clause makes it pass.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
