### PR TITLE
[DBMON-6787] Remove duplicated agent_hostname logic from clickhouse

### DIFF
--- a/clickhouse/changelog.d/24268.fixed
+++ b/clickhouse/changelog.d/24268.fixed
@@ -1,0 +1,1 @@
+Remove duplicated agent_hostname logic now provided by the DatabaseCheck base class.

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -59,7 +59,6 @@ class ClickhouseCheck(DatabaseCheck):
         self._resolved_hostname = None
         self._database_hostname = None
         self._database_identifier = None
-        self._agent_hostname = None
         self._dbms_version = None
 
         # Track last emission time for database instance metadata (rate limiting)
@@ -359,13 +358,6 @@ class ClickhouseCheck(DatabaseCheck):
         if self._database_hostname is None:
             self._database_hostname = resolve_db_host(self._config.server)
         return self._database_hostname
-
-    @property
-    def agent_hostname(self):
-        """Get the agent hostname."""
-        if self._agent_hostname is None:
-            self._agent_hostname = datadog_agent.get_hostname()
-        return self._agent_hostname
 
     @property
     def database_identifier(self) -> str:


### PR DESCRIPTION
### What does this PR do?
Removes the duplicated `agent_hostname` property from the `clickhouse` check now that it is implemented on the shared `DatabaseCheck` base class (#24243). The minimum `datadog-checks-base` requirement already includes the base implementation.

### Motivation
Support work for simplifying and unifying database check logic across DBM integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)