### PR TITLE
Fix wording in Consul overview dashboard

### DIFF
--- a/consul/assets/dashboards/consul_overview.json
+++ b/consul/assets/dashboards/consul_overview.json
@@ -74,7 +74,7 @@
                         "id": 2570179001713344,
                         "definition": {
                             "type": "note",
-                            "content": "This is an overview of service checks, monitors and connect statuses of your Consul deployment",
+                            "content": "This is an overview of service checks, monitors and connection statuses of your Consul deployment",
                             "background_color": "pink",
                             "font_size": "14",
                             "text_align": "center",


### PR DESCRIPTION
### What does this PR do?

Change `connect statuses` to `connection statuses` in the Consul overview dashboard.

### Motivation

This wording issue is visible in the shipped dashboard template and reduces readability.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)