### PR TITLE
Resolve SLURM scontrol namespace PIDs

### DIFF
--- a/slurm/assets/configuration/spec.yaml
+++ b/slurm/assets/configuration/spec.yaml
@@ -49,8 +49,16 @@ files:
         example: True
     - name: collect_scontrol_stats
       description: |
-        Whether or not to collect statistics from the scontrol command. This is mainly used in the worker 
+        Whether or not to collect statistics from the scontrol command. This is mainly used in the worker
         node to collect the list of running jobs along with their PIDs.
+      fleet_configurable: true
+      value:
+        type: boolean
+        example: False
+    - name: resolve_scontrol_host_pids
+      description: |
+        Whether or not to resolve PIDs reported by scontrol through the host proc filesystem before collecting
+        process tags. Enable this when scontrol reports namespace PIDs instead of host PIDs.
       fleet_configurable: true
       value:
         type: boolean
@@ -70,8 +78,8 @@ files:
     - name: sinfo_collection_level
       description: |
         The level of detail to collect from the sinfo command. The default is 'basic'. Available options are 1, 2 and
-        3. Level 1 collects data only for partitions. Level 2 collects data from individual nodes. Level 3 
-        collects data from from individual nodes as well but is more verbose and includes data such as CPU and 
+        3. Level 1 collects data only for partitions. Level 2 collects data from individual nodes. Level 3
+        collects data from from individual nodes as well but is more verbose and includes data such as CPU and
         memory usage as reported from the OS, as well as additional tags.
       fleet_configurable: true
       value:
@@ -187,7 +195,7 @@ files:
           https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
 
           Most Slurm metrics are collected from calling the different binaries. Depending on the size of the Slurm cluster,
-          this can be a very expensive operation. It is recommended to set this to a higher value than the default 15 
+          this can be a very expensive operation. It is recommended to set this to a higher value than the default 15
           seconds, but this can be adjusted based on the size of the cluster and the desired granularity of the metrics.
         min_collection_interval.value.display_default: 60
         min_collection_interval.value.default: 60
@@ -196,7 +204,7 @@ files:
   - template: logs
     example:
     - type: file
-      path: /var/log/slurm/slurmd.log 
+      path: /var/log/slurm/slurmd.log
       source: slurm
       service: slurm
     - type: file

--- a/slurm/changelog.d/24384.fixed
+++ b/slurm/changelog.d/24384.fixed
@@ -1,0 +1,1 @@
+Fix process tag enrichment when SLURM scontrol reports namespace PIDs.

--- a/slurm/datadog_checks/slurm/check.py
+++ b/slurm/datadog_checks/slurm/check.py
@@ -640,6 +640,7 @@ class SlurmCheck(AgentCheck, ConfigMixin):
             return ProcessPidMatch(host_pid=namespace_pid, namespace_pids=[])
 
         if len(host_pid_matches) > 1:
+            # We do not disambiguate by container yet, so use the first matching host PID.
             matches = [
                 {"host_pid": match.host_pid, "namespace_pids": match.namespace_pids} for match in host_pid_matches
             ]

--- a/slurm/datadog_checks/slurm/check.py
+++ b/slurm/datadog_checks/slurm/check.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import time
+from dataclasses import dataclass
 from datetime import timedelta
 
 from datadog_checks.base import AgentCheck, is_affirmative
@@ -49,6 +50,12 @@ def parse_duration(time_str):
         return duration.total_seconds()
     except Exception:
         return None
+
+
+@dataclass
+class ProcessPidMatch:
+    host_pid: str
+    namespace_pids: list[str]
 
 
 class SlurmCheck(AgentCheck, ConfigMixin):
@@ -590,7 +597,9 @@ class SlurmCheck(AgentCheck, ConfigMixin):
 
         # Cache for job details to avoid duplicate calls
         job_details_cache = {}
-        host_pids_by_namespace_pid = self._get_host_pids_by_namespace_pid() if self.resolve_scontrol_host_pids else {}
+        host_pid_matches_by_namespace_pid = (
+            self._get_host_pid_matches_by_namespace_pid() if self.resolve_scontrol_host_pids else {}
+        )
 
         for line in lines[1:]:
             tags = [f"slurm_node_name:{slurm_node.strip()}"]
@@ -601,12 +610,12 @@ class SlurmCheck(AgentCheck, ConfigMixin):
                 new_header = SCONTROL_TAG_MAPPING.get(header, f"slurm_{header.lower()}")
 
                 if new_header == "pid":
-                    value = self._resolve_scontrol_host_pid(value, host_pids_by_namespace_pid)
-                    # Example gpu tags being returned:
-                    # ['gpu_vendor:nvidia', 'gpu_device:tesla_v100', 'gpu_uuid:gpu_xxxx...']
-                    pidtags = tagger.tag(f"process://{value}", tagger.ORCHESTRATOR)
-                    if pidtags:  # Guard against tagger.tag returning None
-                        tags.extend(pidtags)
+                    host_pid_match = self._resolve_scontrol_host_pid(value, host_pid_matches_by_namespace_pid)
+                    tags.extend(self._get_process_tags(value))
+                    if host_pid_match is not None:
+                        tags.append(f"nspid:{value}")
+                        value = host_pid_match.host_pid
+                        tags.extend(self._get_process_tags(value))
 
                 tags.append(f"{new_header}:{value}")
 
@@ -621,40 +630,56 @@ class SlurmCheck(AgentCheck, ConfigMixin):
 
             self.gauge("scontrol.jobs.info", 1, tags=tags + self.tags)
 
-    def _resolve_scontrol_host_pid(self, namespace_pid, host_pids_by_namespace_pid):
-        host_pids = host_pids_by_namespace_pid.get(namespace_pid)
-        if not host_pids:
-            return namespace_pid
+    def _resolve_scontrol_host_pid(self, namespace_pid, host_pid_matches_by_namespace_pid):
+        host_pid_matches = host_pid_matches_by_namespace_pid.get(namespace_pid)
+        if not host_pid_matches:
+            return None
 
-        if len(host_pids) > 1:
+        if len(host_pid_matches) > 1:
+            matches = [
+                {"host_pid": match.host_pid, "namespace_pids": match.namespace_pids} for match in host_pid_matches
+            ]
             self.log.debug(
-                "Found multiple host PIDs matching scontrol namespace PID %s: %s. Using %s.",
+                "Found multiple host PID matches for scontrol namespace PID %s: %s. Using host PID %s.",
                 namespace_pid,
-                host_pids,
-                host_pids[0],
+                matches,
+                host_pid_matches[0].host_pid,
             )
 
-        return host_pids[0]
+        return host_pid_matches[0]
 
-    def _get_host_pids_by_namespace_pid(self):
+    def _get_process_tags(self, pid):
+        # Example gpu tags being returned:
+        # ['gpu_vendor:nvidia', 'gpu_device:tesla_v100', 'gpu_uuid:gpu_xxxx...']
+        pidtags = tagger.tag(f"process://{pid}", tagger.ORCHESTRATOR)
+        if pidtags:  # Guard against tagger.tag returning None
+            return pidtags
+
+        return []
+
+    def _get_host_pid_matches_by_namespace_pid(self):
         host_proc = os.environ.get("HOST_PROC", "/host/proc")
-        host_pids_by_namespace_pid = {}
+        host_pid_matches_by_namespace_pid = {}
 
         try:
             proc_entries = os.scandir(host_proc)
         except OSError as e:
             self.log.debug("Unable to scan host proc path '%s': %s", host_proc, e)
-            return host_pids_by_namespace_pid
+            return host_pid_matches_by_namespace_pid
 
         with proc_entries:
             for entry in proc_entries:
                 if not entry.name.isdigit():
                     continue
 
-                for namespace_pid in self._read_namespace_pids(entry.path, entry.name):
-                    host_pids_by_namespace_pid.setdefault(namespace_pid, []).append(entry.name)
+                pid_match = ProcessPidMatch(
+                    host_pid=entry.name,
+                    namespace_pids=self._read_namespace_pids(entry.path, entry.name),
+                )
+                for namespace_pid in pid_match.namespace_pids:
+                    host_pid_matches_by_namespace_pid.setdefault(namespace_pid, []).append(pid_match)
 
-        return host_pids_by_namespace_pid
+        return host_pid_matches_by_namespace_pid
 
     def _read_namespace_pids(self, proc_path, host_pid):
         try:

--- a/slurm/datadog_checks/slurm/check.py
+++ b/slurm/datadog_checks/slurm/check.py
@@ -597,7 +597,7 @@ class SlurmCheck(AgentCheck, ConfigMixin):
 
         # Cache for job details to avoid duplicate calls
         job_details_cache = {}
-        host_pid_matches_by_namespace_pid = (
+        host_pid_matches_by_namespace_pid: dict[str, list[ProcessPidMatch]] = (
             self._get_host_pid_matches_by_namespace_pid() if self.resolve_scontrol_host_pids else {}
         )
 
@@ -611,11 +611,13 @@ class SlurmCheck(AgentCheck, ConfigMixin):
 
                 if new_header == "pid":
                     host_pid_match = self._resolve_scontrol_host_pid(value, host_pid_matches_by_namespace_pid)
-                    tags.extend(self._get_process_tags(value))
-                    if host_pid_match is not None:
-                        tags.append(f"nspid:{value}")
-                        value = host_pid_match.host_pid
-                        tags.extend(self._get_process_tags(value))
+                    tags.extend(self._get_process_tags(host_pid_match.host_pid))
+                    for namespace_pid in host_pid_match.namespace_pids:
+                        if namespace_pid == host_pid_match.host_pid:
+                            continue
+                        tags.append(f"nspid:{namespace_pid}")
+                        tags.extend(self._get_process_tags(namespace_pid))
+                    value = host_pid_match.host_pid
 
                 tags.append(f"{new_header}:{value}")
 
@@ -630,10 +632,12 @@ class SlurmCheck(AgentCheck, ConfigMixin):
 
             self.gauge("scontrol.jobs.info", 1, tags=tags + self.tags)
 
-    def _resolve_scontrol_host_pid(self, namespace_pid, host_pid_matches_by_namespace_pid):
+    def _resolve_scontrol_host_pid(
+        self, namespace_pid: str, host_pid_matches_by_namespace_pid: dict[str, list[ProcessPidMatch]]
+    ) -> ProcessPidMatch:
         host_pid_matches = host_pid_matches_by_namespace_pid.get(namespace_pid)
         if not host_pid_matches:
-            return None
+            return ProcessPidMatch(host_pid=namespace_pid, namespace_pids=[])
 
         if len(host_pid_matches) > 1:
             matches = [

--- a/slurm/datadog_checks/slurm/check.py
+++ b/slurm/datadog_checks/slurm/check.py
@@ -70,6 +70,7 @@ class SlurmCheck(AgentCheck, ConfigMixin):
         self.collect_sacct_stats = is_affirmative(self.instance.get('collect_sacct_stats', True))
         self.collect_scontrol_stats = is_affirmative(self.instance.get('collect_scontrol_stats', False))
         self.collect_seff_stats = is_affirmative(self.instance.get('collect_seff_stats', False))
+        self.resolve_scontrol_host_pids = is_affirmative(self.instance.get('resolve_scontrol_host_pids', False))
 
         # Additional configurations
         self.gpu_stats = is_affirmative(self.instance.get('collect_gpu_stats', False))
@@ -589,6 +590,7 @@ class SlurmCheck(AgentCheck, ConfigMixin):
 
         # Cache for job details to avoid duplicate calls
         job_details_cache = {}
+        host_pid_by_namespace_pid = self._get_host_pid_by_namespace_pid() if self.resolve_scontrol_host_pids else {}
 
         for line in lines[1:]:
             tags = [f"slurm_node_name:{slurm_node.strip()}"]
@@ -597,14 +599,16 @@ class SlurmCheck(AgentCheck, ConfigMixin):
 
             for header, value in zip(headers, fields):
                 new_header = SCONTROL_TAG_MAPPING.get(header, f"slurm_{header.lower()}")
-                tags.append(f"{new_header}:{value}")
 
                 if new_header == "pid":
+                    value = host_pid_by_namespace_pid.get(value, value)
                     # Example gpu tags being returned:
                     # ['gpu_vendor:nvidia', 'gpu_device:tesla_v100', 'gpu_uuid:gpu_xxxx...']
                     pidtags = tagger.tag(f"process://{value}", tagger.ORCHESTRATOR)
                     if pidtags:  # Guard against tagger.tag returning None
                         tags.extend(pidtags)
+
+                tags.append(f"{new_header}:{value}")
 
                 if header == "JOBID" and value.isdigit():
                     job_id = value
@@ -616,6 +620,37 @@ class SlurmCheck(AgentCheck, ConfigMixin):
                 tags.extend(job_details_cache[job_id])
 
             self.gauge("scontrol.jobs.info", 1, tags=tags + self.tags)
+
+    def _get_host_pid_by_namespace_pid(self):
+        host_proc = os.environ.get("HOST_PROC", "/host/proc")
+        host_pid_by_namespace_pid = {}
+
+        try:
+            proc_entries = os.scandir(host_proc)
+        except OSError as e:
+            self.log.debug("Unable to scan host proc path '%s': %s", host_proc, e)
+            return host_pid_by_namespace_pid
+
+        with proc_entries:
+            for entry in proc_entries:
+                if not entry.name.isdigit():
+                    continue
+
+                for namespace_pid in self._read_namespace_pids(entry.path, entry.name):
+                    host_pid_by_namespace_pid.setdefault(namespace_pid, entry.name)
+
+        return host_pid_by_namespace_pid
+
+    def _read_namespace_pids(self, proc_path, host_pid):
+        try:
+            with open(os.path.join(proc_path, "status")) as status_file:
+                for line in status_file:
+                    if line.startswith("NSpid:"):
+                        return line.split()[1:]
+        except OSError as e:
+            self.log.debug("Unable to read process status for PID %s: %s", host_pid, e)
+
+        return [host_pid]
 
     def _enrich_scontrol_tags(self, job_id):
         # Tries to enrich the scontrol job with additional details from squeue.

--- a/slurm/datadog_checks/slurm/check.py
+++ b/slurm/datadog_checks/slurm/check.py
@@ -616,7 +616,6 @@ class SlurmCheck(AgentCheck, ConfigMixin):
                         if namespace_pid == host_pid_match.host_pid:
                             continue
                         tags.append(f"nspid:{namespace_pid}")
-                        tags.extend(self._get_process_tags(namespace_pid))
                     value = host_pid_match.host_pid
 
                 tags.append(f"{new_header}:{value}")
@@ -640,7 +639,13 @@ class SlurmCheck(AgentCheck, ConfigMixin):
             return ProcessPidMatch(host_pid=namespace_pid, namespace_pids=[])
 
         if len(host_pid_matches) > 1:
-            # We do not disambiguate by container yet, so use the first matching host PID.
+            namespace_match = host_pid_matches[0]
+            for host_pid_match in host_pid_matches:
+                # Prefer a translated namespace PID, but do not disambiguate by container yet.
+                if namespace_pid != host_pid_match.host_pid and namespace_pid in host_pid_match.namespace_pids:
+                    namespace_match = host_pid_match
+                    break
+
             matches = [
                 {"host_pid": match.host_pid, "namespace_pids": match.namespace_pids} for match in host_pid_matches
             ]
@@ -648,8 +653,9 @@ class SlurmCheck(AgentCheck, ConfigMixin):
                 "Found multiple host PID matches for scontrol namespace PID %s: %s. Using host PID %s.",
                 namespace_pid,
                 matches,
-                host_pid_matches[0].host_pid,
+                namespace_match.host_pid,
             )
+            return namespace_match
 
         return host_pid_matches[0]
 

--- a/slurm/datadog_checks/slurm/check.py
+++ b/slurm/datadog_checks/slurm/check.py
@@ -590,7 +590,7 @@ class SlurmCheck(AgentCheck, ConfigMixin):
 
         # Cache for job details to avoid duplicate calls
         job_details_cache = {}
-        host_pid_by_namespace_pid = self._get_host_pid_by_namespace_pid() if self.resolve_scontrol_host_pids else {}
+        host_pids_by_namespace_pid = self._get_host_pids_by_namespace_pid() if self.resolve_scontrol_host_pids else {}
 
         for line in lines[1:]:
             tags = [f"slurm_node_name:{slurm_node.strip()}"]
@@ -601,7 +601,7 @@ class SlurmCheck(AgentCheck, ConfigMixin):
                 new_header = SCONTROL_TAG_MAPPING.get(header, f"slurm_{header.lower()}")
 
                 if new_header == "pid":
-                    value = host_pid_by_namespace_pid.get(value, value)
+                    value = self._resolve_scontrol_host_pid(value, host_pids_by_namespace_pid)
                     # Example gpu tags being returned:
                     # ['gpu_vendor:nvidia', 'gpu_device:tesla_v100', 'gpu_uuid:gpu_xxxx...']
                     pidtags = tagger.tag(f"process://{value}", tagger.ORCHESTRATOR)
@@ -621,15 +621,30 @@ class SlurmCheck(AgentCheck, ConfigMixin):
 
             self.gauge("scontrol.jobs.info", 1, tags=tags + self.tags)
 
-    def _get_host_pid_by_namespace_pid(self):
+    def _resolve_scontrol_host_pid(self, namespace_pid, host_pids_by_namespace_pid):
+        host_pids = host_pids_by_namespace_pid.get(namespace_pid)
+        if not host_pids:
+            return namespace_pid
+
+        if len(host_pids) > 1:
+            self.log.debug(
+                "Found multiple host PIDs matching scontrol namespace PID %s: %s. Using %s.",
+                namespace_pid,
+                host_pids,
+                host_pids[0],
+            )
+
+        return host_pids[0]
+
+    def _get_host_pids_by_namespace_pid(self):
         host_proc = os.environ.get("HOST_PROC", "/host/proc")
-        host_pid_by_namespace_pid = {}
+        host_pids_by_namespace_pid = {}
 
         try:
             proc_entries = os.scandir(host_proc)
         except OSError as e:
             self.log.debug("Unable to scan host proc path '%s': %s", host_proc, e)
-            return host_pid_by_namespace_pid
+            return host_pids_by_namespace_pid
 
         with proc_entries:
             for entry in proc_entries:
@@ -637,9 +652,9 @@ class SlurmCheck(AgentCheck, ConfigMixin):
                     continue
 
                 for namespace_pid in self._read_namespace_pids(entry.path, entry.name):
-                    host_pid_by_namespace_pid.setdefault(namespace_pid, entry.name)
+                    host_pids_by_namespace_pid.setdefault(namespace_pid, []).append(entry.name)
 
-        return host_pid_by_namespace_pid
+        return host_pids_by_namespace_pid
 
     def _read_namespace_pids(self, proc_path, host_pid):
         try:

--- a/slurm/datadog_checks/slurm/config_models/defaults.py
+++ b/slurm/datadog_checks/slurm/config_models/defaults.py
@@ -84,6 +84,10 @@ def instance_min_collection_interval():
     return 60
 
 
+def instance_resolve_scontrol_host_pids():
+    return False
+
+
 def instance_sacct_path():
     return '/usr/bin/sacct'
 

--- a/slurm/datadog_checks/slurm/config_models/instance.py
+++ b/slurm/datadog_checks/slurm/config_models/instance.py
@@ -58,6 +58,7 @@ class InstanceConfig(BaseModel):
     enable_legacy_tags_normalization: Optional[bool] = None
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None
+    resolve_scontrol_host_pids: Optional[bool] = None
     sacct_path: Optional[str] = None
     scontrol_path: Optional[str] = None
     sdiag_path: Optional[str] = None

--- a/slurm/datadog_checks/slurm/data/conf.yaml.example
+++ b/slurm/datadog_checks/slurm/data/conf.yaml.example
@@ -51,6 +51,12 @@ instances:
     #
     # collect_scontrol_stats: false
 
+    ## @param resolve_scontrol_host_pids - boolean - optional - default: false
+    ## Whether or not to resolve PIDs reported by scontrol through the host proc filesystem before collecting
+    ## process tags. Enable this when scontrol reports namespace PIDs instead of host PIDs.
+    #
+    # resolve_scontrol_host_pids: false
+
     ## @param collect_gpu_stats - boolean - optional - default: false
     ## Whether or not to collect GPU statistics when Slurm is configured to use GPUs.
     #

--- a/slurm/datadog_checks/slurm/data/conf.yaml.example
+++ b/slurm/datadog_checks/slurm/data/conf.yaml.example
@@ -46,7 +46,7 @@ instances:
     # collect_sshare_stats: true
 
     ## @param collect_scontrol_stats - boolean - optional - default: false
-    ## Whether or not to collect statistics from the scontrol command. This is mainly used in the worker 
+    ## Whether or not to collect statistics from the scontrol command. This is mainly used in the worker
     ## node to collect the list of running jobs along with their PIDs.
     #
     # collect_scontrol_stats: false
@@ -69,8 +69,8 @@ instances:
 
     ## @param sinfo_collection_level - integer - optional - default: 1
     ## The level of detail to collect from the sinfo command. The default is 'basic'. Available options are 1, 2 and
-    ## 3. Level 1 collects data only for partitions. Level 2 collects data from individual nodes. Level 3 
-    ## collects data from from individual nodes as well but is more verbose and includes data such as CPU and 
+    ## 3. Level 1 collects data only for partitions. Level 2 collects data from individual nodes. Level 3
+    ## collects data from from individual nodes as well but is more verbose and includes data such as CPU and
     ## memory usage as reported from the OS, as well as additional tags.
     #
     # sinfo_collection_level: 1
@@ -131,7 +131,7 @@ instances:
     ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
     ##
     ## Most Slurm metrics are collected from calling the different binaries. Depending on the size of the Slurm cluster,
-    ## this can be a very expensive operation. It is recommended to set this to a higher value than the default 15 
+    ## this can be a very expensive operation. It is recommended to set this to a higher value than the default 15
     ## seconds, but this can be adjusted based on the size of the cluster and the desired granularity of the metrics.
     #
     min_collection_interval: 60

--- a/slurm/tests/test_unit.py
+++ b/slurm/tests/test_unit.py
@@ -335,6 +335,12 @@ def test_resolve_scontrol_host_pid_logs_multiple_matches(instance, caplog):
     assert "Found multiple host PID matches for scontrol namespace PID 3771" in caplog.text
 
 
+def test_resolve_scontrol_host_pid_returns_match_without_nspids_when_missing(instance):
+    check = SlurmCheck('slurm', {}, [instance])
+
+    assert check._resolve_scontrol_host_pid("3771", {}) == ProcessPidMatch(host_pid="3771", namespace_pids=[])
+
+
 @patch('datadog_checks.slurm.check.get_subprocess_output')
 @patch('datadog_checks.slurm.check.SlurmCheck._get_process_tags')
 def test_scontrol_processing_gets_process_tags_for_pid_and_nspid(
@@ -358,8 +364,8 @@ def test_scontrol_processing_gets_process_tags_for_pid_and_nspid(
 
     check.check(None)
 
-    mock_get_process_tags.assert_any_call("3771")
     mock_get_process_tags.assert_any_call("12345")
+    mock_get_process_tags.assert_any_call("3771")
     mock_get_process_tags.assert_any_call("3772")
     mock_get_process_tags.assert_any_call("3773")
 

--- a/slurm/tests/test_unit.py
+++ b/slurm/tests/test_unit.py
@@ -324,6 +324,13 @@ def test_scontrol_processing_does_not_resolve_host_pid_by_default(
     aggregator.assert_all_metrics_covered()
 
 
+def test_resolve_scontrol_host_pid_logs_multiple_matches(instance, caplog):
+    check = SlurmCheck('slurm', {}, [instance])
+
+    assert check._resolve_scontrol_host_pid("3771", {"3771": ["12345", "23456"]}) == "12345"
+    assert "Found multiple host PIDs matching scontrol namespace PID 3771" in caplog.text
+
+
 @patch('datadog_checks.slurm.check.get_subprocess_output')
 def test_metadata(mock_get_subprocess_out, instance, datadog_agent, dd_run_check):
     instance['collect_sinfo_stats'] = True

--- a/slurm/tests/test_unit.py
+++ b/slurm/tests/test_unit.py
@@ -228,6 +228,103 @@ def test_scontrol_processing(mock_get_subprocess_output, instance, aggregator):
 
 
 @patch('datadog_checks.slurm.check.get_subprocess_output')
+def test_scontrol_processing_resolves_host_pid(mock_get_subprocess_output, instance, aggregator, monkeypatch, tmp_path):
+    instance['collect_scontrol_stats'] = True
+    instance['resolve_scontrol_host_pids'] = True
+    check = SlurmCheck('slurm', {}, [instance])
+    host_proc = tmp_path / "proc"
+    host_process = host_proc / "12345"
+    other_process = host_proc / "999"
+    host_process.mkdir(parents=True)
+    other_process.mkdir()
+    (host_process / "status").write_text("Name:\tjob\nNSpid:\t12345\t3771\n")
+    (other_process / "status").write_text("Name:\tother\n")
+    monkeypatch.setenv("HOST_PROC", str(host_proc))
+
+    mock_get_subprocess_output.side_effect = [
+        (mock_output('scontrol.txt'), "", 0),
+        ("c1", "", 0),
+        (mock_output('scontrol_squeue.txt'), "", 0),
+        (mock_output('scontrol_squeue2.txt'), "", 0),
+    ]
+
+    check.check(None)
+
+    aggregator.assert_metric(
+        name='slurm.scontrol.jobs.info',
+        value=1,
+        tags=[
+            "pid:12345",
+            "slurm_global_id:0",
+            "slurm_job_id:14",
+            "slurm_local_id:0",
+            "slurm_node_name:c1",
+            "slurm_step_id:batch",
+            "slurm_job_name:my_job",
+            "slurm_job_state:RUNNING",
+            "slurm_job_user:root",
+        ],
+    )
+    aggregator.assert_metric(
+        name='slurm.scontrol.jobs.info',
+        value=1,
+        tags=[
+            "pid:3772",
+            "slurm_global_id:-",
+            "slurm_job_id:14",
+            "slurm_local_id:-",
+            "slurm_node_name:c1",
+            "slurm_step_id:batch",
+            "slurm_job_name:my_job",
+            "slurm_job_state:RUNNING",
+            "slurm_job_user:root",
+        ],
+    )
+    aggregator.assert_metric(
+        name='slurm.scontrol.jobs.info',
+        value=1,
+        tags=[
+            "pid:3773",
+            "slurm_global_id:0",
+            "slurm_job_id:15",
+            "slurm_local_id:0",
+            "slurm_node_name:c1",
+            "slurm_step_id:batch",
+            "slurm_job_name:my_job2",
+            "slurm_job_state:RUNNING",
+            "slurm_job_user:root",
+        ],
+    )
+    aggregator.assert_all_metrics_covered()
+
+
+@patch('datadog_checks.slurm.check.get_subprocess_output')
+def test_scontrol_processing_does_not_resolve_host_pid_by_default(
+    mock_get_subprocess_output, instance, aggregator, monkeypatch, tmp_path
+):
+    instance['collect_scontrol_stats'] = True
+    check = SlurmCheck('slurm', {}, [instance])
+    host_proc = tmp_path / "proc"
+    host_process = host_proc / "12345"
+    host_process.mkdir(parents=True)
+    (host_process / "status").write_text("Name:\tjob\nNSpid:\t12345\t3771\n")
+    monkeypatch.setenv("HOST_PROC", str(host_proc))
+
+    mock_get_subprocess_output.side_effect = [
+        (mock_output('scontrol.txt'), "", 0),
+        ("c1", "", 0),
+        (mock_output('scontrol_squeue.txt'), "", 0),
+        (mock_output('scontrol_squeue2.txt'), "", 0),
+    ]
+
+    check.check(None)
+
+    for metric in SCONTROL_MAP['metrics']:
+        aggregator.assert_metric(name=metric['name'], value=metric['value'], tags=metric['tags'])
+    aggregator.assert_all_metrics_covered()
+
+
+@patch('datadog_checks.slurm.check.get_subprocess_output')
 def test_metadata(mock_get_subprocess_out, instance, datadog_agent, dd_run_check):
     instance['collect_sinfo_stats'] = True
     instance['sinfo_collection_level'] = 1

--- a/slurm/tests/test_unit.py
+++ b/slurm/tests/test_unit.py
@@ -328,11 +328,11 @@ def test_scontrol_processing_does_not_resolve_host_pid_by_default(
 
 def test_resolve_scontrol_host_pid_logs_multiple_matches(instance, caplog):
     check = SlurmCheck('slurm', {}, [instance])
-    first_match = ProcessPidMatch(host_pid="12345", namespace_pids=["12345", "3771"])
-    second_match = ProcessPidMatch(host_pid="23456", namespace_pids=["23456", "3771"])
+    first_match = ProcessPidMatch(host_pid="1", namespace_pids=["1"])
+    second_match = ProcessPidMatch(host_pid="12345", namespace_pids=["12345", "1"])
 
-    assert check._resolve_scontrol_host_pid("3771", {"3771": [first_match, second_match]}) == first_match
-    assert "Found multiple host PID matches for scontrol namespace PID 3771" in caplog.text
+    assert check._resolve_scontrol_host_pid("1", {"1": [first_match, second_match]}) == second_match
+    assert "Found multiple host PID matches for scontrol namespace PID 1" in caplog.text
 
 
 def test_resolve_scontrol_host_pid_returns_match_without_nspids_when_missing(instance):
@@ -343,7 +343,7 @@ def test_resolve_scontrol_host_pid_returns_match_without_nspids_when_missing(ins
 
 @patch('datadog_checks.slurm.check.get_subprocess_output')
 @patch('datadog_checks.slurm.check.SlurmCheck._get_process_tags')
-def test_scontrol_processing_gets_process_tags_for_pid_and_nspid(
+def test_scontrol_processing_gets_process_tags_for_host_pid_only(
     mock_get_process_tags, mock_get_subprocess_output, instance, monkeypatch, tmp_path
 ):
     instance['collect_scontrol_stats'] = True
@@ -365,9 +365,9 @@ def test_scontrol_processing_gets_process_tags_for_pid_and_nspid(
     check.check(None)
 
     mock_get_process_tags.assert_any_call("12345")
-    mock_get_process_tags.assert_any_call("3771")
     mock_get_process_tags.assert_any_call("3772")
     mock_get_process_tags.assert_any_call("3773")
+    assert mock_get_process_tags.call_count == 3
 
 
 @patch('datadog_checks.slurm.check.get_subprocess_output')

--- a/slurm/tests/test_unit.py
+++ b/slurm/tests/test_unit.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from datadog_checks.slurm import SlurmCheck
+from datadog_checks.slurm.check import ProcessPidMatch
 from datadog_checks.slurm.constants import SACCT_PARAMS
 
 from .common import (
@@ -254,6 +255,7 @@ def test_scontrol_processing_resolves_host_pid(mock_get_subprocess_output, insta
         name='slurm.scontrol.jobs.info',
         value=1,
         tags=[
+            "nspid:3771",
             "pid:12345",
             "slurm_global_id:0",
             "slurm_job_id:14",
@@ -326,9 +328,40 @@ def test_scontrol_processing_does_not_resolve_host_pid_by_default(
 
 def test_resolve_scontrol_host_pid_logs_multiple_matches(instance, caplog):
     check = SlurmCheck('slurm', {}, [instance])
+    first_match = ProcessPidMatch(host_pid="12345", namespace_pids=["12345", "3771"])
+    second_match = ProcessPidMatch(host_pid="23456", namespace_pids=["23456", "3771"])
 
-    assert check._resolve_scontrol_host_pid("3771", {"3771": ["12345", "23456"]}) == "12345"
-    assert "Found multiple host PIDs matching scontrol namespace PID 3771" in caplog.text
+    assert check._resolve_scontrol_host_pid("3771", {"3771": [first_match, second_match]}) == first_match
+    assert "Found multiple host PID matches for scontrol namespace PID 3771" in caplog.text
+
+
+@patch('datadog_checks.slurm.check.get_subprocess_output')
+@patch('datadog_checks.slurm.check.SlurmCheck._get_process_tags')
+def test_scontrol_processing_gets_process_tags_for_pid_and_nspid(
+    mock_get_process_tags, mock_get_subprocess_output, instance, monkeypatch, tmp_path
+):
+    instance['collect_scontrol_stats'] = True
+    instance['resolve_scontrol_host_pids'] = True
+    check = SlurmCheck('slurm', {}, [instance])
+    host_proc = tmp_path / "proc"
+    host_process = host_proc / "12345"
+    host_process.mkdir(parents=True)
+    (host_process / "status").write_text("Name:\tjob\nNSpid:\t12345\t3771\n")
+    monkeypatch.setenv("HOST_PROC", str(host_proc))
+    mock_get_process_tags.return_value = []
+    mock_get_subprocess_output.side_effect = [
+        (mock_output('scontrol.txt'), "", 0),
+        ("c1", "", 0),
+        (mock_output('scontrol_squeue.txt'), "", 0),
+        (mock_output('scontrol_squeue2.txt'), "", 0),
+    ]
+
+    check.check(None)
+
+    mock_get_process_tags.assert_any_call("3771")
+    mock_get_process_tags.assert_any_call("12345")
+    mock_get_process_tags.assert_any_call("3772")
+    mock_get_process_tags.assert_any_call("3773")
 
 
 @patch('datadog_checks.slurm.check.get_subprocess_output')


### PR DESCRIPTION
### What does this PR do?

Fixes SLURM `scontrol` process tag enrichment when reported PIDs are namespace PIDs by resolving them to host PIDs before querying process tags.

### Motivation

In containerized SLURM worker setups, `scontrol listpid` can return namespace PIDs, which prevents the Agent from attaching process and GPU tags to SLURM job metrics.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged