### PR TITLE
[DBMON-6787] Remove duplicated agent_hostname logic from sqlserver

### DIFF
--- a/sqlserver/changelog.d/24271.fixed
+++ b/sqlserver/changelog.d/24271.fixed
@@ -1,0 +1,1 @@
+Remove duplicated agent_hostname logic now provided by the DatabaseCheck base class.

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -146,7 +146,6 @@ class SQLServer(DatabaseCheck):
         )
 
         self._resolved_hostname = None
-        self._agent_hostname = None
         self._database_hostname = None
         self._database_identifier = None
         self._connection = None
@@ -503,13 +502,6 @@ class SQLServer(DatabaseCheck):
             "hostname": self.reported_hostname,
             "raw": True,
         }
-
-    @property
-    def agent_hostname(self):
-        # type: () -> str
-        if self._agent_hostname is None:
-            self._agent_hostname = datadog_agent.get_hostname()
-        return self._agent_hostname
 
     @property
     def connection(self):


### PR DESCRIPTION
### What does this PR do?
Removes the duplicated `agent_hostname` property from the `sqlserver` check now that it is implemented on the shared `DatabaseCheck` base class (#24243). The minimum `datadog-checks-base` requirement already includes the base implementation.

### Motivation
Support work for simplifying and unifying database check logic across DBM integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)