### PR TITLE
[cert_manager] strengthen tests to lift mutation score

### DIFF
--- a/cert_manager/tests/test_unit.py
+++ b/cert_manager/tests/test_unit.py
@@ -1,0 +1,33 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.cert_manager import CertManagerCheck
+from datadog_checks.cert_manager.metrics import ACME_METRICS, CERT_METRICS, CONTROLLER_METRICS
+
+from .common import MOCK_INSTANCE
+
+pytestmark = pytest.mark.unit
+
+
+def test_default_metric_limit_is_zero():
+    # Kills the core/NumberReplacer mutant at cert_manager.py:13 (DEFAULT_METRIC_LIMIT 0 -> -1).
+    assert CertManagerCheck.DEFAULT_METRIC_LIMIT == 0
+
+
+def test_get_default_config_merges_all_metric_sets():
+    check = CertManagerCheck('cert_manager', {}, [MOCK_INSTANCE])
+    metric_map = check.get_default_config()['metrics'][0]
+
+    for source in (CONTROLLER_METRICS, ACME_METRICS, CERT_METRICS):
+        for metric_name, metric_value in source.items():
+            assert metric_map[metric_name] == metric_value
+
+
+def test_get_default_config_metric_count_matches_all_sources():
+    check = CertManagerCheck('cert_manager', {}, [MOCK_INSTANCE])
+    metric_map = check.get_default_config()['metrics'][0]
+
+    expected_keys = set(CONTROLLER_METRICS) | set(ACME_METRICS) | set(CERT_METRICS)
+    assert set(metric_map) == expected_keys


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `cert_manager` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `cert_manager` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch

[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ