### PR TITLE
Fix grammar and wording in integration dashboard descriptions

### DIFF
--- a/airflow/assets/dashboards/overview.json
+++ b/airflow/assets/dashboards/overview.json
@@ -73,7 +73,7 @@
                         "id": 628034008442880,
                         "definition": {
                             "type": "note",
-                            "content": "This is an overview of service checks, monitors and connect statuses of your Airflow deployment",
+                            "content": "This is an overview of service checks, monitors and connection statuses of your Airflow deployment",
                             "background_color": "pink",
                             "font_size": "14",
                             "text_align": "left",

--- a/argo_rollouts/assets/dashboards/argo_rollouts_overview.json
+++ b/argo_rollouts/assets/dashboards/argo_rollouts_overview.json
@@ -94,7 +94,7 @@
                     {
                         "definition": {
                             "background_color": "blue",
-                            "content": "This is an overview of service checks, monitors and connect statuses of your Argo Rollouts rollouts.",
+                            "content": "This is an overview of service checks, monitors and connection statuses of your Argo Rollouts deployment.",
                             "font_size": "16",
                             "has_padding": true,
                             "show_tick": false,

--- a/argocd/assets/dashboards/argo_cd_overview.json
+++ b/argocd/assets/dashboards/argo_cd_overview.json
@@ -1,6 +1,6 @@
 {
     "author_name": "Datadog",
-    "description": "## Argo CD Overview\n\n### The Argo CD dashboard gives you broad visibility into your Argo CD Clusters\n\nThis dashboard provides a high-level overview of your Argo CD clusters so that you can monitor the deployments, performance, and overall health of a cluster.\n\n### Useful Links\n\n- [Datadog Argo CD Integration Documentation](https://docs.datadoghq.com/integrations/argocd/)\n- [Argo CD Official Documentation](https://argo-cd.readthedocs.io/en/latest/)\n- [Monitoring Argo CD Blogpost](https://www.datadoghq.com/blog/argo-cd-datadog/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
+    "description": "## Argo CD Overview\n\n### The Argo CD dashboard gives you broad visibility into your Argo CD Clusters\n\nThis dashboard provides a high-level overview of your Argo CD clusters so that you can monitor the deployments, performance, and overall health of a cluster.\n\n### Useful Links\n\n- [Datadog Argo CD Integration Documentation](https://docs.datadoghq.com/integrations/argocd/)\n- [Argo CD Official Documentation](https://argo-cd.readthedocs.io/en/latest/)\n- [Monitoring Argo CD Blog Post](https://www.datadoghq.com/blog/argo-cd-datadog/)\n\nClone this template dashboard to make changes and add your own graph widgets.",
     "layout_type": "ordered",
     "template_variables": [
         {
@@ -68,7 +68,7 @@
                     {
                         "definition": {
                             "background_color": "transparent",
-                            "content": "\n### Useful Links\n- [Datadog Argo CD Integration Documentation](https://docs.datadoghq.com/integrations/argocd/)\n- [Argo CD Official Documentation](https://argo-cd.readthedocs.io/en/latest/)\n- [Monitor Argo CD Blogpost](https://www.datadoghq.com/blog/argo-cd-datadog/)",
+                            "content": "\n### Useful Links\n- [Datadog Argo CD Integration Documentation](https://docs.datadoghq.com/integrations/argocd/)\n- [Argo CD Official Documentation](https://argo-cd.readthedocs.io/en/latest/)\n- [Monitor Argo CD Blog Post](https://www.datadoghq.com/blog/argo-cd-datadog/)",
                             "font_size": "14",
                             "has_padding": true,
                             "show_tick": false,

--- a/celery/assets/dashboards/celery_overview.json
+++ b/celery/assets/dashboards/celery_overview.json
@@ -75,7 +75,7 @@
                         "id": 628034008442880,
                         "definition": {
                             "type": "note",
-                            "content": "This is an overview of service checks, monitors and connect statuses of your Celery integration",
+                            "content": "This is an overview of service checks, monitors and connection statuses of your Celery integration",
                             "background_color": "green",
                             "font_size": "14",
                             "text_align": "left",

--- a/consul/assets/dashboards/consul_overview.json
+++ b/consul/assets/dashboards/consul_overview.json
@@ -74,7 +74,7 @@
                         "id": 2570179001713344,
                         "definition": {
                             "type": "note",
-                            "content": "This is an overview of service checks, monitors and connect statuses of your Consul deployment",
+                            "content": "This is an overview of service checks, monitors and connection statuses of your Consul deployment",
                             "background_color": "pink",
                             "font_size": "14",
                             "text_align": "center",

--- a/nvidia_triton/assets/dashboards/nvidia_triton_overview.json
+++ b/nvidia_triton/assets/dashboards/nvidia_triton_overview.json
@@ -1,6 +1,6 @@
 {
     "author_name": "Datadog",
-    "description": "**Nvidia Triton**\n\nThis dashboard provides insights into your Nvidia Triton Server. You can use this dashboard to check resource consumption in GPU and CPU. You can also use it to get in depth look at your inference requests per model and cache stats(if enabled).\n\n**Useful Links**\n\n* [Integration Docs]()",
+    "description": "**Nvidia Triton**\n\nThis dashboard provides insights into your Nvidia Triton Server. You can use this dashboard to check resource consumption in GPU and CPU. You can also use it to get an in-depth look at your inference requests per model and cache stats (if enabled).\n\n**Useful Links**\n\n* [Integration Docs]()",
     "layout_type": "ordered",
     "template_variables": [
         {

--- a/supabase/assets/dashboards/supabase_overview.json
+++ b/supabase/assets/dashboards/supabase_overview.json
@@ -75,7 +75,7 @@
             "id": 628034008442880,
             "definition": {
               "type": "note",
-              "content": "This is an overview of service checks, monitors, and connect statuses of your Supabase deployment",
+              "content": "This is an overview of service checks, monitors, and connection statuses of your Supabase deployment",
               "background_color": "green",
               "font_size": "14",
               "text_align": "left",

--- a/traefik_mesh/assets/dashboards/traefik_mesh_overview.json
+++ b/traefik_mesh/assets/dashboards/traefik_mesh_overview.json
@@ -73,7 +73,7 @@
                         "id": 628034008442880,
                         "definition": {
                             "type": "note",
-                            "content": "This is an overview of service checks, monitors and connect statuses of your Traefik Mesh deployments",
+                            "content": "This is an overview of service checks, monitors and connection statuses of your Traefik Mesh deployments",
                             "background_color": "purple",
                             "font_size": "14",
                             "text_align": "left",


### PR DESCRIPTION
### What does this PR do?

Fixes grammar and wording issues in shipped integration dashboard descriptions and overview content:

- **airflow, celery, consul, supabase, traefik_mesh, argo_rollouts:** `connect statuses` → `connection statuses`
- **argo_rollouts:** `your Argo Rollouts rollouts` → `your Argo Rollouts deployment`
- **nvidia_triton:** `get in depth look` → `get an in-depth look`; `stats(if enabled)` → `stats (if enabled)`
- **argocd:** `Blogpost` → `Blog Post` in dashboard link text

### Motivation

These wording issues are visible in shipped dashboard templates and reduce readability. Kubernetes resource naming (for example `CronJob`, `DaemonSet`, and `ReplicaSet`) is intentionally unchanged.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)