### PR TITLE
feat: change display priority of sql server to keep only most important fields on top

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -36,6 +36,7 @@ files:
       Note: All '%' characters must be escaped as '%%'.
     options:
     - name: host
+      display_priority: 3
       description: |
         Host and port of your SQL server. If a port is ommitted, a default port of 1433 will be used.
         If you use Sql Server Browser Service or a similar port autodiscovery service, pass in a port
@@ -47,11 +48,13 @@ files:
         type: string
         example: <HOST>,<PORT>
     - name: username
+      display_priority: 2
       description: Username for the Datadog-SQL server check user. It will be ignored if using Windows authentication.
       fleet_configurable: true
       value:
         type: string
     - name: password
+      display_priority: 1
       description: Password for the Datadog-SQL server check user. It will be ignored if using Windows authentication.
       fleet_configurable: true
       secret: true


### PR DESCRIPTION
### What does this PR do?

Adjusts the `display_priority` values in the SQL Server specs so that only the 3 most important fields (e.g. `host`, `user` and `password`) surface in the main form section, all other fields being moved in the the advanced section.

### Motivation

The SQL Server integration had no display_priority set, causing all fields to appear in the main section of the Fleet Automation form.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged