### PR TITLE
kafka_consumer: store broker_timestamps as marshal instead of json

### DIFF
--- a/kafka_consumer/changelog.d/24471.fixed
+++ b/kafka_consumer/changelog.d/24471.fixed
@@ -1,0 +1,1 @@
+Reduce cluster-check-runner memory churn by persisting the DSM broker timestamps cache in a compact binary format (marshal) instead of serializing it as JSON on every run.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -1,8 +1,10 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import base64
 import heapq
 import json
+import marshal
 from collections import defaultdict
 from time import time
 
@@ -281,9 +283,7 @@ class KafkaCheck(AgentCheck):
         """Loads broker timestamps from persistent cache."""
         broker_timestamps = defaultdict(dict)
         try:
-            for topic_partition, content in json.loads(self.read_persistent_cache(persistent_cache_key)).items():
-                for offset, timestamp in content.items():
-                    broker_timestamps[topic_partition][int(offset)] = timestamp
+            broker_timestamps.update(marshal.loads(base64.b64decode(self.read_persistent_cache(persistent_cache_key))))
         except Exception as e:
             self.log.warning('Could not read broker timestamps from cache: %s', str(e))
         return broker_timestamps
@@ -314,7 +314,8 @@ class KafkaCheck(AgentCheck):
 
     def _save_broker_timestamps(self, broker_timestamps, persistent_cache_key):
         """Saves broker timestamps to persistent cache."""
-        self.write_persistent_cache(persistent_cache_key, json.dumps(broker_timestamps))
+        blob = marshal.dumps(dict(broker_timestamps))
+        self.write_persistent_cache(persistent_cache_key, base64.b64encode(blob).decode('ascii'))
 
     def report_highwater_offsets(self, highwater_offsets, contexts_limit, cluster_id):
         """Report the broker highwater offsets."""

--- a/kafka_consumer/tests/test_integration.py
+++ b/kafka_consumer/tests/test_integration.py
@@ -1,8 +1,9 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import json
+import base64
 import logging
+import marshal
 from collections import defaultdict
 from contextlib import nullcontext as does_not_raise
 
@@ -27,7 +28,7 @@ def mocked_read_persistent_cache(cache_key):
     cached_offsets["dc_0"][40] = 200
     cached_offsets["dc_1"][25] = 150
     cached_offsets["dc_1"][40] = 200
-    return json.dumps(cached_offsets)
+    return base64.b64encode(marshal.dumps(dict(cached_offsets))).decode('ascii')
 
 
 def mocked_time():

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -1,8 +1,10 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import base64
 import json
 import logging
+import marshal
 from contextlib import nullcontext as does_not_raise
 
 import mock
@@ -12,6 +14,16 @@ from datadog_checks.kafka_consumer import KafkaCheck
 from datadog_checks.kafka_consumer.client import KafkaClient
 
 pytestmark = [pytest.mark.unit]
+
+
+def encode_broker_timestamps(cache):
+    """Encode a broker_timestamps dict the way the check persists it (marshal+base64)."""
+    return base64.b64encode(marshal.dumps(cache)).decode('ascii')
+
+
+def written_broker_timestamps(check):
+    """Decode the broker_timestamps blob the check wrote to its persistent cache (marshal+base64)."""
+    return marshal.loads(base64.b64decode(check.write_persistent_cache.call_args[0][1]))
 
 
 def fake_get_partition_offsets(partitions, offset=-1):
@@ -504,16 +516,16 @@ def test_check_clears_cache_on_partial_reset(kafka_instance, check, dd_run_check
     kafka_consumer_check.client = mock_client
 
     # Cache has entries below (5, 50) and above (200) the new highwater of 100 — all must be cleared.
-    initial_cache = {"topic1_0": {"5": 1.0, "50": 2.0, "200": 3.0}}
-    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=json.dumps(initial_cache))
+    initial_cache = {"topic1_0": {5: 1.0, 50: 2.0, 200: 3.0}}
+    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=encode_broker_timestamps(initial_cache))
     kafka_consumer_check.write_persistent_cache = mock.Mock()
 
     dd_run_check(kafka_consumer_check)
 
-    written = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    written = written_broker_timestamps(kafka_consumer_check)
     timestamps = written["topic1_0"]
     assert len(timestamps) == 1
-    assert "100" in timestamps
+    assert 100 in timestamps
 
 
 @pytest.mark.parametrize(
@@ -522,7 +534,7 @@ def test_check_clears_cache_on_partial_reset(kafka_instance, check, dd_run_check
     [
         pytest.param(
             4,
-            {"topic1_0": {"10": 1000.0, "20": 2000.0, "30": 3000.0}},
+            {"topic1_0": {10: 1000.0, 20: 2000.0, 30: 3000.0}},
             40,
             4000.0,
             25,
@@ -532,7 +544,7 @@ def test_check_clears_cache_on_partial_reset(kafka_instance, check, dd_run_check
         ),
         pytest.param(
             4,
-            {"topic1_0": {"10": 1000.0, "20": 2000.0, "30": 3000.0}},
+            {"topic1_0": {10: 1000.0, 20: 2000.0, 30: 3000.0}},
             40,
             4000.0,
             10,
@@ -542,7 +554,7 @@ def test_check_clears_cache_on_partial_reset(kafka_instance, check, dd_run_check
         ),
         pytest.param(
             4,
-            {"topic1_0": {"10": 1000.0, "20": 2000.0, "30": 3000.0}},
+            {"topic1_0": {10: 1000.0, 20: 2000.0, 30: 3000.0}},
             40,
             4000.0,
             40,
@@ -552,7 +564,7 @@ def test_check_clears_cache_on_partial_reset(kafka_instance, check, dd_run_check
         ),
         pytest.param(
             6,
-            {"topic1_0": {"10": 1000.0, "20": 2000.0, "30": 3000.0, "40": 4000.0, "50": 5000.0}},
+            {"topic1_0": {10: 1000.0, 20: 2000.0, 30: 3000.0, 40: 4000.0, 50: 5000.0}},
             60,
             6000.0,
             35,
@@ -588,13 +600,13 @@ def test_check_compacts_timestamps_and_preserves_lag_accuracy(
     mock_client.get_partition_offsets = lambda partitions, offset=-1: [("topic1", 0, highwater_offset)]
     kafka_consumer_check.client = mock_client
 
-    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=json.dumps(initial_cache))
+    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=encode_broker_timestamps(initial_cache))
     kafka_consumer_check.write_persistent_cache = mock.Mock()
 
     with mock.patch('datadog_checks.kafka_consumer.kafka_consumer.time', return_value=highwater_time):
         dd_run_check(kafka_consumer_check)
 
-    written = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    written = written_broker_timestamps(kafka_consumer_check)
     assert len(written["topic1_0"]) == expected_cache_size
     aggregator.assert_metric("kafka.estimated_consumer_lag", value=expected_lag, count=1)
 
@@ -614,17 +626,17 @@ def test_check_prunes_timestamps_below_earliest_consumer_offset(kafka_instance, 
 
     # Pre-seed the cache with 3 entries. Adding the new highwater at 40 fills the 4-entry
     # budget and triggers compaction+pruning with the earliest consumer offset (25) as the floor.
-    initial_cache = {"topic1_0": {"10": 1.0, "20": 2.0, "30": 3.0}}
-    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=json.dumps(initial_cache))
+    initial_cache = {"topic1_0": {10: 1.0, 20: 2.0, 30: 3.0}}
+    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=encode_broker_timestamps(initial_cache))
     kafka_consumer_check.write_persistent_cache = mock.Mock()
 
     dd_run_check(kafka_consumer_check)
 
-    written = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    written = written_broker_timestamps(kafka_consumer_check)
     timestamps = written["topic1_0"]
-    assert "10" not in timestamps  # pruned: below the anchor; no consumer will interpolate here
-    assert "20" in timestamps  # anchor: largest sample at/below consumer floor of 25
-    assert "40" in timestamps  # new highwater sample
+    assert 10 not in timestamps  # pruned: below the anchor; no consumer will interpolate here
+    assert 20 in timestamps  # anchor: largest sample at/below consumer floor of 25
+    assert 40 in timestamps  # new highwater sample
 
 
 def test_report_lag_in_time_interpolates_consumer_between_samples(kafka_instance, check, aggregator):
@@ -752,16 +764,16 @@ def test_check_prunes_floor_uses_minimum_offset_across_groups(kafka_instance, ch
 
     # With floor=5 (correct min), nothing below 5 exists, so no pruning; VW keeps {10, 40}.
     # With floor=25 (wrong, single-group), entry 10 would be pruned; VW keeps {20, 40} instead.
-    initial_cache = {"topic1_0": {"10": 1.0, "20": 2.0, "30": 3.0}}
-    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=json.dumps(initial_cache))
+    initial_cache = {"topic1_0": {10: 1.0, 20: 2.0, 30: 3.0}}
+    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=encode_broker_timestamps(initial_cache))
     kafka_consumer_check.write_persistent_cache = mock.Mock()
 
     dd_run_check(kafka_consumer_check)
 
-    written = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    written = written_broker_timestamps(kafka_consumer_check)
     timestamps = written["topic1_0"]
-    assert "10" in timestamps  # floor=5 means nothing below 10 exists, so 10 is the oldest endpoint
-    assert "40" in timestamps
+    assert 10 in timestamps  # floor=5 means nothing below 10 exists, so 10 is the oldest endpoint
+    assert 40 in timestamps
 
 
 def test_check_prunes_anchor_at_floor_boundary(kafka_instance, check, dd_run_check):
@@ -779,17 +791,17 @@ def test_check_prunes_anchor_at_floor_boundary(kafka_instance, check, dd_run_che
     mock_client.get_partition_offsets = lambda partitions, offset=-1: [("topic1", 0, 40)]
     kafka_consumer_check.client = mock_client
 
-    initial_cache = {"topic1_0": {"10": 1.0, "20": 2.0, "30": 3.0}}
-    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=json.dumps(initial_cache))
+    initial_cache = {"topic1_0": {10: 1.0, 20: 2.0, 30: 3.0}}
+    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=encode_broker_timestamps(initial_cache))
     kafka_consumer_check.write_persistent_cache = mock.Mock()
 
     dd_run_check(kafka_consumer_check)
 
-    written = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    written = written_broker_timestamps(kafka_consumer_check)
     timestamps = written["topic1_0"]
-    assert "10" not in timestamps  # pruned: below the anchor
-    assert "20" in timestamps  # correct anchor (strict-< floor means 30 is not below 30)
-    assert "40" in timestamps  # new highwater
+    assert 10 not in timestamps  # pruned: below the anchor
+    assert 20 in timestamps  # correct anchor (strict-< floor means 30 is not below 30)
+    assert 40 in timestamps  # new highwater
 
 
 def test_check_keeps_sole_entry_below_floor_as_anchor(kafka_instance, check, dd_run_check):
@@ -805,16 +817,16 @@ def test_check_keeps_sole_entry_below_floor_as_anchor(kafka_instance, check, dd_
     mock_client.get_partition_offsets = lambda partitions, offset=-1: [("topic1", 0, 40)]
     kafka_consumer_check.client = mock_client
 
-    initial_cache = {"topic1_0": {"20": 2.0, "30": 3.0}}
-    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=json.dumps(initial_cache))
+    initial_cache = {"topic1_0": {20: 2.0, 30: 3.0}}
+    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=encode_broker_timestamps(initial_cache))
     kafka_consumer_check.write_persistent_cache = mock.Mock()
 
     dd_run_check(kafka_consumer_check)
 
-    written = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    written = written_broker_timestamps(kafka_consumer_check)
     timestamps = written["topic1_0"]
-    assert "20" in timestamps  # sole entry below floor — kept as the anchor
-    assert "40" in timestamps  # new highwater
+    assert 20 in timestamps  # sole entry below floor — kept as the anchor
+    assert 40 in timestamps  # new highwater
 
 
 def test_count_consumer_contexts(check, kafka_instance):


### PR DESCRIPTION
### What does this PR do?

Persists the `kafka_consumer` DSM `broker_timestamps` cache with **`marshal`** (a compact binary codec, base64-wrapped so it still rides the string-based persistent-cache API) instead of `json`.

No change to emitted metrics — `kafka.estimated_consumer_lag` and friends are computed from the same data.

### Motivation

Cluster-check runners running `kafka_consumer` with `enable_cluster_monitoring` on large clusters have been OOMing (#incident-57455). Investigation (repro pod + live `/proc` + the Datadog continuous profiler) showed the growth is glibc malloc fragmentation fed by very high allocation churn — not a leak. The profiler's top Python allocator was `_save_broker_timestamps -> json.dumps -> iterencode`: every run re-serialized the entire (growing) timestamps dict, and JSON encodes every offset/timestamp as text.

Benchmarked at the incident's real cardinality (31,870 partitions), the `broker_timestamps` serialization on the save path dropped **~100x** with `marshal` (and per-run load/save churn dropped several-fold overall). `marshal` keeps integer offsets and float timestamps native, avoiding JSON's per-number text encoding.

This is the source-side half of the mitigation; the allocator-side half (`MALLOC_ARENA_MAX=2` on the runners) is a separate ops PR.

### Why `marshal` (and not `pickle`)

`pickle` would be faster still, but it executes arbitrary opcodes on load — deserializing an on-disk cache file with `pickle.loads` turns a cache-tampering risk into remote code execution in the Agent process if anything else can write the run volume. `marshal` only (de)serializes basic built-in types and cannot construct/execute objects, so a tampered cache cannot run code (worst case is a crash — a large step down from RCE). `marshal` is also stdlib, so it adds no dependency and keeps the `test-minimum-base-package` job green (`msgpack`/`orjson` are not guaranteed in the minimum base).

Trade-offs, called out for review:
- `marshal` is not hardened against maliciously-crafted input — a tampered blob could crash the check (DoS), but not execute code.
- The `marshal` format is Python-version-specific, so the cache is discarded once (and rebuilt) after a Python upgrade or a format change. Handled by the `try/except` in `_load_broker_timestamps`.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests — updated `test_unit.py` and `test_integration.py` to seed/read the cache in the marshal format with integer offset keys. Full unit suite (144) passes; lint clean.
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. → `qa/required` (agent-impacting runtime change; validate memory reduction + no `estimated_consumer_lag` regression on a live cluster).
- [ ] If you need to backport this PR to another branch, add the `backport/<branch-name>` label.
