### PR TITLE
[DBMON-6788] Remove duplicated tags logic from clickhouse

### DIFF
--- a/clickhouse/changelog.d/24272.fixed
+++ b/clickhouse/changelog.d/24272.fixed
@@ -1,0 +1,1 @@
+Remove duplicated tags logic now provided by the DatabaseCheck base class.

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -10,7 +10,7 @@ from clickhouse_connect.driver import httputil
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.db import DatabaseCheck
 from datadog_checks.base.utils.db import QueryManager
-from datadog_checks.base.utils.db.utils import TagManager, default_json_event_encoding, resolve_db_host
+from datadog_checks.base.utils.db.utils import default_json_event_encoding, resolve_db_host
 from datadog_checks.base.utils.serialization import json
 
 from . import advanced_queries, queries, utils
@@ -65,8 +65,6 @@ class ClickhouseCheck(DatabaseCheck):
         # Track last emission time for database instance metadata (rate limiting)
         self._database_instance_last_emitted = 0
 
-        # Initialize TagManager for tag management (similar to MySQL)
-        self.tag_manager = TagManager()
         self.tag_manager.set_tags_from_list(self._config.tags, replace=True)
         self._add_core_tags()
 
@@ -142,11 +140,6 @@ class ClickhouseCheck(DatabaseCheck):
             self.parts_and_merges = ClickhousePartsAndMerges(self, self._config.parts_and_merges)
         else:
             self.parts_and_merges = None
-
-    @property
-    def tags(self) -> list[str]:
-        """Return the current list of tags from the TagManager."""
-        return list(self.tag_manager.get_tags())
 
     def _add_core_tags(self):
         """


### PR DESCRIPTION
### What does this PR do?
Removes the duplicated `tags` property from the `clickhouse` check now that it is implemented on the shared `DatabaseCheck` base class (#24244). Also drops the redundant `TagManager` instantiation, which the base class now provides. The minimum `datadog-checks-base` requirement already includes the base implementation.

### Motivation
Support work for simplifying and unifying database check logic across DBM integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)