### PR TITLE
[boundary] strengthen tests to lift mutation score

### DIFF
--- a/boundary/tests/test_unit.py
+++ b/boundary/tests/test_unit.py
@@ -4,10 +4,16 @@
 import pytest
 
 from datadog_checks.base.constants import ServiceCheck
+from datadog_checks.boundary import BoundaryCheck
 
 from .common import HEALTH_ENDPOINT, METRIC_ENDPOINT
 
 pytestmark = [pytest.mark.unit]
+
+
+def test_default_metric_limit_is_zero():
+    # Kills the core/NumberReplacer mutants at check.py:14 (DEFAULT_METRIC_LIMIT 0 -> 1 and 0 -> -1).
+    assert BoundaryCheck.DEFAULT_METRIC_LIMIT == 0
 
 
 def test_without_extra_tags(aggregator, dd_run_check, get_check, instance, mock_http_response):
@@ -52,4 +58,30 @@ def test_health_warning(aggregator, dd_run_check, get_check, instance, mock_http
 
     aggregator.assert_service_check(
         'boundary.openmetrics.health', ServiceCheck.CRITICAL, tags=[f'endpoint:{METRIC_ENDPOINT}', *instance['tags']]
+    )
+
+
+def test_health_critical_for_non_503_error_status(aggregator, dd_run_check, get_check, instance, mock_http_response):
+    # Kills the core/ReplaceComparisonOperator_Eq_GtE mutant at check.py:27 (status_code == 503 -> >= 503).
+    mock_http_response(status_code=504)
+
+    check = get_check(instance)
+    with pytest.raises(Exception):
+        dd_run_check(check)
+
+    aggregator.assert_service_check(
+        'boundary.controller.health', ServiceCheck.CRITICAL, tags=[f'endpoint:{HEALTH_ENDPOINT}', *instance['tags']]
+    )
+
+
+def test_health_endpoint_connection_error(aggregator, dd_run_check, get_check, instance, mocker):
+    # Kills the core/ExceptionReplacer mutant at check.py:21 (except Exception -> except CosmicRayTestingException).
+    mocker.patch('requests.Session.get', side_effect=Exception('connection refused'))
+
+    check = get_check(instance)
+    with pytest.raises(Exception):
+        dd_run_check(check)
+
+    aggregator.assert_service_check(
+        'boundary.controller.health', ServiceCheck.CRITICAL, tags=[f'endpoint:{HEALTH_ENDPOINT}', *instance['tags']]
     )


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `boundary` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `boundary` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch

[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INTS-1355]: https://datadoghq.atlassian.net/browse/INTS-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ