### PR TITLE
Make CI Visibility job tagging non-blocking

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -229,15 +229,6 @@ jobs:
         DD_GITHUB_USER: ${{ github.actor }}
         DD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Tag job for CI Visibility
-      # Skip on fork PRs and non-core repos since secrets won't be available
-      if: env.INPUT_IS_FORK != 'true' && env.INPUT_REPO == 'core'
-      uses: ./.github/actions/tag-job
-      with:
-        tags: ${{ env.DD_TAGS }}
-        dd_api_key: ${{ secrets.DD_API_KEY }}
-        dd_site: ${{ env.DD_SITE }}
-
     - name: Set up Python 2.7
       if: inputs.test-py2
       run: |
@@ -365,3 +356,17 @@ jobs:
         name: "${{ env.MINIMUM_BASE_PACKAGE_PREFIX }}coverage-${{ inputs.target }}${{ inputs.target-env && format('-{0}', inputs.target-env) || '' }}-${{ inputs.platform }}"
         path: "${{ inputs.target }}/coverage.xml"
         if-no-files-found: ignore
+
+    - name: Tag job for CI Visibility
+      # Runs AFTER the tests and result/coverage uploads. Tagging is best-effort
+      # observability (it decorates the CI Visibility job entity); it must never be able
+      # to skip the test run, so it is placed last. continue-on-error keeps a flaky npm
+      # install or Datadog API call from reddening a job whose tests already ran, and
+      # !cancelled() ensures failed test jobs are still tagged (skipping only cancelled ones).
+      if: ${{ !cancelled() && env.INPUT_IS_FORK != 'true' && env.INPUT_REPO == 'core' }}
+      continue-on-error: true
+      uses: ./.github/actions/tag-job
+      with:
+        tags: ${{ env.DD_TAGS }}
+        dd_api_key: ${{ secrets.DD_API_KEY }}
+        dd_site: ${{ env.DD_SITE }}


### PR DESCRIPTION
### What does this PR do?

Makes the **"Tag job for CI Visibility"** step in `test-target.yml` non-blocking so a transient tagging failure can no longer abort a test job before the tests run. Two changes:

1. Move the step from *before* the tests to the **end** of the job (after the test run and the result/coverage uploads).
2. Add `continue-on-error: true` and gate it with `if: ${{ !cancelled() && ... }}` so it still runs on both passing and failing test jobs, but its own failure never fails the job.

### Motivation

The tag step performs several network operations (`setup-node`, `npm install -g @datadog/datadog-ci`, and a Datadog API call via `./.github/actions/tag-job`). It previously ran **before** the tests with no `continue-on-error`, so any transient failure in those network calls caused the whole job — including the entire test run — to be skipped and the job to go red, even though no test actually failed. This has been a recurring source of spurious master CI failures that the on-call rotation has to manually investigate.

Job tagging is best-effort observability, so it should never be able to block or fail a job whose tests otherwise pass. The fix is safe for CI Visibility dashboards: test results are reported through a separate `DD_CIVISIBILITY_ENABLED` ddtrace flow *during the test run itself*, not by this step. Placing the tag step last with `!cancelled()` keeps both passing **and** failing jobs tagged; `continue-on-error` only stops a tag flake from reddening a job whose tests already ran.

This is a `.github/` workflow (dev-tooling) change with no agent-shipped code, so it needs no changelog entry and is `qa/skip-qa`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e) — N/A, CI workflow change with no shippable code
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required. → `qa/skip-qa`
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

---

_This PR has been created and validated using the paired-review skill from agent-integrations. **Ready for human review**._
