### PR TITLE
[DBMON-6789] Implement database_identifier hooks in mysql

### DIFF
--- a/mysql/changelog.d/24277.fixed
+++ b/mysql/changelog.d/24277.fixed
@@ -1,0 +1,1 @@
+Remove duplicated database_identifier logic now provided by the DatabaseCheck base class.

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -9,7 +9,6 @@ import time
 import traceback
 from collections import defaultdict
 from contextlib import closing, contextmanager
-from string import Template
 from typing import Any, Dict, List, Optional  # noqa: F401
 
 import pymysql
@@ -120,7 +119,6 @@ class MySql(DatabaseCheck):
         self.server_uuid = None
         self.cluster_uuid = None
         self._resolved_hostname = None
-        self._database_identifier = None
         self._database_hostname = None
         self._events_wait_current_enabled = None
         self._group_replication_active = None
@@ -224,27 +222,17 @@ class MySql(DatabaseCheck):
         return self._cloud_metadata
 
     @property
-    def database_identifier(self):
-        # type: () -> str
-        if self._database_identifier is None:
-            template = Template(self._config.database_identifier.get('template') or '$resolved_hostname')
-            tag_dict = {}
-            tags = self.tag_manager.get_tags()
-            # sort tags to ensure consistent ordering
-            tags.sort()
-            for t in tags:
-                if ':' in t:
-                    key, value = t.split(':', 1)
-                    if key in tag_dict:
-                        tag_dict[key] += f",{value}"
-                    else:
-                        tag_dict[key] = value
-            tag_dict['resolved_hostname'] = self.resolved_hostname
-            tag_dict['host'] = str(self._config.host)
-            tag_dict['port'] = str(self._config.port)
-            tag_dict['mysql_sock'] = str(self._config.mysql_sock)
-            self._database_identifier = template.safe_substitute(**tag_dict)
-        return self._database_identifier
+    def database_identifier_template(self) -> str:
+        return self._config.database_identifier.get('template') or '$resolved_hostname'
+
+    @property
+    def database_identifier_params(self) -> dict:
+        return {
+            'resolved_hostname': self.resolved_hostname,
+            'host': str(self._config.host),
+            'port': str(self._config.port),
+            'mysql_sock': str(self._config.mysql_sock),
+        }
 
     @property
     def database_hostname(self):


### PR DESCRIPTION
### What does this PR do?
Replaces the hand-rolled `database_identifier` property in the `mysql` check with the `database_identifier_template` and `database_identifier_params` hooks now provided by the shared `DatabaseCheck` base class (#24250). The base class owns the caching and templating, so this removes the duplicated tag-loop / `Template.safe_substitute` logic. Behavior is unchanged. The minimum `datadog-checks-base` requirement already includes the base implementation.

### Motivation
Support work for simplifying and unifying database check logic across DBM integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)