### PR TITLE
Fix Ray logs annotation example

### DIFF
--- a/ray/README.md
+++ b/ray/README.md
@@ -166,7 +166,7 @@ kind: Pod
 metadata:
   name: ray
   annotations:
-    ad.datadoghq.com/apache.logs: '[{"source":"ray","service":"ray"}]'
+    ad.datadoghq.com/ray.logs: '[{"source":"ray","service":"ray"}]'
 spec:
   containers:
     - name: ray


### PR DESCRIPTION
### What does this PR do?
Fixes the Kubernetes log collection annotation key in the Ray integration README example from `ad.datadoghq.com/apache.logs` to `ad.datadoghq.com/ray.logs`.

### Motivation
The example is in the Ray README and shows a container named `ray`, so the Autodiscovery log annotation should target the Ray container rather than Apache.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
