### PR TITLE
[DBMON-6805] Add DBMS class attribute to DatabaseCheck

### DIFF
--- a/datadog_checks_base/changelog.d/24297.added
+++ b/datadog_checks_base/changelog.d/24297.added
@@ -1,0 +1,1 @@
+Add a `DBMS` class attribute to `DatabaseCheck` so integrations can declare their DBM platform identifier explicitly. The `dbms` property now returns `DBMS` when set and only falls back to the deprecated class-name derivation (with a warning) when it is not.

--- a/datadog_checks_base/datadog_checks/base/checks/db.py
+++ b/datadog_checks_base/datadog_checks/base/checks/db.py
@@ -12,10 +12,16 @@ from . import AgentCheck
 
 
 class DatabaseCheck(AgentCheck):
+    #: Authoritative DBM platform identifier for this integration.
+    #: Subclasses should set this explicitly; it is the value surfaced by
+    #: :attr:`dbms` and used across DBM payloads, metric name prefixes and async jobs.
+    DBMS: str | None = None
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._agent_hostname = None
         self._database_identifier = None
+        self._dbms_fallback_warning_logged = False
         self.tag_manager = TagManager()
 
     def database_monitoring_query_sample(self, raw_event: str):
@@ -110,6 +116,22 @@ class DatabaseCheck(AgentCheck):
 
     @property
     def dbms(self) -> str:
+        """
+        The DBM platform identifier for this integration.
+
+        Returns the :attr:`DBMS` class attribute when set. Integrations that have not yet declared
+        ``DBMS`` fall back to a deprecated derivation from the class name; that fallback is
+        unreliable (it only matches for some integrations) and will be removed in a future version.
+        """
+        if self.DBMS is not None:
+            return self.DBMS
+        if not self._dbms_fallback_warning_logged:
+            self.log.warning(
+                "%s does not set the `DBMS` class attribute; falling back to a name-derived value. "
+                "This fallback is deprecated and will be removed; set `DBMS` explicitly.",
+                type(self).__name__,
+            )
+            self._dbms_fallback_warning_logged = True
         return self.__class__.__name__.lower()
 
     @property


### PR DESCRIPTION
### What does this PR do?

Adds an explicit `DBMS` class attribute to the base `DatabaseCheck` class and makes the
`dbms` property prefer it:

- `DBMS: str | None = None` — the authoritative DBM platform identifier (e.g. `"postgres"`,
  `"sqlserver"`) that integrations declare on their check class.
- The `dbms` property returns `DBMS` when set, and otherwise falls back to the existing
  class-name derivation (`self.__class__.__name__.lower()`). The fallback now logs a one-time
  deprecation warning so integrations that haven't declared `DBMS` are easy to spot.

This is intentionally non-breaking: behavior is unchanged for any check that doesn't set
`DBMS`, so nothing regresses until integrations opt in.

### Motivation

The `dbms` value is the DBM platform identifier used across DBM event payloads, metric name
prefixes, and async jobs. Deriving it from the class name is unreliable — it only produces the
correct value for some integrations (e.g. `PostgreSql` → `postgresql` and `ClickhouseCheck` →
`clickhousecheck` are both wrong), which has already forced ad-hoc property overrides and a
sprawl of hardcoded `"dbms"` string literals throughout the DBM integrations.

This PR lays the groundwork to fix that: it introduces a single, explicit place for each
integration to declare its identifier. Follow-up PRs will set `DBMS` on each `DatabaseCheck`
subclass and route the scattered string literals through the `dbms` property, after which the
deprecated name-derivation fallback can be removed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged