### PR TITLE
Document macOS power_state:battery_critical tag for battery check

### DIFF
--- a/battery/README.md
+++ b/battery/README.md
@@ -34,9 +34,7 @@ The metric `system.battery.power_state` can report any of the following tags:
 - `power_state:battery_charging`: Indicates that the battery is charging
 - `power_state:battery_discharging`: Indicates that the battery is discharging
 - `power_state:battery_power_on_line`: Indicates that the battery is connected to AC power
-
-On Windows and macOS, the metric can also report the following tag:
-- `power_state:battery_critical`: Indicates a critical battery condition. On Windows, this indicates that battery failure is imminent. On macOS (Agent 7.81.0 or later), this indicates that the operating system detected a degraded battery that requires service.
+- `power_state:battery_critical`: Indicates a critical battery condition. On Windows, this indicates that battery failure is imminent. On macOS, this indicates that the operating system detected a degraded battery that requires service.
 
 ### Events
 

--- a/battery/README.md
+++ b/battery/README.md
@@ -35,8 +35,8 @@ The metric `system.battery.power_state` can report any of the following tags:
 - `power_state:battery_discharging`: Indicates that the battery is discharging
 - `power_state:battery_power_on_line`: Indicates that the battery is connected to AC power
 
-In Windows, the metric can also report the following tag:
-- `power_state:battery_critical`: Indicates that battery failure is imminent
+On Windows and macOS, the metric can also report the following tag:
+- `power_state:battery_critical`: Indicates a critical battery condition. On Windows, this indicates that battery failure is imminent. On macOS (Agent 7.81.0 or later), this indicates that the operating system detected a degraded battery that requires service.
 
 ### Events
 


### PR DESCRIPTION
### What does this PR do?

Updates the battery integration README to reflect that the `power_state:battery_critical` tag is now reported on macOS in addition to Windows.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2839

datadog-agent PR #51982 adds macOS support for the `power_state:battery_critical` tag on the `system.battery.power_state` metric (Agent 7.81.0). On macOS, the tag fires when the operating system reports a degraded battery health condition (for example, "Service Recommended"); on Windows it continues to signal imminent battery failure. The published docs previously listed this tag as Windows-only.

### Additional notes

Docs-only change to `battery/README.md`.