### PR TITLE
[DBMON-6788] Remove duplicated tags logic from sqlserver

### DIFF
--- a/sqlserver/changelog.d/24274.fixed
+++ b/sqlserver/changelog.d/24274.fixed
@@ -1,0 +1,1 @@
+Remove duplicated tags logic now provided by the DatabaseCheck base class.

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -338,10 +338,6 @@ class SQLServer(DatabaseCheck):
         return agent_host_resolver(self.host)
 
     @property
-    def tags(self):
-        return self.tag_manager.get_tags()
-
-    @property
     def cloud_metadata(self):
         return self._cloud_metadata
 


### PR DESCRIPTION
### What does this PR do?
Removes the duplicated `tags` property from the `sqlserver` check now that it is implemented on the shared `DatabaseCheck` base class (#24244). The check's `TagManager` instantiation is retained because it uses a custom normalizer. The minimum `datadog-checks-base` requirement already includes the base implementation.

### Motivation
Support work for simplifying and unifying database check logic across DBM integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)