### PR TITLE
Preserve the cancellation reason when EventBusOrchestrator times out

### DIFF
--- a/ddev/changelog.d/24315.fixed
+++ b/ddev/changelog.d/24315.fixed
@@ -1,0 +1,1 @@
+Fix the EventBusOrchestrator overwriting a task's timeout cancellation reason with a bare cancel during shutdown cleanup.

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -315,7 +315,11 @@ class EventBusOrchestrator(ABC):
             if running_tasks:
                 self._logger.info("Cancelling %s remaining tasks...", len(running_tasks))
                 for task in running_tasks:
-                    task.cancel()
+                    # A task already has a cancellation request pending if __should_stop cancelled
+                    # it directly (e.g. on max_timeout) with a reason; don't clobber that message
+                    # with a bare, reason-less cancel() here.
+                    if not task.cancelling():
+                        task.cancel()
 
                 # Wait for them to actually finish cancelling
                 await asyncio.wait(running_tasks)
@@ -339,6 +343,9 @@ class EventBusOrchestrator(ABC):
                 self._max_timeout,
                 len(running_tasks),
             )
+            timeout_msg = f"Orchestrator exceeded max_timeout of {self._max_timeout}s"
+            for task in running_tasks:
+                task.cancel(timeout_msg)
             get_task.cancel()
             return True
 

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -25,6 +25,15 @@ from .exceptions import (
 type ErrorHandler[E: Exception] = Callable[[E], Awaitable[None]]
 
 
+class _OrchestratorTimeout(Exception):
+    """Internal signal raised when ``max_timeout`` is exceeded.
+
+    Caught by :meth:`EventBusOrchestrator.process_messages` so the timeout reason can be
+    handed to the single cancellation loop in its ``finally`` block, instead of cancelling
+    tasks from two places.
+    """
+
+
 @dataclass
 class BaseMessage:
     """
@@ -294,6 +303,7 @@ class EventBusOrchestrator(ABC):
         get_task = asyncio.create_task(self._queue.get())
 
         start_time = asyncio.get_running_loop().time()
+        cancel_reason: str | None = None
 
         try:
             while not await self.__should_stop(start_time, running_tasks, get_task):
@@ -309,17 +319,17 @@ class EventBusOrchestrator(ABC):
                         break
 
                 self.__process_finished_tasks(done, current_get_task, running_tasks)
+        except _OrchestratorTimeout as timeout:
+            cancel_reason = str(timeout)
         finally:
             # If we exit the loop and tasks are still running (e.g. timeout or forced break),
             # we must clean them up before returning to ensure finalize() runs in a safe state.
+            # This is the single place that cancels ``running_tasks``, so every remaining task
+            # is cancelled exactly once, with the reason (if any) attached.
             if running_tasks:
                 self._logger.info("Cancelling %s remaining tasks...", len(running_tasks))
                 for task in running_tasks:
-                    # A task already has a cancellation request pending if __should_stop cancelled
-                    # it directly (e.g. on max_timeout) with a reason; don't clobber that message
-                    # with a bare, reason-less cancel() here.
-                    if not task.cancelling():
-                        task.cancel()
+                    task.cancel(cancel_reason)
 
                 # Wait for them to actually finish cancelling
                 await asyncio.wait(running_tasks)
@@ -343,11 +353,8 @@ class EventBusOrchestrator(ABC):
                 self._max_timeout,
                 len(running_tasks),
             )
-            timeout_msg = f"Orchestrator exceeded max_timeout of {self._max_timeout}s"
-            for task in running_tasks:
-                task.cancel(timeout_msg)
             get_task.cancel()
-            return True
+            raise _OrchestratorTimeout(f"Orchestrator exceeded max_timeout of {self._max_timeout}s")
 
         # Check exit condition: empty queue (implied by get_task not done) and no running processors
         if not running_tasks and not get_task.done() and self._queue.empty():

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -25,7 +25,7 @@ from .exceptions import (
 type ErrorHandler[E: Exception] = Callable[[E], Awaitable[None]]
 
 
-class _OrchestratorTimeout(Exception):
+class OrchestratorTimeout(Exception):
     """Internal signal raised when ``max_timeout`` is exceeded.
 
     Caught by :meth:`EventBusOrchestrator.process_messages` so the timeout reason can be
@@ -319,7 +319,7 @@ class EventBusOrchestrator(ABC):
                         break
 
                 self.__process_finished_tasks(done, current_get_task, running_tasks)
-        except _OrchestratorTimeout as timeout:
+        except OrchestratorTimeout as timeout:
             cancel_reason = str(timeout)
         finally:
             # If we exit the loop and tasks are still running (e.g. timeout or forced break),
@@ -354,7 +354,7 @@ class EventBusOrchestrator(ABC):
                 len(running_tasks),
             )
             get_task.cancel()
-            raise _OrchestratorTimeout(f"Orchestrator exceeded max_timeout of {self._max_timeout}s")
+            raise OrchestratorTimeout(f"Orchestrator exceeded max_timeout of {self._max_timeout}s")
 
         # Check exit condition: empty queue (implied by get_task not done) and no running processors
         if not running_tasks and not get_task.done() and self._queue.empty():

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Generator
-from contextlib import AbstractContextManager, contextmanager
+from contextlib import AbstractContextManager, contextmanager, suppress
 from contextlib import nullcontext as does_not_raise
 from dataclasses import dataclass
 
@@ -634,6 +634,54 @@ def test_max_timeout_interruption_preserves_cancellation_reason(orchestrator: Mo
 
     assert slow_processor.cancellation_message
     assert "max_timeout" in slow_processor.cancellation_message
+
+
+def test_fatal_processing_error_cancels_task_that_already_swallowed_a_cancellation(
+    orchestrator: MockOrchestrator,
+):
+    # A task that previously caught and suppressed a CancelledError (without calling
+    # Task.uncancel()) still has a pending cancellation count. The shutdown cleanup
+    # must not treat that as "already being cancelled" and skip it: it should still be
+    # cancelled (and stopped) when a sibling processor's FatalProcessingError shuts
+    # the bus down.
+    class StubbornAnalyst(AsyncProcessor[TaskAssignment]):
+        def __init__(self, name: str):
+            super().__init__(name)
+            self.cancelled_again = False
+            self.finished = False
+
+        async def process_message(self, message: TaskAssignment):
+            asyncio.current_task().cancel()  # simulate an earlier, unrelated cancellation
+            with suppress(asyncio.CancelledError):
+                await asyncio.sleep(0)
+
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                self.cancelled_again = True
+                raise
+            self.finished = True
+
+    stubborn = StubbornAnalyst("stubborn")
+    orchestrator.register_processor(stubborn, [TaskAssignment])
+
+    original_on_message = orchestrator.on_message_received
+
+    async def on_message_fatal(message: BaseMessage):
+        await original_on_message(message)
+        if message.id == "fatal_msg":
+            raise FatalProcessingError("Fatal error triggered")
+
+    orchestrator.on_message_received = on_message_fatal  # type: ignore[method-assign]
+
+    orchestrator.submit_message(TaskAssignment("stubborn_msg", task_type="slow"))
+    orchestrator.submit_message(Memo("fatal_msg"))
+
+    with assert_time(0, 2.0), pytest.raises(FatalProcessingError, match="Fatal error triggered"):
+        orchestrator.run()
+
+    assert stubborn.cancelled_again
+    assert not stubborn.finished
 
 
 def test_sync_processor_thread_execution(orchestrator: MockOrchestrator, secretary: Secretary):

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -606,6 +606,36 @@ def test_max_timeout_interruption(orchestrator: MockOrchestrator):
     assert slow_processor.cancelled
 
 
+def test_max_timeout_interruption_preserves_cancellation_reason(orchestrator: MockOrchestrator):
+    # A timed-out task's CancelledError should carry the timeout reason, not be
+    # silently re-cancelled without a message by the generic shutdown cleanup.
+    orchestrator._max_timeout = 0.5
+    orchestrator._grace_period = 5.0
+
+    class SlowProcessor(AsyncProcessor[Memo]):
+        def __init__(self, name: str):
+            super().__init__(name)
+            self.cancellation_message: str | None = None
+
+        async def process_message(self, message: Memo):
+            try:
+                await asyncio.sleep(2.0)
+            except asyncio.CancelledError as e:
+                self.cancellation_message = str(e)
+                raise
+
+    slow_processor = SlowProcessor("slow_processor")
+    orchestrator.register_processor(slow_processor, [Memo])
+
+    orchestrator.submit_message(Memo("slow_memo"))
+
+    with assert_time(0.5, 1.5):
+        orchestrator.run()
+
+    assert slow_processor.cancellation_message
+    assert "max_timeout" in slow_processor.cancellation_message
+
+
 def test_sync_processor_thread_execution(orchestrator: MockOrchestrator, secretary: Secretary):
     import threading
 


### PR DESCRIPTION
### What does this PR do?
When `EventBusOrchestrator` hits its `max_timeout` budget, it cancels in-flight tasks. The generic cleanup path in `process_messages`'s `finally` block would then bare-cancel those same tasks again, discarding any cancellation reason. This moves the timeout cancellation (with a descriptive message) to the exact point where the timeout is detected in `__should_stop`, and hardens the generic cleanup to skip tasks that already have a pending cancellation request (via `task.cancelling()`), so it never clobbers a reason set elsewhere.

### Motivation
Discovered while debugging a ddev AI flow run that failed with a bare `CancelledError` and no context. The orchestrator already knows *why* it's cancelling the task (timeout exceeded); that reason should survive to consumers instead of being erased by the shared cleanup code.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged