### PR TITLE
ci: bump issue-triage-action to v1.0.1

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -17,8 +17,7 @@ jobs:
       contents: read
       issues: write
       actions: write
-      id-token: write
-    uses: DataDog/issue-triage-action/.github/workflows/issue-triage.yml@ee200860ba35ba6ed3ad565e918afb16811fe975 # v1.0.0
+    uses: DataDog/issue-triage-action/.github/workflows/issue-triage.yml@b39f0bc12abc52fe8aa70dc9b9353bf307a13219 # v1.0.1
     with:
       slack_map_path: .github/workflows/config/github_slack_map.yaml
       environment_name: issue-assigner


### PR DESCRIPTION
## What

Bump the reusable `DataDog/issue-triage-action` workflow used by issue assignment to the `v1.0.1` release commit.

Also removes the caller-side `id-token: write` permission, which is no longer needed by the reusable workflow.

## Why

`v1.0.1` includes the permission fix for issue-triggered triage from non-writer issue authors while keeping the LLM analysis job read-only.

## Validation

- Parsed `.github/workflows/assign-issue.yml` as YAML
- Ran `actionlint .github/workflows/assign-issue.yml`
- Ran `git diff --check`