### PR TITLE
[milvus] strengthen tests to lift mutation score

### DIFF
--- a/milvus/tests/test_unit.py
+++ b/milvus/tests/test_unit.py
@@ -9,6 +9,8 @@ from datadog_checks.milvus import MilvusCheck
 
 from .common import STANDALONE_TEST_METRICS, get_fixture_path
 
+pytestmark = pytest.mark.unit
+
 
 def test_check(dd_run_check, aggregator, instance, mock_http_response):
     mock_http_response(file_path=get_fixture_path('milvus_payload.txt'))
@@ -41,3 +43,9 @@ def test_custom_validation(dd_run_check):
     ):
         check = MilvusCheck('milvus', {}, [{'openmetrics_endpoint': endpoint}])
         dd_run_check(check)
+
+
+def test_default_metric_limit_is_zero(instance):
+    # Kills the core/NumberReplacer mutant at check.py:12 (DEFAULT_METRIC_LIMIT 0 -> -1).
+    check = MilvusCheck('milvus', {}, [instance])
+    assert check.DEFAULT_METRIC_LIMIT == 0


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `milvus` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `milvus` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch

[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ