### PR TITLE
Add azure.resource_id to sqlserver, postgres and mysql for Azure log correlation

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -855,6 +855,19 @@ files:
                   type: string
                   example: mysql-database.database.windows.net
                 fleet_configurable: false
+              - name: resource_id
+                description: |
+                  The full Azure Resource Manager (ARM) resource ID of this MySQL server, for example
+                  /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.DBforMySQL/flexibleServers/<server>.
+
+                  Set this when the automatic mapping from the fully qualified domain name to the Azure
+                  resource cannot be made (for example, proxy connections, a custom `reported_hostname`, or
+                  when the Azure resource is not crawled), so that DBM can correlate Azure resource logs to
+                  this database instance.
+                value:
+                  type: string
+                  example: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.DBforMySQL/flexibleServers/my-server
+                fleet_configurable: false
 
           - name: obfuscator_options
             display_priority: 0

--- a/mysql/changelog.d/24428.added
+++ b/mysql/changelog.d/24428.added
@@ -1,0 +1,1 @@
+Add the `azure.resource_id` option to declare the Azure Resource Manager resource ID used to correlate Azure MySQL resource logs in DBM.

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -49,6 +49,7 @@ class Azure(BaseModel):
     )
     deployment_type: Optional[str] = None
     fully_qualified_domain_name: Optional[str] = None
+    resource_id: Optional[str] = None
 
 
 class CollectSchemas(BaseModel):

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -616,6 +616,17 @@ instances:
         #
         # fully_qualified_domain_name: mysql-database.database.windows.net
 
+        ## @param resource_id - string - optional - default: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.DBforMySQL/flexibleServers/my-server
+        ## The full Azure Resource Manager (ARM) resource ID of this MySQL server, for example
+        ## /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.DBforMySQL/flexibleServers/<server>.
+        ##
+        ## Set this when the automatic mapping from the fully qualified domain name to the Azure
+        ## resource cannot be made (for example, proxy connections, a custom `reported_hostname`, or
+        ## when the Azure resource is not crawled), so that DBM can correlate Azure resource logs to
+        ## this database instance.
+        #
+        # resource_id: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.DBforMySQL/flexibleServers/my-server
+
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.
     #

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -275,15 +275,16 @@ class MySql(DatabaseCheck):
                 "instance_endpoint": self.resolved_hostname,
             }
         if self.cloud_metadata.get("azure") is not None:
-            deployment_type = self.cloud_metadata.get("azure")["deployment_type"]
+            azure = self.cloud_metadata.get("azure")
+            deployment_type = azure.get("deployment_type")
             # some `deployment_type`s map to multiple `resource_type`s
             resource_type = AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPE.get(deployment_type)
             if resource_type:
                 self.tag_manager.set_tag(
                     "dd.internal.resource",
-                    "{}:{}".format(resource_type, self.cloud_metadata.get("azure")["name"]),
+                    "{}:{}".format(resource_type, azure.get("name")),
                 )
-            resource_id = self.cloud_metadata.get("azure").get("resource_id")
+            resource_id = azure.get("resource_id")
             if resource_id:
                 # Emitted as a regular tag (not a dd.internal.resource) so it survives to the
                 # database_instance metadata and lets DBM correlate Azure resource logs when the

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -283,6 +283,12 @@ class MySql(DatabaseCheck):
                     "dd.internal.resource",
                     "{}:{}".format(resource_type, self.cloud_metadata.get("azure")["name"]),
                 )
+            resource_id = self.cloud_metadata.get("azure").get("resource_id")
+            if resource_id:
+                # Emitted as a regular tag (not a dd.internal.resource) so it survives to the
+                # database_instance metadata and lets DBM correlate Azure resource logs when the
+                # automatic FQDN-to-resource mapping is unavailable.
+                self.tag_manager.set_tag("resource_id", resource_id, replace=True)
         # finally, emit a `database_instance` resource for this instance
         self.tag_manager.set_tag(
             "dd.internal.resource",

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -288,7 +288,7 @@ class MySql(DatabaseCheck):
                 # Emitted as a regular tag (not a dd.internal.resource) so it survives to the
                 # database_instance metadata and lets DBM correlate Azure resource logs when the
                 # automatic FQDN-to-resource mapping is unavailable.
-                self.tag_manager.set_tag("resource_id", resource_id, replace=True)
+                self.tag_manager.set_tag("azure_resource_id", resource_id, replace=True)
         # finally, emit a `database_instance` resource for this instance
         self.tag_manager.set_tag(
             "dd.internal.resource",

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -360,9 +360,9 @@ def test_azure_resource_id_emitted_as_tag(resource_id):
     if resource_id is not None:
         # Emitted verbatim (canonical case) as a regular tag so it survives to the
         # database_instance metadata for Azure log correlation.
-        assert 'resource_id:{}'.format(resource_id) in tags
+        assert 'azure_resource_id:{}'.format(resource_id) in tags
     else:
-        assert not any(tag.startswith('resource_id:') for tag in tags)
+        assert not any(tag.startswith('azure_resource_id:') for tag in tags)
 
 
 class DummyLogger:

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -335,6 +335,36 @@ def test_service_check(disable_generic_tags, expected_tags, hostname):
     assert set(check._service_check_tags(hostname)) == expected_tags
 
 
+@pytest.mark.parametrize(
+    'resource_id',
+    [
+        pytest.param(
+            '/subscriptions/11111111-2222-3333-4444-555555555555/resourceGroups/example-resource-group'
+            '/providers/Microsoft.DBforMySQL/flexibleServers/example-mysql-server',
+            id='resource_id_set',
+        ),
+        pytest.param(None, id='resource_id_unset'),
+    ],
+)
+def test_azure_resource_id_emitted_as_tag(resource_id):
+    azure = {
+        'deployment_type': 'flexible_server',
+        'fully_qualified_domain_name': 'example-mysql-server.mysql.database.azure.com',
+    }
+    if resource_id is not None:
+        azure['resource_id'] = resource_id
+    config = {'server': 'localhost', 'user': 'datadog', 'azure': azure}
+    check = MySql(common.CHECK_NAME, {}, instances=[config])
+    tags = check.tag_manager.get_tags()
+
+    if resource_id is not None:
+        # Emitted verbatim (canonical case) as a regular tag so it survives to the
+        # database_instance metadata for Azure log correlation.
+        assert 'resource_id:{}'.format(resource_id) in tags
+    else:
+        assert not any(tag.startswith('resource_id:') for tag in tags)
+
+
 class DummyLogger:
     def debug(*args):
         pass

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -335,32 +335,42 @@ def test_service_check(disable_generic_tags, expected_tags, hostname):
     assert set(check._service_check_tags(hostname)) == expected_tags
 
 
+AZURE_TEST_RESOURCE_ID = (
+    '/subscriptions/11111111-2222-3333-4444-555555555555/resourceGroups/example-resource-group'
+    '/providers/Microsoft.DBforMySQL/flexibleServers/example-mysql-server'
+)
+
+
 @pytest.mark.parametrize(
-    'resource_id',
+    'azure, expected_resource_id',
     [
+        pytest.param({'resource_id': AZURE_TEST_RESOURCE_ID}, AZURE_TEST_RESOURCE_ID, id='resource_id_only'),
         pytest.param(
-            '/subscriptions/11111111-2222-3333-4444-555555555555/resourceGroups/example-resource-group'
-            '/providers/Microsoft.DBforMySQL/flexibleServers/example-mysql-server',
-            id='resource_id_set',
+            {
+                'deployment_type': 'flexible_server',
+                'fully_qualified_domain_name': 'example-mysql-server.mysql.database.azure.com',
+                'resource_id': AZURE_TEST_RESOURCE_ID,
+            },
+            AZURE_TEST_RESOURCE_ID,
+            id='resource_id_with_deployment_type',
         ),
-        pytest.param(None, id='resource_id_unset'),
+        pytest.param(
+            {
+                'deployment_type': 'flexible_server',
+                'fully_qualified_domain_name': 'example-mysql-server.mysql.database.azure.com',
+            },
+            None,
+            id='no_resource_id',
+        ),
     ],
 )
-def test_azure_resource_id_emitted_as_tag(resource_id):
-    azure = {
-        'deployment_type': 'flexible_server',
-        'fully_qualified_domain_name': 'example-mysql-server.mysql.database.azure.com',
-    }
-    if resource_id is not None:
-        azure['resource_id'] = resource_id
+def test_azure_resource_id_emitted_as_tag(azure, expected_resource_id):
     config = {'server': 'localhost', 'user': 'datadog', 'azure': azure}
     check = MySql(common.CHECK_NAME, {}, instances=[config])
     tags = check.tag_manager.get_tags()
 
-    if resource_id is not None:
-        # Emitted verbatim (canonical case) as a regular tag so it survives to the
-        # database_instance metadata for Azure log correlation.
-        assert 'azure_resource_id:{}'.format(resource_id) in tags
+    if expected_resource_id is not None:
+        assert 'azure_resource_id:{}'.format(expected_resource_id) in tags
     else:
         assert not any(tag.startswith('azure_resource_id:') for tag in tags)
 

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -1332,6 +1332,19 @@ files:
             type: string
             example: my-postgres-database.database.windows.net
           fleet_configurable: false
+        - name: resource_id
+          description: |
+            The full Azure Resource Manager (ARM) resource ID of this PostgreSQL server, for example
+            /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.DBforPostgreSQL/flexibleServers/<server>.
+
+            Set this when the automatic mapping from the fully qualified domain name to the Azure
+            resource cannot be made (for example, proxy connections, a custom `reported_hostname`, or
+            when the Azure resource is not crawled), so that DBM can correlate Azure resource logs to
+            this database instance.
+          value:
+            type: string
+            example: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.DBforPostgreSQL/flexibleServers/my-server
+          fleet_configurable: false
         - name: managed_authentication
           description: |
             Configuration section used for Azure AD Authentication.

--- a/postgres/changelog.d/24428.added
+++ b/postgres/changelog.d/24428.added
@@ -1,0 +1,1 @@
+Add the `azure.resource_id` option to declare the Azure Resource Manager resource ID used to correlate Azure PostgreSQL resource logs in DBM.

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -85,6 +85,7 @@ class Azure(BaseModel):
     deployment_type: Optional[str] = None
     fully_qualified_domain_name: Optional[str] = None
     managed_authentication: Optional[ManagedAuthentication1] = None
+    resource_id: Optional[str] = None
 
 
 class CollectColumnStatistics(BaseModel):

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -751,6 +751,17 @@ instances:
         #
         # fully_qualified_domain_name: my-postgres-database.database.windows.net
 
+        ## @param resource_id - string - optional - default: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.DBforPostgreSQL/flexibleServers/my-server
+        ## The full Azure Resource Manager (ARM) resource ID of this PostgreSQL server, for example
+        ## /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.DBforPostgreSQL/flexibleServers/<server>.
+        ##
+        ## Set this when the automatic mapping from the fully qualified domain name to the Azure
+        ## resource cannot be made (for example, proxy connections, a custom `reported_hostname`, or
+        ## when the Azure resource is not crawled), so that DBM can correlate Azure resource logs to
+        ## this database instance.
+        #
+        # resource_id: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.DBforPostgreSQL/flexibleServers/my-server
+
         ## @param managed_authentication - mapping - optional
         ## Configuration section used for Azure AD Authentication.
         ##

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -288,7 +288,7 @@ class PostgreSql(DatabaseCheck):
             # Emitted as a regular tag (not a dd.internal.resource) so it survives to the
             # database_instance metadata and lets DBM correlate Azure resource logs when the
             # automatic FQDN-to-resource mapping is unavailable.
-            self.tag_manager.set_tag("resource_id", self._config.azure.resource_id, replace=True)
+            self.tag_manager.set_tag("azure_resource_id", self._config.azure.resource_id, replace=True)
         # finally, tag the `database_instance` resource for this instance
         # metrics intake will use this tag to add all the tags for the instance
         self.tag_manager.set_tag(

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -284,6 +284,11 @@ class PostgreSql(DatabaseCheck):
                     "dd.internal.resource",
                     "{}:{}".format(resource_type, self._config.azure.fully_qualified_domain_name),
                 )
+        if self._config.azure.resource_id:
+            # Emitted as a regular tag (not a dd.internal.resource) so it survives to the
+            # database_instance metadata and lets DBM correlate Azure resource logs when the
+            # automatic FQDN-to-resource mapping is unavailable.
+            self.tag_manager.set_tag("resource_id", self._config.azure.resource_id, replace=True)
         # finally, tag the `database_instance` resource for this instance
         # metrics intake will use this tag to add all the tags for the instance
         self.tag_manager.set_tag(

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -199,9 +199,9 @@ def test_azure_resource_id_emitted_as_tag(pg_instance, integration_check, resour
     if resource_id is not None:
         # Emitted verbatim (canonical case) as a regular tag so it survives to the
         # database_instance metadata for Azure log correlation.
-        assert 'resource_id:{}'.format(resource_id) in tags
+        assert 'azure_resource_id:{}'.format(resource_id) in tags
     else:
-        assert not any(tag.startswith('resource_id:') for tag in tags)
+        assert not any(tag.startswith('azure_resource_id:') for tag in tags)
 
 
 @pytest.mark.parametrize(

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -173,6 +173,38 @@ def test_server_tag_(disable_generic_tags, expected_tags, pg_instance, integrati
 
 
 @pytest.mark.parametrize(
+    'resource_id',
+    [
+        pytest.param(
+            '/subscriptions/11111111-2222-3333-4444-555555555555/resourceGroups/example-resource-group'
+            '/providers/Microsoft.DBforPostgreSQL/flexibleServers/example-pg-server',
+            id='resource_id_set',
+        ),
+        pytest.param(None, id='resource_id_unset'),
+    ],
+)
+def test_azure_resource_id_emitted_as_tag(pg_instance, integration_check, resource_id):
+    instance = copy.deepcopy(pg_instance)
+    azure = {
+        'deployment_type': 'flexible_server',
+        'fully_qualified_domain_name': 'example-pg-server.postgres.database.azure.com',
+    }
+    if resource_id is not None:
+        azure['resource_id'] = resource_id
+    instance['azure'] = azure
+
+    check = integration_check(instance)
+    tags = check.tag_manager.get_tags()
+
+    if resource_id is not None:
+        # Emitted verbatim (canonical case) as a regular tag so it survives to the
+        # database_instance metadata for Azure log correlation.
+        assert 'resource_id:{}'.format(resource_id) in tags
+    else:
+        assert not any(tag.startswith('resource_id:') for tag in tags)
+
+
+@pytest.mark.parametrize(
     'disable_generic_tags, expected_hostname', [(True, 'resolved.hostname'), (False, 'resolved.hostname')]
 )
 def test_resolved_hostname(disable_generic_tags, expected_hostname, pg_instance, integration_check):

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -829,6 +829,19 @@ files:
             type: string
             example: my-sqlserver-database.database.windows.net
           fleet_configurable: false
+        - name: resource_id
+          description: |
+            The full Azure Resource Manager (ARM) resource ID of this SQL resource, for example
+            /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Sql/servers/<server>/databases/<db>.
+
+            Set this when the automatic mapping from the fully qualified domain name to the Azure
+            resource cannot be made (for example, proxy connections, a custom `reported_hostname`, or
+            when the Azure resource is not crawled), so that DBM can correlate Azure resource logs to
+            this database instance.
+          value:
+            type: string
+            example: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Sql/servers/my-server/databases/my-database
+          fleet_configurable: false
         - name: aggregate_sql_databases
           description: |
             Aggregate individual Azure SQL Databases under a single logical SQL server database instance.

--- a/sqlserver/changelog.d/24428.added
+++ b/sqlserver/changelog.d/24428.added
@@ -1,0 +1,1 @@
+Add the `azure.resource_id` option to declare the Azure Resource Manager resource ID used to correlate Azure SQL resource logs in DBM.

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -46,6 +46,7 @@ class Azure(BaseModel):
     aggregate_sql_databases: Optional[bool] = None
     deployment_type: Optional[str] = None
     fully_qualified_domain_name: Optional[str] = None
+    resource_id: Optional[str] = None
 
 
 class CollectDeadlocks(BaseModel):

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -535,6 +535,17 @@ instances:
         #
         # fully_qualified_domain_name: my-sqlserver-database.database.windows.net
 
+        ## @param resource_id - string - optional - default: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Sql/servers/my-server/databases/my-database
+        ## The full Azure Resource Manager (ARM) resource ID of this SQL resource, for example
+        ## /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Sql/servers/<server>/databases/<db>.
+        ##
+        ## Set this when the automatic mapping from the fully qualified domain name to the Azure
+        ## resource cannot be made (for example, proxy connections, a custom `reported_hostname`, or
+        ## when the Azure resource is not crawled), so that DBM can correlate Azure resource logs to
+        ## this database instance.
+        #
+        # resource_id: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Sql/servers/my-server/databases/my-database
+
         ## @param aggregate_sql_databases - boolean - optional - default: false
         ## Aggregate individual Azure SQL Databases under a single logical SQL server database instance.
         ## Only applicable when `deployment_type` is set to `sql_database`.

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -292,24 +292,28 @@ class SQLServer(DatabaseCheck):
                 "instance_endpoint": self.resolved_hostname,
             }
         if self.cloud_metadata.get("azure") is not None:
-            deployment_type = self.cloud_metadata.get("azure")["deployment_type"]
-            name = self.cloud_metadata.get("azure")["name"]
-            db_instance = None
-            if "sql_database" in deployment_type and self._config.dbm_enabled:
-                # azure_sql_server_database resource should be set to {fully_qualified_server_name}/{database_name}
-                # for correct resource aliasing
-                dbname = self.instance.get("database", "master")
-                db_instance = f"{name}/{dbname}"
-            # some `deployment_type`s map to multiple `resource_type`s
-            resource_types = AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPES.get(deployment_type).split(",")
-            for r_type in resource_types:
-                if "azure_sql_server_database" in r_type and db_instance:
-                    self.tag_manager.set_tag(
-                        "dd.internal.resource:{}".format(r_type), "{}".format(db_instance), replace=True
-                    )
-                else:
-                    self.tag_manager.set_tag("dd.internal.resource:{}".format(r_type), "{}".format(name), replace=True)
-            resource_id = self.cloud_metadata.get("azure").get("resource_id")
+            azure = self.cloud_metadata.get("azure")
+            deployment_type = azure.get("deployment_type")
+            name = azure.get("name")
+            if deployment_type and name:
+                db_instance = None
+                if "sql_database" in deployment_type and self._config.dbm_enabled:
+                    # azure_sql_server_database resource should be set to {fully_qualified_server_name}/{database_name}
+                    # for correct resource aliasing
+                    dbname = self.instance.get("database", "master")
+                    db_instance = f"{name}/{dbname}"
+                # some `deployment_type`s map to multiple `resource_type`s
+                resource_types = AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPES.get(deployment_type)
+                for r_type in resource_types.split(",") if resource_types else []:
+                    if "azure_sql_server_database" in r_type and db_instance:
+                        self.tag_manager.set_tag(
+                            "dd.internal.resource:{}".format(r_type), "{}".format(db_instance), replace=True
+                        )
+                    else:
+                        self.tag_manager.set_tag(
+                            "dd.internal.resource:{}".format(r_type), "{}".format(name), replace=True
+                        )
+            resource_id = azure.get("resource_id")
             if resource_id:
                 # Emitted as a regular tag (not a dd.internal.resource) so it survives to the
                 # database_instance metadata and lets DBM correlate Azure resource logs when the

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -314,7 +314,7 @@ class SQLServer(DatabaseCheck):
                 # Emitted as a regular tag (not a dd.internal.resource) so it survives to the
                 # database_instance metadata and lets DBM correlate Azure resource logs when the
                 # automatic FQDN-to-resource mapping is unavailable.
-                self.tag_manager.set_tag("resource_id", resource_id, replace=True)
+                self.tag_manager.set_tag("azure_resource_id", resource_id, replace=True)
         # finally, emit a `database_instance` resource for this instance
         self.tag_manager.set_tag(
             "dd.internal.resource:database_instance",

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -309,6 +309,12 @@ class SQLServer(DatabaseCheck):
                     )
                 else:
                     self.tag_manager.set_tag("dd.internal.resource:{}".format(r_type), "{}".format(name), replace=True)
+            resource_id = self.cloud_metadata.get("azure").get("resource_id")
+            if resource_id:
+                # Emitted as a regular tag (not a dd.internal.resource) so it survives to the
+                # database_instance metadata and lets DBM correlate Azure resource logs when the
+                # automatic FQDN-to-resource mapping is unavailable.
+                self.tag_manager.set_tag("resource_id", resource_id, replace=True)
         # finally, emit a `database_instance` resource for this instance
         self.tag_manager.set_tag(
             "dd.internal.resource:database_instance",

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -552,9 +552,9 @@ def test_azure_resource_id_emitted_as_tag(instance_minimal_defaults, resource_id
     if resource_id is not None:
         # Emitted verbatim (canonical case) as a regular tag so it survives to the
         # database_instance metadata for Azure log correlation.
-        assert 'resource_id:{}'.format(resource_id) in tags
+        assert 'azure_resource_id:{}'.format(resource_id) in tags
     else:
-        assert not any(tag.startswith('resource_id:') for tag in tags)
+        assert not any(tag.startswith('azure_resource_id:') for tag in tags)
 
 
 def test_autodiscovery_matches_all_by_default(instance_autodiscovery):

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -521,38 +521,45 @@ def test_azure_cross_database_queries_excluded(get_cursor, mock_connect, instanc
     assert len(cross_database_metrics) == 0
 
 
+AZURE_TEST_RESOURCE_ID = (
+    '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/My-RG'
+    '/providers/Microsoft.Sql/servers/my-server/databases/my-db'
+)
+
+
 @pytest.mark.parametrize(
-    'resource_id',
+    'azure, expected_resource_id',
     [
+        pytest.param({'resource_id': AZURE_TEST_RESOURCE_ID}, AZURE_TEST_RESOURCE_ID, id='resource_id_only'),
         pytest.param(
-            '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/My-RG'
-            '/providers/Microsoft.Sql/servers/my-server/databases/my-db',
-            id='resource_id_set',
+            {
+                'deployment_type': 'sql_database',
+                'fully_qualified_domain_name': 'my-instance.database.windows.net',
+                'resource_id': AZURE_TEST_RESOURCE_ID,
+            },
+            AZURE_TEST_RESOURCE_ID,
+            id='resource_id_with_deployment_type',
         ),
-        pytest.param(None, id='resource_id_unset'),
+        pytest.param(
+            {'deployment_type': 'sql_database', 'fully_qualified_domain_name': 'my-instance.database.windows.net'},
+            None,
+            id='no_resource_id',
+        ),
     ],
 )
-def test_azure_resource_id_emitted_as_tag(instance_minimal_defaults, resource_id):
+def test_azure_resource_id_emitted_as_tag(instance_minimal_defaults, azure, expected_resource_id):
     instance = copy.deepcopy(instance_minimal_defaults)
     instance['dbm'] = True
     instance['reported_hostname'] = 'my-instance.database.windows.net'
     instance['database'] = 'my-db'
-    azure = {
-        'deployment_type': 'sql_database',
-        'fully_qualified_domain_name': 'my-instance.database.windows.net',
-    }
-    if resource_id is not None:
-        azure['resource_id'] = resource_id
     instance['azure'] = azure
 
     check = SQLServer(CHECK_NAME, {}, [instance])
     check.set_resource_tags()
     tags = check.tag_manager.get_tags()
 
-    if resource_id is not None:
-        # Emitted verbatim (canonical case) as a regular tag so it survives to the
-        # database_instance metadata for Azure log correlation.
-        assert 'azure_resource_id:{}'.format(resource_id) in tags
+    if expected_resource_id is not None:
+        assert 'azure_resource_id:{}'.format(expected_resource_id) in tags
     else:
         assert not any(tag.startswith('azure_resource_id:') for tag in tags)
 

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -521,6 +521,42 @@ def test_azure_cross_database_queries_excluded(get_cursor, mock_connect, instanc
     assert len(cross_database_metrics) == 0
 
 
+@pytest.mark.parametrize(
+    'resource_id',
+    [
+        pytest.param(
+            '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/My-RG'
+            '/providers/Microsoft.Sql/servers/my-server/databases/my-db',
+            id='resource_id_set',
+        ),
+        pytest.param(None, id='resource_id_unset'),
+    ],
+)
+def test_azure_resource_id_emitted_as_tag(instance_minimal_defaults, resource_id):
+    instance = copy.deepcopy(instance_minimal_defaults)
+    instance['dbm'] = True
+    instance['reported_hostname'] = 'my-instance.database.windows.net'
+    instance['database'] = 'my-db'
+    azure = {
+        'deployment_type': 'sql_database',
+        'fully_qualified_domain_name': 'my-instance.database.windows.net',
+    }
+    if resource_id is not None:
+        azure['resource_id'] = resource_id
+    instance['azure'] = azure
+
+    check = SQLServer(CHECK_NAME, {}, [instance])
+    check.set_resource_tags()
+    tags = check.tag_manager.get_tags()
+
+    if resource_id is not None:
+        # Emitted verbatim (canonical case) as a regular tag so it survives to the
+        # database_instance metadata for Azure log correlation.
+        assert 'resource_id:{}'.format(resource_id) in tags
+    else:
+        assert not any(tag.startswith('resource_id:') for tag in tags)
+
+
 def test_autodiscovery_matches_all_by_default(instance_autodiscovery):
     fetchall_results, mock_cursor = _mock_database_list()
     all_dbs = {Database(r.name) for r in fetchall_results}


### PR DESCRIPTION
### What does this PR do?

Adds an optional `azure.resource_id` option to the **sqlserver**, **postgres**, and **mysql** checks. When set, the check emits the full Azure Resource Manager (ARM) resource ID as a regular `azure_resource_id` tag, which flows onto the `database_instance` metadata payload and the check's metrics.

The value is emitted as a plain tag (not a `dd.internal.resource:*` tag) so it survives the DBM metadata pipeline and reaches `dbEntity.tags`, where the companion web-ui change reads it to build the Logs-tab query.

### Motivation

Azure managed-database resource logs (`source:azure.sql`, `source:azure.dbforpostgresql`, `source:azure.dbformysql`) are forwarded with an empty `host` tag, so the DBM per-host **Logs** tab — which queries `host:<FQDN>` — shows *"Log collection is not set up for this host"*. The logs instead carry the lowercased ARM resourceId in a `dd_resource_key` tag.

DBM normally reconstructs that key from the Azure inventory tags joined on FQDN, but when that join fails — proxy connections, a custom `reported_hostname`, or an uncrawled resource — there is no way to correlate. `azure.resource_id` lets a customer declare the canonical ARM id directly so the frontend can match the logs.

- Ticket: [SDBM-2685](https://datadoghq.atlassian.net/browse/SDBM-2685)
- Companion frontend change: DataDog/web-ui#326711

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[SDBM-2685]: https://datadoghq.atlassian.net/browse/SDBM-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
