### PR TITLE
Add DispatcherConfig model read from .ddev/config.toml

### DIFF
--- a/ddev/changelog.d/24434.added
+++ b/ddev/changelog.d/24434.added
@@ -1,1 +1,0 @@
-Add a DispatcherConfig model that reads Dispatcher settings from the repo config.toml.

--- a/ddev/changelog.d/24434.added
+++ b/ddev/changelog.d/24434.added
@@ -1,0 +1,1 @@
+Add a DispatcherConfig model that reads Dispatcher settings from the repo config.toml.

--- a/ddev/changelog.d/24434.fixed
+++ b/ddev/changelog.d/24434.fixed
@@ -1,0 +1,1 @@
+Add an internal DispatcherConfig model for reading Dispatcher settings from the repo config.

--- a/ddev/src/ddev/cli/ci/tests/dispatcher_config.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher_config.py
@@ -20,7 +20,7 @@ class DispatcherConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    max_jobs_per_batch: int = Field(default=240, gt=0)  # 256 max jobs per workflow minus a 16-job buffer for setup jobs
+    max_jobs_per_batch: int = Field(default=240, gt=0, le=240)  # 256 GitHub job cap - 16-job setup buffer; the safe max
     global_timeout_seconds: float = Field(default=10800.0, gt=0)  # 3 hours
     github_rate_limits: RateLimiterFactoryConfig = RateLimiterFactoryConfig()
 

--- a/ddev/src/ddev/cli/ci/tests/dispatcher_config.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher_config.py
@@ -20,8 +20,8 @@ class DispatcherConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    max_jobs_per_batch: int = Field(default=240, gt=0)
-    global_timeout_seconds: float = Field(default=10800.0, gt=0)
+    max_jobs_per_batch: int = Field(default=240, gt=0)  # 256 max jobs per workflow minus a 16-job buffer for setup jobs
+    global_timeout_seconds: float = Field(default=10800.0, gt=0)  # 3 hours
     github_rate_limits: RateLimiterFactoryConfig = RateLimiterFactoryConfig()
 
     @classmethod

--- a/ddev/src/ddev/cli/ci/tests/dispatcher_config.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher_config.py
@@ -1,0 +1,30 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Per-repository Dispatcher configuration read from `.ddev/config.toml`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ddev.cli.ci.tests.rate_limiting import RateLimiterFactoryConfig
+
+if TYPE_CHECKING:
+    from ddev.repo.config import RepositoryConfig
+
+
+class DispatcherConfig(BaseModel):
+    """Per-repository Dispatcher configuration."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    max_jobs_per_batch: int = Field(default=240, gt=0)
+    global_timeout_seconds: float = Field(default=10800.0, gt=0)
+    github_rate_limits: RateLimiterFactoryConfig = RateLimiterFactoryConfig()
+
+    @classmethod
+    def from_repo_config(cls, repo_config: RepositoryConfig) -> DispatcherConfig:
+        """Build a DispatcherConfig from the `/dispatcher` table of `.ddev/config.toml`."""
+        return cls(**repo_config.get("/dispatcher", {}))

--- a/ddev/tests/cli/ci/tests/test_dispatcher_config.py
+++ b/ddev/tests/cli/ci/tests/test_dispatcher_config.py
@@ -27,7 +27,7 @@ def repo_config(tmp_path: Path) -> RepoConfigBuilder:
     return build
 
 
-def test_from_repo_config_reads_full_dispatcher_table(repo_config: RepoConfigBuilder) -> None:
+def test_from_repo_config_reads_full_dispatcher_table(repo_config: RepoConfigBuilder):
     config = repo_config(
         """
         [dispatcher]
@@ -56,7 +56,7 @@ def test_from_repo_config_reads_full_dispatcher_table(repo_config: RepoConfigBui
     assert result.github_rate_limits.slow.max_rate == 120
 
 
-def test_from_repo_config_reads_scalars_without_rate_limits_subtable(repo_config: RepoConfigBuilder) -> None:
+def test_from_repo_config_reads_scalars_without_rate_limits_subtable(repo_config: RepoConfigBuilder):
     config = repo_config(
         """
         [dispatcher]
@@ -72,7 +72,7 @@ def test_from_repo_config_reads_scalars_without_rate_limits_subtable(repo_config
     assert result.github_rate_limits == RateLimiterFactoryConfig()
 
 
-def test_from_repo_config_falls_back_to_defaults_when_dispatcher_table_missing(repo_config: RepoConfigBuilder) -> None:
+def test_from_repo_config_falls_back_to_defaults_when_dispatcher_table_missing(repo_config: RepoConfigBuilder):
     config = repo_config(
         """
         validations = []

--- a/ddev/tests/cli/ci/tests/test_dispatcher_config.py
+++ b/ddev/tests/cli/ci/tests/test_dispatcher_config.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 
 from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
@@ -12,9 +14,11 @@ from ddev.cli.ci.tests.rate_limiting import RateLimiterFactoryConfig
 from ddev.repo.config import RepositoryConfig
 from ddev.utils.fs import Path
 
+RepoConfigBuilder = Callable[[str], RepositoryConfig]
+
 
 @pytest.fixture
-def repo_config(tmp_path):
+def repo_config(tmp_path: Path) -> RepoConfigBuilder:
     def build(toml_content: str) -> RepositoryConfig:
         config_path = Path(tmp_path) / "config.toml"
         config_path.write_text(toml_content)
@@ -23,7 +27,7 @@ def repo_config(tmp_path):
     return build
 
 
-def test_from_repo_config_reads_full_dispatcher_table(repo_config):
+def test_from_repo_config_reads_full_dispatcher_table(repo_config: RepoConfigBuilder) -> None:
     config = repo_config(
         """
         [dispatcher]
@@ -52,7 +56,7 @@ def test_from_repo_config_reads_full_dispatcher_table(repo_config):
     assert result.github_rate_limits.slow.max_rate == 120
 
 
-def test_from_repo_config_reads_scalars_without_rate_limits_subtable(repo_config):
+def test_from_repo_config_reads_scalars_without_rate_limits_subtable(repo_config: RepoConfigBuilder) -> None:
     config = repo_config(
         """
         [dispatcher]
@@ -68,7 +72,7 @@ def test_from_repo_config_reads_scalars_without_rate_limits_subtable(repo_config
     assert result.github_rate_limits == RateLimiterFactoryConfig()
 
 
-def test_from_repo_config_falls_back_to_defaults_when_dispatcher_table_missing(repo_config):
+def test_from_repo_config_falls_back_to_defaults_when_dispatcher_table_missing(repo_config: RepoConfigBuilder) -> None:
     config = repo_config(
         """
         validations = []

--- a/ddev/tests/cli/ci/tests/test_dispatcher_config.py
+++ b/ddev/tests/cli/ci/tests/test_dispatcher_config.py
@@ -1,0 +1,80 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for DispatcherConfig.from_repo_config."""
+
+from __future__ import annotations
+
+import pytest
+
+from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
+from ddev.cli.ci.tests.rate_limiting import RateLimiterFactoryConfig
+from ddev.repo.config import RepositoryConfig
+from ddev.utils.fs import Path
+
+
+@pytest.fixture
+def repo_config(tmp_path):
+    def build(toml_content: str) -> RepositoryConfig:
+        config_path = Path(tmp_path) / "config.toml"
+        config_path.write_text(toml_content)
+        return RepositoryConfig(config_path)
+
+    return build
+
+
+def test_from_repo_config_reads_full_dispatcher_table(repo_config):
+    config = repo_config(
+        """
+        [dispatcher]
+        max_jobs_per_batch = 120
+        global_timeout_seconds = 3600.0
+
+        [dispatcher.github_rate_limits]
+        total_hourly_max_rate = 1500
+        slow_integrations = ["mongo", "mysql"]
+
+        [dispatcher.github_rate_limits.default]
+        max_rate = 360
+
+        [dispatcher.github_rate_limits.slow]
+        max_rate = 120
+        """
+    )
+
+    result = DispatcherConfig.from_repo_config(config)
+
+    assert result.max_jobs_per_batch == 120
+    assert result.global_timeout_seconds == 3600.0
+    assert result.github_rate_limits.total_hourly_max_rate == 1500
+    assert result.github_rate_limits.slow_integrations == frozenset({"mongo", "mysql"})
+    assert result.github_rate_limits.default.max_rate == 360
+    assert result.github_rate_limits.slow.max_rate == 120
+
+
+def test_from_repo_config_reads_scalars_without_rate_limits_subtable(repo_config):
+    config = repo_config(
+        """
+        [dispatcher]
+        max_jobs_per_batch = 120
+        global_timeout_seconds = 3600.0
+        """
+    )
+
+    result = DispatcherConfig.from_repo_config(config)
+
+    assert result.max_jobs_per_batch == 120
+    assert result.global_timeout_seconds == 3600.0
+    assert result.github_rate_limits == RateLimiterFactoryConfig()
+
+
+def test_from_repo_config_falls_back_to_defaults_when_dispatcher_table_missing(repo_config):
+    config = repo_config(
+        """
+        validations = []
+        """
+    )
+
+    result = DispatcherConfig.from_repo_config(config)
+
+    assert result == DispatcherConfig()


### PR DESCRIPTION
> **Stacked PR.** Review/merge order (bottom-up):
>
> 1. #24179 Add async GitHub client rate limiting for the Dispatcher — ✅ merged to master
> 2. #24434 Add DispatcherConfig model read from .ddev/config.toml  ← **this PR** (base: `master`)
> 3. #24462 Simplify and restructure the async GitHub client tests (base: #24434)
>
> Each open PR's base is the one above it, so its diff shows only its own changes.

### What does this PR do?

Adds a `DispatcherConfig` pydantic model that holds per-repository Dispatcher configuration read from `.ddev/config.toml`. For now it carries:

- `max_jobs_per_batch` (default 240)
- `global_timeout_seconds` (default 10800, i.e. 3 hours)
- `github_rate_limits`, the existing `RateLimiterFactoryConfig`

The config is read through the standard repo-config mechanism: `DispatcherConfig.from_repo_config` resolves the `/dispatcher` table via the `RepositoryConfig` JSON pointer and deserializes it. The model is `frozen` and uses `extra="forbid"` so typos in `config.toml` fail loudly. An absent `[dispatcher]` table yields a fully-defaulted config.

This PR only adds the model, its loader, and tests. Wiring it into an actual Dispatcher run is a separate ticket.

Stacked on #24179 (rate limiting), which provides `RateLimiterFactoryConfig`.

### Motivation

AI-6482: we want to configure the Dispatcher on a per-repository basis. Using the repo `config.toml` keeps configuration in one well-known place, and a pydantic model enforces a validated schema.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

