### PR TITLE
[vllm] strengthen tests to lift mutation score

### DIFF
--- a/vllm/tests/test_unit.py
+++ b/vllm/tests/test_unit.py
@@ -13,6 +13,13 @@ from datadog_checks.vllm import vLLMCheck
 
 from .common import METRICS_MOCK, get_fixture_path
 
+pytestmark = pytest.mark.unit
+
+
+def test_default_metric_limit_is_zero():
+    # Kills the core/NumberReplacer mutant at check.py:10 (DEFAULT_METRIC_LIMIT 0 -> -1).
+    assert vLLMCheck.DEFAULT_METRIC_LIMIT == 0
+
 
 def test_check_vllm(dd_run_check, aggregator, datadog_agent, instance):
     check = vLLMCheck("vLLM", {}, [instance])
@@ -71,6 +78,53 @@ def _get_version_metadata(raw_version):
         "version.patch": patch,
         "version.raw": raw_version,
     }
+
+
+def test_submit_version_metadata_skipped_when_metadata_collection_disabled(datadog_agent, mock_http_response, instance):
+    # Kills the core/RemoveDecorator mutant at check.py:23 (removing @AgentCheck.metadata_entrypoint would run
+    # version submission even though metadata collection is disabled).
+    datadog_agent._config['enable_metadata_collection'] = False
+    mock_http_response(json_data={"version": "1.2.3"})
+    check = vLLMCheck("vLLM", {}, [instance])
+    check.check_id = "test:123"
+
+    check._submit_version_metadata()
+
+    datadog_agent.assert_metadata_count(0)
+
+
+def test_submit_version_metadata_with_too_few_parts_is_ignored(datadog_agent, mock_http_response, instance):
+    # Kills the core/ReplaceComparisonOperator_GtE_LtE and core/NumberReplacer(3->2) mutants at check.py:32
+    # (`len(version_split) >= 3` mutated to `<= 3` or `>= 2`), which would index a non-existent third
+    # version part for a 2-part version and either raise or submit bogus metadata.
+    mock_http_response(json_data={"version": "1.2"})
+    check = vLLMCheck("vLLM", {}, [instance])
+    check.check_id = "test:123"
+
+    check._submit_version_metadata()
+
+    datadog_agent.assert_metadata_count(0)
+
+
+def test_submit_version_metadata_with_extra_parts_uses_first_three(datadog_agent, mock_http_response, instance):
+    # Kills the core/ReplaceComparisonOperator_GtE_Eq mutant at check.py:32 (`len(version_split) >= 3` mutated to
+    # `== 3`), which would skip metadata submission for a version with more than 3 dot-separated parts.
+    mock_http_response(json_data={"version": "1.2.3.4"})
+    check = vLLMCheck("vLLM", {}, [instance])
+    check.check_id = "test:123"
+
+    check._submit_version_metadata()
+
+    datadog_agent.assert_metadata(
+        "test:123",
+        {
+            "version.scheme": "semver",
+            "version.major": "1",
+            "version.minor": "2",
+            "version.patch": "3",
+            "version.raw": "1.2.3",
+        },
+    )
 
 
 def test_emits_critical_openemtrics_service_check_when_service_is_down(


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `vllm` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `vllm` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch

[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ