### PR TITLE
[DOCS-14596] Clarify Redis check doesn't support ElastiCache IAM auth

### DIFF
--- a/redisdb/README.md
+++ b/redisdb/README.md
@@ -54,6 +54,8 @@ To configure this check for an Agent running on a host:
        # password: <PASSWORD>
    ```
 
+   **Note**: The Redis check does not support Amazon ElastiCache IAM authentication. Use the `username` and `password` parameters for Redis-level authentication instead.
+
 2. If using Redis 6+ and ACLs, ensure that the user has at least `DB  Viewer` permissions at the Database level, `Cluster Viewer` permissions if operating in a cluster environment, and `+config|get +info +slowlog|get` ACL rules. For more details, see [Database access control][4].
 
 3. [Restart the Agent][5].


### PR DESCRIPTION
### What does this PR do?
Adds a note that the Redis check does not support Amazon ElastiCache IAM authentication (the short-lived IAM-token-as-password method), and that standard Redis `username`/`password` authentication is required instead.

### Motivation
A customer reported confusion about this — the AWS integration's IAM role only authenticates CloudWatch metric collection, not the Redis check's connection to Redis for native `redis.*` metrics. See companion PR in integrations-internal-core (amazon_elasticache README) for the other half of this clarification.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged