### PR TITLE
[DBMON-6789] Implement database_identifier hooks in postgres

### DIFF
--- a/postgres/changelog.d/24278.fixed
+++ b/postgres/changelog.d/24278.fixed
@@ -1,0 +1,1 @@
+Remove duplicated database_identifier logic now provided by the DatabaseCheck base class.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -6,7 +6,6 @@ import copy
 import functools
 import os
 import threading
-from string import Template
 from time import time
 
 import psycopg
@@ -120,7 +119,6 @@ class PostgreSql(DatabaseCheck):
         super(PostgreSql, self).__init__(name, init_config, instances)
         self.health = PostgresHealth(self)
         self._resolved_hostname = None
-        self._database_identifier = None
         self._database_hostname = None
         self._db = None
         self._cloud_metadata: dict[str, dict] = None
@@ -696,26 +694,16 @@ class PostgreSql(DatabaseCheck):
         return self._resolved_hostname
 
     @property
-    def database_identifier(self):
-        # type: () -> str
-        if self._database_identifier is None:
-            template = Template(self._config.database_identifier.template)
-            tag_dict = {}
-            tags = self.tags.copy()
-            # sort tags to ensure consistent ordering
-            tags.sort()
-            for t in tags:
-                if ':' in t:
-                    key, value = t.split(':', 1)
-                    if key in tag_dict:
-                        tag_dict[key] += f",{value}"
-                    else:
-                        tag_dict[key] = value
-            tag_dict['resolved_hostname'] = self.resolved_hostname
-            tag_dict['host'] = str(self._config.host)
-            tag_dict['port'] = str(self._config.port)
-            self._database_identifier = template.safe_substitute(**tag_dict)
-        return self._database_identifier
+    def database_identifier_template(self) -> str:
+        return self._config.database_identifier.template
+
+    @property
+    def database_identifier_params(self) -> dict:
+        return {
+            'resolved_hostname': self.resolved_hostname,
+            'host': str(self._config.host),
+            'port': str(self._config.port),
+        }
 
     @property
     def cloud_metadata(self):


### PR DESCRIPTION
### What does this PR do?
Replaces the hand-rolled `database_identifier` property in the `postgres` check with the `database_identifier_template` and `database_identifier_params` hooks now provided by the shared `DatabaseCheck` base class (#24250). The base class owns the caching and templating, so this removes the duplicated tag-loop / `Template.safe_substitute` logic. Behavior is unchanged. The minimum `datadog-checks-base` requirement already includes the base implementation.

### Motivation
Support work for simplifying and unifying database check logic across DBM integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)