### PR TITLE
Fix duplicate widget list in Cisco Secure Firewall transparent firewall dashboard

### DIFF
--- a/cisco_secure_firewall/assets/dashboards/cisco_secure_firewall_transparent_firewall.json
+++ b/cisco_secure_firewall/assets/dashboards/cisco_secure_firewall_transparent_firewall.json
@@ -46,7 +46,7 @@
             "id": 3979223334086134,
             "definition": {
                 "type": "note",
-                "content": "## Widgets\n\n1. Transparent Firewall Events Over Time \n2. Number Of Times Failure Occured \n3. Top 10 Source Interface \n4. Top 10 Source IPs of the Packet \n5. Top 10 Destination IPs of the Packet \n6. Log Details \n7. Number of Times Routing Failed \n8. Events by Protocol \n9. Top 10 Source IP \n10. Top 10 Destination IP \n11. Top 10 Source Interface \n12. Log Details \n13. Log Details ",
+                "content": "## Widgets\n\n1. Transparent Firewall Events Over Time \n2. Failed To Locate  Egress Interface - Number Of Times Failure Occured \n3. Failed To Locate  Egress Interface - Top 10 Source Interface \n4. Failed To Locate  Egress Interface - Top 10 Source IPs of the Packet \n5. Failed To Locate  Egress Interface - Top 10 Destination IPs of the Packet \n6. Failed To Locate  Egress Interface - Log Details \n7. Routing Failed To Locate Next-Hop - Number of Times Routing Failed \n8. Routing Failed To Locate Next-Hop - Events by Protocol \n9. Routing Failed To Locate Next-Hop - Top 10 Source IP \n10. Routing Failed To Locate Next-Hop - Top 10 Destination IP \n11. Routing Failed To Locate Next-Hop - Top 10 Source Interface \n12. Routing Failed To Locate Next-Hop - Log Details \n13. Flow Changes On The Egress Interface - Log Details ",
                 "background_color": "white",
                 "font_size": "14",
                 "text_align": "left",


### PR DESCRIPTION
### What does this PR do?

Replace the duplicated widget list in the transparent firewall dashboard with section-prefixed entries that match each dashboard group.

### Motivation

The dashboard widget list note repeated entries without section context, making the overview content confusing for users.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)