### PR TITLE
[AI-6866] Allow elastic custom_queries to target the root of a flat response

### DIFF
--- a/elastic/README.md
+++ b/elastic/README.md
@@ -98,7 +98,7 @@ The Elasticsearch integration allows you to collect custom metrics through custo
 Each custom query has the following parameters:
 
 - `endpoint` (required): The Elasticsearch API endpoint to query.
-- `data_path` (required): The JSON path up to (not including) the metric. Cannot contain wildcards. For example: if you are querying for the size of a parent circuit breaker, and the full path is `breakers.parent.estimated_size_in_bytes`, then the `data_path` is `breakers.parent`.
+- `data_path` (optional): The JSON path up to (not including) the metric. Cannot contain wildcards. For example: if you are querying for the size of a parent circuit breaker, and the full path is `breakers.parent.estimated_size_in_bytes`, then the `data_path` is `breakers.parent`. If omitted or empty, `value_path` is resolved against the root of the response, which is useful for flat responses such as `/<index>/_count`.
 - `columns` (required): A list representing the data to be collected from the JSON query. Each item in this list includes:
    - `value_path` (required): The JSON path from the `data_path` to the metric. This path can include string keys and list indices. For example: if you are querying for the size of a parent circuit breaker, and the full path is `breakers.parent.estimated_size_in_bytes`, then the `value_path` is `estimated_size_in_bytes`.
    - `name` (required): The full metric name sent to Datadog. If you also set `type` to `tag`, then every metric collected by this query is tagged with this name.

--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -166,17 +166,19 @@ files:
       display_priority: 0
       description: |
         Run custom queries for Elasticsearch. Each custom query endpoint can collect multiple metrics and tags.
-        Note: Each custom query requires an `endpoint`, `data_path`, and `columns` parameter. Each `columns` parameter
+        Note: Each custom query requires an `endpoint` and `columns` parameter. Each `columns` parameter
         should have at least one value containing `name` and `value_path`.
 
         Each query can have the following parameters:
 
         1. endpoint - The Elasticsearch API endpoint to query.
 
-        2. data_path - The JSON path up to, but not including, the metric. For example, if querying for size of parent
-                       circuit breaker, the full path is 'breakers.parent.estimated_size_in_bytes', which means the
-                       `data_path` is 'breakers.parent'. `data_path` cannot contain any wildcards, so accessing data
-                       indexed by ID (such as node or index) is not possible.
+        2. data_path (optional) - The JSON path up to, but not including, the metric. For example, if querying for size
+                       of parent circuit breaker, the full path is 'breakers.parent.estimated_size_in_bytes', which
+                       means the `data_path` is 'breakers.parent'. `data_path` cannot contain any wildcards, so
+                       accessing data indexed by ID (such as node or index) is not possible. If `data_path` is omitted
+                       or empty, `value_path` is resolved against the root of the response, which is useful for flat
+                       responses such as `/<index>/_count`.
 
         3. columns - The list representing the data to be collected from the JSON query. There are two required pieces
                      of data:

--- a/elastic/changelog.d/24323.added
+++ b/elastic/changelog.d/24323.added
@@ -1,0 +1,1 @@
+Allow custom queries to target the root of a flat response by making `data_path` optional.

--- a/elastic/datadog_checks/elastic/config_models/validators.py
+++ b/elastic/datadog_checks/elastic/config_models/validators.py
@@ -9,9 +9,9 @@ def initialize_instance(values, **kwargs):
     if 'custom_queries' in values:
         custom_queries = values['custom_queries']
         for custom_query in custom_queries:
-            # Each custom query must have `endpoint`, `data_path`, and 'columns`
-            if not (custom_query.get('endpoint') and custom_query.get('data_path') and custom_query.get('columns')):
-                raise ValueError('Each custom query must have an `endpoint`, `data_path`, and `columns` values')
+            # Each custom query must have `endpoint` and `columns`; `data_path` is optional
+            if not (custom_query.get('endpoint') and custom_query.get('columns')):
+                raise ValueError('Each custom query must have an `endpoint` and `columns` values')
 
             columns = custom_query.get('columns')
             for column in columns:

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -152,17 +152,19 @@ instances:
 
     ## @param custom_queries - list of mappings - optional
     ## Run custom queries for Elasticsearch. Each custom query endpoint can collect multiple metrics and tags.
-    ## Note: Each custom query requires an `endpoint`, `data_path`, and `columns` parameter. Each `columns` parameter
+    ## Note: Each custom query requires an `endpoint` and `columns` parameter. Each `columns` parameter
     ## should have at least one value containing `name` and `value_path`.
     ##
     ## Each query can have the following parameters:
     ##
     ## 1. endpoint - The Elasticsearch API endpoint to query.
     ##
-    ## 2. data_path - The JSON path up to, but not including, the metric. For example, if querying for size of parent
-    ##                circuit breaker, the full path is 'breakers.parent.estimated_size_in_bytes', which means the
-    ##                `data_path` is 'breakers.parent'. `data_path` cannot contain any wildcards, so accessing data
-    ##                indexed by ID (such as node or index) is not possible.
+    ## 2. data_path (optional) - The JSON path up to, but not including, the metric. For example, if querying for size
+    ##                of parent circuit breaker, the full path is 'breakers.parent.estimated_size_in_bytes', which
+    ##                means the `data_path` is 'breakers.parent'. `data_path` cannot contain any wildcards, so
+    ##                accessing data indexed by ID (such as node or index) is not possible. If `data_path` is omitted
+    ##                or empty, `value_path` is resolved against the root of the response, which is useful for flat
+    ##                responses such as `/<index>/_count`.
     ##
     ## 3. columns - The list representing the data to be collected from the JSON query. There are two required pieces
     ##              of data:

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -73,6 +73,10 @@ def get_dynamic_tags(columns):
 def get_value_from_path(value, path):
     result = value
 
+    # An empty or missing path targets the root of the response
+    if not path:
+        return result
+
     # Traverse the nested dictionaries
     for key in re.split(REGEX, path):
         if result is not None:
@@ -597,7 +601,7 @@ class ESCheck(AgentCheck):
         """
 
         tags_to_submit = deepcopy(tags)
-        path = '{}.{}'.format(data_path, value_path)
+        path = '.'.join(part for part in (data_path, value_path) if part)
 
         # Collect the value of tags first, and then append to tags_to_submit
         for dynamic_tag_path, dynamic_tag_name in dynamic_tags:

--- a/elastic/tests/conftest.py
+++ b/elastic/tests/conftest.py
@@ -11,9 +11,20 @@ from packaging import version
 
 from datadog_checks.base.utils.common import exclude_undefined_keys
 from datadog_checks.dev import WaitFor, docker_run
+from datadog_checks.dev.http import MockResponse
 from datadog_checks.elastic import ESCheck
 
-from .common import CLUSTER_TAG, ELASTIC_CLUSTER_TAG, ELASTIC_FLAVOR, ELASTIC_VERSION, HERE, PASSWORD, URL, USER
+from .common import (
+    CLUSTER_TAG,
+    ELASTIC_CLUSTER_TAG,
+    ELASTIC_FLAVOR,
+    ELASTIC_VERSION,
+    HERE,
+    PASSWORD,
+    URL,
+    USER,
+    get_fixture_path,
+)
 
 CUSTOM_TAGS = ['foo:bar', 'baz']
 
@@ -116,6 +127,52 @@ def elastic_check():
 @pytest.fixture
 def instance():
     return copy.deepcopy(INSTANCE)
+
+
+@pytest.fixture
+def mock_es_endpoints(mock_http_response_per_endpoint):
+    """
+    Mock every endpoint a default `ESCheck.check()` run hits, with representative data, so unit tests can
+    exercise the whole check through `dd_run_check` and target specific behavior purely through the instance
+    config. Pass `overrides` (keyed by full URL) to swap individual responses, for example to simulate an error.
+    """
+
+    def setup(overrides=None):
+        responses = {
+            # `_get_es_version` probes the base URL.
+            URL: [MockResponse(json_data={'version': {'number': '8.8.0'}})],
+            # Node stats: the local URL is used by default, the cluster-wide one when `cluster_stats` is on.
+            '{}/_nodes/_local/stats'.format(URL): [MockResponse(file_path=get_fixture_path('stats_v8.json'))],
+            '{}/_nodes/stats'.format(URL): [MockResponse(file_path=get_fixture_path('stats_v8.json'))],
+            '{}/_cat/templates?format=json'.format(URL): [MockResponse(file_path=get_fixture_path('templates.json'))],
+            # A single-node cluster reports `yellow`; `green` would make the health service check OK, and the
+            # aggregator stub rejects an OK service check that carries a message.
+            '{}/_cluster/health'.format(URL): [
+                MockResponse(
+                    json_data={
+                        'cluster_name': 'test-cluster',
+                        'status': 'yellow',
+                        'active_primary_shards': 1,
+                        'active_shards': 1,
+                        'relocating_shards': 0,
+                        'initializing_shards': 0,
+                        'unassigned_shards': 1,
+                        'number_of_nodes': 1,
+                        'number_of_data_nodes': 1,
+                        'timed_out': False,
+                    }
+                )
+            ],
+            # `pending_task_stats` defaults to on, so the check always hits this endpoint.
+            '{}/_cluster/pending_tasks'.format(URL): [MockResponse(json_data={'tasks': []})],
+            # The default `instance` fixture ships a `/_search` custom query.
+            '{}/_search'.format(URL): [MockResponse(json_data={'hits': {'total': {'value': 0, 'relation': 'eq'}}})],
+        }
+        if overrides:
+            responses.update(overrides)
+        mock_http_response_per_endpoint(responses)
+
+    return setup
 
 
 @pytest.fixture

--- a/elastic/tests/test_config.py
+++ b/elastic/tests/test_config.py
@@ -134,19 +134,6 @@ def test_from_instance():
 @pytest.mark.parametrize(
     'invalid_custom_queries',
     [
-        # Missing `data_path`
-        [
-            {
-                'endpoint': '/_nodes',
-                'columns': [
-                    {
-                        'value_path': 'total',
-                        'name': 'elasticsearch.custom.metric',
-                    },
-                ],
-                'tags': ['custom_tag:1'],
-            },
-        ],
         # Missing `columns`
         [
             {'endpoint': '/_nodes', 'data_path': '_nodes.', 'tags': ['custom_tag:1']},

--- a/elastic/tests/test_integration.py
+++ b/elastic/tests/test_integration.py
@@ -51,11 +51,17 @@ def test_custom_queries_valid_metrics(dd_environment, dd_run_check, instance, ag
 
 
 def test_custom_queries_root_data_path(dd_environment, dd_run_check, instance, aggregator):
-    # A flat endpoint such as `/_count` returns `{"count": N, "_shards": {...}}`, so the metric
-    # lives at the root of the response. Omitting `data_path` must resolve `value_path` against it.
+    # Mirror the reported use case: a flat `/<index>/_count` response is `{"count": N, "_shards": {...}}`,
+    # so the metric lives at the root and `data_path` is omitted. Index a known number of documents and
+    # assert the exact count, which also guards against reading a sibling key such as `_shards.total`.
+    index = 'root_data_path_test'
+    for doc_id in range(3):
+        requests.put("{}/{}/_doc/{}".format(instance['url'], index, doc_id), json={'value': doc_id}).raise_for_status()
+    requests.post("{}/{}/_refresh".format(instance['url'], index)).raise_for_status()
+
     custom_queries = [
         {
-            'endpoint': '/_count',
+            'endpoint': '/{}/_count'.format(index),
             'columns': [
                 {
                     'value_path': 'count',
@@ -69,7 +75,7 @@ def test_custom_queries_root_data_path(dd_environment, dd_run_check, instance, a
     check = ESCheck('elastic', {}, instances=[instance])
     dd_run_check(check)
 
-    aggregator.assert_metric('elasticsearch.custom.doc_count', metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('elasticsearch.custom.doc_count', value=3, metric_type=aggregator.GAUGE)
 
 
 def test_custom_queries_one_invalid(dd_environment, dd_run_check, instance, aggregator):

--- a/elastic/tests/test_integration.py
+++ b/elastic/tests/test_integration.py
@@ -50,6 +50,28 @@ def test_custom_queries_valid_metrics(dd_environment, dd_run_check, instance, ag
     aggregator.assert_metric('elasticsearch.custom.metric', metric_type=aggregator.GAUGE)
 
 
+def test_custom_queries_root_data_path(dd_environment, dd_run_check, instance, aggregator):
+    # A flat endpoint such as `/_count` returns `{"count": N, "_shards": {...}}`, so the metric
+    # lives at the root of the response. Omitting `data_path` must resolve `value_path` against it.
+    custom_queries = [
+        {
+            'endpoint': '/_count',
+            'columns': [
+                {
+                    'value_path': 'count',
+                    'name': 'elasticsearch.custom.doc_count',
+                },
+            ],
+        },
+    ]
+
+    instance['custom_queries'] = custom_queries
+    check = ESCheck('elastic', {}, instances=[instance])
+    dd_run_check(check)
+
+    aggregator.assert_metric('elasticsearch.custom.doc_count', metric_type=aggregator.GAUGE)
+
+
 def test_custom_queries_one_invalid(dd_environment, dd_run_check, instance, aggregator):
     custom_queries = [
         {

--- a/elastic/tests/test_integration.py
+++ b/elastic/tests/test_integration.py
@@ -51,17 +51,12 @@ def test_custom_queries_valid_metrics(dd_environment, dd_run_check, instance, ag
 
 
 def test_custom_queries_root_data_path(dd_environment, dd_run_check, instance, aggregator):
-    # Mirror the reported use case: a flat `/<index>/_count` response is `{"count": N, "_shards": {...}}`,
-    # so the metric lives at the root and `data_path` is omitted. Index a known number of documents and
-    # assert the exact count, which also guards against reading a sibling key such as `_shards.total`.
-    index = 'root_data_path_test'
-    for doc_id in range(3):
-        requests.put("{}/{}/_doc/{}".format(instance['url'], index, doc_id), json={'value': doc_id}).raise_for_status()
-    requests.post("{}/{}/_refresh".format(instance['url'], index)).raise_for_status()
-
+    # Mirror the reported use case: a flat `/_count` response is `{"count": N, "_shards": {...}}`, so the
+    # metric lives at the root and `data_path` is omitted. This exercises the end-to-end wiring against a
+    # live cluster; that the correct key is read from a given response is covered by the unit tests.
     custom_queries = [
         {
-            'endpoint': '/{}/_count'.format(index),
+            'endpoint': '/_count',
             'columns': [
                 {
                     'value_path': 'count',
@@ -75,7 +70,7 @@ def test_custom_queries_root_data_path(dd_environment, dd_run_check, instance, a
     check = ESCheck('elastic', {}, instances=[instance])
     dd_run_check(check)
 
-    aggregator.assert_metric('elasticsearch.custom.doc_count', value=3, metric_type=aggregator.GAUGE)
+    aggregator.assert_metric('elasticsearch.custom.doc_count', metric_type=aggregator.GAUGE)
 
 
 def test_custom_queries_one_invalid(dd_environment, dd_run_check, instance, aggregator):

--- a/elastic/tests/test_unit.py
+++ b/elastic/tests/test_unit.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import json
 import logging
 from copy import deepcopy
 
@@ -12,9 +11,9 @@ from datadog_checks.base import ConfigurationError, is_affirmative
 from datadog_checks.dev.http import MockResponse
 from datadog_checks.elastic import ESCheck
 from datadog_checks.elastic.elastic import AuthenticationError, get_value_from_path
-from datadog_checks.elastic.metrics import INDEX_STATS_METRICS, stats_for_version
+from datadog_checks.elastic.metrics import INDEX_STATS_METRICS
 
-from .common import URL, get_fixture_path
+from .common import URL
 
 log = logging.getLogger('test_elastic')
 
@@ -124,23 +123,21 @@ def test_aws_auth_no_url(instance, expected_aws_host, expected_aws_service):
         ESCheck('elastic', {}, instances=[instance])
 
 
-def test_get_template_metrics(aggregator, instance, mock_http_response):
-    mock_http_response(file_path=get_fixture_path('templates.json'))
+def test_get_template_metrics(aggregator, instance, dd_run_check, mock_es_endpoints):
+    mock_es_endpoints()
     check = ESCheck('elastic', {}, instances=[instance])
 
-    check._get_template_metrics(False, [])
+    dd_run_check(check)
 
     aggregator.assert_metric("elasticsearch.templates.count", value=6)
 
 
-def test_get_template_metrics_raise_exception(aggregator, instance):
-    with mock.patch(
-        'requests.Session.get',
-        return_value=MockResponse(status_code=403),
-    ):
-        check = ESCheck('elastic', {}, instances=[instance])
-        # Make sure we do not throw an exception and move on
-        check._get_template_metrics(False, [])
+def test_get_template_metrics_raise_exception(aggregator, instance, dd_run_check, mock_es_endpoints):
+    # A failing templates endpoint must not abort the check; the metric is simply not emitted.
+    mock_es_endpoints({'{}/_cat/templates?format=json'.format(URL): [MockResponse(status_code=403)]})
+    check = ESCheck('elastic', {}, instances=[instance])
+
+    dd_run_check(check)
 
     aggregator.assert_metric("elasticsearch.templates.count", count=0)
 
@@ -158,27 +155,18 @@ def test_get_value_from_path(value, path, expected):
 
 
 @pytest.mark.parametrize('data_path', ['', None], ids=['empty_data_path', 'omitted_data_path'])
-def test_run_custom_queries_root_data_path(
-    aggregator, instance, dd_run_check, mock_http_response_per_endpoint, data_path
-):
+def test_run_custom_queries_root_data_path(aggregator, instance, dd_run_check, mock_es_endpoints, data_path):
     # A flat endpoint such as `/my-index/_count` returns `{"count": N, "_shards": {...}}`, so the metric
     # lives at the response root. Omitting or emptying `data_path` must resolve `value_path` against it.
     instance = deepcopy(instance)
-    instance['pending_task_stats'] = False
     column = {'value_path': 'count', 'name': 'elasticsearch.custom.count', 'type': 'gauge'}
     custom_query = {'endpoint': '/my-index/_count', 'columns': [column]}
     if data_path is not None:
         custom_query['data_path'] = data_path
     instance['custom_queries'] = [custom_query]
 
-    mock_http_response_per_endpoint(
-        {
-            URL: [MockResponse(json_data={'version': {'number': '8.8.0'}})],
-            '{}/_nodes/_local/stats'.format(URL): [MockResponse(json_data={'cluster_name': 'test', 'nodes': {}})],
-            '{}/_cat/templates?format=json'.format(URL): [MockResponse(json_data=[])],
-            '{}/_cluster/health'.format(URL): [MockResponse(json_data={'status': 'yellow', 'cluster_name': 'test'})],
-            '{}/my-index/_count'.format(URL): [MockResponse(json_data={'count': 42, '_shards': {'total': 5}})],
-        }
+    mock_es_endpoints(
+        {'{}/my-index/_count'.format(URL): [MockResponse(json_data={'count': 42, '_shards': {'total': 5}})]}
     )
 
     check = ESCheck('elastic', {}, instances=[instance])
@@ -268,12 +256,11 @@ def test_collect_template_metrics_returns_valid_result(instance, version, return
     assert check._collect_template_metrics(es_version=version) == return_value
 
 
-def test_v8_process_stats_data(aggregator, instance):
+def test_v8_process_stats_data(aggregator, instance, dd_run_check, mock_es_endpoints):
+    mock_es_endpoints()
     check = ESCheck('elastic', {}, instances=[instance])
-    v8 = [8, 0, 0]
-    with open(get_fixture_path('stats_v8.json')) as f:
-        stats_data = json.load(f)
-        check._process_stats_data(stats_data, stats_for_version(v8), {})
+
+    dd_run_check(check)
 
     aggregator.assert_metric("elasticsearch.breakers.inflight_requests.tripped", metric_type=aggregator.GAUGE)
     aggregator.assert_metric("elasticsearch.breakers.inflight_requests.overhead", metric_type=aggregator.GAUGE)

--- a/elastic/tests/test_unit.py
+++ b/elastic/tests/test_unit.py
@@ -158,17 +158,31 @@ def test_get_value_from_path(value, path, expected):
 
 
 @pytest.mark.parametrize('data_path', ['', None], ids=['empty_data_path', 'omitted_data_path'])
-def test_run_custom_queries_root_data_path(aggregator, instance, data_path):
+def test_run_custom_queries_root_data_path(
+    aggregator, instance, dd_run_check, mock_http_response_per_endpoint, data_path
+):
+    # A flat endpoint such as `/my-index/_count` returns `{"count": N, "_shards": {...}}`, so the metric
+    # lives at the response root. Omitting or emptying `data_path` must resolve `value_path` against it.
     instance = deepcopy(instance)
+    instance['pending_task_stats'] = False
     column = {'value_path': 'count', 'name': 'elasticsearch.custom.count', 'type': 'gauge'}
     custom_query = {'endpoint': '/my-index/_count', 'columns': [column]}
     if data_path is not None:
         custom_query['data_path'] = data_path
     instance['custom_queries'] = [custom_query]
 
+    mock_http_response_per_endpoint(
+        {
+            URL: [MockResponse(json_data={'version': {'number': '8.8.0'}})],
+            '{}/_nodes/_local/stats'.format(URL): [MockResponse(json_data={'cluster_name': 'test', 'nodes': {}})],
+            '{}/_cat/templates?format=json'.format(URL): [MockResponse(json_data=[])],
+            '{}/_cluster/health'.format(URL): [MockResponse(json_data={'status': 'yellow', 'cluster_name': 'test'})],
+            '{}/my-index/_count'.format(URL): [MockResponse(json_data={'count': 42, '_shards': {'total': 5}})],
+        }
+    )
+
     check = ESCheck('elastic', {}, instances=[instance])
-    with mock.patch.object(check, '_get_data', return_value={'count': 42, '_shards': {'total': 5}}):
-        check._run_custom_queries(admin_forwarder=False, base_tags=[])
+    dd_run_check(check)
 
     aggregator.assert_metric('elasticsearch.custom.count', value=42, count=1)
 

--- a/elastic/tests/test_unit.py
+++ b/elastic/tests/test_unit.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
 import logging
+from copy import deepcopy
 
 import mock
 import pytest
@@ -144,9 +145,32 @@ def test_get_template_metrics_raise_exception(aggregator, instance):
     aggregator.assert_metric("elasticsearch.templates.count", count=0)
 
 
-def test_get_value_from_path():
-    value = get_value_from_path({"5": {"b": [0, 1, 2, {"a": ["foo"]}]}}, "5.b.3.a.0")
-    assert value == "foo"
+@pytest.mark.parametrize(
+    'value, path, expected',
+    [
+        pytest.param({"5": {"b": [0, 1, 2, {"a": ["foo"]}]}}, "5.b.3.a.0", "foo", id='nested_path'),
+        pytest.param({"count": 42, "_shards": {}}, "", {"count": 42, "_shards": {}}, id='empty_path_returns_root'),
+        pytest.param({"count": 42, "_shards": {}}, None, {"count": 42, "_shards": {}}, id='none_path_returns_root'),
+    ],
+)
+def test_get_value_from_path(value, path, expected):
+    assert get_value_from_path(value, path) == expected
+
+
+@pytest.mark.parametrize('data_path', ['', None], ids=['empty_data_path', 'omitted_data_path'])
+def test_run_custom_queries_root_data_path(aggregator, instance, data_path):
+    instance = deepcopy(instance)
+    column = {'value_path': 'count', 'name': 'elasticsearch.custom.count', 'type': 'gauge'}
+    custom_query = {'endpoint': '/my-index/_count', 'columns': [column]}
+    if data_path is not None:
+        custom_query['data_path'] = data_path
+    instance['custom_queries'] = [custom_query]
+
+    check = ESCheck('elastic', {}, instances=[instance])
+    with mock.patch.object(check, '_get_data', return_value={'count': 42, '_shards': {'total': 5}}):
+        check._run_custom_queries(admin_forwarder=False, base_tags=[])
+
+    aggregator.assert_metric('elasticsearch.custom.count', value=42, count=1)
 
 
 def test__get_data_throws_authentication_error(instance):


### PR DESCRIPTION
### What does this PR do?

Makes `data_path` optional in the elastic `custom_queries` feature so a query can target the root of a flat/scalar JSON response.

- Config validator now requires only `endpoint` and `columns`; `data_path` is optional.
- `get_value_from_path` short-circuits an empty or omitted path to return the response root (previously `re.split('', '')` produced `['']`, so it did `dict.get('')` and returned `None`).
- Debug-log path string no longer renders `None.count` when `data_path` is absent.
- Docs (spec, generated `conf.yaml.example`, README) document `data_path` as optional and explain the root-of-response behavior.

### Motivation

Reported in [#17475](https://github.com/DataDog/integrations-core/issues/17475). Flat endpoints such as `GET /<index>/_count` return `{"count": N, "_shards": {...}}`, where the metric lives at the response root. There was no way to point a custom query at the root: the validator rejected `data_path: ""`, and even bypassing it, the traversal helper resolved an empty path to `None` instead of the root object. Users had to restructure the query into an aggregation `_search` shape as a workaround. This change makes the direct `_count`-style query work. Backward compatible: existing configs with a non-empty `data_path` are unaffected.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
