### PR TITLE
[kubeflow] strengthen tests to lift mutation score

### DIFF
--- a/kubeflow/tests/test_unit.py
+++ b/kubeflow/tests/test_unit.py
@@ -7,8 +7,11 @@ import pytest
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.kubeflow import KubeflowCheck
+from datadog_checks.kubeflow.metrics import METRIC_MAP, RENAME_LABELS_MAP
 
 from .common import METRICS_MOCK, get_fixture_path
+
+pytestmark = pytest.mark.unit
 
 
 def test_check_kubeflow(dd_run_check, aggregator, instance, mock_http_response):
@@ -32,3 +35,16 @@ def test_empty_instance(dd_run_check):
     ):
         check = KubeflowCheck('KubeflowCheck', {}, [{}])
         dd_run_check(check)
+
+
+def test_default_metric_limit_is_zero():
+    # Kills the core/NumberReplacer mutant at check.py:11 (DEFAULT_METRIC_LIMIT 0 -> -1).
+    assert KubeflowCheck.DEFAULT_METRIC_LIMIT == 0
+
+
+def test_get_default_config_uses_metric_map_and_rename_labels(instance):
+    # Confirms get_default_config wires METRIC_MAP/RENAME_LABELS_MAP into the returned config.
+    check = KubeflowCheck('kubeflow', {}, [instance])
+    config = check.get_default_config()
+    assert config['metrics'] == [METRIC_MAP]
+    assert config['rename_labels'] == RENAME_LABELS_MAP


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `kubeflow` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `kubeflow` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch

[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ