### PR TITLE
Fail the pending-release Slack notification on misconfiguration

### DIFF
--- a/.github/workflows/scripts/notify_slack.py
+++ b/.github/workflows/scripts/notify_slack.py
@@ -1,14 +1,39 @@
 """Post a 'wheel release starting' Slack notification via chat.postMessage.
 
 Env: SLACK_API_TOKEN, SLACK_CHANNEL_ID (both required or no-op), SOURCE_REPO,
-REF, PACKAGES, RUN_URL. Slack/network errors warn and never fail the job.
+REF, PACKAGES, RUN_URL.
+
+Error handling distinguishes two failure classes so a broken token is never
+silently swallowed as a green run:
+
+* Persistent misconfigurations (missing OAuth scope, bad/expired token, wrong
+  channel, bot not in channel) recur on every release. They are reported to the
+  GitHub step summary and fail the step so they get fixed immediately. This is
+  safe because the notify job is not a dependency of the release itself.
+* Transient problems (network, timeout, 5xx, rate limiting) only warn and never
+  fail the job, so a momentary Slack blip does not create release noise.
 """
 import json
 import os
+import sys
 import urllib.error
 import urllib.request
 
 SLACK_URL = "https://slack.com/api/chat.postMessage"
+
+# Slack API `error` codes that mean the notifier is misconfigured rather than
+# hitting a transient blip. These will fail on every release until fixed.
+CONFIG_ERRORS = frozenset(
+    {
+        "missing_scope",
+        "invalid_auth",
+        "not_authed",
+        "token_revoked",
+        "account_inactive",
+        "channel_not_found",
+        "not_in_channel",
+    }
+)
 
 
 def build_text(source_repo: str, ref: str, packages: str, run_url: str) -> str:
@@ -24,8 +49,26 @@ def build_text(source_repo: str, ref: str, packages: str, run_url: str) -> str:
     )
 
 
-def post(token: str, channel: str, text: str) -> None:
-    """Post *text* to *channel*, warning (not failing) on error."""
+def report_config_error(error: str) -> None:
+    """Surface a persistent misconfiguration loudly in the GitHub step summary."""
+    message = (
+        f"Slack notification misconfigured: `{error}`. The pending-release message was NOT delivered. "
+        "Verify SLACK_API_TOKEN has the `chat:write` scope and is valid, and that the bot is a member "
+        "of SLACK_CHANNEL_ID."
+    )
+    print(f"::error::{message}")
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as summary:
+            summary.write(f"### \u274c Slack notification failed\n\n{message}\n")
+
+
+def post(token: str, channel: str, text: str) -> bool:
+    """Post *text* to *channel*; return False only on a persistent misconfiguration.
+
+    Success and transient failures return True (transient ones only warn), so the
+    caller fails the step exclusively for config errors that need a human fix.
+    """
     data = json.dumps({"channel": channel, "text": text, "unfurl_links": False}).encode()
     request = urllib.request.Request(
         SLACK_URL,
@@ -36,10 +79,16 @@ def post(token: str, channel: str, text: str) -> None:
         with urllib.request.urlopen(request, timeout=15) as response:
             body = json.loads(response.read())
     except (urllib.error.URLError, TimeoutError, ValueError) as e:
-        print(f"::warning::Slack request failed: {e}")
-        return
-    if not body.get("ok"):
-        print(f"::warning::Slack notification failed: {body.get('error', 'unknown error')}")
+        print(f"::warning::Slack request failed (transient): {e}")
+        return True
+    if body.get("ok"):
+        return True
+    error = body.get("error", "unknown error")
+    if error in CONFIG_ERRORS:
+        report_config_error(error)
+        return False
+    print(f"::warning::Slack notification failed: {error}")
+    return True
 
 
 def main() -> None:
@@ -48,7 +97,7 @@ def main() -> None:
     if not token or not channel:
         print("Slack token or channel not configured; skipping notification.")
         return
-    post(
+    delivered = post(
         token,
         channel,
         build_text(
@@ -58,6 +107,8 @@ def main() -> None:
             os.environ.get("RUN_URL", ""),
         ),
     )
+    if not delivered:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/scripts/tests/test_notify_slack.py
+++ b/.github/workflows/scripts/tests/test_notify_slack.py
@@ -1,8 +1,22 @@
 """Tests for notify_slack."""
+import io
+import json
 import urllib.error
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import notify_slack
+import pytest
+
+
+@contextmanager
+def fake_slack_response(payload):
+    """Patch urlopen to return *payload* as the Slack API JSON body."""
+    response = io.BytesIO(json.dumps(payload).encode())
+    response.__enter__ = lambda self=response: self
+    response.__exit__ = lambda *args: False
+    with patch("urllib.request.urlopen", return_value=response):
+        yield
 
 
 def test_build_text_lists_packages():
@@ -35,7 +49,44 @@ def test_main_posts_when_configured(monkeypatch):
     post.assert_called_once()
 
 
-def test_post_warns_on_error(capsys):
+def test_post_warns_on_transient_network_error(capsys):
     with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("boom")):
-        notify_slack.post("token", "C1", "hi")
-    assert "failed" in capsys.readouterr().out
+        result = notify_slack.post("token", "C1", "hi")
+    assert result is True
+    out = capsys.readouterr().out
+    assert "transient" in out
+    assert "::error::" not in out
+
+
+def test_post_returns_true_on_success():
+    with fake_slack_response({"ok": True}):
+        assert notify_slack.post("token", "C1", "hi") is True
+
+
+def test_post_warns_on_transient_api_error(capsys):
+    with fake_slack_response({"ok": False, "error": "rate_limited"}):
+        result = notify_slack.post("token", "C1", "hi")
+    assert result is True
+    out = capsys.readouterr().out
+    assert "rate_limited" in out
+    assert "::error::" not in out
+
+
+@pytest.mark.parametrize("error", sorted(notify_slack.CONFIG_ERRORS))
+def test_post_fails_on_config_error(error, capsys, tmp_path, monkeypatch):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    with fake_slack_response({"ok": False, "error": error}):
+        result = notify_slack.post("token", "C1", "hi")
+    assert result is False
+    assert "::error::" in capsys.readouterr().out
+    assert error in summary.read_text()
+
+
+def test_main_exits_nonzero_on_config_error(monkeypatch):
+    monkeypatch.setenv("SLACK_API_TOKEN", "xoxb")
+    monkeypatch.setenv("SLACK_CHANNEL_ID", "C1")
+    with patch.object(notify_slack, "post", return_value=False):
+        with pytest.raises(SystemExit) as excinfo:
+            notify_slack.main()
+    assert excinfo.value.code == 1


### PR DESCRIPTION
### What does this PR do?

Hardens `.github/workflows/scripts/notify_slack.py` so a persistent Slack misconfiguration no longer passes as a green CI run.

- Classifies `chat.postMessage` errors: persistent config errors (`missing_scope`, `invalid_auth`, `not_authed`, `token_revoked`, `account_inactive`, `channel_not_found`, `not_in_channel`) are separated from transient ones (network, timeout, 5xx, `rate_limited`).
- On a config error the script writes a clear message to `$GITHUB_STEP_SUMMARY` and exits non-zero, so the step turns red and the broken token is caught immediately.
- Transient errors still only warn and never fail the job, preserving the "don't block a release on a Slack blip" intent.
- Tests updated to cover success, transient errors, every config error (fail + step summary), and `main()` exiting non-zero.

Failing the `notify` job is safe: it is not a dependency of `approve`/`dispatch` in `release-trigger.yml`, so it surfaces the problem without blocking releases.

### Motivation

Run [28951470627](https://github.com/DataDog/integrations-core/actions/runs/28951470627/job/85899068702) posted the pending-release message and got `missing_scope`, but the job stayed green because every Slack error was downgraded to a `::warning::`. The message was never delivered yet CI showed success. The operational fix (granting `chat:write` to the bot token) is being handled separately; this change ensures such a misconfiguration can never again fail silently.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged