### PR TITLE
Allow edit_file to apply multiple edits in one call

### DIFF
--- a/ddev/src/ddev/ai/tools/core/base.py
+++ b/ddev/src/ddev/ai/tools/core/base.py
@@ -25,22 +25,30 @@ class BaseToolInput(BaseModel):
     def to_input_schema(cls) -> dict[str, object]:
         schema = cls.model_json_schema()
         schema.pop('title', None)
-        cls._clean_properties(schema.get('properties', {}))
+        cls._clean_properties(schema.get('properties', {}), schema.get('required', []))
         for definition in schema.get('$defs', {}).values():
             definition.pop('title', None)
-            cls._clean_properties(definition.get('properties', {}))
+            cls._clean_properties(definition.get('properties', {}), definition.get('required', []))
         return schema
 
     @staticmethod
-    def _clean_properties(properties: dict[str, dict]):
-        for prop in properties.values():
+    def _clean_properties(properties: dict[str, dict], required: list[str]):
+        for name, prop in properties.items():
             prop.pop('title', None)
             prop.pop('default', None)
-            if 'anyOf' in prop:
-                non_null = [t for t in prop['anyOf'] if t != {'type': 'null'}]
-                if len(non_null) == 1:
-                    prop.update(non_null[0])
-                    del prop['anyOf']
+            if 'anyOf' not in prop:
+                continue
+            # Only drop the redundant null branch for optional fields.
+            if name in required:
+                continue
+            non_null = [t for t in prop['anyOf'] if t != {'type': 'null'}]
+            if not non_null or len(non_null) == len(prop['anyOf']):
+                continue
+            del prop['anyOf']
+            if len(non_null) == 1:
+                prop.update(non_null[0])
+            else:
+                prop['anyOf'] = non_null
 
 
 def _get_input_type(cls: type) -> type[BaseToolInput]:

--- a/ddev/src/ddev/ai/tools/core/base.py
+++ b/ddev/src/ddev/ai/tools/core/base.py
@@ -25,7 +25,15 @@ class BaseToolInput(BaseModel):
     def to_input_schema(cls) -> dict[str, object]:
         schema = cls.model_json_schema()
         schema.pop('title', None)
-        for prop in schema.get('properties', {}).values():
+        cls._clean_properties(schema.get('properties', {}))
+        for definition in schema.get('$defs', {}).values():
+            definition.pop('title', None)
+            cls._clean_properties(definition.get('properties', {}))
+        return schema
+
+    @staticmethod
+    def _clean_properties(properties: dict[str, dict]):
+        for prop in properties.values():
             prop.pop('title', None)
             prop.pop('default', None)
             if 'anyOf' in prop:
@@ -33,7 +41,6 @@ class BaseToolInput(BaseModel):
                 if len(non_null) == 1:
                     prop.update(non_null[0])
                     del prop['anyOf']
-        return schema
 
 
 def _get_input_type(cls: type) -> type[BaseToolInput]:

--- a/ddev/src/ddev/ai/tools/fs/edit_file.py
+++ b/ddev/src/ddev/ai/tools/fs/edit_file.py
@@ -1,9 +1,11 @@
 # (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
 from typing import Annotated
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from ddev.ai.tools.core.base import BaseToolInput
 from ddev.ai.tools.core.types import ToolResult
@@ -12,27 +14,51 @@ from .base import FileRegistryTool
 from .file_access_policy import FileAccessError
 
 
-class EditFileInput(BaseToolInput):
-    path: Annotated[str, Field(description="Path of the file to edit")]
+class Edit(BaseToolInput):
     old_string: Annotated[
         str,
         Field(
+            min_length=1,
             description=(
                 "Exact non-empty text to replace. Must appear exactly once in the file "
-                "(hint: include surrounding context if needed). Keep this to the smallest "
-                "unique region that needs changing — do not paste the whole file. To rewrite "
-                "a file extensively, apply several small edits rather than one huge one."
+                "and must not be shared with any other edit in this call (hint: include "
+                "surrounding context if needed). Keep this to the smallest unique region "
+                "that needs changing — do not paste the whole file."
             ),
-            min_length=1,
         ),
     ]
-    new_string: Annotated[str, Field(description="Text to replace old_string with")]
+    new_string: Annotated[str, Field(description="Text to replace old_string with.")]
+
+
+class EditFileInput(BaseToolInput):
+    path: Annotated[str, Field(description="Path of the file to edit")]
+    edits: Annotated[
+        list[Edit],
+        Field(
+            min_length=1,
+            description=(
+                "One or more replacements to apply. Each edit is matched against the original "
+                "file content, not applied incrementally, so edits must target distinct, "
+                "non-overlapping regions. Order in this list does not matter."
+            ),
+        ),
+    ]
+
+    @model_validator(mode="after")
+    def _reject_duplicate_old_strings(self) -> EditFileInput:
+        seen: set[str] = set()
+        for edit in self.edits:
+            if edit.old_string in seen:
+                raise ValueError(f"duplicate old_string {edit.old_string!r} appears in more than one edit")
+            seen.add(edit.old_string)
+        return self
 
 
 class EditFileTool(FileRegistryTool[EditFileInput]):
-    """Edits a file by replacing an exact string with a new one.
+    """Edits a file by applying one or more exact string replacements in a single call.
     Fails if the file was modified since the last read.
-    old_string must appear exactly once in the file — if it appears multiple times, the call fails.
+    All edits are matched against the original file content and are applied all-or-nothing:
+    if any edit fails, the file is left unchanged.
     Prefer small, targeted edits over large ones: a single edit that spans most of the file can
     exceed the response token limit and be truncated. Break big rewrites into several edits."""
 
@@ -59,23 +85,49 @@ class EditFileTool(FileRegistryTool[EditFileInput]):
                 return fail
 
             # Normalize line endings to avoid issues with different OSs
-            old_string = tool_input.old_string.replace("\r\n", "\n")
-            new_string = tool_input.new_string.replace("\r\n", "\n")
+            content = content.replace("\r\n", "\n")
 
-            count = content.count(old_string)
-            if count == 0:
-                return ToolResult(success=False, error="old_string not found in file")
-            if count > 1:
-                return ToolResult(
-                    success=False,
-                    error=f"old_string appears {count} times in the file",
-                    hint="Include more surrounding context to make it unique",
-                )
+            matches, fail = self._resolve_matches(content, tool_input.edits)
+            if fail:
+                return fail
 
-            new_content = content.replace(old_string, new_string, 1)
+            new_content = content
+            for start, end, new_string in reversed(matches):
+                new_content = new_content[:start] + new_string + new_content[end:]
+
             try:
                 path.write_text(new_content, encoding="utf-8")
             except OSError as e:
                 return ToolResult(success=False, error=str(e))
             self._register(str(path), new_content)
         return ToolResult(success=True, data=f"File edited: {path}")
+
+    def _resolve_matches(self, content: str, edits: list[Edit]) -> tuple[list[tuple[int, int, str]], ToolResult | None]:
+        """Match every edit against the original content and detect not-found, ambiguous, and
+        overlapping cases. Returns matches sorted by start offset, or a failure ToolResult."""
+        matches: list[tuple[int, int, str]] = []  # (start, end, new_string)
+        for i, edit in enumerate(edits):
+            old_string = edit.old_string.replace("\r\n", "\n")
+            new_string = edit.new_string.replace("\r\n", "\n")
+            count = content.count(old_string)
+            if count == 0:
+                return [], ToolResult(success=False, error=f"edits[{i}]: old_string not found in file")
+            if count > 1:
+                return [], ToolResult(
+                    success=False,
+                    error=(
+                        f"edits[{i}]: old_string appears {count} times in the file; "
+                        "include more surrounding context to make it unique"
+                    ),
+                )
+            start = content.index(old_string)
+            matches.append((start, start + len(old_string), new_string))
+
+        matches.sort()
+        for (_, prev_end, _), (next_start, _, _) in zip(matches, matches[1:], strict=False):
+            if prev_end > next_start:
+                return [], ToolResult(
+                    success=False,
+                    error="edits target overlapping regions of the file; merge them into a single edit",
+                )
+        return matches, None

--- a/ddev/src/ddev/ai/tools/fs/edit_file.py
+++ b/ddev/src/ddev/ai/tools/fs/edit_file.py
@@ -115,10 +115,8 @@ class EditFileTool(FileRegistryTool[EditFileInput]):
             if count > 1:
                 return [], ToolResult(
                     success=False,
-                    error=(
-                        f"edits[{i}]: old_string appears {count} times in the file; "
-                        "include more surrounding context to make it unique"
-                    ),
+                    error=f"edits[{i}]: old_string appears {count} times in the file",
+                    hint="include more surrounding context to make it unique",
                 )
             start = content.index(old_string)
             matches.append((start, start + len(old_string), new_string))

--- a/ddev/src/ddev/ai/tools/fs/edit_file.py
+++ b/ddev/src/ddev/ai/tools/fs/edit_file.py
@@ -46,11 +46,14 @@ class EditFileInput(BaseToolInput):
 
     @model_validator(mode="after")
     def _reject_duplicate_old_strings(self) -> EditFileInput:
-        seen: set[str] = set()
-        for edit in self.edits:
-            if edit.old_string in seen:
-                raise ValueError(f"duplicate old_string {edit.old_string!r} appears in more than one edit")
-            seen.add(edit.old_string)
+        first_index: dict[str, int] = {}
+        for i, edit in enumerate(self.edits):
+            if edit.old_string in first_index:
+                j = first_index[edit.old_string]
+                raise ValueError(
+                    f"edits[{i}].old_string duplicates edits[{j}].old_string; old_string values must be unique"
+                )
+            first_index[edit.old_string] = i
         return self
 
 

--- a/ddev/src/ddev/ai/tools/fs/edit_file.py
+++ b/ddev/src/ddev/ai/tools/fs/edit_file.py
@@ -48,8 +48,7 @@ class EditFileInput(BaseToolInput):
     def _reject_duplicate_old_strings(self) -> EditFileInput:
         first_index: dict[str, int] = {}
         for i, edit in enumerate(self.edits):
-            if edit.old_string in first_index:
-                j = first_index[edit.old_string]
+            if (j := first_index.get(edit.old_string, None)) is not None:
                 raise ValueError(
                     f"edits[{i}].old_string duplicates edits[{j}].old_string; old_string values must be unique"
                 )

--- a/ddev/tests/ai/agent/test_build.py
+++ b/ddev/tests/ai/agent/test_build.py
@@ -161,7 +161,9 @@ async def test_shared_registry_does_not_share_parent_read_authorization(file_reg
     child_config = config.model_copy(update={"tools": ["edit_file"]})
     runtime = build_runtime(factory, child_config, system_prompt="sys", owner_id="parent.sub.001-child")
     registry = runtime.tool_registry
-    result = await registry.run("edit_file", {"path": str(path), "old_string": "before", "new_string": "after"})
+    result = await registry.run(
+        "edit_file", {"path": str(path), "edits": [{"old_string": "before", "new_string": "after"}]}
+    )
 
     assert result.success is False
     assert "Not authorized" in result.error

--- a/ddev/tests/ai/tools/core/test_base.py
+++ b/ddev/tests/ai/tools/core/test_base.py
@@ -99,6 +99,30 @@ def test_to_input_schema_anyof_flattened_for_optional_int():
     assert prop["type"] == "integer"
 
 
+def test_to_input_schema_keeps_null_for_required_nullable_field():
+    class RequiredNullable(BaseToolInput):
+        value: Annotated[int | None, Field(description="A required, nullable value")]
+
+    schema = RequiredNullable.to_input_schema()
+    assert schema["required"] == ["value"]
+    assert schema["properties"]["value"] == {
+        "anyOf": [{"type": "integer"}, {"type": "null"}],
+        "description": "A required, nullable value",
+    }
+
+
+def test_to_input_schema_drops_null_but_keeps_multiple_types():
+    class MultiType(BaseToolInput):
+        value: Annotated[str | int | None, Field(description="A string or an int")] = None
+
+    schema = MultiType.to_input_schema()
+    assert "required" not in schema
+    assert schema["properties"]["value"] == {
+        "anyOf": [{"type": "string"}, {"type": "integer"}],
+        "description": "A string or an int",
+    }
+
+
 def test_to_input_schema_all_optional_no_required_key():
     class AllOptional(BaseToolInput):
         x: Annotated[str, Field(description="x")] = "default"

--- a/ddev/tests/ai/tools/core/test_base.py
+++ b/ddev/tests/ai/tools/core/test_base.py
@@ -108,6 +108,28 @@ def test_to_input_schema_all_optional_no_required_key():
     assert "required" not in schema
 
 
+def test_to_input_schema_cleans_nested_defs():
+    class Item(BaseToolInput):
+        name: Annotated[str, Field(description="Item name")]
+        note: Annotated[str | None, Field(description="Optional note")] = None
+
+    class NestedInput(BaseToolInput):
+        items: Annotated[list[Item], Field(description="A list of items")]
+
+    schema = NestedInput.to_input_schema()
+    item_def = schema["$defs"]["Item"]
+    assert "title" not in item_def
+    for prop in item_def["properties"].values():
+        assert "title" not in prop
+        assert "default" not in prop
+    # Field descriptions must be preserved.
+    assert item_def["properties"]["name"]["description"] == "Item name"
+    # anyOf-with-null on nested optional fields is flattened too.
+    note = item_def["properties"]["note"]
+    assert "anyOf" not in note
+    assert note["type"] == "string"
+
+
 # ---------------------------------------------------------------------------
 # _get_input_type
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/tools/core/test_base.py
+++ b/ddev/tests/ai/tools/core/test_base.py
@@ -108,7 +108,8 @@ def test_to_input_schema_all_optional_no_required_key():
     assert "required" not in schema
 
 
-def test_to_input_schema_cleans_nested_defs():
+def test_to_input_schema_nested_model_shape():
+    # A tool input with a nested model emits a $defs block.
     class Item(BaseToolInput):
         name: Annotated[str, Field(description="Item name")]
         note: Annotated[str | None, Field(description="Optional note")] = None
@@ -116,18 +117,29 @@ def test_to_input_schema_cleans_nested_defs():
     class NestedInput(BaseToolInput):
         items: Annotated[list[Item], Field(description="A list of items")]
 
-    schema = NestedInput.to_input_schema()
-    item_def = schema["$defs"]["Item"]
-    assert "title" not in item_def
-    for prop in item_def["properties"].values():
-        assert "title" not in prop
-        assert "default" not in prop
-    # Field descriptions must be preserved.
-    assert item_def["properties"]["name"]["description"] == "Item name"
-    # anyOf-with-null on nested optional fields is flattened too.
-    note = item_def["properties"]["note"]
-    assert "anyOf" not in note
-    assert note["type"] == "string"
+    assert NestedInput.to_input_schema() == {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["items"],
+        "properties": {
+            "items": {
+                "type": "array",
+                "description": "A list of items",
+                "items": {"$ref": "#/$defs/Item"},
+            },
+        },
+        "$defs": {
+            "Item": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["name"],
+                "properties": {
+                    "name": {"type": "string", "description": "Item name"},
+                    "note": {"type": "string", "description": "Optional note"},
+                },
+            },
+        },
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/tools/fs/test_edit_file.py
+++ b/ddev/tests/ai/tools/fs/test_edit_file.py
@@ -122,6 +122,7 @@ async def test_edit_file_fails_if_old_string_ambiguous(
     assert result.success is False
     assert "edits[0]" in result.error
     assert "3" in result.error
+    assert result.hint is not None
     assert f.read_text(encoding="utf-8") == "foo\nfoo\nfoo\n"
 
 

--- a/ddev/tests/ai/tools/fs/test_edit_file.py
+++ b/ddev/tests/ai/tools/fs/test_edit_file.py
@@ -17,7 +17,9 @@ def test_tool_name(registry: FileRegistry) -> None:
 
 
 async def test_edit_file_replaces_string(edit_tool: EditFileTool, known_file) -> None:
-    result = await edit_tool.run({"path": str(known_file), "old_string": "line two", "new_string": "line TWO"})
+    result = await edit_tool.run(
+        {"path": str(known_file), "edits": [{"old_string": "line two", "new_string": "line TWO"}]}
+    )
 
     assert result.success is True
     content = known_file.read_text(encoding="utf-8")
@@ -26,29 +28,87 @@ async def test_edit_file_replaces_string(edit_tool: EditFileTool, known_file) ->
 
 
 async def test_edit_file_deletes_line(edit_tool: EditFileTool, known_file) -> None:
-    result = await edit_tool.run({"path": str(known_file), "old_string": "line two\n", "new_string": ""})
+    result = await edit_tool.run({"path": str(known_file), "edits": [{"old_string": "line two\n", "new_string": ""}]})
 
     assert result.success is True
     assert "line two" not in known_file.read_text(encoding="utf-8")
+
+
+async def test_edit_file_applies_multiple_edits_in_one_write(edit_tool: EditFileTool, known_file) -> None:
+    with patch("pathlib.Path.write_text", wraps=known_file.write_text) as write_text:
+        result = await edit_tool.run(
+            {
+                "path": str(known_file),
+                "edits": [
+                    {"old_string": "line one", "new_string": "LINE ONE"},
+                    {"old_string": "line three", "new_string": "LINE THREE"},
+                ],
+            }
+        )
+
+    assert result.success is True
+    assert known_file.read_text(encoding="utf-8") == "LINE ONE\nline two\nLINE THREE\n"
+    assert write_text.call_count == 1
+
+
+async def test_edit_file_applies_edits_regardless_of_order(edit_tool: EditFileTool, known_file) -> None:
+    # A later-in-file edit listed first must still land in the right place.
+    result = await edit_tool.run(
+        {
+            "path": str(known_file),
+            "edits": [
+                {"old_string": "line three", "new_string": "LINE THREE"},
+                {"old_string": "line one", "new_string": "LINE ONE"},
+            ],
+        }
+    )
+
+    assert result.success is True
+    assert known_file.read_text(encoding="utf-8") == "LINE ONE\nline two\nLINE THREE\n"
 
 
 async def test_edit_file_fails_for_unregistered_file(edit_tool: EditFileTool, tmp_path) -> None:
     f = tmp_path / "unread.txt"
     f.write_text("content", encoding="utf-8")
 
-    result = await edit_tool.run({"path": str(f), "old_string": "content", "new_string": "new"})
+    result = await edit_tool.run({"path": str(f), "edits": [{"old_string": "content", "new_string": "new"}]})
 
     assert result.success is False
     assert "Not authorized" in result.error
 
 
-@pytest.mark.parametrize("old_string", ["does not exist", ""])
-async def test_edit_file_fails_if_old_string_not_found_or_empty(
-    edit_tool: EditFileTool, known_file, old_string
-) -> None:
-    result = await edit_tool.run({"path": str(known_file), "old_string": old_string, "new_string": "x"})
+async def test_edit_file_rejects_duplicate_old_strings(edit_tool: EditFileTool, known_file) -> None:
+    result = await edit_tool.run(
+        {
+            "path": str(known_file),
+            "edits": [
+                {"old_string": "line one", "new_string": "A"},
+                {"old_string": "line one", "new_string": "B"},
+            ],
+        }
+    )
 
     assert result.success is False
+    assert "duplicate" in result.error
+    # Nothing is written on input-validation failure.
+    assert known_file.read_text(encoding="utf-8") == "line one\nline two\nline three\n"
+
+
+async def test_edit_file_fails_if_old_string_not_found(edit_tool: EditFileTool, known_file) -> None:
+    result = await edit_tool.run(
+        {
+            "path": str(known_file),
+            "edits": [
+                {"old_string": "line one", "new_string": "LINE ONE"},
+                {"old_string": "does not exist", "new_string": "x"},
+            ],
+        }
+    )
+
+    assert result.success is False
+    assert "edits[1]" in result.error
+    # All-or-nothing: the found edit must not be applied.
+    assert known_file.read_text(encoding="utf-8") == "line one\nline two\nline three\n"
 
 
 async def test_edit_file_fails_if_old_string_ambiguous(
@@ -57,24 +117,41 @@ async def test_edit_file_fails_if_old_string_ambiguous(
     f = tmp_path / "dup.txt"
     await create_tool.run({"path": str(f), "content": "foo\nfoo\nfoo\n"})
 
-    result = await edit_tool.run({"path": str(f), "old_string": "foo", "new_string": "bar"})
+    result = await edit_tool.run({"path": str(f), "edits": [{"old_string": "foo", "new_string": "bar"}]})
 
     assert result.success is False
+    assert "edits[0]" in result.error
     assert "3" in result.error
-    assert result.hint is not None
+    assert f.read_text(encoding="utf-8") == "foo\nfoo\nfoo\n"
+
+
+async def test_edit_file_fails_if_edits_overlap(edit_tool: EditFileTool, known_file) -> None:
+    result = await edit_tool.run(
+        {
+            "path": str(known_file),
+            "edits": [
+                {"old_string": "line one\nline two", "new_string": "A"},
+                {"old_string": "line two\nline three", "new_string": "B"},
+            ],
+        }
+    )
+
+    assert result.success is False
+    assert "overlap" in result.error
+    assert known_file.read_text(encoding="utf-8") == "line one\nline two\nline three\n"
 
 
 async def test_edit_file_fails_if_file_changed_externally(edit_tool: EditFileTool, known_file) -> None:
     known_file.write_text("externally modified\n", encoding="utf-8")
 
-    result = await edit_tool.run({"path": str(known_file), "old_string": "line one", "new_string": "x"})
+    result = await edit_tool.run({"path": str(known_file), "edits": [{"old_string": "line one", "new_string": "x"}]})
 
     assert result.success is False
     assert "Re-read and retry" in result.error
 
 
 async def test_edit_file_updates_registry(edit_tool: EditFileTool, registry: FileRegistry, known_file) -> None:
-    await edit_tool.run({"path": str(known_file), "old_string": "line one", "new_string": "LINE ONE"})
+    await edit_tool.run({"path": str(known_file), "edits": [{"old_string": "line one", "new_string": "LINE ONE"}]})
 
     new_content = known_file.read_text(encoding="utf-8")
     assert registry.verify(OWNER_ID, str(known_file), new_content) is True
@@ -94,7 +171,7 @@ async def test_edit_file_normalizes_crlf(
     f = tmp_path / "file.txt"
     await create_tool.run({"path": str(f), "content": file_content})
 
-    result = await edit_tool.run({"path": str(f), "old_string": old_string, "new_string": new_string})
+    result = await edit_tool.run({"path": str(f), "edits": [{"old_string": old_string, "new_string": new_string}]})
 
     assert result.success is True
     assert f.read_text(encoding="utf-8") == expected
@@ -104,7 +181,9 @@ async def test_edit_file_oserror_on_write(edit_tool: EditFileTool, registry: Fil
     original_content = known_file.read_text(encoding="utf-8")
 
     with patch("pathlib.Path.write_text", side_effect=PermissionError("permission denied")):
-        result = await edit_tool.run({"path": str(known_file), "old_string": "line one", "new_string": "x"})
+        result = await edit_tool.run(
+            {"path": str(known_file), "edits": [{"old_string": "line one", "new_string": "x"}]}
+        )
 
     assert result.success is False
     assert result.error is not None

--- a/ddev/tests/ai/tools/fs/test_policy_enforcement.py
+++ b/ddev/tests/ai/tools/fs/test_policy_enforcement.py
@@ -60,7 +60,7 @@ async def test_edit_file_refuses_outside_write_root(tmp_path, sandboxed_registry
     sandboxed_registry.record(OWNER_ID, str(outside), "old")
 
     tool = EditFileTool(sandboxed_registry, OWNER_ID)
-    result = await tool.run({"path": str(outside), "old_string": "old", "new_string": "new"})
+    result = await tool.run({"path": str(outside), "edits": [{"old_string": "old", "new_string": "new"}]})
     assert result.success is False
     assert "outside write root" in result.error
     assert outside.read_text() == "old"
@@ -164,7 +164,7 @@ async def test_read_by_one_agent_does_not_authorize_another_to_edit(sandbox) -> 
     assert result.success is True
 
     editor_b = EditFileTool(registry, "agent-b")
-    result = await editor_b.run({"path": str(target), "old_string": "hello", "new_string": "world"})
+    result = await editor_b.run({"path": str(target), "edits": [{"old_string": "hello", "new_string": "world"}]})
     assert result.success is False
     assert "Not authorized" in result.error
     assert target.read_text() == "hello"
@@ -179,14 +179,14 @@ async def test_each_agent_can_edit_after_its_own_read(sandbox) -> None:
     # Agent A reads, then edits — ok.
     await ReadFileTool(registry, "agent-a").run({"path": str(target)})
     result = await EditFileTool(registry, "agent-a").run(
-        {"path": str(target), "old_string": "one", "new_string": "two"}
+        {"path": str(target), "edits": [{"old_string": "one", "new_string": "two"}]}
     )
     assert result.success is True
 
     # Agent B must read first to refresh its own view, then may edit.
     await ReadFileTool(registry, "agent-b").run({"path": str(target)})
     result = await EditFileTool(registry, "agent-b").run(
-        {"path": str(target), "old_string": "two", "new_string": "three"}
+        {"path": str(target), "edits": [{"old_string": "two", "new_string": "three"}]}
     )
     assert result.success is True
     assert target.read_text() == "three"

--- a/ddev/tests/ai/tools/fs/test_workflow.py
+++ b/ddev/tests/ai/tools/fs/test_workflow.py
@@ -28,7 +28,7 @@ async def test_workflow_create_read_edit_append(
     assert r.success is True
 
     # Step 3: edit
-    r = await edit_tool.run({"path": str(f), "old_string": "version: 1", "new_string": "version: 2"})
+    r = await edit_tool.run({"path": str(f), "edits": [{"old_string": "version: 1", "new_string": "version: 2"}]})
     assert r.success is True
     assert "version: 2" in f.read_text(encoding="utf-8")
 
@@ -53,12 +53,14 @@ async def test_workflow_stale_file(
     await create_tool.run({"path": str(f), "content": "original\n"})
     f.write_text("updated externally\n", encoding="utf-8")
 
-    result = await edit_tool.run({"path": str(f), "old_string": "original", "new_string": "my edit"})
+    result = await edit_tool.run({"path": str(f), "edits": [{"old_string": "original", "new_string": "my edit"}]})
     assert result.success is False
     assert "Re-read and retry" in result.error
 
     await read_tool.run({"path": str(f)})
 
-    result = await edit_tool.run({"path": str(f), "old_string": "updated externally", "new_string": "final"})
+    result = await edit_tool.run(
+        {"path": str(f), "edits": [{"old_string": "updated externally", "new_string": "final"}]}
+    )
     assert result.success is True
     assert f.read_text(encoding="utf-8") == "final\n"


### PR DESCRIPTION
### What does this PR do?

Changes the `edit_file` AI tool from a single `old_string`/`new_string` replacement to an ordered list of edits applied in one call, so the model no longer needs a separate tool call (and a full read-verify-write round trip) per edit.

- Introduces a nested `Edit` model (`old_string`, `new_string`) and replaces the two top-level fields on `EditFileInput` with an `edits` list. Both `Edit` fields carry `description=` so the generated tool schema documents each element of the array. This is a clean break — no legacy single-field shape.
- Adds a `model_validator` that rejects two edits sharing the same `old_string` at input-validation time, before any file access.
- Extends `BaseToolInput.to_input_schema()` to also strip `title`/`default` and flatten nullable `anyOf` from nested `$defs` entries (`Edit` is the first nested model used by a tool input), while preserving field descriptions.
- Reworks the apply algorithm: every edit is matched against the **original** file content (not applied sequentially). Not-found, ambiguous, and overlapping cases are detected up front and name the offending `edits[i]`; edits are then applied in reverse offset order with a single write. The whole call is all-or-nothing — if any edit fails the file is left untouched.
- Updates the tool docstring and the `edit_file` test suite, and migrates the other tests that used the old single-edit shape.

Follow-up: `ToolResult.hint` is not forwarded to the model (`_to_tool_result_params` in `agent/anthropic_client.py` only sends `data`/`error`). Fixing `hint` transport is out of scope here and will be handled in a follow-up PR.

Jira: https://datadoghq.atlassian.net/browse/AI-6971

### Motivation

Applying several edits to one file previously required multiple `edit_file` calls, each paying a full read-verify-write cycle and an API round trip. Batching edits into a single call is cheaper and matches how other coding agents work, while the match-against-original design explicitly rejects conflicting/overlapping edits instead of silently producing wrong output.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
