### PR TITLE
[kyverno] strengthen tests to lift mutation score

### DIFF
--- a/kyverno/tests/test_unit.py
+++ b/kyverno/tests/test_unit.py
@@ -6,6 +6,7 @@ import pytest
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.kyverno import KyvernoCheck
+from datadog_checks.kyverno.metrics import METRIC_MAP, RENAME_LABELS_MAP
 
 from .common import (
     ADMISSION_METRICS,
@@ -15,6 +16,20 @@ from .common import (
     REPORTS_METRICS,
     get_fixture_path,
 )
+
+pytestmark = pytest.mark.unit
+
+
+def test_default_metric_limit_is_zero():
+    # Kills the core/NumberReplacer mutant at check.py:11 (DEFAULT_METRIC_LIMIT 0 -> -1).
+    assert KyvernoCheck.DEFAULT_METRIC_LIMIT == 0
+
+
+def test_get_default_config_contains_metric_map_and_rename_labels():
+    check = KyvernoCheck('kyverno', {}, [OM_MOCKED_INSTANCE])
+    default_config = check.get_default_config()
+    assert default_config['metrics'] == [METRIC_MAP]
+    assert default_config['rename_labels'] == RENAME_LABELS_MAP
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `kyverno` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `kyverno` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch