### PR TITLE
[DBMON-6787] Remove duplicated agent_hostname logic from postgres

### DIFF
--- a/postgres/changelog.d/24270.fixed
+++ b/postgres/changelog.d/24270.fixed
@@ -1,0 +1,1 @@
+Remove duplicated agent_hostname logic now provided by the DatabaseCheck base class.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -121,7 +121,6 @@ class PostgreSql(DatabaseCheck):
         self.health = PostgresHealth(self)
         self._resolved_hostname = None
         self._database_identifier = None
-        self._agent_hostname = None
         self._database_hostname = None
         self._db = None
         self._cloud_metadata: dict[str, dict] = None
@@ -736,13 +735,6 @@ class PostgreSql(DatabaseCheck):
         sets the check_id after initialization has completed.
         """
         self.set_metadata('resolved_hostname', self._resolved_hostname)
-
-    @property
-    def agent_hostname(self):
-        # type: () -> str
-        if self._agent_hostname is None:
-            self._agent_hostname = datadog_agent.get_hostname()
-        return self._agent_hostname
 
     @property
     def database_hostname(self):


### PR DESCRIPTION
### What does this PR do?
Removes the duplicated `agent_hostname` property from the `postgres` check now that it is implemented on the shared `DatabaseCheck` base class (#24243). The minimum `datadog-checks-base` requirement already includes the base implementation.

### Motivation
Support work for simplifying and unifying database check logic across DBM integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)