### PR TITLE
Add scheduled master CI failure triage workflow

### DIFF
--- a/.github/workflows/ci-master-triage.yml
+++ b/.github/workflows/ci-master-triage.yml
@@ -1,0 +1,106 @@
+name: CI Master Triage
+
+# Detects failing master test-matrix runs (Master / Master Windows), groups them
+# so one root cause produces one alert, optionally enriches with a Claude
+# root-cause summary, and posts to #agent-integrations-ops.
+#
+# Rollout is gated by the CI_TRIAGE_ENABLED repo variable: scheduled ticks are
+# no-ops until it is set to "true", so merging this file is safe. Use
+# workflow_dispatch to shadow-test (point CI_TRIAGE_SLACK_CHANNEL_ID at a private
+# channel first), then set CI_TRIAGE_ENABLED=true and the ops channel to go live.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"   # realtime sweep — emits only on HIGH severity
+    - cron: "0 14,22 * * *"  # twice-daily digest — emits HIGH + NORMAL
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Triage mode"
+        type: choice
+        options: [realtime, digest]
+        default: digest
+      explicit_run_ids:
+        description: "Comma-separated run IDs to triage (for testing; bypasses dedup state)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: ci-master-triage-${{ github.event.schedule || github.event.inputs.mode || 'dispatch' }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    runs-on: ubuntu-22.04
+    # Scheduled runs only fire on the default branch; gate them behind a repo
+    # variable so go-live is deliberate. Manual dispatches always run.
+    if: github.event_name == 'workflow_dispatch' || vars.CI_TRIAGE_ENABLED == 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Determine mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "mode=${{ github.event.inputs.mode }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event.schedule }}" = "0 14,22 * * *" ]; then
+            echo "mode=digest" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=realtime" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Restore triage dedup state
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ci_triage_state.json
+          key: ci-master-triage-state-${{ github.run_id }}
+          restore-keys: |
+            ci-master-triage-state-
+
+      - name: Detect failing master runs
+        id: detect
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          MODE: ${{ steps.mode.outputs.mode }}
+          REPO_ROOT: ${{ github.workspace }}
+          STATE_FILE: ci_triage_state.json
+          EXPLICIT_RUN_IDS: ${{ github.event.inputs.explicit_run_ids }}
+        run: python3 .github/workflows/scripts/ci_master_triage/detect.py
+
+      - name: Check enrichment availability
+        id: enrich_gate
+        if: steps.detect.outputs.should_alert == 'true'
+        run: echo "enabled=${{ secrets.ANTHROPIC_API_KEY != '' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Enrich root cause with Claude (best-effort)
+        if: steps.detect.outputs.should_alert == 'true' && steps.enrich_gate.outputs.enabled == 'true'
+        continue-on-error: true
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TRIAGE_OUTPUT: triage_output.json
+          ENRICHMENT_FILE: enrichment.json
+        run: |
+          pip install --quiet anthropic
+          python3 .github/workflows/scripts/ci_master_triage/enrich.py
+
+      - name: Post Slack alert
+        if: steps.detect.outputs.should_alert == 'true'
+        env:
+          SLACK_API_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
+          # Override with a private channel during shadow mode; falls back to the
+          # #agent-integrations-ops default in notify.py when unset.
+          SLACK_CHANNEL_ID: ${{ vars.CI_TRIAGE_SLACK_CHANNEL_ID }}
+          TRIAGE_OUTPUT: triage_output.json
+          ENRICHMENT_FILE: enrichment.json
+        run: python3 .github/workflows/scripts/ci_master_triage/notify.py

--- a/.github/workflows/scripts/ci_master_triage/common.py
+++ b/.github/workflows/scripts/ci_master_triage/common.py
@@ -1,0 +1,46 @@
+"""Shared helpers and data contracts for the master CI triage scripts.
+
+``detect.py`` produces ``RunRecord``s; ``notify.py`` and ``enrich.py`` consume
+them from ``triage_output.json``. Keeping ``env()`` and the record shape in one
+place stops the three sibling scripts from drifting.
+"""
+
+from __future__ import annotations
+
+import os
+from enum import StrEnum
+from typing import TypedDict
+
+
+class Severity(StrEnum):
+    HIGH = "HIGH"
+    NORMAL = "NORMAL"
+    NONE = "NONE"
+
+
+class FailedTarget(TypedDict):
+    target: str
+    job_name: str
+    job_id: str
+    gh_job_id: str
+    url: str
+    leg_count: int
+
+
+class RunRecord(TypedDict):
+    run_id: int
+    sha: str
+    short_sha: str
+    title: str
+    actor: str
+    workflow: str
+    url: str
+    created_at: str
+    failed_targets: list[FailedTarget]
+    failed_count: int
+    other_failures: int
+    severity: str
+
+
+def env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()

--- a/.github/workflows/scripts/ci_master_triage/common.py
+++ b/.github/workflows/scripts/ci_master_triage/common.py
@@ -8,6 +8,7 @@ place stops the three sibling scripts from drifting.
 from __future__ import annotations
 
 import os
+from datetime import datetime
 from enum import StrEnum
 from typing import TypedDict
 
@@ -39,8 +40,22 @@ class RunRecord(TypedDict):
     failed_targets: list[FailedTarget]
     failed_count: int
     other_failures: int
-    severity: str
+    severity: Severity
+
+
+class TriageOutput(TypedDict):
+    mode: str
+    severity: Severity
+    runs: list[RunRecord]
+    non_test_failure_count: int
+    enrichment_jobs: list[dict[str, str]]
+    dashboard_url: str
 
 
 def env(name: str, default: str = "") -> str:
     return os.environ.get(name, default).strip()
+
+
+def parse_github_timestamp(ts: str) -> datetime:
+    """Parse a GitHub ISO-8601 timestamp, normalizing the trailing ``Z``."""
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))

--- a/.github/workflows/scripts/ci_master_triage/detect.py
+++ b/.github/workflows/scripts/ci_master_triage/detect.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
-from common import FailedTarget, RunRecord, Severity, env
+from common import FailedTarget, RunRecord, Severity, TriageOutput, env, parse_github_timestamp
 
 API_ROOT = "https://api.github.com"
 REQUEST_TIMEOUT = 30
@@ -110,11 +110,12 @@ def iter_failed_jobs(run_id: int, token: str, repo: str) -> Iterator[dict[str, A
         page += 1
 
 
-def classify(failed_targets: list[FailedTarget], storm_threshold: int) -> str:
+def classify(failed_targets: list[FailedTarget], storm_threshold: int) -> Severity:
     """Severity for one run from its failed test targets."""
     if not failed_targets:
         return Severity.NONE
-    if len(failed_targets) >= storm_threshold:
+    total_legs = sum(t["leg_count"] for t in failed_targets)
+    if len(failed_targets) >= storm_threshold or total_legs >= storm_threshold:
         return Severity.HIGH
     if any(t["target"] in BASE_PACKAGE_TARGETS for t in failed_targets):
         return Severity.HIGH
@@ -184,7 +185,7 @@ def candidate_runs(token: str, repo: str, cutoff: datetime, explicit_ids: list[i
             runs = payload.get("workflow_runs", [])
             reached_cutoff = False
             for run in runs:
-                created = datetime.fromisoformat(run["created_at"].replace("Z", "+00:00"))
+                created = parse_github_timestamp(run["created_at"])
                 if created < cutoff:
                     # Results are newest-first, so nothing past here is in-window.
                     reached_cutoff = True
@@ -206,7 +207,7 @@ def select_runs(records: list[RunRecord], mode: str, posted: dict[int, str]) -> 
     return selected
 
 
-def overall_severity(selected: list[RunRecord]) -> str:
+def overall_severity(selected: list[RunRecord]) -> Severity:
     """Roll the selected runs up to a single alert severity."""
     if any(r["severity"] == Severity.HIGH for r in selected):
         return Severity.HIGH
@@ -218,7 +219,7 @@ def load_posted_state(state_file: Path) -> dict[int, str]:
     if not state_file.exists():
         return {}
     raw = json.loads(state_file.read_text())
-    posted = raw.get("posted", {})
+    posted = raw.get("posted")
     if isinstance(posted, dict):
         return {int(k): v for k, v in posted.items()}
     # Legacy format: a bare list of ids with no timestamps.
@@ -234,7 +235,7 @@ def prune_posted(posted: dict[int, str], now: datetime) -> dict[int, str]:
             kept[run_id] = now.isoformat()
             continue
         try:
-            created = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+            created = parse_github_timestamp(created_at)
         except ValueError:
             kept[run_id] = now.isoformat()
             continue
@@ -277,7 +278,11 @@ def main() -> int:
     storm_threshold = int(env("STORM_THRESHOLD", "25"))
     repo_root = Path(env("REPO_ROOT", "."))
     state_file = Path(env("STATE_FILE", "ci_triage_state.json"))
-    explicit_ids = [int(x) for x in env("EXPLICIT_RUN_IDS").split(",") if x.strip()]
+    try:
+        explicit_ids = [int(x) for x in env("EXPLICIT_RUN_IDS").split(",") if x.strip()]
+    except ValueError as exc:
+        print(f"EXPLICIT_RUN_IDS must be a comma-separated list of ints: {exc}", file=sys.stderr)
+        return 1
 
     lookback = (
         timedelta(minutes=int(env("LOOKBACK_MINUTES", "45")))
@@ -298,7 +303,7 @@ def main() -> int:
     non_test_count = sum(1 for r in records if r["run_id"] not in posted and r["severity"] == Severity.NONE)
     overall = overall_severity(selected)
 
-    output = {
+    output: TriageOutput = {
         "mode": mode,
         "severity": overall,
         "runs": selected,

--- a/.github/workflows/scripts/ci_master_triage/detect.py
+++ b/.github/workflows/scripts/ci_master_triage/detect.py
@@ -257,7 +257,7 @@ def build_enrichment_jobs(selected: list[RunRecord], limit: int = 8) -> list[dic
     return jobs[:limit]
 
 
-def write_outputs(should_alert: bool, severity: str, run_count: int) -> None:
+def write_outputs(should_alert: bool, severity: Severity, run_count: int) -> None:
     out_path = env("GITHUB_OUTPUT")
     if not out_path:
         return

--- a/.github/workflows/scripts/ci_master_triage/detect.py
+++ b/.github/workflows/scripts/ci_master_triage/detect.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Detect and group failing master CI runs from the GitHub Actions API.
+
+Deterministic and LLM-free: this script decides *whether* to alert and *how
+severe* a breakage is. It groups failures by run/commit so one root cause
+produces one alert instead of one alert per failing target.
+
+Output contract (``triage_output.json`` + ``$GITHUB_OUTPUT``) is consumed by
+``notify.py`` and the optional ``enrich.py`` LLM enrichment step.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+API_ROOT = "https://api.github.com"
+
+# Reusable-workflow job names surface in the API as
+#   "test / <job-id>[ (<matrix>)] / <leaf>"
+# The job-id is the YAML key in test-all*.yml and our stable join key.
+TEST_JOB_NAME_RE = re.compile(r"^test / (j[0-9a-f]+)(?: \(.*\))? / ")
+JOB_KEY_RE = re.compile(r"^  (j[0-9a-f]+):\s*$")
+JOB_NAME_RE = re.compile(r"^\s+job-name:\s*(.+?)\s*$")
+TARGET_RE = re.compile(r"^\s+target:\s*(.+?)\s*$")
+
+# A failure touching these targets means the shared base is broken, which
+# usually cascades into every integration: always alert in real time.
+BASE_PACKAGE_TARGETS = {
+    "datadog_checks_base",
+    "datadog_checks_dev",
+    "datadog_checks_downloader",
+    "ddev",
+}
+
+MASTER_WORKFLOWS = ("master.yml", "master-windows.yml")
+
+
+class Severity:
+    HIGH = "HIGH"
+    NORMAL = "NORMAL"
+    NONE = "NONE"
+
+
+def env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def github_request(path: str, token: str) -> Any:
+    """GET an absolute or repo-relative GitHub API path and decode JSON."""
+    url = path if path.startswith("http") else f"{API_ROOT}{path}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "ci-master-triage",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode())
+
+
+def parse_target_map(repo_root: Path) -> dict[str, dict[str, str]]:
+    """Map each test-target job-id to its human job-name and target slug."""
+    mapping: dict[str, dict[str, str]] = {}
+    for fname in ("test-all.yml", "test-all-windows.yml"):
+        path = repo_root / ".github" / "workflows" / fname
+        if not path.exists():
+            continue
+        current_id: str | None = None
+        job_name: str | None = None
+        for line in path.read_text().splitlines():
+            key = JOB_KEY_RE.match(line)
+            if key:
+                current_id, job_name = key.group(1), None
+                continue
+            if current_id is None:
+                continue
+            name_match = JOB_NAME_RE.match(line)
+            if name_match:
+                job_name = name_match.group(1).strip("\"'")
+                continue
+            target_match = TARGET_RE.match(line)
+            if target_match:
+                target = target_match.group(1).strip("\"'")
+                mapping[current_id] = {"job_name": job_name or current_id, "target": target}
+                current_id = None
+    return mapping
+
+
+def iter_failed_jobs(run_id: int, token: str, repo: str) -> Iterator[dict[str, Any]]:
+    """Yield the latest-attempt jobs of a run that ended in failure."""
+    page = 1
+    while True:
+        payload = github_request(
+            f"/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100&filter=latest&page={page}",
+            token,
+        )
+        jobs = payload.get("jobs", [])
+        for job in jobs:
+            if job.get("conclusion") == "failure":
+                yield job
+        if len(jobs) < 100:
+            return
+        page += 1
+
+
+def classify(failed_targets: list[dict[str, str]], storm_threshold: int) -> str:
+    """Severity for one run from its failed test targets."""
+    if not failed_targets:
+        return Severity.NONE
+    if len(failed_targets) >= storm_threshold:
+        return Severity.HIGH
+    if any(t["target"] in BASE_PACKAGE_TARGETS for t in failed_targets):
+        return Severity.HIGH
+    return Severity.NORMAL
+
+
+def build_run_record(
+    run: dict[str, Any], token: str, repo: str, target_map: dict[str, dict[str, str]], storm_threshold: int
+) -> dict[str, Any]:
+    """Collect failed test-target jobs for a run and classify its severity."""
+    failed_targets: list[dict[str, str]] = []
+    other_failures = 0
+    seen_job_ids: set[str] = set()
+    for job in iter_failed_jobs(run["id"], token, repo):
+        match = TEST_JOB_NAME_RE.match(job.get("name", ""))
+        if not match:
+            other_failures += 1
+            continue
+        job_id = match.group(1)
+        if job_id in seen_job_ids:
+            continue
+        seen_job_ids.add(job_id)
+        meta = target_map.get(job_id, {"job_name": job_id, "target": job_id})
+        failed_targets.append(
+            {
+                "target": meta["target"],
+                "job_name": meta["job_name"],
+                "job_id": job_id,
+                "gh_job_id": str(job.get("id", "")),
+                "url": job.get("html_url", ""),
+            }
+        )
+    failed_targets.sort(key=lambda t: t["job_name"].lower())
+    return {
+        "run_id": run["id"],
+        "sha": run.get("head_sha", ""),
+        "short_sha": run.get("head_sha", "")[:8],
+        "title": run.get("display_title", ""),
+        "actor": (run.get("actor") or {}).get("login", ""),
+        "workflow": run.get("name", ""),
+        "url": run.get("html_url", ""),
+        "created_at": run.get("created_at", ""),
+        "failed_targets": failed_targets,
+        "failed_count": len(failed_targets),
+        "other_failures": other_failures,
+        "severity": classify(failed_targets, storm_threshold),
+    }
+
+
+def candidate_runs(token: str, repo: str, cutoff: datetime, explicit_ids: list[int]) -> Iterator[dict[str, Any]]:
+    """Yield failed master runs to inspect: explicit IDs, or recent failures in-window."""
+    if explicit_ids:
+        for run_id in explicit_ids:
+            yield github_request(f"/repos/{repo}/actions/runs/{run_id}", token)
+        return
+    for workflow in MASTER_WORKFLOWS:
+        payload = github_request(
+            f"/repos/{repo}/actions/workflows/{workflow}/runs"
+            f"?branch=master&status=failure&per_page=50",
+            token,
+        )
+        for run in payload.get("workflow_runs", []):
+            created = datetime.fromisoformat(run["created_at"].replace("Z", "+00:00"))
+            if created >= cutoff:
+                yield run
+
+
+def write_outputs(should_alert: bool, severity: str, run_count: int) -> None:
+    out_path = env("GITHUB_OUTPUT")
+    if not out_path:
+        return
+    with open(out_path, "a") as fh:
+        fh.write(f"should_alert={'true' if should_alert else 'false'}\n")
+        fh.write(f"severity={severity}\n")
+        fh.write(f"run_count={run_count}\n")
+
+
+def main() -> int:
+    token = env("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN is required", file=sys.stderr)
+        return 1
+
+    repo = env("GITHUB_REPOSITORY", "DataDog/integrations-core")
+    mode = env("MODE", "digest")  # "realtime" or "digest"
+    storm_threshold = int(env("STORM_THRESHOLD", "25"))
+    repo_root = Path(env("REPO_ROOT", "."))
+    state_file = Path(env("STATE_FILE", "ci_triage_state.json"))
+    explicit_ids = [int(x) for x in env("EXPLICIT_RUN_IDS").split(",") if x.strip()]
+
+    lookback = (
+        timedelta(minutes=int(env("LOOKBACK_MINUTES", "45")))
+        if mode == "realtime"
+        else timedelta(hours=int(env("LOOKBACK_HOURS", "12")))
+    )
+    cutoff = datetime.now(timezone.utc) - lookback
+
+    posted: set[int] = set()
+    if state_file.exists():
+        posted = set(json.loads(state_file.read_text()).get("posted_run_ids", []))
+
+    target_map = parse_target_map(repo_root)
+    records = [build_run_record(r, token, repo, target_map, storm_threshold) for r in candidate_runs(token, repo, cutoff, explicit_ids)]
+
+    fresh = [r for r in records if r["run_id"] not in posted]
+    if mode == "realtime":
+        selected = [r for r in fresh if r["severity"] == Severity.HIGH]
+    else:
+        selected = [r for r in fresh if r["severity"] in (Severity.HIGH, Severity.NORMAL)]
+
+    non_test_count = sum(1 for r in fresh if r["severity"] == Severity.NONE)
+    overall = Severity.HIGH if any(r["severity"] == Severity.HIGH for r in selected) else (
+        Severity.NORMAL if selected else Severity.NONE
+    )
+
+    enrichment_jobs: list[dict[str, str]] = []
+    for record in selected:
+        for target in record["failed_targets"][:8]:
+            enrichment_jobs.append({"run_id": str(record["run_id"]), **target})
+
+    output = {
+        "mode": mode,
+        "severity": overall,
+        "runs": selected,
+        "non_test_failure_count": non_test_count,
+        "enrichment_jobs": enrichment_jobs[:8],
+        "dashboard_url": env(
+            "DASHBOARD_URL",
+            "https://app-dev-prod.datadoghq.com/dashboard/knc-6sp-caq/agent-integrations-overview",
+        ),
+    }
+    Path("triage_output.json").write_text(json.dumps(output, indent=2))
+
+    should_alert = bool(selected)
+    if should_alert and not explicit_ids:
+        posted.update(r["run_id"] for r in selected)
+        state_file.write_text(json.dumps({"posted_run_ids": sorted(posted)}))
+
+    write_outputs(should_alert, overall, len(selected))
+    print(json.dumps(output, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/scripts/ci_master_triage/detect.py
+++ b/.github/workflows/scripts/ci_master_triage/detect.py
@@ -12,16 +12,17 @@ Output contract (``triage_output.json`` + ``$GITHUB_OUTPUT``) is consumed by
 from __future__ import annotations
 
 import json
-import os
 import re
 import sys
-import urllib.error
 import urllib.request
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
+from common import FailedTarget, RunRecord, Severity, env
+
 API_ROOT = "https://api.github.com"
+REQUEST_TIMEOUT = 30
 
 # Reusable-workflow job names surface in the API as
 #   "test / <job-id>[ (<matrix>)] / <leaf>"
@@ -42,15 +43,10 @@ BASE_PACKAGE_TARGETS = {
 
 MASTER_WORKFLOWS = ("master.yml", "master-windows.yml")
 
-
-class Severity:
-    HIGH = "HIGH"
-    NORMAL = "NORMAL"
-    NONE = "NONE"
-
-
-def env(name: str, default: str = "") -> str:
-    return os.environ.get(name, default).strip()
+# Drop dedup state older than this so the persisted set can't grow without
+# bound. Must comfortably exceed the largest lookback window (18h digest) so a
+# run still in a lookback window is never pruned and re-alerted.
+STATE_RETENTION_HOURS = 72
 
 
 def github_request(path: str, token: str) -> Any:
@@ -65,7 +61,7 @@ def github_request(path: str, token: str) -> Any:
             "User-Agent": "ci-master-triage",
         },
     )
-    with urllib.request.urlopen(req) as resp:
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
         return json.loads(resp.read().decode())
 
 
@@ -114,7 +110,7 @@ def iter_failed_jobs(run_id: int, token: str, repo: str) -> Iterator[dict[str, A
         page += 1
 
 
-def classify(failed_targets: list[dict[str, str]], storm_threshold: int) -> str:
+def classify(failed_targets: list[FailedTarget], storm_threshold: int) -> str:
     """Severity for one run from its failed test targets."""
     if not failed_targets:
         return Severity.NONE
@@ -127,31 +123,34 @@ def classify(failed_targets: list[dict[str, str]], storm_threshold: int) -> str:
 
 def build_run_record(
     run: dict[str, Any], token: str, repo: str, target_map: dict[str, dict[str, str]], storm_threshold: int
-) -> dict[str, Any]:
-    """Collect failed test-target jobs for a run and classify its severity."""
-    failed_targets: list[dict[str, str]] = []
+) -> RunRecord:
+    """Collect failed test-target jobs for a run and classify its severity.
+
+    Matrix legs of one target share a reusable-workflow job-id, so they collapse
+    to a single target entry whose ``leg_count`` records how many legs failed.
+    """
+    target_records: dict[str, FailedTarget] = {}
     other_failures = 0
-    seen_job_ids: set[str] = set()
     for job in iter_failed_jobs(run["id"], token, repo):
         match = TEST_JOB_NAME_RE.match(job.get("name", ""))
         if not match:
             other_failures += 1
             continue
         job_id = match.group(1)
-        if job_id in seen_job_ids:
-            continue
-        seen_job_ids.add(job_id)
-        meta = target_map.get(job_id, {"job_name": job_id, "target": job_id})
-        failed_targets.append(
-            {
+        record = target_records.get(job_id)
+        if record is None:
+            meta = target_map.get(job_id, {"job_name": job_id, "target": job_id})
+            record = {
                 "target": meta["target"],
                 "job_name": meta["job_name"],
                 "job_id": job_id,
                 "gh_job_id": str(job.get("id", "")),
                 "url": job.get("html_url", ""),
+                "leg_count": 0,
             }
-        )
-    failed_targets.sort(key=lambda t: t["job_name"].lower())
+            target_records[job_id] = record
+        record["leg_count"] += 1
+    failed_targets = sorted(target_records.values(), key=lambda t: t["job_name"].lower())
     return {
         "run_id": run["id"],
         "sha": run.get("head_sha", ""),
@@ -175,15 +174,86 @@ def candidate_runs(token: str, repo: str, cutoff: datetime, explicit_ids: list[i
             yield github_request(f"/repos/{repo}/actions/runs/{run_id}", token)
         return
     for workflow in MASTER_WORKFLOWS:
-        payload = github_request(
-            f"/repos/{repo}/actions/workflows/{workflow}/runs"
-            f"?branch=master&status=failure&per_page=50",
-            token,
-        )
-        for run in payload.get("workflow_runs", []):
-            created = datetime.fromisoformat(run["created_at"].replace("Z", "+00:00"))
-            if created >= cutoff:
+        page = 1
+        while True:
+            payload = github_request(
+                f"/repos/{repo}/actions/workflows/{workflow}/runs"
+                f"?branch=master&status=failure&per_page=100&page={page}",
+                token,
+            )
+            runs = payload.get("workflow_runs", [])
+            reached_cutoff = False
+            for run in runs:
+                created = datetime.fromisoformat(run["created_at"].replace("Z", "+00:00"))
+                if created < cutoff:
+                    # Results are newest-first, so nothing past here is in-window.
+                    reached_cutoff = True
+                    break
                 yield run
+            if reached_cutoff or len(runs) < 100:
+                return
+            page += 1
+
+
+def select_runs(records: list[RunRecord], mode: str, posted: dict[int, str]) -> list[RunRecord]:
+    """Pick the fresh runs worth alerting on for this mode, worst-severity first."""
+    fresh = [r for r in records if r["run_id"] not in posted]
+    if mode == "realtime":
+        selected = [r for r in fresh if r["severity"] == Severity.HIGH]
+    else:
+        selected = [r for r in fresh if r["severity"] in (Severity.HIGH, Severity.NORMAL)]
+    selected.sort(key=lambda r: 0 if r["severity"] == Severity.HIGH else 1)
+    return selected
+
+
+def overall_severity(selected: list[RunRecord]) -> str:
+    """Roll the selected runs up to a single alert severity."""
+    if any(r["severity"] == Severity.HIGH for r in selected):
+        return Severity.HIGH
+    return Severity.NORMAL if selected else Severity.NONE
+
+
+def load_posted_state(state_file: Path) -> dict[int, str]:
+    """Read the run_id -> created_at dedup map, tolerating the legacy list format."""
+    if not state_file.exists():
+        return {}
+    raw = json.loads(state_file.read_text())
+    posted = raw.get("posted", {})
+    if isinstance(posted, dict):
+        return {int(k): v for k, v in posted.items()}
+    # Legacy format: a bare list of ids with no timestamps.
+    return {int(rid): "" for rid in raw.get("posted_run_ids", [])}
+
+
+def prune_posted(posted: dict[int, str], now: datetime) -> dict[int, str]:
+    """Drop entries older than the retention window (undated entries are kept once)."""
+    horizon = now - timedelta(hours=STATE_RETENTION_HOURS)
+    kept: dict[int, str] = {}
+    for run_id, created_at in posted.items():
+        if not created_at:
+            kept[run_id] = now.isoformat()
+            continue
+        try:
+            created = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        except ValueError:
+            kept[run_id] = now.isoformat()
+            continue
+        if created >= horizon:
+            kept[run_id] = created_at
+    return kept
+
+
+def build_enrichment_jobs(selected: list[RunRecord], limit: int = 8) -> list[dict[str, str]]:
+    """Flatten failed targets into enrichment jobs, capped globally at ``limit``.
+
+    The cap bounds log volume and Claude cost; ``selected`` is severity-sorted so
+    the budget is spent on the most severe runs first.
+    """
+    jobs: list[dict[str, str]] = []
+    for record in selected:
+        for target in record["failed_targets"]:
+            jobs.append({"run_id": str(record["run_id"]), **target})
+    return jobs[:limit]
 
 
 def write_outputs(should_alert: bool, severity: str, run_count: int) -> None:
@@ -212,39 +282,28 @@ def main() -> int:
     lookback = (
         timedelta(minutes=int(env("LOOKBACK_MINUTES", "45")))
         if mode == "realtime"
-        else timedelta(hours=int(env("LOOKBACK_HOURS", "12")))
+        else timedelta(hours=int(env("LOOKBACK_HOURS", "18")))
     )
-    cutoff = datetime.now(timezone.utc) - lookback
+    now = datetime.now(timezone.utc)
+    cutoff = now - lookback
 
-    posted: set[int] = set()
-    if state_file.exists():
-        posted = set(json.loads(state_file.read_text()).get("posted_run_ids", []))
-
+    posted = load_posted_state(state_file)
     target_map = parse_target_map(repo_root)
-    records = [build_run_record(r, token, repo, target_map, storm_threshold) for r in candidate_runs(token, repo, cutoff, explicit_ids)]
+    records = [
+        build_run_record(r, token, repo, target_map, storm_threshold)
+        for r in candidate_runs(token, repo, cutoff, explicit_ids)
+    ]
 
-    fresh = [r for r in records if r["run_id"] not in posted]
-    if mode == "realtime":
-        selected = [r for r in fresh if r["severity"] == Severity.HIGH]
-    else:
-        selected = [r for r in fresh if r["severity"] in (Severity.HIGH, Severity.NORMAL)]
-
-    non_test_count = sum(1 for r in fresh if r["severity"] == Severity.NONE)
-    overall = Severity.HIGH if any(r["severity"] == Severity.HIGH for r in selected) else (
-        Severity.NORMAL if selected else Severity.NONE
-    )
-
-    enrichment_jobs: list[dict[str, str]] = []
-    for record in selected:
-        for target in record["failed_targets"][:8]:
-            enrichment_jobs.append({"run_id": str(record["run_id"]), **target})
+    selected = select_runs(records, mode, posted)
+    non_test_count = sum(1 for r in records if r["run_id"] not in posted and r["severity"] == Severity.NONE)
+    overall = overall_severity(selected)
 
     output = {
         "mode": mode,
         "severity": overall,
         "runs": selected,
         "non_test_failure_count": non_test_count,
-        "enrichment_jobs": enrichment_jobs[:8],
+        "enrichment_jobs": build_enrichment_jobs(selected),
         "dashboard_url": env(
             "DASHBOARD_URL",
             "https://app-dev-prod.datadoghq.com/dashboard/knc-6sp-caq/agent-integrations-overview",
@@ -254,8 +313,10 @@ def main() -> int:
 
     should_alert = bool(selected)
     if should_alert and not explicit_ids:
-        posted.update(r["run_id"] for r in selected)
-        state_file.write_text(json.dumps({"posted_run_ids": sorted(posted)}))
+        for record in selected:
+            posted[record["run_id"]] = record["created_at"] or now.isoformat()
+        posted = prune_posted(posted, now)
+        state_file.write_text(json.dumps({"posted": {str(k): v for k, v in posted.items()}}))
 
     write_outputs(should_alert, overall, len(selected))
     print(json.dumps(output, indent=2))

--- a/.github/workflows/scripts/ci_master_triage/enrich.py
+++ b/.github/workflows/scripts/ci_master_triage/enrich.py
@@ -13,20 +13,17 @@ to an empty mapping so the Slack alert is still posted (with links only).
 from __future__ import annotations
 
 import json
-import os
 import re
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
+from common import env
+
 MODEL = "claude-opus-4-8"
 MAX_TOKENS = 8000
 MAX_LOG_LINES = 200
-
-
-def env(name: str, default: str = "") -> str:
-    return os.environ.get(name, default).strip()
 
 
 def fetch_failed_log(repo: str, gh_job_id: str) -> str:
@@ -42,7 +39,10 @@ def fetch_failed_log(repo: str, gh_job_id: str) -> str:
         )
     except (subprocess.SubprocessError, OSError) as exc:
         return f"(log fetch failed: {exc})"
-    output = proc.stdout or proc.stderr or "(no output)"
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or "no stderr"
+        return f"(gh exit {proc.returncode}: {detail})"
+    output = proc.stdout or "(no output)"
     lines = output.splitlines()
     return "\n".join(lines[-MAX_LOG_LINES:])
 
@@ -89,13 +89,16 @@ def parse_enrichment(text: str) -> dict[str, str]:
     """Pull a ``{run_id: note}`` object out of the model response."""
     if not text:
         return {}
-    match = re.search(r"\{.*\}", text, re.DOTALL)
-    if not match:
-        return {}
+    parsed: Any = None
     try:
-        parsed = json.loads(match.group(0))
+        parsed = json.loads(text)
     except json.JSONDecodeError:
-        return {}
+        match = re.search(r"\{.*?\}", text, re.DOTALL)
+        if match:
+            try:
+                parsed = json.loads(match.group(0))
+            except json.JSONDecodeError:
+                return {}
     return {str(k): str(v) for k, v in parsed.items()} if isinstance(parsed, dict) else {}
 
 

--- a/.github/workflows/scripts/ci_master_triage/enrich.py
+++ b/.github/workflows/scripts/ci_master_triage/enrich.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Best-effort root-cause enrichment for the master CI triage alert.
+
+Reads ``triage_output.json`` (produced by ``detect.py``), fetches the
+failed-step logs for each enrichment job via ``gh``, asks Claude for a one-line
+root cause per run, and writes ``{run_id: note}`` to ``ENRICHMENT_FILE``.
+
+This step is optional and gated by ``detect.py``: it only runs when there is
+something to alert on and ``ANTHROPIC_API_KEY`` is present. Any failure degrades
+to an empty mapping so the Slack alert is still posted (with links only).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+MODEL = "claude-opus-4-8"
+MAX_TOKENS = 8000
+MAX_LOG_LINES = 200
+
+
+def env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def fetch_failed_log(repo: str, gh_job_id: str) -> str:
+    """Return the failed-step logs for a single job, trimmed to the tail."""
+    if not gh_job_id:
+        return "(no job id)"
+    try:
+        proc = subprocess.run(
+            ["gh", "run", "view", "--repo", repo, "--job", gh_job_id, "--log-failed"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        return f"(log fetch failed: {exc})"
+    output = proc.stdout or proc.stderr or "(no output)"
+    lines = output.splitlines()
+    return "\n".join(lines[-MAX_LOG_LINES:])
+
+
+def build_logs_section(repo: str, jobs: list[dict[str, str]]) -> str:
+    """Assemble the ``{{LOGS}}`` body: one delimited block per enrichment job."""
+    blocks: list[str] = []
+    for job in jobs:
+        header = f"### RUN {job.get('run_id', '?')} · TARGET {job.get('target', '?')}"
+        blocks.append(f"{header}\n{fetch_failed_log(repo, job.get('gh_job_id', ''))}")
+    return "\n\n".join(blocks)
+
+
+def render_prompt(prompt_file: Path, logs: str) -> str:
+    template = prompt_file.read_text()
+    return template.replace("{{LOGS}}", logs)
+
+
+def call_claude(prompt: str) -> str:
+    """Return Claude's text response, or empty string on a handled API error."""
+    from anthropic import Anthropic, APIConnectionError, APIStatusError
+
+    client = Anthropic()
+    try:
+        resp = client.messages.create(
+            model=MODEL,
+            max_tokens=MAX_TOKENS,
+            thinking={"type": "adaptive"},
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except APIStatusError as exc:
+        print(f"Anthropic API error ({exc.status_code}); skipping enrichment.", file=sys.stderr)
+        return ""
+    except APIConnectionError as exc:
+        print(f"Anthropic connection error ({exc}); skipping enrichment.", file=sys.stderr)
+        return ""
+    if resp.stop_reason == "refusal":
+        print("Request refused; skipping enrichment.", file=sys.stderr)
+        return ""
+    return "".join(block.text for block in resp.content if block.type == "text")
+
+
+def parse_enrichment(text: str) -> dict[str, str]:
+    """Pull a ``{run_id: note}`` object out of the model response."""
+    if not text:
+        return {}
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        return {}
+    try:
+        parsed = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return {}
+    return {str(k): str(v) for k, v in parsed.items()} if isinstance(parsed, dict) else {}
+
+
+def main() -> int:
+    out_path = Path(env("ENRICHMENT_FILE", "enrichment.json"))
+    out_path.write_text("{}")  # ensure the file exists even if we bail early
+
+    data = json.loads(Path(env("TRIAGE_OUTPUT", "triage_output.json")).read_text())
+    jobs: list[dict[str, str]] = data.get("enrichment_jobs", [])
+    if not jobs:
+        print("No enrichment jobs; wrote empty mapping.")
+        return 0
+
+    repo = env("GITHUB_REPOSITORY", "DataDog/integrations-core")
+    prompt_file = Path(env("PROMPT_FILE", str(Path(__file__).parent / "enrich_prompt.md")))
+
+    logs = build_logs_section(repo, jobs)
+    text = call_claude(render_prompt(prompt_file, logs))
+    enrichment = parse_enrichment(text)
+
+    out_path.write_text(json.dumps(enrichment, indent=2))
+    print(f"Wrote {len(enrichment)} enrichment note(s) to {out_path}.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # noqa: BLE001 - enrichment must never block the alert
+        print(f"Enrichment failed ({exc}); continuing without it.", file=sys.stderr)
+        Path(env("ENRICHMENT_FILE", "enrichment.json")).write_text("{}")
+        sys.exit(0)

--- a/.github/workflows/scripts/ci_master_triage/enrich.py
+++ b/.github/workflows/scripts/ci_master_triage/enrich.py
@@ -17,9 +17,8 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
 
-from common import env
+from common import TriageOutput, env
 
 MODEL = "claude-opus-4-8"
 MAX_TOKENS = 8000
@@ -89,24 +88,26 @@ def parse_enrichment(text: str) -> dict[str, str]:
     """Pull a ``{run_id: note}`` object out of the model response."""
     if not text:
         return {}
-    parsed: Any = None
     try:
         parsed = json.loads(text)
     except json.JSONDecodeError:
         match = re.search(r"\{.*?\}", text, re.DOTALL)
-        if match:
-            try:
-                parsed = json.loads(match.group(0))
-            except json.JSONDecodeError:
-                return {}
-    return {str(k): str(v) for k, v in parsed.items()} if isinstance(parsed, dict) else {}
+        if not match:
+            return {}
+        try:
+            parsed = json.loads(match.group(0))
+        except json.JSONDecodeError:
+            return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(k): str(v) for k, v in parsed.items()}
 
 
 def main() -> int:
     out_path = Path(env("ENRICHMENT_FILE", "enrichment.json"))
     out_path.write_text("{}")  # ensure the file exists even if we bail early
 
-    data = json.loads(Path(env("TRIAGE_OUTPUT", "triage_output.json")).read_text())
+    data: TriageOutput = json.loads(Path(env("TRIAGE_OUTPUT", "triage_output.json")).read_text())
     jobs: list[dict[str, str]] = data.get("enrichment_jobs", [])
     if not jobs:
         print("No enrichment jobs; wrote empty mapping.")

--- a/.github/workflows/scripts/ci_master_triage/enrich_prompt.md
+++ b/.github/workflows/scripts/ci_master_triage/enrich_prompt.md
@@ -1,0 +1,31 @@
+# Master CI failure triage
+
+You are triaging failed jobs from the integrations-core master CI test matrix.
+Below are the failed-step logs, grouped by run and by target. Each block is
+delimited by a line of the form `### RUN <run_id> · TARGET <target>`.
+
+For every distinct `run_id`, write a single concise root-cause line that:
+
+- names the probable cause (e.g. assertion failure, import error, container
+  failed to start, dependency/version mismatch, timeout, runner/network issue);
+- states whether it looks like a **real regression** or a **likely flake/infra**
+  issue, based on the log signature (timeouts, connection resets, image pulls,
+  and runner errors lean flake/infra; assertion and traceback errors in test
+  code lean real);
+- stays under ~240 characters and references the target(s) when useful.
+
+Do not speculate beyond the logs. If a run's logs are empty or inconclusive,
+say so plainly.
+
+## Output format
+
+Return **only** a single JSON object mapping each `run_id` (as a string) to its
+root-cause line. No prose, no code fences. Example:
+
+```
+{"28380428073": "ClickHouse: assertion on metric count — likely real regression. SNMP: container failed to start — likely infra/flake."}
+```
+
+## Logs
+
+{{LOGS}}

--- a/.github/workflows/scripts/ci_master_triage/enrich_prompt.md
+++ b/.github/workflows/scripts/ci_master_triage/enrich_prompt.md
@@ -6,7 +6,7 @@ delimited by a line of the form `### RUN <run_id> · TARGET <target>`.
 
 For every distinct `run_id`, write a single concise root-cause line that:
 
-- names the probable cause (e.g. assertion failure, import error, container
+- names the probable cause (e.g., assertion failure, import error, container
   failed to start, dependency/version mismatch, timeout, runner/network issue);
 - states whether it looks like a **real regression** or a **likely flake/infra**
   issue, based on the log signature (timeouts, connection resets, image pulls,

--- a/.github/workflows/scripts/ci_master_triage/notify.py
+++ b/.github/workflows/scripts/ci_master_triage/notify.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Format and post a Slack alert from ``triage_output.json``.
+
+Real-time alerts (HIGH severity) lead with the breakage; digests summarize all
+new failed runs since the last digest. Optional root-cause enrichment is read
+from ``ENRICHMENT_FILE`` when present. Set ``DRY_RUN=1`` to print the payload
+without posting (used by the verification step).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+POST_URL = "https://slack.com/api/chat.postMessage"
+MAX_RUNS_SHOWN = 15
+MAX_TARGETS_PER_RUN = 20
+
+
+def env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def target_line(targets: list[dict[str, str]]) -> str:
+    """Render failed targets as linked job-names, capped for readability."""
+    shown = targets[:MAX_TARGETS_PER_RUN]
+    links = [f"<{t['url']}|{t['job_name']}>" for t in shown]
+    extra = len(targets) - len(shown)
+    if extra > 0:
+        links.append(f"_+{extra} more_")
+    return ", ".join(links)
+
+
+def run_block(run: dict[str, Any], enrichment: dict[str, str]) -> dict[str, Any]:
+    """One Slack section block summarizing a single broken run."""
+    header = (
+        f"*<{run['url']}|{run['workflow']}>* · `{run['short_sha']}` · "
+        f"{run['failed_count']} target(s) failing · _{run['actor']}_"
+    )
+    lines = [header, f">{run['title']}", target_line(run["failed_targets"])]
+    note = enrichment.get(str(run["run_id"]))
+    if note:
+        lines.append(f":mag: {note}")
+    return {"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(lines)}}
+
+
+def build_blocks(data: dict[str, Any], enrichment: dict[str, str]) -> list[dict[str, Any]]:
+    runs = data["runs"]
+    realtime = data["mode"] == "realtime"
+    if realtime:
+        title = f":rotating_light: Master CI broken ({data['severity']}) — {len(runs)} run(s)"
+    else:
+        title = f":bar_chart: Master CI digest — {len(runs)} new broken run(s)"
+
+    blocks: list[dict[str, Any]] = [
+        {"type": "header", "text": {"type": "plain_text", "text": title[:150], "emoji": True}}
+    ]
+    for run in runs[:MAX_RUNS_SHOWN]:
+        blocks.append(run_block(run, enrichment))
+
+    if len(runs) > MAX_RUNS_SHOWN:
+        blocks.append(
+            {"type": "context", "elements": [{"type": "mrkdwn", "text": f"_…and {len(runs) - MAX_RUNS_SHOWN} more run(s)._"}]}
+        )
+
+    footer = [f"<{data['dashboard_url']}|CI Overview dashboard>"]
+    if data.get("non_test_failure_count"):
+        footer.append(f"{data['non_test_failure_count']} failed run(s) had no failing tests (infra / re-run).")
+    blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": " · ".join(footer)}]})
+    return blocks
+
+
+def fallback_text(data: dict[str, Any]) -> str:
+    return f"Master CI {data['mode']} — {len(data['runs'])} broken run(s) ({data['severity']})"
+
+
+def post(channel: str, token: str, blocks: list[dict[str, Any]], text: str) -> None:
+    body = json.dumps({"channel": channel, "blocks": blocks, "text": text}).encode()
+    req = urllib.request.Request(
+        POST_URL,
+        data=body,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json; charset=utf-8"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        result = json.loads(resp.read().decode())
+    if not result.get("ok"):
+        raise SystemExit(f"Slack API error: {result.get('error')}")
+    print(f"Posted to {channel} (ts={result.get('ts')})")
+
+
+def main() -> int:
+    data = json.loads(Path(env("TRIAGE_OUTPUT", "triage_output.json")).read_text())
+    if not data.get("runs"):
+        print("No runs to report; nothing posted.")
+        return 0
+
+    enrichment: dict[str, str] = {}
+    enrichment_file = env("ENRICHMENT_FILE")
+    if enrichment_file and Path(enrichment_file).exists():
+        try:
+            enrichment = json.loads(Path(enrichment_file).read_text())
+        except json.JSONDecodeError:
+            print("Enrichment file is not valid JSON; posting without it.", file=sys.stderr)
+
+    blocks = build_blocks(data, enrichment)
+    text = fallback_text(data)
+
+    if env("DRY_RUN"):
+        print(json.dumps({"text": text, "blocks": blocks}, indent=2))
+        return 0
+
+    token = env("SLACK_API_TOKEN")
+    channel = env("SLACK_CHANNEL_ID", "C026U34QMLL")
+    if not token:
+        print("SLACK_API_TOKEN is required to post", file=sys.stderr)
+        return 1
+    post(channel, token, blocks, text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/scripts/ci_master_triage/notify.py
+++ b/.github/workflows/scripts/ci_master_triage/notify.py
@@ -15,7 +15,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
-from common import env
+from common import FailedTarget, RunRecord, TriageOutput, env
 
 POST_URL = "https://slack.com/api/chat.postMessage"
 MAX_RUNS_SHOWN = 15
@@ -23,7 +23,7 @@ MAX_TARGETS_PER_RUN = 20
 REQUEST_TIMEOUT = 30
 
 
-def target_line(targets: list[dict[str, Any]]) -> str:
+def target_line(targets: list[FailedTarget]) -> str:
     """Render failed targets as linked job-names, capped for readability."""
     shown = targets[:MAX_TARGETS_PER_RUN]
     links = []
@@ -38,7 +38,7 @@ def target_line(targets: list[dict[str, Any]]) -> str:
     return ", ".join(links)
 
 
-def run_block(run: dict[str, Any], enrichment: dict[str, str]) -> dict[str, Any]:
+def run_block(run: RunRecord, enrichment: dict[str, str]) -> dict[str, Any]:
     """One Slack section block summarizing a single broken run."""
     header = (
         f"*<{run['url']}|{run['workflow']}>* · `{run['short_sha']}` · "
@@ -51,7 +51,7 @@ def run_block(run: dict[str, Any], enrichment: dict[str, str]) -> dict[str, Any]
     return {"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(lines)}}
 
 
-def build_blocks(data: dict[str, Any], enrichment: dict[str, str]) -> list[dict[str, Any]]:
+def build_blocks(data: TriageOutput, enrichment: dict[str, str]) -> list[dict[str, Any]]:
     runs = data["runs"]
     realtime = data["mode"] == "realtime"
     if realtime:
@@ -77,7 +77,7 @@ def build_blocks(data: dict[str, Any], enrichment: dict[str, str]) -> list[dict[
     return blocks
 
 
-def fallback_text(data: dict[str, Any]) -> str:
+def fallback_text(data: TriageOutput) -> str:
     return f"Master CI {data['mode']} — {len(data['runs'])} broken run(s) ({data['severity']})"
 
 

--- a/.github/workflows/scripts/ci_master_triage/notify.py
+++ b/.github/workflows/scripts/ci_master_triage/notify.py
@@ -10,25 +10,28 @@ without posting (used by the verification step).
 from __future__ import annotations
 
 import json
-import os
 import sys
 import urllib.request
 from pathlib import Path
 from typing import Any
 
+from common import env
+
 POST_URL = "https://slack.com/api/chat.postMessage"
 MAX_RUNS_SHOWN = 15
 MAX_TARGETS_PER_RUN = 20
+REQUEST_TIMEOUT = 30
 
 
-def env(name: str, default: str = "") -> str:
-    return os.environ.get(name, default).strip()
-
-
-def target_line(targets: list[dict[str, str]]) -> str:
+def target_line(targets: list[dict[str, Any]]) -> str:
     """Render failed targets as linked job-names, capped for readability."""
     shown = targets[:MAX_TARGETS_PER_RUN]
-    links = [f"<{t['url']}|{t['job_name']}>" for t in shown]
+    links = []
+    for t in shown:
+        link = f"<{t['url']}|{t['job_name']}>"
+        if t.get("leg_count", 1) > 1:
+            link += f" _×{t['leg_count']}_"
+        links.append(link)
     extra = len(targets) - len(shown)
     if extra > 0:
         links.append(f"_+{extra} more_")
@@ -86,10 +89,10 @@ def post(channel: str, token: str, blocks: list[dict[str, Any]], text: str) -> N
         headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json; charset=utf-8"},
         method="POST",
     )
-    with urllib.request.urlopen(req) as resp:
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
         result = json.loads(resp.read().decode())
     if not result.get("ok"):
-        raise SystemExit(f"Slack API error: {result.get('error')}")
+        raise RuntimeError(f"Slack API error: {result}")
     print(f"Posted to {channel} (ts={result.get('ts')})")
 
 
@@ -119,7 +122,11 @@ def main() -> int:
     if not token:
         print("SLACK_API_TOKEN is required to post", file=sys.stderr)
         return 1
-    post(channel, token, blocks, text)
+    try:
+        post(channel, token, blocks, text)
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
+        return 1
     return 0
 
 


### PR DESCRIPTION
### What does this PR do?

Adds a scheduled GitHub Actions workflow that detects failing `Master` / `Master Windows` test-matrix runs, groups failures by run so one root cause produces one alert, optionally attaches a Claude root-cause line, and posts to `#agent-integrations-ops`. It is gated behind the `CI_TRIAGE_ENABLED` repo variable, so merging is a no-op until the variable is set.

### Motivation

Master test-matrix failures have no automated alert today — the on-call finds them by watching a dashboard. This pushes grouped, severity-classified breakages to the team instead of relying on polling.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e) — N/A, `.github/` dev tooling with no agent-shipped code
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required. → `qa/skip-qa`
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

---

_This PR has been created and validated using the paired-review skill from agent-integrations. **Ready for human review**._
