### PR TITLE
Support unbounded max_timeout in EventBusOrchestrator

### DIFF
--- a/ddev/changelog.d/24314.added
+++ b/ddev/changelog.d/24314.added
@@ -1,1 +1,1 @@
-Add unbounded option to EventBusOrchestrator
+Support running EventBusOrchestrator unbounded by passing `max_timeout=None`.

--- a/ddev/changelog.d/24314.added
+++ b/ddev/changelog.d/24314.added
@@ -1,0 +1,1 @@
+Add unbounded option to EventBusOrchestrator

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -96,17 +96,21 @@ class EventBusOrchestrator(ABC):
     def __init__(
         self,
         logger: logging.Logger,
-        max_timeout: float | None = None,
+        max_timeout: float | None = DEFAULT_ORCHESTRATOR_MAX_TIMEOUT,
         grace_period: float = 10,
         executor: Executor | None = None,
         fail_fast: bool = False,
-        unbounded: bool = False,
     ):
         """
         Args:
             logger: The logger to use for the orchestrator.
             max_timeout: The maximum time in seconds to wait for the orchestrator to complete.
-                Defaults to 300 seconds unless ``unbounded`` is True and no value is given here.
+                Defaults to 300 seconds. Pass ``None`` to run with no overall time limit; only
+                the idle ``grace_period`` check can stop it.
+
+                Running unbounded removes the only safety net against a hung or
+                deadlocked processor and only external cancellation (e.g. Ctrl+C
+                or killing the process) will stop it.
             grace_period: The timeout in seconds to wait for a new message to be submitted after all
                 messages have been processed.
             executor: The executor to use for running sync processors.
@@ -115,17 +119,8 @@ class EventBusOrchestrator(ABC):
                        the orchestrator. If False (default), such exceptions are logged
                        and processing continues. ``FatalProcessingError`` always stops the
                        orchestrator regardless of this flag.
-            unbounded: If True and ``max_timeout`` is not explicitly provided, the orchestrator
-                       runs with no overall time limit; only the idle ``grace_period`` check can
-                       stop it. If ``max_timeout`` is explicitly provided together with
-                       ``unbounded=True``, a warning is logged and ``max_timeout`` is enforced
-                       instead, for safety.
-
-                       Running unbounded removes the only safety net against a hung or
-                       deadlocked processor and only external cancellation (e.g. Ctrl+C
-                       or killing the process) will stop it.
         """
-        resolved_max_timeout = self.__resolve_max_timeout(max_timeout, unbounded, logger)
+        resolved_max_timeout = max_timeout if max_timeout is not None else math.inf
         self.__validate_parameters(resolved_max_timeout, grace_period)
         self._logger = logger
         self._max_timeout = resolved_max_timeout
@@ -137,36 +132,16 @@ class EventBusOrchestrator(ABC):
         self._queue = asyncio.Queue[BaseMessage]()
         self._running = False
 
-    @staticmethod
-    def __resolve_max_timeout(max_timeout: float | None, unbounded: bool, logger: logging.Logger) -> float | None:
-        """
-        Resolves the effective max_timeout from the given max_timeout/unbounded combination.
-
-        Returns None when the orchestrator should run with no overall time limit.
-        """
-        if unbounded:
-            if max_timeout is None:
-                return None
-            logger.warning(
-                "unbounded=True was set together with an explicit max_timeout=%s; "
-                "ignoring unbounded and enforcing max_timeout=%s",
-                max_timeout,
-                max_timeout,
-            )
-            return max_timeout
-        return max_timeout if max_timeout is not None else DEFAULT_ORCHESTRATOR_MAX_TIMEOUT
-
-    def __validate_parameters(self, max_timeout: float | None, grace_period: float):
+    def __validate_parameters(self, max_timeout: float, grace_period: float):
         """
         Validates the parameters passed to the orchestrator.
         """
         if grace_period < 0:
             raise ValueError("grace_period must be greater than or equal to 0")
-        if max_timeout is not None:
-            if max_timeout <= 0:
-                raise ValueError("max_timeout must be greater than 0")
-            if max_timeout <= grace_period:
-                raise ValueError("max_timeout must be greater than grace_period")
+        if max_timeout <= 0:
+            raise ValueError("max_timeout must be greater than 0")
+        if max_timeout <= grace_period:
+            raise ValueError("max_timeout must be greater than grace_period")
 
     def register_processor[T: BaseMessage](self, processor: Processor[T], message_types: list[type[T]]):
         """Registers a processor to receive specific message types."""
@@ -312,10 +287,8 @@ class EventBusOrchestrator(ABC):
         """
         Calculates the remaining time until the max timeout is reached.
 
-        Returns ``math.inf`` when running unbounded (no max_timeout set).
+        Returns ``math.inf`` when running unbounded.
         """
-        if self._max_timeout is None:
-            return math.inf
         elapsed = asyncio.get_running_loop().time() - start_time
         return self._max_timeout - elapsed
 

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -136,10 +136,10 @@ class EventBusOrchestrator(ABC):
         """
         Validates the parameters passed to the orchestrator.
         """
-        if grace_period < 0:
-            raise ValueError("grace_period must be greater than or equal to 0")
         if max_timeout <= 0:
             raise ValueError("max_timeout must be greater than 0")
+        if grace_period < 0:
+            raise ValueError("grace_period must be greater than or equal to 0")
         if max_timeout <= grace_period:
             raise ValueError("max_timeout must be greater than grace_period")
 

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import math
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from concurrent.futures import Executor, ThreadPoolExecutor
@@ -23,6 +24,8 @@ from .exceptions import (
 )
 
 type ErrorHandler[E: Exception] = Callable[[E], Awaitable[None]]
+
+DEFAULT_ORCHESTRATOR_MAX_TIMEOUT = 300.0
 
 
 @dataclass
@@ -93,15 +96,17 @@ class EventBusOrchestrator(ABC):
     def __init__(
         self,
         logger: logging.Logger,
-        max_timeout: float = 300,
+        max_timeout: float | None = None,
         grace_period: float = 10,
         executor: Executor | None = None,
         fail_fast: bool = False,
+        unbounded: bool = False,
     ):
         """
         Args:
             logger: The logger to use for the orchestrator.
             max_timeout: The maximum time in seconds to wait for the orchestrator to complete.
+                Defaults to 300 seconds unless ``unbounded`` is True and no value is given here.
             grace_period: The timeout in seconds to wait for a new message to be submitted after all
                 messages have been processed.
             executor: The executor to use for running sync processors.
@@ -110,10 +115,20 @@ class EventBusOrchestrator(ABC):
                        the orchestrator. If False (default), such exceptions are logged
                        and processing continues. ``FatalProcessingError`` always stops the
                        orchestrator regardless of this flag.
+            unbounded: If True and ``max_timeout`` is not explicitly provided, the orchestrator
+                       runs with no overall time limit; only the idle ``grace_period`` check can
+                       stop it. If ``max_timeout`` is explicitly provided together with
+                       ``unbounded=True``, a warning is logged and ``max_timeout`` is enforced
+                       instead, for safety.
+
+                       Running unbounded removes the only safety net against a hung or
+                       deadlocked processor and only external cancellation (e.g. Ctrl+C
+                       or killing the process) will stop it.
         """
-        self.__validate_parameters(max_timeout, grace_period)
+        resolved_max_timeout = self.__resolve_max_timeout(max_timeout, unbounded, logger)
+        self.__validate_parameters(resolved_max_timeout, grace_period)
         self._logger = logger
-        self._max_timeout = max_timeout
+        self._max_timeout = resolved_max_timeout
         self._grace_period = grace_period
         self._executor = executor or ThreadPoolExecutor(max_workers=4)
         self._fail_fast = fail_fast
@@ -122,16 +137,36 @@ class EventBusOrchestrator(ABC):
         self._queue = asyncio.Queue[BaseMessage]()
         self._running = False
 
-    def __validate_parameters(self, max_timeout: float, grace_period: float):
+    @staticmethod
+    def __resolve_max_timeout(max_timeout: float | None, unbounded: bool, logger: logging.Logger) -> float | None:
+        """
+        Resolves the effective max_timeout from the given max_timeout/unbounded combination.
+
+        Returns None when the orchestrator should run with no overall time limit.
+        """
+        if max_timeout is not None and unbounded:
+            logger.warning(
+                "unbounded=True was set together with an explicit max_timeout=%s; ignoring unbounded "
+                "and enforcing max_timeout=%s",
+                max_timeout,
+                max_timeout,
+            )
+            return max_timeout
+        if max_timeout is None and unbounded:
+            return None
+        return max_timeout if max_timeout is not None else DEFAULT_ORCHESTRATOR_MAX_TIMEOUT
+
+    def __validate_parameters(self, max_timeout: float | None, grace_period: float):
         """
         Validates the parameters passed to the orchestrator.
         """
-        if max_timeout <= 0:
-            raise ValueError("max_timeout must be greater than 0")
         if grace_period < 0:
             raise ValueError("grace_period must be greater than or equal to 0")
-        if max_timeout <= grace_period:
-            raise ValueError("max_timeout must be greater than grace_period")
+        if max_timeout is not None:
+            if max_timeout <= 0:
+                raise ValueError("max_timeout must be greater than 0")
+            if max_timeout <= grace_period:
+                raise ValueError("max_timeout must be greater than grace_period")
 
     def register_processor[T: BaseMessage](self, processor: Processor[T], message_types: list[type[T]]):
         """Registers a processor to receive specific message types."""
@@ -276,7 +311,11 @@ class EventBusOrchestrator(ABC):
     def _remaining_time(self, start_time: float) -> float:
         """
         Calculates the remaining time until the max timeout is reached.
+
+        Returns ``math.inf`` when running unbounded (no max_timeout set).
         """
+        if self._max_timeout is None:
+            return math.inf
         elapsed = asyncio.get_running_loop().time() - start_time
         return self._max_timeout - elapsed
 

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -144,16 +144,16 @@ class EventBusOrchestrator(ABC):
 
         Returns None when the orchestrator should run with no overall time limit.
         """
-        if max_timeout is not None and unbounded:
+        if unbounded:
+            if max_timeout is None:
+                return None
             logger.warning(
-                "unbounded=True was set together with an explicit max_timeout=%s; ignoring unbounded "
-                "and enforcing max_timeout=%s",
+                "unbounded=True was set together with an explicit max_timeout=%s; "
+                "ignoring unbounded and enforcing max_timeout=%s",
                 max_timeout,
                 max_timeout,
             )
             return max_timeout
-        if max_timeout is None and unbounded:
-            return None
         return max_timeout if max_timeout is not None else DEFAULT_ORCHESTRATOR_MAX_TIMEOUT
 
     def __validate_parameters(self, max_timeout: float | None, grace_period: float):

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -24,7 +24,13 @@ from ddev.event_bus.exceptions import (
     ProcessorQueueError,
     SkipMessageError,
 )
-from ddev.event_bus.orchestrator import AsyncProcessor, BaseMessage, EventBusOrchestrator, SyncProcessor
+from ddev.event_bus.orchestrator import (
+    DEFAULT_ORCHESTRATOR_MAX_TIMEOUT,
+    AsyncProcessor,
+    BaseMessage,
+    EventBusOrchestrator,
+    SyncProcessor,
+)
 
 # Test Structure Documentation
 # --------------------------
@@ -139,15 +145,17 @@ class MockOrchestrator(EventBusOrchestrator):
     def __init__(
         self,
         logger: logging.Logger,
-        max_timeout: float = 300,
+        max_timeout: float | None = None,
         grace_period: float = 10,
         fail_fast: bool = False,
+        unbounded: bool = False,
     ):
         super().__init__(
             logger=logger,
             max_timeout=max_timeout,
             grace_period=grace_period,
             fail_fast=fail_fast,
+            unbounded=unbounded,
         )
         self.events: list[str] = []
         self.received_messages: list[BaseMessage] = []
@@ -348,6 +356,45 @@ def test_validate_parameters(max_timeout: float, grace_period: float, expectatio
     logger = logging.getLogger("test")
     with expectation:
         MockOrchestrator(logger, max_timeout=max_timeout, grace_period=grace_period)
+
+
+def test_omitted_max_timeout_resolves_to_default():
+    """Not passing max_timeout still resolves to default."""
+    logger = logging.getLogger("test")
+    orchestrator = MockOrchestrator(logger, grace_period=1)
+
+    assert orchestrator._max_timeout == DEFAULT_ORCHESTRATOR_MAX_TIMEOUT
+
+
+def test_unbounded_without_max_timeout_has_no_max_timeout(caplog: pytest.LogCaptureFixture):
+    """unbounded=True with no explicit max_timeout runs with no overall time limit."""
+    logger = logging.getLogger("test")
+    orchestrator = MockOrchestrator(logger, grace_period=0.1, unbounded=True)
+
+    assert orchestrator._max_timeout is None
+
+
+def test_unbounded_with_explicit_max_timeout_warns_and_falls_back(caplog: pytest.LogCaptureFixture):
+    """unbounded=True together with an explicit max_timeout falls back to enforcing max_timeout."""
+    logger = logging.getLogger("test")
+    with caplog.at_level(logging.WARNING):
+        orchestrator = MockOrchestrator(logger, max_timeout=5, grace_period=1, unbounded=True)
+
+    assert orchestrator._max_timeout == 5
+    assert "unbounded=True" in caplog.text
+    assert "max_timeout=5" in caplog.text
+
+
+def test_unbounded_still_stops_via_grace_period():
+    """Unbounded mode still exits when the queue is empty and the grace period elapses."""
+    logger = logging.getLogger("test")
+    orchestrator = MockOrchestrator(logger, grace_period=0.1, unbounded=True)
+
+    with assert_time(0.0, 1.0):
+        orchestrator.run()
+
+    assert "finalize" in orchestrator.events
+    assert orchestrator.finalized_exception is None
 
 
 def test_default_on_error_with_default_policy_logs_and_continues(

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -366,7 +366,7 @@ def test_omitted_max_timeout_resolves_to_default():
     assert orchestrator._max_timeout == DEFAULT_ORCHESTRATOR_MAX_TIMEOUT
 
 
-def test_unbounded_without_max_timeout_has_no_max_timeout(caplog: pytest.LogCaptureFixture):
+def test_unbounded_without_max_timeout_has_no_max_timeout():
     """unbounded=True with no explicit max_timeout runs with no overall time limit."""
     logger = logging.getLogger("test")
     orchestrator = MockOrchestrator(logger, grace_period=0.1, unbounded=True)

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import time
 from collections.abc import Generator
 from contextlib import AbstractContextManager, contextmanager
@@ -145,17 +146,15 @@ class MockOrchestrator(EventBusOrchestrator):
     def __init__(
         self,
         logger: logging.Logger,
-        max_timeout: float | None = None,
+        max_timeout: float | None = DEFAULT_ORCHESTRATOR_MAX_TIMEOUT,
         grace_period: float = 10,
         fail_fast: bool = False,
-        unbounded: bool = False,
     ):
         super().__init__(
             logger=logger,
             max_timeout=max_timeout,
             grace_period=grace_period,
             fail_fast=fail_fast,
-            unbounded=unbounded,
         )
         self.events: list[str] = []
         self.received_messages: list[BaseMessage] = []
@@ -366,29 +365,18 @@ def test_omitted_max_timeout_resolves_to_default():
     assert orchestrator._max_timeout == DEFAULT_ORCHESTRATOR_MAX_TIMEOUT
 
 
-def test_unbounded_without_max_timeout_has_no_max_timeout():
-    """unbounded=True with no explicit max_timeout runs with no overall time limit."""
+def test_none_max_timeout_runs_unbounded():
+    """max_timeout=None runs with no overall time limit."""
     logger = logging.getLogger("test")
-    orchestrator = MockOrchestrator(logger, grace_period=0.1, unbounded=True)
+    orchestrator = MockOrchestrator(logger, max_timeout=None, grace_period=0.1)
 
-    assert orchestrator._max_timeout is None
-
-
-def test_unbounded_with_explicit_max_timeout_warns_and_falls_back(caplog: pytest.LogCaptureFixture):
-    """unbounded=True together with an explicit max_timeout falls back to enforcing max_timeout."""
-    logger = logging.getLogger("test")
-    with caplog.at_level(logging.WARNING):
-        orchestrator = MockOrchestrator(logger, max_timeout=5, grace_period=1, unbounded=True)
-
-    assert orchestrator._max_timeout == 5
-    assert "unbounded=True" in caplog.text
-    assert "max_timeout=5" in caplog.text
+    assert orchestrator._max_timeout == math.inf
 
 
 def test_unbounded_still_stops_via_grace_period():
     """Unbounded mode still exits when the queue is empty and the grace period elapses."""
     logger = logging.getLogger("test")
-    orchestrator = MockOrchestrator(logger, grace_period=0.1, unbounded=True)
+    orchestrator = MockOrchestrator(logger, max_timeout=None, grace_period=0.1)
 
     with assert_time(0.0, 1.0):
         orchestrator.run()

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -357,14 +357,6 @@ def test_validate_parameters(max_timeout: float, grace_period: float, expectatio
         MockOrchestrator(logger, max_timeout=max_timeout, grace_period=grace_period)
 
 
-def test_omitted_max_timeout_resolves_to_default():
-    """Not passing max_timeout still resolves to default."""
-    logger = logging.getLogger("test")
-    orchestrator = MockOrchestrator(logger, grace_period=1)
-
-    assert orchestrator._max_timeout == DEFAULT_ORCHESTRATOR_MAX_TIMEOUT
-
-
 def test_none_max_timeout_runs_unbounded():
     """max_timeout=None runs with no overall time limit."""
     logger = logging.getLogger("test")


### PR DESCRIPTION
### What does this PR do?

Lets `EventBusOrchestrator` run with no overall time limit by passing `max_timeout=None`, without introducing a separate flag.

- `max_timeout` stays `float | None`, defaulting to `DEFAULT_ORCHESTRATOR_MAX_TIMEOUT` (300 seconds), same as before.
- Passing `max_timeout=None` explicitly now means unbounded: the orchestrator runs with no overall time limit; only the idle `grace_period` check (queue empty and no running tasks) can still stop it.
- Internally, `None` resolves to `math.inf` once in `__init__`, so `_max_timeout` is always a plain `float`. `_remaining_time` and the existing timeout checks in `__should_stop` need no special-casing for the unbounded case — `math.inf - elapsed` naturally stays `math.inf`.
- Added tests covering the `None`/unbounded resolution and the still-bounded default.

### Motivation

In Togo (our AI-generated integrations project), some runs need to be unbounded: we don't know upfront how long the agents will take to research an integration and generate its implementation, so a fixed `max_timeout` can cut off a run that's still making progress.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged