### PR TITLE
Improve ai tools input validation with pydantic

### DIFF
--- a/ddev/src/ddev/ai/tools/agents/spawn_identical_subagents.py
+++ b/ddev/src/ddev/ai/tools/agents/spawn_identical_subagents.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Annotated
 
-from pydantic import Field, field_validator
+from pydantic import AfterValidator, Field
 
 from ddev.ai.tools.agents.base import SPAWN_IDENTICAL_NAME, BaseSpawnTool, ChildOutcome
 from ddev.ai.tools.core.base import BaseToolInput
@@ -37,6 +37,13 @@ class Assignment(BaseToolInput):
     ]
 
 
+def names_must_be_unique(assignments: list[Assignment]) -> list[Assignment]:
+    names = [a.name for a in assignments]
+    if len(set(names)) != len(names):
+        raise ValueError("Assignment names must be unique.")
+    return assignments
+
+
 class SpawnIdenticalSubagentsInput(BaseToolInput):
     system_prompt: Annotated[
         str,
@@ -55,19 +62,12 @@ class SpawnIdenticalSubagentsInput(BaseToolInput):
             min_length=1,
             max_length=MAX_ASSIGNMENTS,
         ),
+        AfterValidator(names_must_be_unique),
     ]
     max_parallel: Annotated[
         int,
         Field(description="Cap on concurrent children.", ge=1),
     ] = DEFAULT_PARALLEL
-
-    @field_validator("assignments")
-    @classmethod
-    def names_must_be_unique(cls, assignments: list[Assignment]) -> list[Assignment]:
-        names = [a.name for a in assignments]
-        if len(set(names)) != len(names):
-            raise ValueError("Assignment names must be unique.")
-        return assignments
 
 
 class SpawnIdenticalSubagentsTool(BaseSpawnTool[SpawnIdenticalSubagentsInput]):

--- a/ddev/src/ddev/ai/tools/core/base.py
+++ b/ddev/src/ddev/ai/tools/core/base.py
@@ -13,6 +13,7 @@ from anthropic.types import ToolParam
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from .types import ToolResult
+from .validation import format_validation_error
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,9 @@ class BaseTool[TInput: BaseToolInput](ABC):
         try:
             input_cls = _get_input_type(type(self))
             validated: TInput = input_cls.model_validate(raw)  # type: ignore[assignment]
-        except (ValidationError, TypeError, ValueError) as e:
+        except ValidationError as e:
+            return ToolResult(success=False, error=format_validation_error(e))
+        except (TypeError, ValueError) as e:
             return ToolResult(success=False, error=str(e))
         try:
             return await self(validated)

--- a/ddev/src/ddev/ai/tools/core/validation.py
+++ b/ddev/src/ddev/ai/tools/core/validation.py
@@ -1,0 +1,37 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from pydantic import ValidationError
+from pydantic_core import ErrorDetails
+
+
+def format_validation_error(exc: ValidationError) -> str:
+    """Build a compact, model-facing message from a pydantic ValidationError.
+
+    Drops the pydantic docs URL and the echoed input value, and renders each
+    failing field as ``<loc-path>: <reason>`` with list indices in brackets
+    (e.g. ``assignments[0].name``).
+    """
+    errors = exc.errors(include_url=False, include_input=False)
+    count = len(errors)
+    header = "1 validation error:" if count == 1 else f"{count} validation errors:"
+    lines = [_format_error(error) for error in errors]
+    return "\n".join([header, *lines])
+
+
+def _format_error(error: ErrorDetails) -> str:
+    loc = _format_loc(error["loc"])
+    msg = error["msg"]
+    return f"- {loc}: {msg}" if loc else f"- {msg}"
+
+
+def _format_loc(loc: tuple[str | int, ...]) -> str:
+    parts: list[str] = []
+    for item in loc:
+        if isinstance(item, int):
+            parts.append(f"[{item}]")
+        elif parts:
+            parts.append(f".{item}")
+        else:
+            parts.append(str(item))
+    return "".join(parts)

--- a/ddev/src/ddev/ai/tools/http/http_get.py
+++ b/ddev/src/ddev/ai/tools/http/http_get.py
@@ -4,23 +4,26 @@
 from typing import Annotated
 
 import httpx
-from pydantic import Field, field_validator
+from pydantic import AfterValidator, Field
 
 from ddev.ai.tools.core.base import BaseTool, BaseToolInput
 from ddev.ai.tools.core.truncation import make_tool_result, truncate
 from ddev.ai.tools.core.types import ToolResult
 
 
-class HttpGetInput(BaseToolInput):
-    url: Annotated[str, Field(description="Full URL to probe (must start with http:// or https://)")]
-    timeout: Annotated[float, Field(description="Request timeout in seconds (default: 10)", gt=0)] = 10.0
+def requires_http_scheme(url: str) -> str:
+    if not url.startswith(("http://", "https://")):
+        raise ValueError("URL must start with http:// or https://")
+    return url
 
-    @field_validator("url")
-    @classmethod
-    def url_must_have_http_scheme(cls, url: str) -> str:
-        if not url.startswith(("http://", "https://")):
-            raise ValueError("URL must start with http:// or https://")
-        return url
+
+class HttpGetInput(BaseToolInput):
+    url: Annotated[
+        str,
+        Field(description="Full URL to probe (must start with http:// or https://)"),
+        AfterValidator(requires_http_scheme),
+    ]
+    timeout: Annotated[float, Field(description="Request timeout in seconds (default: 10)", gt=0)] = 10.0
 
 
 class HttpGetTool(BaseTool[HttpGetInput]):

--- a/ddev/src/ddev/ai/tools/http/http_get.py
+++ b/ddev/src/ddev/ai/tools/http/http_get.py
@@ -4,7 +4,7 @@
 from typing import Annotated
 
 import httpx
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from ddev.ai.tools.core.base import BaseTool, BaseToolInput
 from ddev.ai.tools.core.truncation import make_tool_result, truncate
@@ -14,6 +14,13 @@ from ddev.ai.tools.core.types import ToolResult
 class HttpGetInput(BaseToolInput):
     url: Annotated[str, Field(description="Full URL to probe (must start with http:// or https://)")]
     timeout: Annotated[float, Field(description="Request timeout in seconds (default: 10)", gt=0)] = 10.0
+
+    @field_validator("url")
+    @classmethod
+    def url_must_have_http_scheme(cls, url: str) -> str:
+        if not url.startswith(("http://", "https://")):
+            raise ValueError("URL must start with http:// or https://")
+        return url
 
 
 class HttpGetTool(BaseTool[HttpGetInput]):
@@ -28,9 +35,6 @@ class HttpGetTool(BaseTool[HttpGetInput]):
     async def __call__(self, tool_input: HttpGetInput) -> ToolResult:
         url: str = tool_input.url
         timeout: float = tool_input.timeout
-
-        if not url.startswith(("http://", "https://")):
-            return ToolResult(success=False, error="URL must start with http:// or https://")
 
         try:
             async with httpx.AsyncClient(timeout=timeout) as client:

--- a/ddev/tests/ai/tools/core/test_validation.py
+++ b/ddev/tests/ai/tools/core/test_validation.py
@@ -18,32 +18,30 @@ class Model(BaseModel):
     count: Annotated[int, Field(ge=1)] = 1
 
 
-def test_single_error_header_and_line():
+def capture(**kwargs) -> ValidationError:
     with pytest.raises(ValidationError) as exc_info:
-        Model(items=[{"name": "ok"}], count=0)
-    msg = format_validation_error(exc_info.value)
+        Model(**kwargs)
+    return exc_info.value
+
+
+def test_single_error_header_and_line():
+    msg = format_validation_error(capture(items=[{"name": "ok"}], count=0))
     assert msg.startswith("1 validation error:\n")
 
 
 def test_plural_header_counts_all_errors():
-    with pytest.raises(ValidationError) as exc_info:
-        Model(items=[{"name": "BAD"}], count=0)
-    msg = format_validation_error(exc_info.value)
+    msg = format_validation_error(capture(items=[{"name": "BAD"}], count=0))
     assert msg.startswith("2 validation errors:\n")
 
 
 def test_no_pydantic_docs_url():
-    with pytest.raises(ValidationError) as exc_info:
-        Model(items=[{"name": "BAD"}], count=0)
-    msg = format_validation_error(exc_info.value)
+    msg = format_validation_error(capture(items=[{"name": "BAD"}], count=0))
     assert "errors.pydantic.dev" not in msg
     assert "https://" not in msg
 
 
 def test_does_not_echo_offending_input():
-    with pytest.raises(ValidationError) as exc_info:
-        Model(items=[{"name": "BAD_VALUE_123"}], count=1)
-    msg = format_validation_error(exc_info.value)
+    msg = format_validation_error(capture(items=[{"name": "BAD_VALUE_123"}], count=1))
     assert "BAD_VALUE_123" not in msg
 
 
@@ -56,7 +54,5 @@ def test_does_not_echo_offending_input():
     ],
 )
 def test_loc_paths(kwargs, expected_loc):
-    with pytest.raises(ValidationError) as exc_info:
-        Model(**kwargs)
-    msg = format_validation_error(exc_info.value)
+    msg = format_validation_error(capture(**kwargs))
     assert f"- {expected_loc}: " in msg

--- a/ddev/tests/ai/tools/core/test_validation.py
+++ b/ddev/tests/ai/tools/core/test_validation.py
@@ -18,32 +18,32 @@ class Model(BaseModel):
     count: Annotated[int, Field(ge=1)] = 1
 
 
-def capture(**kwargs) -> ValidationError:
-    try:
-        Model(**kwargs)
-    except ValidationError as e:
-        return e
-    raise AssertionError("expected a ValidationError")
-
-
 def test_single_error_header_and_line():
-    msg = format_validation_error(capture(items=[{"name": "ok"}], count=0))
+    with pytest.raises(ValidationError) as exc_info:
+        Model(items=[{"name": "ok"}], count=0)
+    msg = format_validation_error(exc_info.value)
     assert msg.startswith("1 validation error:\n")
 
 
 def test_plural_header_counts_all_errors():
-    msg = format_validation_error(capture(items=[{"name": "BAD"}], count=0))
+    with pytest.raises(ValidationError) as exc_info:
+        Model(items=[{"name": "BAD"}], count=0)
+    msg = format_validation_error(exc_info.value)
     assert msg.startswith("2 validation errors:\n")
 
 
 def test_no_pydantic_docs_url():
-    msg = format_validation_error(capture(items=[{"name": "BAD"}], count=0))
+    with pytest.raises(ValidationError) as exc_info:
+        Model(items=[{"name": "BAD"}], count=0)
+    msg = format_validation_error(exc_info.value)
     assert "errors.pydantic.dev" not in msg
     assert "https://" not in msg
 
 
 def test_does_not_echo_offending_input():
-    msg = format_validation_error(capture(items=[{"name": "BAD_VALUE_123"}], count=1))
+    with pytest.raises(ValidationError) as exc_info:
+        Model(items=[{"name": "BAD_VALUE_123"}], count=1)
+    msg = format_validation_error(exc_info.value)
     assert "BAD_VALUE_123" not in msg
 
 
@@ -56,5 +56,7 @@ def test_does_not_echo_offending_input():
     ],
 )
 def test_loc_paths(kwargs, expected_loc):
-    msg = format_validation_error(capture(**kwargs))
+    with pytest.raises(ValidationError) as exc_info:
+        Model(**kwargs)
+    msg = format_validation_error(exc_info.value)
     assert f"- {expected_loc}: " in msg

--- a/ddev/tests/ai/tools/core/test_validation.py
+++ b/ddev/tests/ai/tools/core/test_validation.py
@@ -1,0 +1,60 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from typing import Annotated
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from ddev.ai.tools.core.validation import format_validation_error
+
+
+class Item(BaseModel):
+    name: Annotated[str, Field(pattern=r"^[a-z]+$")]
+
+
+class Model(BaseModel):
+    items: Annotated[list[Item], Field(min_length=1)]
+    count: Annotated[int, Field(ge=1)] = 1
+
+
+def capture(**kwargs) -> ValidationError:
+    try:
+        Model(**kwargs)
+    except ValidationError as e:
+        return e
+    raise AssertionError("expected a ValidationError")
+
+
+def test_single_error_header_and_line():
+    msg = format_validation_error(capture(items=[{"name": "ok"}], count=0))
+    assert msg.startswith("1 validation error:\n")
+
+
+def test_plural_header_counts_all_errors():
+    msg = format_validation_error(capture(items=[{"name": "BAD"}], count=0))
+    assert msg.startswith("2 validation errors:\n")
+
+
+def test_no_pydantic_docs_url():
+    msg = format_validation_error(capture(items=[{"name": "BAD"}], count=0))
+    assert "errors.pydantic.dev" not in msg
+    assert "https://" not in msg
+
+
+def test_does_not_echo_offending_input():
+    msg = format_validation_error(capture(items=[{"name": "BAD_VALUE_123"}], count=1))
+    assert "BAD_VALUE_123" not in msg
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_loc",
+    [
+        ({"items": [{"name": "ok"}], "count": 0}, "count"),
+        ({"items": [], "count": 1}, "items"),
+        ({"items": [{"name": "BAD"}], "count": 1}, "items[0].name"),
+    ],
+)
+def test_loc_paths(kwargs, expected_loc):
+    msg = format_validation_error(capture(**kwargs))
+    assert f"- {expected_loc}: " in msg

--- a/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
+++ b/ddev/tests/ai/tools/shell/ddev/test_ddev_tools.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
-from pydantic import ValidationError
 
 from ddev.ai.tools.shell.ddev.create import DdevCreateInput, DdevCreateTool
 from ddev.ai.tools.shell.ddev.ddev_test import DdevTestInput, DdevTestTool
@@ -43,18 +42,6 @@ def test_create_cmd():
 def test_create_cmd_platforms_joined():
     cmd = DdevCreateTool().cmd(DdevCreateInput(**{**VALID_CREATE_INPUT, "platforms": ["linux", "mac_os"]}))
     assert cmd[cmd.index("--platforms") + 1] == "linux,mac_os"
-
-
-@pytest.mark.parametrize(
-    "platforms",
-    [
-        ["linux", "bsd"],
-        [],
-    ],
-)
-def test_create_invalid_platform_raises(platforms):
-    with pytest.raises(ValidationError):
-        DdevCreateInput(**{**VALID_CREATE_INPUT, "platforms": platforms})
 
 
 # --- ddev test ---
@@ -189,11 +176,6 @@ def test_release_changelog_cmd_message_placement():
     assert cmd[-1] == "Some message"
 
 
-def test_release_changelog_invalid_change_type_raises():
-    with pytest.raises(ValidationError):
-        ReleaseChangelogInput(change_type="patch", integration="mycheck", message="Some message")
-
-
 # --- ddev validate ---
 
 
@@ -212,8 +194,3 @@ def test_validate_cmd_sync_flag_per_subcommand(subcommand: str):
 def test_validate_cmd_all_uses_fix_flag():
     cmd = DdevValidateTool().cmd(DdevValidateInput(subcommand="all", integration="mycheck", sync=True))
     assert cmd == ["ddev", "--no-interactive", "validate", "all", "--fix", "mycheck"]
-
-
-def test_validate_invalid_subcommand_raises():
-    with pytest.raises(ValidationError):
-        DdevValidateInput(subcommand="lint", integration="mycheck")


### PR DESCRIPTION
### What does this PR do?
Improves input validation for the agent tools under `ddev/src/ddev/ai/tools/`:

- **Centralizes input-shaped validation in the pydantic models.** The `http_get` URL scheme check (`http://`/`https://`) moves from an imperative check inside `HttpGetTool.__call__` into a `field_validator` on `HttpGetInput.url`, so it runs at `model_validate` time. Runtime/side-effecting checks (file-access policy, file existence, read-before-write, `old_string` matching, subagent tool-subset checks) intentionally stay in `__call__` since they depend on runtime state, not input shape.
- **Adds a clean, model-facing validation-error formatter** in `core/validation.py`. When a `pydantic.ValidationError` is raised, `BaseTool.run()` now returns a compact message built from the error object instead of pydantic's raw `str(e)` dump. It drops the `errors.pydantic.dev` docs link and the echoed input value, leads with the error count, and lists one line per failing field as `<loc>: <reason>` with list indices in brackets (e.g. `assignments[0].name`).
- **Removes redundant tests** that only asserted bare pydantic constraints (`Literal`/`min_length`) fire, and adds unit tests for the new formatter.

Example of the new error message:
```
2 validation errors:
- assignments[0].name: String should match pattern '^[A-Za-z0-9._-]{1,64}$'
- max_parallel: Input should be greater than or equal to 1
```

### Motivation
Tools validated their inputs inconsistently — some via pydantic `Field` constraints, others imperatively inside `__call__`. On top of that, the raw `str(ValidationError)` returned to the model was noisy: multi-line, with a docs URL and the echoed input the model has no use for. This consolidates input-shaped validation in one place (the model) and gives the model a clean, actionable error string.

Note: unlike the linked issue, the formatter does not prefix the tool name. The result is delivered to the API as a `tool_result` keyed by `tool_use_id`, which the model already maps back to the originating tool call, so repeating the name would be redundant.

Jira: https://datadoghq.atlassian.net/browse/AI-6972

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
