### PR TITLE
[traefik_mesh] strengthen tests to lift mutation score

### DIFF
--- a/traefik_mesh/tests/test_unit.py
+++ b/traefik_mesh/tests/test_unit.py
@@ -1,8 +1,11 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+
 import mock
 import pytest
+import requests
 
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.utils import assert_service_checks, get_metadata_metrics
@@ -18,6 +21,8 @@ from .common import (
     get_fixture_path,
     read_json_fixture,
 )
+
+pytestmark = pytest.mark.unit
 
 
 def test_check_mock_traefik_mesh_openmetrics(dd_run_check, aggregator, mock_http_response):
@@ -156,3 +161,78 @@ def test_submit_version(datadog_agent, dd_run_check, mock_http_response):
     }
 
     datadog_agent.assert_metadata('test:123', version_metadata)
+
+
+def test_default_metric_limit_is_zero():
+    # Kills the core/NumberReplacer mutant at check.py:20 (DEFAULT_METRIC_LIMIT 0 -> -1).
+    assert TraefikMeshCheck.DEFAULT_METRIC_LIMIT == 0
+
+
+def test_submit_mesh_ready_status_true_string_reports_one(aggregator):
+    # Kills the core/ReplaceComparisonOperator_Eq_Is mutant at check.py:72 (status == 'true' -> status is 'true'):
+    # json.loads produces a fresh, non-interned string so an `is` comparison would not match, and also kills
+    # the core/NumberReplacer mutants that change the true-case gauge value from 1 to 2 or to 0.
+    check = TraefikMeshCheck('traefik_mesh', {}, [OM_MOCKED_INSTANCE])
+    nodes = json.loads('[{"Name": "node-a", "IP": "10.0.0.1", "Ready": "true"}]')
+
+    check.submit_mesh_ready_status(nodes)
+
+    aggregator.assert_metric('traefik_mesh.node.ready', value=1, count=1)
+
+
+def test_submit_mesh_ready_status_non_true_reports_zero(aggregator):
+    # Complements the above so the true/false branches of `1 if status == 'true' else 0` are both covered.
+    check = TraefikMeshCheck('traefik_mesh', {}, [OM_MOCKED_INSTANCE])
+    nodes = json.loads('[{"Name": "node-a", "IP": "10.0.0.1", "Ready": "false"}]')
+
+    check.submit_mesh_ready_status(nodes)
+
+    aggregator.assert_metric('traefik_mesh.node.ready', value=0, count=1)
+
+
+def test_get_mesh_ready_status_returns_none_for_empty_status(mock_http_response):
+    # Kills the core/ReplaceUnaryOperator_Delete_Not and core/AddNot mutants at check.py:79: both collapse
+    # `if not node_status:` to a check equivalent to `if node_status:`, which would return the falsy `[]`
+    # unchanged instead of the explicit `None`.
+    mock_http_response(json_data=[])
+    check = TraefikMeshCheck('traefik_mesh', {}, [OM_MOCKED_INSTANCE_CONTROLLER])
+
+    assert check.get_mesh_ready_status() is None
+
+
+def test_metadata_entrypoint_skips_submit_version_when_disabled(
+    datadog_agent, dd_run_check, mock_http_response_per_endpoint
+):
+    # Kills the core/RemoveDecorator mutant at check.py:99 (removing @AgentCheck.metadata_entrypoint from
+    # _submit_version): without the decorator, version metadata would still be submitted while disabled, even
+    # though `get_version()` here is wired to succeed (unlike OM_MOCKED_INSTANCE, which has no version endpoint
+    # and would report zero metadata either way).
+    from datadog_checks.dev.http import MockResponse
+
+    instance = {
+        'openmetrics_endpoint': 'http://localhost:8080/metrics',
+        'traefik_proxy_api_endpoint': 'http://localhost:8080',
+        'tags': ['test:traefik_mesh'],
+    }
+    check = TraefikMeshCheck('traefik_mesh', {}, [instance])
+    check.check_id = 'test:123'
+    datadog_agent._config['enable_metadata_collection'] = False
+
+    mock_http_response_per_endpoint(
+        {
+            'http://localhost:8080/metrics': [MockResponse(file_path=get_fixture_path('traefik_proxy.txt'))],
+            'http://localhost:8080/api/version': [MockResponse(file_path=get_fixture_path('mesh_proxy_version.json'))],
+        }
+    )
+    dd_run_check(check)
+
+    datadog_agent.assert_metadata_count(0)
+
+
+def test_get_json_timeout_is_handled(mocker):
+    # Kills the core/ExceptionReplacer mutant at check.py:119 (requests.exceptions.Timeout -> an undefined
+    # exception name): the broken except clause raises NameError instead of returning None gracefully.
+    mocker.patch('requests.Session.get', side_effect=requests.exceptions.Timeout)
+    check = TraefikMeshCheck('traefik_mesh', {}, [OM_MOCKED_INSTANCE])
+
+    assert check._get_json('http://localhost:8080/some-endpoint') is None


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `traefik_mesh` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `traefik_mesh` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch

[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ