### PR TITLE
Fix auto-backport failures from cherry-picked dependency resolution

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -28,14 +28,17 @@ jobs:
         with:
           scope: DataDog/integrations-core
           policy: self.backport.pull-request-target
-      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          label_pattern: "^backport/(?<base>([^ ]+))$"
-          labels_template: "[\"backport\", \"bot\"]"
-          body_template: |
-            Backport <%= mergeCommitSha %> from #<%= number %>.
-
-            ___
-
-            <%= body %>
-          github_token: ${{ steps.octo-sts.outputs.token }}
+          fetch-depth: 0
+          token: ${{ steps.octo-sts.outputs.token }}
+      - name: Backport to release branches
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          EVENT_ACTION: ${{ github.event.action }}
+          ADDED_LABEL: ${{ github.event.label.name }}
+          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: .github/workflows/scripts/backport.sh

--- a/.github/workflows/scripts/backport.sh
+++ b/.github/workflows/scripts/backport.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Backport a merged PR to one or more release branches.
+#
+# Builder/CVE and dependency bumps merge to master as a squash commit that
+# bundles the human-authored inputs (.builders/**, agent_requirements.in,
+# pyproject.toml) with the bot-generated lockfiles under .deps/**. Cherry-picking
+# that whole squash onto a release branch conflicts on the branch's already
+# drifted .deps/ lockfiles, which is why the previous tibdex-based backport died
+# with "git exit code 1" and never opened a PR.
+#
+# We cherry-pick without committing, reset .deps/ back to the target branch, then
+# commit only the inputs. The push re-triggers resolve-build-deps.yaml (which
+# already runs on backport-* branches), and that regenerates correct lockfiles
+# for this release line -- exactly the flow the original master PR went through.
+# Promotion (`ddev dep promote`) stays the same manual step it is on master.
+#
+# Required environment:
+#   GH_TOKEN      token with contents:write + pull-requests:write (from dd-octo-sts)
+#   PR_NUMBER     merged PR number
+#   MERGE_SHA     merge/squash commit SHA of the merged PR
+#   EVENT_ACTION  triggering event action ("closed" or "labeled")
+#   ADDED_LABEL   label just added (only meaningful when EVENT_ACTION == "labeled")
+#   LABELS_JSON   JSON array of every label name on the PR
+
+BOT_NAME="dd-agent-integrations-bot[bot]"
+BOT_EMAIL="dd-agent-integrations-bot[bot]@users.noreply.github.com"
+LABEL_PREFIX="backport/"
+
+comment_pr() {
+  gh pr comment "${PR_NUMBER}" --body "$1"
+}
+
+# Collect the release branches to target from the PR's backport/<base> labels.
+# On a `labeled` event act only on the label just added; on merge (`closed`)
+# process every backport/* label on the PR.
+targets=()
+if [[ "${EVENT_ACTION}" == "labeled" ]]; then
+  if [[ "${ADDED_LABEL}" == "${LABEL_PREFIX}"* ]]; then
+    targets+=("${ADDED_LABEL#"${LABEL_PREFIX}"}")
+  fi
+else
+  while IFS= read -r base; do
+    [[ -n "${base}" ]] && targets+=("${base}")
+  done < <(printf '%s' "${LABELS_JSON}" | jq -r --arg p "${LABEL_PREFIX}" '.[] | select(startswith($p)) | ltrimstr($p)')
+fi
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+  echo "No backport/* labels to process."
+  exit 0
+fi
+
+git config user.name "${BOT_NAME}"
+git config user.email "${BOT_EMAIL}"
+
+# Squash merges are single-parent; a true merge commit needs an explicit mainline.
+parent_words=$(git rev-list --parents -n 1 "${MERGE_SHA}" | wc -w)
+mainline=()
+if [[ "${parent_words}" -gt 2 ]]; then
+  mainline=(-m 1)
+fi
+
+pr_title=$(gh pr view "${PR_NUMBER}" --json title --jq '.title')
+commit_subject=$(git log -1 --format=%s "${MERGE_SHA}")
+
+exit_status=0
+for base in "${targets[@]}"; do
+  echo "::group::Backport #${PR_NUMBER} to ${base}"
+  backport_branch="backport-${PR_NUMBER}-to-${base}"
+
+  git fetch --quiet origin "${base}"
+
+  if gh pr list --head "${backport_branch}" --state open --json number --jq '.[].number' | grep -q .; then
+    echo "A backport PR for ${base} is already open; skipping."
+    echo "::endgroup::"
+    continue
+  fi
+
+  # Clean slate for this base: force the working tree and branch to the target.
+  git checkout --quiet -f -B "${backport_branch}" "origin/${base}"
+
+  git cherry-pick -n "${mainline[@]}" "${MERGE_SHA}" || \
+    echo "Cherry-pick reported conflicts; resolving generated .deps/ automatically."
+
+  # Match the target branch's .deps/ exactly (handles added/removed/edited files),
+  # dropping the cherry-picked lockfiles that were resolved against master.
+  rm -rf .deps
+  git checkout "origin/${base}" -- .deps 2>/dev/null || true
+  git add -A .deps
+
+  # Anything still unmerged is a genuine conflict a human has to resolve.
+  conflicts=$(git diff --name-only --diff-filter=U)
+  if [[ -n "${conflicts}" ]]; then
+    echo "Conflicts outside .deps/ that need manual resolution:"
+    echo "${conflicts}"
+    comment_pr "⚠️ Backport to \`${base}\` failed: cherry-pick conflicts outside \`.deps/\` that need manual resolution:
+\`\`\`
+${conflicts}
+\`\`\`
+Please open the backport by hand."
+    exit_status=1
+    echo "::endgroup::"
+    continue
+  fi
+
+  if git diff --cached --quiet; then
+    echo "Backport to ${base} is empty (payload already present); skipping."
+    echo "::endgroup::"
+    continue
+  fi
+
+  git commit --quiet -m "${commit_subject} (backport #${PR_NUMBER})"
+  git push --force origin "HEAD:${backport_branch}"
+
+  new_pr_url=$(gh pr create \
+    --base "${base}" \
+    --head "${backport_branch}" \
+    --title "[Backport ${base}] ${pr_title}" \
+    --body "Backport of #${PR_NUMBER} to \`${base}\`.
+
+Generated dependency resolution (\`.deps/\`) was reset to the target branch; \`resolve-build-deps.yaml\` re-resolves it for this release line on push. Wheels must still be promoted before merge with \`ddev dep promote <PR_URL>\`." \
+    --label backport \
+    --label bot)
+
+  comment_pr "Backported to \`${base}\`: ${new_pr_url}"
+  echo "Opened ${new_pr_url}"
+  echo "::endgroup::"
+done
+
+exit "${exit_status}"

--- a/.github/workflows/scripts/backport.sh
+++ b/.github/workflows/scripts/backport.sh
@@ -33,11 +33,21 @@ comment_pr() {
 }
 
 # Log a final line for the current base and close its Actions log group. Every
-# return path in backport_to_branch calls this exactly once, so the ::group::
-# opened by the caller is always balanced.
+# return path in backport_to_branch closes the group exactly once -- directly on
+# the success/skip paths, or via fail_branch on the failure paths -- so the
+# ::group:: opened by the caller is always balanced.
 end_group() {
   echo "$1"
   echo "::endgroup::"
+}
+
+# Report a failed base: post the PR comment ($1), then close the Actions log
+# group with the log line ($2). The caller must still `return 1` itself -- a
+# return here would leave fail_branch, not backport_to_branch, and fall through
+# the guard.
+fail_branch() {
+  comment_pr "$1"
+  end_group "$2"
 }
 
 # Backport MERGE_SHA onto a single release branch. Returns 0 when the base was
@@ -54,8 +64,8 @@ backport_to_branch() {
   local backport_branch="backport-${PR_NUMBER}-to-${base}"
 
   if ! git fetch --quiet origin "${base}"; then
-    comment_pr "⚠️ Backport to \`${base}\`: could not fetch \`origin/${base}\` -- does the release branch exist?"
-    end_group "Fetch of origin/${base} failed."
+    fail_branch "⚠️ Backport to \`${base}\`: could not fetch \`origin/${base}\` -- does the release branch exist?" \
+      "Fetch of origin/${base} failed."
     return 1
   fi
 
@@ -66,8 +76,8 @@ backport_to_branch() {
 
   # Clean slate for this base: force the working tree and branch to the target.
   if ! git checkout --quiet -f -B "${backport_branch}" "origin/${base}"; then
-    comment_pr "⚠️ Backport to \`${base}\`: could not check out \`origin/${base}\`."
-    end_group "Checkout of origin/${base} failed."
+    fail_branch "⚠️ Backport to \`${base}\`: could not check out \`origin/${base}\`." \
+      "Checkout of origin/${base} failed."
     return 1
   fi
 
@@ -75,21 +85,30 @@ backport_to_branch() {
   git cherry-pick -n "${mainline[@]}" "${MERGE_SHA}" || cherry_pick_rc=$?
 
   # Match the target branch's .deps/ exactly (handles added/removed/edited files),
-  # dropping the cherry-picked lockfiles that were resolved against master.
+  # dropping the cherry-picked lockfiles that were resolved against master. Only
+  # restore when the target actually has a .deps/ tree; a blanket "|| true" would
+  # make a real checkout failure indistinguishable from "this branch has no
+  # .deps/" and silently stage a wholesale .deps/ deletion into the backport.
   rm -rf .deps
-  git checkout "origin/${base}" -- .deps 2>/dev/null || true
+  if git rev-parse --quiet --verify "origin/${base}:.deps" >/dev/null 2>&1; then
+    if ! git checkout "origin/${base}" -- .deps; then
+      fail_branch "⚠️ Backport to \`${base}\`: failed to restore \`.deps/\` from the target branch." \
+        "Restore of .deps from origin/${base} failed."
+      return 1
+    fi
+  fi
   git add -A .deps
 
   # Anything still unmerged is a genuine conflict a human has to resolve.
   local conflicts
   conflicts=$(git diff --name-only --diff-filter=U)
   if [[ -n "${conflicts}" ]]; then
-    comment_pr "⚠️ Backport to \`${base}\` failed: cherry-pick conflicts outside \`.deps/\` that need manual resolution:
+    fail_branch "⚠️ Backport to \`${base}\` failed: cherry-pick conflicts outside \`.deps/\` that need manual resolution:
 \`\`\`
 ${conflicts}
 \`\`\`
-Please open the backport by hand."
-    end_group "Conflicts outside .deps/ that need manual resolution:
+Please open the backport by hand." \
+      "Conflicts outside .deps/ that need manual resolution:
 ${conflicts}"
     return 1
   fi
@@ -100,8 +119,8 @@ ${conflicts}"
     # itself hard-failed (unreachable SHA, wrong mainline, git error) -- surface
     # that instead of silently reporting it as "already applied".
     if [[ "${cherry_pick_rc}" -ne 0 ]]; then
-      comment_pr "⚠️ Backport to \`${base}\` failed: cherry-pick exited ${cherry_pick_rc} with nothing to commit -- resolve by hand."
-      end_group "Cherry-pick exited ${cherry_pick_rc} with no staged changes."
+      fail_branch "⚠️ Backport to \`${base}\` failed: cherry-pick exited ${cherry_pick_rc} with nothing to commit -- resolve by hand." \
+        "Cherry-pick exited ${cherry_pick_rc} with no staged changes."
       return 1
     fi
     end_group "Backport to ${base} is empty (payload already present); skipping."
@@ -109,14 +128,14 @@ ${conflicts}"
   fi
 
   if ! git commit --quiet -m "${commit_subject} (backport #${PR_NUMBER})"; then
-    comment_pr "⚠️ Backport to \`${base}\`: git commit failed."
-    end_group "Commit for ${base} failed."
+    fail_branch "⚠️ Backport to \`${base}\`: git commit failed." \
+      "Commit for ${base} failed."
     return 1
   fi
 
   if ! git push --force origin "HEAD:${backport_branch}"; then
-    comment_pr "⚠️ Backport to \`${base}\`: push failed. Please retry the backport."
-    end_group "Push to ${backport_branch} failed."
+    fail_branch "⚠️ Backport to \`${base}\`: push failed. Please retry the backport." \
+      "Push to ${backport_branch} failed."
     return 1
   fi
 
@@ -130,8 +149,8 @@ ${conflicts}"
 Generated dependency resolution (\`.deps/\`) was reset to the target branch; \`resolve-build-deps.yaml\` re-resolves it for this release line on push. Wheels must still be promoted before merge with \`ddev dep promote <PR_URL>\`." \
     --label backport \
     --label bot); then
-    comment_pr "⚠️ Backport to \`${base}\`: branch pushed but \`gh pr create\` failed. Open the PR from \`${backport_branch}\` by hand."
-    end_group "gh pr create for ${base} failed (branch ${backport_branch} was pushed)."
+    fail_branch "⚠️ Backport to \`${base}\`: branch pushed but \`gh pr create\` failed. Open the PR from \`${backport_branch}\` by hand." \
+      "gh pr create for ${base} failed (branch ${backport_branch} was pushed)."
     return 1
   fi
 

--- a/.github/workflows/scripts/backport.sh
+++ b/.github/workflows/scripts/backport.sh
@@ -32,6 +32,114 @@ comment_pr() {
   gh pr comment "${PR_NUMBER}" --body "$1"
 }
 
+# Log a final line for the current base and close its Actions log group. Every
+# return path in backport_to_branch calls this exactly once, so the ::group::
+# opened by the caller is always balanced.
+end_group() {
+  echo "$1"
+  echo "::endgroup::"
+}
+
+# Backport MERGE_SHA onto a single release branch. Returns 0 when the base was
+# handled (PR opened, already open, already applied, or nothing to port) and 1
+# on a failure a human must resolve. It never aborts the whole run, so one bad
+# base does not skip the others.
+#
+# This function is invoked as `backport_to_branch "${base}" || exit_status=1`,
+# which means bash runs it with `set -e` suppressed for its whole body. Every
+# fallible git/gh call is therefore guarded explicitly rather than relying on
+# errexit.
+backport_to_branch() {
+  local base="$1"
+  local backport_branch="backport-${PR_NUMBER}-to-${base}"
+
+  if ! git fetch --quiet origin "${base}"; then
+    comment_pr "⚠️ Backport to \`${base}\`: could not fetch \`origin/${base}\` -- does the release branch exist?"
+    end_group "Fetch of origin/${base} failed."
+    return 1
+  fi
+
+  if gh pr list --head "${backport_branch}" --state open --json number --jq '.[].number' | grep -q .; then
+    end_group "A backport PR for ${base} is already open; skipping."
+    return 0
+  fi
+
+  # Clean slate for this base: force the working tree and branch to the target.
+  if ! git checkout --quiet -f -B "${backport_branch}" "origin/${base}"; then
+    comment_pr "⚠️ Backport to \`${base}\`: could not check out \`origin/${base}\`."
+    end_group "Checkout of origin/${base} failed."
+    return 1
+  fi
+
+  local cherry_pick_rc=0
+  git cherry-pick -n "${mainline[@]}" "${MERGE_SHA}" || cherry_pick_rc=$?
+
+  # Match the target branch's .deps/ exactly (handles added/removed/edited files),
+  # dropping the cherry-picked lockfiles that were resolved against master.
+  rm -rf .deps
+  git checkout "origin/${base}" -- .deps 2>/dev/null || true
+  git add -A .deps
+
+  # Anything still unmerged is a genuine conflict a human has to resolve.
+  local conflicts
+  conflicts=$(git diff --name-only --diff-filter=U)
+  if [[ -n "${conflicts}" ]]; then
+    comment_pr "⚠️ Backport to \`${base}\` failed: cherry-pick conflicts outside \`.deps/\` that need manual resolution:
+\`\`\`
+${conflicts}
+\`\`\`
+Please open the backport by hand."
+    end_group "Conflicts outside .deps/ that need manual resolution:
+${conflicts}"
+    return 1
+  fi
+
+  if git diff --cached --quiet; then
+    # A redundant cherry-pick (payload already on the branch) exits 0 and leaves
+    # an empty index. A *nonzero* exit with nothing staged means the cherry-pick
+    # itself hard-failed (unreachable SHA, wrong mainline, git error) -- surface
+    # that instead of silently reporting it as "already applied".
+    if [[ "${cherry_pick_rc}" -ne 0 ]]; then
+      comment_pr "⚠️ Backport to \`${base}\` failed: cherry-pick exited ${cherry_pick_rc} with nothing to commit -- resolve by hand."
+      end_group "Cherry-pick exited ${cherry_pick_rc} with no staged changes."
+      return 1
+    fi
+    end_group "Backport to ${base} is empty (payload already present); skipping."
+    return 0
+  fi
+
+  if ! git commit --quiet -m "${commit_subject} (backport #${PR_NUMBER})"; then
+    comment_pr "⚠️ Backport to \`${base}\`: git commit failed."
+    end_group "Commit for ${base} failed."
+    return 1
+  fi
+
+  if ! git push --force origin "HEAD:${backport_branch}"; then
+    comment_pr "⚠️ Backport to \`${base}\`: push failed. Please retry the backport."
+    end_group "Push to ${backport_branch} failed."
+    return 1
+  fi
+
+  local new_pr_url
+  if ! new_pr_url=$(gh pr create \
+    --base "${base}" \
+    --head "${backport_branch}" \
+    --title "[Backport ${base}] ${pr_title}" \
+    --body "Backport of #${PR_NUMBER} to \`${base}\`.
+
+Generated dependency resolution (\`.deps/\`) was reset to the target branch; \`resolve-build-deps.yaml\` re-resolves it for this release line on push. Wheels must still be promoted before merge with \`ddev dep promote <PR_URL>\`." \
+    --label backport \
+    --label bot); then
+    comment_pr "⚠️ Backport to \`${base}\`: branch pushed but \`gh pr create\` failed. Open the PR from \`${backport_branch}\` by hand."
+    end_group "gh pr create for ${base} failed (branch ${backport_branch} was pushed)."
+    return 1
+  fi
+
+  comment_pr "Backported to \`${base}\`: ${new_pr_url}"
+  end_group "Opened ${new_pr_url}"
+  return 0
+}
+
 # Collect the release branches to target from the PR's backport/<base> labels.
 # On a `labeled` event act only on the label just added; on merge (`closed`)
 # process every backport/* label on the PR.
@@ -54,10 +162,15 @@ fi
 git config user.name "${BOT_NAME}"
 git config user.email "${BOT_EMAIL}"
 
-# Squash merges are single-parent; a true merge commit needs an explicit mainline.
-parent_words=$(git rev-list --parents -n 1 "${MERGE_SHA}" | wc -w)
+# `git rev-list --parents -n 1` prints the commit SHA followed by each of its
+# parents. A squash merge has a single parent (2 words); a true merge commit has
+# two or more parents (>2 words) and needs an explicit mainline to cherry-pick.
+is_merge_commit=false
+if [[ "$(git rev-list --parents -n 1 "${MERGE_SHA}" | wc -w)" -gt 2 ]]; then
+  is_merge_commit=true
+fi
 mainline=()
-if [[ "${parent_words}" -gt 2 ]]; then
+if [[ "${is_merge_commit}" == true ]]; then
   mainline=(-m 1)
 fi
 
@@ -67,65 +180,7 @@ commit_subject=$(git log -1 --format=%s "${MERGE_SHA}")
 exit_status=0
 for base in "${targets[@]}"; do
   echo "::group::Backport #${PR_NUMBER} to ${base}"
-  backport_branch="backport-${PR_NUMBER}-to-${base}"
-
-  git fetch --quiet origin "${base}"
-
-  if gh pr list --head "${backport_branch}" --state open --json number --jq '.[].number' | grep -q .; then
-    echo "A backport PR for ${base} is already open; skipping."
-    echo "::endgroup::"
-    continue
-  fi
-
-  # Clean slate for this base: force the working tree and branch to the target.
-  git checkout --quiet -f -B "${backport_branch}" "origin/${base}"
-
-  git cherry-pick -n "${mainline[@]}" "${MERGE_SHA}" || \
-    echo "Cherry-pick reported conflicts; resolving generated .deps/ automatically."
-
-  # Match the target branch's .deps/ exactly (handles added/removed/edited files),
-  # dropping the cherry-picked lockfiles that were resolved against master.
-  rm -rf .deps
-  git checkout "origin/${base}" -- .deps 2>/dev/null || true
-  git add -A .deps
-
-  # Anything still unmerged is a genuine conflict a human has to resolve.
-  conflicts=$(git diff --name-only --diff-filter=U)
-  if [[ -n "${conflicts}" ]]; then
-    echo "Conflicts outside .deps/ that need manual resolution:"
-    echo "${conflicts}"
-    comment_pr "⚠️ Backport to \`${base}\` failed: cherry-pick conflicts outside \`.deps/\` that need manual resolution:
-\`\`\`
-${conflicts}
-\`\`\`
-Please open the backport by hand."
-    exit_status=1
-    echo "::endgroup::"
-    continue
-  fi
-
-  if git diff --cached --quiet; then
-    echo "Backport to ${base} is empty (payload already present); skipping."
-    echo "::endgroup::"
-    continue
-  fi
-
-  git commit --quiet -m "${commit_subject} (backport #${PR_NUMBER})"
-  git push --force origin "HEAD:${backport_branch}"
-
-  new_pr_url=$(gh pr create \
-    --base "${base}" \
-    --head "${backport_branch}" \
-    --title "[Backport ${base}] ${pr_title}" \
-    --body "Backport of #${PR_NUMBER} to \`${base}\`.
-
-Generated dependency resolution (\`.deps/\`) was reset to the target branch; \`resolve-build-deps.yaml\` re-resolves it for this release line on push. Wheels must still be promoted before merge with \`ddev dep promote <PR_URL>\`." \
-    --label backport \
-    --label bot)
-
-  comment_pr "Backported to \`${base}\`: ${new_pr_url}"
-  echo "Opened ${new_pr_url}"
-  echo "::endgroup::"
+  backport_to_branch "${base}" || exit_status=1
 done
 
 exit "${exit_status}"


### PR DESCRIPTION
### What does this PR do?

Replaces the `tibdex/backport` step in `backport-pr.yml` with a scripted backport (`.github/workflows/scripts/backport.sh`) that cherry-picks the merged commit, then resets `.deps/` back to the target branch before pushing. `resolve-build-deps.yaml` re-resolves correct lockfiles for the release line on push.

### Motivation

Builder/CVE and dependency bumps merge to master as a squash that bundles human-authored inputs with the bot-generated `.deps/` lockfiles. Cherry-picking that whole squash onto a release branch conflicts on the branch's already-drifted `.deps/`, so tibdex failed with `git exit code 1` and never opened a backport PR (confirmed on #23771, #24073, #24074, #24078, #23767). The existing `self.backport.pull-request-target` trust policy already grants `contents: write`, so no new policy is needed.

Tracked in AI-7014.

### Test plan

- [x] `shellcheck` clean on `backport.sh`.
- [x] Validated end-to-end against the real failed backports (#23771 -> 7.79.x, #24073 -> 7.81.x): after cherry-pick + `.deps` reset the `.deps` delta vs base is empty, no unmerged files remain, and the real payload (changelog fragments, code) is preserved.
- [x] Genuine non-`.deps` conflicts still abort that base and comment on the PR.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

---

_This PR has been created and validated using the paired-review skill from agent-integrations. **Ready for human review**._