### PR TITLE
[DBMON-6788] Remove duplicated tags logic from mysql

### DIFF
--- a/mysql/changelog.d/24273.fixed
+++ b/mysql/changelog.d/24273.fixed
@@ -1,0 +1,1 @@
+Remove duplicated tags logic now provided by the DatabaseCheck base class.

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -19,7 +19,6 @@ from datadog_checks.base import AgentCheck, DatabaseCheck, is_affirmative
 from datadog_checks.base.utils.db import QueryExecutor, QueryManager
 from datadog_checks.base.utils.db.health import HealthEvent, HealthStatus
 from datadog_checks.base.utils.db.utils import (
-    TagManager,
     default_json_event_encoding,
     tracked_query,
 )
@@ -128,7 +127,6 @@ class MySql(DatabaseCheck):
         self._replication_role = None
         self._initialized_at = int(time.time() * 1000)
         self._config = MySQLConfig(self.instance, init_config)
-        self.tag_manager = TagManager()
         self.tag_manager.set_tags_from_list(self._config.tags, replace=True)  # Initialize from static config tags
         self.add_core_tags()
         self._cloud_metadata = self._config.cloud_metadata
@@ -198,10 +196,6 @@ class MySql(DatabaseCheck):
         self.set_metadata('version', self.version.version + '+' + self.version.build)
         self.set_metadata('flavor', self.version.flavor)
         self.set_metadata('resolved_hostname', self.resolved_hostname)
-
-    @property
-    def tags(self):
-        return self.tag_manager.get_tags()
 
     @property
     def reported_hostname(self):


### PR DESCRIPTION
### What does this PR do?
Removes the duplicated `tags` property from the `mysql` check now that it is implemented on the shared `DatabaseCheck` base class (#24244). Also drops the redundant `TagManager` instantiation, which the base class now provides. The minimum `datadog-checks-base` requirement already includes the base implementation.

### Motivation
Support work for simplifying and unifying database check logic across DBM integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)