### PR TITLE
Parse the goal reviewer verdict from the last line of its reply

### DIFF
--- a/ddev/src/ddev/ai/phases/goal.py
+++ b/ddev/src/ddev/ai/phases/goal.py
@@ -38,11 +38,15 @@ How to work:
 - Be specific in your reasoning. Vague rejections are useless to the worker.
 
 Output contract:
-- Reply with ONLY a JSON object as your final response, with no surrounding prose
-  and no markdown code fences.
+- End your reply with the verdict as a single-line JSON object on the LAST line,
+  with nothing after it.
+- That final line must be valid JSON on one line, with no markdown code fences
+  and not split across multiple lines.
 - Schema: {"valid": <bool>, "reason": <string>}.
 - "reason" must be specific and actionable when "valid" is false.
 - "reason" may be an empty string when "valid" is true.
+- You may write your reasoning as prose before that final line; only the last
+  line is read as the verdict.
 """
 
 GOAL_TASK_SUFFIX = """
@@ -68,9 +72,9 @@ why clearly in your final summary (do not silently ignore it).
 """
 
 GOAL_PARSE_RETRY_PROMPT = (
-    "Your previous reply was not a valid JSON object matching the schema "
-    '{"valid": <bool>, "reason": <string>}. Reply with only that JSON object, '
-    "with no surrounding prose and no markdown code fences."
+    "Your previous reply did not end with a valid JSON verdict. End your reply with a "
+    'single-line JSON object as the LAST line: {"valid": <bool>, "reason": <string>}, '
+    "with no markdown code fences and nothing after it."
 )
 
 
@@ -134,9 +138,9 @@ def build_reviewer_user_message(
     )
 
 
-def parse_reviewer_output(text: str) -> tuple[bool, str] | None:
-    """Return (valid, reason) if text parses; None if it does not."""
-    stripped = text.strip()
+def _parse_verdict(candidate: str) -> tuple[bool, str] | None:
+    """Parse a single candidate string into (valid, reason); None if it does not match the schema."""
+    stripped = candidate.strip()
     if stripped.startswith("```"):
         stripped = stripped.strip("`")
         if stripped.lower().startswith("json"):
@@ -153,6 +157,28 @@ def parse_reviewer_output(text: str) -> tuple[bool, str] | None:
     if not isinstance(valid, bool) or not isinstance(reason, str):
         return None
     return valid, reason
+
+
+def parse_reviewer_output(text: str) -> tuple[bool, str] | None:
+    """Return (valid, reason) from the reviewer's verdict; None if it does not parse.
+
+    The reviewer is instructed to emit the verdict as a single-line JSON object on the
+    last line of its reply, so we parse that last non-empty line first and ignore any
+    preceding prose. As a fallback we also try the whole reply, which covers a reviewer
+    that returns only the JSON object (possibly pretty-printed across several lines).
+    """
+    candidates: list[str] = []
+    non_empty_lines = [line for line in text.splitlines() if line.strip()]
+    if non_empty_lines:
+        candidates.append(non_empty_lines[-1])
+    whole = text.strip()
+    if whole and whole not in candidates:
+        candidates.append(whole)
+    for candidate in candidates:
+        parsed = _parse_verdict(candidate)
+        if parsed is not None:
+            return parsed
+    return None
 
 
 async def _run_reviewer_once(

--- a/ddev/tests/ai/phases/test_goal.py
+++ b/ddev/tests/ai/phases/test_goal.py
@@ -39,8 +39,26 @@ from .conftest import MockAgent, make_response, resolve_key
         ('  {"valid": true, "reason": "ok"}  ', (True, "ok")),
         ('```json\n{"valid": true, "reason": ""}\n```', (True, "")),
         ('```\n{"valid": false, "reason": "no"}\n```', (False, "no")),
+        (
+            'I read every file and verified the prefix.\nEverything checks out.\n{"valid": true, "reason": ""}',
+            (True, ""),
+        ),
+        (
+            'Detailed reasoning across\nseveral lines of prose.\n{"valid": false, "reason": "missing metric x"}\n',
+            (False, "missing metric x"),
+        ),
+        ('{\n  "valid": true,\n  "reason": "ok"\n}', (True, "ok")),
     ],
-    ids=["plain_true", "plain_false", "whitespace", "fenced_json", "fenced_plain"],
+    ids=[
+        "plain_true",
+        "plain_false",
+        "whitespace",
+        "fenced_json",
+        "fenced_plain",
+        "prose_then_verdict_line",
+        "multiline_prose_then_verdict_line",
+        "pretty_printed_pure_json",
+    ],
 )
 def test_parse_reviewer_output_accepts(text, expected):
     assert parse_reviewer_output(text) == expected


### PR DESCRIPTION
### What does this PR do?

Parses the goal reviewer's verdict from the **last line** of its reply instead of requiring the entire reply to be a bare JSON object.

The reviewer agent commonly writes its reasoning as prose and then emits the `{"valid": ..., "reason": ...}` verdict at the end. `parse_reviewer_output` previously ran `json.loads()` on the whole reply, which failed whenever any prose preceded the JSON. That failure triggered an extra "reply with only JSON" parse-retry turn on nearly every check — wasted tokens and latency.

Changes:
- `parse_reviewer_output` now reads the last non-empty line as the verdict, falling back to the whole reply (covers a pure-JSON or pretty-printed response).
- The reviewer system prompt and the parse-retry prompt now instruct the agent to emit the verdict as a single-line JSON object on the last line, with prose allowed before it.

### Motivation

The goal reviewer was failing JSON parsing and re-running on essentially every check, because its natural output is "reasoning, then verdict". Reading just the final line matches how the model actually responds and removes the spurious retries.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
