### PR TITLE
[DBMON-6789] Implement database_identifier hooks in sqlserver

### DIFF
--- a/sqlserver/changelog.d/24279.fixed
+++ b/sqlserver/changelog.d/24279.fixed
@@ -1,0 +1,1 @@
+Remove duplicated database_identifier logic now provided by the DatabaseCheck base class.

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -7,7 +7,6 @@ from __future__ import division
 import functools
 import time
 from collections import defaultdict
-from string import Template
 
 from cachetools import TTLCache
 
@@ -147,7 +146,6 @@ class SQLServer(DatabaseCheck):
 
         self._resolved_hostname = None
         self._database_hostname = None
-        self._database_identifier = None
         self._connection = None
         self.failed_connections = {}
         self.instance_metrics = []
@@ -362,38 +360,28 @@ class SQLServer(DatabaseCheck):
         return self._resolved_hostname
 
     @property
-    def database_identifier(self):
-        # type: () -> str
-        if self._database_identifier is None:
-            template = Template(self._config.database_identifier.get('template') or '$resolved_hostname')
-            # Copy self.tag_manager._tags and map values to single values instead of lists
-            tag_dict = {}
-            tags = self.tag_manager.get_tags()
-            # sort tags to ensure consistent ordering
-            tags.sort()
-            for t in tags:
-                if ':' in t:
-                    key, value = t.split(':', 1)
-                    if key in tag_dict:
-                        tag_dict[key] += f",{value}"
-                    else:
-                        tag_dict[key] = value
-            tag_dict['resolved_hostname'] = self.resolved_hostname
-            tag_dict['host'] = str(self.host)
-            tag_dict['port'] = str(self.port) if self.port is not None else None
-            database = self.instance.get('database', self.connection.DEFAULT_DATABASE if self.connection else None)
-            if database is not None:
-                tag_dict['database'] = database
-            if self.resolved_hostname.endswith(AZURE_SERVER_SUFFIX):
-                tag_dict['azure_name'] = self.resolved_hostname[: -len(AZURE_SERVER_SUFFIX)]
-            if self.static_info_cache.get(STATIC_INFO_SERVERNAME) is not None:
-                tag_dict['server_name'] = self.static_info_cache.get(STATIC_INFO_SERVERNAME)
-            if self.static_info_cache.get(STATIC_INFO_INSTANCENAME) is not None:
-                tag_dict['instance_name'] = self.static_info_cache.get(STATIC_INFO_INSTANCENAME)
-            if self.static_info_cache.get(STATIC_INFO_FULL_SERVERNAME) is not None:
-                tag_dict['full_server_name'] = self.static_info_cache.get(STATIC_INFO_FULL_SERVERNAME)
-            self._database_identifier = template.safe_substitute(**tag_dict)
-        return self._database_identifier
+    def database_identifier_template(self) -> str:
+        return self._config.database_identifier.get('template') or '$resolved_hostname'
+
+    @property
+    def database_identifier_params(self) -> dict:
+        params = {
+            'resolved_hostname': self.resolved_hostname,
+            'host': str(self.host),
+            'port': str(self.port) if self.port is not None else None,
+        }
+        database = self.instance.get('database', self.connection.DEFAULT_DATABASE if self.connection else None)
+        if database is not None:
+            params['database'] = database
+        if self.resolved_hostname.endswith(AZURE_SERVER_SUFFIX):
+            params['azure_name'] = self.resolved_hostname[: -len(AZURE_SERVER_SUFFIX)]
+        if self.static_info_cache.get(STATIC_INFO_SERVERNAME) is not None:
+            params['server_name'] = self.static_info_cache.get(STATIC_INFO_SERVERNAME)
+        if self.static_info_cache.get(STATIC_INFO_INSTANCENAME) is not None:
+            params['instance_name'] = self.static_info_cache.get(STATIC_INFO_INSTANCENAME)
+        if self.static_info_cache.get(STATIC_INFO_FULL_SERVERNAME) is not None:
+            params['full_server_name'] = self.static_info_cache.get(STATIC_INFO_FULL_SERVERNAME)
+        return params
 
     @property
     def database_hostname(self):


### PR DESCRIPTION
### What does this PR do?
Replaces the hand-rolled `database_identifier` property in the `sqlserver` check with the `database_identifier_template` and `database_identifier_params` hooks now provided by the shared `DatabaseCheck` base class (#24250). The base class owns the caching and templating, so this removes the duplicated tag-loop / `Template.safe_substitute` logic while preserving the SQL Server-specific connection params (database, Azure name, server/instance/full server name). Behavior is unchanged. The minimum `datadog-checks-base` requirement already includes the base implementation.

### Motivation
Support work for simplifying and unifying database check logic across DBM integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)