### PR TITLE
[Backport 7.81.x] kafka_consumer: store broker_timestamps as marshal instead of json

### DIFF
--- a/kafka_consumer/changelog.d/24472.fixed
+++ b/kafka_consumer/changelog.d/24472.fixed
@@ -1,0 +1,1 @@
+Reduce cluster-check-runner memory churn by persisting the DSM broker timestamps cache in a compact binary format (marshal) instead of serializing it as JSON on every run.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -1,7 +1,9 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import base64
 import json
+import marshal
 from collections import defaultdict
 from time import time
 
@@ -242,9 +244,7 @@ class KafkaCheck(AgentCheck):
         """Loads broker timestamps from persistent cache."""
         broker_timestamps = defaultdict(dict)
         try:
-            for topic_partition, content in json.loads(self.read_persistent_cache(persistent_cache_key)).items():
-                for offset, timestamp in content.items():
-                    broker_timestamps[topic_partition][int(offset)] = timestamp
+            broker_timestamps.update(marshal.loads(base64.b64decode(self.read_persistent_cache(persistent_cache_key))))
         except Exception as e:
             self.log.warning('Could not read broker timestamps from cache: %s', str(e))
         return broker_timestamps
@@ -268,7 +268,8 @@ class KafkaCheck(AgentCheck):
 
     def _save_broker_timestamps(self, broker_timestamps, persistent_cache_key):
         """Saves broker timestamps to persistent cache."""
-        self.write_persistent_cache(persistent_cache_key, json.dumps(broker_timestamps))
+        blob = marshal.dumps(dict(broker_timestamps))
+        self.write_persistent_cache(persistent_cache_key, base64.b64encode(blob).decode('ascii'))
 
     def report_highwater_offsets(self, highwater_offsets, contexts_limit, cluster_id):
         """Report the broker highwater offsets."""

--- a/kafka_consumer/tests/test_integration.py
+++ b/kafka_consumer/tests/test_integration.py
@@ -1,8 +1,9 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import json
+import base64
 import logging
+import marshal
 from collections import defaultdict
 from contextlib import nullcontext as does_not_raise
 
@@ -27,7 +28,7 @@ def mocked_read_persistent_cache(cache_key):
     cached_offsets["dc_0"][40] = 200
     cached_offsets["dc_1"][25] = 150
     cached_offsets["dc_1"][40] = 200
-    return json.dumps(cached_offsets)
+    return base64.b64encode(marshal.dumps(dict(cached_offsets))).decode('ascii')
 
 
 def mocked_time():


### PR DESCRIPTION
### What does this PR do?

Backport of #24471 to `7.81.x`. Persists the `kafka_consumer` DSM `broker_timestamps` cache with `marshal` (a compact binary codec, base64-wrapped so it still rides the string persistent-cache API) instead of `json`. No change to emitted metrics.

### Motivation

Cluster-check runners running `kafka_consumer` with `enable_cluster_monitoring` on large clusters OOM (#incident-57455). The Datadog profiler flagged `_save_broker_timestamps -> json.dumps -> iterencode` as the top allocator: every run re-serialized the whole (growing) timestamps dict, and JSON encodes every offset/timestamp as text, feeding glibc arena fragmentation. `marshal` keeps ints/floats native and cuts the save-path serialization ~100x.

`marshal` (not `pickle`) because the cache is read from disk: `marshal` cannot deserialize into code execution, so a tampered cache file cannot run code in the Agent process. It is also stdlib, so it adds no dependency. The on-disk format is version-specific, so a cache written by an older agent is discarded once and rebuilt (handled by the `try/except` in `_load_broker_timestamps`).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests — `test_integration.py` seeds the cache in the marshal format; unit suite passes and lint is clean on this branch.
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. → `qa/required`.
- [ ] If you need to backport this PR to another branch, add the `backport/<branch-name>` label.
