### PR TITLE
Stop the AI flow when a worker or reviewer turn is incomplete

### DIFF
--- a/ddev/src/ddev/ai/agent/exceptions.py
+++ b/ddev/src/ddev/ai/agent/exceptions.py
@@ -2,9 +2,25 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ddev.ai.agent.types import StopReason
+
 
 class AgentError(Exception):
     """Base class for all errors raised by an agent."""
+
+
+class IncompleteResponseError(AgentError):
+    """A turn that was required to complete ended without END_TURN
+    (e.g. truncated by max_tokens, or an abnormal stop reason)."""
+
+    def __init__(self, message: str, *, stop_reason: StopReason):
+        super().__init__(message)
+        self.stop_reason = stop_reason
 
 
 class AgentConnectionError(AgentError):

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -208,7 +208,7 @@ class AgenticPhase(Phase):
         process: ReActProcess,
         prompt: str,
     ) -> ReActResult:
-        result = await process.start(prompt)
+        result = await process.start(prompt, require_complete=True)
         self._add_tokens(result.total_input_tokens, result.total_output_tokens)
         return result
 

--- a/ddev/src/ddev/ai/phases/goal.py
+++ b/ddev/src/ddev/ai/phases/goal.py
@@ -164,13 +164,13 @@ async def _run_reviewer_once(
     On parse failure, ask the reviewer once more for valid JSON. If that
     second response still does not parse, raise GoalParseError.
     """
-    result = await reviewer_process.start(user_message)
+    result = await reviewer_process.start(user_message, require_complete=True)
     in_tokens = result.total_input_tokens
     out_tokens = result.total_output_tokens
 
     parsed = parse_reviewer_output(result.final_response.text or "")
     if parsed is None:
-        retry_result = await reviewer_process.start(GOAL_PARSE_RETRY_PROMPT)
+        retry_result = await reviewer_process.start(GOAL_PARSE_RETRY_PROMPT, require_complete=True)
         in_tokens += retry_result.total_input_tokens
         out_tokens += retry_result.total_output_tokens
         parsed = parse_reviewer_output(retry_result.final_response.text or "")
@@ -240,7 +240,7 @@ async def _drive_goal_loop(
             total_out += compact_out
 
             retry_prompt = GOAL_RETRY_PROMPT_TEMPLATE.format(goal=goal_text, reason=check.reason)
-            worker_result = await worker_process.start(retry_prompt)
+            worker_result = await worker_process.start(retry_prompt, require_complete=True)
             total_in += worker_result.total_input_tokens
             total_out += worker_result.total_output_tokens
     except GoalValidationError as e:

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -5,7 +5,7 @@
 import asyncio
 
 from ddev.ai.agent.build import AgentRuntime
-from ddev.ai.agent.exceptions import AgentError
+from ddev.ai.agent.exceptions import AgentError, IncompleteResponseError
 from ddev.ai.agent.scope import AgentScope
 from ddev.ai.agent.types import AgentResponse, StopReason, ToolResultMessage
 from ddev.ai.callbacks.callbacks import Callbacks
@@ -77,18 +77,27 @@ class ReActProcess:
             return False
         return True
 
-    async def start(self, prompt: str, allowed_tools: list[str] | None = None) -> ReActResult:
+    async def start(
+        self,
+        prompt: str,
+        allowed_tools: list[str] | None = None,
+        *,
+        require_complete: bool = False,
+    ) -> ReActResult:
         """
         Run the ReAct loop for a single task.
 
         Args:
             prompt: The initial user prompt to send to the agent.
             allowed_tools: Optional subset of tools the agent may call in this run. None means all.
+            require_complete: If True, raise IncompleteResponseError when the terminal stop reason
+                is not END_TURN.
 
         Returns:
             A ReActResult summarising the final response, token counts, and iteration count.
 
         Raises:
+            IncompleteResponseError: If require_complete is True and the turn did not end cleanly.
             Every exception is forwarded after notifying callbacks.
         """
         try:
@@ -139,6 +148,13 @@ class ReActProcess:
                     compact_in, compact_out = await self.compact(response)
                     total_input += compact_in
                     total_output += compact_out
+
+            if require_complete and response.stop_reason != StopReason.END_TURN:
+                raise IncompleteResponseError(
+                    f"{self._scope.owner_id} finished with stop_reason="
+                    f"{response.stop_reason.value!r} (expected END_TURN); the turn is incomplete.",
+                    stop_reason=response.stop_reason,
+                )
 
             react_result = ReActResult(
                 final_response=response,

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from ddev.ai.agent.build import AgentRuntime
+from ddev.ai.agent.exceptions import IncompleteResponseError
 from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.agent.types import AgentResponse, StopReason, TokenUsage, ToolCall
 from ddev.ai.callbacks.callbacks import Callbacks
@@ -852,3 +853,36 @@ async def test_goal_parse_error_logged_and_tokens_captured(flow_dir, monkeypatch
     assert phase._goal_attempt_log == [{"task": "t1", "attempts": 1, "final_valid": False}]
     assert phase._total_input_tokens == 10 + 8 + 6
     assert phase._total_output_tokens == 5 + 4 + 3
+
+
+# ---------------------------------------------------------------------------
+# Incomplete turn — worker initial turn raises before goal validation
+# ---------------------------------------------------------------------------
+
+
+async def test_worker_initial_max_tokens_raises_before_goal_validation(flow_dir, monkeypatch, message_queue):
+    """A worker turn truncated by MAX_TOKENS raises IncompleteResponseError; goal validation is never entered."""
+    goal_builder_calls: list = []
+
+    def goal_builder(owner_id: str) -> AgentRuntime:
+        goal_builder_calls.append(owner_id)
+        return AgentRuntime(agent=MockAgent([]), tool_registry=ToolRegistry([]))
+
+    worker = MockAgent(
+        [make_response("partial work", stop_reason=StopReason.MAX_TOKENS, input_tokens=10, output_tokens=5)]
+    )
+    phase, mgr = make_agent_phase(
+        flow_dir,
+        worker,
+        monkeypatch,
+        message_queue,
+        tasks=[TaskConfig(name="t1", prompt="Do it.", goal="verify it")],
+        goal_runtime_builder=goal_builder,
+    )
+
+    with pytest.raises(IncompleteResponseError) as exc_info:
+        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert exc_info.value.stop_reason == StopReason.MAX_TOKENS
+    assert goal_builder_calls == [], "goal validation must not be entered after an incomplete worker turn"
+    assert mgr.read() == {}

--- a/ddev/tests/ai/phases/test_goal.py
+++ b/ddev/tests/ai/phases/test_goal.py
@@ -7,7 +7,9 @@ import json
 import pytest
 
 from ddev.ai.agent.build import AgentRuntime
+from ddev.ai.agent.exceptions import IncompleteResponseError
 from ddev.ai.agent.scope import AgentRole, AgentScope
+from ddev.ai.agent.types import StopReason
 from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
 from ddev.ai.phases.config import AgentConfig, TaskConfig
 from ddev.ai.phases.goal import (
@@ -380,6 +382,68 @@ async def test_run_goal_loop_parse_retry_fails_raises(tmp_path):
     err = exc_info.value
     assert err.input_tokens == 5 + 7
     assert err.output_tokens == 3 + 4
+
+
+async def test_run_goal_loop_reviewer_max_tokens_raises(tmp_path):
+    worker_process, _ = _make_worker_process([])
+    initial_result = ReActResult(
+        final_response=make_response("done"),
+        iterations=1,
+        total_input_tokens=0,
+        total_output_tokens=0,
+        context_usage=None,
+    )
+    factory, _, _ = _reviewer_factory(
+        [make_response("partial", stop_reason=StopReason.MAX_TOKENS, input_tokens=5, output_tokens=3)]
+    )
+
+    with pytest.raises(IncompleteResponseError) as exc_info:
+        await run_goal_loop(
+            task=TaskConfig(name="t1", prompt="x", goal="g"),
+            goal_text="g",
+            rendered_task_prompt="TASK",
+            worker_process=worker_process,
+            initial_result=initial_result,
+            parent_agent_config=AgentConfig(tools=[]),
+            process_factory=factory,
+            callbacks=Callbacks(),
+            phase_id="p1",
+            compact_if_needed=_noop_compact,
+        )
+
+    assert exc_info.value.stop_reason == StopReason.MAX_TOKENS
+
+
+async def test_run_goal_loop_worker_retry_max_tokens_raises(tmp_path):
+    worker_process, _ = _make_worker_process(
+        [make_response("truncated retry", stop_reason=StopReason.MAX_TOKENS, input_tokens=10, output_tokens=5)]
+    )
+    initial_result = ReActResult(
+        final_response=make_response("initial work"),
+        iterations=1,
+        total_input_tokens=0,
+        total_output_tokens=0,
+        context_usage=None,
+    )
+    factory, _, _ = _reviewer_factory(
+        [make_response('{"valid": false, "reason": "fix something"}', input_tokens=5, output_tokens=3)]
+    )
+
+    with pytest.raises(IncompleteResponseError) as exc_info:
+        await run_goal_loop(
+            task=TaskConfig(name="t1", prompt="x", goal="g"),
+            goal_text="g",
+            rendered_task_prompt="TASK",
+            worker_process=worker_process,
+            initial_result=initial_result,
+            parent_agent_config=AgentConfig(tools=[]),
+            process_factory=factory,
+            callbacks=Callbacks(),
+            phase_id="p1",
+            compact_if_needed=_noop_compact,
+        )
+
+    assert exc_info.value.stop_reason == StopReason.MAX_TOKENS
 
 
 async def test_run_goal_loop_fires_callbacks(tmp_path):

--- a/ddev/tests/ai/react/test_process.py
+++ b/ddev/tests/ai/react/test_process.py
@@ -9,7 +9,7 @@ import pytest
 
 from ddev.ai.agent.base import BaseAgent
 from ddev.ai.agent.build import AgentRuntime
-from ddev.ai.agent.exceptions import AgentConnectionError
+from ddev.ai.agent.exceptions import AgentConnectionError, IncompleteResponseError
 from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.agent.types import AgentResponse, ContextUsage, StopReason, TokenUsage, ToolCall, ToolResultMessage
 from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
@@ -724,3 +724,40 @@ async def test_auto_compact_tokens_included_in_result() -> None:
 
     assert result.total_input_tokens == 100 + 200 + 30
     assert result.total_output_tokens == 50 + 80 + 10
+
+
+# ---------------------------------------------------------------------------
+# require_complete flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("stop_reason", [StopReason.MAX_TOKENS, StopReason.OTHER])
+async def test_require_complete_raises_on_incomplete_stop_reason(stop_reason: StopReason) -> None:
+    agent = MockAgent([make_response(stop_reason)])
+    recorder = CallbackRecorder()
+
+    with pytest.raises(IncompleteResponseError) as exc_info:
+        await make_process(agent, callbacks=Callbacks([recorder.callback_set])).start("Hi", require_complete=True)
+
+    assert exc_info.value.stop_reason == stop_reason
+    assert stop_reason.value in str(exc_info.value)
+    assert len(recorder.errors) == 1
+    assert isinstance(recorder.errors[0], IncompleteResponseError)
+    assert len(recorder.complete_results) == 0
+
+
+async def test_require_complete_returns_normally_on_end_turn() -> None:
+    agent = MockAgent([make_response(StopReason.END_TURN)])
+
+    result = await make_process(agent).start("Hi", require_complete=True)
+
+    assert result.final_response.stop_reason == StopReason.END_TURN
+    assert result.iterations == 1
+
+
+async def test_require_complete_false_does_not_raise_on_max_tokens() -> None:
+    agent = MockAgent([make_response(StopReason.MAX_TOKENS)])
+
+    result = await make_process(agent).start("Hi", require_complete=False)
+
+    assert result.final_response.stop_reason == StopReason.MAX_TOKENS


### PR DESCRIPTION
### What does this PR do?

Adds an `IncompleteResponseError` exception and a `require_complete` flag to `ReActProcess.start()`. When `require_complete=True`, the method raises if the terminal stop reason is anything other than `END_TURN` (i.e. `MAX_TOKENS` or `OTHER`). The flag is opted in at the worker and reviewer call sites in `AgenticPhase._start_task`, `_run_reviewer_once`, and the worker-retry path in `_drive_goal_loop`. Subagents and the memory step are deliberately left on the default `require_complete=False`.

### Motivation

During a demo run, a worker agent hit `max_tokens` mid-task — its output was cut off. Because `AgenticPhase` ignored the stop reason, the truncated result was handed straight to the goal reviewer. The reviewer (correctly) rejected the incomplete work, and the retry path then crashed the run.

The root issue is that a truncated turn is not a valid basis for goal validation or for advancing the flow — the model wanted to produce more output and was stopped. Rather than silently proceeding into the reviewer with half-finished work, we now fail fast with a clear, deliberate error.

Subagents keep their existing soft behavior (`[SUBAGENT HIT MAX_TOKENS — RESPONSE MAY BE TRUNCATED]` prefix) because a truncated subagent is a localized, recoverable degradation, not a reason to abort the whole run.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged