### PR TITLE
Fix duplicate widget list in Cisco Secure Firewall IP stack dashboard

### DIFF
--- a/cisco_secure_firewall/assets/dashboards/cisco_secure_firewall_ip_stack.json
+++ b/cisco_secure_firewall/assets/dashboards/cisco_secure_firewall_ip_stack.json
@@ -46,7 +46,7 @@
             "id": 7538493592267036,
             "definition": {
                 "type": "note",
-                "content": "## Widgets\n1. Protocol Types \n2. Top 10 Source Address \n3. Top 10 Destination Address \n4. Log Details \n5. Protocol Types \n6. Top 10 Source Address \n7. Top 10 Destination Address \n8. Log Details \n9. Return Codes \n10. Top 10 Source IPs \n11. Top 10 Interface \n12. Log Details \n13. Top 10 Interface \n14. Top 10 Source Address \n15. Top 10 Destination Address \n16. Log Details ",
+                "content": "## Widgets\n\n1. Fragment Database Limit Exceeded - Protocol Types \n2. Fragment Database Limit Exceeded - Top 10 Source Address \n3. Fragment Database Limit Exceeded - Top 10 Destination Address \n4. Fragment Database Limit Exceeded - Log Details \n5. Invalid IP Fragment - Protocol Types \n6. Invalid IP Fragment - Top 10 Source Address \n7. Invalid IP Fragment - Top 10 Destination Address \n8. Invalid IP Fragment - Log Details \n9. Denied ICMP Packet - Return Codes \n10. Denied ICMP Packet - Top 10 Source IPs \n11. Denied ICMP Packet - Top 10 Interface \n12. Denied ICMP Packet - Log Details \n13. Dropped ICMP Packet - Top 10 Interface \n14. Dropped ICMP Packet - Top 10 Source Address \n15. Dropped ICMP Packet - Top 10 Destination Address \n16. Dropped ICMP Packet - Log Details ",
                 "background_color": "white",
                 "font_size": "14",
                 "text_align": "left",


### PR DESCRIPTION
### What does this PR do?

Replace the duplicated widget list in the IP stack dashboard with section-prefixed entries that match each dashboard group.

### Motivation

The dashboard widget list note repeated entries without section context, making the overview content confusing for users.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)