### PR TITLE
Add handling for explicit Postgres image tag for testing

### DIFF
--- a/postgres/hatch.toml
+++ b/postgres/hatch.toml
@@ -12,14 +12,14 @@ mypy-deps = [
 
 [[envs.default.matrix]]
 python = ["3.13"]
-version = ["9.6", "10.0", "11.0", "12.17", "13.0", "14.0", "15.0", "16.0", "17.0", "18.0"]
+version = ["9.6", "10.0", "11.0", "12.17", "13.0", "14.0", "15.0", "16.0", "17.0", "18.0", "19.0"]
 locale = ["UTF8"]
 
 
 # We only support SQLASCII encoding in 10+
 [[envs.default.matrix]]
 python = ["3.13"]
-version = ["10.0", "11.0", "12.17", "13.0", "14.0", "15.0", "16.0", "17.0", "18.0"]
+version = ["10.0", "11.0", "12.17", "13.0", "14.0", "15.0", "16.0", "17.0", "18.0", "19.0"]
 locale = ["C"]
 
 [envs.default.overrides]
@@ -33,6 +33,8 @@ matrix.version.env-vars = [
   { key = "POSTGRES_VERSION", value = "16", if = ["16.0"] },
   { key = "POSTGRES_VERSION", value = "17", if = ["17.0"] },
   { key = "POSTGRES_VERSION", value = "18", if = ["18.0"] },
+  { key = "POSTGRES_VERSION", value = "19", if = ["19.0"] },
+  { key = "POSTGRES_IMAGE_TAG", value = "19beta1", if = ["19.0"] },
 ]
 matrix.locale.env-vars = [
   { key = "POSTGRES_LOCALE", value = "C", if = ["C"] },

--- a/postgres/hatch.toml
+++ b/postgres/hatch.toml
@@ -12,14 +12,14 @@ mypy-deps = [
 
 [[envs.default.matrix]]
 python = ["3.13"]
-version = ["9.6", "10.0", "11.0", "12.17", "13.0", "14.0", "15.0", "16.0", "17.0", "18.0", "19.0"]
+version = ["9.6", "10.0", "11.0", "12.17", "13.0", "14.0", "15.0", "16.0", "17.0", "18.0"]
 locale = ["UTF8"]
 
 
 # We only support SQLASCII encoding in 10+
 [[envs.default.matrix]]
 python = ["3.13"]
-version = ["10.0", "11.0", "12.17", "13.0", "14.0", "15.0", "16.0", "17.0", "18.0", "19.0"]
+version = ["10.0", "11.0", "12.17", "13.0", "14.0", "15.0", "16.0", "17.0", "18.0"]
 locale = ["C"]
 
 [envs.default.overrides]
@@ -33,8 +33,6 @@ matrix.version.env-vars = [
   { key = "POSTGRES_VERSION", value = "16", if = ["16.0"] },
   { key = "POSTGRES_VERSION", value = "17", if = ["17.0"] },
   { key = "POSTGRES_VERSION", value = "18", if = ["18.0"] },
-  { key = "POSTGRES_VERSION", value = "19", if = ["19.0"] },
-  { key = "POSTGRES_IMAGE_TAG", value = "19beta1", if = ["19.0"] },
 ]
 matrix.locale.env-vars = [
   { key = "POSTGRES_LOCALE", value = "C", if = ["C"] },

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -46,13 +46,18 @@ DB_NAME = 'datadog_test'
 POSTGRES_VERSION = os.environ.get('POSTGRES_VERSION', None)
 POSTGRES_IMAGE = "alpine"
 POSTGRES_LOCALE = os.environ.get('POSTGRES_LOCALE', "UTF8")
+POSTGRES_IMAGE_TAG = os.environ.get('POSTGRES_IMAGE_TAG', None)
 
 REPLICA_CONTAINER_1_NAME = 'compose-postgres_replica-1'
 REPLICA_CONTAINER_2_NAME = 'compose-postgres_replica2-1'
 REPLICA_LOGICAL_1_NAME = 'compose-postgres_logical_replica-1'
 USING_LATEST = False
 
-if POSTGRES_VERSION is not None:
+print(f"POSTGRES_IMAGE_TAG: {POSTGRES_IMAGE_TAG}")
+print(f"POSTGRES_VERSION: {POSTGRES_VERSION}")
+if POSTGRES_IMAGE_TAG is not None:
+    POSTGRES_IMAGE = POSTGRES_IMAGE_TAG + "-alpine"
+elif POSTGRES_VERSION is not None:
     USING_LATEST = POSTGRES_VERSION.endswith('latest')
     POSTGRES_IMAGE = POSTGRES_VERSION + "-alpine"
 

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -53,8 +53,6 @@ REPLICA_CONTAINER_2_NAME = 'compose-postgres_replica2-1'
 REPLICA_LOGICAL_1_NAME = 'compose-postgres_logical_replica-1'
 USING_LATEST = False
 
-print(f"POSTGRES_IMAGE_TAG: {POSTGRES_IMAGE_TAG}")
-print(f"POSTGRES_VERSION: {POSTGRES_VERSION}")
 if POSTGRES_IMAGE_TAG is not None:
     POSTGRES_IMAGE = POSTGRES_IMAGE_TAG + "-alpine"
 elif POSTGRES_VERSION is not None:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds the ability to specify an explicit Docker tag for Postgres test versions.

### Motivation
<!-- What inspired you to submit this pull request? -->
Postgres tags beta versions with, e.g., `19beta` rather than just `19`. We want to be able to test support ahead of version releases.

Check the [initial commit](https://github.com/DataDog/integrations-core/pull/24291/commits/b7103186befa8c3cebbeecb16c698b075fbf5976) for an example.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
