### PR TITLE
Default COMPOSE_PROJECT_NAME in docker_run() to the check's directory name

### DIFF
--- a/celery/tests/docker/proj/tasks.py
+++ b/celery/tests/docker/proj/tasks.py
@@ -1,6 +1,6 @@
 from celery import Celery
 
-app = Celery('tasks', broker='redis://default:devops-best-friend@docker-redis-standalone-1:6379')
+app = Celery('tasks', broker='redis://default:devops-best-friend@redis-standalone:6379')
 
 
 @app.task(bind=True)

--- a/datadog_checks_dev/changelog.d/24482.fixed
+++ b/datadog_checks_dev/changelog.d/24482.fixed
@@ -1,0 +1,1 @@
+Default `COMPOSE_PROJECT_NAME` in `docker_run()` to the check's directory name to avoid Compose project-name collisions between concurrent E2E test runs.

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -378,9 +378,9 @@ def docker_run(
             A list of callable objects that will be executed before yielding to check for errors
         env_vars (dict[str, str]):
             A dictionary to update `os.environ` with during execution. When `compose_file` is provided and
-            `COMPOSE_PROJECT_NAME` isn't set here or already in `os.environ`, it defaults to the check's
-            directory name so that concurrent E2E runs sharing a Docker daemon don't collide on Compose's
-            own directory-basename-derived default project name.
+            `COMPOSE_PROJECT_NAME` isn't set here, already in `os.environ`, or saved from a previous E2E
+            start run, it defaults to the check's directory name so that concurrent E2E runs sharing a
+            Docker daemon don't collide on Compose's own directory-basename-derived default project name.
         wrappers (list[callable]):
             A list of context managers to use during execution
         attempts (int):
@@ -398,7 +398,10 @@ def docker_run(
         env_vars = dict(env_vars) if env_vars else {}
         if not env_vars.get('COMPOSE_PROJECT_NAME') and not os.getenv('COMPOSE_PROJECT_NAME'):
             # An extra level deep because of the context manager
-            env_vars['COMPOSE_PROJECT_NAME'] = os.path.basename(find_check_root(depth=2))
+            docker_metadata = get_state('docker_compose_metadata', {})
+            env_vars['COMPOSE_PROJECT_NAME'] = docker_metadata.get('project_name') or os.path.basename(
+                find_check_root(depth=2)
+            )
 
         composeFileArgs = {'compose_file': compose_file, 'build': build, 'service_name': service_name}
         if capture is not None:

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -377,7 +377,10 @@ def docker_run(
         conditions (callable):
             A list of callable objects that will be executed before yielding to check for errors
         env_vars (dict[str, str]):
-            A dictionary to update `os.environ` with during execution
+            A dictionary to update `os.environ` with during execution. When `compose_file` is provided and
+            `COMPOSE_PROJECT_NAME` isn't set here or already in `os.environ`, it defaults to the check's
+            directory name so that concurrent E2E runs sharing a Docker daemon don't collide on Compose's
+            own directory-basename-derived default project name.
         wrappers (list[callable]):
             A list of context managers to use during execution
         attempts (int):
@@ -391,6 +394,11 @@ def docker_run(
     if compose_file is not None:
         if not isinstance(compose_file, str):
             raise TypeError('The path to the compose file is not a string: {}'.format(repr(compose_file)))
+
+        env_vars = dict(env_vars) if env_vars else {}
+        if not env_vars.get('COMPOSE_PROJECT_NAME') and not os.getenv('COMPOSE_PROJECT_NAME'):
+            # An extra level deep because of the context manager
+            env_vars['COMPOSE_PROJECT_NAME'] = os.path.basename(find_check_root(depth=2))
 
         composeFileArgs = {'compose_file': compose_file, 'build': build, 'service_name': service_name}
         if capture is not None:
@@ -445,7 +453,7 @@ def docker_run(
             'docker_compose_metadata',
             {
                 'compose_file': compose_file,
-                'project_name': (env_vars or {}).get('COMPOSE_PROJECT_NAME') or os.getenv('COMPOSE_PROJECT_NAME'),
+                'project_name': env_vars.get('COMPOSE_PROJECT_NAME'),
                 'service_name': service_name,
             },
         )

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -17,7 +17,7 @@ from .fs import create_file, file_exists
 from .spec import load_spec
 from .structures import EnvVars, LazyFunction, TempDir
 from .subprocess import run_command
-from .utils import find_check_root
+from .utils import find_check_root, get_current_check_name
 
 try:
     from contextlib import ExitStack
@@ -397,11 +397,9 @@ def docker_run(
 
         env_vars = dict(env_vars) if env_vars else {}
         if not env_vars.get('COMPOSE_PROJECT_NAME') and not os.getenv('COMPOSE_PROJECT_NAME'):
-            # An extra level deep because of the context manager
             docker_metadata = get_state('docker_compose_metadata', {})
-            env_vars['COMPOSE_PROJECT_NAME'] = docker_metadata.get('project_name') or os.path.basename(
-                find_check_root(depth=2)
-            )
+            # An extra level deep because of the context manager
+            env_vars['COMPOSE_PROJECT_NAME'] = docker_metadata.get('project_name') or get_current_check_name(depth=2)
 
         composeFileArgs = {'compose_file': compose_file, 'build': build, 'service_name': service_name}
         if capture is not None:

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -453,7 +453,7 @@ def docker_run(
             'docker_compose_metadata',
             {
                 'compose_file': compose_file,
-                'project_name': env_vars.get('COMPOSE_PROJECT_NAME'),
+                'project_name': env_vars.get('COMPOSE_PROJECT_NAME') or os.getenv('COMPOSE_PROJECT_NAME'),
                 'service_name': service_name,
             },
         )

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -294,60 +294,49 @@ def test_docker_run_saves_compose_metadata(monkeypatch):
     assert os.environ['DDEV_E2E_ENV_docker_compose_metadata']
 
 
-def test_docker_run_defaults_compose_project_name(monkeypatch):
-    captured_env_vars = {}
+@pytest.fixture
+def captured_env_vars():
+    captured = {}
 
     @contextmanager
     def fake_environment_run(**kwargs):
-        captured_env_vars.update(kwargs['env_vars'])
+        captured.update(kwargs['env_vars'])
         yield None
 
+    with mock.patch('datadog_checks.dev.docker.environment_run', fake_environment_run):
+        yield captured
+
+
+def test_docker_run_defaults_compose_project_name(monkeypatch, captured_env_vars):
     monkeypatch.delenv('COMPOSE_PROJECT_NAME', raising=False)
     monkeypatch.delenv('DDEV_E2E_ENV_docker_compose_metadata', raising=False)
 
-    with mock.patch('datadog_checks.dev.docker.environment_run', fake_environment_run):
-        with docker_run('/tmp/docker-compose.yml', service_name='service'):
-            pass
+    with docker_run('/tmp/docker-compose.yml', service_name='service'):
+        pass
 
     assert captured_env_vars['COMPOSE_PROJECT_NAME'] == 'datadog_checks_dev'
-    assert os.environ['DDEV_E2E_ENV_docker_compose_metadata']
+    assert get_state('docker_compose_metadata')['project_name'] == 'datadog_checks_dev'
 
 
-def test_docker_run_respects_explicit_compose_project_name(monkeypatch):
-    captured_env_vars = {}
-
-    @contextmanager
-    def fake_environment_run(**kwargs):
-        captured_env_vars.update(kwargs['env_vars'])
-        yield None
-
+def test_docker_run_respects_explicit_compose_project_name(monkeypatch, captured_env_vars):
     monkeypatch.delenv('COMPOSE_PROJECT_NAME', raising=False)
 
-    with mock.patch('datadog_checks.dev.docker.environment_run', fake_environment_run):
-        with docker_run(
-            '/tmp/docker-compose.yml',
-            env_vars={'COMPOSE_PROJECT_NAME': 'custom'},
-            service_name='service',
-        ):
-            pass
+    with docker_run(
+        '/tmp/docker-compose.yml',
+        env_vars={'COMPOSE_PROJECT_NAME': 'custom'},
+        service_name='service',
+    ):
+        pass
 
     assert captured_env_vars['COMPOSE_PROJECT_NAME'] == 'custom'
 
 
-def test_docker_run_respects_compose_project_name_env_var(monkeypatch):
-    captured_env_vars = {}
-
-    @contextmanager
-    def fake_environment_run(**kwargs):
-        captured_env_vars.update(kwargs['env_vars'])
-        yield None
-
+def test_docker_run_respects_compose_project_name_env_var(monkeypatch, captured_env_vars):
     monkeypatch.setenv('COMPOSE_PROJECT_NAME', 'from_environ')
     monkeypatch.delenv('DDEV_E2E_ENV_docker_compose_metadata', raising=False)
 
-    with mock.patch('datadog_checks.dev.docker.environment_run', fake_environment_run):
-        with docker_run('/tmp/docker-compose.yml', service_name='service'):
-            pass
+    with docker_run('/tmp/docker-compose.yml', service_name='service'):
+        pass
 
     assert 'COMPOSE_PROJECT_NAME' not in captured_env_vars
     assert get_state('docker_compose_metadata')['project_name'] == 'from_environ'

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -293,6 +293,63 @@ def test_docker_run_saves_compose_metadata(monkeypatch):
     assert os.environ['DDEV_E2E_ENV_docker_compose_metadata']
 
 
+def test_docker_run_defaults_compose_project_name(monkeypatch):
+    captured_env_vars = {}
+
+    @contextmanager
+    def fake_environment_run(**kwargs):
+        captured_env_vars.update(kwargs['env_vars'])
+        yield None
+
+    monkeypatch.delenv('COMPOSE_PROJECT_NAME', raising=False)
+    monkeypatch.delenv('DDEV_E2E_ENV_docker_compose_metadata', raising=False)
+
+    with mock.patch('datadog_checks.dev.docker.environment_run', fake_environment_run):
+        with docker_run('/tmp/docker-compose.yml', service_name='service'):
+            pass
+
+    assert captured_env_vars['COMPOSE_PROJECT_NAME'] == 'datadog_checks_dev'
+    assert os.environ['DDEV_E2E_ENV_docker_compose_metadata']
+
+
+def test_docker_run_respects_explicit_compose_project_name(monkeypatch):
+    captured_env_vars = {}
+
+    @contextmanager
+    def fake_environment_run(**kwargs):
+        captured_env_vars.update(kwargs['env_vars'])
+        yield None
+
+    monkeypatch.delenv('COMPOSE_PROJECT_NAME', raising=False)
+
+    with mock.patch('datadog_checks.dev.docker.environment_run', fake_environment_run):
+        with docker_run(
+            '/tmp/docker-compose.yml',
+            env_vars={'COMPOSE_PROJECT_NAME': 'custom'},
+            service_name='service',
+        ):
+            pass
+
+    assert captured_env_vars['COMPOSE_PROJECT_NAME'] == 'custom'
+
+
+def test_docker_run_respects_compose_project_name_env_var(monkeypatch):
+    captured_env_vars = {}
+
+    @contextmanager
+    def fake_environment_run(**kwargs):
+        captured_env_vars.update(kwargs['env_vars'])
+        yield None
+
+    monkeypatch.setenv('COMPOSE_PROJECT_NAME', 'from_environ')
+
+    with mock.patch('datadog_checks.dev.docker.environment_run', fake_environment_run):
+        with docker_run('/tmp/docker-compose.yml', service_name='service'):
+            pass
+
+    assert 'COMPOSE_PROJECT_NAME' not in captured_env_vars
+
+
 def test_assert_all_discovery_candidates_stable_reports_incremental_logs(caplog):
     class DiscoveryCheck:
         @classmethod

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -10,6 +10,7 @@ import mock
 import pytest
 import tenacity
 
+from datadog_checks.dev._env import get_state
 from datadog_checks.dev.ci import running_on_ci
 from datadog_checks.dev.docker import (
     ComposeFileUp,
@@ -342,12 +343,14 @@ def test_docker_run_respects_compose_project_name_env_var(monkeypatch):
         yield None
 
     monkeypatch.setenv('COMPOSE_PROJECT_NAME', 'from_environ')
+    monkeypatch.delenv('DDEV_E2E_ENV_docker_compose_metadata', raising=False)
 
     with mock.patch('datadog_checks.dev.docker.environment_run', fake_environment_run):
         with docker_run('/tmp/docker-compose.yml', service_name='service'):
             pass
 
     assert 'COMPOSE_PROJECT_NAME' not in captured_env_vars
+    assert get_state('docker_compose_metadata')['project_name'] == 'from_environ'
 
 
 def test_assert_all_discovery_candidates_stable_reports_incremental_logs(caplog):

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -10,7 +10,7 @@ import mock
 import pytest
 import tenacity
 
-from datadog_checks.dev._env import get_state
+from datadog_checks.dev._env import get_state, serialize_data
 from datadog_checks.dev.ci import running_on_ci
 from datadog_checks.dev.docker import (
     ComposeFileUp,
@@ -340,6 +340,22 @@ def test_docker_run_respects_compose_project_name_env_var(monkeypatch, captured_
 
     assert 'COMPOSE_PROJECT_NAME' not in captured_env_vars
     assert get_state('docker_compose_metadata')['project_name'] == 'from_environ'
+
+
+def test_docker_run_reuses_saved_compose_project_name(monkeypatch, captured_env_vars):
+    monkeypatch.delenv('COMPOSE_PROJECT_NAME', raising=False)
+    monkeypatch.setenv(
+        'DDEV_E2E_ENV_docker_compose_metadata',
+        serialize_data(
+            {'compose_file': '/tmp/docker-compose.yml', 'project_name': 'saved_project', 'service_name': 'service'}
+        ),
+    )
+
+    with docker_run('/tmp/docker-compose.yml', service_name='service'):
+        pass
+
+    assert captured_env_vars['COMPOSE_PROJECT_NAME'] == 'saved_project'
+    assert get_state('docker_compose_metadata')['project_name'] == 'saved_project'
 
 
 def test_assert_all_discovery_candidates_stable_reports_incremental_logs(caplog):

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -48,9 +48,9 @@ POSTGRES_IMAGE = "alpine"
 POSTGRES_LOCALE = os.environ.get('POSTGRES_LOCALE', "UTF8")
 POSTGRES_IMAGE_TAG = os.environ.get('POSTGRES_IMAGE_TAG', None)
 
-REPLICA_CONTAINER_1_NAME = 'compose-postgres_replica-1'
-REPLICA_CONTAINER_2_NAME = 'compose-postgres_replica2-1'
-REPLICA_LOGICAL_1_NAME = 'compose-postgres_logical_replica-1'
+REPLICA_CONTAINER_1_NAME = 'postgres-postgres_replica-1'
+REPLICA_CONTAINER_2_NAME = 'postgres-postgres_replica2-1'
+REPLICA_LOGICAL_1_NAME = 'postgres-postgres_logical_replica-1'
 USING_LATEST = False
 
 if POSTGRES_IMAGE_TAG is not None:


### PR DESCRIPTION
### What does this PR do?
`datadog_checks_dev`'s `docker_run()` never set `COMPOSE_PROJECT_NAME`. When it isn't set, Docker Compose derives the project name from the compose file's parent directory basename, which is commonly just `compose` (many integrations name their fixture directory `tests/compose`). This PR makes `docker_run()` default `COMPOSE_PROJECT_NAME` to the check's own directory name whenever a compose file is used and the caller hasn't already set it (via `env_vars` or the environment), so each integration's Compose resources (containers, networks, volumes) get their own isolated project namespace by default.

An explicit `COMPOSE_PROJECT_NAME` — set via `env_vars` passed to `docker_run()`, or already present in `os.environ` — is always respected and left untouched.

Changing the default project name also changes the resulting container names (Compose names containers `<project>-<service>-<n>`), so this PR also updates the two integrations whose tests depended on the *old* project-name-derived container names:

- **postgres**: `tests/common.py` hardcoded replica container names as `compose-postgres_replica-1`, etc. (project name `compose`, from the old `tests/compose` directory basename). Updated to `postgres-postgres_replica-1`, etc. to match the new default project name (`postgres`).
- **celery**: the test fixture's Celery app (`tests/docker/proj/tasks.py`) hardcoded its Redis broker URL to the container hostname `docker-redis-standalone-1` (project name `docker`, from the old `tests/docker` directory basename). With the new default project name (`celery`), that hostname no longer resolves, so the worker/flower containers couldn't reach Redis and `celery.flower.events.count` was never emitted, failing the E2E test. Switched to the Compose service name `redis-standalone`, which resolves via Compose's service DNS regardless of project name — the more robust fix, since it no longer depends on the project name at all.

### Motivation
Running multiple integrations' E2E tests concurrently against the same Docker daemon causes Compose project-name collisions under the current default naming behavior: tearing down one integration's environment (`docker compose down`) can take down another integration's already-running containers/networks if they resolve to the same default project name. This was hit independently by 6 different agents in one batch of E2E discovery-support PRs sharing a Docker daemon.

Verification performed with `ddev env` using two integrations whose compose files live under `tests/compose` (`openmetrics` and `php_fpm`):

- Without this PR, `ddev env start --dev openmetrics py3.13` created `compose-openmetrics-1`. Then `ddev env start --dev php_fpm py3.13` emitted `Found orphan containers ([compose-openmetrics-1])` and created `compose-php-1` / `compose-nginx-1`; `docker ps --filter label=com.docker.compose.project=compose` showed all three containers under project `compose`. Running `ddev env stop php_fpm py3.13` removed `compose-openmetrics-1` as an orphan, and `ddev env agent openmetrics py3.13 check` then reported `Connection refused` for `localhost:9090`.
- With this PR, the same starts created `openmetrics-openmetrics-1` under project `openmetrics` and `php_fpm-php-1` / `php_fpm-nginx-1` under project `php_fpm`, with no containers under project `compose`. Running `ddev env stop php_fpm py3.13` removed only the PHP-FPM containers; `openmetrics-openmetrics-1` remained running, and `ddev env agent openmetrics py3.13 check` returned `[OK]` with service check status `0` and 20 metric samples.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
