### PR TITLE
Fix sqlserver embedded ODBC driver paths breaking after fleet automation upgrades

### DIFF
--- a/sqlserver/changelog.d/24473.fixed
+++ b/sqlserver/changelog.d/24473.fixed
@@ -1,0 +1,1 @@
+Fix embedded ODBC driver paths (FreeTDS and msodbcsql) breaking after fleet automation agent upgrades on Linux.

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -60,7 +60,7 @@ def set_default_driver_conf():
         The agent running on Linux has msodbcsql18 and FreeTDS installed.
         The default driver is msodbcsql18.
         To best leverage the default driver, we set the ODBCSYSINI environment variable to the directory
-        containing the pre-configured odbcinst.ini file.
+        containing the odbcinst.ini file, which is patched at runtime with the correct embedded driver paths.
         However, if the user has already configured the ODBCSYSINI environment variable,
         OR if the user has already created or copied the odbcinst.ini file in the unixODBC sysconfig location,
         we do not override the ODBCSYSINI environment variable.
@@ -83,7 +83,19 @@ def set_default_driver_conf():
                 # This means user has copied odbcinst.ini and odbc.ini to the unixODBC sysconfig location
                 return
 
-        # Use default `./driver_config/odbcinst.ini` to let the integration use agent embedded odbc driver.
+        # Patch the bundled odbcinst.ini with the correct embedded dir path i.e.
+        # /opt/datadog-agent/ or /opt/datadog-packages/.
+        embedded_dir = os.path.dirname(linux_unixodbc_sysconfig)
+        ini_path = os.path.join(DRIVER_CONFIG_DIR, ODBC_INST_INI)
+        try:
+            with open(ini_path, 'r+') as f:
+                content = f.read().replace('/opt/datadog-agent/embedded', embedded_dir)
+                f.seek(0)
+                f.write(content)
+                f.truncate()
+        except OSError:
+            pass
+
         os.environ.setdefault('ODBCSYSINI', DRIVER_CONFIG_DIR)
 
         # required when using pyodbc with FreeTDS on Ubuntu 18.04


### PR DESCRIPTION
### What does this PR do?

Dynamically generates `odbcinst.ini` at runtime using driver paths derived from `sys.executable` rather than relying on a static bundled file with hardcoded `/opt/datadog-agent/` paths.

### Motivation

Fleet automation upgrades move the Datadog Agent from `/opt/datadog-agent/` to `/opt/datadog-packages/datadog-agent/<version>/`, taking the embedded ODBC drivers (FreeTDS and msodbcsql) with them. The bundled `data/driver_config/odbcinst.ini` had these paths hardcoded, causing the unixODBC driver manager to fail loading the drivers after any fleet automation upgrade with errors like:

```
[unixODBC][Driver Manager]Can't open lib '/opt/datadog-agent/embedded/msodbcsql/lib64/libmsodbcsql-18.3.so.3.1' : file not found
```

This affects any Linux customer using the ODBC connector (`connector: odbc`) with either FreeTDS or msodbcsql who upgrades via fleet automation. A fresh install is unaffected — only upgrades via fleet automation trigger the issue.

The fix derives the correct embedded directory from `sys.executable`, which always points to the current agent's Python regardless of install location. This makes the driver paths self-correcting on every agent start.

Related escalations: SDBM-2640, SDBM-2761, SDBM-2769

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged