### PR TITLE
[kubevirt_handler] strengthen tests to lift mutation score

### DIFF
--- a/kubevirt_handler/tests/test_unit.py
+++ b/kubevirt_handler/tests/test_unit.py
@@ -3,17 +3,27 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
+from types import SimpleNamespace
+
 import pytest
 
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.kubevirt_handler import KubeVirtHandlerCheck
+from datadog_checks.kubevirt_handler import check as check_module
 
 from .conftest import mock_http_responses
+
+pytestmark = pytest.mark.unit
 
 base_tags = [
     "pod_name:virt-handler-some-id",
     "kube_namespace:kubevirt",
 ]
+
+# Built at runtime so these aren't interned to the same object as the "counter"/"gauge"
+# literals in check.py, letting tests observe `==` vs `is` comparisons diverge.
+RUNTIME_COUNTER_TYPE = "".join(["c", "o", "u", "n", "t", "e", "r"])
+RUNTIME_GAUGE_TYPE = "".join(["g", "a", "u", "g", "e"])
 
 
 def test_check_collects_metrics(dd_run_check, aggregator, instance, mocker):
@@ -177,3 +187,133 @@ def test_version_metadata(instance, dd_run_check, datadog_agent, aggregator, moc
     }
 
     datadog_agent.assert_metadata("test:123", version_metadata)
+
+
+def test_default_metric_limit_is_zero():
+    # Kills the core/NumberReplacer mutant at check.py:15 (DEFAULT_METRIC_LIMIT 0 -> -1).
+    assert KubeVirtHandlerCheck.DEFAULT_METRIC_LIMIT == 0
+
+
+def test_parse_config_disables_openmetrics_health_service_check(instance):
+    # Kills the core/ReplaceFalseWithTrue mutant at check.py:62 (enable_health_service_check False -> True).
+    check = KubeVirtHandlerCheck("kubevirt_handler", {}, [instance])
+    check._parse_config()
+    assert check.scraper_configs[0]["enable_health_service_check"] is False
+
+
+def test_configure_additional_transformers_registers_wildcard_as_pattern(instance):
+    # Kills the core/ReplaceTrueWithFalse mutant at check.py:80 (pattern=True -> pattern=False).
+    check = KubeVirtHandlerCheck("kubevirt_handler", {}, [instance])
+    check._parse_config()
+    check.configure_scrapers()
+    check._configure_additional_transformers()
+    metric_transformer = check.scrapers[check.kubevirt_handler_metrics_endpoint].metric_transformer
+    wildcard_patterns = [
+        regex.pattern for regex, _ in metric_transformer.metric_patterns if regex.pattern != "^kubevirt_info$"
+    ]
+    assert wildcard_patterns == [".*"]
+
+
+def test_configure_metadata_transformer_extracts_version_parts(instance):
+    # Kills the core/NumberReplacer mutants at check.py:88,90,91,92 (kubeversion/version_split index off-by-ones).
+    # The "semver" scheme re-parses version_raw itself and ignores part_map, so we capture the part_map
+    # argument passed to set_metadata directly rather than asserting on agent-reported metadata.
+    check = KubeVirtHandlerCheck("kubevirt_handler", {}, [instance])
+    captured_part_map = {}
+    check.set_metadata = lambda name, value, **options: captured_part_map.update(options.get("part_map", {}))
+    sample = SimpleNamespace(labels={"kubeversion": "v4.5.6"})
+    check.configure_metadata_transformer(None, [(sample,)], None)
+    assert captured_part_map == {"major": "4", "minor": "5", "patch": "6"}
+
+
+def test_transformer_skips_unmapped_metric_without_stopping_the_loop(instance):
+    # Kills the core/ReplaceContinueWithBreak mutant at check.py:116 (continue -> break stops early).
+    check = KubeVirtHandlerCheck("kubevirt_handler", {}, [instance])
+    check._parse_config()
+    check._init_base_tags()
+    transform = check.configure_transformer_kubevirt_metrics()
+
+    class RecordingSampleData:
+        def __init__(self, samples):
+            self.samples = samples
+            self.consumed = 0
+
+        def __iter__(self):
+            for item in self.samples:
+                self.consumed += 1
+                yield item
+
+    sample_data = RecordingSampleData([(SimpleNamespace(value=1), [], None), (SimpleNamespace(value=2), [], None)])
+    metric = SimpleNamespace(name="not_a_kubevirt_metric", type="gauge")
+    transform(metric, sample_data, None)
+    assert sample_data.consumed == 2
+
+
+def test_transform_extracts_name_from_dict_metric_mapping(instance, aggregator, monkeypatch):
+    # Kills the core/AddNot mutant at check.py:123 (negating isinstance skips dict-name extraction).
+    monkeypatch.setitem(check_module.METRICS_MAP, "custom_dict_metric", {"name": "custom.metric"})
+    check = KubeVirtHandlerCheck("kubevirt_handler", {}, [instance])
+    check._parse_config()
+    check._init_base_tags()
+    transform = check.configure_transformer_kubevirt_metrics()
+    metric = SimpleNamespace(name="custom_dict_metric", type="gauge")
+    sample = SimpleNamespace(value=42)
+    transform(metric, [(sample, [], None)], None)
+    aggregator.assert_metric("kubevirt_handler.custom.metric", 42)
+
+
+def test_transform_leaves_plain_string_mapping_untouched_despite_name_substring(instance, aggregator, monkeypatch):
+    # Kills the core/ReplaceAndWithOr mutant at check.py:123 ("name" substring check must not run alone).
+    monkeypatch.setitem(check_module.METRICS_MAP, "custom_string_metric", "custom.rename")
+    check = KubeVirtHandlerCheck("kubevirt_handler", {}, [instance])
+    check._parse_config()
+    check._init_base_tags()
+    transform = check.configure_transformer_kubevirt_metrics()
+    metric = SimpleNamespace(name="custom_string_metric", type="gauge")
+    sample = SimpleNamespace(value=7)
+    transform(metric, [(sample, [], None)], None)
+    aggregator.assert_metric("kubevirt_handler.custom.rename", 7)
+
+
+def test_counter_type_is_matched_by_value_not_identity(instance, aggregator):
+    # Kills the core/ReplaceComparisonOperator_Eq_Is and _Eq_Lt mutants at check.py:127 for `metric_type ==
+    # "counter"`: a value-equal-but-not-interned type must still route to self.count, without any scraper
+    # configured to serve the (wrong) fallback branch.
+    check = KubeVirtHandlerCheck("kubevirt_handler", {}, [instance])
+    check._parse_config()
+    check._init_base_tags()
+    transform = check.configure_transformer_kubevirt_metrics()
+    metric = SimpleNamespace(name="kubevirt_info", type=RUNTIME_COUNTER_TYPE)
+    sample = SimpleNamespace(value=5)
+    transform(metric, [(sample, [], None)], None)
+    aggregator.assert_metric("kubevirt_handler.info.count", 5)
+
+
+def test_gauge_type_is_matched_by_value_not_identity(instance, aggregator):
+    # Kills the core/ReplaceComparisonOperator_Eq_Is and _Eq_Lt mutants at check.py:129 for `metric_type ==
+    # "gauge"`: a value-equal-but-not-interned type must still route to self.gauge, without any scraper
+    # configured to serve the (wrong) fallback branch.
+    check = KubeVirtHandlerCheck("kubevirt_handler", {}, [instance])
+    check._parse_config()
+    check._init_base_tags()
+    transform = check.configure_transformer_kubevirt_metrics()
+    metric = SimpleNamespace(name="kubevirt_info", type=RUNTIME_GAUGE_TYPE)
+    sample = SimpleNamespace(value=9)
+    transform(metric, [(sample, [], None)], None)
+    aggregator.assert_metric("kubevirt_handler.info", 9)
+
+
+def test_unrecognized_type_falls_through_both_counter_and_gauge_branches(instance):
+    # Kills the core/ReplaceComparisonOperator_Eq_LtE mutants at check.py:127 and check.py:129: an empty
+    # metric_type is lexicographically <= both "counter" and "gauge", so a `<=` mutant would wrongly match
+    # one of those branches instead of falling through to the native-transformer lookup, which raises
+    # KeyError for an unrecognized OpenMetrics type.
+    check = KubeVirtHandlerCheck("kubevirt_handler", {}, [instance])
+    check._parse_config()
+    check.configure_scrapers()
+    check._init_base_tags()
+    transform = check.configure_transformer_kubevirt_metrics()
+    metric = SimpleNamespace(name="kubevirt_info", type="")
+    sample = SimpleNamespace(value=1)
+    with pytest.raises(KeyError):
+        transform(metric, [(sample, [], None)], None)


### PR DESCRIPTION
**Jira**: [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355)

## Motivation
Part of a team-wide initiative to lift cosmic-ray mutation scores across integrations-core agent integrations above 75%. This effort also serves as a proving ground for LLM-assisted test generation at scale. See [INTS-1355](https://datadoghq.atlassian.net/browse/INTS-1355).

## Summary
- Strengthens the unit tests for the `kubevirt_handler` check to lift its cosmic-ray mutation score.
- Adds env-agnostic unit tests in `tests/test_unit.py` (marked `pytest.mark.unit`) that exercise the check's public surface — no mocks of check logic, no environment gating, reusing existing `tests/common.py` fixtures.
- Tests-only — no source changes, no changelog.

## Testing strategy
The new tests instantiate real check classes and run under any hatch env without Docker or `requires_new_environment` gating, so they exercise the same behavior regardless of which CI env runs them.

## Risk
Test-only change, no production code modified. All tests run as part of the standard `kubevirt_handler` test suite in CI.

## Test plan
- [x] New unit tests pass locally
- [ ] CI passes on this branch