### PR TITLE
Fix wording in Airflow overview dashboard

### DIFF
--- a/airflow/assets/dashboards/overview.json
+++ b/airflow/assets/dashboards/overview.json
@@ -73,7 +73,7 @@
                         "id": 628034008442880,
                         "definition": {
                             "type": "note",
-                            "content": "This is an overview of service checks, monitors and connect statuses of your Airflow deployment",
+                            "content": "This is an overview of service checks, monitors and connection statuses of your Airflow deployment",
                             "background_color": "pink",
                             "font_size": "14",
                             "text_align": "left",


### PR DESCRIPTION
### What does this PR do?

Change `connect statuses` to `connection statuses` in the Airflow overview dashboard.

### Motivation

This wording issue is visible in the shipped dashboard template and reduces readability.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)