### PR TITLE
Change display priority of postgres and mysql to keep only most important fields on top

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -70,7 +70,7 @@ files:
               type: string
 
           - name: dbm
-            display_priority: 2
+            display_priority: 0
             fleet_configurable: true
             description: |
               Set to `true` to enable Database Monitoring.
@@ -1023,7 +1023,7 @@ files:
                   tags:
                     - test:mysql
                   metric_prefix: mysql
-              custom_queries.display_priority: 1
+              custom_queries.display_priority: 0
           - template: instances/default
             overrides:
               disable_generic_tags.hidden: false
@@ -1032,7 +1032,7 @@ files:
                 Replaces generic tag such as `server` with `mysql_server` to avoid getting it mixed with
                 other integrations tags.
 
-              tags.display_priority: 3
+              tags.display_priority: 0
       - template: logs
         example:
           - type: file

--- a/mysql/changelog.d/24287.fixed
+++ b/mysql/changelog.d/24287.fixed
@@ -1,0 +1,1 @@
+Change display priority of postgres and mysql to keep only most important fields on top

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -52,79 +52,10 @@ instances:
     #
     password: <PASSWORD>
 
-    ## @param tags - list of strings - optional
-    ## A list of tags to attach to every metric and service check emitted by this instance.
-    ##
-    ## Learn more about tagging at https://docs.datadoghq.com/tagging
-    #
-    # tags:
-    #   - <KEY_1>:<VALUE_1>
-    #   - <KEY_2>:<VALUE_2>
-
     ## @param dbm - boolean - optional - default: false
     ## Set to `true` to enable Database Monitoring.
     #
     # dbm: false
-
-    ## @param custom_queries - list of mappings - optional
-    ## Each query must have 2 fields, and can have a third optional field:
-    ##
-    ## 1. query - The SQL to execute. It can be a simple statement or a multi-line script.
-    ##     Use the pipe `|` if you require a multi-line script.
-    ## 2. columns - The list representing each column, ordered sequentially from left to right.
-    ##     The number of columns must equal the number of columns returned in the query.
-    ##     There are 2 required pieces of data:
-    ##       1. name - The suffix to append to `<INTEGRATION>.` to form
-    ##           the full metric name. If `type` is a `tag` type, this column is considered a tag and applied
-    ##           to every metric collected by this particular query.
-    ##       2. type - The submission method (gauge, monotonic_count, etc.).
-    ##           This can also be set to the following `tag` types to tag each metric in the row with the name
-    ##           and value of the item in this column:
-    ##             1. tag - This is the default tag type
-    ##             2. tag_list - This allows multiple values to be attached to the tag name. For example: 
-    ##                 ```
-    ##                 query = {
-    ##                   "name": "example",
-    ##                   "query": "...",
-    ##                   "columns": [
-    ##                     {"name": "server_tag", "type": "tag_list"},
-    ##                     {"name": "foo", "type": "gauge"},
-    ##                   ]
-    ##                 }
-    ##                 ```
-    ##                 May result in:
-    ##                 ```
-    ##                 gauge("foo", tags=["server_tag:us", "server_tag:primary", "server_tag:default"])
-    ##                 gauge("foo", tags=["server_tag:eu"])
-    ##                 gauge("foo", tags=["server_tag:eu", "server_tag:primary"])
-    ##                 ```
-    ##             3. tag_not_null - This only sets tags in the metric if the value is not null
-    ##           You can use the `count` type to perform aggregation for queries that return multiple rows with
-    ##           the same or no tags.
-    ##     Columns without a name are ignored. To skip a column, enter:
-    ##     ```
-    ##       - {}
-    ##     ```
-    ## 3. tags (optional) - A list of tags to apply to each metric.
-    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##     If collection_interval is not set, the query will be run every check run.
-    ##     If the collection interval is less than check collection interval, the query will be run every check
-    ##     run.
-    ##     If the collection interval is greater than check collection interval, the query will NOT BE RUN
-    ##     exactly at the collection interval.
-    ##     The query will be run at the next check run after the collection interval has passed.
-    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
-    #
-    # custom_queries:
-    #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
-    #     columns:
-    #     - name: foo
-    #       type: tag
-    #     - name: event.total
-    #       type: gauge
-    #     tags:
-    #     - test:mysql
-    #     metric_prefix: mysql
 
     ## @param propagate_agent_tags - boolean - optional - default: false
     ## Set to `true` to propagate the tags from `datadog.yaml` to the check.
@@ -783,6 +714,75 @@ instances:
     ## 3. extend - `global_custom_queries` are used in addition to any `custom_queries`.
     #
     # use_global_custom_queries: 'true'
+
+    ## @param custom_queries - list of mappings - optional
+    ## Each query must have 2 fields, and can have a third optional field:
+    ##
+    ## 1. query - The SQL to execute. It can be a simple statement or a multi-line script.
+    ##     Use the pipe `|` if you require a multi-line script.
+    ## 2. columns - The list representing each column, ordered sequentially from left to right.
+    ##     The number of columns must equal the number of columns returned in the query.
+    ##     There are 2 required pieces of data:
+    ##       1. name - The suffix to append to `<INTEGRATION>.` to form
+    ##           the full metric name. If `type` is a `tag` type, this column is considered a tag and applied
+    ##           to every metric collected by this particular query.
+    ##       2. type - The submission method (gauge, monotonic_count, etc.).
+    ##           This can also be set to the following `tag` types to tag each metric in the row with the name
+    ##           and value of the item in this column:
+    ##             1. tag - This is the default tag type
+    ##             2. tag_list - This allows multiple values to be attached to the tag name. For example: 
+    ##                 ```
+    ##                 query = {
+    ##                   "name": "example",
+    ##                   "query": "...",
+    ##                   "columns": [
+    ##                     {"name": "server_tag", "type": "tag_list"},
+    ##                     {"name": "foo", "type": "gauge"},
+    ##                   ]
+    ##                 }
+    ##                 ```
+    ##                 May result in:
+    ##                 ```
+    ##                 gauge("foo", tags=["server_tag:us", "server_tag:primary", "server_tag:default"])
+    ##                 gauge("foo", tags=["server_tag:eu"])
+    ##                 gauge("foo", tags=["server_tag:eu", "server_tag:primary"])
+    ##                 ```
+    ##             3. tag_not_null - This only sets tags in the metric if the value is not null
+    ##           You can use the `count` type to perform aggregation for queries that return multiple rows with
+    ##           the same or no tags.
+    ##     Columns without a name are ignored. To skip a column, enter:
+    ##     ```
+    ##       - {}
+    ##     ```
+    ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, the query will be run every check
+    ##     run.
+    ##     If the collection interval is greater than check collection interval, the query will NOT BE RUN
+    ##     exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
+    #
+    # custom_queries:
+    #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
+    #     columns:
+    #     - name: foo
+    #       type: tag
+    #     - name: event.total
+    #       type: gauge
+    #     tags:
+    #     - test:mysql
+    #     metric_prefix: mysql
+
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>
 
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -49,7 +49,7 @@ files:
       value:
         type: string
     - name: dbname
-      display_priority: 19
+      display_priority: 0
       description: |
         The name of the PostgreSQL database to monitor.
         Note: If omitted, the default system Postgres database is queried.
@@ -58,7 +58,7 @@ files:
         type: string
         display_default: postgres
     - name: dbm
-      display_priority: 18
+      display_priority: 0
       fleet_configurable: true
       description: |
         Set to `true` to enable Database Monitoring.
@@ -67,7 +67,7 @@ files:
         example: false
         display_default: false
     - name: relations
-      display_priority: 17
+      display_priority: 0
       fleet_configurable: true
       description: |
         The list of relations/tables must be specified here to track per-relation (table, index, view, etc.) metrics.
@@ -129,7 +129,7 @@ files:
               - r
               - p
     - name: collect_activity_metrics
-      display_priority: 15
+      display_priority: 0
       fleet_configurable: true
       description: |
         Collect metrics regarding transactions from pg_stat_activity. Please make sure the user
@@ -138,7 +138,7 @@ files:
         type: boolean
         example: false
     - name: collect_function_metrics
-      display_priority: 14
+      display_priority: 0
       fleet_configurable: true
       description: |
         If set to true, collects metrics regarding PL/pgSQL functions from pg_stat_user_functions.
@@ -146,14 +146,14 @@ files:
         type: boolean
         example: false
     - name: collect_database_size_metrics
-      display_priority: 13
+      display_priority: 0
       fleet_configurable: true
       description: Collect database size metrics.
       value:
         type: boolean
         example: true
     - name: collect_bloat_metrics
-      display_priority: 12
+      display_priority: 0
       fleet_configurable: true
       description: Collect metrics about table bloat. Only available when `relation` metrics are enabled.
       enabled: true
@@ -161,7 +161,7 @@ files:
         type: boolean
         example: false
     - name: tag_replication_role
-      display_priority: 10
+      display_priority: 0
       fleet_configurable: true
       hidden: true
       description: Tag metrics and checks with `replication_role:<master|standby>`.
@@ -169,21 +169,21 @@ files:
         type: boolean
         example: true
     - name: collect_count_metrics
-      display_priority: 9
+      display_priority: 0
       fleet_configurable: true
       description: Collect count of user tables from pg_class.
       value:
         type: boolean
         example: true
     - name: max_relations
-      display_priority: 8
+      display_priority: 0
       fleet_configurable: true
       description: Determines the maximum number of relations to fetch.
       value:
         type: integer
         example: 300
     - name: ssl
-      display_priority: 7
+      display_priority: 0
       description: |
         This option determines whether or not and with what priority a secure SSL TCP/IP connection
         is negotiated with the server.
@@ -206,14 +206,14 @@ files:
         example: 'allow'
         default: 'allow'
     - name: collect_default_database
-      display_priority: 4
+      display_priority: 0
       fleet_configurable: true
       description: Include statistics from the default database 'postgres' in the check metrics.
       value:
         type: boolean
         example: true
     - name: query_timeout
-      display_priority: 3
+      display_priority: 0
       fleet_configurable: true
       description: |
         Adds a statement_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STATEMENT-TIMEOUT
@@ -224,7 +224,7 @@ files:
         type: integer
         example: 5000
     - name: reported_hostname
-      display_priority: 2
+      display_priority: 0
       description: |
         Set the reported hostname for this instance. This value overrides the hostname detected by the Agent
         and can be useful to set a custom hostname when connecting to a remote database through a proxy.
@@ -233,7 +233,7 @@ files:
         type: string
         default: null
     - name: ignore_databases
-      display_priority: 1
+      display_priority: 0
       fleet_configurable: true
       description: |
         A list of databases to ignore. No metrics or statement samples will be collected for these databases.
@@ -1628,16 +1628,16 @@ files:
             tags:
               - test:postgresql
             metric_prefix: postgresql
-        custom_queries.display_priority: 16
+        custom_queries.display_priority: 0
     - template: instances/default
       overrides:
         disable_generic_tags.hidden: False
         disable_generic_tags.enabled: True
         disable_generic_tags.description: The integration will stop sending server tag as is reduntant with host tag
-        tags.display_priority: 20
-        min_collection_interval.display_priority: 11
-        disable_generic_tags.display_priority: 6
-        empty_default_hostname.display_priority: 5
+        tags.display_priority: 0
+        min_collection_interval.display_priority: 0
+        disable_generic_tags.display_priority: 0
+        empty_default_hostname.display_priority: 0
   - template: logs
     example:
     - type: file

--- a/postgres/changelog.d/24287.fixed
+++ b/postgres/changelog.d/24287.fixed
@@ -1,0 +1,1 @@
+Change display priority of postgres and mysql to keep only most important fields on top

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -53,15 +53,6 @@ instances:
     #
     # password: <PASSWORD>
 
-    ## @param tags - list of strings - optional
-    ## A list of tags to attach to every metric and service check emitted by this instance.
-    ##
-    ## Learn more about tagging at https://docs.datadoghq.com/tagging
-    #
-    # tags:
-    #   - <KEY_1>:<VALUE_1>
-    #   - <KEY_2>:<VALUE_2>
-
     ## @param dbname - string - optional - default: postgres
     ## The name of the PostgreSQL database to monitor.
     ## Note: If omitted, the default system Postgres database is queried.
@@ -112,66 +103,6 @@ instances:
     #     - r
     #     - p
 
-    ## @param custom_queries - list of mappings - optional
-    ## Each query must have 2 fields, and can have a third optional field:
-    ##
-    ## 1. query - The SQL to execute. It can be a simple statement or a multi-line script.
-    ##     Use the pipe `|` if you require a multi-line script.
-    ## 2. columns - The list representing each column, ordered sequentially from left to right.
-    ##     The number of columns must equal the number of columns returned in the query.
-    ##     There are 2 required pieces of data:
-    ##       1. name - The suffix to append to `<INTEGRATION>.` to form
-    ##           the full metric name. If `type` is a `tag` type, this column is considered a tag and applied
-    ##           to every metric collected by this particular query.
-    ##       2. type - The submission method (gauge, monotonic_count, etc.).
-    ##           This can also be set to the following `tag` types to tag each metric in the row with the name
-    ##           and value of the item in this column:
-    ##             1. tag - This is the default tag type
-    ##             2. tag_list - This allows multiple values to be attached to the tag name. For example: 
-    ##                 ```
-    ##                 query = {
-    ##                   "name": "example",
-    ##                   "query": "...",
-    ##                   "columns": [
-    ##                     {"name": "server_tag", "type": "tag_list"},
-    ##                     {"name": "foo", "type": "gauge"},
-    ##                   ]
-    ##                 }
-    ##                 ```
-    ##                 May result in:
-    ##                 ```
-    ##                 gauge("foo", tags=["server_tag:us", "server_tag:primary", "server_tag:default"])
-    ##                 gauge("foo", tags=["server_tag:eu"])
-    ##                 gauge("foo", tags=["server_tag:eu", "server_tag:primary"])
-    ##                 ```
-    ##             3. tag_not_null - This only sets tags in the metric if the value is not null
-    ##           You can use the `count` type to perform aggregation for queries that return multiple rows with
-    ##           the same or no tags.
-    ##     Columns without a name are ignored. To skip a column, enter:
-    ##     ```
-    ##       - {}
-    ##     ```
-    ## 3. tags (optional) - A list of tags to apply to each metric.
-    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
-    ##     If collection_interval is not set, the query will be run every check run.
-    ##     If the collection interval is less than check collection interval, the query will be run every check
-    ##     run.
-    ##     If the collection interval is greater than check collection interval, the query will NOT BE RUN
-    ##     exactly at the collection interval.
-    ##     The query will be run at the next check run after the collection interval has passed.
-    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
-    #
-    # custom_queries:
-    #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
-    #     columns:
-    #     - name: foo
-    #       type: tag
-    #     - name: event.total
-    #       type: gauge
-    #     tags:
-    #     - test:postgresql
-    #     metric_prefix: postgresql
-
     ## @param collect_activity_metrics - boolean - optional - default: false
     ## Collect metrics regarding transactions from pg_stat_activity. Please make sure the user
     ## has sufficient privileges to read from pg_stat_activity before enabling this option.
@@ -192,12 +123,6 @@ instances:
     ## Collect metrics about table bloat. Only available when `relation` metrics are enabled.
     #
     collect_bloat_metrics: false
-
-    ## @param min_collection_interval - number - optional - default: 15
-    ## This changes the collection interval of the check. For more information, see:
-    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
-    #
-    # min_collection_interval: 15
 
     ## @param collect_count_metrics - boolean - optional - default: true
     ## Collect count of user tables from pg_class.
@@ -227,18 +152,6 @@ instances:
     ## For a detailed description of how these options work see https://www.postgresql.org/docs/current/libpq-ssl.html
     #
     # ssl: allow
-
-    ## @param disable_generic_tags - boolean - optional - default: false
-    ## The integration will stop sending server tag as is reduntant with host tag
-    #
-    disable_generic_tags: true
-
-    ## @param empty_default_hostname - boolean - optional - default: false
-    ## This forces the check to send metrics with no hostname.
-    ##
-    ## This is useful for cluster-level checks.
-    #
-    # empty_default_hostname: false
 
     ## @param collect_default_database - boolean - optional - default: true
     ## Include statistics from the default database 'postgres' in the check metrics.
@@ -1002,12 +915,99 @@ instances:
     #
     # use_global_custom_queries: 'true'
 
+    ## @param custom_queries - list of mappings - optional
+    ## Each query must have 2 fields, and can have a third optional field:
+    ##
+    ## 1. query - The SQL to execute. It can be a simple statement or a multi-line script.
+    ##     Use the pipe `|` if you require a multi-line script.
+    ## 2. columns - The list representing each column, ordered sequentially from left to right.
+    ##     The number of columns must equal the number of columns returned in the query.
+    ##     There are 2 required pieces of data:
+    ##       1. name - The suffix to append to `<INTEGRATION>.` to form
+    ##           the full metric name. If `type` is a `tag` type, this column is considered a tag and applied
+    ##           to every metric collected by this particular query.
+    ##       2. type - The submission method (gauge, monotonic_count, etc.).
+    ##           This can also be set to the following `tag` types to tag each metric in the row with the name
+    ##           and value of the item in this column:
+    ##             1. tag - This is the default tag type
+    ##             2. tag_list - This allows multiple values to be attached to the tag name. For example: 
+    ##                 ```
+    ##                 query = {
+    ##                   "name": "example",
+    ##                   "query": "...",
+    ##                   "columns": [
+    ##                     {"name": "server_tag", "type": "tag_list"},
+    ##                     {"name": "foo", "type": "gauge"},
+    ##                   ]
+    ##                 }
+    ##                 ```
+    ##                 May result in:
+    ##                 ```
+    ##                 gauge("foo", tags=["server_tag:us", "server_tag:primary", "server_tag:default"])
+    ##                 gauge("foo", tags=["server_tag:eu"])
+    ##                 gauge("foo", tags=["server_tag:eu", "server_tag:primary"])
+    ##                 ```
+    ##             3. tag_not_null - This only sets tags in the metric if the value is not null
+    ##           You can use the `count` type to perform aggregation for queries that return multiple rows with
+    ##           the same or no tags.
+    ##     Columns without a name are ignored. To skip a column, enter:
+    ##     ```
+    ##       - {}
+    ##     ```
+    ## 3. tags (optional) - A list of tags to apply to each metric.
+    ## 4. collection_interval (optional) - The frequency at which to collect the metrics.
+    ##     If collection_interval is not set, the query will be run every check run.
+    ##     If the collection interval is less than check collection interval, the query will be run every check
+    ##     run.
+    ##     If the collection interval is greater than check collection interval, the query will NOT BE RUN
+    ##     exactly at the collection interval.
+    ##     The query will be run at the next check run after the collection interval has passed.
+    ## 5. metric_prefix (optional) - The prefix to apply to each metric.
+    #
+    # custom_queries:
+    #   - query: SELECT foo, COUNT(*) FROM table.events GROUP BY foo
+    #     columns:
+    #     - name: foo
+    #       type: tag
+    #     - name: event.total
+    #       type: gauge
+    #     tags:
+    #     - test:postgresql
+    #     metric_prefix: postgresql
+
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>
+
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
     ##
     ## Overrides any `service` defined in the `init_config` section.
     #
     # service: <SERVICE>
+
+    ## @param min_collection_interval - number - optional - default: 15
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    # min_collection_interval: 15
+
+    ## @param empty_default_hostname - boolean - optional - default: false
+    ## This forces the check to send metrics with no hostname.
+    ##
+    ## This is useful for cluster-level checks.
+    #
+    # empty_default_hostname: false
+
+    ## @param disable_generic_tags - boolean - optional - default: false
+    ## The integration will stop sending server tag as is reduntant with host tag
+    #
+    disable_generic_tags: true
 
     ## @param metric_patterns - mapping - optional
     ## A mapping of metrics to include or exclude, with each entry being a regular expression.


### PR DESCRIPTION
### What does this PR do?

Adjusts the `display_priority` values in the mysql and postgres configuration specs so that only the 4 most important fields (e.g. `host`, `post`, `user` and `password`) surface in the main form section, all other fields being moved in the the advanced section.

### Motivation

<img width="577" height="121" alt="image" src="https://github.com/user-attachments/assets/002eaeb4-94cc-40a3-b8a8-beb1cee9024e" />


The mysql and postgres integration had to many fields with strictly positive display priority, making the main section of the Fleet Automation form too long.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged