### PR TITLE
Reconcile dangling tool_use blocks after a truncated agent turn

### DIFF
--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -107,6 +107,29 @@ class AnthropicAgent(BaseAgent[MessageParam]):
         self._max_tokens = max_tokens
         self._context_window: int | None = None
 
+    def reconcile_pending_tool_calls(self, placeholder_error: str) -> int:
+        if not self._history or self._history[-1]["role"] != "assistant":
+            return 0
+
+        content = self._history[-1]["content"]
+        tool_use_ids: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "tool_use":
+                    tool_use_ids.append(block["id"])
+            elif getattr(block, "type", None) == "tool_use":
+                tool_use_ids.append(block.id)
+
+        if not tool_use_ids:
+            return 0
+
+        synthetic_results = [
+            {"type": "tool_result", "tool_use_id": id_, "is_error": True, "content": placeholder_error}
+            for id_ in tool_use_ids
+        ]
+        self._history.append({"role": "user", "content": synthetic_results})
+        return len(tool_use_ids)
+
     async def _get_context_window(self) -> int:
         if self._context_window is None:
             try:

--- a/ddev/src/ddev/ai/agent/base.py
+++ b/ddev/src/ddev/ai/agent/base.py
@@ -99,6 +99,14 @@ class BaseAgent[TMessage](ABC):
         return response
 
     @abstractmethod
+    def reconcile_pending_tool_calls(self, placeholder_error: str) -> int:
+        """Append a synthetic error tool_result for each unanswered tool_use in the last assistant turn.
+
+        No-op if the last turn is not an assistant message or has no tool_use blocks.
+        Returns the number of tool calls reconciled. Performs no API call.
+        """
+
+    @abstractmethod
     async def send(
         self,
         content: str | list[ToolResultMessage],

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -140,6 +140,10 @@ class ReActProcess:
                     total_input += compact_in
                     total_output += compact_out
 
+            self._agent.reconcile_pending_tool_calls(
+                "Not executed: the assistant turn was truncated by the token limit before this tool call could run."
+            )
+
             react_result = ReActResult(
                 final_response=response,
                 iterations=iterations,

--- a/ddev/tests/ai/agent/test_anthropic_client.py
+++ b/ddev/tests/ai/agent/test_anthropic_client.py
@@ -1116,3 +1116,120 @@ async def test_pause_turn_raises_after_max_continuations() -> None:
         await agent.send("Hi")
 
     assert client.messages.create.await_count == MAX_CONTINUATIONS
+
+
+# ---------------------------------------------------------------------------
+# reconcile_pending_tool_calls
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_noop_on_empty_history() -> None:
+    agent, _ = make_agent()
+    count = agent.reconcile_pending_tool_calls("err")
+    assert count == 0
+    assert agent.history == []
+
+
+async def test_reconcile_noop_when_last_message_is_not_assistant() -> None:
+    resp = make_response("end_turn", [make_text_block("ok")])
+    agent, _ = make_agent(mock_response=resp)
+    await agent.send("Hi")
+    agent._history.append({"role": "user", "content": "extra"})
+
+    count = agent.reconcile_pending_tool_calls("err")
+
+    assert count == 0
+    assert agent.history[-1] == {"role": "user", "content": "extra"}
+
+
+async def test_reconcile_noop_when_no_tool_use_blocks() -> None:
+    resp = make_response("end_turn", [make_text_block("ok")])
+    agent, _ = make_agent(mock_response=resp)
+    await agent.send("Hi")
+    history_before = agent.history[:]
+
+    count = agent.reconcile_pending_tool_calls("err")
+
+    assert count == 0
+    assert agent.history == history_before
+
+
+@pytest.mark.parametrize(
+    "tool_names, expected_count",
+    [
+        (["read_file"], 1),
+        (["a", "b"], 2),
+    ],
+)
+async def test_reconcile_pending_tool_calls(tool_names: list[str], expected_count: int) -> None:
+    """Pending tool calls are correctly reconciled with error messages when the model stops."""
+    blocks = [make_tool_use_block(id=f"toolu_{i:02d}", name=name) for i, name in enumerate(tool_names, 1)]
+    resp = make_response("max_tokens", blocks)
+    agent, _ = make_agent(mock_response=resp)
+    await agent.send("Do something")
+
+    count = agent.reconcile_pending_tool_calls("placeholder error")
+
+    assert count == expected_count
+    assert len(agent.history) == 3
+    last = agent.history[-1]
+    assert last["role"] == "user"
+
+    last_content = last["content"]
+    assert len(last_content) == expected_count
+
+    expected_ids = {f"toolu_{i:02d}" for i in range(1, expected_count + 1)}
+    assert {b["tool_use_id"] for b in last_content} == expected_ids
+    assert all(b["type"] == "tool_result" for b in last_content)
+    assert all(b["is_error"] is True for b in last_content)
+    assert all(b["content"] == "placeholder error" for b in last_content)
+
+
+def test_reconcile_handles_dict_shaped_blocks() -> None:
+    """History blocks stored as dicts (not SDK objects) are also covered."""
+    agent, _ = make_agent()
+    agent._history.append(
+        {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_99", "name": "foo", "input": {}}]}
+    )
+
+    count = agent.reconcile_pending_tool_calls("err")
+
+    assert count == 1
+    assert agent.history[-1]["role"] == "user"
+    assert agent.history[-1]["content"][0]["tool_use_id"] == "toolu_99"
+
+
+async def test_reconcile_subsequent_send_has_no_dangling_tool_use() -> None:
+    """After reconcile, the messages sent on the next send() have every tool_use answered."""
+    block = make_tool_use_block(id="toolu_01")
+    resp1 = make_response("max_tokens", [block])
+    resp2 = make_response("end_turn", [make_text_block("done")])
+
+    client = MagicMock(spec=anthropic.AsyncAnthropic)
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(side_effect=[resp1, resp2])
+    client.models = MagicMock()
+    client.models.retrieve = AsyncMock(return_value=SimpleNamespace(max_input_tokens=FAKE_CONTEXT_WINDOW))
+    agent = AnthropicAgent(client=client, tools=ToolRegistry([]), system_prompt="", name="t")
+
+    await agent.send("Do something")
+    agent.reconcile_pending_tool_calls("truncated")
+
+    result = await agent.send("continue")
+    assert result.stop_reason is StopReason.END_TURN
+
+    second_call_messages = client.messages.create.call_args_list[1].kwargs["messages"]
+    tool_use_ids: set[str] = set()
+    tool_result_ids: set[str] = set()
+    for msg in second_call_messages:
+        content = msg.get("content", [])
+        if isinstance(content, list):
+            for blk in content:
+                if isinstance(blk, dict):
+                    if blk.get("type") == "tool_use":
+                        tool_use_ids.add(blk["id"])
+                    elif blk.get("type") == "tool_result":
+                        tool_result_ids.add(blk["tool_use_id"])
+                elif getattr(blk, "type", None) == "tool_use":
+                    tool_use_ids.add(blk.id)
+    assert tool_use_ids == tool_result_ids

--- a/ddev/tests/ai/agent/test_base.py
+++ b/ddev/tests/ai/agent/test_base.py
@@ -25,6 +25,9 @@ class ConcreteAgent(BaseAgent[dict]):
         self._idx = 0
         self.send_calls: list[dict] = []
 
+    def reconcile_pending_tool_calls(self, placeholder_error: str) -> int:
+        return 0
+
     async def send(
         self,
         content: str | list[ToolResultMessage],

--- a/ddev/tests/ai/phases/conftest.py
+++ b/ddev/tests/ai/phases/conftest.py
@@ -97,6 +97,9 @@ class MockAgent:
         self.compact_call_count += 1
         return None
 
+    def reconcile_pending_tool_calls(self, placeholder_error: str) -> int:
+        return 0
+
 
 class MockProcessFactory:
     """Minimal ReActProcessFactory that wraps a MockAgent in a ReActProcess.

--- a/ddev/tests/ai/react/test_factory.py
+++ b/ddev/tests/ai/react/test_factory.py
@@ -19,6 +19,9 @@ class _StubAgent(BaseAgent[Any]):
     def __init__(self, name: str) -> None:
         super().__init__(name=name, system_prompt="", tools=ToolRegistry([]))
 
+    def reconcile_pending_tool_calls(self, placeholder_error: str) -> int:
+        return 0
+
     async def send(
         self, content: str | list[ToolResultMessage], allowed_tools: list[str] | None = None
     ) -> AgentResponse:

--- a/ddev/tests/ai/react/test_process.py
+++ b/ddev/tests/ai/react/test_process.py
@@ -37,6 +37,11 @@ class MockAgent(BaseAgent[Any]):
         self.compact_response: AgentResponse | None = None
         self.compact_token_response: AgentResponse | None = None
         self.reset_calls: int = 0
+        self.reconcile_calls: int = 0
+
+    def reconcile_pending_tool_calls(self, placeholder_error: str) -> int:
+        self.reconcile_calls += 1
+        return 0
 
     async def send(
         self,
@@ -480,6 +485,9 @@ class ErrorAgent(BaseAgent[Any]):
     def __init__(self) -> None:
         super().__init__(name="error", system_prompt="", tools=ToolRegistry([]))
 
+    def reconcile_pending_tool_calls(self, placeholder_error: str) -> int:
+        return 0
+
     async def send(
         self, content: str | list[ToolResultMessage], allowed_tools: list[str] | None = None
     ) -> AgentResponse:
@@ -507,6 +515,9 @@ class InterruptAgent(BaseAgent[Any]):
     def __init__(self) -> None:
         super().__init__(name="interrupt", system_prompt="", tools=ToolRegistry([]))
 
+    def reconcile_pending_tool_calls(self, placeholder_error: str) -> int:
+        return 0
+
     async def send(
         self, content: str | list[ToolResultMessage], allowed_tools: list[str] | None = None
     ) -> AgentResponse:
@@ -532,6 +543,9 @@ async def test_keyboard_interrupt_notifies_and_reraises() -> None:
 class CancelledAgent(BaseAgent[Any]):
     def __init__(self) -> None:
         super().__init__(name="cancelled", system_prompt="", tools=ToolRegistry([]))
+
+    def reconcile_pending_tool_calls(self, placeholder_error: str) -> int:
+        return 0
 
     async def send(
         self, content: str | list[ToolResultMessage], allowed_tools: list[str] | None = None
@@ -724,3 +738,30 @@ async def test_auto_compact_tokens_included_in_result() -> None:
 
     assert result.total_input_tokens == 100 + 200 + 30
     assert result.total_output_tokens == 50 + 80 + 10
+
+
+# ---------------------------------------------------------------------------
+# reconcile_pending_tool_calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "responses",
+    [
+        pytest.param([make_response(StopReason.END_TURN)], id="end_turn"),
+        pytest.param([make_response(StopReason.MAX_TOKENS)], id="max_tokens_text_only"),
+        pytest.param(
+            [make_response(StopReason.MAX_TOKENS, tool_calls=[make_tool_call("tc_01", "spawn_subagent")])],
+            id="max_tokens_with_tool_calls",
+        ),
+        pytest.param(
+            [make_response(StopReason.TOOL_USE, tool_calls=[make_tool_call()]), make_response(StopReason.END_TURN)],
+            id="successful_tool_loop",
+        ),
+    ],
+)
+async def test_reconcile_called_after_loop_exits(responses: list[AgentResponse]) -> None:
+    """reconcile_pending_tool_calls is called unconditionally after the ReAct loop exits."""
+    agent = MockAgent(responses)
+    await make_process(agent).start("task")
+    assert agent.reconcile_calls == 1

--- a/ddev/tests/ai/tools/agents/test_spawn_subagent.py
+++ b/ddev/tests/ai/tools/agents/test_spawn_subagent.py
@@ -34,6 +34,9 @@ class MockAgent(BaseAgent[Any]):
         self._responses = list(responses)
         self._index = 0
 
+    def reconcile_pending_tool_calls(self, placeholder_error: str) -> int:
+        return 0
+
     async def send(
         self,
         content: str | list[ToolResultMessage],
@@ -59,6 +62,9 @@ class _RaisingAgent(BaseAgent[Any]):
     def __init__(self, exc: BaseException) -> None:
         super().__init__("raising", "", ToolRegistry([]))
         self._exc = exc
+
+    def reconcile_pending_tool_calls(self, placeholder_error: str) -> int:
+        return 0
 
     async def send(
         self,


### PR DESCRIPTION
### What does this PR do?

Adds `reconcile_pending_tool_calls` to the AI agent framework so that a truncated assistant turn never leaves the conversation history in an un-sendable state.

When the model hits the `max_tokens` limit mid-turn while emitting `tool_use` blocks, the API returns `stop_reason=max_tokens` and the ReAct loop exits — leaving those `tool_use` ids unanswered in history. Any subsequent `send()` on the same agent then fails with a 400:

```
messages.N: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_…
```

The fix:
- `BaseAgent` gains an abstract `reconcile_pending_tool_calls(placeholder_error)` method.
- `AnthropicAgent` implements it: walks the last assistant message, collects every `tool_use` id (tolerant of both SDK objects and plain dicts), and appends a synthetic error `tool_result` for each. No API call is made.
- `ReActProcess.start()` calls it unconditionally after the `while` loop exits — a no-op on clean `END_TURN` or text-only `MAX_TOKENS` turns, and a repair on truncated turns with pending tool calls.

`compact_preserving_last_turn` is unaffected: it operates while the loop is still running on a valid `TOOL_USE` turn; reconciliation happens at loop exit, so compaction never observes a dangling turn.

### Motivation

Observed live: a worker hit `max_tokens` while emitting `spawn_subagent` calls. A later `send()` on the same agent crashed with the 400 above and aborted the run. Both tool ids — one fully formed, one partial — appeared in the error even though only one call was complete.