### PR TITLE
kafka_consumer: elect a single collector across identical Agent deployments

### DIFF
--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -345,6 +345,36 @@ files:
           type: integer
           example: 180
           display_default: 180
+      - name: auto_load_distribution
+        description: |
+          When multiple Datadog Agents are configured identically and pointed at the same
+          Kafka cluster (common when configuration is distributed to a whole fleet rather
+          than a single designated host), setting this to `true` elects a single instance
+          to perform collection each cycle instead of every instance collecting redundantly.
+
+          Election happens through a dedicated topic on the monitored cluster
+          (`__datadog_kafka_consumer_leader_election`, 1 partition), created automatically
+          if missing. This requires the check's Kafka principal to additionally have
+          create-topic, and produce/consume/describe ACLs on that topic and on the
+          `datadog-kafka-consumer-leader-election` consumer group.
+
+          If the election itself fails (for example, due to missing ACLs), the check does
+          not collect that run rather than falling back to collecting from every instance,
+          to avoid recreating the duplicate-collection problem this option exists to prevent.
+        fleet_configurable: true
+        value:
+          type: boolean
+          example: false
+          display_default: false
+      - name: auto_load_distribution_interval
+        description: |
+          Minimum time in seconds between two collections across all Agents sharing
+          `auto_load_distribution`. Only used when `auto_load_distribution` is `true`.
+        fleet_configurable: true
+        value:
+          type: integer
+          example: 60
+          display_default: 60
       - name: schema_registry_url
         description: |
           Schema Registry URL. When set with enable_cluster_monitoring, collects schema information.

--- a/kafka_consumer/changelog.d/24435.added
+++ b/kafka_consumer/changelog.d/24435.added
@@ -1,0 +1,1 @@
+Add `auto_load_distribution` to elect a single collector when multiple identically configured checks monitor the same Kafka cluster.

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -3,8 +3,16 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from concurrent.futures import as_completed
 
-from confluent_kafka import Consumer, ConsumerGroupTopicPartitions, IsolationLevel, KafkaException, TopicPartition
-from confluent_kafka.admin import AdminClient, OffsetSpec
+from confluent_kafka import (
+    Consumer,
+    ConsumerGroupTopicPartitions,
+    IsolationLevel,
+    KafkaException,
+    Producer,
+    TopicPartition,
+)
+from confluent_kafka.admin import AdminClient, NewTopic, OffsetSpec
+from confluent_kafka.error import KafkaError
 
 # AWS MSK IAM authentication support
 try:
@@ -57,6 +65,34 @@ class KafkaClient:
     def close_consumer(self):
         self.log.debug("Closing consumer instance %s", self._consumer)
         self._consumer.close()
+
+    def build_election_consumer(self, group_id, extra_config=None):
+        config = dict(extra_config or {})
+        config.setdefault("bootstrap.servers", self.config._kafka_connect_str)
+        config.setdefault("group.id", group_id)
+        config.setdefault("enable.auto.commit", False)
+        config.setdefault("enable.partition.eof", True)
+        config.setdefault("log_level", self.config._librdkafka_log_level)
+        config.update(self.__get_authentication_config())
+        return Consumer(config, logger=self.log)
+
+    def build_election_producer(self, extra_config=None):
+        config = dict(extra_config or {})
+        config.setdefault("bootstrap.servers", self.config._kafka_connect_str)
+        config.setdefault("log_level", self.config._librdkafka_log_level)
+        config.update(self.__get_authentication_config())
+        return Producer(config, logger=self.log)
+
+    def ensure_topic(self, topic, num_partitions=1):
+        """Create `topic` with `num_partitions` if it doesn't already exist."""
+        futures = self.kafka_client.create_topics([NewTopic(topic, num_partitions=num_partitions)])
+        for created_topic, future in futures.items():
+            try:
+                future.result()
+            except KafkaException as e:
+                if e.args[0].code() != KafkaError.TOPIC_ALREADY_EXISTS:
+                    raise
+                self.log.debug("Topic %s already exists", created_topic)
 
     def __get_authentication_config(self):
         config = {

--- a/kafka_consumer/datadog_checks/kafka_consumer/config.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config.py
@@ -108,6 +108,9 @@ class KafkaConfig:
 
         self._kafka_configs_refresh_interval = int(instance.get('kafka_configs_refresh_interval', 180))
 
+        self._auto_load_distribution = is_affirmative(instance.get('auto_load_distribution', False))
+        self._auto_load_distribution_interval = int(instance.get('auto_load_distribution_interval', 60))
+
         self._collect_schema_registry = instance.get('schema_registry_url')
 
         # Schema Registry authentication

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
@@ -12,6 +12,14 @@ def shared_kafka_timeout():
     return 5
 
 
+def instance_auto_load_distribution():
+    return False
+
+
+def instance_auto_load_distribution_interval():
+    return 60
+
+
 def instance_close_admin_client():
     return True
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
@@ -79,6 +79,8 @@ class InstanceConfig(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    auto_load_distribution: Optional[bool] = None
+    auto_load_distribution_interval: Optional[int] = None
     close_admin_client: Optional[bool] = None
     collect_consumer_group_state: Optional[bool] = None
     consumer_groups: Optional[MappingProxyType[str, Any]] = None

--- a/kafka_consumer/datadog_checks/kafka_consumer/constants.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/constants.py
@@ -24,3 +24,9 @@ OFFSET_INVALID = -1001
 
 # offsets_for_times sentinel for "latest"
 HIGH_WATERMARK = -1
+
+# Coordination topic/group used to elect a single collector when auto_load_distribution
+# is enabled. Fixed rather than configurable: a static group name is safe because
+# consumer groups are already scoped per-cluster by the broker that hosts them.
+LEADER_ELECTION_TOPIC = "__datadog_kafka_consumer_leader_election"
+LEADER_ELECTION_GROUP_ID = "datadog-kafka-consumer-leader-election"

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -374,6 +374,30 @@ instances:
     #
     # kafka_configs_refresh_interval: 180
 
+    ## @param auto_load_distribution - boolean - optional - default: false
+    ## When multiple Datadog Agents are configured identically and pointed at the same
+    ## Kafka cluster (common when configuration is distributed to a whole fleet rather
+    ## than a single designated host), setting this to `true` elects a single instance
+    ## to perform collection each cycle instead of every instance collecting redundantly.
+    ##
+    ## Election happens through a dedicated topic on the monitored cluster
+    ## (`__datadog_kafka_consumer_leader_election`, 1 partition), created automatically
+    ## if missing. This requires the check's Kafka principal to additionally have
+    ## create-topic, and produce/consume/describe ACLs on that topic and on the
+    ## `datadog-kafka-consumer-leader-election` consumer group.
+    ##
+    ## If the election itself fails (for example, due to missing ACLs), the check does
+    ## not collect that run rather than falling back to collecting from every instance,
+    ## to avoid recreating the duplicate-collection problem this option exists to prevent.
+    #
+    # auto_load_distribution: false
+
+    ## @param auto_load_distribution_interval - integer - optional - default: 60
+    ## Minimum time in seconds between two collections across all Agents sharing
+    ## `auto_load_distribution`. Only used when `auto_load_distribution` is `true`.
+    #
+    # auto_load_distribution_interval: 60
+
     ## @param schema_registry_url - string - optional - default: http://localhost:8081
     ## Schema Registry URL. When set with enable_cluster_monitoring, collects schema information.
     #

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -16,6 +16,7 @@ from datadog_checks.kafka_consumer.constants import (
     KAFKA_INTERNAL_TOPICS,
     OFFSET_INVALID,
 )
+from datadog_checks.kafka_consumer.leader_election import LeaderElection
 
 MAX_TIMESTAMPS = 1000
 
@@ -40,9 +41,23 @@ class KafkaCheck(AgentCheck):
         # Eagerly constructed so the check object owns the collector's lifetime; collect() is a
         # no-op when _kafka_connect_urls is empty, so this is safe without a URL guard.
         self._connector_collector = KafkaConnectCollector(self, self.config, self.log)
+        self.leader_election = (
+            LeaderElection(self, self.client, self.config, self.log) if self.config._auto_load_distribution else None
+        )
 
     def check(self, _):
         """The main entrypoint of the check."""
+        if self.leader_election is not None:
+            if not self.leader_election.should_collect():
+                return
+            self.leader_election.start_heartbeat()
+        try:
+            self._check(_)
+        finally:
+            if self.leader_election is not None:
+                self.leader_election.finish()
+
+    def _check(self, _):
         # Fetch Kafka consumer offsets
 
         consumer_offsets = {}

--- a/kafka_consumer/datadog_checks/kafka_consumer/leader_election.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/leader_election.py
@@ -1,0 +1,129 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+import threading
+import time
+
+from confluent_kafka.error import KafkaError
+
+from datadog_checks.kafka_consumer.constants import LEADER_ELECTION_GROUP_ID, LEADER_ELECTION_TOPIC
+
+HEARTBEAT_TICK_SECONDS = 5
+
+
+class LeaderElection:
+    """Elects a single collector among check instances pointed at the same Kafka cluster.
+
+    Relies on the broker's own consumer-group rebalance protocol: a single-partition
+    coordination topic is only ever assigned to one group member at a time. A persistent
+    log of "last collected at T" messages on that partition gives a freshly elected
+    leader (e.g. after a failover) shared memory of collection cadence, so a failover
+    never causes a burst of back-to-back collections.
+    """
+
+    def __init__(self, check, client, config, log):
+        self.check = check
+        self.client = client
+        self.config = config
+        self.log = log
+        self._consumer = None
+        self._producer = None
+        self._pending_commit_message = None
+        self._collecting_this_round = False
+        self._stop_heartbeat = None
+        self._heartbeat_thread = None
+
+    def _ensure_clients(self):
+        if self._consumer is None:
+            self.client.ensure_topic(LEADER_ELECTION_TOPIC, num_partitions=1)
+            self._consumer = self.client.build_election_consumer(LEADER_ELECTION_GROUP_ID)
+            self._consumer.subscribe([LEADER_ELECTION_TOPIC])
+        if self._producer is None:
+            self._producer = self.client.build_election_producer()
+
+    def should_collect(self):
+        """Decide, via the coordination topic, whether this instance should collect this round."""
+        self._pending_commit_message = None
+        self._collecting_this_round = False
+        try:
+            self._ensure_clients()
+            message = self._consumer.poll(timeout=self.config._request_timeout)
+        except Exception:
+            self.log.exception("Leader election failed; skipping collection this round.")
+            self._submit_is_leader(False)
+            return False
+
+        if message is None:
+            # No partition assignment yet (still joining/rebalancing) - stand down conservatively.
+            self._submit_is_leader(False)
+            return False
+
+        error = message.error()
+        if error is not None:
+            if error.code() == KafkaError._PARTITION_EOF:
+                # Caught up with nothing ever written: nobody has collected yet, so we should.
+                self._collecting_this_round = True
+                self._submit_is_leader(True)
+                return True
+            self.log.warning("Leader election poll error: %s; skipping collection this round.", error)
+            self._submit_is_leader(False)
+            return False
+
+        try:
+            payload = json.loads(message.value())
+            last_collected_at = float(payload["timestamp"])
+        except (TypeError, ValueError, KeyError) as e:
+            self.log.warning("Unreadable leader election message, treating it as stale: %s", e)
+            last_collected_at = 0.0
+
+        if time.time() - last_collected_at < self.config._auto_load_distribution_interval:
+            # Someone else collected recently enough; don't commit so a takeover leader
+            # still sees this message and re-evaluates its own staleness.
+            self._submit_is_leader(False)
+            return False
+
+        self._pending_commit_message = message
+        self._collecting_this_round = True
+        self._submit_is_leader(True)
+        return True
+
+    def start_heartbeat(self):
+        """Keep polling in the background so a slow collection can't exceed max.poll.interval.ms."""
+        if not self._collecting_this_round:
+            return
+        self._stop_heartbeat = threading.Event()
+
+        def _tick():
+            while not self._stop_heartbeat.wait(HEARTBEAT_TICK_SECONDS):
+                try:
+                    self._consumer.poll(0)
+                except Exception:
+                    self.log.exception("Leader election heartbeat poll failed.")
+
+        self._heartbeat_thread = threading.Thread(target=_tick, daemon=True)
+        self._heartbeat_thread.start()
+
+    def finish(self):
+        """Stop the heartbeat, publish a fresh timestamp, and commit the message that triggered this round."""
+        if not self._collecting_this_round:
+            return
+        if self._stop_heartbeat is not None:
+            self._stop_heartbeat.set()
+            self._heartbeat_thread.join()
+            self._stop_heartbeat = None
+            self._heartbeat_thread = None
+
+        try:
+            self._producer.produce(LEADER_ELECTION_TOPIC, json.dumps({"timestamp": time.time()}).encode())
+            self._producer.flush(self.config._request_timeout)
+            if self._pending_commit_message is not None:
+                self._consumer.commit(message=self._pending_commit_message, asynchronous=False)
+        except Exception:
+            self.log.exception("Failed to finalize leader election heartbeat.")
+        finally:
+            self._pending_commit_message = None
+            self._collecting_this_round = False
+
+    def _submit_is_leader(self, is_leader):
+        self.check.gauge('leader_election.is_leader', int(is_leader), tags=list(self.config._custom_tags))

--- a/kafka_consumer/tests/test_leader_election.py
+++ b/kafka_consumer/tests/test_leader_election.py
@@ -1,0 +1,116 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+import time
+
+import mock
+import pytest
+from confluent_kafka.error import KafkaError
+
+from datadog_checks.kafka_consumer.leader_election import LeaderElection
+
+pytestmark = [pytest.mark.unit]
+
+
+def make_election(interval=60):
+    check = mock.MagicMock()
+    client = mock.MagicMock()
+    config = mock.MagicMock()
+    config._auto_load_distribution_interval = interval
+    config._request_timeout = 5
+    config._custom_tags = ['env:test']
+    log = mock.MagicMock()
+
+    election = LeaderElection(check, client, config, log)
+    election._consumer = client.build_election_consumer.return_value
+    election._producer = client.build_election_producer.return_value
+    return election, check, client
+
+
+def make_message(value=None, error=None):
+    message = mock.MagicMock()
+    message.error.return_value = error
+    message.value.return_value = value
+    return message
+
+
+def make_eof_error():
+    error = mock.MagicMock()
+    error.code.return_value = KafkaError._PARTITION_EOF
+    return error
+
+
+def timestamp_payload(age_seconds):
+    return json.dumps({"timestamp": time.time() - age_seconds}).encode()
+
+
+def test_no_assignment_yet_stands_down():
+    election, check, _ = make_election()
+    election._consumer.poll.return_value = None
+
+    assert election.should_collect() is False
+    check.gauge.assert_called_once_with('leader_election.is_leader', 0, tags=['env:test'])
+
+
+def test_partition_eof_bootstraps_collection():
+    election, check, _ = make_election()
+    election._consumer.poll.return_value = make_message(error=make_eof_error())
+
+    assert election.should_collect() is True
+    check.gauge.assert_called_once_with('leader_election.is_leader', 1, tags=['env:test'])
+    assert election._pending_commit_message is None
+
+
+def test_fresh_message_skips_without_committing():
+    election, check, _ = make_election(interval=60)
+    election._consumer.poll.return_value = make_message(value=timestamp_payload(age_seconds=5))
+
+    assert election.should_collect() is False
+    check.gauge.assert_called_once_with('leader_election.is_leader', 0, tags=['env:test'])
+
+    election.finish()
+    election._consumer.commit.assert_not_called()
+
+
+def test_stale_message_collects_and_commit_happens_on_finish():
+    election, check, _ = make_election(interval=60)
+    message = make_message(value=timestamp_payload(age_seconds=120))
+    election._consumer.poll.return_value = message
+
+    assert election.should_collect() is True
+    check.gauge.assert_called_once_with('leader_election.is_leader', 1, tags=['env:test'])
+    assert election._pending_commit_message is message
+
+    election.finish()
+
+    election._producer.produce.assert_called_once()
+    election._producer.flush.assert_called_once()
+    election._consumer.commit.assert_called_once_with(message=message, asynchronous=False)
+    assert election._collecting_this_round is False
+
+
+def test_finish_is_a_noop_when_standing_down():
+    election, _, _ = make_election()
+    election._consumer.poll.return_value = None
+
+    election.should_collect()
+    election.finish()
+
+    election._producer.produce.assert_not_called()
+    election._consumer.commit.assert_not_called()
+
+
+def test_heartbeat_keeps_polling_during_collection():
+    election, _, _ = make_election()
+    election._consumer.poll.return_value = make_message(error=make_eof_error())
+    election.should_collect()
+
+    with mock.patch('datadog_checks.kafka_consumer.leader_election.HEARTBEAT_TICK_SECONDS', 0.01):
+        election.start_heartbeat()
+        time.sleep(0.05)
+        election.finish()
+
+    # At least one heartbeat tick (poll(0)) plus the initial should_collect() poll.
+    poll_calls = [call for call in election._consumer.poll.call_args_list if call.args == (0,)]
+    assert len(poll_calls) >= 1


### PR DESCRIPTION
### What does this PR do?
Adds an opt-in `auto_load_distribution` instance option (plus `auto_load_distribution_interval`) to the `kafka_consumer` check. When enabled, each check instance negotiates via a dedicated coordination topic on the monitored Kafka cluster (auto-created if missing) so that only one instance actually collects each cycle, using the broker's own consumer-group rebalance protocol as a mutual-exclusion lock. Non-collecting instances stand down without touching the API; collecting instances run a background heartbeat poll to avoid a mid-collection rebalance under `max.poll.interval.ms`. Every run — leader or standby — emits a `kafka_consumer.leader_election.is_leader` gauge for monitoring.

### Motivation
Fleets commonly deploy the exact same `kafka_consumer` config to every host pointed at a shared Kafka cluster (the common non-k8s pattern), which today causes redundant collection from every instance and trips the "multiple `kafka_consumer` checks monitoring the same cluster" warning. The only current workaround is manually carving out config-management exceptions so a single designated host runs the check, with no automatic failover. This flag lets the same config ship everywhere while the checks themselves elect a single collector, with automatic failover if that instance goes down.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged