### PR TITLE
[ray] strengthen tests to lift mutation score

### DIFF
--- a/ray/tests/test_unit.py
+++ b/ray/tests/test_unit.py
@@ -5,8 +5,22 @@ import pytest
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.dev.utils import get_metadata_metrics
+from datadog_checks.ray import RayCheck
+from datadog_checks.ray.metrics import METRIC_MAP
 
 from .common import HEAD_METRICS, MOCKED_HEAD_INSTANCE, MOCKED_WORKER_INSTANCE, WORKER_METRICS, mock_http_responses
+
+pytestmark = pytest.mark.unit
+
+
+def test_default_metric_limit_is_zero():
+    # Kills the core/NumberReplacer mutant at check.py:13 (DEFAULT_METRIC_LIMIT 0 -> -1).
+    assert RayCheck.DEFAULT_METRIC_LIMIT == 0
+
+
+def test_get_default_config_uses_metric_map():
+    check = RayCheck('ray', {}, [MOCKED_HEAD_INSTANCE])
+    assert check.get_default_config() == {"metrics": [METRIC_MAP]}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `ray` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `ray` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch

[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ