### PR TITLE
[DBMON-6787] Remove duplicated agent_hostname logic from mysql

### DIFF
--- a/mysql/changelog.d/24269.fixed
+++ b/mysql/changelog.d/24269.fixed
@@ -1,0 +1,1 @@
+Remove duplicated agent_hostname logic now provided by the DatabaseCheck base class.

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -121,7 +121,6 @@ class MySql(DatabaseCheck):
         self.cluster_uuid = None
         self._resolved_hostname = None
         self._database_identifier = None
-        self._agent_hostname = None
         self._database_hostname = None
         self._events_wait_current_enabled = None
         self._group_replication_active = None
@@ -246,13 +245,6 @@ class MySql(DatabaseCheck):
             tag_dict['mysql_sock'] = str(self._config.mysql_sock)
             self._database_identifier = template.safe_substitute(**tag_dict)
         return self._database_identifier
-
-    @property
-    def agent_hostname(self):
-        # type: () -> str
-        if self._agent_hostname is None:
-            self._agent_hostname = datadog_agent.get_hostname()
-        return self._agent_hostname
 
     @property
     def database_hostname(self):


### PR DESCRIPTION
### What does this PR do?
Removes the duplicated `agent_hostname` property from the `mysql` check now that it is implemented on the shared `DatabaseCheck` base class (#24243). The minimum `datadog-checks-base` requirement already includes the base implementation.

### Motivation
Support work for simplifying and unifying database check logic across DBM integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)