### PR TITLE
[vertica] strengthen tests to lift mutation score

### DIFF
--- a/vertica/tests/test_unit.py
+++ b/vertica/tests/test_unit.py
@@ -10,11 +10,15 @@ import pytest
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.log import TRACE_LEVEL
 from datadog_checks.vertica import VerticaCheck
+from datadog_checks.vertica.queries import QueryBuilder
 from datadog_checks.vertica.utils import parse_major_version
+from datadog_checks.vertica.vertica import VerticaClient
 
 CERTIFICATE_DIR = os.path.join(os.path.dirname(__file__), 'certificate')
 cert = os.path.join(CERTIFICATE_DIR, 'cert.cert')
 private_key = os.path.join(CERTIFICATE_DIR, 'server.pem')
+
+pytestmark = pytest.mark.unit
 
 
 def test_ssl_config_ok(aggregator, tls_instance):
@@ -182,3 +186,157 @@ def test_VerticaCheck_parse_db_version(version_string, expected):
 @pytest.mark.parametrize('version_string, expected', [('v9.2.0-7', 9), ('v11.1.1-0', 11)])
 def test_parse_major_version(version_string, expected):
     assert parse_major_version(version_string) == expected
+
+
+def test_parse_db_version_only_replaces_first_dash():
+    # Kills the core/NumberReplacer mutant at vertica.py:129 (.replace('-', '+', 1) count 1 -> 2).
+    assert VerticaCheck.parse_db_version('Vertica Analytic Database v11.1.1-0-beta') == '11.1.1+0-beta'
+
+
+def test_default_connection_options(instance):
+    # Kills NumberReplacer mutants at vertica.py:38 (port default 5433) and vertica.py:47 (timeout default 10),
+    # and the core/ReplaceFalseWithTrue mutant at vertica.py:46 (connection_load_balance default False).
+    instance.pop('port', None)
+    instance.pop('timeout', None)
+    instance.pop('connection_load_balance', None)
+
+    check = VerticaCheck('vertica', {}, [instance])
+
+    assert check._port == 5433
+    assert check._timeout == 10
+    assert check._connection_load_balance is False
+
+
+def test_parse_metric_groups_all_valid(instance):
+    # Kills the core/AddNot mutant at vertica.py:146 (flips `group not in default_metric_groups`).
+    instance['metric_groups'] = ['system']
+    check = VerticaCheck('vertica', {}, [instance])
+
+    check.parse_metric_groups()
+
+    assert check._metric_groups == ['system']
+
+
+def test_set_version_metadata_skipped_when_metadata_collection_disabled(instance, datadog_agent):
+    # Kills the core/RemoveDecorator mutant at vertica.py:120 (removes @AgentCheck.metadata_entrypoint);
+    # without it, set_version_metadata would call self._version() and blow up on the absent connection.
+    check = VerticaCheck('vertica', {}, [instance])
+    check.check_id = 'test:123'
+    datadog_agent._config['enable_metadata_collection'] = False
+
+    check.set_version_metadata()
+
+    datadog_agent.assert_metadata_count(0)
+
+
+def test_vertica_client_log_defaults_to_root_logger_when_not_provided():
+    # Kills the core/ReplaceOrWithAnd mutant at vertica.py:165 (`log or logging.getLogger()` -> `log and ...`).
+    assert isinstance(VerticaClient({}, log=None).log, logging.Logger)
+
+    custom_log = logging.getLogger('vertica_test_custom_logger')
+    assert VerticaClient({}, log=custom_log).log is custom_log
+
+
+def test_vertica_client_reconnects_when_load_balance_enabled():
+    # Kills the core/AddNot and core/ReplaceOrWithAnd mutants at vertica.py:175 (reconnect condition).
+    with mock.patch('datadog_checks.vertica.vertica.vertica') as vertica_mod:
+        first_connection = mock.MagicMock()
+        first_connection.closed.return_value = False
+        vertica_mod.connect.return_value = first_connection
+
+        client = VerticaClient({'connection_load_balance': True})
+        client.connect()
+
+        client.connect()
+
+        first_connection.close.assert_called_once()
+
+
+def test_vertica_client_reuses_connection_without_load_balance():
+    # Kills the core/RemoveDecorator mutant at vertica.py:215 (connection_load_balance property removed).
+    with mock.patch('datadog_checks.vertica.vertica.vertica') as vertica_mod:
+        first_connection = mock.MagicMock()
+        first_connection.closed.return_value = False
+        vertica_mod.connect.return_value = first_connection
+
+        client = VerticaClient({})
+        client.connect()
+
+        client.connect()
+
+        first_connection.close.assert_not_called()
+
+
+def test_vertica_client_query_version_returns_first_column():
+    # Kills NumberReplacer mutants at vertica.py:192 (fetchone()[0] -> fetchone()[1] / fetchone()[-1]).
+    client = VerticaClient({})
+    client.connection = mock.MagicMock()
+    client.connection.cursor.return_value.execute.return_value.fetchone.return_value = ['first', 'second']
+
+    assert client.query_version() == 'first'
+
+
+def test_vertica_client_options_omit_ssl_when_tls_disabled():
+    # Kills the core/AddNot mutant at vertica.py:208 and core/RemoveDecorator mutant at vertica.py:211 (use_tls).
+    client = VerticaClient({}, tls_context=None)
+
+    assert 'ssl' not in client.options
+
+
+def test_vertica_client_connection_load_balance_defaults_false():
+    # Kills the core/ReplaceFalseWithTrue mutant at vertica.py:217 (connection_load_balance default False -> True).
+    assert VerticaClient({}).connection_load_balance is False
+
+
+@pytest.mark.parametrize('version, includes_legacy_fields', [(9, True), (10, True), (11, False), (12, False)])
+def test_build_projection_storage_queries_legacy_fields_boundary(version, includes_legacy_fields):
+    # Kills queries.py:251 mutants: operator swaps raise on tuple concatenation for version < 11, and the
+    # comparison/AddNot/NumberReplacer mutants shift the </==/!=/<=/>/>= 11 boundary tested across versions.
+    query = QueryBuilder(version).build_projection_storage_queries()[0]['query']
+
+    assert ('wos_used_bytes' in query) is includes_legacy_fields
+
+
+@pytest.mark.parametrize('version, includes_storage_type', [(9, True), (10, True), (11, False), (12, False)])
+def test_build_storage_containers_queries_storage_type_boundary(version, includes_storage_type):
+    # Kills queries.py:293 comparison/AddNot/NumberReplacer mutants shifting the version < 11 boundary.
+    query = QueryBuilder(version).build_storage_containers_queries()[0]['query']
+
+    assert ('storage_type' in query) is includes_storage_type
+
+
+def test_build_grouped_query_total_has_no_prefix():
+    # Kills queries.py:310 (ReplaceUnaryOperator_Delete_Not / AddNot flips the empty-group_columns branch).
+    query = QueryBuilder(9)._build_grouped_query(
+        'total',
+        [],
+        schema='s',
+        table_name='t',
+        column_to_metric_mapping={'a': 'metric.a'},
+        value_select_columns=['sum(a) as a'],
+        value_columns=['a'],
+    )
+
+    assert query['name'] == 't_total'
+    assert query['query'] == 'SELECT sum(a) as a FROM s.t'
+    assert query['columns'] == [{'name': 'metric.a', 'type': 'gauge'}]
+
+
+def test_build_grouped_query_non_empty_group_columns():
+    # Kills queries.py:319/323/327/329 (Add_X operator swaps raise on str/list concatenation for a real group).
+    query = QueryBuilder(9)._build_grouped_query(
+        'grouping',
+        ['a'],
+        schema='s',
+        table_name='t',
+        column_to_metric_mapping={'a': 'metric.a', 'b': 'metric.b'},
+        value_select_columns=['sum(b) as b'],
+        value_columns=['b'],
+    )
+
+    assert query['name'] == 't_per_grouping'
+    assert query['query'] == 'SELECT a, sum(b) as b FROM s.t GROUP BY a'
+    assert query['columns'] == [
+        {'name': 'metric.a', 'type': 'tag'},
+        {'name': 'grouping.metric.b', 'type': 'gauge'},
+    ]


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `vertica` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `vertica` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch

[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ