### PR TITLE
Restructure AGENTS.md with clearer sections and stricter naming rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 These are the binding conventions for any change made in this repository, whether by a human or an AI agent. When one of these rules conflicts with your own default instincts (for example, general Python style conventions you'd normally apply), follow the rule below instead — it exists because the default produced a problem here before. Where a rule doesn't cover your situation, prefer the narrowest, most focused change that accomplishes the task.
 
-Some directories have their own `AGENTS.md`/`CLAUDE.md` with narrower, directory-specific guidance (for example `clickhouse/AGENTS.md`, which covers the ClickHouse `advanced_queries` pipeline). Those files *supplement* this one — read both; nothing here is overridden by a nested file unless that file says so explicitly.
+Some directories have their own `AGENTS.md`/`CLAUDE.md` with narrower, directory-specific guidance (for example `clickhouse/AGENTS.md`, which covers the ClickHouse `advanced_queries` pipeline, or `ddev/src/ddev/utils/github_async/AGENTS.md`). Those files *supplement* this one — read both. Where a nested file's guidance conflicts with this one, the narrower, more specific file takes precedence for the code it covers.
 
 ## Contents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,22 @@ Some directories have their own `AGENTS.md`/`CLAUDE.md` with narrower, directory
 
 ## Contents
 
+- [Maintaining This File](#maintaining-this-file)
 - [Python Code Style](#python-code-style)
 - [Configuration Models](#configuration-models)
 - [Development Workflow](#development-workflow)
 - [Pull Requests](#pull-requests)
 - [Documentation](#documentation)
+
+## Maintaining This File
+
+- Before adding a rule, check whether it fits under an existing section. Only create a new top-level section when the rule doesn't belong anywhere else — most additions should extend an existing section, not spawn a new one.
+- Keep the [Contents](#contents) list in sync with the section headings.
+- Scope rules with an explicit **Applicable to:** line when they don't apply to the whole repository (see [Python Code Style](#python-code-style) or [Configuration Models](#configuration-models) for the pattern).
+- Prefer directory-specific guidance in a nested `AGENTS.md`/`CLAUDE.md` over adding it here. This file is for conventions that apply repo-wide; narrow, single-directory guidance belongs next to the code it governs and should link back to this file, the way `clickhouse/AGENTS.md` does.
+- State each rule once. If a rule already exists here or in a nested file, extend or correct it in place rather than restating it elsewhere.
+- Justify non-obvious rules with the failure mode they prevent, but keep it to a sentence or two — this file is read by agents on every task, so verbosity has a real, recurring cost.
+- When a rule becomes obsolete (the tooling changed, the pitfall no longer applies), remove it instead of leaving it to accumulate.
 
 ## Python Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ This way, `a` and `b` can each be `str` or `bytes`, but can't be mixed with each
 
 Most code in this repository is not published as a public library API — it lives behind package boundaries, in integrations, in test suites, or in scripts nobody imports. "Not part of the public API" is the *default* state of almost everything here, so a leading underscore is not how we signal it. **Do not add a leading underscore to a method or variable name unless it matches one of the narrow exceptions below.** This applies everywhere, including test files, fixtures, internal tooling, and one-off scripts — not just files intended for external/public consumption.
 
+This rule is about the single-leading-underscore privacy convention; it does not apply to dunder methods (`__init__`, `__repr__`, `__enter__`, `__exit__`, `__iter__`, and similar). Those are Python protocol hooks, not a privacy signal — implement them with their required names whenever the protocol calls for them.
+
 **Methods** — a leading underscore is allowed only:
 
 1. On instance methods of a class, to flag that the method is not part of that class's public API.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,40 @@
 # Development Guidelines
 
-## General Development Guidelines
+These are the binding conventions for any change made in this repository, whether by a human or an AI agent. When one of these rules conflicts with your own default instincts (for example, general Python style conventions you'd normally apply), follow the rule below instead — it exists because the default produced a problem here before. Where a rule doesn't cover your situation, prefer the narrowest, most focused change that accomplishes the task.
 
-- Auto-format code with `ddev test -fs`.
+Some directories have their own `AGENTS.md`/`CLAUDE.md` with narrower, directory-specific guidance (for example `clickhouse/AGENTS.md`, which covers the ClickHouse `advanced_queries` pipeline). Those files *supplement* this one — read both; nothing here is overridden by a nested file unless that file says so explicitly.
 
-## Python Type Hinting
+## Contents
 
-### Generating new code
+- [Python Code Style](#python-code-style)
+- [Configuration Models](#configuration-models)
+- [Development Workflow](#development-workflow)
+- [Pull Requests](#pull-requests)
+- [Documentation](#documentation)
 
-When generating python code, always add type hinting to the methods. Use modern syntaxis, for example, instead of using `Optional[str]` use `str | None` and instead of using `List[str]` use `list[str]`.
+## Python Code Style
 
-If a method yields a value but we are not returning anything or we do not accept anything sent to the generator, it is better to type the method as Iterator to explicitely expose the API of the method as simply something the caller can iterate over.
+**Applicable to:** all Python files (`*.py`).
 
-### Refactoring code
+### Type Hints
 
-When refactoring existing code, never add type hints to method that are not type hinted unless asked explicitely.
+#### Generating New Code
 
-### The case of AnyStr
+When generating python code, always add type hinting to the methods. Use modern syntax: prefer `str | None` over `Optional[str]`, and `list[str]` over `List[str]`.
 
-AnyStr is normally used to define the type of a variable that can be either a string or bytes. This is soon to be deprecated and, instead, type parameter lits are a better solution. If AnyStr is used as type of several arguments in a given method signature, it is better to use type parameter lists and define the function as a generic function.
+If a method yields a value but does not return anything or accept anything sent to the generator, type it as `Iterator` rather than `Generator`. This makes the method's contract explicit to the caller: something to iterate over, nothing more.
+
+#### Refactoring Existing Code
+
+When refactoring existing code, never add type hints to a method that wasn't already type-hinted, unless explicitly asked to. This is one instance of a broader rule: keep diffs focused on the task at hand. Don't use a refactor as an opportunity to also add type hints, rename things, or otherwise "clean up" code you weren't asked to touch — it obscures the actual change under review and makes the diff harder to reason about.
+
+#### The Case of AnyStr
+
+`AnyStr` is normally used to type a variable that can be either a string or bytes. It's on its way to deprecation; type parameter lists are the modern replacement. If `AnyStr` is used for several arguments in one method signature, define the function as generic instead:
 
 ```python
 # Soon to be deprecated
-def func(a: AnySTr, b: AnyStr):
+def func(a: AnyStr, b: AnyStr):
     pass
 
 # Preferred
@@ -30,50 +42,52 @@ def func[T: (str, bytes)](a: T, b: T):
     pass
 ```
 
-This way, whether a and b are either strings or bytes, they cannot be mixed.
+This way, `a` and `b` can each be `str` or `bytes`, but can't be mixed with each other. If a single argument is present in the function, `str | bytes` is preferred instead.
 
-If a single argument is present in the function, `str | bytes` is preferred.
+### Naming: Leading Underscores
 
-## Code Style and Organization
+Most code in this repository is not published as a public library API — it lives behind package boundaries, in integrations, in test suites, or in scripts nobody imports. "Not part of the public API" is the *default* state of almost everything here, so a leading underscore is not how we signal it. **Do not add a leading underscore to a method or variable name unless it matches one of the narrow exceptions below.** This applies everywhere, including test files, fixtures, internal tooling, and one-off scripts — not just files intended for external/public consumption.
 
-### Docstrings
+**Methods** — a leading underscore is allowed only:
 
-- Use concise one-liner docstrings for most methods
-- Method names should be self-descriptive
-- Multi-line docstrings with Args/Returns are acceptable only for important public interface methods that require detailed documentation
-- Avoid verbose docstrings for internal/private methods
+1. On instance methods of a class, to flag that the method is not part of that class's public API.
+2. On functions in a module that is explicitly designed as a reusable library module, when the function has non-obvious side effects or behavior that its name alone doesn't make clear.
 
-### Comments
+In every other case — module-level/free functions, helpers in test files, functions in scripts, functions in files no one else will ever import — do **not** add a leading underscore, even if the function feels "internal" or "private". Internal is the default; it doesn't need marking.
 
-- Avoid unnecessary inline comments
-- Write self-explanatory code instead
-- If a comment is needed, keep it to one line
-- Code clarity should come from descriptive names, not comments
+**Variables** — a leading underscore is allowed only for Pydantic model private attributes (e.g. `_cache: dict = PrivateAttr(default_factory=dict)`). That is the only case. This includes module constants: do not prefix uppercase module constants with a leading underscore (for example `_GIT_REMOTE_PATTERNS`); name them without the underscore instead (`GIT_REMOTE_PATTERNS`). The same applies to class attributes, instance attributes outside Pydantic models, and local variables.
 
-### Code Duplication
+If you're unsure whether something qualifies, it doesn't — leave the underscore off.
 
-- Extract helper functions to eliminate duplicated logic
-- Small, focused functions with descriptive names are better than repeated code blocks
-- Reusable helpers improve maintainability and reduce the need for comments
+### Docstrings and Comments
 
-### Module Constants
+- Use concise one-liner docstrings for most methods; method names should be self-descriptive enough that little else is needed.
+- Multi-line docstrings with Args/Returns are acceptable only for important public interface methods that genuinely need detailed documentation.
+- Avoid verbose docstrings for methods that are internal or not meant for outside callers. Note that "internal"/"private" here is a judgment call about who's expected to call the method — it has nothing to do with the leading-underscore naming rule above. Docstring verbosity and naming are two separate decisions; don't infer one from the other.
+- Prefer self-explanatory code over inline comments. If a comment is genuinely needed, keep it to one line — code clarity should come from descriptive names, not from comments compensating for unclear ones.
 
-- Do not prefix uppercase module constants with a leading underscore (for example `_GIT_REMOTE_PATTERNS`). Module-private constants are fine; just name them without the underscore (`GIT_REMOTE_PATTERNS`). This is a style choice for consistency, not a scoping rule.
+### Avoiding Duplication
+
+Extract small, focused helper functions to eliminate duplicated logic rather than repeating code blocks or leaning on comments to explain repetition.
 
 ## Configuration Models
 
-**Applicable to:** `**/config_models/*.py`, `*/assets/configuration/spec.yaml`
+**Applicable to:** `**/config_models/*.py`, `*/assets/configuration/spec.yaml`.
 
-Don't modify files in `**/config_models/*.py` directly. To change those files edit assets/configuration/spec.yaml and then run the following commands:
+Don't modify files in `**/config_models/*.py` directly. To change those files, edit `assets/configuration/spec.yaml` and then run:
 
 ```shell
 ddev -x validate config -s <INTEGRATION_NAME>
 ddev -x validate models -s <INTEGRATION_NAME>
 ```
 
-## Worktrees
+## Development Workflow
 
-When working in a git worktree (anything other than the primary checkout), run `ddev config override` as the first step after entering the directory. This writes a gitignored `.ddev.toml` that points the `core` repo at the current worktree.
+### Worktrees
+
+**Applicable to:** any git worktree other than the primary checkout.
+
+When working in a git worktree, run `ddev config override` as the first step after entering the directory. This writes a gitignored `.ddev.toml` that points the `core` repo at the current worktree.
 
 Without this override, `ddev` resolves `core` to whatever the global configuration points at, which is usually a different worktree. Every `ddev test`, `ddev test --lint`, and `ddev env` command would then run against the wrong checkout and produce misleading results.
 
@@ -88,7 +102,7 @@ repo = "core"
 core = "<absolute-path-to-this-worktree>"
 ```
 
-## Testing
+### Testing
 
 Run unit and integration tests with `ddev --no-interactive test <INTEGRATION>`. For example, for the pgbouncer integration, run `ddev --no-interactive test pgbouncer`.
 
@@ -128,7 +142,7 @@ ddev env stop pgbouncer py3.11-1.23
 
 Run specific tests with `ddev --no-interactive test <INTEGRATION> -- -k <PYTEST_FILTER_STRING>`, for example `ddev --no-interactive test kuma -- -k test_code_class_injection -s`.
 
-### Recreating Environments
+#### Recreating Environments
 
 Add `--recreate` to recreate test environments from scratch:
 
@@ -142,28 +156,33 @@ ddev env test --dev --recreate <INTEGRATION> <ENV>
 
 For E2E tests, `--recreate` performs `docker compose down --volumes` followed by `docker compose up -d --force-recreate`.
 
-## Code Formatting
+### Linting and Formatting
 
-Format code with `ddev test -fs <INTEGRATION>`. For example, for the pgbouncer integration, run `ddev test -fs pgbouncer`.
+Always run linting and formatting through `ddev`; never invoke `ruff`, `black`, or `mypy` directly. CI runs them inside `ddev`'s pinned hatch lint environment, and a different locally installed version can report different results — passing locally while failing CI, or the other way around.
 
-Always run linting and formatting through `ddev`: use `ddev test -fs <INTEGRATION>` to fix issues and `ddev test --lint <INTEGRATION>` (or `-s`) to check them. Do not invoke `ruff`, `black`, or `mypy` directly. CI runs them inside `ddev`'s pinned hatch lint environment, and a different locally installed version can report different results, passing locally while failing CI or the other way around.
+- Check for issues without changing anything: `ddev test --lint <INTEGRATION>` (or `-s`).
+- Fix issues automatically: `ddev test -fs <INTEGRATION>`. For example, for the pgbouncer integration, run `ddev test -fs pgbouncer`.
+- `-fsu`/`--fmt-unsafe` additionally applies fixes ruff marks as unsafe. Review those diffs before keeping them — "unsafe" means ruff can't guarantee the fix is behavior-preserving.
 
-## Changelog Management
+`<INTEGRATION>` is optional. Omitting it targets whichever integrations currently have uncommitted changes (`ddev`'s `changed` target) — convenient mid-task, but pass the integration name explicitly when you need to be sure of the scope, such as right before opening a PR.
+
+### Changelog Management
 
 Changelog entries are required for any change to a file that is shipped with the Agent. This includes Python sources under `datadog_checks/`, `pyproject.toml`, and the integration's `conf.yaml.example`. Changes limited to tests, fixtures, or developer-only assets do not need a changelog entry.
+For `datadog_checks_dev` and `ddev` we also need to track changelog entries even if they are not shipped with the agent. Those are the only exception to the rule.
 
 **IMPORTANT:** Always open the pull request first and only then add the changelog entry. The entry filename embeds the PR number; creating the file before the PR exists almost always results in the wrong number and a broken entry.
 
 **IMPORTANT:** Do not use `ddev release changelog new` to create entries. That command resolves the repository from the active `ddev` configuration, which may not match the worktree or branch you are working in, and it can silently target the wrong repo or write to the wrong location. Create the file by hand instead.
 
-### How to create an entry
+#### How to create an entry
 
 1. Open the PR and note the PR number (e.g. `23655`).
 2. Pick the entry type from the valid list below.
 3. Create the file at `<INTEGRATION>/changelog.d/<PR_NUMBER>.<TYPE>` (for example `ddev/changelog.d/23655.changed`).
 4. Write a single line describing the change. End the line with a period.
 
-### Valid entry types
+#### Valid entry types
 
 The valid types are defined in `ddev/src/ddev/release/constants.py` (`ENTRY_TYPES`):
 
@@ -171,10 +190,10 @@ The valid types are defined in `ddev/src/ddev/release/constants.py` (`ENTRY_TYPE
 - `changed` - Breaking changes or significant modifications. Bumps the **major** version (e.g., 1.0.0 → 2.0.0).
 - `deprecated` - Marks functionality as deprecated. Bumps the **minor** version.
 - `removed` - Removes functionality. Bumps the **major** version.
-- `fixed` - Bug fixes. Bumps the **patch** version (e.g., 1.0.0 → 1.0.1).
+- `fixed` - Bug fixes or internal modifications with no impact on outside users. These do not deserve a `changed` or `added` (major or minor) version bump. Bumps the **patch** version (e.g., 1.0.0 → 1.0.1).
 - `security` - Security-related fixes. Bumps the **minor** version.
 
-### Examples
+#### Examples
 
 ```shell
 # New feature for kafka_consumer in PR #23700
@@ -194,12 +213,10 @@ echo "Fix a bug where ``tempdb`` is wrongly excluded from database files metrics
 
 ## Documentation
 
-### New files added
+### New Files Added
 
-When a new file is added make sure to make it available through the navigation configuration in the mkdocs file. If it is not clear where it should go, ask.
+When a new file is added, make sure to make it available through the navigation configuration in the mkdocs file. If it is not clear where it should go, ask.
 
 ### Style
 
-Maintain style consistent. The style should be technical and professional.
-
-Do not start lines/paragraphs with an inline code.
+Maintain a consistent style: technical and professional. Do not start lines or paragraphs with an inline code span.

--- a/clickhouse/AGENTS.md
+++ b/clickhouse/AGENTS.md
@@ -1,7 +1,9 @@
 # ClickHouse integration agent notes
 
-A small orientation guide. Read this before touching `advanced_queries/` or
-`scripts/generate_metrics.py`.
+This supplements the repository's root `AGENTS.md` — read that first for general
+conventions (naming, testing, changelogs, PRs); it still applies here. This file
+adds ClickHouse-specific orientation. Read it before touching `advanced_queries/`
+or `scripts/generate_metrics.py`.
 
 ## Bulk match queries live in JSON, not Python
 


### PR DESCRIPTION
### What does this PR do?
Restructures the root `AGENTS.md` into clearer, cross-referenced sections (Python Code Style, Configuration Models, Development Workflow, Pull Requests, Documentation) and tightens the guidance on leading-underscore naming for methods and variables. Also updates `clickhouse/AGENTS.md` to explicitly note that it supplements the root `AGENTS.md` rather than replacing it.

### Motivation
The previous `AGENTS.md` had grown organically and lacked clear organization, making it harder for agents and humans to find the relevant rule. This restructuring adds a table of contents, groups related rules together, and clarifies how nested `AGENTS.md`/`CLAUDE.md` files relate to the root file.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged