### PR TITLE
Fix wording in Argo Rollouts overview dashboard

### DIFF
--- a/argo_rollouts/assets/dashboards/argo_rollouts_overview.json
+++ b/argo_rollouts/assets/dashboards/argo_rollouts_overview.json
@@ -94,7 +94,7 @@
                     {
                         "definition": {
                             "background_color": "blue",
-                            "content": "This is an overview of service checks, monitors and connect statuses of your Argo Rollouts rollouts.",
+                            "content": "This is an overview of service checks, monitors and connection statuses of your Argo Rollouts deployment.",
                             "font_size": "16",
                             "has_padding": true,
                             "show_tick": false,


### PR DESCRIPTION
### What does this PR do?

Change `connect statuses` to `connection statuses` and replace awkward `your Argo Rollouts rollouts` phrasing with `your Argo Rollouts deployment` in the Argo Rollouts overview dashboard.

### Motivation

This wording issue is visible in the shipped dashboard template and reduces readability.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)