### PR TITLE
Fix Kafka Connect collection crash on null info/status sections

### DIFF
--- a/kafka_consumer/changelog.d/24261.fixed
+++ b/kafka_consumer/changelog.d/24261.fixed
@@ -1,0 +1,1 @@
+Fix a crash in Kafka Connect collection when a connector returns a null info or status section.

--- a/kafka_consumer/datadog_checks/kafka_consumer/connectors.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/connectors.py
@@ -193,8 +193,8 @@ class KafkaConnectCollector:
 
     def _emit_connector_metrics(self, connectors_data: dict[str, Any], tags_base: list[str]) -> None:
         for name, data in connectors_data.items():
-            info = data.get('info', {})
-            status = data.get('status', {})
+            info = data.get('info') or {}
+            status = data.get('status') or {}
 
             connector_type = info.get('type', 'unknown')
             full_class = (info.get('config') or {}).get('connector.class', '')
@@ -230,8 +230,8 @@ class KafkaConnectCollector:
         connector_contents: dict[str, str] = {}
 
         for name, data in connectors_data.items():
-            info = data.get('info', {})
-            status = data.get('status', {})
+            info = data.get('info') or {}
+            status = data.get('status') or {}
 
             connector_type = info.get('type', 'unknown')
             connector_state = (status.get('connector') or {}).get('state', 'UNKNOWN')

--- a/kafka_consumer/tests/test_connectors.py
+++ b/kafka_consumer/tests/test_connectors.py
@@ -183,6 +183,37 @@ def test_legacy_worker_list_response_skipped(run_connect_check, aggregator):
     assert dsm_events(aggregator, 'connector') == []
 
 
+def test_null_info_or_status_sections_do_not_crash_collection(run_connect_check, aggregator):
+    # Some Connect REST implementations (e.g. connectors mid-provisioning or the Confluent Cloud
+    # managed Connect API) return an explicit null for the info or status section. dict.get with a
+    # default only fills missing keys, not keys set to null, so these must be handled gracefully.
+    connectors = {
+        'null-info': {
+            'info': None,
+            'status': {'connector': {'state': 'RUNNING'}, 'tasks': []},
+        },
+        'null-status': {
+            'info': {'type': 'sink', 'config': {'connector.class': 'io.confluent.SomeSink'}},
+            'status': None,
+        },
+    }
+    run_connect_check(connectors_response=connectors)
+
+    aggregator.assert_metric('kafka.connector.count', value=2)
+
+    null_info = metrics_with_tag(aggregator, 'kafka.connector.task.count', 'connector:null-info')
+    assert null_info, "connector with null info section should still be reported"
+    assert 'connector_type:unknown' in null_info[0].tags
+
+    null_status = metrics_with_tag(aggregator, 'kafka.connector.task.count', 'connector:null-status')
+    assert null_status, "connector with null status section should still be reported"
+    assert 'connector_state:unknown' in null_status[0].tags
+
+    events = dsm_events(aggregator, 'connector')
+    null_status_event = next(event for event in events if event['connector'] == 'null-status')
+    assert null_status_event['connector_state'] == 'UNKNOWN'
+
+
 def test_collection_survives_corrupt_cache(run_connect_check, aggregator):
     def corrupt(key):
         return 'not-valid-json' if 'connector' in key else ''


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in the Kafka Connect collection path of the `kafka_consumer` integration when a Connect REST response returns a connector whose `info` or `status` section is an explicit JSON `null`.

The collector parses `/connectors?expand=info&expand=status` and, in both `_emit_connector_metrics` and `_emit_connector_config_events`, did:

```python
info = data.get('info', {})
status = data.get('status', {})
```

`dict.get('info', {})` only returns the `{}` default when the key is **absent**. When the key is present with a value of `null`, `.get` returns `None`, and the following `info.get('type', ...)` / `(status.get('connector') or {})` raised `AttributeError: 'NoneType' object has no attribute 'get'`. That exception propagated out of `_collect_rest`, aborting connector collection for the affected endpoint and surfacing as a check error.

The fix coalesces a null section to `{}` so it is treated the same as a missing one:

```python
info = data.get('info') or {}
status = data.get('status') or {}
```

The connector is then still counted and reported with default/`unknown` values instead of crashing the whole collection.

### Motivation

Some Connect REST implementations and proxies legitimately return null sections. Real-world sources include connectors mid-provisioning (whose config/status isn't available yet) and the Confluent Cloud managed Connect REST API, which can return `"info": null` or `"status": null` when only one `expand` value is honored. In these cases a single connector with a null section would take down the entire connector collection for that endpoint, dropping `kafka.connector.*` metrics for all connectors on it.

This is a minimal, targeted fix: it only coalesces the null sections to `{}`. It does not introduce any multi-call/expand fallback logic.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
