### PR TITLE
[datadog_cluster_agent] strengthen tests to lift mutation score

### DIFF
--- a/datadog_cluster_agent/tests/test_unit.py
+++ b/datadog_cluster_agent/tests/test_unit.py
@@ -1,0 +1,34 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.datadog_cluster_agent import DatadogClusterAgentCheck
+
+pytestmark = pytest.mark.unit
+
+
+def test_default_metric_limit_is_zero():
+    # Kills the core/NumberReplacer mutant at check.py:93 (DEFAULT_METRIC_LIMIT 0 -> -1).
+    assert DatadogClusterAgentCheck.DEFAULT_METRIC_LIMIT == 0
+
+
+def test_send_histograms_buckets_defaults_to_true(instance):
+    # Kills the core/ReplaceTrueWithFalse mutant at check.py:111 (send_histograms_buckets True -> False).
+    check = DatadogClusterAgentCheck('datadog_cluster_agent', {}, [instance])
+    scraper_config = check.get_scraper_config(instance)
+    assert scraper_config['send_histograms_buckets'] is True
+
+
+def test_send_distribution_counts_as_monotonic_defaults_to_true(instance):
+    # Kills the core/ReplaceTrueWithFalse mutant at check.py:112 (send_distribution_counts_as_monotonic True -> False).
+    check = DatadogClusterAgentCheck('datadog_cluster_agent', {}, [instance])
+    scraper_config = check.get_scraper_config(instance)
+    assert scraper_config['send_distribution_counts_as_monotonic'] is True
+
+
+def test_send_distribution_sums_as_monotonic_defaults_to_true(instance):
+    # Kills the core/ReplaceTrueWithFalse mutant at check.py:113 (send_distribution_sums_as_monotonic True -> False).
+    check = DatadogClusterAgentCheck('datadog_cluster_agent', {}, [instance])
+    scraper_config = check.get_scraper_config(instance)
+    assert scraper_config['send_distribution_sums_as_monotonic'] is True


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `datadog_cluster_agent` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `datadog_cluster_agent` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch