### PR TITLE
Fix typo and type for pulsar.broker_lookup.quantile in metadata.csv

### DIFF
--- a/pulsar/changelog.d/24258.fixed
+++ b/pulsar/changelog.d/24258.fixed
@@ -1,1 +1,0 @@
-Fix typo and metric type for pulsar.broker_lookup.quantile in metadata.csv.

--- a/pulsar/changelog.d/24258.fixed
+++ b/pulsar/changelog.d/24258.fixed
@@ -1,0 +1,1 @@
+Fix typo and metric type for pulsar.broker_lookup.quantile in metadata.csv.

--- a/pulsar/metadata.csv
+++ b/pulsar/metadata.csv
@@ -30,7 +30,7 @@ pulsar.brk_ml_cursor_writeLedgerLogicalSize,gauge,,,,The size of write to ledger
 pulsar.brk_ml_cursor_writeLedgerSize,gauge,,,,The size of write to ledger.,0,pulsar,,
 pulsar.broker_load_manager_bundle_assignment,gauge,,,,The summary of latency of bundles ownership operations.,0,pulsar,,
 pulsar.broker_lookup.count,count,,,,Number of samples of the latency of all lookup operations.,0,pulsar,,
-pulsar.broker_lookup.quantile,gauge,,,,Latency of all lookup operations.,0,pulsar,,
+pulsar.broker_lookup.quantile,gauge,,,,Latency of all lookup operations by `quantile`.,0,pulsar,,
 pulsar.broker_lookup.sum,count,,,,Total latency of all lookup operations.,0,pulsar,,
 pulsar.broker_lookup_answers.count,count,,response,,The number of lookup responses (i.e. not redirected requests).,0,pulsar,,
 pulsar.broker_lookup_failures.count,count,,,,The number of lookup failures.,0,pulsar,,

--- a/pulsar/metadata.csv
+++ b/pulsar/metadata.csv
@@ -30,7 +30,7 @@ pulsar.brk_ml_cursor_writeLedgerLogicalSize,gauge,,,,The size of write to ledger
 pulsar.brk_ml_cursor_writeLedgerSize,gauge,,,,The size of write to ledger.,0,pulsar,,
 pulsar.broker_load_manager_bundle_assignment,gauge,,,,The summary of latency of bundles ownership operations.,0,pulsar,,
 pulsar.broker_lookup.count,count,,,,Number of samples of the latency of all lookup operations.,0,pulsar,,
-pulsar.broker_lookup.quantle,count,,,,Latency of all lookup operations.,0,pulsar,,
+pulsar.broker_lookup.quantile,gauge,,,,Latency of all lookup operations.,0,pulsar,,
 pulsar.broker_lookup.sum,count,,,,Total latency of all lookup operations.,0,pulsar,,
 pulsar.broker_lookup_answers.count,count,,response,,The number of lookup responses (i.e. not redirected requests).,0,pulsar,,
 pulsar.broker_lookup_failures.count,count,,,,The number of lookup failures.,0,pulsar,,


### PR DESCRIPTION
### What does this PR do?

Fixes two pre-existing bugs on line 33 of `pulsar/metadata.csv`:

- **Typo**: `pulsar.broker_lookup.quantle` → `pulsar.broker_lookup.quantile` (missing `i`)
- **Wrong type**: `count` → `gauge` (summary quantiles are submitted as gauge by the OpenMetrics transformer, see `datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transformers/summary.py`)

### Motivation

The typo was introduced in the original Pulsar integration and went undetected because `test_check` does not use `assert_metrics_using_metadata`. It was discovered while adding config discovery support (#24116), where `test_e2e_discovery` calls `assert_metrics_using_metadata` and fails whenever Pulsar emits the quantile metric during the CI run.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] `qa/skip-qa`