### PR TITLE
[external_dns] strengthen tests to lift mutation score

### DIFF
--- a/external_dns/tests/test_unit.py
+++ b/external_dns/tests/test_unit.py
@@ -1,0 +1,22 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.external_dns import ExternalDNSCheck
+
+from .common import CHECK_NAME
+
+pytestmark = pytest.mark.unit
+
+
+def test_default_metric_limit_is_zero():
+    # Kills the core/NumberReplacer mutant at external_dns.py:14 (DEFAULT_METRIC_LIMIT 0 -> -1).
+    assert ExternalDNSCheck.DEFAULT_METRIC_LIMIT == 0
+
+
+def test_send_histograms_buckets_defaults_to_true(instance):
+    # Kills the core/ReplaceTrueWithFalse mutant at external_dns.py:26 (send_histograms_buckets True -> False).
+    check = ExternalDNSCheck(CHECK_NAME, {}, [instance])
+    scraper_config = check.get_scraper_config(instance)
+    assert scraper_config['send_histograms_buckets'] is True


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `external_dns` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `external_dns` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch