### PR TITLE
[nvidia_nim] strengthen tests to lift mutation score

### DIFF
--- a/nvidia_nim/tests/test_unit.py
+++ b/nvidia_nim/tests/test_unit.py
@@ -13,6 +13,8 @@ from datadog_checks.nvidia_nim import NvidiaNIMCheck
 
 from .common import METRICS_MOCK, get_fixture_path
 
+pytestmark = pytest.mark.unit
+
 
 def test_check_nvidia_nim(dd_run_check, aggregator, datadog_agent, instance):
     check = NvidiaNIMCheck("nvidia_nim", {}, [instance])
@@ -59,3 +61,50 @@ def test_emits_critical_openemtrics_service_check_when_service_is_down(
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_service_check("nvidia_nim.openmetrics.health", ServiceCheck.CRITICAL)
+
+
+def test_default_metric_limit():
+    # Kills the core/NumberReplacer mutant at check.py:10 (DEFAULT_METRIC_LIMIT 0 -> -1).
+    assert NvidiaNIMCheck.DEFAULT_METRIC_LIMIT == 0
+
+
+def test_version_metadata_skipped_when_metadata_collection_disabled(datadog_agent, instance):
+    # Kills the core/RemoveDecorator mutant at check.py:20 (dropping @AgentCheck.metadata_entrypoint
+    # would submit version metadata even though metadata collection is disabled).
+    check = NvidiaNIMCheck("nvidia_nim", {}, [instance])
+    check.check_id = "test:123"
+    datadog_agent._config["enable_metadata_collection"] = False
+    with mock.patch('requests.Session.get', return_value=MockResponse(json_data={"release": "1.2.3"})):
+        check._submit_version_metadata()
+
+    datadog_agent.assert_metadata_count(0)
+
+
+def test_version_metadata_uses_first_three_components(datadog_agent, instance):
+    # Kills the core/ReplaceComparisonOperator_GtE_Eq and core/ReplaceComparisonOperator_GtE_LtE
+    # mutants at check.py:29 (>= 3 -> == 3 / <= 3), plus the core/NumberReplacer mutants at
+    # check.py:31 and check.py:32 (minor/patch reading the wrong version_split index).
+    check = NvidiaNIMCheck("nvidia_nim", {}, [instance])
+    check.check_id = "test:123"
+    with mock.patch('requests.Session.get', return_value=MockResponse(json_data={"release": "1.2.3.4"})):
+        check._submit_version_metadata()
+
+    version_metadata = {
+        "version.scheme": "semver",
+        "version.major": "1",
+        "version.minor": "2",
+        "version.patch": "3",
+        "version.raw": "1.2.3",
+    }
+    datadog_agent.assert_metadata("test:123", version_metadata)
+
+
+def test_version_metadata_skipped_for_short_version(datadog_agent, instance):
+    # Kills the core/NumberReplacer mutant at check.py:29 (len(version_split) >= 3 -> >= 2), which
+    # would index version_split[2] on a two-component version and raise instead of skipping.
+    check = NvidiaNIMCheck("nvidia_nim", {}, [instance])
+    check.check_id = "test:123"
+    with mock.patch('requests.Session.get', return_value=MockResponse(json_data={"release": "1.2"})):
+        check._submit_version_metadata()
+
+    datadog_agent.assert_metadata_count(0)


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `nvidia_nim` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `nvidia_nim` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch

[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ