### PR TITLE
[DBMON-6786] Bump minimum datadog-checks-base to 37.41.0 for DBM integrations

### DIFF
--- a/clickhouse/changelog.d/24267.added
+++ b/clickhouse/changelog.d/24267.added
@@ -1,0 +1,1 @@
+Bump the minimum supported version of `datadog-checks-base` to 37.41.0.

--- a/clickhouse/pyproject.toml
+++ b/clickhouse/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.39.1",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/mongo/changelog.d/24267.added
+++ b/mongo/changelog.d/24267.added
@@ -1,0 +1,1 @@
+Bump the minimum supported version of `datadog-checks-base` to 37.41.0.

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.39.1",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/mysql/changelog.d/24267.added
+++ b/mysql/changelog.d/24267.added
@@ -1,0 +1,1 @@
+Bump the minimum supported version of `datadog-checks-base` to 37.41.0.

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.39.1",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/postgres/changelog.d/24267.added
+++ b/postgres/changelog.d/24267.added
@@ -1,0 +1,1 @@
+Bump the minimum supported version of `datadog-checks-base` to 37.41.0.

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.39.1",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/sqlserver/changelog.d/24267.added
+++ b/sqlserver/changelog.d/24267.added
@@ -1,0 +1,1 @@
+Bump the minimum supported version of `datadog-checks-base` to 37.41.0.

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.39.1",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
Bumps the minimum `datadog-checks-base` package in DBM integrations Clickhouse, Mongo, Mysql, Postgres, SqlServer to 37.41.0

### Motivation
This is pre-requisite work for us to consolidate duplicate logic across these integrations into the base `DatabaseCheck` class.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
