### PR TITLE
Delete dead unscoped-catalog fallback in openstack

### DIFF
--- a/openstack/changelog.d/24464.fixed
+++ b/openstack/changelog.d/24464.fixed
@@ -1,0 +1,1 @@
+Remove dead unscoped-catalog fallback code that could never execute.

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -410,33 +410,10 @@ class KeystoneCatalog(object):
         self.neutron_endpoint = neutron_endpoint
 
     @classmethod
-    def from_auth_response(cls, json_response, nova_api_version, keystone_server_url=None, auth_token=None, proxy=None):
-        try:
-            return cls(
-                nova_endpoint=cls.get_nova_endpoint(json_response, nova_api_version),
-                neutron_endpoint=cls.get_neutron_endpoint(json_response),
-            )
-        except (MissingNeutronEndpoint, MissingNovaEndpoint) as e:
-            if keystone_server_url and auth_token:
-                return cls.from_unscoped_token(keystone_server_url, auth_token, nova_api_version, proxy)
-            else:
-                raise e
-
-    @classmethod
-    def from_unscoped_token(cls, keystone_server_url, auth_token, nova_api_version, ssl_verify=True, proxy=None):
-        catalog_url = urljoin(keystone_server_url, "{0}/auth/catalog".format(DEFAULT_KEYSTONE_API_VERSION))
-        headers = {'X-Auth-Token': auth_token}
-
-        resp = requests.get(
-            catalog_url, headers=headers, verify=ssl_verify, timeout=DEFAULT_API_REQUEST_TIMEOUT, proxies=proxy
-        )
-        resp.raise_for_status()
-        json_resp = resp.json()
-        json_resp = {'token': json_resp}
-
+    def from_auth_response(cls, json_response, nova_api_version):
         return cls(
-            nova_endpoint=cls.get_nova_endpoint(json_resp, nova_api_version),
-            neutron_endpoint=cls.get_neutron_endpoint(json_resp),
+            nova_endpoint=cls.get_nova_endpoint(json_response, nova_api_version),
+            neutron_endpoint=cls.get_neutron_endpoint(json_response),
         )
 
     @classmethod


### PR DESCRIPTION
### What does this PR do?
Removes `KeystoneCatalog.from_unscoped_token` and the `except` branch in `from_auth_response` that calls it, along with the now-unused `keystone_server_url`, `auth_token`, and `proxy` parameters on `from_auth_response`. A missing nova or neutron endpoint now raises `MissingNovaEndpoint`/`MissingNeutronEndpoint` directly, as it already effectively does today.

### Motivation
The fallback gate in `from_auth_response` requires both `keystone_server_url` and `auth_token` ([ref](https://github.com/DataDog/integrations-core/blob/master/openstack/datadog_checks/openstack/openstack.py#L413-L421)), but all four call sites pass only two positional arguments ([ref1](https://github.com/DataDog/integrations-core/blob/master/openstack/datadog_checks/openstack/openstack.py#L302), [ref2](https://github.com/DataDog/integrations-core/blob/master/openstack/datadog_checks/openstack/openstack.py#L304), [ref3](https://github.com/DataDog/integrations-core/blob/master/openstack/datadog_checks/openstack/openstack.py#L380), [ref4](https://github.com/DataDog/integrations-core/blob/master/openstack/datadog_checks/openstack/openstack.py#L382)). The gate is always false, so `from_unscoped_token` has never executed in production or in tests. This was already true before the httpx migration work. See [the cleanup writeup](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6960218222/Cleanup+openstack+unscoped-catalog+fallback+is+unreachable+dead+code) for the full analysis and the decision to go with deletion over reviving and testing the fallback.

### Verification
- `ddev -x --no-interactive test openstack`: 17 passed, 1 skipped (E2E, not run).
- `ddev -x test --lint openstack`: ruff format and ruff check both pass.
- Confirmed by grep that the only calls to `from_auth_response` (`openstack.py:302,304,380,382`) pass exactly two positional arguments, so `keystone_server_url`/`auth_token` were always `None` and the deleted branch never executed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged