### PR TITLE
Add spawn_identical_subagents tool to the AI framework

### DIFF
--- a/ddev/src/ddev/ai/tools/agents/base.py
+++ b/ddev/src/ddev/ai/tools/agents/base.py
@@ -31,6 +31,13 @@ class ChildOutcome:
     output_tokens: int = 0
     error: str | None = None
 
+    def as_md_section(self) -> str:
+        """Render this outcome as a labeled markdown section for aggregated multi-child output."""
+        if self.error is not None:
+            return f"## {self.name} - {self.error}"
+        status = "TRUNCATED (max_tokens)" if self.stop_reason == StopReason.MAX_TOKENS else "ok"
+        return f"## {self.name} — {status}\n{self.text}"
+
 
 class BaseSpawnTool[TInput: BaseToolInput](BaseTool[TInput]):
     def __init__(

--- a/ddev/src/ddev/ai/tools/agents/base.py
+++ b/ddev/src/ddev/ai/tools/agents/base.py
@@ -45,16 +45,16 @@ class BaseSpawnTool[TInput: BaseToolInput](BaseTool[TInput]):
         # Parent may itself have a spawn tool; never offer either to children.
         self._allowed_tools = set(agent_config.tools) - {SPAWN_SUBAGENT_NAME, SPAWN_IDENTICAL_NAME}
 
-    def _validate_tools(self, tools: list[str], label: str) -> str | None:
+    def _validate_tools(self, tools: list[str], label: str = "Subagent") -> str | None:
         if SPAWN_SUBAGENT_NAME in tools or SPAWN_IDENTICAL_NAME in tools:
             return (
-                f"Subagent {label!r} not spawned: subagents cannot spawn further subagents "
+                f"{label!r} not spawned: subagents cannot spawn further subagents "
                 f"('{SPAWN_SUBAGENT_NAME}'/'{SPAWN_IDENTICAL_NAME}' are not allowed in 'tools')."
             )
         disallowed = sorted(set(tools) - self._allowed_tools)
         if disallowed:
             return (
-                f"Subagent {label!r} not spawned: disallowed tools requested: {disallowed}. "
+                f"{label!r} not spawned: disallowed tools requested: {disallowed}. "
                 f"Allowed subset: {sorted(self._allowed_tools)}."
             )
         return None

--- a/ddev/src/ddev/ai/tools/agents/base.py
+++ b/ddev/src/ddev/ai/tools/agents/base.py
@@ -1,0 +1,96 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from pydantic import ValidationError
+
+from ddev.ai.agent.scope import AgentRole, AgentScope
+from ddev.ai.agent.types import StopReason
+from ddev.ai.tools.core.base import BaseTool, BaseToolInput
+
+if TYPE_CHECKING:
+    from ddev.ai.phases.config import AgentConfig
+    from ddev.ai.react.factory import ReActProcessFactory
+
+SPAWN_SUBAGENT_NAME = "spawn_subagent"
+SPAWN_IDENTICAL_NAME = "spawn_identical_subagents"
+MAX_TOKENS_NOTICE = "[SUBAGENT HIT MAX_TOKENS — RESPONSE MAY BE TRUNCATED]"
+
+
+@dataclass
+class ChildOutcome:
+    name: str
+    text: str | None = None
+    stop_reason: StopReason | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    error: str | None = None
+
+
+class BaseSpawnTool[TInput: BaseToolInput](BaseTool[TInput]):
+    def __init__(
+        self,
+        owner_id: str,
+        agent_config: AgentConfig,
+        process_factory: ReActProcessFactory,
+    ) -> None:
+        self._owner_id = owner_id
+        self._agent_config = agent_config
+        self._process_factory = process_factory
+        # Parent may itself have a spawn tool; never offer either to children.
+        self._allowed_tools = set(agent_config.tools) - {SPAWN_SUBAGENT_NAME, SPAWN_IDENTICAL_NAME}
+
+    def _validate_tools(self, tools: list[str], label: str) -> str | None:
+        if SPAWN_SUBAGENT_NAME in tools or SPAWN_IDENTICAL_NAME in tools:
+            return (
+                f"Subagent {label!r} not spawned: subagents cannot spawn further subagents "
+                f"('{SPAWN_SUBAGENT_NAME}'/'{SPAWN_IDENTICAL_NAME}' are not allowed in 'tools')."
+            )
+        disallowed = sorted(set(tools) - self._allowed_tools)
+        if disallowed:
+            return (
+                f"Subagent {label!r} not spawned: disallowed tools requested: {disallowed}. "
+                f"Allowed subset: {sorted(self._allowed_tools)}."
+            )
+        return None
+
+    async def _run_child(
+        self,
+        subagent_id: str,
+        name: str,
+        system_prompt: str,
+        prompt: str,
+        tools: list[str],
+    ) -> ChildOutcome:
+        child_scope = AgentScope(owner_id=subagent_id, role=AgentRole.SUBAGENT)
+        try:
+            child_config = self._agent_config.model_copy(update={"tools": tools})
+            process = self._process_factory.create(
+                scope=child_scope, agent_config=child_config, system_prompt=system_prompt
+            )
+        except ValidationError as e:
+            return ChildOutcome(name=name, error=f"Invalid child config: {e.error_count()} validation error(s)")
+        except Exception as e:
+            return ChildOutcome(name=name, error=f"failed to build: {type(e).__name__}: {e}")
+
+        try:
+            result = await process.start(prompt)
+        except Exception as e:
+            return ChildOutcome(name=name, error=f"failed: {type(e).__name__}: {e}")
+
+        text = result.final_response.text
+        stop_reason = result.final_response.stop_reason
+        if stop_reason == StopReason.MAX_TOKENS:
+            text = f"{MAX_TOKENS_NOTICE}\n\n{text}"
+        return ChildOutcome(
+            name=name,
+            text=text,
+            stop_reason=stop_reason,
+            input_tokens=result.total_input_tokens,
+            output_tokens=result.total_output_tokens,
+        )

--- a/ddev/src/ddev/ai/tools/agents/spawn_identical_subagents.py
+++ b/ddev/src/ddev/ai/tools/agents/spawn_identical_subagents.py
@@ -78,7 +78,7 @@ class SpawnIdenticalSubagentsTool(BaseSpawnTool[SpawnIdenticalSubagentsInput]):
             return ToolResult(
                 success=False, error=f"Too many assignments: {len(tool_input.assignments)} > {MAX_ASSIGNMENTS}."
             )
-        if error := self._validate_tools(tool_input.tools, "parallel"):
+        if error := self._validate_tools(tool_input.tools, "Parallel subagents"):
             return ToolResult(success=False, error=error)
 
         limit = tool_input.max_parallel or min(len(tool_input.assignments), DEFAULT_PARALLEL)

--- a/ddev/src/ddev/ai/tools/agents/spawn_identical_subagents.py
+++ b/ddev/src/ddev/ai/tools/agents/spawn_identical_subagents.py
@@ -1,0 +1,119 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated
+
+from pydantic import Field
+
+from ddev.ai.agent.types import StopReason
+from ddev.ai.tools.agents.base import SPAWN_IDENTICAL_NAME, BaseSpawnTool, ChildOutcome
+from ddev.ai.tools.core.base import BaseToolInput
+from ddev.ai.tools.core.types import ToolResult
+
+DEFAULT_PARALLEL = 8
+MAX_ASSIGNMENTS = 32
+CONCISE_DIRECTIVE = (
+    "Keep your final answer as concise as possible: report only the essential result, with no preamble "
+    "or restating of the task. Your output is aggregated with many sibling subagents', so verbosity "
+    "risks overflowing the parent's context."
+)
+
+
+class Assignment(BaseToolInput):
+    name: Annotated[
+        str,
+        Field(description="Short label, unique within the call.", pattern=r"^[A-Za-z0-9._-]{1,64}$"),
+    ]
+    prompt: Annotated[
+        str,
+        Field(description="This child's user turn."),
+    ]
+
+
+class SpawnIdenticalSubagentsInput(BaseToolInput):
+    system_prompt: Annotated[
+        str,
+        Field(
+            description="Shared system prompt used verbatim for every child. Put the role and common instructions here."
+        ),
+    ]
+    tools: Annotated[
+        list[str],
+        Field(description="Tool subset granted to every child. Must be a subset of your tools; no spawn tool allowed."),
+    ] = []
+    assignments: Annotated[
+        list[Assignment],
+        Field(
+            description="One entry per child. Keep each prompt small — only the assignment-specific part.", min_length=1
+        ),
+    ]
+    max_parallel: Annotated[
+        int | None,
+        Field(description="Optional cap on concurrent children.", ge=1),
+    ] = None
+
+
+class SpawnIdenticalSubagentsTool(BaseSpawnTool[SpawnIdenticalSubagentsInput]):
+    """Run the SAME subagent (identical system prompt and tools) over many different assignments.
+
+    Prefer this over issuing several 'spawn_subagent' calls when the children share a role: the shared
+    system prompt and tool set are sent once, not repeated per child, saving output tokens. Each child
+    differs only by its short assignment prompt — e.g. renaming metrics where each child handles one
+    batch of metric families. Children run in parallel; results come back in assignment order and one
+    failing child never affects its siblings."""
+
+    @property
+    def name(self) -> str:
+        return SPAWN_IDENTICAL_NAME
+
+    async def __call__(self, tool_input: SpawnIdenticalSubagentsInput) -> ToolResult:
+        names = [a.name for a in tool_input.assignments]
+        if len(set(names)) != len(names):
+            return ToolResult(success=False, error="Assignment names must be unique.")
+        if len(tool_input.assignments) > MAX_ASSIGNMENTS:
+            return ToolResult(
+                success=False, error=f"Too many assignments: {len(tool_input.assignments)} > {MAX_ASSIGNMENTS}."
+            )
+        if error := self._validate_tools(tool_input.tools, "parallel"):
+            return ToolResult(success=False, error=error)
+
+        limit = tool_input.max_parallel or min(len(tool_input.assignments), DEFAULT_PARALLEL)
+        semaphore = asyncio.Semaphore(limit)
+        system_prompt = f"{tool_input.system_prompt}\n\n{CONCISE_DIRECTIVE}"
+
+        async def run(index: int, assignment: Assignment) -> ChildOutcome:
+            async with semaphore:
+                subagent_id = f"{self._owner_id}.par.{index:03d}-{assignment.name}"
+                return await self._run_child(
+                    subagent_id, assignment.name, system_prompt, assignment.prompt, tool_input.tools
+                )
+
+        results = await asyncio.gather(
+            *(run(i, a) for i, a in enumerate(tool_input.assignments)), return_exceptions=True
+        )
+
+        outcomes: list[ChildOutcome] = []
+        for assignment, result in zip(tool_input.assignments, results, strict=True):
+            if isinstance(result, BaseException):
+                outcomes.append(ChildOutcome(name=assignment.name, error=f"failed: {type(result).__name__}: {result}"))
+            else:
+                outcomes.append(result)
+
+        sections = "\n\n".join(self._format(o) for o in outcomes)
+        return ToolResult(
+            success=any(o.error is None for o in outcomes),
+            data=sections,
+            error=None if any(o.error is None for o in outcomes) else "All children failed.",
+            total_input_tokens=sum(o.input_tokens for o in outcomes),
+            total_output_tokens=sum(o.output_tokens for o in outcomes),
+        )
+
+    def _format(self, outcome: ChildOutcome) -> str:
+        if outcome.error is not None:
+            return f"## {outcome.name} — FAILED: {outcome.error}"
+        status = "TRUNCATED (max_tokens)" if outcome.stop_reason == StopReason.MAX_TOKENS else "ok"
+        return f"## {outcome.name} — {status}\n{outcome.text}"

--- a/ddev/src/ddev/ai/tools/agents/spawn_identical_subagents.py
+++ b/ddev/src/ddev/ai/tools/agents/spawn_identical_subagents.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from pydantic import Field
 
@@ -13,6 +13,10 @@ from ddev.ai.agent.types import StopReason
 from ddev.ai.tools.agents.base import SPAWN_IDENTICAL_NAME, BaseSpawnTool, ChildOutcome
 from ddev.ai.tools.core.base import BaseToolInput
 from ddev.ai.tools.core.types import ToolResult
+
+if TYPE_CHECKING:
+    from ddev.ai.phases.config import AgentConfig
+    from ddev.ai.react.factory import ReActProcessFactory
 
 DEFAULT_PARALLEL = 8
 MAX_ASSIGNMENTS = 32
@@ -66,6 +70,15 @@ class SpawnIdenticalSubagentsTool(BaseSpawnTool[SpawnIdenticalSubagentsInput]):
     batch of metric families. Children run in parallel; results come back in assignment order and one
     failing child never affects its siblings."""
 
+    def __init__(
+        self,
+        owner_id: str,
+        agent_config: AgentConfig,
+        process_factory: ReActProcessFactory,
+    ) -> None:
+        super().__init__(owner_id, agent_config, process_factory)
+        self._call_counter = 0
+
     @property
     def name(self) -> str:
         return SPAWN_IDENTICAL_NAME
@@ -85,9 +98,12 @@ class SpawnIdenticalSubagentsTool(BaseSpawnTool[SpawnIdenticalSubagentsInput]):
         semaphore = asyncio.Semaphore(limit)
         system_prompt = f"{tool_input.system_prompt}\n\n{CONCISE_DIRECTIVE}"
 
+        self._call_counter += 1
+        call_id = self._call_counter
+
         async def run(index: int, assignment: Assignment) -> ChildOutcome:
             async with semaphore:
-                subagent_id = f"{self._owner_id}.par.{index:03d}-{assignment.name}"
+                subagent_id = f"{self._owner_id}.par.{call_id:03d}.{index:03d}-{assignment.name}"
                 return await self._run_child(
                     subagent_id, assignment.name, system_prompt, assignment.prompt, tool_input.tools
                 )
@@ -114,6 +130,6 @@ class SpawnIdenticalSubagentsTool(BaseSpawnTool[SpawnIdenticalSubagentsInput]):
 
     def _format(self, outcome: ChildOutcome) -> str:
         if outcome.error is not None:
-            return f"## {outcome.name} — FAILED: {outcome.error}"
+            return f"## {outcome.name} - {outcome.error}"
         status = "TRUNCATED (max_tokens)" if outcome.stop_reason == StopReason.MAX_TOKENS else "ok"
         return f"## {outcome.name} — {status}\n{outcome.text}"

--- a/ddev/src/ddev/ai/tools/agents/spawn_identical_subagents.py
+++ b/ddev/src/ddev/ai/tools/agents/spawn_identical_subagents.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Annotated
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
-from ddev.ai.agent.types import StopReason
 from ddev.ai.tools.agents.base import SPAWN_IDENTICAL_NAME, BaseSpawnTool, ChildOutcome
 from ddev.ai.tools.core.base import BaseToolInput
 from ddev.ai.tools.core.types import ToolResult
@@ -52,13 +51,23 @@ class SpawnIdenticalSubagentsInput(BaseToolInput):
     assignments: Annotated[
         list[Assignment],
         Field(
-            description="One entry per child. Keep each prompt small — only the assignment-specific part.", min_length=1
+            description="One entry per child. Keep each prompt small — only the assignment-specific part.",
+            min_length=1,
+            max_length=MAX_ASSIGNMENTS,
         ),
     ]
     max_parallel: Annotated[
-        int | None,
-        Field(description="Optional cap on concurrent children.", ge=1),
-    ] = None
+        int,
+        Field(description="Cap on concurrent children.", ge=1),
+    ] = DEFAULT_PARALLEL
+
+    @field_validator("assignments")
+    @classmethod
+    def names_must_be_unique(cls, assignments: list[Assignment]) -> list[Assignment]:
+        names = [a.name for a in assignments]
+        if len(set(names)) != len(names):
+            raise ValueError("Assignment names must be unique.")
+        return assignments
 
 
 class SpawnIdenticalSubagentsTool(BaseSpawnTool[SpawnIdenticalSubagentsInput]):
@@ -84,18 +93,10 @@ class SpawnIdenticalSubagentsTool(BaseSpawnTool[SpawnIdenticalSubagentsInput]):
         return SPAWN_IDENTICAL_NAME
 
     async def __call__(self, tool_input: SpawnIdenticalSubagentsInput) -> ToolResult:
-        names = [a.name for a in tool_input.assignments]
-        if len(set(names)) != len(names):
-            return ToolResult(success=False, error="Assignment names must be unique.")
-        if len(tool_input.assignments) > MAX_ASSIGNMENTS:
-            return ToolResult(
-                success=False, error=f"Too many assignments: {len(tool_input.assignments)} > {MAX_ASSIGNMENTS}."
-            )
         if error := self._validate_tools(tool_input.tools, "Parallel subagents"):
             return ToolResult(success=False, error=error)
 
-        limit = tool_input.max_parallel or min(len(tool_input.assignments), DEFAULT_PARALLEL)
-        semaphore = asyncio.Semaphore(limit)
+        semaphore = asyncio.Semaphore(tool_input.max_parallel)
         system_prompt = f"{tool_input.system_prompt}\n\n{CONCISE_DIRECTIVE}"
 
         self._call_counter += 1
@@ -119,7 +120,7 @@ class SpawnIdenticalSubagentsTool(BaseSpawnTool[SpawnIdenticalSubagentsInput]):
             else:
                 outcomes.append(result)
 
-        sections = "\n\n".join(self._format(o) for o in outcomes)
+        sections = "\n\n".join(o.as_md_section() for o in outcomes)
         return ToolResult(
             success=any(o.error is None for o in outcomes),
             data=sections,
@@ -127,9 +128,3 @@ class SpawnIdenticalSubagentsTool(BaseSpawnTool[SpawnIdenticalSubagentsInput]):
             total_input_tokens=sum(o.input_tokens for o in outcomes),
             total_output_tokens=sum(o.output_tokens for o in outcomes),
         )
-
-    def _format(self, outcome: ChildOutcome) -> str:
-        if outcome.error is not None:
-            return f"## {outcome.name} - {outcome.error}"
-        status = "TRUNCATED (max_tokens)" if outcome.stop_reason == StopReason.MAX_TOKENS else "ok"
-        return f"## {outcome.name} — {status}\n{outcome.text}"

--- a/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
+++ b/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
@@ -4,18 +4,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 
-from pydantic import Field, ValidationError
+from pydantic import Field
 
-from ddev.ai.agent.scope import AgentRole, AgentScope
-from ddev.ai.agent.types import StopReason
-from ddev.ai.tools.core.base import BaseTool, BaseToolInput
+from ddev.ai.tools.agents.base import SPAWN_SUBAGENT_NAME, BaseSpawnTool
+from ddev.ai.tools.core.base import BaseToolInput
 from ddev.ai.tools.core.types import ToolResult
-
-if TYPE_CHECKING:
-    from ddev.ai.phases.config import AgentConfig
-    from ddev.ai.react.factory import ReActProcessFactory
 
 
 class SpawnSubagentInput(BaseToolInput):
@@ -46,7 +41,7 @@ class SpawnSubagentInput(BaseToolInput):
     ] = None
 
 
-class SpawnSubagentTool(BaseTool[SpawnSubagentInput]):
+class SpawnSubagentTool(BaseSpawnTool[SpawnSubagentInput]):
     """Delegate a self-contained subtask to a fresh subagent.
 
     The subagent runs one Reason-Action loop with the provided system prompt, user prompt, and tool subset.
@@ -54,76 +49,30 @@ class SpawnSubagentTool(BaseTool[SpawnSubagentInput]):
     to put anything you need in its final message. Include every piece of context the subagent needs
     inside the system prompt and the user prompt."""
 
-    def __init__(
-        self,
-        owner_id: str,
-        agent_config: AgentConfig,
-        process_factory: ReActProcessFactory,
-    ) -> None:
-        self._owner_id = owner_id
-        self._agent_config = agent_config
-        self._process_factory = process_factory
-        # Parent may itself have spawn_subagent; never offer it to children.
-        self._allowed_tools = set(agent_config.tools) - {self.name}
+    def __init__(self, owner_id, agent_config, process_factory) -> None:
+        super().__init__(owner_id, agent_config, process_factory)
         self._counter = 0
 
     @property
     def name(self) -> str:
-        return "spawn_subagent"
-
-    def _label(self, tool_input: SpawnSubagentInput) -> str:
-        return tool_input.name or "unnamed"
+        return SPAWN_SUBAGENT_NAME
 
     async def __call__(self, tool_input: SpawnSubagentInput) -> ToolResult:
-        label = self._label(tool_input)
+        label = tool_input.name or "unnamed"
 
-        if self.name in tool_input.tools:
-            return ToolResult(
-                success=False,
-                error=(
-                    f"Subagent {label!r} not spawned: subagents cannot spawn further subagents "
-                    f"('{self.name}' is not allowed in 'tools')."
-                ),
-            )
-        disallowed = sorted(set(tool_input.tools) - self._allowed_tools)
-        if disallowed:
-            return ToolResult(
-                success=False,
-                error=(
-                    f"Subagent {label!r} not spawned: disallowed tools requested: {disallowed}. "
-                    f"Allowed subset: {sorted(self._allowed_tools)}."
-                ),
-            )
+        if error := self._validate_tools(tool_input.tools, label):
+            return ToolResult(success=False, error=error)
 
         self._counter += 1
         subagent_id = f"{self._owner_id}.sub.{self._counter:03d}-{label}"
-        child_scope = AgentScope(owner_id=subagent_id, role=AgentRole.SUBAGENT)
-
-        try:
-            child_config = self._agent_config.model_copy(update={"tools": tool_input.tools})
-            process = self._process_factory.create(
-                scope=child_scope,
-                agent_config=child_config,
-                system_prompt=tool_input.system_prompt,
-            )
-        except ValidationError as e:
-            return ToolResult(
-                success=False, error=f"Invalid child config for {label!r}: {e.error_count()} validation error(s)"
-            )
-        except Exception as e:
-            return ToolResult(success=False, error=f"Subagent {label!r} failed to build: {type(e).__name__}: {e}")
-
-        try:
-            result = await process.start(tool_input.prompt)
-        except Exception as e:
-            return ToolResult(success=False, error=f"Subagent {label!r} failed: {type(e).__name__}: {e}")
-
-        data = result.final_response.text
-        if result.final_response.stop_reason == StopReason.MAX_TOKENS:
-            data = "[SUBAGENT HIT MAX_TOKENS — RESPONSE MAY BE TRUNCATED]\n\n" + data
+        outcome = await self._run_child(
+            subagent_id, label, tool_input.system_prompt, tool_input.prompt, tool_input.tools
+        )
+        if outcome.error is not None:
+            return ToolResult(success=False, error=f"Subagent {label!r} {outcome.error}")
         return ToolResult(
             success=True,
-            data=data,
-            total_input_tokens=result.total_input_tokens,
-            total_output_tokens=result.total_output_tokens,
+            data=outcome.text,
+            total_input_tokens=outcome.input_tokens,
+            total_output_tokens=outcome.output_tokens,
         )

--- a/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
+++ b/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
@@ -4,13 +4,17 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from pydantic import Field
 
 from ddev.ai.tools.agents.base import SPAWN_SUBAGENT_NAME, BaseSpawnTool
 from ddev.ai.tools.core.base import BaseToolInput
 from ddev.ai.tools.core.types import ToolResult
+
+if TYPE_CHECKING:
+    from ddev.ai.phases.config import AgentConfig
+    from ddev.ai.react.process import ReActProcessFactory
 
 
 class SpawnSubagentInput(BaseToolInput):
@@ -49,7 +53,12 @@ class SpawnSubagentTool(BaseSpawnTool[SpawnSubagentInput]):
     to put anything you need in its final message. Include every piece of context the subagent needs
     inside the system prompt and the user prompt."""
 
-    def __init__(self, owner_id, agent_config, process_factory) -> None:
+    def __init__(
+        self,
+        owner_id: str,
+        agent_config: AgentConfig,
+        process_factory: ReActProcessFactory,
+    ) -> None:
         super().__init__(owner_id, agent_config, process_factory)
         self._counter = 0
 

--- a/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
+++ b/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
@@ -69,7 +69,7 @@ class SpawnSubagentTool(BaseSpawnTool[SpawnSubagentInput]):
     async def __call__(self, tool_input: SpawnSubagentInput) -> ToolResult:
         label = tool_input.name or "unnamed"
 
-        if error := self._validate_tools(tool_input.tools, label):
+        if error := self._validate_tools(tool_input.tools, f"Subagent {label!r}"):
             return ToolResult(success=False, error=error)
 
         self._counter += 1

--- a/ddev/src/ddev/ai/tools/core/base.py
+++ b/ddev/src/ddev/ai/tools/core/base.py
@@ -10,7 +10,7 @@ from types import get_original_bases
 from typing import Any
 
 from anthropic.types import ToolParam
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from .types import ToolResult
 
@@ -105,7 +105,7 @@ class BaseTool[TInput: BaseToolInput](ABC):
         try:
             input_cls = _get_input_type(type(self))
             validated: TInput = input_cls.model_validate(raw)  # type: ignore[assignment]
-        except (TypeError, ValueError) as e:
+        except (ValidationError, TypeError, ValueError) as e:
             return ToolResult(success=False, error=str(e))
         try:
             return await self(validated)

--- a/ddev/src/ddev/ai/tools/registry.py
+++ b/ddev/src/ddev/ai/tools/registry.py
@@ -102,6 +102,12 @@ TOOL_MANIFEST: dict[str, ToolSpec] = {
         factory=_spawn_subagent_factory,
         read_only=False,
     ),
+    "spawn_identical_subagents": ToolSpec(
+        "agents.spawn_identical_subagents",
+        "SpawnIdenticalSubagentsTool",
+        factory=_spawn_subagent_factory,
+        read_only=False,
+    ),
 }
 
 

--- a/ddev/tests/ai/tools/agents/conftest.py
+++ b/ddev/tests/ai/tools/agents/conftest.py
@@ -1,0 +1,149 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+"""Shared doubles for the spawn-tool tests: fake agents and a fake ReActProcessFactory.
+
+Use the `mock_agent`, `raising_agent`, `make_response`, and `process_factory` fixtures rather than
+importing the classes below directly.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ddev.ai.agent.base import BaseAgent
+from ddev.ai.agent.build import AgentRuntime
+from ddev.ai.agent.scope import AgentScope
+from ddev.ai.agent.types import AgentResponse, StopReason, TokenUsage, ToolCall, ToolResultMessage
+from ddev.ai.callbacks.callbacks import Callbacks
+from ddev.ai.phases.config import AgentConfig
+from ddev.ai.react.process import ReActProcess
+from ddev.ai.runtime.agent_log import AgentLogger
+from ddev.ai.tools.registry import ToolRegistry
+
+
+class MockAgent(BaseAgent[Any]):
+    """Replays a fixed list of responses, one per send()."""
+
+    def __init__(self, responses: list[AgentResponse]) -> None:
+        super().__init__("mock", "", ToolRegistry([]))
+        self._responses = list(responses)
+        self._index = 0
+
+    async def send(
+        self, content: str | list[ToolResultMessage], allowed_tools: list[str] | None = None
+    ) -> AgentResponse:
+        response = self._responses[self._index]
+        self._index += 1
+        return response
+
+    def reset(self) -> None:
+        self._history = []
+
+    async def compact(self) -> AgentResponse | None:
+        return None
+
+    async def compact_preserving_last_turn(self) -> AgentResponse | None:
+        return None
+
+
+class RaisingAgent(MockAgent):
+    """Raises a fixed exception on every send() call."""
+
+    def __init__(self, exc: BaseException) -> None:
+        super().__init__([])
+        self._exc = exc
+
+    async def send(
+        self, content: str | list[ToolResultMessage], allowed_tools: list[str] | None = None
+    ) -> AgentResponse:
+        raise self._exc
+
+
+def _make_response(
+    text: str = "",
+    stop_reason: StopReason = StopReason.END_TURN,
+    tool_calls: list[ToolCall] | None = None,
+) -> AgentResponse:
+    return AgentResponse(
+        stop_reason=stop_reason,
+        text=text,
+        tool_calls=tool_calls or [],
+        usage=TokenUsage(input_tokens=10, output_tokens=5, cache_read_input_tokens=0, cache_creation_input_tokens=0),
+    )
+
+
+class FakeProcessFactory:
+    """Stand-in ReActProcessFactory that records create() calls and wires child
+    processes to an AgentLogger rooted at ``root`` so logging can be asserted."""
+
+    def __init__(
+        self,
+        root: Path,
+        agent_factory=None,
+        tool_registry: ToolRegistry | None = None,
+        build_error: BaseException | None = None,
+    ) -> None:
+        self._agent_factory = agent_factory or (lambda: MockAgent([_make_response()]))
+        self._tool_registry = tool_registry or ToolRegistry([])
+        self._build_error = build_error
+        self.callbacks = Callbacks([AgentLogger(root).as_callback_set()])
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, *, scope: AgentScope, agent_config: AgentConfig, system_prompt: str) -> ReActProcess:
+        self.calls.append({"owner_id": scope.owner_id, "agent_config": agent_config, "system_prompt": system_prompt})
+        if self._build_error is not None:
+            raise self._build_error
+        runtime = AgentRuntime(agent=self._agent_factory(), tool_registry=self._tool_registry)
+        return ReActProcess(runtime, callbacks=self.callbacks, scope=scope)
+
+
+ResponseFactory = Callable[..., AgentResponse]
+ProcessFactoryBuilder = Callable[..., FakeProcessFactory]
+SubagentLog = Callable[[str], Path]
+ReadEvents = Callable[[Path], list[dict]]
+
+
+@pytest.fixture
+def mock_agent() -> type[MockAgent]:
+    return MockAgent
+
+
+@pytest.fixture
+def raising_agent() -> type[RaisingAgent]:
+    return RaisingAgent
+
+
+@pytest.fixture
+def make_response() -> ResponseFactory:
+    return _make_response
+
+
+@pytest.fixture
+def process_factory(tmp_path: Path) -> ProcessFactoryBuilder:
+    def build(agent_factory=None, tool_registry=None, build_error=None) -> FakeProcessFactory:
+        return FakeProcessFactory(tmp_path, agent_factory, tool_registry, build_error)
+
+    return build
+
+
+@pytest.fixture
+def subagent_log(tmp_path: Path) -> SubagentLog:
+    def path(subagent_id: str) -> Path:
+        return tmp_path / "subagent" / f"{subagent_id}.jsonl"
+
+    return path
+
+
+@pytest.fixture
+def read_events() -> ReadEvents:
+    def read(log_path: Path) -> list[dict]:
+        return [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    return read

--- a/ddev/tests/ai/tools/agents/conftest.py
+++ b/ddev/tests/ai/tools/agents/conftest.py
@@ -31,7 +31,7 @@ from ddev.ai.tools.registry import ToolRegistry
 class MockAgent(BaseAgent[Any]):
     """Replays a fixed list of responses, one per send()."""
 
-    def __init__(self, responses: list[AgentResponse]) -> None:
+    def __init__(self, responses: list[AgentResponse]):
         super().__init__("mock", "", ToolRegistry([]))
         self._responses = list(responses)
         self._index = 0
@@ -43,7 +43,7 @@ class MockAgent(BaseAgent[Any]):
         self._index += 1
         return response
 
-    def reset(self) -> None:
+    def reset(self):
         self._history = []
 
     async def compact(self) -> AgentResponse | None:
@@ -56,7 +56,7 @@ class MockAgent(BaseAgent[Any]):
 class RaisingAgent(MockAgent):
     """Raises a fixed exception on every send() call."""
 
-    def __init__(self, exc: BaseException) -> None:
+    def __init__(self, exc: BaseException):
         super().__init__([])
         self._exc = exc
 
@@ -89,7 +89,7 @@ class FakeProcessFactory:
         agent_factory=None,
         tool_registry: ToolRegistry | None = None,
         build_error: BaseException | None = None,
-    ) -> None:
+    ):
         self._agent_factory = agent_factory or (lambda: MockAgent([_make_response()]))
         self._tool_registry = tool_registry or ToolRegistry([])
         self._build_error = build_error

--- a/ddev/tests/ai/tools/agents/test_base.py
+++ b/ddev/tests/ai/tools/agents/test_base.py
@@ -1,0 +1,46 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import pytest
+
+from ddev.ai.phases.config import AgentConfig
+from ddev.ai.tools.agents.base import SPAWN_IDENTICAL_NAME, SPAWN_SUBAGENT_NAME, BaseSpawnTool
+from ddev.ai.tools.core.base import BaseToolInput
+from ddev.ai.tools.core.types import ToolResult
+
+
+class _ConcreteSpawnTool(BaseSpawnTool):
+    @property
+    def name(self) -> str:
+        return "concrete"
+
+    async def __call__(self, tool_input: BaseToolInput) -> ToolResult:
+        return ToolResult(success=True)
+
+
+def make_tool(tools: list[str]) -> _ConcreteSpawnTool:
+    return _ConcreteSpawnTool(owner_id="p", agent_config=AgentConfig(tools=tools), process_factory=None)
+
+
+def test_allowed_tools_excludes_both_spawn_tools() -> None:
+    tool = make_tool(["read_file", "edit_file", SPAWN_SUBAGENT_NAME, SPAWN_IDENTICAL_NAME])
+    assert tool._allowed_tools == {"read_file", "edit_file"}
+
+
+@pytest.mark.parametrize(
+    "requested,fragment",
+    [
+        ([SPAWN_SUBAGENT_NAME], "spawn further"),
+        ([SPAWN_IDENTICAL_NAME], "spawn further"),
+        (["edit_file"], "disallowed"),
+        (["read_file"], None),
+    ],
+)
+def test_validate_tools(requested: list[str], fragment: str | None) -> None:
+    error = make_tool(["read_file"])._validate_tools(requested, "child")
+    if fragment is None:
+        assert error is None
+    else:
+        assert fragment in error

--- a/ddev/tests/ai/tools/agents/test_base.py
+++ b/ddev/tests/ai/tools/agents/test_base.py
@@ -24,7 +24,7 @@ def make_tool(tools: list[str]) -> _ConcreteSpawnTool:
     return _ConcreteSpawnTool(owner_id="p", agent_config=AgentConfig(tools=tools), process_factory=None)
 
 
-def test_allowed_tools_excludes_both_spawn_tools() -> None:
+def test_allowed_tools_excludes_both_spawn_tools():
     tool = make_tool(["read_file", "edit_file", SPAWN_SUBAGENT_NAME, SPAWN_IDENTICAL_NAME])
     assert tool._allowed_tools == {"read_file", "edit_file"}
 
@@ -38,7 +38,7 @@ def test_allowed_tools_excludes_both_spawn_tools() -> None:
         (["read_file"], None),
     ],
 )
-def test_validate_tools(requested: list[str], fragment: str | None) -> None:
+def test_validate_tools(requested: list[str], fragment: str | None):
     error = make_tool(["read_file"])._validate_tools(requested, "child")
     if fragment is None:
         assert error is None

--- a/ddev/tests/ai/tools/agents/test_spawn_identical_subagents.py
+++ b/ddev/tests/ai/tools/agents/test_spawn_identical_subagents.py
@@ -41,21 +41,10 @@ def assignments(*names: str) -> list[Assignment]:
 
 async def test_duplicate_names_rejected(process_factory: ProcessFactoryBuilder):
     factory = process_factory()
-    result = await make_tool(factory)(
-        SpawnIdenticalSubagentsInput(system_prompt="s", assignments=assignments("a", "a"))
-    )
+    raw = {"system_prompt": "s", "assignments": [{"name": "a", "prompt": "do a"}, {"name": "a", "prompt": "do a"}]}
+    result = await make_tool(factory).run(raw)
     assert result.success is False
     assert "unique" in result.error
-    assert factory.calls == []
-
-
-async def test_over_cap_rejected(process_factory: ProcessFactoryBuilder):
-    factory = process_factory()
-    result = await make_tool(factory)(
-        SpawnIdenticalSubagentsInput(system_prompt="s", assignments=assignments(*[f"a{i}" for i in range(33)]))
-    )
-    assert result.success is False
-    assert "Too many" in result.error
     assert factory.calls == []
 
 

--- a/ddev/tests/ai/tools/agents/test_spawn_identical_subagents.py
+++ b/ddev/tests/ai/tools/agents/test_spawn_identical_subagents.py
@@ -39,7 +39,7 @@ def assignments(*names: str) -> list[Assignment]:
     return [Assignment(name=n, prompt=f"do {n}") for n in names]
 
 
-async def test_duplicate_names_rejected(process_factory: ProcessFactoryBuilder) -> None:
+async def test_duplicate_names_rejected(process_factory: ProcessFactoryBuilder):
     factory = process_factory()
     result = await make_tool(factory)(
         SpawnIdenticalSubagentsInput(system_prompt="s", assignments=assignments("a", "a"))
@@ -49,7 +49,7 @@ async def test_duplicate_names_rejected(process_factory: ProcessFactoryBuilder) 
     assert factory.calls == []
 
 
-async def test_over_cap_rejected(process_factory: ProcessFactoryBuilder) -> None:
+async def test_over_cap_rejected(process_factory: ProcessFactoryBuilder):
     factory = process_factory()
     result = await make_tool(factory)(
         SpawnIdenticalSubagentsInput(system_prompt="s", assignments=assignments(*[f"a{i}" for i in range(33)]))
@@ -61,7 +61,7 @@ async def test_over_cap_rejected(process_factory: ProcessFactoryBuilder) -> None
 
 async def test_happy_path(
     process_factory: ProcessFactoryBuilder, mock_agent: type[MockAgent], make_response: ResponseFactory
-) -> None:
+):
     factory = process_factory(lambda: mock_agent([make_response(text="done")]))
     result = await make_tool(factory)(
         SpawnIdenticalSubagentsInput(system_prompt="sys", tools=["read_file"], assignments=assignments("a", "b", "c"))
@@ -74,11 +74,25 @@ async def test_happy_path(
     )
     assert all(c["agent_config"].tools == ["read_file"] for c in factory.calls)
     assert [c["owner_id"] for c in factory.calls] == [
-        "parent.par.000-a",
-        "parent.par.001-b",
-        "parent.par.002-c",
+        "parent.par.001.000-a",
+        "parent.par.001.001-b",
+        "parent.par.001.002-c",
     ]
     assert result.data.index("## a") < result.data.index("## b") < result.data.index("## c")
+
+
+async def test_repeated_calls_produce_distinct_owner_ids(
+    process_factory: ProcessFactoryBuilder, mock_agent: type[MockAgent], make_response: ResponseFactory
+):
+    factory = process_factory(lambda: mock_agent([make_response(text="done")]))
+    tool = make_tool(factory)
+    tool_input = SpawnIdenticalSubagentsInput(system_prompt="sys", assignments=assignments("a"))
+
+    await tool(tool_input)
+    await tool(tool_input)
+
+    owner_ids = [c["owner_id"] for c in factory.calls]
+    assert owner_ids == ["parent.par.001.000-a", "parent.par.002.000-a"]
 
 
 async def test_partial_failure(
@@ -86,7 +100,7 @@ async def test_partial_failure(
     mock_agent: type[MockAgent],
     raising_agent: type[RaisingAgent],
     make_response: ResponseFactory,
-) -> None:
+):
     def agent_factory():
         agent_factory.n += 1
         if agent_factory.n == 2:
@@ -102,7 +116,7 @@ async def test_partial_failure(
     assert result.data.count("— ok") == 2
 
 
-async def test_all_fail(process_factory: ProcessFactoryBuilder, raising_agent: type[RaisingAgent]) -> None:
+async def test_all_fail(process_factory: ProcessFactoryBuilder, raising_agent: type[RaisingAgent]):
     factory = process_factory(lambda: raising_agent(RuntimeError("boom")))
     result = await make_tool(factory)(
         SpawnIdenticalSubagentsInput(system_prompt="s", assignments=assignments("a", "b"))
@@ -113,7 +127,7 @@ async def test_all_fail(process_factory: ProcessFactoryBuilder, raising_agent: t
 
 async def test_max_tokens_notice(
     process_factory: ProcessFactoryBuilder, mock_agent: type[MockAgent], make_response: ResponseFactory
-) -> None:
+):
     factory = process_factory(lambda: mock_agent([make_response(text="partial", stop_reason=StopReason.MAX_TOKENS)]))
     result = await make_tool(factory)(SpawnIdenticalSubagentsInput(system_prompt="s", assignments=assignments("a")))
     assert result.success is True
@@ -123,7 +137,7 @@ async def test_max_tokens_notice(
 
 async def test_max_parallel_respected(
     process_factory: ProcessFactoryBuilder, mock_agent: type[MockAgent], make_response: ResponseFactory
-) -> None:
+):
     active = 0
     peak = 0
 

--- a/ddev/tests/ai/tools/agents/test_spawn_identical_subagents.py
+++ b/ddev/tests/ai/tools/agents/test_spawn_identical_subagents.py
@@ -1,0 +1,149 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from ddev.ai.agent.types import StopReason
+from ddev.ai.phases.config import AgentConfig
+from ddev.ai.tools.agents.spawn_identical_subagents import (
+    CONCISE_DIRECTIVE,
+    Assignment,
+    SpawnIdenticalSubagentsInput,
+    SpawnIdenticalSubagentsTool,
+)
+
+if TYPE_CHECKING:
+    from tests.ai.tools.agents.conftest import (
+        FakeProcessFactory,
+        MockAgent,
+        ProcessFactoryBuilder,
+        RaisingAgent,
+        ResponseFactory,
+    )
+
+
+def make_tool(
+    factory: FakeProcessFactory, parent_tools: list[str] | None = None, owner_id: str = "parent"
+) -> SpawnIdenticalSubagentsTool:
+    return SpawnIdenticalSubagentsTool(
+        owner_id=owner_id,
+        agent_config=AgentConfig(tools=parent_tools or ["read_file", "edit_file"]),
+        process_factory=factory,
+    )
+
+
+def assignments(*names: str) -> list[Assignment]:
+    return [Assignment(name=n, prompt=f"do {n}") for n in names]
+
+
+async def test_duplicate_names_rejected(process_factory: ProcessFactoryBuilder) -> None:
+    factory = process_factory()
+    result = await make_tool(factory)(
+        SpawnIdenticalSubagentsInput(system_prompt="s", assignments=assignments("a", "a"))
+    )
+    assert result.success is False
+    assert "unique" in result.error
+    assert factory.calls == []
+
+
+async def test_over_cap_rejected(process_factory: ProcessFactoryBuilder) -> None:
+    factory = process_factory()
+    result = await make_tool(factory)(
+        SpawnIdenticalSubagentsInput(system_prompt="s", assignments=assignments(*[f"a{i}" for i in range(33)]))
+    )
+    assert result.success is False
+    assert "Too many" in result.error
+    assert factory.calls == []
+
+
+async def test_happy_path(
+    process_factory: ProcessFactoryBuilder, mock_agent: type[MockAgent], make_response: ResponseFactory
+) -> None:
+    factory = process_factory(lambda: mock_agent([make_response(text="done")]))
+    result = await make_tool(factory)(
+        SpawnIdenticalSubagentsInput(system_prompt="sys", tools=["read_file"], assignments=assignments("a", "b", "c"))
+    )
+    assert result.success is True
+    assert result.total_input_tokens == 30
+    assert result.total_output_tokens == 15
+    assert all(
+        c["system_prompt"].startswith("sys\n\n") and CONCISE_DIRECTIVE in c["system_prompt"] for c in factory.calls
+    )
+    assert all(c["agent_config"].tools == ["read_file"] for c in factory.calls)
+    assert [c["owner_id"] for c in factory.calls] == [
+        "parent.par.000-a",
+        "parent.par.001-b",
+        "parent.par.002-c",
+    ]
+    assert result.data.index("## a") < result.data.index("## b") < result.data.index("## c")
+
+
+async def test_partial_failure(
+    process_factory: ProcessFactoryBuilder,
+    mock_agent: type[MockAgent],
+    raising_agent: type[RaisingAgent],
+    make_response: ResponseFactory,
+) -> None:
+    def agent_factory():
+        agent_factory.n += 1
+        if agent_factory.n == 2:
+            return raising_agent(RuntimeError("boom"))
+        return mock_agent([make_response(text="ok")])
+
+    agent_factory.n = 0
+    result = await make_tool(process_factory(agent_factory))(
+        SpawnIdenticalSubagentsInput(system_prompt="s", assignments=assignments("a", "b", "c"))
+    )
+    assert result.success is True
+    assert "FAILED" in result.data
+    assert result.data.count("— ok") == 2
+
+
+async def test_all_fail(process_factory: ProcessFactoryBuilder, raising_agent: type[RaisingAgent]) -> None:
+    factory = process_factory(lambda: raising_agent(RuntimeError("boom")))
+    result = await make_tool(factory)(
+        SpawnIdenticalSubagentsInput(system_prompt="s", assignments=assignments("a", "b"))
+    )
+    assert result.success is False
+    assert result.error == "All children failed."
+
+
+async def test_max_tokens_notice(
+    process_factory: ProcessFactoryBuilder, mock_agent: type[MockAgent], make_response: ResponseFactory
+) -> None:
+    factory = process_factory(lambda: mock_agent([make_response(text="partial", stop_reason=StopReason.MAX_TOKENS)]))
+    result = await make_tool(factory)(SpawnIdenticalSubagentsInput(system_prompt="s", assignments=assignments("a")))
+    assert result.success is True
+    assert "TRUNCATED (max_tokens)" in result.data
+    assert "SUBAGENT HIT MAX_TOKENS" in result.data
+
+
+async def test_max_parallel_respected(
+    process_factory: ProcessFactoryBuilder, mock_agent: type[MockAgent], make_response: ResponseFactory
+) -> None:
+    active = 0
+    peak = 0
+
+    class CountingAgent(mock_agent):
+        def __init__(self):
+            super().__init__([make_response(text="ok")])
+
+        async def send(self, content, allowed_tools=None):
+            nonlocal active, peak
+            active += 1
+            peak = max(peak, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+            return await super().send(content, allowed_tools)
+
+    factory = process_factory(CountingAgent)
+    result = await make_tool(factory)(
+        SpawnIdenticalSubagentsInput(
+            system_prompt="s", max_parallel=2, assignments=assignments(*[f"a{i}" for i in range(6)])
+        )
+    )
+    assert result.success is True
+    assert peak <= 2

--- a/ddev/tests/ai/tools/agents/test_spawn_identical_subagents.py
+++ b/ddev/tests/ai/tools/agents/test_spawn_identical_subagents.py
@@ -112,7 +112,6 @@ async def test_partial_failure(
         SpawnIdenticalSubagentsInput(system_prompt="s", assignments=assignments("a", "b", "c"))
     )
     assert result.success is True
-    assert "FAILED" in result.data
     assert result.data.count("— ok") == 2
 
 

--- a/ddev/tests/ai/tools/agents/test_spawn_subagent.py
+++ b/ddev/tests/ai/tools/agents/test_spawn_subagent.py
@@ -4,119 +4,30 @@
 from __future__ import annotations
 
 import asyncio
-import json
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 
-from ddev.ai.agent.base import BaseAgent
-from ddev.ai.agent.build import AgentRuntime
 from ddev.ai.agent.exceptions import AgentError
-from ddev.ai.agent.scope import AgentScope
-from ddev.ai.agent.types import AgentResponse, StopReason, TokenUsage, ToolCall, ToolResultMessage
-from ddev.ai.callbacks.callbacks import Callbacks
+from ddev.ai.agent.types import StopReason, ToolCall
 from ddev.ai.phases.config import AgentConfig
-from ddev.ai.react.process import ReActProcess
-from ddev.ai.runtime.agent_log import AgentLogger
 from ddev.ai.tools.agents.spawn_subagent import SpawnSubagentInput, SpawnSubagentTool
 from ddev.ai.tools.core.types import ToolResult
 from ddev.ai.tools.registry import ToolRegistry
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from tests.ai.conftest import FakeToolFactory
-
-# ---------------------------------------------------------------------------
-# Mock helpers
-# ---------------------------------------------------------------------------
-
-
-class MockAgent(BaseAgent[Any]):
-    def __init__(self, responses: list[AgentResponse]) -> None:
-        super().__init__("mock", "", ToolRegistry([]))
-        self._responses = list(responses)
-        self._index = 0
-
-    async def send(
-        self,
-        content: str | list[ToolResultMessage],
-        allowed_tools: list[str] | None = None,
-    ) -> AgentResponse:
-        response = self._responses[self._index]
-        self._index += 1
-        return response
-
-    def reset(self) -> None:
-        self._history = []
-
-    async def compact(self) -> AgentResponse | None:
-        return None
-
-    async def compact_preserving_last_turn(self) -> AgentResponse | None:
-        return None
-
-
-class _RaisingAgent(BaseAgent[Any]):
-    """Raises a fixed exception on every send() call."""
-
-    def __init__(self, exc: BaseException) -> None:
-        super().__init__("raising", "", ToolRegistry([]))
-        self._exc = exc
-
-    async def send(
-        self,
-        content: str | list[ToolResultMessage],
-        allowed_tools: list[str] | None = None,
-    ) -> AgentResponse:
-        raise self._exc
-
-    def reset(self) -> None:
-        self._history = []
-
-    async def compact(self) -> AgentResponse | None:
-        return None
-
-    async def compact_preserving_last_turn(self) -> AgentResponse | None:
-        return None
-
-
-def make_response(
-    text: str = "",
-    stop_reason: StopReason = StopReason.END_TURN,
-    tool_calls: list[ToolCall] | None = None,
-) -> AgentResponse:
-    return AgentResponse(
-        stop_reason=stop_reason,
-        text=text,
-        tool_calls=tool_calls or [],
-        usage=TokenUsage(input_tokens=10, output_tokens=5, cache_read_input_tokens=0, cache_creation_input_tokens=0),
+    from tests.ai.tools.agents.conftest import (
+        FakeProcessFactory,
+        MockAgent,
+        ProcessFactoryBuilder,
+        RaisingAgent,
+        ReadEvents,
+        ResponseFactory,
+        SubagentLog,
     )
-
-
-class FakeProcessFactory:
-    """Stand-in ReActProcessFactory that records create() calls and wires child
-    processes to an AgentLogger rooted at ``root`` so logging can be asserted."""
-
-    def __init__(
-        self,
-        root: Path,
-        agent_factory=None,
-        tool_registry: ToolRegistry | None = None,
-        build_error: BaseException | None = None,
-    ) -> None:
-        self._root = root
-        self._agent_factory = agent_factory or (lambda: MockAgent([make_response()]))
-        self._tool_registry = tool_registry or ToolRegistry([])
-        self._build_error = build_error
-        self.callbacks = Callbacks([AgentLogger(root).as_callback_set()])
-        self.calls: list[dict[str, Any]] = []
-
-    def create(self, *, scope: AgentScope, agent_config: AgentConfig, system_prompt: str) -> ReActProcess:
-        self.calls.append({"owner_id": scope.owner_id, "agent_config": agent_config, "system_prompt": system_prompt})
-        if self._build_error is not None:
-            raise self._build_error
-        runtime = AgentRuntime(agent=self._agent_factory(), tool_registry=self._tool_registry)
-        return ReActProcess(runtime, callbacks=self.callbacks, scope=scope)
 
 
 def make_tool(
@@ -130,40 +41,6 @@ def make_tool(
         agent_config=agent_config or AgentConfig(tools=parent_tools or ["read_file", "edit_file"]),
         process_factory=factory,
     )
-
-
-def subagent_log(root: Path, subagent_id: str) -> Path:
-    return root / "subagent" / f"{subagent_id}.jsonl"
-
-
-def read_events(log_path: Path) -> list[dict]:
-    return [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
-
-
-# ---------------------------------------------------------------------------
-# Input validation — fails before the child process is created
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "tools,allowed,error_fragment",
-    [
-        (["spawn_subagent"], ["read_file"], "spawn further subagents"),
-        (["read_file", "edit_file"], ["read_file"], "edit_file"),
-    ],
-    ids=["recursive", "disallowed"],
-)
-async def test_input_validation_fails_before_create(tmp_path, tools, allowed, error_fragment):
-    factory = FakeProcessFactory(tmp_path, lambda: MockAgent([make_response()]))
-    tool = make_tool(factory, parent_tools=allowed)
-    result = await tool(SpawnSubagentInput(system_prompt="s", prompt="p", tools=tools, name="x"))
-
-    assert result.success is False
-    assert error_fragment in result.error
-    assert "x" in result.error
-    assert factory.calls == []
-    assert tool._counter == 0
-    assert not (tmp_path / "subagent").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -180,10 +57,17 @@ async def test_input_validation_fails_before_create(tmp_path, tools, allowed, er
     ],
     ids=["named", "none", "empty"],
 )
-async def test_happy_path(tmp_path: Path, name: str | None, expected_id: str) -> None:
-    factory = FakeProcessFactory(tmp_path, lambda: MockAgent([make_response(text="ok")]))
-    tool = make_tool(factory)
-    result = await tool(SpawnSubagentInput(system_prompt="sys", prompt="do it", tools=[], name=name))
+async def test_happy_path(
+    process_factory: ProcessFactoryBuilder,
+    mock_agent: type[MockAgent],
+    make_response: ResponseFactory,
+    subagent_log: SubagentLog,
+    read_events: ReadEvents,
+    name: str | None,
+    expected_id: str,
+) -> None:
+    factory = process_factory(lambda: mock_agent([make_response(text="ok")]))
+    result = await make_tool(factory)(SpawnSubagentInput(system_prompt="sys", prompt="do it", tools=[], name=name))
 
     assert result.success is True
     assert result.data == "ok"
@@ -191,73 +75,78 @@ async def test_happy_path(tmp_path: Path, name: str | None, expected_id: str) ->
     assert result.total_output_tokens == 5
     assert factory.calls[0]["owner_id"] == expected_id
 
-    events = read_events(subagent_log(tmp_path, expected_id))
+    events = read_events(subagent_log(expected_id))
     assert events[0]["event"] == "start"
     assert events[-1]["event"] == "finish"
     assert events[-1]["success"] is True
 
 
-async def test_multi_iteration_wires_callbacks(tmp_path: Path, fake_tool: FakeToolFactory) -> None:
+async def test_multi_iteration_wires_callbacks(
+    process_factory: ProcessFactoryBuilder,
+    mock_agent: type[MockAgent],
+    make_response: ResponseFactory,
+    subagent_log: SubagentLog,
+    read_events: ReadEvents,
+    fake_tool: FakeToolFactory,
+) -> None:
     """A subagent tool call produces a tool_call log event via the run-wide callbacks."""
     tool_call = ToolCall(id="tc1", name="read_file", input={"path": "/f"})
-    factory = FakeProcessFactory(
-        tmp_path,
-        lambda: MockAgent(
+    factory = process_factory(
+        lambda: mock_agent(
             [make_response(stop_reason=StopReason.TOOL_USE, tool_calls=[tool_call]), make_response(text="done")]
         ),
         tool_registry=ToolRegistry([fake_tool("read_file", result=ToolResult(success=True, data="content"))]),
     )
-    tool = make_tool(factory, parent_tools=["read_file"])
-
-    result = await tool(SpawnSubagentInput(system_prompt="sys", prompt="go", tools=["read_file"]))
+    result = await make_tool(factory, parent_tools=["read_file"])(
+        SpawnSubagentInput(system_prompt="sys", prompt="go", tools=["read_file"])
+    )
 
     assert result.success is True
     assert result.data == "done"
-    events = read_events(subagent_log(tmp_path, "parent.sub.001-unnamed"))
+    events = read_events(subagent_log("parent.sub.001-unnamed"))
     assert "tool_call" in [e["event"] for e in events]
 
 
-async def test_child_runtime_config_inherits_parent_settings_and_requested_tools(tmp_path):
+async def test_child_runtime_config_inherits_parent_settings_and_requested_tools(
+    process_factory: ProcessFactoryBuilder, mock_agent: type[MockAgent], make_response: ResponseFactory
+) -> None:
     parent_config = AgentConfig(
         provider="anthropic",
         tools=["read_file", "edit_file", "spawn_subagent"],
         model="custom-model",
         max_tokens=123,
     )
-    factory = FakeProcessFactory(tmp_path, lambda: MockAgent([make_response(text="ok")]))
-    tool = make_tool(
-        factory,
-        parent_tools=["read_file", "edit_file", "spawn_subagent"],
-        agent_config=parent_config,
-    )
-
-    result = await tool(
+    factory = process_factory(lambda: mock_agent([make_response(text="ok")]))
+    result = await make_tool(factory, agent_config=parent_config)(
         SpawnSubagentInput(system_prompt="child system", prompt="go", tools=["read_file"], name="child")
     )
 
     assert result.success is True
-    call = factory.calls[0]
-    child_config = call["agent_config"]
+    child_config = factory.calls[0]["agent_config"]
     assert isinstance(child_config, AgentConfig)
     assert child_config.provider == "anthropic"
     assert child_config.model == "custom-model"
     assert child_config.max_tokens == 123
     assert child_config.tools == ["read_file"]
-    assert call["system_prompt"] == "child system"
-    assert call["owner_id"] == "parent.sub.001-child"
+    assert factory.calls[0]["system_prompt"] == "child system"
+    assert factory.calls[0]["owner_id"] == "parent.sub.001-child"
 
 
-async def test_max_tokens_response_prefixed(tmp_path):
-    responses = [make_response(text="partial", stop_reason=StopReason.MAX_TOKENS)]
-    factory = FakeProcessFactory(tmp_path, lambda: MockAgent(list(responses)))
-    tool = make_tool(factory)
-    result = await tool(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="mt"))
+async def test_max_tokens_response_prefixed(
+    process_factory: ProcessFactoryBuilder,
+    mock_agent: type[MockAgent],
+    make_response: ResponseFactory,
+    subagent_log: SubagentLog,
+    read_events: ReadEvents,
+) -> None:
+    factory = process_factory(lambda: mock_agent([make_response(text="partial", stop_reason=StopReason.MAX_TOKENS)]))
+    result = await make_tool(factory)(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="mt"))
 
     assert result.success is True
     assert result.data.startswith("[SUBAGENT HIT MAX_TOKENS — RESPONSE MAY BE TRUNCATED]")
     assert "partial" in result.data
 
-    finish = next(e for e in read_events(subagent_log(tmp_path, "parent.sub.001-mt")) if e["event"] == "finish")
+    finish = next(e for e in read_events(subagent_log("parent.sub.001-mt")) if e["event"] == "finish")
     assert finish["stop_reason"] == "max_tokens"
 
 
@@ -266,26 +155,31 @@ async def test_max_tokens_response_prefixed(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-async def test_build_failure_returns_tool_result(tmp_path):
-    factory = FakeProcessFactory(tmp_path, build_error=ValueError("boom"))
-    tool = make_tool(factory)
-    result = await tool(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="fail"))
+async def test_build_failure_returns_tool_result(
+    process_factory: ProcessFactoryBuilder, subagent_log: SubagentLog
+) -> None:
+    factory = process_factory(build_error=ValueError("boom"))
+    result = await make_tool(factory)(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="fail"))
 
     assert result.success is False
     assert "fail" in result.error and "ValueError" in result.error and "boom" in result.error
     # create() raised before any process ran, so no child log exists.
-    assert not subagent_log(tmp_path, "parent.sub.001-fail").exists()
+    assert not subagent_log("parent.sub.001-fail").exists()
 
 
-async def test_react_process_failure(tmp_path):
-    factory = FakeProcessFactory(tmp_path, lambda: _RaisingAgent(AgentError("rate limit")))
-    tool = make_tool(factory)
-    result = await tool(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="rl"))
+async def test_react_process_failure(
+    process_factory: ProcessFactoryBuilder,
+    raising_agent: type[RaisingAgent],
+    subagent_log: SubagentLog,
+    read_events: ReadEvents,
+) -> None:
+    factory = process_factory(lambda: raising_agent(AgentError("rate limit")))
+    result = await make_tool(factory)(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="rl"))
 
     assert result.success is False
     assert "rl" in result.error and "AgentError" in result.error
 
-    events = read_events(subagent_log(tmp_path, "parent.sub.001-rl"))
+    events = read_events(subagent_log("parent.sub.001-rl"))
     names = [e["event"] for e in events]
     assert "error" in names and "finish" in names
     assert names.index("error") < names.index("finish")
@@ -297,25 +191,33 @@ async def test_react_process_failure(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-async def test_counter_increments_per_invocation(tmp_path):
-    factory = FakeProcessFactory(tmp_path, lambda: MockAgent([make_response(text="r")]))
-    tool = make_tool(factory)
+async def test_counter_increments_per_invocation(
+    process_factory: ProcessFactoryBuilder,
+    mock_agent: type[MockAgent],
+    make_response: ResponseFactory,
+    subagent_log: SubagentLog,
+) -> None:
+    tool = make_tool(process_factory(lambda: mock_agent([make_response(text="r")])))
 
     await tool(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="a"))
     await tool(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="b"))
 
-    assert subagent_log(tmp_path, "parent.sub.001-a").exists()
-    assert subagent_log(tmp_path, "parent.sub.002-b").exists()
+    assert subagent_log("parent.sub.001-a").exists()
+    assert subagent_log("parent.sub.002-b").exists()
 
 
-async def test_parallel_spawns_get_distinct_counters(tmp_path):
-    factory = FakeProcessFactory(tmp_path, lambda: MockAgent([make_response(text="ok")]))
+async def test_parallel_spawns_get_distinct_counters(
+    tmp_path: Path,
+    process_factory: ProcessFactoryBuilder,
+    mock_agent: type[MockAgent],
+    make_response: ResponseFactory,
+) -> None:
+    factory = process_factory(lambda: mock_agent([make_response(text="ok")]))
     tool = make_tool(factory)
     results = await asyncio.gather(
         *[tool(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name=n)) for n in ["x", "y", "z"]]
     )
 
     assert all(r.success for r in results)
-    owner_ids = {c["owner_id"] for c in factory.calls}
-    assert len(owner_ids) == 3
+    assert len({c["owner_id"] for c in factory.calls}) == 3
     assert len(list((tmp_path / "subagent").glob("*.jsonl"))) == 3

--- a/ddev/tests/ai/tools/agents/test_spawn_subagent.py
+++ b/ddev/tests/ai/tools/agents/test_spawn_subagent.py
@@ -65,7 +65,7 @@ async def test_happy_path(
     read_events: ReadEvents,
     name: str | None,
     expected_id: str,
-) -> None:
+):
     factory = process_factory(lambda: mock_agent([make_response(text="ok")]))
     result = await make_tool(factory)(SpawnSubagentInput(system_prompt="sys", prompt="do it", tools=[], name=name))
 
@@ -88,7 +88,7 @@ async def test_multi_iteration_wires_callbacks(
     subagent_log: SubagentLog,
     read_events: ReadEvents,
     fake_tool: FakeToolFactory,
-) -> None:
+):
     """A subagent tool call produces a tool_call log event via the run-wide callbacks."""
     tool_call = ToolCall(id="tc1", name="read_file", input={"path": "/f"})
     factory = process_factory(
@@ -109,7 +109,7 @@ async def test_multi_iteration_wires_callbacks(
 
 async def test_child_runtime_config_inherits_parent_settings_and_requested_tools(
     process_factory: ProcessFactoryBuilder, mock_agent: type[MockAgent], make_response: ResponseFactory
-) -> None:
+):
     parent_config = AgentConfig(
         provider="anthropic",
         tools=["read_file", "edit_file", "spawn_subagent"],
@@ -138,7 +138,7 @@ async def test_max_tokens_response_prefixed(
     make_response: ResponseFactory,
     subagent_log: SubagentLog,
     read_events: ReadEvents,
-) -> None:
+):
     factory = process_factory(lambda: mock_agent([make_response(text="partial", stop_reason=StopReason.MAX_TOKENS)]))
     result = await make_tool(factory)(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="mt"))
 
@@ -155,9 +155,7 @@ async def test_max_tokens_response_prefixed(
 # ---------------------------------------------------------------------------
 
 
-async def test_build_failure_returns_tool_result(
-    process_factory: ProcessFactoryBuilder, subagent_log: SubagentLog
-) -> None:
+async def test_build_failure_returns_tool_result(process_factory: ProcessFactoryBuilder, subagent_log: SubagentLog):
     factory = process_factory(build_error=ValueError("boom"))
     result = await make_tool(factory)(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="fail"))
 
@@ -172,7 +170,7 @@ async def test_react_process_failure(
     raising_agent: type[RaisingAgent],
     subagent_log: SubagentLog,
     read_events: ReadEvents,
-) -> None:
+):
     factory = process_factory(lambda: raising_agent(AgentError("rate limit")))
     result = await make_tool(factory)(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="rl"))
 
@@ -196,7 +194,7 @@ async def test_counter_increments_per_invocation(
     mock_agent: type[MockAgent],
     make_response: ResponseFactory,
     subagent_log: SubagentLog,
-) -> None:
+):
     tool = make_tool(process_factory(lambda: mock_agent([make_response(text="r")])))
 
     await tool(SpawnSubagentInput(system_prompt="s", prompt="p", tools=[], name="a"))
@@ -211,7 +209,7 @@ async def test_parallel_spawns_get_distinct_counters(
     process_factory: ProcessFactoryBuilder,
     mock_agent: type[MockAgent],
     make_response: ResponseFactory,
-) -> None:
+):
     factory = process_factory(lambda: mock_agent([make_response(text="ok")]))
     tool = make_tool(factory)
     results = await asyncio.gather(


### PR DESCRIPTION
### What does this PR do?

Adds a new `spawn_identical_subagents` tool to the ddev AI framework. It runs the **same** subagent — identical system prompt and tool set — over many different assignments in parallel, sending the shared system prompt and tools **once** instead of repeating them per child.

- New `SpawnIdenticalSubagentsTool` (`ai/tools/agents/spawn_identical_subagents.py`): validates assignments (non-empty, unique names, a cap on fan-out) and the requested tool subset, fans out under an `asyncio.Semaphore`, and aggregates per-child results in assignment order. One child failing (or hitting `max_tokens`) never affects its siblings; the call succeeds on partial results and only fails when validation fails or every child errors.
- Each child is given a concise-output directive appended to the shared system prompt, so aggregated results stay small and don't overflow the parent's context.
- Extracts the machinery shared with `spawn_subagent` into an abstract `BaseSpawnTool[TInput]` (child config/scope construction, tool-subset validation, `max_tokens` handling). `SpawnSubagentTool` is refactored onto it with no external behavior change. Neither spawn tool is ever offered to a child.
- Registers the tool in the manifest (reusing the existing spawn factory — no `ToolContext` changes). Flows opt in by listing `spawn_identical_subagents` in an agent's `tools`.
- Tests: a shared `conftest.py` provides fake-agent and fake-process-factory fixtures; base-class restriction logic is tested once in `test_base.py`; per-tool behavior (aggregation/order, partial and total failure, `max_tokens` notice, concurrency cap, config inheritance) is covered in the respective files.

### Motivation

`spawn_subagent` delegates one subtask to one child, re-inlining the full `system_prompt` on every call. Running the same worker over N input slices therefore cost `N×(system_prompt + prompt)` of output tokens — enough to push a worker turn past `max_tokens` and truncate it mid `tool_use`. This tool makes "same agent, many assignments" first-class, so output scales as `1×system_prompt + N×(tiny assignment prompt)`.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
