### PR TITLE
Use tool result hints in Anthropic client

### DIFF
--- a/ddev/src/ddev/ai/agent/anthropic_client.py
+++ b/ddev/src/ddev/ai/agent/anthropic_client.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
         ToolResultBlockParam,
     )
 
+    from ddev.ai.tools.core.types import ToolResult
+
 DEFAULT_MODEL: Final[str] = "claude-sonnet-4-6"
 DEFAULT_MAX_TOKENS: Final[int] = 8192  # max tokens per response
 MAX_CONTINUATIONS: Final[int] = 10
@@ -249,23 +251,43 @@ class AnthropicAgent(BaseAgent[MessageParam]):
             messages = [*messages, paused_turn]
         raise AgentError(f"pause_turn did not resolve after {MAX_CONTINUATIONS} continuations")
 
+    @staticmethod
+    def _tool_result_content(result: ToolResult) -> str | list[TextBlockParam] | None:
+        """Build the tool_result content: primary data/error plus a hint block when present.
+
+        Returns a bare string when there is no hint, a list of text blocks when a hint must
+        be surfaced alongside the result, or None to omit content.
+        """
+        if result.data is not None:
+            primary = result.data
+        elif not result.success:
+            primary = result.error or "(unknown error)"
+        else:
+            primary = None
+
+        if not result.hint:
+            return primary
+
+        blocks: list[TextBlockParam] = []
+        if primary is not None:
+            blocks.append({"type": "text", "text": primary})
+        blocks.append({"type": "text", "text": f"Hint: {result.hint}"})
+        return blocks
+
     def _to_tool_result_params(self, messages: list[ToolResultMessage]) -> list[ToolResultBlockParam]:
         """Convert model-agnostic ToolResultMessages to Anthropic SDK ToolResultBlockParams."""
-        return [
-            {
-                "type": "tool_result",
-                "tool_use_id": msg.tool_call_id,
-                "is_error": not msg.result.success,
-                **(
-                    {"content": msg.result.data}
-                    if msg.result.data is not None
-                    else {"content": msg.result.error or "(unknown error)"}
-                    if not msg.result.success
-                    else {}
-                ),
-            }
-            for msg in messages
-        ]
+        params: list[ToolResultBlockParam] = []
+        for msg in messages:
+            content = self._tool_result_content(msg.result)
+            params.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": msg.tool_call_id,
+                    "is_error": not msg.result.success,
+                    **({"content": content} if content is not None else {}),
+                }
+            )
+        return params
 
     @overload
     @staticmethod

--- a/ddev/tests/ai/agent/test_anthropic_client.py
+++ b/ddev/tests/ai/agent/test_anthropic_client.py
@@ -1064,6 +1064,62 @@ async def test_failed_tool_result_without_error_text_falls_back_to_placeholder()
 
 
 # ---------------------------------------------------------------------------
+# Hints are surfaced to the model as a distinct text block inside tool_result.content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "success, data, error, hint, is_error, expected_text",
+    [
+        pytest.param(
+            False,
+            None,
+            "File exists.",
+            "Set overwrite=True to replace it.",
+            True,
+            "File exists.",
+            id="failed_result",
+        ),
+        pytest.param(
+            True,
+            "partial output",
+            None,
+            "Output truncated: showing 100 of 500.",
+            False,
+            "partial output",
+            id="successful_result",
+        ),
+    ],
+)
+async def test_tool_result_with_hint_appends_hint_block(
+    success: bool,
+    data: str | None,
+    error: str | None,
+    hint: str,
+    is_error: bool,
+    expected_text: str,
+) -> None:
+    resp = make_response("end_turn", [make_text_block("ok")])
+    agent, create_mock = make_agent(mock_response=resp)
+
+    await agent.send(
+        [
+            ToolResultMessage(
+                tool_call_id="tc_01",
+                result=ToolResult(success=success, data=data, error=error, hint=hint),
+            )
+        ]
+    )
+
+    block = create_mock.call_args.kwargs["messages"][-1]["content"][0]
+    assert block["is_error"] is is_error
+    assert block["content"] == [
+        {"type": "text", "text": expected_text},
+        {"type": "text", "text": f"Hint: {hint}"},
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Prompt caching: history must not retain cache_control markers
 # (otherwise multi-turn requests would exceed the 4-marker limit)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?

Serializes `ToolResult.hint` into the Anthropic request. When a tool result carries a hint, the Anthropic client now sends it as a distinct `text` block inside the `tool_result` content (alongside the data/error) so the model can actually see it. Previously the `hint` field was silently dropped, so the model only ever saw the raw data or error.

The hint is kept as its own text block inside the same `tool_result` — rather than concatenated onto the error string or sent as a separate user message — so it stays attributed to the specific tool call (which matters under parallel tool use) and works for both the success path (truncation notices) and the failure path (recovery guidance). When there is no hint, the wire format is unchanged (a bare string).

### Motivation

Tools populate `ToolResult.hint` with recovery guidance (e.g. "Set overwrite=True to replace it.") and truncation notices, but the Anthropic client never forwarded it, so the model lost the guidance that would help it retry correctly. The Anthropic API has no dedicated hint field on `tool_result` — content is the only channel the model sees — so the hint has to be folded into that content.

Full context and analysis in [AI-7005](https://datadoghq.atlassian.net/browse/AI-7005).

Follow-up: `tests/ai/agent/test_anthropic_client.py` has grown quite large and should be split/trimmed in a separate PR.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7005]: https://datadoghq.atlassian.net/browse/AI-7005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ