### PR TITLE
Notify Slack when a release is pending approval

### DIFF
--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -62,6 +62,30 @@ jobs:
             echo "is-stable-release=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # TODO: this notification currently runs before the approval gate, so it
+  # announces a *pending* release. Once the `release` environment gate is removed
+  # the release starts immediately — switch `needs` back to the release step and
+  # update the wording in notify_slack.py to "release starting".
+  notify:
+    name: Notify pending release
+    needs: context
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout notification script
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          sparse-checkout: .github/workflows/scripts
+      - name: Notify Slack of pending release
+        env:
+          SLACK_API_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_AGENT_INTEGRATIONS_RELEASE }}
+          SOURCE_REPO: integrations-core
+          REF: ${{ github.event_name == 'workflow_dispatch' && inputs.source-repo-ref || github.sha }}
+          PACKAGES: ${{ inputs.packages || '' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: python3 .github/workflows/scripts/notify_slack.py
+
   approve:
     name: Await release approval
     needs: context

--- a/.github/workflows/scripts/notify_slack.py
+++ b/.github/workflows/scripts/notify_slack.py
@@ -1,0 +1,64 @@
+"""Post a 'wheel release starting' Slack notification via chat.postMessage.
+
+Env: SLACK_API_TOKEN, SLACK_CHANNEL_ID (both required or no-op), SOURCE_REPO,
+REF, PACKAGES, RUN_URL. Slack/network errors warn and never fail the job.
+"""
+import json
+import os
+import urllib.error
+import urllib.request
+
+SLACK_URL = "https://slack.com/api/chat.postMessage"
+
+
+def build_text(source_repo: str, ref: str, packages: str, run_url: str) -> str:
+    """Return the release notification Slack message body."""
+    # TODO: this fires before the approval gate, so the release is pending. Once
+    # the `release` environment gate is removed, reword to "Wheel release starting"
+    # with a "View release run" link, since the release will start immediately.
+    return (
+        f":hourglass_flowing_sand: *Wheel release pending approval* — `{source_repo}`\n"
+        f"• ref: `{ref[:12] or '—'}`\n"
+        f"• packages: {packages.strip() or 'auto-detect from tags at HEAD'}\n"
+        f"• <{run_url}|Review &amp; approve →>"
+    )
+
+
+def post(token: str, channel: str, text: str) -> None:
+    """Post *text* to *channel*, warning (not failing) on error."""
+    data = json.dumps({"channel": channel, "text": text, "unfurl_links": False}).encode()
+    request = urllib.request.Request(
+        SLACK_URL,
+        data=data,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json; charset=utf-8"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            body = json.loads(response.read())
+    except (urllib.error.URLError, TimeoutError, ValueError) as e:
+        print(f"::warning::Slack request failed: {e}")
+        return
+    if not body.get("ok"):
+        print(f"::warning::Slack notification failed: {body.get('error', 'unknown error')}")
+
+
+def main() -> None:
+    token = os.environ.get("SLACK_API_TOKEN", "").strip()
+    channel = os.environ.get("SLACK_CHANNEL_ID", "").strip()
+    if not token or not channel:
+        print("Slack token or channel not configured; skipping notification.")
+        return
+    post(
+        token,
+        channel,
+        build_text(
+            os.environ.get("SOURCE_REPO", "integrations-core"),
+            os.environ.get("REF", ""),
+            os.environ.get("PACKAGES", ""),
+            os.environ.get("RUN_URL", ""),
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/tests/test_notify_slack.py
+++ b/.github/workflows/scripts/tests/test_notify_slack.py
@@ -1,0 +1,41 @@
+"""Tests for notify_slack."""
+import urllib.error
+from unittest.mock import patch
+
+import notify_slack
+
+
+def test_build_text_lists_packages():
+    text = notify_slack.build_text("integrations-core", "abcdef1234567890", '["postgres"]', "http://run")
+    assert "pending approval" in text
+    assert '["postgres"]' in text
+    assert "`abcdef123456`" in text
+    assert "http://run" in text
+
+
+def test_build_text_auto_detect_and_dash_ref():
+    text = notify_slack.build_text("marketplace", "", "", "http://run")
+    assert "auto-detect from tags at HEAD" in text
+    assert "ref: `—`" in text
+
+
+def test_main_no_op_without_config(monkeypatch):
+    monkeypatch.delenv("SLACK_API_TOKEN", raising=False)
+    monkeypatch.setenv("SLACK_CHANNEL_ID", "C1")
+    with patch.object(notify_slack, "post") as post:
+        notify_slack.main()
+    post.assert_not_called()
+
+
+def test_main_posts_when_configured(monkeypatch):
+    monkeypatch.setenv("SLACK_API_TOKEN", "xoxb")
+    monkeypatch.setenv("SLACK_CHANNEL_ID", "C1")
+    with patch.object(notify_slack, "post") as post:
+        notify_slack.main()
+    post.assert_called_once()
+
+
+def test_post_warns_on_error(capsys):
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("boom")):
+        notify_slack.post("token", "C1", "hi")
+    assert "failed" in capsys.readouterr().out


### PR DESCRIPTION
### What does this PR do?

Adds a Slack notification when a release is triggered. A `notify` job in `release-trigger.yml` runs before the approval gate and posts (via `scripts/notify_slack.py`) that a release is pending approval, with the ref, packages, and a run link. It reuses the existing `SLACK_API_TOKEN` secret and the `SLACK_CHANNEL_ID_AGENT_INTEGRATIONS_RELEASE` channel secret, is a no-op when unconfigured, and never fails the release on Slack errors. A TODO notes the wording should switch to "release starting" once the approval gate is removed.

### Motivation

The approval gate is going away, making releases fully automatic; this keeps us aware when a release is happening once there is no human checkpoint.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
