### PR TITLE
Verify TLS by default in OpenStack Keystone authentication

### DIFF
--- a/openstack/changelog.d/24440.security
+++ b/openstack/changelog.d/24440.security
@@ -1,0 +1,1 @@
+Enable TLS certificate verification by default for the Keystone authentication request.

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -210,7 +210,7 @@ class OpenStackScope(object):
         if not keystone_server_url:
             raise IncompleteConfig()
 
-        ssl_verify = is_affirmative(init_config.get("ssl_verify", False))
+        ssl_verify = is_affirmative(init_config.get("ssl_verify", True))
 
         auth_scope = cls.get_auth_scope(instance_config)
         identity = cls.get_user_identity(instance_config)

--- a/openstack/tests/test_openstack.py
+++ b/openstack/tests/test_openstack.py
@@ -107,6 +107,30 @@ def test_from_config():
         assert scope.service_catalog.nova_endpoint == 'http://10.0.2.15:8773/test_project_id'
 
 
+def test_keystone_auth_ssl_verify_default():
+    """Keystone auth verifies TLS by default and honors an explicit ``ssl_verify: false`` opt-out."""
+    instance_config = {
+        'user': common.GOOD_USERS[0]['user'],
+        'auth_scope': common.GOOD_AUTH_SCOPES[0]['auth_scope'],
+    }
+    base_init_config = {'keystone_server_url': 'http://10.0.2.15:5000', 'nova_api_version': 'v2'}
+
+    def capture_ssl_verify(init_config):
+        with mock.patch(
+            'datadog_checks.openstack.openstack.OpenStackProjectScope.request_auth_token',
+            return_value=MOCK_HTTP_RESPONSE,
+        ) as mock_request_auth_token:
+            OpenStackProjectScope.from_config(init_config, instance_config)
+        # request_auth_token(cls, auth_scope, identity, keystone_server_url, ssl_verify, proxy=None)
+        return mock_request_auth_token.call_args.args[3]
+
+    default_ssl_verify = capture_ssl_verify(base_init_config)
+    explicit_off_ssl_verify = capture_ssl_verify({**base_init_config, 'ssl_verify': False})
+
+    assert default_ssl_verify is True
+    assert explicit_off_ssl_verify is False
+
+
 def test_unscoped_from_config():
     init_config = {'keystone_server_url': 'http://10.0.2.15:5000', 'nova_api_version': 'v2'}
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Changes the default value of `ssl_verify` for the OpenStack Keystone authentication request from `False` to `True`, so TLS certificate verification is enabled by default on that request. Users who explicitly set `ssl_verify: false` are unaffected. A unit test covers both the new default and the preserved opt-out.

### Motivation
<!-- What inspired you to submit this pull request? -->

The check reads `ssl_verify` from `init_config` in three places. Two of them, project and token scoping and the check's own API calls, already default to `True`. Only the Keystone authentication path defaulted to `False`. That means the single request that transmits OpenStack credentials skipped certificate verification by default, while the read-only metric calls verified.

The `False` default has been present since the integration's first commit with no documented rationale. It is inconsistent with the sibling code paths and applies weaker verification to the most sensitive request. Those sibling paths are `OpenStackUnscoped.from_config` ([code ref](https://github.com/DataDog/integrations-core/blob/master/openstack/datadog_checks/openstack/openstack.py#L269)) and `OpenStackCheck.__init__` ([code ref](https://github.com/DataDog/integrations-core/blob/master/openstack/datadog_checks/openstack/openstack.py#L524)), both resolving `is_affirmative(init_config.get("ssl_verify", True))`. 

This was discovered during the httpx migration and is being split out as a standalone fix.

### Verification

- `ddev --no-interactive test openstack`: 18 passed, 1 skipped, no regressions.
- The added `test_keystone_auth_ssl_verify_default` fails on the old default (`assert False is True`) and passes after the fix, confirming verification is on by default while an explicit `ssl_verify: false` still disables it.
- `ddev test -fs openstack`: format and lint clean.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
