### PR TITLE
Add test-debug label to run PR tests with verbose pytest logging

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,10 @@ jobs:
     uses: ./.github/workflows/pr-test.yml
     with:
       repo: core
+      # Set the "test-debug" label on a PR to run its tests with verbose pytest
+      # logging. Useful for inspecting test output, such as E2E discovery
+      # candidate probing, on platforms where tests can't be run locally.
+      pytest-args: ${{ contains(github.event.pull_request.labels.*.name, 'test-debug') && '-rP --log-level=DEBUG' || '' }}
     secrets: inherit
 
     permissions:


### PR DESCRIPTION
### What does this PR do?

Adds a conditional to the top-level `pr.yml` workflow: when a PR has the `test-debug` label, its tests run with `-rP --log-level=DEBUG` passed to pytest via the existing `pytest-args` input.

### Motivation

Some servers (e.g. `kong 1.5.0`) only provide Docker images for amd64, so their E2E tests can't be run locally on non-amd64 dev machines to inspect debug output such as discovery candidate probing (`assert_all_discovery_candidates_stable`). With this change, adding the `test-debug` label to a PR surfaces that debug output directly in the CI job log instead, without needing any local run. By requiring a separate label, we don't pollute the logs for the common case.

This was validated against the `kong-discovery` branch (PR #24318): the label correctly threaded `-rP --log-level=DEBUG` through to the [pytest invocation](https://github.com/DataDog/integrations-core/actions/runs/28948920828/job/85890279373#step:20:48), and `test_e2e_discovery_all_candidates`'s captured debug output appeared in the CI job log even though the test passed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged