### PR TITLE
Add Agent version and pricing detail to ClickHouse DBM preview note

### DIFF
--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -6,7 +6,7 @@ This check monitors [ClickHouse][1] through the Datadog Agent.
 
 Enable [Database Monitoring][11] (DBM) for enhanced insights into query performance and database health. In addition to the standard integration, Datadog DBM provides query-level metrics, live and historical query snapshots, query explain plans, query errors, and parts and merges observability.
 
-**Note**: Database Monitoring for ClickHouse is in Preview.
+**Note**: Database Monitoring for ClickHouse is in Preview and requires Datadog Agent v7.78 or later. Customers who participate in the preview will not be charged for usage incurred during the preview period.
 
 **Minimum Agent version:** 7.16.0
 


### PR DESCRIPTION
### What does this PR do?

Updates the Database Monitoring preview note in the ClickHouse integration README to include the required Agent version and preview pricing detail:

> Database Monitoring for ClickHouse is in Preview and requires Datadog Agent v7.78 or later. Customers who participate in the preview will not be charged for usage incurred during the preview period.

### Motivation

The [Database Monitoring for ClickHouse setup docs](https://docs.datadoghq.com/database_monitoring/setup_clickhouse/) state the Agent version requirement and no-charge-during-preview detail, but the shorter note on the [ClickHouse integration page](https://docs.datadoghq.com/integrations/clickhouse/?tab=host) (sourced from this README) didn't carry the same detail. This aligns the two.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged