### PR TITLE
[bentoml] strengthen tests to lift mutation score

### DIFF
--- a/bentoml/tests/test_unit.py
+++ b/bentoml/tests/test_unit.py
@@ -15,6 +15,8 @@ from .common import (
     get_fixture_path,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def test_bentoml_mock_metrics(dd_run_check, aggregator, mock_http_response):
     mock_http_response(file_path=get_fixture_path('metrics.txt'))
@@ -62,3 +64,28 @@ def test_bentoml_mock_valid_endpoint_invalid_health(dd_run_check, aggregator, mo
         aggregator.assert_metric(metric, value=0, tags=['test:tag', 'status_code:500'])
 
     aggregator.assert_service_check('bentoml.openmetrics.health', ServiceCheck.OK)
+
+
+def test_default_metric_limit_is_zero():
+    # Kills the core/NumberReplacer mutant at check.py:12 (DEFAULT_METRIC_LIMIT 0 -> -1).
+    assert BentomlCheck.DEFAULT_METRIC_LIMIT == 0
+
+
+def test_extract_base_url_strips_only_the_last_path_segment():
+    # Kills the core/AddNot and core/NumberReplacer mutants at check.py:23: with a nested
+    # path, rsplit('/', 1) must drop exactly the last segment, not zero or two segments.
+    instance = {'openmetrics_endpoint': 'http://bentoml:3000/api/metrics', 'tags': ['test:tag']}
+    check = BentomlCheck('bentoml', {}, [instance])
+    assert check.base_url == 'http://bentoml:3000/api'
+
+
+def test_check_health_endpoint_handles_exception_without_response_attribute(aggregator, mocker):
+    # Kills the core/ReplaceAndWithOr mutant at check.py:50: an exception without a
+    # `.response` attribute must short-circuit instead of raising AttributeError.
+    check = BentomlCheck('bentoml', {}, [OM_MOCKED_INSTANCE])
+    mocker.patch('datadog_checks.base.utils.http.RequestsWrapper.get', side_effect=ValueError('boom'))
+
+    check.check_health_endpoint()
+
+    for metric in ENDPOINT_METRICS:
+        aggregator.assert_metric(metric, value=0, tags=['test:tag'])


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `bentoml` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `bentoml` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch

[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ