### PR TITLE
[SCI2-5909] Apply OCSF style guide fixes to linux audit logs pipeline

### DIFF
--- a/linux_audit_logs/assets/logs/linux-audit-logs.yaml
+++ b/linux_audit_logs/assets/logs/linux-audit-logs.yaml
@@ -121,7 +121,7 @@ facets:
     source: log
   - groups:
       - OCSF
-    name: Device IP Address
+    name: Device IP
     path: ocsf.device.ip
     source: log
   - groups:
@@ -154,11 +154,13 @@ facets:
     name: Destination Endpoint Name
     path: ocsf.dst_endpoint.name
     source: log
-  - groups:
+  - facetType: range
+    groups:
       - OCSF
     name: Dst Endpoint Port
     path: ocsf.dst_endpoint.port
     source: log
+    type: integer
   - groups:
       - OCSF
     name: File Extension
@@ -244,11 +246,13 @@ facets:
     name: Process Unique ID
     path: ocsf.process.uid
     source: log
-  - groups:
+  - facetType: range
+    groups:
       - OCSF
     name: Event Time
     path: ocsf.time
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Target Name
@@ -1641,6 +1645,15 @@ pipeline:
                 - ocsf.process.cmd_line
               sourceType: attribute
               target: ocsf.process.cmd_line
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.actor.app_name` to `ocsf.actor.app_name`
+              sources:
+                - ocsf.actor.app_name
+              sourceType: attribute
+              target: ocsf.actor.app_name
               targetFormat: string
               preserveSource: false
               overrideOnConflict: true

--- a/linux_audit_logs/assets/logs/linux-audit-logs.yaml
+++ b/linux_audit_logs/assets/logs/linux-audit-logs.yaml
@@ -54,14 +54,11 @@ facets:
     name: User Name
     path: usr.name
     source: log
-  - description: ''
-    facetType: list
-    groups:
+  - groups:
       - Linux Audit Logs
     name: Config
     path: linux_audit_logs.bool
     source: log
-    type: string
   - groups:
       - OCSF
     name: Activity Name
@@ -69,18 +66,103 @@ facets:
     source: log
   - groups:
       - OCSF
-    name: Severity
-    path: ocsf.severity
+    name: Actor Application Name
+    path: ocsf.actor.app_name
     source: log
   - groups:
       - OCSF
-    name: Device Type
-    path: ocsf.device.type
+    name: Actor Process Name
+    path: ocsf.actor.process.name
     source: log
   - groups:
       - OCSF
-    name: File Type
-    path: ocsf.file.type
+    name: Actor Process Path
+    path: ocsf.actor.process.path
+    source: log
+  - groups:
+      - OCSF
+    name: Actor Process ID
+    path: ocsf.actor.process.pid
+    source: log
+  - groups:
+      - OCSF
+    name: Actor Process User Name
+    path: ocsf.actor.process.user.name
+    source: log
+  - groups:
+      - OCSF
+    name: Actor Process User Unique ID
+    path: ocsf.actor.process.user.uid
+    source: log
+  - groups:
+      - OCSF
+    name: Actor Session Terminal
+    path: ocsf.actor.session.terminal
+    source: log
+  - groups:
+      - OCSF
+    name: Session Unique ID
+    path: ocsf.actor.session.uid
+    source: log
+  - groups:
+      - OCSF
+    name: Name
+    path: ocsf.actor.user.name
+    source: log
+  - groups:
+      - OCSF
+    name: Unique ID
+    path: ocsf.actor.user.uid
+    source: log
+  - groups:
+      - OCSF
+    name: Device Hostname
+    path: ocsf.device.hostname
+    source: log
+  - groups:
+      - OCSF
+    name: Device IP Address
+    path: ocsf.device.ip
+    source: log
+  - groups:
+      - OCSF
+    name: Device Name
+    path: ocsf.device.name
+    source: log
+  - groups:
+      - OCSF
+    name: Device OS Name
+    path: ocsf.device.os.name
+    source: log
+  - groups:
+      - OCSF
+    name: Device Unique ID
+    path: ocsf.device.uid
+    source: log
+  - groups:
+      - OCSF
+    name: Dst Endpoint Hostname
+    path: ocsf.dst_endpoint.hostname
+    source: log
+  - groups:
+      - OCSF
+    name: Destination IP Address
+    path: ocsf.dst_endpoint.ip
+    source: log
+  - groups:
+      - OCSF
+    name: Destination Endpoint Name
+    path: ocsf.dst_endpoint.name
+    source: log
+  - groups:
+      - OCSF
+    name: Dst Endpoint Port
+    path: ocsf.dst_endpoint.port
+    source: log
+  - groups:
+      - OCSF
+    name: File Extension
+    path: ocsf.file.ext
     source: log
   - groups:
       - OCSF
@@ -89,8 +171,93 @@ facets:
     source: log
   - groups:
       - OCSF
+    name: File Path
+    path: ocsf.file.path
+    source: log
+  - groups:
+      - OCSF
+    name: File Unique ID
+    path: ocsf.file.uid
+    source: log
+  - groups:
+      - OCSF
+    name: Group Name
+    path: ocsf.group.name
+    source: log
+  - groups:
+      - OCSF
+    name: Group Unique ID
+    path: ocsf.group.uid
+    source: log
+  - groups:
+      - OCSF
+    name: Event Code
+    path: ocsf.metadata.event_code
+    source: log
+  - groups:
+      - OCSF
+    name: Metadata Original Time
+    path: ocsf.metadata.original_time
+    source: log
+  - groups:
+      - OCSF
+    name: Product Name
+    path: ocsf.metadata.product.name
+    source: log
+  - groups:
+      - OCSF
+    name: Vendor Name
+    path: ocsf.metadata.product.vendor_name
+    source: log
+  - groups:
+      - OCSF
+    name: Metadata Event UID
+    path: ocsf.metadata.uid
+    source: log
+  - groups:
+      - OCSF
+    name: Privileges
+    path: ocsf.privileges
+    source: log
+  - groups:
+      - OCSF
+    name: Process Command Line
+    path: ocsf.process.cmd_line
+    source: log
+  - groups:
+      - OCSF
     name: Process Name
     path: ocsf.process.name
+    source: log
+  - groups:
+      - OCSF
+    name: Process Path
+    path: ocsf.process.path
+    source: log
+  - groups:
+      - OCSF
+    name: Process ID
+    path: ocsf.process.pid
+    source: log
+  - groups:
+      - OCSF
+    name: Process Unique ID
+    path: ocsf.process.uid
+    source: log
+  - groups:
+      - OCSF
+    name: Event Time
+    path: ocsf.time
+    source: log
+  - groups:
+      - OCSF
+    name: Target Name
+    path: ocsf.user.name
+    source: log
+  - groups:
+      - OCSF
+    name: Target Unique ID
+    path: ocsf.user.uid
     source: log
 pipeline:
   type: pipeline
@@ -439,6 +606,8 @@ pipeline:
     - type: pipeline
       name: OCSF pre transformations
       enabled: true
+      ocsf:
+        isOcsf: true
       filter:
         query: "@type:(ADD_GROUP OR DEL_GROUP OR ADD_USER OR DEL_USER OR USER_CHAUTHTOK
           OR USER_AUTH OR ROLE_ASSIGN OR ROLE_REMOVE OR PATH OR USER_ROLE_CHANGE
@@ -485,157 +654,6 @@ pipeline:
           expression: timestamp/1000
           target: original_timestamp
           replaceMissing: false
-    - type: pipeline
-      name: OCSF sub pipeline for class Base Event [0]
-      enabled: true
-      ocsf:
-        isOcsf: true
-      filter:
-        query: "@type:(USER_ROLE_CHANGE OR USER_SELINUX_ERR OR DAEMON_CONFIG OR DAEMON_ABORT OR MAC_CONFIG_CHANGE OR MAC_STATUS OR MAC_POLICY_LOAD OR AVC OR CONFIG_CHANGE)"
-      processors:
-        - type: schema-processor
-          name: Apply OCSF schema for 0
-          enabled: true
-          schema:
-            schemaType: ocsf
-            version: 1.5.0
-            className: Base Event
-            classUid: 0
-            extensions: []
-            profiles:
-              - host
-          mappers:
-            - name: ocsf.activity_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Other
-                  id: 99
-              targets:
-                name: ocsf.activity_name
-                id: ocsf.activity_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.severity_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Informational
-                  id: 1
-              targets:
-                name: ocsf.severity
-                id: ocsf.severity_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.status_id
-              categories:
-                - filter:
-                    query: '@msg.res:("success" OR 1)'
-                  name: Success
-                  id: 1
-                - filter:
-                    query: '@msg.res:("failed" OR 2)'
-                  name: Failure
-                  id: 2
-              targets:
-                name: ocsf.status
-                id: ocsf.status_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: Map `timestamp` to `ocsf.time`
-              sources:
-                - timestamp
-              sourceType: attribute
-              target: ocsf.time
-              targetFormat: integer
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
-              sources:
-                - ocsf.metadata.product.name
-              sourceType: attribute
-              target: ocsf.metadata.product.name
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
-              sources:
-                - ocsf.metadata.product.vendor_name
-              sourceType: attribute
-              target: ocsf.metadata.product.vendor_name
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `type` to `ocsf.metadata.event_code`
-              sources:
-                - type
-              sourceType: attribute
-              target: ocsf.metadata.event_code
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `event_id` to `ocsf.metadata.uid`
-              sources:
-                - event_id
-              sourceType: attribute
-              target: ocsf.metadata.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `original_timestamp` to `ocsf.metadata.original_time`
-              sources:
-                - original_timestamp
-              sourceType: attribute
-              target: ocsf.metadata.original_time
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `type` to `ocsf.activity_name`
-              sources:
-                - type
-              sourceType: attribute
-              target: ocsf.activity_name
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: ocsf.device.os.type_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Linux
-                  id: 200
-              targets:
-                name: ocsf.device.os.type
-                id: ocsf.device.os.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.device.type_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Unknown
-                  id: 0
-              targets:
-                name: ocsf.device.type
-                id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
     - type: pipeline
       name: OCSF sub pipeline for class File System Activity [1001]
       enabled: true
@@ -738,12 +756,13 @@ pipeline:
                     query: "@mode:[120000 TO 127777]"
                   name: Symbolic Link
                   id: 3
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
               targets:
                 name: ocsf.file.type
                 id: ocsf.file.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.severity_id
               categories:
@@ -754,9 +773,6 @@ pipeline:
               targets:
                 name: ocsf.severity
                 id: ocsf.severity_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.device.type_id
               categories:
@@ -767,9 +783,6 @@ pipeline:
               targets:
                 name: ocsf.device.type
                 id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: Map `timestamp` to `ocsf.time`
               sources:
@@ -873,7 +886,7 @@ pipeline:
               sourceType: attribute
               target: ocsf.actor.user.uid
               targetFormat: string
-              preserveSource: false
+              preserveSource: true
               overrideOnConflict: true
               type: schema-remapper
             - name: Map `OUID` to `ocsf.actor.user.name`
@@ -881,6 +894,24 @@ pipeline:
                 - OUID
               sourceType: attribute
               target: ocsf.actor.user.name
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.name` to `ocsf.device.name`
+              sources:
+                - ocsf.device.name
+              sourceType: attribute
+              target: ocsf.device.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.os.name` to `ocsf.device.os.name`
+              sources:
+                - ocsf.device.os.name
+              sourceType: attribute
+              target: ocsf.device.os.name
               targetFormat: string
               preserveSource: false
               overrideOnConflict: true
@@ -894,9 +925,6 @@ pipeline:
               targets:
                 name: ocsf.device.os.type
                 id: ocsf.device.os.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
     - type: pipeline
       name: OCSF sub pipeline for class File System Activity [1001] from SYSCALL
@@ -979,7 +1007,9 @@ pipeline:
                 values:
                   ocsf.activity_id: "99"
                   ocsf.activity_name: Other
-                sources: {}
+                sources:
+                  ocsf.activity_name:
+                    - SYSCALL
               type: schema-category-mapper
             - name: ocsf.severity_id
               categories:
@@ -990,9 +1020,6 @@ pipeline:
               targets:
                 name: ocsf.severity
                 id: ocsf.severity_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.device.type_id
               categories:
@@ -1003,9 +1030,6 @@ pipeline:
               targets:
                 name: ocsf.device.type
                 id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.file.type_id
               categories:
@@ -1016,9 +1040,6 @@ pipeline:
               targets:
                 name: ocsf.file.type
                 id: ocsf.file.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.status_id
               categories:
@@ -1033,9 +1054,6 @@ pipeline:
               targets:
                 name: ocsf.status
                 id: ocsf.status_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: Map `timestamp` to `ocsf.time`
               sources:
@@ -1172,6 +1190,24 @@ pipeline:
               preserveSource: true
               overrideOnConflict: true
               type: schema-remapper
+            - name: Map `ocsf.device.name` to `ocsf.device.name`
+              sources:
+                - ocsf.device.name
+              sourceType: attribute
+              target: ocsf.device.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.os.name` to `ocsf.device.os.name`
+              sources:
+                - ocsf.device.os.name
+              sourceType: attribute
+              target: ocsf.device.os.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
             - name: ocsf.device.os.type_id
               categories:
                 - filter:
@@ -1181,9 +1217,6 @@ pipeline:
               targets:
                 name: ocsf.device.os.type
                 id: ocsf.device.os.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
     - type: pipeline
       name: OCSF sub pipeline for class Module Activity [1005]
@@ -1225,9 +1258,6 @@ pipeline:
               targets:
                 name: ocsf.activity_name
                 id: ocsf.activity_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.module.load_type_id
               categories:
@@ -1238,9 +1268,6 @@ pipeline:
               targets:
                 name: ocsf.module.load_type
                 id: ocsf.module.load_type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.severity_id
               categories:
@@ -1251,9 +1278,6 @@ pipeline:
               targets:
                 name: ocsf.severity
                 id: ocsf.severity_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.device.type_id
               categories:
@@ -1264,9 +1288,6 @@ pipeline:
               targets:
                 name: ocsf.device.type
                 id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.status_id
               categories:
@@ -1281,9 +1302,6 @@ pipeline:
               targets:
                 name: ocsf.status
                 id: ocsf.status_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: Map `timestamp` to `ocsf.time`
               sources:
@@ -1420,269 +1438,20 @@ pipeline:
               preserveSource: true
               overrideOnConflict: true
               type: schema-remapper
-            - name: ocsf.device.os.type_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Linux
-                  id: 200
-              targets:
-                name: ocsf.device.os.type
-                id: ocsf.device.os.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-    - type: pipeline
-      name: OCSF sub pipeline for class Account Change [3001]
-      enabled: true
-      ocsf:
-        isOcsf: true
-      filter:
-        query: "@type:(ADD_USER OR DEL_USER OR USER_CHAUTHTOK)"
-      processors:
-        - type: schema-processor
-          name: Apply OCSF schema for 3001
-          enabled: true
-          schema:
-            schemaType: ocsf
-            version: 1.5.0
-            className: Account Change
-            classUid: 3001
-            extensions: []
-            profiles:
-              - host
-          mappers:
-            - name: Map `timestamp` to `ocsf.time`
+            - name: Map `ocsf.device.name` to `ocsf.device.name`
               sources:
-                - timestamp
+                - ocsf.device.name
               sourceType: attribute
-              target: ocsf.time
-              targetFormat: integer
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
-              sources:
-                - ocsf.metadata.product.name
-              sourceType: attribute
-              target: ocsf.metadata.product.name
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `type` to `ocsf.metadata.event_code`
-              sources:
-                - type
-              sourceType: attribute
-              target: ocsf.metadata.event_code
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `event_id` to `ocsf.metadata.uid`
-              sources:
-                - event_id
-              sourceType: attribute
-              target: ocsf.metadata.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
-              sources:
-                - ocsf.metadata.product.vendor_name
-              sourceType: attribute
-              target: ocsf.metadata.product.vendor_name
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `pid` to `ocsf.actor.process.pid`
-              sources:
-                - pid
-              sourceType: attribute
-              target: ocsf.actor.process.pid
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `uid` to `ocsf.actor.process.user.uid`
-              sources:
-                - uid
-              sourceType: attribute
-              target: ocsf.actor.process.user.uid
+              target: ocsf.device.name
               targetFormat: string
               preserveSource: false
               overrideOnConflict: true
               type: schema-remapper
-            - name: Map `auid` to `ocsf.actor.user.uid`
+            - name: Map `ocsf.device.os.name` to `ocsf.device.os.name`
               sources:
-                - auid
+                - ocsf.device.os.name
               sourceType: attribute
-              target: ocsf.actor.user.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ses` to `ocsf.actor.session.uid`
-              sources:
-                - ses
-              sourceType: attribute
-              target: ocsf.actor.session.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `AUID` to `ocsf.actor.user.name`
-              sources:
-                - AUID
-              sourceType: attribute
-              target: ocsf.actor.user.name
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `UID` to `ocsf.actor.process.user.name`
-              sources:
-                - UID
-              sourceType: attribute
-              target: ocsf.actor.process.user.name
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.acct`, `ID` to `ocsf.user.name`
-              sources:
-                - msg.acct
-                - ID
-              sourceType: attribute
-              target: ocsf.user.name
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.id` to `ocsf.user.uid`
-              sources:
-                - msg.id
-              sourceType: attribute
-              target: ocsf.user.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.terminal` to `ocsf.actor.session.terminal`
-              sources:
-                - msg.terminal
-              sourceType: attribute
-              target: ocsf.actor.session.terminal
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.exe` to `ocsf.actor.process.path`
-              sources:
-                - msg.exe
-              sourceType: attribute
-              target: ocsf.actor.process.path
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: ocsf.activity_id
-              categories:
-                - filter:
-                    query: "@type:ADD_USER"
-                  name: Create
-                  id: 1
-                - filter:
-                    query: "@type:DEL_USER"
-                  name: Delete
-                  id: 6
-                - filter:
-                    query: "@type:USER_CHAUTHTOK"
-                  name: Password Change
-                  id: 3
-              targets:
-                name: ocsf.activity_name
-                id: ocsf.activity_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.severity_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Informational
-                  id: 1
-              targets:
-                name: ocsf.severity
-                id: ocsf.severity_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.status_id
-              categories:
-                - filter:
-                    query: "@msg.res:success"
-                  name: Success
-                  id: 1
-                - filter:
-                    query: "@msg.res:failed"
-                  name: Failure
-                  id: 2
-              targets:
-                name: ocsf.status
-                id: ocsf.status_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.device.type_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Unknown
-                  id: 0
-              targets:
-                name: ocsf.device.type
-                id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: Set `ocsf.device.name` to Unknown when hostname is absent
-              categories:
-                - filter:
-                    query: "-@msg.hostname:*"
-                  name: Unknown
-                  id: 0
-              targets:
-                name: ocsf.device.name
-                id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: Map `msg.hostname` to `ocsf.device.hostname`
-              sources:
-                - msg.hostname
-              sourceType: attribute
-              target: ocsf.device.hostname
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.addr` to `ocsf.device.ip`
-              sources:
-                - msg.addr
-              sourceType: attribute
-              target: ocsf.device.ip
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `original_timestamp` to `ocsf.metadata.original_time`
-              sources:
-                - original_timestamp
-              sourceType: attribute
-              target: ocsf.metadata.original_time
+              target: ocsf.device.os.name
               targetFormat: string
               preserveSource: false
               overrideOnConflict: true
@@ -1696,1091 +1465,6 @@ pipeline:
               targets:
                 name: ocsf.device.os.type
                 id: ocsf.device.os.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-    - type: pipeline
-      name: OCSF sub pipeline for class Authentication [3002]
-      enabled: true
-      ocsf:
-        isOcsf: true
-      filter:
-        query: "@type:USER_AUTH"
-      processors:
-        - type: schema-processor
-          name: Apply OCSF schema for 3002
-          enabled: true
-          schema:
-            schemaType: ocsf
-            version: 1.5.0
-            className: Authentication
-            classUid: 3002
-            extensions: []
-            profiles:
-              - host
-          mappers:
-            - name: ocsf.activity_id
-              categories:
-                - filter:
-                    query: "@type:USER_AUTH"
-                  name: Logon
-                  id: 1
-              targets:
-                name: ocsf.activity_name
-                id: ocsf.activity_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.severity_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Informational
-                  id: 1
-              targets:
-                name: ocsf.severity
-                id: ocsf.severity_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.status_id
-              categories:
-                - filter:
-                    query: "@msg.res:success"
-                  name: Success
-                  id: 1
-                - filter:
-                    query: "@msg.res:failed"
-                  name: Failure
-                  id: 2
-              targets:
-                name: ocsf.status
-                id: ocsf.status_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.device.type_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Unknown
-                  id: 0
-              targets:
-                name: ocsf.device.type
-                id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: Set `ocsf.device.name` to Unknown when hostname is absent
-              categories:
-                - filter:
-                    query: "-@msg.hostname:*"
-                  name: Unknown
-                  id: 0
-              targets:
-                name: ocsf.device.name
-                id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: Map `timestamp` to `ocsf.time`
-              sources:
-                - timestamp
-              sourceType: attribute
-              target: ocsf.time
-              targetFormat: integer
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
-              sources:
-                - ocsf.metadata.product.name
-              sourceType: attribute
-              target: ocsf.metadata.product.name
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `type` to `ocsf.metadata.event_code`
-              sources:
-                - type
-              sourceType: attribute
-              target: ocsf.metadata.event_code
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `event_id` to `ocsf.metadata.uid`
-              sources:
-                - event_id
-              sourceType: attribute
-              target: ocsf.metadata.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
-              sources:
-                - ocsf.metadata.product.vendor_name
-              sourceType: attribute
-              target: ocsf.metadata.product.vendor_name
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `pid` to `ocsf.actor.process.pid`
-              sources:
-                - pid
-              sourceType: attribute
-              target: ocsf.actor.process.pid
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `auid` to `ocsf.actor.user.uid`
-              sources:
-                - auid
-              sourceType: attribute
-              target: ocsf.actor.user.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ses` to `ocsf.actor.session.uid`
-              sources:
-                - ses
-              sourceType: attribute
-              target: ocsf.actor.session.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `AUID` to `ocsf.actor.user.name`
-              sources:
-                - AUID
-              sourceType: attribute
-              target: ocsf.actor.user.name
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.acct`, `ID` to `ocsf.user.name`
-              sources:
-                - msg.acct
-                - ID
-              sourceType: attribute
-              target: ocsf.user.name
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.terminal` to `ocsf.actor.session.terminal`
-              sources:
-                - msg.terminal
-              sourceType: attribute
-              target: ocsf.actor.session.terminal
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.addr` to `ocsf.dst_endpoint.ip`
-              sources:
-                - msg.addr
-              sourceType: attribute
-              target: ocsf.dst_endpoint.ip
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.hostname` to `ocsf.dst_endpoint.hostname`
-              sources:
-                - msg.hostname
-              sourceType: attribute
-              target: ocsf.dst_endpoint.hostname
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `UID` to `ocsf.actor.process.user.name`
-              sources:
-                - UID
-              sourceType: attribute
-              target: ocsf.actor.process.user.name
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `uid` to `ocsf.actor.process.user.uid`
-              sources:
-                - uid
-              sourceType: attribute
-              target: ocsf.actor.process.user.uid
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.exe` to `ocsf.actor.process.path`
-              sources:
-                - msg.exe
-              sourceType: attribute
-              target: ocsf.actor.process.path
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.id` to `ocsf.user.uid`
-              sources:
-                - msg.id
-              sourceType: attribute
-              target: ocsf.user.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.hostname` to `ocsf.device.hostname`
-              sources:
-                - msg.hostname
-              sourceType: attribute
-              target: ocsf.device.hostname
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.addr` to `ocsf.device.ip`
-              sources:
-                - msg.addr
-              sourceType: attribute
-              target: ocsf.device.ip
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `original_timestamp` to `ocsf.metadata.original_time`
-              sources:
-                - original_timestamp
-              sourceType: attribute
-              target: ocsf.metadata.original_time
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: ocsf.device.os.type_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Linux
-                  id: 200
-              targets:
-                name: ocsf.device.os.type
-                id: ocsf.device.os.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-    - type: pipeline
-      name: OCSF sub pipeline for role assign logs
-      enabled: true
-      filter:
-        query: "@type:ROLE_ASSIGN"
-      processors:
-        - type: grok-parser
-          name: Convert `msg.new-role` into an array
-          enabled: true
-          source: msg.new-role
-          samples:
-            - staff_r
-          grok:
-            supportRules: ""
-            matchRules: rule_convert_role_into_array %{data:ocsf.privileges:array}
-    - type: pipeline
-      name: OCSF sub pipeline for role remove logs
-      enabled: true
-      filter:
-        query: "@type:ROLE_REMOVE"
-      processors:
-        - type: grok-parser
-          name: Convert `msg.old-role` into an array
-          enabled: true
-          source: msg.old-role
-          samples:
-            - staff_r
-          grok:
-            supportRules: ""
-            matchRules: rule_convert_role_into_array %{data:ocsf.privileges:array}
-    - type: pipeline
-      name: OCSF sub pipeline for class User Access Management [3005]
-      enabled: true
-      ocsf:
-        isOcsf: true
-      filter:
-        query: "@type:(ROLE_ASSIGN OR ROLE_REMOVE)"
-      processors:
-        - type: schema-processor
-          name: Apply OCSF schema for 3005
-          enabled: true
-          schema:
-            schemaType: ocsf
-            version: 1.5.0
-            className: User Access Management
-            classUid: 3005
-            extensions: []
-            profiles:
-              - host
-          mappers:
-            - name: Map `timestamp` to `ocsf.time`
-              sources:
-                - timestamp
-              sourceType: attribute
-              target: ocsf.time
-              targetFormat: integer
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ocsf.privileges` to `ocsf.privileges`
-              sources:
-                - ocsf.privileges
-              sourceType: attribute
-              target: ocsf.privileges
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
-              sources:
-                - ocsf.metadata.product.name
-              sourceType: attribute
-              target: ocsf.metadata.product.name
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
-              sources:
-                - ocsf.metadata.product.vendor_name
-              sourceType: attribute
-              target: ocsf.metadata.product.vendor_name
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ID` to `ocsf.user.name`
-              sources:
-                - ID
-              sourceType: attribute
-              target: ocsf.user.name
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `pid` to `ocsf.actor.process.pid`
-              sources:
-                - pid
-              sourceType: attribute
-              target: ocsf.actor.process.pid
-              targetFormat: integer
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `uid` to `ocsf.actor.process.user.uid`
-              sources:
-                - uid
-              sourceType: attribute
-              target: ocsf.actor.process.user.uid
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `UID` to `ocsf.actor.process.user.name`
-              sources:
-                - UID
-              sourceType: attribute
-              target: ocsf.actor.process.user.name
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `auid` to `ocsf.actor.user.uid`
-              sources:
-                - auid
-              sourceType: attribute
-              target: ocsf.actor.user.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `AUID` to `ocsf.actor.user.name`
-              sources:
-                - AUID
-              sourceType: attribute
-              target: ocsf.actor.user.name
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `type` to `ocsf.metadata.event_code`
-              sources:
-                - type
-              sourceType: attribute
-              target: ocsf.metadata.event_code
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `event_id` to `ocsf.metadata.uid`
-              sources:
-                - event_id
-              sourceType: attribute
-              target: ocsf.metadata.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.exe` to `ocsf.actor.process.path`
-              sources:
-                - msg.exe
-              sourceType: attribute
-              target: ocsf.actor.process.path
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.terminal` to `ocsf.actor.session.terminal`
-              sources:
-                - msg.terminal
-              sourceType: attribute
-              target: ocsf.actor.session.terminal
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: ocsf.activity_id
-              categories:
-                - filter:
-                    query: "@type:ROLE_REMOVE"
-                  name: Revoke Privileges
-                  id: 2
-                - filter:
-                    query: "@type:ROLE_ASSIGN"
-                  name: Assign Privileges
-                  id: 1
-              targets:
-                name: ocsf.activity_name
-                id: ocsf.activity_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.severity_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Informational
-                  id: 1
-              targets:
-                name: ocsf.severity
-                id: ocsf.severity_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.status_id
-              categories:
-                - filter:
-                    query: "@msg.res:success"
-                  name: Success
-                  id: 1
-                - filter:
-                    query: "@msg.res:failed"
-                  name: Failure
-                  id: 2
-              targets:
-                name: ocsf.status
-                id: ocsf.status_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.device.type_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Unknown
-                  id: 0
-              targets:
-                name: ocsf.device.type
-                id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: Set `ocsf.device.name` to Unknown when hostname is absent
-              categories:
-                - filter:
-                    query: "-@msg.hostname:*"
-                  name: Unknown
-                  id: 0
-              targets:
-                name: ocsf.device.name
-                id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: Map `msg.hostname` to `ocsf.device.hostname`
-              sources:
-                - msg.hostname
-              sourceType: attribute
-              target: ocsf.device.hostname
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.addr` to `ocsf.device.ip`
-              sources:
-                - msg.addr
-              sourceType: attribute
-              target: ocsf.device.ip
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `original_timestamp` to `ocsf.metadata.original_time`
-              sources:
-                - original_timestamp
-              sourceType: attribute
-              target: ocsf.metadata.original_time
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.id` to `ocsf.user.uid`
-              sources:
-                - msg.id
-              sourceType: attribute
-              target: ocsf.user.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ses` to `ocsf.actor.session.uid`
-              sources:
-                - ses
-              sourceType: attribute
-              target: ocsf.actor.session.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: ocsf.device.os.type_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Linux
-                  id: 200
-              targets:
-                name: ocsf.device.os.type
-                id: ocsf.device.os.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-    - type: pipeline
-      name: OCSF sub pipeline for class Group Management [3006]
-      enabled: true
-      ocsf:
-        isOcsf: true
-      filter:
-        query: "@type:(ADD_GROUP OR DEL_GROUP)"
-      processors:
-        - type: schema-processor
-          name: Apply OCSF schema for 3006
-          enabled: true
-          schema:
-            schemaType: ocsf
-            version: 1.5.0
-            className: Group Management
-            classUid: 3006
-            extensions: []
-            profiles:
-              - host
-          mappers:
-            - name: Map `timestamp` to `ocsf.time`
-              sources:
-                - timestamp
-              sourceType: attribute
-              target: ocsf.time
-              targetFormat: integer
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
-              sources:
-                - ocsf.metadata.product.name
-              sourceType: attribute
-              target: ocsf.metadata.product.name
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `type` to `ocsf.metadata.event_code`
-              sources:
-                - type
-              sourceType: attribute
-              target: ocsf.metadata.event_code
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `event_id` to `ocsf.metadata.uid`
-              sources:
-                - event_id
-              sourceType: attribute
-              target: ocsf.metadata.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.acct` to `ocsf.group.name`
-              sources:
-                - msg.acct
-              sourceType: attribute
-              target: ocsf.group.name
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
-              sources:
-                - ocsf.metadata.product.vendor_name
-              sourceType: attribute
-              target: ocsf.metadata.product.vendor_name
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `pid` to `ocsf.actor.process.pid`
-              sources:
-                - pid
-              sourceType: attribute
-              target: ocsf.actor.process.pid
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `uid` to `ocsf.actor.process.user.uid`
-              sources:
-                - uid
-              sourceType: attribute
-              target: ocsf.actor.process.user.uid
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `auid` to `ocsf.actor.user.uid`
-              sources:
-                - auid
-              sourceType: attribute
-              target: ocsf.actor.user.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ses` to `ocsf.actor.session.uid`
-              sources:
-                - ses
-              sourceType: attribute
-              target: ocsf.actor.session.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `AUID` to `ocsf.actor.user.name`
-              sources:
-                - AUID
-              sourceType: attribute
-              target: ocsf.actor.user.name
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `UID` to `ocsf.actor.process.user.name`
-              sources:
-                - UID
-              sourceType: attribute
-              target: ocsf.actor.process.user.name
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.id` to `ocsf.group.uid`
-              sources:
-                - msg.id
-              sourceType: attribute
-              target: ocsf.group.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.terminal` to `ocsf.actor.session.terminal`
-              sources:
-                - msg.terminal
-              sourceType: attribute
-              target: ocsf.actor.session.terminal
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.exe` to `ocsf.actor.process.path`
-              sources:
-                - msg.exe
-              sourceType: attribute
-              target: ocsf.actor.process.path
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: ocsf.activity_id
-              categories:
-                - filter:
-                    query: "@type:ADD_GROUP"
-                  name: Create
-                  id: 6
-                - filter:
-                    query: "@type:DEL_GROUP"
-                  name: Delete
-                  id: 5
-              targets:
-                name: ocsf.activity_name
-                id: ocsf.activity_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.severity_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Informational
-                  id: 1
-              targets:
-                name: ocsf.severity
-                id: ocsf.severity_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.status_id
-              categories:
-                - filter:
-                    query: "@msg.res:success"
-                  name: Success
-                  id: 1
-                - filter:
-                    query: "@msg.res:failed"
-                  name: Failure
-                  id: 2
-              targets:
-                name: ocsf.status
-                id: ocsf.status_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.device.type_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Unknown
-                  id: 0
-              targets:
-                name: ocsf.device.type
-                id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: Set `ocsf.device.name` to Unknown when hostname is absent
-              categories:
-                - filter:
-                    query: "-@msg.hostname:*"
-                  name: Unknown
-                  id: 0
-              targets:
-                name: ocsf.device.name
-                id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: Map `msg.hostname` to `ocsf.device.hostname`
-              sources:
-                - msg.hostname
-              sourceType: attribute
-              target: ocsf.device.hostname
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.addr` to `ocsf.device.ip`
-              sources:
-                - msg.addr
-              sourceType: attribute
-              target: ocsf.device.ip
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `original_timestamp` to `ocsf.metadata.original_time`
-              sources:
-                - original_timestamp
-              sourceType: attribute
-              target: ocsf.metadata.original_time
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: ocsf.device.os.type_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Linux
-                  id: 200
-              targets:
-                name: ocsf.device.os.type
-                id: ocsf.device.os.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-    - type: pipeline
-      name: OCSF sub pipeline for class Device Config State Change [5019]
-      enabled: true
-      ocsf:
-        isOcsf: true
-      filter:
-        query: "@type:USER_MAC_CONFIG_CHANGE"
-      processors:
-        - type: schema-processor
-          name: Apply OCSF schema for 5019
-          enabled: true
-          schema:
-            schemaType: ocsf
-            version: 1.5.0
-            className: Device Config State Change
-            classUid: 5019
-            extensions: []
-            profiles: []
-          mappers:
-            - name: ocsf.activity_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Log
-                  id: 1
-              targets:
-                name: ocsf.activity_name
-                id: ocsf.activity_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.severity_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Informational
-                  id: 1
-              targets:
-                name: ocsf.severity
-                id: ocsf.severity_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.device.type_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Unknown
-                  id: 0
-              targets:
-                name: ocsf.device.type
-                id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: Set `ocsf.device.name` to Unknown when hostname is absent
-              categories:
-                - filter:
-                    query: "-@msg.hostname:*"
-                  name: Unknown
-                  id: 0
-              targets:
-                name: ocsf.device.name
-                id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: ocsf.status_id
-              categories:
-                - filter:
-                    query: "@msg.res:success"
-                  name: Success
-                  id: 1
-                - filter:
-                    query: "@msg.res:failed"
-                  name: Failure
-                  id: 2
-              targets:
-                name: ocsf.status
-                id: ocsf.status_id
-              fallback:
-                values: {}
-                sources: {}
-              type: schema-category-mapper
-            - name: Map `timestamp` to `ocsf.time`
-              sources:
-                - timestamp
-              sourceType: attribute
-              target: ocsf.time
-              targetFormat: integer
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `type` to `ocsf.metadata.event_code`
-              sources:
-                - type
-              sourceType: attribute
-              target: ocsf.metadata.event_code
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `event_id` to `ocsf.metadata.uid`
-              sources:
-                - event_id
-              sourceType: attribute
-              target: ocsf.metadata.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `original_timestamp` to `ocsf.metadata.original_time`
-              sources:
-                - original_timestamp
-              sourceType: attribute
-              target: ocsf.metadata.original_time
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.hostname` to `ocsf.device.hostname`
-              sources:
-                - msg.hostname
-              sourceType: attribute
-              target: ocsf.device.hostname
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.addr` to `ocsf.device.ip`
-              sources:
-                - msg.addr
-              sourceType: attribute
-              target: ocsf.device.ip
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ses` to `ocsf.actor.session.uid`
-              sources:
-                - ses
-              sourceType: attribute
-              target: ocsf.actor.session.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `auid` to `ocsf.actor.user.uid`
-              sources:
-                - auid
-              sourceType: attribute
-              target: ocsf.actor.user.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `uid` to `ocsf.actor.process.user.uid`
-              sources:
-                - uid
-              sourceType: attribute
-              target: ocsf.actor.process.user.uid
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
-              sources:
-                - ocsf.metadata.product.name
-              sourceType: attribute
-              target: ocsf.metadata.product.name
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `AUID` to `ocsf.actor.user.name`
-              sources:
-                - AUID
-              sourceType: attribute
-              target: ocsf.actor.user.name
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.exe` to `ocsf.actor.process.path`
-              sources:
-                - msg.exe
-              sourceType: attribute
-              target: ocsf.actor.process.path
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `pid` to `ocsf.actor.process.pid`
-              sources:
-                - pid
-              sourceType: attribute
-              target: ocsf.actor.process.pid
-              targetFormat: integer
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `UID` to `ocsf.actor.process.user.name`
-              sources:
-                - UID
-              sourceType: attribute
-              target: ocsf.actor.process.user.name
-              targetFormat: string
-              preserveSource: false
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: Map `msg.terminal` to `ocsf.actor.session.terminal`
-              sources:
-                - msg.terminal
-              sourceType: attribute
-              target: ocsf.actor.session.terminal
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-              type: schema-remapper
-            - name: ocsf.device.os.type_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Linux
-                  id: 200
-              targets:
-                name: ocsf.device.os.type
-                id: ocsf.device.os.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
     - type: pipeline
       name: OCSF sub pipeline for class Process Activity [1007] for EXECVE
@@ -2859,9 +1543,6 @@ pipeline:
               targets:
                 name: ocsf.activity_name
                 id: ocsf.activity_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.severity_id
               categories:
@@ -2872,9 +1553,6 @@ pipeline:
               targets:
                 name: ocsf.severity
                 id: ocsf.severity_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.device.type_id
               categories:
@@ -2885,9 +1563,6 @@ pipeline:
               targets:
                 name: ocsf.device.type
                 id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: Map `timestamp` to `ocsf.time`
               sources:
@@ -2970,6 +1645,24 @@ pipeline:
               preserveSource: false
               overrideOnConflict: true
               type: schema-remapper
+            - name: Map `ocsf.device.name` to `ocsf.device.name`
+              sources:
+                - ocsf.device.name
+              sourceType: attribute
+              target: ocsf.device.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.os.name` to `ocsf.device.os.name`
+              sources:
+                - ocsf.device.os.name
+              sourceType: attribute
+              target: ocsf.device.os.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
             - name: ocsf.device.os.type_id
               categories:
                 - filter:
@@ -2979,9 +1672,6 @@ pipeline:
               targets:
                 name: ocsf.device.os.type
                 id: ocsf.device.os.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
     - type: pipeline
       name: OCSF sub pipeline for class Process Activity [1007] from SYSCALL
@@ -3017,9 +1707,6 @@ pipeline:
               targets:
                 name: ocsf.activity_name
                 id: ocsf.activity_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.severity_id
               categories:
@@ -3030,9 +1717,6 @@ pipeline:
               targets:
                 name: ocsf.severity
                 id: ocsf.severity_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.device.type_id
               categories:
@@ -3043,9 +1727,6 @@ pipeline:
               targets:
                 name: ocsf.device.type
                 id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.status_id
               categories:
@@ -3060,9 +1741,6 @@ pipeline:
               targets:
                 name: ocsf.status
                 id: ocsf.status_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: Map `timestamp` to `ocsf.time`
               sources:
@@ -3217,6 +1895,24 @@ pipeline:
               preserveSource: true
               overrideOnConflict: true
               type: schema-remapper
+            - name: Map `ocsf.device.name` to `ocsf.device.name`
+              sources:
+                - ocsf.device.name
+              sourceType: attribute
+              target: ocsf.device.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.os.name` to `ocsf.device.os.name`
+              sources:
+                - ocsf.device.os.name
+              sourceType: attribute
+              target: ocsf.device.os.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
             - name: ocsf.device.os.type_id
               categories:
                 - filter:
@@ -3226,9 +1922,1135 @@ pipeline:
               targets:
                 name: ocsf.device.os.type
                 id: ocsf.device.os.type_id
-              fallback:
-                values: {}
-                sources: {}
+              type: schema-category-mapper
+    - type: pipeline
+      name: OCSF sub pipeline for class Account Change [3001]
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "@type:(ADD_USER OR DEL_USER OR USER_CHAUTHTOK)"
+      processors:
+        - type: schema-processor
+          name: Apply OCSF schema for 3001
+          enabled: true
+          schema:
+            schemaType: ocsf
+            version: 1.5.0
+            className: Account Change
+            classUid: 3001
+            extensions: []
+            profiles:
+              - host
+          mappers:
+            - name: Map `timestamp` to `ocsf.time`
+              sources:
+                - timestamp
+              sourceType: attribute
+              target: ocsf.time
+              targetFormat: integer
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
+              sources:
+                - ocsf.metadata.product.name
+              sourceType: attribute
+              target: ocsf.metadata.product.name
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `type` to `ocsf.metadata.event_code`
+              sources:
+                - type
+              sourceType: attribute
+              target: ocsf.metadata.event_code
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `event_id` to `ocsf.metadata.uid`
+              sources:
+                - event_id
+              sourceType: attribute
+              target: ocsf.metadata.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
+              sources:
+                - ocsf.metadata.product.vendor_name
+              sourceType: attribute
+              target: ocsf.metadata.product.vendor_name
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `pid` to `ocsf.actor.process.pid`
+              sources:
+                - pid
+              sourceType: attribute
+              target: ocsf.actor.process.pid
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `uid` to `ocsf.actor.process.user.uid`
+              sources:
+                - uid
+              sourceType: attribute
+              target: ocsf.actor.process.user.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `auid` to `ocsf.actor.user.uid`
+              sources:
+                - auid
+              sourceType: attribute
+              target: ocsf.actor.user.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ses` to `ocsf.actor.session.uid`
+              sources:
+                - ses
+              sourceType: attribute
+              target: ocsf.actor.session.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `AUID` to `ocsf.actor.user.name`
+              sources:
+                - AUID
+              sourceType: attribute
+              target: ocsf.actor.user.name
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `UID` to `ocsf.actor.process.user.name`
+              sources:
+                - UID
+              sourceType: attribute
+              target: ocsf.actor.process.user.name
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.acct`, `ID` to `ocsf.user.name`
+              sources:
+                - msg.acct
+                - ID
+              sourceType: attribute
+              target: ocsf.user.name
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.id` to `ocsf.user.uid`
+              sources:
+                - msg.id
+              sourceType: attribute
+              target: ocsf.user.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.terminal` to `ocsf.actor.session.terminal`
+              sources:
+                - msg.terminal
+              sourceType: attribute
+              target: ocsf.actor.session.terminal
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.exe` to `ocsf.actor.process.path`
+              sources:
+                - msg.exe
+              sourceType: attribute
+              target: ocsf.actor.process.path
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: ocsf.activity_id
+              categories:
+                - filter:
+                    query: "@type:ADD_USER"
+                  name: Create
+                  id: 1
+                - filter:
+                    query: "@type:DEL_USER"
+                  name: Delete
+                  id: 6
+                - filter:
+                    query: "@type:USER_CHAUTHTOK"
+                  name: Password Change
+                  id: 3
+              targets:
+                name: ocsf.activity_name
+                id: ocsf.activity_id
+              type: schema-category-mapper
+            - name: ocsf.severity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Informational
+                  id: 1
+              targets:
+                name: ocsf.severity
+                id: ocsf.severity_id
+              type: schema-category-mapper
+            - name: ocsf.status_id
+              categories:
+                - filter:
+                    query: "@msg.res:success"
+                  name: Success
+                  id: 1
+                - filter:
+                    query: "@msg.res:failed"
+                  name: Failure
+                  id: 2
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.status
+                id: ocsf.status_id
+              type: schema-category-mapper
+            - name: ocsf.device.type_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.device.type
+                id: ocsf.device.type_id
+              type: schema-category-mapper
+            - name: ocsf.device.name
+              categories:
+                - filter:
+                    query: "-@msg.hostname:*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.device.name
+                id: ocsf.device.type_id
+              type: schema-category-mapper
+            - name: Map `msg.hostname` to `ocsf.device.hostname`
+              sources:
+                - msg.hostname
+              sourceType: attribute
+              target: ocsf.device.hostname
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.addr` to `ocsf.device.ip`
+              sources:
+                - msg.addr
+              sourceType: attribute
+              target: ocsf.device.ip
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `original_timestamp` to `ocsf.metadata.original_time`
+              sources:
+                - original_timestamp
+              sourceType: attribute
+              target: ocsf.metadata.original_time
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.name` to `ocsf.device.name`
+              sources:
+                - ocsf.device.name
+              sourceType: attribute
+              target: ocsf.device.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.os.name` to `ocsf.device.os.name`
+              sources:
+                - ocsf.device.os.name
+              sourceType: attribute
+              target: ocsf.device.os.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: ocsf.device.os.type_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Linux
+                  id: 200
+              targets:
+                name: ocsf.device.os.type
+                id: ocsf.device.os.type_id
+              type: schema-category-mapper
+    - type: pipeline
+      name: OCSF sub pipeline for class Authentication [3002]
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "@type:USER_AUTH"
+      processors:
+        - type: schema-processor
+          name: Apply OCSF schema for 3002
+          enabled: true
+          schema:
+            schemaType: ocsf
+            version: 1.5.0
+            className: Authentication
+            classUid: 3002
+            extensions: []
+            profiles:
+              - host
+          mappers:
+            - name: ocsf.activity_id
+              categories:
+                - filter:
+                    query: "@type:USER_AUTH"
+                  name: Logon
+                  id: 1
+              targets:
+                name: ocsf.activity_name
+                id: ocsf.activity_id
+              type: schema-category-mapper
+            - name: ocsf.severity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Informational
+                  id: 1
+              targets:
+                name: ocsf.severity
+                id: ocsf.severity_id
+              type: schema-category-mapper
+            - name: ocsf.status_id
+              categories:
+                - filter:
+                    query: "@msg.res:success"
+                  name: Success
+                  id: 1
+                - filter:
+                    query: "@msg.res:failed"
+                  name: Failure
+                  id: 2
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.status
+                id: ocsf.status_id
+              type: schema-category-mapper
+            - name: ocsf.device.type_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.device.type
+                id: ocsf.device.type_id
+              type: schema-category-mapper
+            - name: ocsf.device.name
+              categories:
+                - filter:
+                    query: "-@msg.hostname:*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.device.name
+                id: ocsf.device.type_id
+              type: schema-category-mapper
+            - name: Map `timestamp` to `ocsf.time`
+              sources:
+                - timestamp
+              sourceType: attribute
+              target: ocsf.time
+              targetFormat: integer
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
+              sources:
+                - ocsf.metadata.product.name
+              sourceType: attribute
+              target: ocsf.metadata.product.name
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `type` to `ocsf.metadata.event_code`
+              sources:
+                - type
+              sourceType: attribute
+              target: ocsf.metadata.event_code
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `event_id` to `ocsf.metadata.uid`
+              sources:
+                - event_id
+              sourceType: attribute
+              target: ocsf.metadata.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
+              sources:
+                - ocsf.metadata.product.vendor_name
+              sourceType: attribute
+              target: ocsf.metadata.product.vendor_name
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `pid` to `ocsf.actor.process.pid`
+              sources:
+                - pid
+              sourceType: attribute
+              target: ocsf.actor.process.pid
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `auid` to `ocsf.actor.user.uid`
+              sources:
+                - auid
+              sourceType: attribute
+              target: ocsf.actor.user.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ses` to `ocsf.actor.session.uid`
+              sources:
+                - ses
+              sourceType: attribute
+              target: ocsf.actor.session.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `AUID` to `ocsf.actor.user.name`
+              sources:
+                - AUID
+              sourceType: attribute
+              target: ocsf.actor.user.name
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.acct`, `ID` to `ocsf.user.name`
+              sources:
+                - msg.acct
+                - ID
+              sourceType: attribute
+              target: ocsf.user.name
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.terminal` to `ocsf.actor.session.terminal`
+              sources:
+                - msg.terminal
+              sourceType: attribute
+              target: ocsf.actor.session.terminal
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.addr` to `ocsf.dst_endpoint.ip`
+              sources:
+                - msg.addr
+              sourceType: attribute
+              target: ocsf.dst_endpoint.ip
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.hostname` to `ocsf.dst_endpoint.hostname`
+              sources:
+                - msg.hostname
+              sourceType: attribute
+              target: ocsf.dst_endpoint.hostname
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `UID` to `ocsf.actor.process.user.name`
+              sources:
+                - UID
+              sourceType: attribute
+              target: ocsf.actor.process.user.name
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `uid` to `ocsf.actor.process.user.uid`
+              sources:
+                - uid
+              sourceType: attribute
+              target: ocsf.actor.process.user.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.exe` to `ocsf.actor.process.path`
+              sources:
+                - msg.exe
+              sourceType: attribute
+              target: ocsf.actor.process.path
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.id` to `ocsf.user.uid`
+              sources:
+                - msg.id
+              sourceType: attribute
+              target: ocsf.user.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.hostname` to `ocsf.device.hostname`
+              sources:
+                - msg.hostname
+              sourceType: attribute
+              target: ocsf.device.hostname
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.addr` to `ocsf.device.ip`
+              sources:
+                - msg.addr
+              sourceType: attribute
+              target: ocsf.device.ip
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `original_timestamp` to `ocsf.metadata.original_time`
+              sources:
+                - original_timestamp
+              sourceType: attribute
+              target: ocsf.metadata.original_time
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.name` to `ocsf.device.name`
+              sources:
+                - ocsf.device.name
+              sourceType: attribute
+              target: ocsf.device.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.os.name` to `ocsf.device.os.name`
+              sources:
+                - ocsf.device.os.name
+              sourceType: attribute
+              target: ocsf.device.os.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: ocsf.device.os.type_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Linux
+                  id: 200
+              targets:
+                name: ocsf.device.os.type
+                id: ocsf.device.os.type_id
+              type: schema-category-mapper
+    - type: pipeline
+      name: Pre-process role assign logs
+      enabled: true
+      filter:
+        query: "@type:ROLE_ASSIGN"
+      processors:
+        - type: grok-parser
+          name: Convert `msg.new-role` into an array
+          enabled: true
+          source: msg.new-role
+          samples:
+            - staff_r
+          grok:
+            supportRules: ""
+            matchRules: rule_convert_role_into_array %{data:ocsf.privileges:array}
+    - type: pipeline
+      name: Pre-process role remove logs
+      enabled: true
+      filter:
+        query: "@type:ROLE_REMOVE"
+      processors:
+        - type: grok-parser
+          name: Convert `msg.old-role` into an array
+          enabled: true
+          source: msg.old-role
+          samples:
+            - staff_r
+          grok:
+            supportRules: ""
+            matchRules: rule_convert_role_into_array %{data:ocsf.privileges:array}
+    - type: pipeline
+      name: OCSF sub pipeline for class User Access Management [3005]
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "@type:(ROLE_ASSIGN OR ROLE_REMOVE)"
+      processors:
+        - type: schema-processor
+          name: Apply OCSF schema for 3005
+          enabled: true
+          schema:
+            schemaType: ocsf
+            version: 1.5.0
+            className: User Access Management
+            classUid: 3005
+            extensions: []
+            profiles:
+              - host
+          mappers:
+            - name: Map `timestamp` to `ocsf.time`
+              sources:
+                - timestamp
+              sourceType: attribute
+              target: ocsf.time
+              targetFormat: integer
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.privileges` to `ocsf.privileges`
+              sources:
+                - ocsf.privileges
+              sourceType: attribute
+              target: ocsf.privileges
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
+              sources:
+                - ocsf.metadata.product.name
+              sourceType: attribute
+              target: ocsf.metadata.product.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
+              sources:
+                - ocsf.metadata.product.vendor_name
+              sourceType: attribute
+              target: ocsf.metadata.product.vendor_name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ID` to `ocsf.user.name`
+              sources:
+                - ID
+              sourceType: attribute
+              target: ocsf.user.name
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `pid` to `ocsf.actor.process.pid`
+              sources:
+                - pid
+              sourceType: attribute
+              target: ocsf.actor.process.pid
+              targetFormat: integer
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `uid` to `ocsf.actor.process.user.uid`
+              sources:
+                - uid
+              sourceType: attribute
+              target: ocsf.actor.process.user.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `UID` to `ocsf.actor.process.user.name`
+              sources:
+                - UID
+              sourceType: attribute
+              target: ocsf.actor.process.user.name
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `auid` to `ocsf.actor.user.uid`
+              sources:
+                - auid
+              sourceType: attribute
+              target: ocsf.actor.user.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `AUID` to `ocsf.actor.user.name`
+              sources:
+                - AUID
+              sourceType: attribute
+              target: ocsf.actor.user.name
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `type` to `ocsf.metadata.event_code`
+              sources:
+                - type
+              sourceType: attribute
+              target: ocsf.metadata.event_code
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `event_id` to `ocsf.metadata.uid`
+              sources:
+                - event_id
+              sourceType: attribute
+              target: ocsf.metadata.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.exe` to `ocsf.actor.process.path`
+              sources:
+                - msg.exe
+              sourceType: attribute
+              target: ocsf.actor.process.path
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.terminal` to `ocsf.actor.session.terminal`
+              sources:
+                - msg.terminal
+              sourceType: attribute
+              target: ocsf.actor.session.terminal
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: ocsf.activity_id
+              categories:
+                - filter:
+                    query: "@type:ROLE_REMOVE"
+                  name: Revoke Privileges
+                  id: 2
+                - filter:
+                    query: "@type:ROLE_ASSIGN"
+                  name: Assign Privileges
+                  id: 1
+              targets:
+                name: ocsf.activity_name
+                id: ocsf.activity_id
+              type: schema-category-mapper
+            - name: ocsf.severity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Informational
+                  id: 1
+              targets:
+                name: ocsf.severity
+                id: ocsf.severity_id
+              type: schema-category-mapper
+            - name: ocsf.status_id
+              categories:
+                - filter:
+                    query: "@msg.res:success"
+                  name: Success
+                  id: 1
+                - filter:
+                    query: "@msg.res:failed"
+                  name: Failure
+                  id: 2
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.status
+                id: ocsf.status_id
+              type: schema-category-mapper
+            - name: ocsf.device.type_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.device.type
+                id: ocsf.device.type_id
+              type: schema-category-mapper
+            - name: ocsf.device.name
+              categories:
+                - filter:
+                    query: "-@msg.hostname:*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.device.name
+                id: ocsf.device.type_id
+              type: schema-category-mapper
+            - name: Map `msg.hostname` to `ocsf.device.hostname`
+              sources:
+                - msg.hostname
+              sourceType: attribute
+              target: ocsf.device.hostname
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.addr` to `ocsf.device.ip`
+              sources:
+                - msg.addr
+              sourceType: attribute
+              target: ocsf.device.ip
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `original_timestamp` to `ocsf.metadata.original_time`
+              sources:
+                - original_timestamp
+              sourceType: attribute
+              target: ocsf.metadata.original_time
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.id` to `ocsf.user.uid`
+              sources:
+                - msg.id
+              sourceType: attribute
+              target: ocsf.user.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ses` to `ocsf.actor.session.uid`
+              sources:
+                - ses
+              sourceType: attribute
+              target: ocsf.actor.session.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.name` to `ocsf.device.name`
+              sources:
+                - ocsf.device.name
+              sourceType: attribute
+              target: ocsf.device.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.os.name` to `ocsf.device.os.name`
+              sources:
+                - ocsf.device.os.name
+              sourceType: attribute
+              target: ocsf.device.os.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: ocsf.device.os.type_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Linux
+                  id: 200
+              targets:
+                name: ocsf.device.os.type
+                id: ocsf.device.os.type_id
+              type: schema-category-mapper
+    - type: pipeline
+      name: OCSF sub pipeline for class Group Management [3006]
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "@type:(ADD_GROUP OR DEL_GROUP)"
+      processors:
+        - type: schema-processor
+          name: Apply OCSF schema for 3006
+          enabled: true
+          schema:
+            schemaType: ocsf
+            version: 1.5.0
+            className: Group Management
+            classUid: 3006
+            extensions: []
+            profiles:
+              - host
+          mappers:
+            - name: Map `timestamp` to `ocsf.time`
+              sources:
+                - timestamp
+              sourceType: attribute
+              target: ocsf.time
+              targetFormat: integer
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
+              sources:
+                - ocsf.metadata.product.name
+              sourceType: attribute
+              target: ocsf.metadata.product.name
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `type` to `ocsf.metadata.event_code`
+              sources:
+                - type
+              sourceType: attribute
+              target: ocsf.metadata.event_code
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `event_id` to `ocsf.metadata.uid`
+              sources:
+                - event_id
+              sourceType: attribute
+              target: ocsf.metadata.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.acct` to `ocsf.group.name`
+              sources:
+                - msg.acct
+              sourceType: attribute
+              target: ocsf.group.name
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
+              sources:
+                - ocsf.metadata.product.vendor_name
+              sourceType: attribute
+              target: ocsf.metadata.product.vendor_name
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `pid` to `ocsf.actor.process.pid`
+              sources:
+                - pid
+              sourceType: attribute
+              target: ocsf.actor.process.pid
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `uid` to `ocsf.actor.process.user.uid`
+              sources:
+                - uid
+              sourceType: attribute
+              target: ocsf.actor.process.user.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `auid` to `ocsf.actor.user.uid`
+              sources:
+                - auid
+              sourceType: attribute
+              target: ocsf.actor.user.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ses` to `ocsf.actor.session.uid`
+              sources:
+                - ses
+              sourceType: attribute
+              target: ocsf.actor.session.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `AUID` to `ocsf.actor.user.name`
+              sources:
+                - AUID
+              sourceType: attribute
+              target: ocsf.actor.user.name
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `UID` to `ocsf.actor.process.user.name`
+              sources:
+                - UID
+              sourceType: attribute
+              target: ocsf.actor.process.user.name
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.id` to `ocsf.group.uid`
+              sources:
+                - msg.id
+              sourceType: attribute
+              target: ocsf.group.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.terminal` to `ocsf.actor.session.terminal`
+              sources:
+                - msg.terminal
+              sourceType: attribute
+              target: ocsf.actor.session.terminal
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.exe` to `ocsf.actor.process.path`
+              sources:
+                - msg.exe
+              sourceType: attribute
+              target: ocsf.actor.process.path
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: ocsf.activity_id
+              categories:
+                - filter:
+                    query: "@type:DEL_GROUP"
+                  name: Delete
+                  id: 5
+                - filter:
+                    query: "@type:ADD_GROUP"
+                  name: Create
+                  id: 6
+              targets:
+                name: ocsf.activity_name
+                id: ocsf.activity_id
+              type: schema-category-mapper
+            - name: ocsf.severity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Informational
+                  id: 1
+              targets:
+                name: ocsf.severity
+                id: ocsf.severity_id
+              type: schema-category-mapper
+            - name: ocsf.status_id
+              categories:
+                - filter:
+                    query: "@msg.res:success"
+                  name: Success
+                  id: 1
+                - filter:
+                    query: "@msg.res:failed"
+                  name: Failure
+                  id: 2
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.status
+                id: ocsf.status_id
+              type: schema-category-mapper
+            - name: ocsf.device.type_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.device.type
+                id: ocsf.device.type_id
+              type: schema-category-mapper
+            - name: ocsf.device.name
+              categories:
+                - filter:
+                    query: "-@msg.hostname:*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.device.name
+                id: ocsf.device.type_id
+              type: schema-category-mapper
+            - name: Map `msg.hostname` to `ocsf.device.hostname`
+              sources:
+                - msg.hostname
+              sourceType: attribute
+              target: ocsf.device.hostname
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.addr` to `ocsf.device.ip`
+              sources:
+                - msg.addr
+              sourceType: attribute
+              target: ocsf.device.ip
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `original_timestamp` to `ocsf.metadata.original_time`
+              sources:
+                - original_timestamp
+              sourceType: attribute
+              target: ocsf.metadata.original_time
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.name` to `ocsf.device.name`
+              sources:
+                - ocsf.device.name
+              sourceType: attribute
+              target: ocsf.device.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.os.name` to `ocsf.device.os.name`
+              sources:
+                - ocsf.device.os.name
+              sourceType: attribute
+              target: ocsf.device.os.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: ocsf.device.os.type_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Linux
+                  id: 200
+              targets:
+                name: ocsf.device.os.type
+                id: ocsf.device.os.type_id
               type: schema-category-mapper
     - type: pipeline
       name: OCSF sub pipeline for class Network Activity [4001] from SOCKADDR
@@ -3270,9 +3092,6 @@ pipeline:
               targets:
                 name: ocsf.activity_name
                 id: ocsf.activity_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.severity_id
               categories:
@@ -3283,9 +3102,6 @@ pipeline:
               targets:
                 name: ocsf.severity
                 id: ocsf.severity_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: Map `timestamp` to `ocsf.time`
               sources:
@@ -3359,6 +3175,24 @@ pipeline:
               preserveSource: true
               overrideOnConflict: true
               type: schema-remapper
+            - name: Map `ocsf.device.name` to `ocsf.device.name`
+              sources:
+                - ocsf.device.name
+              sourceType: attribute
+              target: ocsf.device.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.os.name` to `ocsf.device.os.name`
+              sources:
+                - ocsf.device.os.name
+              sourceType: attribute
+              target: ocsf.device.os.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
             - name: ocsf.device.os.type_id
               categories:
                 - filter:
@@ -3368,9 +3202,6 @@ pipeline:
               targets:
                 name: ocsf.device.os.type
                 id: ocsf.device.os.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.device.type_id
               categories:
@@ -3381,9 +3212,6 @@ pipeline:
               targets:
                 name: ocsf.device.type
                 id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
     - type: pipeline
       name: OCSF sub pipeline for class Network Activity [4001] from Syscall
@@ -3433,8 +3261,12 @@ pipeline:
                 name: ocsf.activity_name
                 id: ocsf.activity_id
               fallback:
-                values: {}
-                sources: {}
+                values:
+                  ocsf.activity_id: "99"
+                  ocsf.activity_name: Other
+                sources:
+                  ocsf.activity_name:
+                    - SYSCALL
               type: schema-category-mapper
             - name: ocsf.severity_id
               categories:
@@ -3445,9 +3277,6 @@ pipeline:
               targets:
                 name: ocsf.severity
                 id: ocsf.severity_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.status_id
               categories:
@@ -3462,9 +3291,6 @@ pipeline:
               targets:
                 name: ocsf.status
                 id: ocsf.status_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: Map `timestamp` to `ocsf.time`
               sources:
@@ -3601,6 +3427,24 @@ pipeline:
               preserveSource: true
               overrideOnConflict: true
               type: schema-remapper
+            - name: Map `ocsf.device.name` to `ocsf.device.name`
+              sources:
+                - ocsf.device.name
+              sourceType: attribute
+              target: ocsf.device.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.os.name` to `ocsf.device.os.name`
+              sources:
+                - ocsf.device.os.name
+              sourceType: attribute
+              target: ocsf.device.os.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
             - name: ocsf.device.os.type_id
               categories:
                 - filter:
@@ -3610,9 +3454,6 @@ pipeline:
               targets:
                 name: ocsf.device.os.type
                 id: ocsf.device.os.type_id
-              fallback:
-                values: {}
-                sources: {}
               type: schema-category-mapper
             - name: ocsf.device.type_id
               categories:
@@ -3623,7 +3464,402 @@ pipeline:
               targets:
                 name: ocsf.device.type
                 id: ocsf.device.type_id
-              fallback:
-                values: {}
-                sources: {}
+              type: schema-category-mapper
+    - type: pipeline
+      name: OCSF sub pipeline for class Device Config State Change [5019]
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "@type:USER_MAC_CONFIG_CHANGE"
+      processors:
+        - type: schema-processor
+          name: Apply OCSF schema for 5019
+          enabled: true
+          schema:
+            schemaType: ocsf
+            version: 1.5.0
+            className: Device Config State Change
+            classUid: 5019
+            extensions: []
+            profiles: []
+          mappers:
+            - name: ocsf.activity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Log
+                  id: 1
+              targets:
+                name: ocsf.activity_name
+                id: ocsf.activity_id
+              type: schema-category-mapper
+            - name: ocsf.severity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Informational
+                  id: 1
+              targets:
+                name: ocsf.severity
+                id: ocsf.severity_id
+              type: schema-category-mapper
+            - name: ocsf.device.type_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.device.type
+                id: ocsf.device.type_id
+              type: schema-category-mapper
+            - name: ocsf.device.name
+              categories:
+                - filter:
+                    query: "-@msg.hostname:*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.device.name
+                id: ocsf.device.type_id
+              type: schema-category-mapper
+            - name: ocsf.status_id
+              categories:
+                - filter:
+                    query: "@msg.res:success"
+                  name: Success
+                  id: 1
+                - filter:
+                    query: "@msg.res:failed"
+                  name: Failure
+                  id: 2
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.status
+                id: ocsf.status_id
+              type: schema-category-mapper
+            - name: Map `timestamp` to `ocsf.time`
+              sources:
+                - timestamp
+              sourceType: attribute
+              target: ocsf.time
+              targetFormat: integer
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `type` to `ocsf.metadata.event_code`
+              sources:
+                - type
+              sourceType: attribute
+              target: ocsf.metadata.event_code
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `event_id` to `ocsf.metadata.uid`
+              sources:
+                - event_id
+              sourceType: attribute
+              target: ocsf.metadata.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `original_timestamp` to `ocsf.metadata.original_time`
+              sources:
+                - original_timestamp
+              sourceType: attribute
+              target: ocsf.metadata.original_time
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.hostname` to `ocsf.device.hostname`
+              sources:
+                - msg.hostname
+              sourceType: attribute
+              target: ocsf.device.hostname
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.addr` to `ocsf.device.ip`
+              sources:
+                - msg.addr
+              sourceType: attribute
+              target: ocsf.device.ip
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ses` to `ocsf.actor.session.uid`
+              sources:
+                - ses
+              sourceType: attribute
+              target: ocsf.actor.session.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `auid` to `ocsf.actor.user.uid`
+              sources:
+                - auid
+              sourceType: attribute
+              target: ocsf.actor.user.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `uid` to `ocsf.actor.process.user.uid`
+              sources:
+                - uid
+              sourceType: attribute
+              target: ocsf.actor.process.user.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
+              sources:
+                - ocsf.metadata.product.name
+              sourceType: attribute
+              target: ocsf.metadata.product.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `AUID` to `ocsf.actor.user.name`
+              sources:
+                - AUID
+              sourceType: attribute
+              target: ocsf.actor.user.name
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.exe` to `ocsf.actor.process.path`
+              sources:
+                - msg.exe
+              sourceType: attribute
+              target: ocsf.actor.process.path
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `pid` to `ocsf.actor.process.pid`
+              sources:
+                - pid
+              sourceType: attribute
+              target: ocsf.actor.process.pid
+              targetFormat: integer
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `UID` to `ocsf.actor.process.user.name`
+              sources:
+                - UID
+              sourceType: attribute
+              target: ocsf.actor.process.user.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `msg.terminal` to `ocsf.actor.session.terminal`
+              sources:
+                - msg.terminal
+              sourceType: attribute
+              target: ocsf.actor.session.terminal
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.name` to `ocsf.device.name`
+              sources:
+                - ocsf.device.name
+              sourceType: attribute
+              target: ocsf.device.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.os.name` to `ocsf.device.os.name`
+              sources:
+                - ocsf.device.os.name
+              sourceType: attribute
+              target: ocsf.device.os.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: ocsf.device.os.type_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Linux
+                  id: 200
+              targets:
+                name: ocsf.device.os.type
+                id: ocsf.device.os.type_id
+              type: schema-category-mapper
+    - type: pipeline
+      name: OCSF sub pipeline for class Base Event [0]
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "@type:(USER_ROLE_CHANGE OR USER_SELINUX_ERR OR DAEMON_CONFIG OR DAEMON_ABORT OR MAC_CONFIG_CHANGE OR MAC_STATUS OR MAC_POLICY_LOAD OR AVC OR CONFIG_CHANGE)"
+      processors:
+        - type: schema-processor
+          name: Apply OCSF schema for 0
+          enabled: true
+          schema:
+            schemaType: ocsf
+            version: 1.5.0
+            className: Base Event
+            classUid: 0
+            extensions: []
+            profiles:
+              - host
+          mappers:
+            - name: ocsf.activity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Other
+                  id: 99
+              targets:
+                name: ocsf.activity_name
+                id: ocsf.activity_id
+              type: schema-category-mapper
+            - name: ocsf.severity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Informational
+                  id: 1
+              targets:
+                name: ocsf.severity
+                id: ocsf.severity_id
+              type: schema-category-mapper
+            - name: ocsf.status_id
+              categories:
+                - filter:
+                    query: '@msg.res:("success" OR 1)'
+                  name: Success
+                  id: 1
+                - filter:
+                    query: '@msg.res:("failed" OR 2)'
+                  name: Failure
+                  id: 2
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.status
+                id: ocsf.status_id
+              type: schema-category-mapper
+            - name: Map `timestamp` to `ocsf.time`
+              sources:
+                - timestamp
+              sourceType: attribute
+              target: ocsf.time
+              targetFormat: integer
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
+              sources:
+                - ocsf.metadata.product.name
+              sourceType: attribute
+              target: ocsf.metadata.product.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
+              sources:
+                - ocsf.metadata.product.vendor_name
+              sourceType: attribute
+              target: ocsf.metadata.product.vendor_name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `type` to `ocsf.metadata.event_code`
+              sources:
+                - type
+              sourceType: attribute
+              target: ocsf.metadata.event_code
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `event_id` to `ocsf.metadata.uid`
+              sources:
+                - event_id
+              sourceType: attribute
+              target: ocsf.metadata.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `original_timestamp` to `ocsf.metadata.original_time`
+              sources:
+                - original_timestamp
+              sourceType: attribute
+              target: ocsf.metadata.original_time
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `type` to `ocsf.activity_name`
+              sources:
+                - type
+              sourceType: attribute
+              target: ocsf.activity_name
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.name` to `ocsf.device.name`
+              sources:
+                - ocsf.device.name
+              sourceType: attribute
+              target: ocsf.device.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.device.os.name` to `ocsf.device.os.name`
+              sources:
+                - ocsf.device.os.name
+              sourceType: attribute
+              target: ocsf.device.os.name
+              targetFormat: string
+              preserveSource: false
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: ocsf.device.os.type_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Linux
+                  id: 200
+              targets:
+                name: ocsf.device.os.type
+                id: ocsf.device.os.type_id
+              type: schema-category-mapper
+            - name: ocsf.device.type_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.device.type
+                id: ocsf.device.type_id
               type: schema-category-mapper

--- a/linux_audit_logs/assets/logs/linux-audit-logs_tests.yaml
+++ b/linux_audit_logs/assets/logs/linux-audit-logs_tests.yaml
@@ -14,7 +14,7 @@ tests:
         hostname: "10.10.10.10"
         lport: 3307
         op:
-         - "add"
+          - "add"
         proto: 6
         res: "success"
         resrc: "port"
@@ -74,15 +74,16 @@ tests:
       ses: 138
       status: "ok"
       subj: "unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023"
-      timestamp: 1.736329118112E12
+      timestamp: 1736329118112
       type: "USER_MAC_CONFIG_CHANGE"
       usr:
         id: 0
         name: "root"
+      uid: 0
     message: "type=USER_MAC_CONFIG_CHANGE msg=audit(1736329118.112:6532): pid=381980 uid=0 auid=0 ses=138 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='resrc=port op=add lport=3307 proto=6 tcontext=system_u:object_r:mysqld_port_t:s0 comm=\"semanage\" exe=\"/usr/libexec/platform-python3.6\" hostname=10.10.10.10 addr=10.10.10.10 terminal=ssh res=success'UID=\"root\" AUID=\"root\""
     status: "ok"
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1736329118112
  -
   sample: "type=USER_AUTH msg=audit(1740139921.923:1778): pid=155615 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='op=PAM:authentication grantors=pam_usertype,pam_localuser,pam_unix acct=\"devuser\" exe=\"/usr/sbin/sshd\" hostname=10.10.10.10 addr=10.10.10.10 terminal=ssh res=success'UID=\"root\" AUID=\"unset\""
@@ -95,12 +96,12 @@ tests:
         acct: "devuser"
         exe: "/usr/sbin/sshd"
         grantors:
-         - "pam_usertype"
-         - "pam_localuser"
-         - "pam_unix"
+          - "pam_usertype"
+          - "pam_localuser"
+          - "pam_unix"
         hostname: "10.10.10.10"
         op:
-         - "PAM:authentication"
+          - "PAM:authentication"
         res: "success"
         terminal: "ssh"
       msg_raw: ""
@@ -148,7 +149,7 @@ tests:
             name: "Auditd"
             vendor_name: "Linux"
           profiles:
-           - "host"
+            - "host"
           uid: "1778"
           version: "1.5.0"
         severity: "Informational"
@@ -164,15 +165,17 @@ tests:
       ses: 4294967295
       status: "ok"
       subj: "system_u:system_r:sshd_t:s0-s0:c0.c1023"
-      timestamp: 1.740139921923E12
+      timestamp: 1740139921923
       type: "USER_AUTH"
       usr:
         id: 0
         name: "root"
+      uid: 0
+      UID: root
     message: "type=USER_AUTH msg=audit(1740139921.923:1778): pid=155615 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='op=PAM:authentication grantors=pam_usertype,pam_localuser,pam_unix acct=\"devuser\" exe=\"/usr/sbin/sshd\" hostname=10.10.10.10 addr=10.10.10.10 terminal=ssh res=success'UID=\"root\" AUID=\"unset\""
     status: "ok"
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1740139921923
  -
   sample: "type=MAC_STATUS msg=audit(1740386730.535:1674): enforcing=0 old_enforcing=1 auid=1001 ses=36 enabled=1 old-enabled=1 lsm=selinux res=1AUID=\"devuser\""
@@ -264,12 +267,14 @@ tests:
             name: "Auditd"
             vendor_name: "Linux"
           profiles:
-           - "host"
+            - "host"
           uid: "182"
           version: "1.5.0"
         severity: "Informational"
         severity_id: 1
         time: 1669185724533
+        status_id: 0
+        status: Unknown
       operation: "getattr"
       outcome: "DENIED"
       permissive: 0
@@ -279,11 +284,11 @@ tests:
       scontext: "unconfined_u:unconfined_r:groupadd_t:s0-s0:c0.c1023"
       tclass: "filesystem"
       tcontext: "system_u:object_r:proc_t:s0"
-      timestamp: 1.669185724533E12
+      timestamp: 1669185724533
       type: "AVC"
     message: "type=AVC msg=audit(1669185724.533:182): avc:  denied  { getattr } for  pid=16660 comm=\"groupadd\" name=\"/\" dev=\"proc\" ino=1 scontext=unconfined_u:unconfined_r:groupadd_t:s0-s0:c0.c1023 tcontext=system_u:object_r:proc_t:s0 tclass=filesystem permissive=0"
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1669185724533
  -
   sample: "type=USER_SELINUX_ERR msg=audit(1669714331.555:198): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='Regex version mismatch, expected: 10.37 2021-05-26 actual: 10.40 2022-04-14  exe=\"/usr/lib/systemd/systemd\" sauid=0 hostname=10.10.10.10 addr=10.10.10.10 terminal=ssh'UID=\"root\" AUID=\"unset\" SAUID=\"root\""
@@ -327,18 +332,20 @@ tests:
             name: "Auditd"
             vendor_name: "Linux"
           profiles:
-           - "host"
+            - "host"
           uid: "198"
           version: "1.5.0"
         severity: "Informational"
         severity_id: 1
         time: 1669714331555
+        status_id: 0
+        status: Unknown
       pid: 1
       post_msg_kv: ""
       pre_msg_kv: ""
       ses: 4294967295
       subj: "system_u:system_r:init_t:s0"
-      timestamp: 1.669714331555E12
+      timestamp: 1669714331555
       type: "USER_SELINUX_ERR"
       uid: 0
       usr:
@@ -346,7 +353,7 @@ tests:
         name: "root"
     message: "type=USER_SELINUX_ERR msg=audit(1669714331.555:198): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='Regex version mismatch, expected: 10.37 2021-05-26 actual: 10.40 2022-04-14  exe=\"/usr/lib/systemd/systemd\" sauid=0 hostname=10.10.10.10 addr=10.10.10.10 terminal=ssh'UID=\"root\" AUID=\"unset\" SAUID=\"root\""
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1669714331555
  -
   sample: "type=USER_ROLE_CHANGE msg=audit(1741000050.325:2606): pid=60958 uid=0 auid=1001 ses=64 subj=system_u:system_r:sshd_t:s0-s0:c0.c1023 msg='pam: default-context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 selected-context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 exe=\"/usr/sbin/sshd\" hostname=10.10.10.10 addr=10.10.10.10 terminal=ssh res=success'UID=\"root\" AUID=\"devuser\""
@@ -446,25 +453,27 @@ tests:
             name: "Auditd"
             vendor_name: "Linux"
           profiles:
-           - "host"
+            - "host"
           uid: "121"
           version: "1.5.0"
         severity: "Informational"
         severity_id: 1
         time: 1678360880644
+        status_id: 0
+        status: Unknown
       old_val: 0
       post_msg_kv: ""
       pre_msg_kv: ""
       ses: 1
-      timestamp: 1.678360880644E12
+      timestamp: 1678360880644
       type: "MAC_CONFIG_CHANGE"
       usr:
         id: 1000
         name: "serviceuser"
       val: 1
-    message: "type=MAC_CONFIG_CHANGE msg=audit(1678360880.644:121): bool=virt_use_nfs val=1 old_val=0 auid=1000 ses=1\x1dAUID=\"serviceuser\""
+    message: "type=MAC_CONFIG_CHANGE msg=audit(1678360880.644:121): bool=virt_use_nfs val=1 old_val=0 auid=1000 ses=1\x1DAUID=\"serviceuser\""
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1678360880644
  -
   sample: "type=ADD_GROUP msg=audit(1740980591.704:5766): pid=12258 uid=0 auid=1001 ses=535 subj=unconfined msg='op=adding group to /etc/group id=1004 exe=\"/usr/sbin/groupadd\" hostname=ub10-10-10-10 addr=10.10.10.10 terminal=pts/3 res=success'UID=\"root\" AUID=\"serviceuser\" ID=\"demo\""
@@ -479,7 +488,7 @@ tests:
         hostname: "ub10-10-10-10"
         id: 1004
         op:
-         - "adding group to /etc/group"
+          - "adding group to /etc/group"
         res: "success"
         terminal: "pts/3"
       msg_raw: ""
@@ -526,7 +535,7 @@ tests:
             name: "Auditd"
             vendor_name: "Linux"
           profiles:
-           - "host"
+            - "host"
           uid: "5766"
           version: "1.5.0"
         severity: "Informational"
@@ -540,15 +549,17 @@ tests:
       ses: 535
       status: "ok"
       subj: "unconfined"
-      timestamp: 1.740980591704E12
+      timestamp: 1740980591704
       type: "ADD_GROUP"
       usr:
         id: 0
         name: "root"
+      uid: 0
+      UID: root
     message: "type=ADD_GROUP msg=audit(1740980591.704:5766): pid=12258 uid=0 auid=1001 ses=535 subj=unconfined msg='op=adding group to /etc/group id=1004 exe=\"/usr/sbin/groupadd\" hostname=ub10-10-10-10 addr=10.10.10.10 terminal=pts/3 res=success'UID=\"root\" AUID=\"serviceuser\" ID=\"demo\""
     status: "ok"
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1740980591704
  -
   sample: "type=DEL_GROUP msg=audit(1765794074.279:2333): pid=161731 uid=0 auid=1001 ses=27 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=delete-group grp=\"testuser\" acct=\"testuser\" exe=\"/usr/sbin/userdel\" hostname=localhost addr=10.10.10.10 terminal=pts/1 res=success'\x1dUID=\"root\" AUID=\"serviceuser\""
@@ -563,7 +574,7 @@ tests:
         grp: "testuser"
         hostname: "localhost"
         op:
-         - "delete-group"
+          - "delete-group"
         res: "success"
         terminal: "pts/1"
       msg_raw: ""
@@ -610,7 +621,7 @@ tests:
             name: "Auditd"
             vendor_name: "Linux"
           profiles:
-           - "host"
+            - "host"
           uid: "2333"
           version: "1.5.0"
         severity: "Informational"
@@ -624,15 +635,17 @@ tests:
       ses: 27
       status: "ok"
       subj: "unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023"
-      timestamp: 1.765794074279E12
+      timestamp: 1765794074279
       type: "DEL_GROUP"
       usr:
         id: 0
         name: "root"
-    message: "type=DEL_GROUP msg=audit(1765794074.279:2333): pid=161731 uid=0 auid=1001 ses=27 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=delete-group grp=\"testuser\" acct=\"testuser\" exe=\"/usr/sbin/userdel\" hostname=localhost addr=10.10.10.10 terminal=pts/1 res=success'\x1dUID=\"root\" AUID=\"serviceuser\""
+      uid: 0
+      UID: root
+    message: "type=DEL_GROUP msg=audit(1765794074.279:2333): pid=161731 uid=0 auid=1001 ses=27 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=delete-group grp=\"testuser\" acct=\"testuser\" exe=\"/usr/sbin/userdel\" hostname=localhost addr=10.10.10.10 terminal=pts/1 res=success'\x1DUID=\"root\" AUID=\"serviceuser\""
     status: "ok"
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1765794074279
  -
   sample: "type=ADD_USER msg=audit(1635509157.089:345): pid=73290 uid=0 auid=0 ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=add-user acct=\"serviceuser\" exe=\"/usr/sbin/useradd\" hostname=localhost addr=10.10.10.10 terminal=pts/1 res=success'\x1dUID=\"root\" AUID=\"root\""
@@ -646,7 +659,7 @@ tests:
         exe: "/usr/sbin/useradd"
         hostname: "localhost"
         op:
-         - "add-user"
+          - "add-user"
         res: "success"
         terminal: "pts/1"
       msg_raw: ""
@@ -691,7 +704,7 @@ tests:
             name: "Auditd"
             vendor_name: "Linux"
           profiles:
-           - "host"
+            - "host"
           uid: "345"
           version: "1.5.0"
         severity: "Informational"
@@ -707,15 +720,17 @@ tests:
       ses: 3
       status: "ok"
       subj: "unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023"
-      timestamp: 1.635509157089E12
+      timestamp: 1635509157089
       type: "ADD_USER"
       usr:
         id: 0
         name: "root"
-    message: "type=ADD_USER msg=audit(1635509157.089:345): pid=73290 uid=0 auid=0 ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=add-user acct=\"serviceuser\" exe=\"/usr/sbin/useradd\" hostname=localhost addr=10.10.10.10 terminal=pts/1 res=success'\x1dUID=\"root\" AUID=\"root\""
+      uid: 0
+      UID: root
+    message: "type=ADD_USER msg=audit(1635509157.089:345): pid=73290 uid=0 auid=0 ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=add-user acct=\"serviceuser\" exe=\"/usr/sbin/useradd\" hostname=localhost addr=10.10.10.10 terminal=pts/1 res=success'\x1DUID=\"root\" AUID=\"root\""
     status: "ok"
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1635509157089
  -
   sample: "type=DEL_USER msg=audit(1740379094.277:2332): pid=161731 uid=0 auid=1001 ses=27 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=delete-user id=1003 exe=\"/usr/sbin/userdel\" hostname=localhost addr=10.10.10.10 terminal=pts/1 res=success'\x1dUID=\"root\" AUID=\"serviceuser\" ID=\"testuser\""
@@ -730,7 +745,7 @@ tests:
         hostname: "localhost"
         id: 1003
         op:
-         - "delete-user"
+          - "delete-user"
         res: "success"
         terminal: "pts/1"
       msg_raw: ""
@@ -775,7 +790,7 @@ tests:
             name: "Auditd"
             vendor_name: "Linux"
           profiles:
-           - "host"
+            - "host"
           uid: "2332"
           version: "1.5.0"
         severity: "Informational"
@@ -792,15 +807,17 @@ tests:
       ses: 27
       status: "ok"
       subj: "unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023"
-      timestamp: 1.740379094277E12
+      timestamp: 1740379094277
       type: "DEL_USER"
       usr:
         id: 0
         name: "root"
-    message: "type=DEL_USER msg=audit(1740379094.277:2332): pid=161731 uid=0 auid=1001 ses=27 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=delete-user id=1003 exe=\"/usr/sbin/userdel\" hostname=localhost addr=10.10.10.10 terminal=pts/1 res=success'\x1dUID=\"root\" AUID=\"serviceuser\" ID=\"testuser\""
+      uid: 0
+      UID: root
+    message: "type=DEL_USER msg=audit(1740379094.277:2332): pid=161731 uid=0 auid=1001 ses=27 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=delete-user id=1003 exe=\"/usr/sbin/userdel\" hostname=localhost addr=10.10.10.10 terminal=pts/1 res=success'\x1DUID=\"root\" AUID=\"serviceuser\" ID=\"testuser\""
     status: "ok"
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1740379094277
  -
   sample: "type=USER_CHAUTHTOK msg=audit(1635509189.860:347): pid=73297 uid=0 auid=0 ses=3 subj=unconfined_u:unconfined_r:passwd_t:s0-s0:c0.c1023 msg='op=PAM:chauthtok grantors=pam_pwquality,pam_unix acct=\"serviceuser\" exe=\"/usr/bin/passwd\" hostname=localhost addr=10.10.10.10 terminal=pts/1 res=success'\x1dUID=\"root\" AUID=\"root\""
@@ -813,11 +830,11 @@ tests:
         acct: "serviceuser"
         exe: "/usr/bin/passwd"
         grantors:
-         - "pam_pwquality"
-         - "pam_unix"
+          - "pam_pwquality"
+          - "pam_unix"
         hostname: "localhost"
         op:
-         - "PAM:chauthtok"
+          - "PAM:chauthtok"
         res: "success"
         terminal: "pts/1"
       msg_raw: ""
@@ -862,7 +879,7 @@ tests:
             name: "Auditd"
             vendor_name: "Linux"
           profiles:
-           - "host"
+            - "host"
           uid: "347"
           version: "1.5.0"
         severity: "Informational"
@@ -878,15 +895,17 @@ tests:
       ses: 3
       status: "ok"
       subj: "unconfined_u:unconfined_r:passwd_t:s0-s0:c0.c1023"
-      timestamp: 1.63550918986E12
+      timestamp: 1635509189860
       type: "USER_CHAUTHTOK"
       usr:
         id: 0
         name: "root"
-    message: "type=USER_CHAUTHTOK msg=audit(1635509189.860:347): pid=73297 uid=0 auid=0 ses=3 subj=unconfined_u:unconfined_r:passwd_t:s0-s0:c0.c1023 msg='op=PAM:chauthtok grantors=pam_pwquality,pam_unix acct=\"serviceuser\" exe=\"/usr/bin/passwd\" hostname=localhost addr=10.10.10.10 terminal=pts/1 res=success'\x1dUID=\"root\" AUID=\"root\""
+      uid: 0
+      UID: root
+    message: "type=USER_CHAUTHTOK msg=audit(1635509189.860:347): pid=73297 uid=0 auid=0 ses=3 subj=unconfined_u:unconfined_r:passwd_t:s0-s0:c0.c1023 msg='op=PAM:chauthtok grantors=pam_pwquality,pam_unix acct=\"serviceuser\" exe=\"/usr/bin/passwd\" hostname=localhost addr=10.10.10.10 terminal=pts/1 res=success'\x1DUID=\"root\" AUID=\"root\""
     status: "ok"
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1635509189860
  -
   sample: "type=ROLE_ASSIGN msg=audit(1740720945.670:879): pid=11107 uid=0 auid=1001 ses=21 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=seuser-role,range id=0 old-seuser=user_u old-role=user_r old-range=s0 new-seuser=user_u new-role=staff_r new-range=s0 exe=/sbin/semanage hostname=localhost addr=10.10.10.10 terminal=pts/0 res=success'\x1dUID=\"root\" AUID=\"serviceuser\" ID=\"root\""
@@ -907,8 +926,8 @@ tests:
         old-role: "user_r"
         old-seuser: "user_u"
         op:
-         - "seuser-role"
-         - "range"
+          - "seuser-role"
+          - "range"
         res: "success"
         terminal: "pts/0"
       msg_raw: ""
@@ -953,11 +972,11 @@ tests:
             name: "Auditd"
             vendor_name: "Linux"
           profiles:
-           - "host"
+            - "host"
           uid: "879"
           version: "1.5.0"
         privileges:
-         - "staff_r"
+          - "staff_r"
         severity: "Informational"
         severity_id: 1
         status: "Success"
@@ -972,15 +991,17 @@ tests:
       ses: 21
       status: "ok"
       subj: "unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023"
-      timestamp: 1.74072094567E12
+      timestamp: 1740720945670
       type: "ROLE_ASSIGN"
       usr:
         id: 0
         name: "root"
-    message: "type=ROLE_ASSIGN msg=audit(1740720945.670:879): pid=11107 uid=0 auid=1001 ses=21 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=seuser-role,range id=0 old-seuser=user_u old-role=user_r old-range=s0 new-seuser=user_u new-role=staff_r new-range=s0 exe=/sbin/semanage hostname=localhost addr=10.10.10.10 terminal=pts/0 res=success'\x1dUID=\"root\" AUID=\"serviceuser\" ID=\"root\""
+      uid: 0
+      UID: root
+    message: "type=ROLE_ASSIGN msg=audit(1740720945.670:879): pid=11107 uid=0 auid=1001 ses=21 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=seuser-role,range id=0 old-seuser=user_u old-role=user_r old-range=s0 new-seuser=user_u new-role=staff_r new-range=s0 exe=/sbin/semanage hostname=localhost addr=10.10.10.10 terminal=pts/0 res=success'\x1DUID=\"root\" AUID=\"serviceuser\" ID=\"root\""
     status: "ok"
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1740720945670
  -
   sample: "type=ROLE_REMOVE msg=audit(1740130059.788:1002): pid=49119 uid=0 auid=1001 ses=17 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=seuser id=0 old-seuser=test1 old-role=user_r old-range=s0 new-seuser=user_u new-role=user_r new-range=s0 exe=/sbin/semanage hostname=localhost addr=10.10.10.10 terminal=pts/0 res=success'\x1dUID=\"root\" AUID=\"devuser\" ID=\"root\""
@@ -1001,7 +1022,7 @@ tests:
         old-role: "user_r"
         old-seuser: "test1"
         op:
-         - "seuser"
+          - "seuser"
         res: "success"
         terminal: "pts/0"
       msg_raw: ""
@@ -1046,11 +1067,11 @@ tests:
             name: "Auditd"
             vendor_name: "Linux"
           profiles:
-           - "host"
+            - "host"
           uid: "1002"
           version: "1.5.0"
         privileges:
-         - "user_r"
+          - "user_r"
         severity: "Informational"
         severity_id: 1
         status: "Success"
@@ -1065,15 +1086,17 @@ tests:
       ses: 17
       status: "ok"
       subj: "unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023"
-      timestamp: 1.740130059788E12
+      timestamp: 1740130059788
       type: "ROLE_REMOVE"
       usr:
         id: 0
         name: "root"
-    message: "type=ROLE_REMOVE msg=audit(1740130059.788:1002): pid=49119 uid=0 auid=1001 ses=17 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=seuser id=0 old-seuser=test1 old-role=user_r old-range=s0 new-seuser=user_u new-role=user_r new-range=s0 exe=/sbin/semanage hostname=localhost addr=10.10.10.10 terminal=pts/0 res=success'\x1dUID=\"root\" AUID=\"devuser\" ID=\"root\""
+      uid: 0
+      UID: root
+    message: "type=ROLE_REMOVE msg=audit(1740130059.788:1002): pid=49119 uid=0 auid=1001 ses=17 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=seuser id=0 old-seuser=test1 old-role=user_r old-range=s0 new-seuser=user_u new-role=user_r new-range=s0 exe=/sbin/semanage hostname=localhost addr=10.10.10.10 terminal=pts/0 res=success'\x1DUID=\"root\" AUID=\"devuser\" ID=\"root\""
     status: "ok"
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1740130059788
  -
   sample: "type=PATH msg=audit(1740378301.873:2247): item=0 name=\"/etc/shadow\" inode=50314523 dev=fd:03 mode=0100000 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:shadow_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\x1dOUID=\"root\" OGID=\"root\""
@@ -1135,14 +1158,16 @@ tests:
       post_msg_kv: ""
       pre_msg_kv: ""
       rdev: "00:00"
-      timestamp: 1.740378301873E12
+      timestamp: 1740378301873
       type: "PATH"
       usr:
         id: 0
         name: "root"
-    message: "type=PATH msg=audit(1740378301.873:2247): item=0 name=\"/etc/shadow\" inode=50314523 dev=fd:03 mode=0100000 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:shadow_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\x1dOUID=\"root\" OGID=\"root\""
+      OUID: root
+      ouid: 0
+    message: "type=PATH msg=audit(1740378301.873:2247): item=0 name=\"/etc/shadow\" inode=50314523 dev=fd:03 mode=0100000 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:shadow_t:s0 nametype=NORMAL cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\x1DOUID=\"root\" OGID=\"root\""
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1740378301873
  -
   sample: "type=PATH msg=audit(1740378301.873:2247): item=0 name=\"/lib/x86_64-linux-gnu/libcrypt.so.1\" inode=50314523 dev=fd:03 mode=0100000 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:shadow_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\x1dOUID=\"root\" OGID=\"root\""
@@ -1205,14 +1230,16 @@ tests:
       post_msg_kv: ""
       pre_msg_kv: ""
       rdev: "00:00"
-      timestamp: 1.740378301873E12
+      timestamp: 1740378301873
       type: "PATH"
       usr:
         id: 0
         name: "root"
-    message: "type=PATH msg=audit(1740378301.873:2247): item=0 name=\"/lib/x86_64-linux-gnu/libcrypt.so.1\" inode=50314523 dev=fd:03 mode=0100000 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:shadow_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\x1dOUID=\"root\" OGID=\"root\""
+      OUID: root
+      ouid: 0
+    message: "type=PATH msg=audit(1740378301.873:2247): item=0 name=\"/lib/x86_64-linux-gnu/libcrypt.so.1\" inode=50314523 dev=fd:03 mode=0100000 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:shadow_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\x1DOUID=\"root\" OGID=\"root\""
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1740378301873
  -
   sample: "type=PATH msg=audit(1740378301.873:2247): item=0 name=\"/lib/\" inode=50314523 dev=fd:03 mode=0040755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:shadow_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\x1dOUID=\"root\" OGID=\"root\""
@@ -1274,14 +1301,16 @@ tests:
       post_msg_kv: ""
       pre_msg_kv: ""
       rdev: "00:00"
-      timestamp: 1.740378301873E12
+      timestamp: 1740378301873
       type: "PATH"
       usr:
         id: 0
         name: "root"
-    message: "type=PATH msg=audit(1740378301.873:2247): item=0 name=\"/lib/\" inode=50314523 dev=fd:03 mode=0040755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:shadow_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\x1dOUID=\"root\" OGID=\"root\""
+      OUID: root
+      ouid: 0
+    message: "type=PATH msg=audit(1740378301.873:2247): item=0 name=\"/lib/\" inode=50314523 dev=fd:03 mode=0040755 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:shadow_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\x1DOUID=\"root\" OGID=\"root\""
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1740378301873
  -
   sample: "type=PATH msg=audit(1740378301.873:2247): item=0 name=\"/run/nginx.pid\" inode=50314523 dev=fd:03 mode=0100000 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:shadow_t:s0 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\x1dOUID=\"root\" OGID=\"root\""
@@ -1344,14 +1373,16 @@ tests:
       post_msg_kv: ""
       pre_msg_kv: ""
       rdev: "00:00"
-      timestamp: 1.740378301873E12
+      timestamp: 1740378301873
       type: "PATH"
       usr:
         id: 0
         name: "root"
-    message: "type=PATH msg=audit(1740378301.873:2247): item=0 name=\"/run/nginx.pid\" inode=50314523 dev=fd:03 mode=0100000 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:shadow_t:s0 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\x1dOUID=\"root\" OGID=\"root\""
+      OUID: root
+      ouid: 0
+    message: "type=PATH msg=audit(1740378301.873:2247): item=0 name=\"/run/nginx.pid\" inode=50314523 dev=fd:03 mode=0100000 ouid=0 ogid=0 rdev=00:00 obj=system_u:object_r:shadow_t:s0 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0\x1DOUID=\"root\" OGID=\"root\""
     tags:
-     - "source:LOGS_SOURCE"
+      - "source:LOGS_SOURCE"
     timestamp: 1740378301873
  -
   sample: "type=DAEMON_CONFIG msg=audit(1740139921.923:946): op=reconfigure state=changed auid=1001 pid=12258 subj=unconfined_u:unconfined_r:rpm_script_t:s0-s0:c0.c1023 res=success AUID=\"serviceuser\""


### PR DESCRIPTION
Jira: https://datadoghq.atlassian.net/browse/SCI2-5909

### What does this PR do?

Apply OCSF style guide fixes and address backend pipeline validation errors in the Linux Audit Logs OCSF pipeline.

### Motivation

Two backend validation errors were identified via Slack:

1. **Fallback with values but empty sources** — the `ocsf.activity_id` mapper in the File System Activity [1001] from SYSCALL sub-pipeline had `fallback.values` populated but `fallback.sources: {}`. The backend requires at least one source when fallback values are provided.

2. **Process Activity [1007] EXECVE pipeline missing actor mapper** — the EXECVE sub-pipeline had no `ocsf.actor.*` schema-remapper entries, which fails backend validation. Since EXECVE records contain only argument lists (no process context), a self-map for `ocsf.actor.app_name` (already set upstream by a string-builder) was added.

Additional fixes from an OCSF style guide review:
- Removed 66 empty `fallback: values: {} sources: {}` stub blocks
- Ordered sub-pipelines ascending by `class_uid` (Base Event [0] last)
- Fixed facet definitions: removed disallowed keys, added missing required keys
- Fixed three facet conflicts flagged by CI (`ocsf.device.ip` name, `ocsf.dst_endpoint.port` and `ocsf.time` missing `facetType`/`type`)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged