### PR TITLE
Add Kueue workload transition duration attribute

### DIFF
--- a/kueue/datadog_checks/kueue/check.py
+++ b/kueue/datadog_checks/kueue/check.py
@@ -42,6 +42,7 @@ WORKLOAD_TRANSITION_EVENT_TYPES = {
     'evicted': 'kueue.workload.evicted',
     'finished': 'kueue.workload.finished',
 }
+WORKLOAD_TRANSITION_ORDER = tuple(WORKLOAD_TRANSITIONS)
 
 DEFAULT_RENAME_LABELS = {
     'cluster_queue': 'kueue_cluster_queue',
@@ -267,6 +268,7 @@ class KueueCheck(OpenMetricsBaseCheckV2, ConfigMixin):
                 'msg_text': self.workload_event_text(transition, workload, condition),
                 'aggregation_key': metadata.get('uid', f'{namespace}/{name}'),
                 'alert_type': alert_type,
+                'attributes': self.workload_event_attributes(condition_type, workload, condition),
                 'tags': self.workload_event_tags(transition, workload, condition, previous_state),
             }
         )
@@ -306,6 +308,32 @@ class KueueCheck(OpenMetricsBaseCheckV2, ConfigMixin):
             parts.append(f'Finished reason: {condition["reason"]}.')
 
         return ' '.join(parts)
+
+    def workload_event_attributes(self, condition_type: str, workload: dict, condition: dict | None) -> dict:
+        time_until_transition = self.workload_time_until_transition(condition_type, workload, condition)
+        if time_until_transition is None:
+            return {}
+        return {'workload_time_until_transition': time_until_transition}
+
+    def workload_time_until_transition(
+        self, condition_type: str, workload: dict, condition: dict | None
+    ) -> float | None:
+        if not condition:
+            return None
+
+        previous_transition_time = self.previous_workload_transition_time(condition_type, workload)
+        return self.duration_seconds(previous_transition_time, condition.get('last_transition_time'))
+
+    def previous_workload_transition_time(self, condition_type: str, workload: dict) -> str | None:
+        condition_index = WORKLOAD_TRANSITION_ORDER.index(condition_type)
+        previous_condition_types = WORKLOAD_TRANSITION_ORDER[:condition_index]
+
+        for previous_condition_type in reversed(previous_condition_types):
+            previous_condition = self.get_condition(workload, previous_condition_type)
+            if previous_condition and previous_condition.get('status') == 'True':
+                return previous_condition.get('lastTransitionTime')
+
+        return workload.get('metadata', {}).get('creationTimestamp')
 
     def workload_event_tags(
         self,

--- a/kueue/tests/test_unit.py
+++ b/kueue/tests/test_unit.py
@@ -229,16 +229,19 @@ def test_workload_events_transitions(dd_run_check, aggregator, instance, mock_ht
         'Workload team-a/training-job quota reserved. Quota reserved in ClusterQueue default',
         source_type_name='kueue',
         tags=[*expected_tags, 'kueue_transition:quota_reserved'],
+        attributes={'workload_time_until_transition': 5.0},
     )
     aggregator.assert_event(
         'Workload team-a/training-job admitted. The workload is admitted Queued wait time was 8s.',
         source_type_name='kueue',
         tags=[*expected_tags, 'kueue_transition:admitted'],
+        attributes={'workload_time_until_transition': 3.0},
     )
     aggregator.assert_event(
         'Workload team-a/training-job running. All pods are ready',
         source_type_name='kueue',
         tags=[*expected_tags, 'kueue_transition:running'],
+        attributes={'workload_time_until_transition': 12.0},
     )
 
 
@@ -312,10 +315,12 @@ def test_workload_events_evicted_and_finished(dd_run_check, aggregator, instance
         'Preemption reason: InClusterQueue.',
         alert_type='warning',
         tags=expected_evicted_tags,
+        attributes={'workload_time_until_transition': 40.0},
     )
     aggregator.assert_event(
         'Workload team-a/training-job finished. Reached expected number of succeeded pods Finished reason: Succeeded.',
         alert_type='info',
+        attributes={'workload_time_until_transition': 30.0},
     )
 
 


### PR DESCRIPTION
### What does this PR do?
Adds `workload_time_until_transition` to Kueue workload lifecycle events so each transition records how long the workload spent before reaching that state.

### Motivation
This makes workload event data useful for understanding queueing and execution delays without parsing event text.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged