### PR TITLE
[AI-7019] Support multiple endpoints in OpenMetrics flow (inspect endpoint phase)

### DIFF
--- a/ddev/src/ddev/ai/phases/openmetrics/inspect_endpoint.py
+++ b/ddev/src/ddev/ai/phases/openmetrics/inspect_endpoint.py
@@ -342,7 +342,7 @@ class InspectEndpointPhase(Phase):
                 return_exceptions=True,
             )
 
-        failures = [(ep.name, r) for ep, r in zip(endpoints, settled, strict=False) if isinstance(r, Exception)]
+        failures = [(ep.name, r) for ep, r in zip(endpoints, settled, strict=True) if isinstance(r, BaseException)]
         if failures:
             for r in settled:
                 if isinstance(r, EndpointResult):
@@ -351,7 +351,7 @@ class InspectEndpointPhase(Phase):
             detail = "; ".join(f"{name}: {err}" for name, err in failures)
             raise EndpointInspectionError(f"{len(failures)} endpoint(s) failed to inspect — {detail}")
 
-        results = [r for r in settled if not isinstance(r, BaseException)]
+        results = [r for r in settled if isinstance(r, EndpointResult)]
         return PhaseOutcome(
             memory_text=_build_memory_text(results),
             total_input_tokens=0,

--- a/ddev/src/ddev/ai/phases/openmetrics/inspect_endpoint.py
+++ b/ddev/src/ddev/ai/phases/openmetrics/inspect_endpoint.py
@@ -4,12 +4,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+import re
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import httpx
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from ddev.ai.config.errors import ConfigError
 from ddev.ai.config.models import PhaseConfig
@@ -33,6 +37,55 @@ EXPOSITION_FILENAME_SUFFIX = "_exposition.txt"
 
 class EndpointInspectionError(Exception):
     """Raised when the endpoint is unreachable, its body is unusable, or the catalog cannot be written."""
+
+
+def normalize_endpoint_name(v: str) -> str:
+    """snake_case an endpoint name and reject anything that isn't a valid identifier."""
+    name = re.sub(r"[^a-z0-9]+", "_", v.strip().lower()).strip("_")
+    if not re.fullmatch(r"[a-z][a-z0-9_]*", name):
+        raise ValueError(f"endpoint name {v!r} is not a valid identifier after normalization")
+    return name
+
+
+def requires_http_scheme(url: str) -> str:
+    if not url.startswith(("http://", "https://")):
+        raise ValueError("URL must start with http:// or https://")
+    return url
+
+
+class EndpointSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: Annotated[str, AfterValidator(normalize_endpoint_name)]
+    url: Annotated[str, Field(min_length=1), AfterValidator(requires_http_scheme)]
+
+
+class InspectInput(BaseModel):
+    """Phase 0's structured input contract."""
+
+    model_config = ConfigDict(extra="forbid")
+    endpoints: list[EndpointSpec]
+
+    @model_validator(mode="after")
+    def _non_empty_unique(self) -> InspectInput:
+        names = [e.name for e in self.endpoints]
+        if not names:
+            raise ValueError("at least one endpoint is required")
+        dupes = sorted({n for n in names if names.count(n) > 1})
+        if dupes:
+            raise ValueError(f"duplicate endpoint names after normalization: {dupes}")
+        return self
+
+
+@dataclass(frozen=True)
+class EndpointResult:
+    name: str
+    url: str
+    status_code: int
+    content_type: str
+    exposition_format: str
+    metric_count: int
+    metrics_jsonl_path: str  # absolute path, as strpat
+    exposition_path: str  # absolute path, as str
 
 
 def _parse_exposition(body: str, content_type: str) -> tuple[list[Metric], str]:
@@ -129,47 +182,131 @@ def _write_exposition(path: Path, body: str) -> None:
         raise EndpointInspectionError(f"Failed to write exposition snapshot at {path}: {e}") from e
 
 
-def _build_memory_text(
-    url: str,
-    status: int,
-    content_type: str,
-    exposition_format: str,
-    metric_count: int,
-    jsonl_path: Path,
-    exposition_path: Path,
-) -> str:
-    """Render the markdown memory file describing the inspected endpoint."""
+def _fixture_name(name: str, single: bool) -> str:
+    """Intended Phase 2 fixture name for an endpoint (single endpoint → generic metrics.txt)."""
+    return "tests/fixtures/metrics.txt" if single else f"tests/fixtures/{name}_metrics.txt"
+
+
+def _build_memory_text(results: list[EndpointResult]) -> str:
+    """Render the markdown memory file describing every inspected endpoint."""
+    single = len(results) == 1
     lines = [
         "# Endpoint inspection",
         "",
-        f"- **URL:** {url}",
-        f"- **HTTP status:** {status}",
-        f"- **Content-Type:** {content_type}",
-        f"- **Exposition format:** {exposition_format}",
-        f"- **Metric families detected:** {metric_count}",
-        f"- **Metrics catalog:** {jsonl_path}",
-        f"- **Raw exposition snapshot:** {exposition_path}",
+        f"Inspected {len(results)} endpoint(s). Each is reachable and serves a Prometheus/OpenMetrics-compatible body.",
         "",
-        "Endpoint is reachable and serves a Prometheus/OpenMetrics-compatible body.",
-        "The full list of metrics with metadata is in the catalog file above. The raw exposition",
-        "snapshot is the verbatim endpoint body, suitable for use as a test fixture.",
+        "| Endpoint | Format | Metric families |",
+        "| --- | --- | --- |",
     ]
-    return "\n".join(lines)
+    for r in results:
+        lines.append(f"| {r.name} | {r.exposition_format} | {r.metric_count} |")
+    lines.append("")
+
+    for r in results:
+        lines.extend(
+            [
+                f"## {r.name}",
+                "",
+                f"- **URL:** {r.url}",
+                f"- **HTTP status:** {r.status_code}",
+                f"- **Content-Type:** {r.content_type}",
+                f"- **Exposition format:** {r.exposition_format}",
+                f"- **Metric families detected:** {r.metric_count}",
+                f"- **Metrics catalog:** {r.metrics_jsonl_path}",
+                f"- **Raw exposition snapshot:** {r.exposition_path}",
+                f"- **Intended fixture:** {_fixture_name(r.name, single)}",
+                "",
+                "The catalog file lists every metric with its metadata. The raw exposition snapshot is the",
+                "verbatim endpoint body, suitable for use as a test fixture.",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip("\n")
+
+
+async def _fetch(client: httpx.AsyncClient, url: str) -> tuple[str, str, int]:
+    """Fetch url, enforce 200 + size limit, return (body, content_type, status_code)."""
+    try:
+        async with client.stream("GET", url) as response:
+            if response.status_code != 200:
+                raise EndpointInspectionError(f"Endpoint returned HTTP {response.status_code} (expected 200): {url}")
+            chunks: list[bytes] = []
+            received = 0
+            async for chunk in response.aiter_bytes():
+                received += len(chunk)
+                if received > RESPONSE_BODY_LIMIT_BYTES:
+                    limit_mb = RESPONSE_BODY_LIMIT_BYTES // (1024 * 1024)
+                    raise EndpointInspectionError(f"Response body exceeds {limit_mb} MB limit: {url}")
+                chunks.append(chunk)
+            body = b"".join(chunks).decode("utf-8", errors="replace")
+            content_type = response.headers.get("Content-Type", "")
+    except httpx.TimeoutException as e:
+        raise EndpointInspectionError(f"Endpoint timed out after {REQUEST_TIMEOUT_SECONDS}s: {url}") from e
+    except httpx.RequestError as e:
+        raise EndpointInspectionError(f"Request failed for {url}: {e}") from e
+
+    return body, content_type, response.status_code
+
+
+async def _inspect_one(
+    client: httpx.AsyncClient,
+    name: str,
+    url: str,
+    memory_dir: Path,
+    phase_id: str,
+) -> EndpointResult:
+    """Fetch, parse, and write the sidecars for a single named endpoint."""
+    try:
+        body, content_type, status_code = await _fetch(client, url)
+    except EndpointInspectionError as e:
+        raise EndpointInspectionError(f"[{name}] {e}") from e
+
+    try:
+        families, exposition_format = _parse_exposition(body, content_type)
+    except EndpointInspectionError as e:
+        raise EndpointInspectionError(f"[{name}] {e} ({url})") from e
+
+    header = {
+        "endpoint_name": name,
+        "endpoint_url": url,
+        "exposition_format": exposition_format,
+        "metric_families": len(families),
+    }
+    rows = _build_jsonl_rows(families)
+
+    jsonl_path = (memory_dir / f"{phase_id}_{name}{JSONL_FILENAME_SUFFIX}").resolve()
+    _write_jsonl(jsonl_path, [header, *rows])
+
+    exposition_path = (memory_dir / f"{phase_id}_{name}{EXPOSITION_FILENAME_SUFFIX}").resolve()
+    _write_exposition(exposition_path, body)
+
+    return EndpointResult(
+        name=name,
+        url=url,
+        status_code=status_code,
+        content_type=content_type,
+        exposition_format=exposition_format,
+        metric_count=len(families),
+        metrics_jsonl_path=str(jsonl_path),
+        exposition_path=str(exposition_path),
+    )
 
 
 class InspectEndpointPhase(Phase):
     """Deterministic Phase 0 for the OpenMetrics pipeline.
 
-    Performs a single HTTP fetch of ``endpoint_url`` and:
+    Fetches every named endpoint in ``inspect_input`` concurrently and, per endpoint:
 
     1. Confirms the endpoint is reachable (HTTP 200).
     2. Confirms the body is valid Prometheus or OpenMetrics exposition.
-    3. Writes a ``<phase_id>_metrics.jsonl`` sidecar next to the memory file,
-       with one row per metric family — the ground-truth catalog later phases
-       use to drive metric renaming, ``metrics.py`` mapping, and
+    3. Writes a ``<phase_id>_<name>_metrics.jsonl`` sidecar (provenance header line 1 +
+       one row per metric family) next to the memory file — the ground-truth catalog
+       later phases use to drive metric renaming, ``metrics.py`` mapping, and
        ``metadata.csv`` generation.
+    4. Writes a ``<phase_id>_<name>_exposition.txt`` verbatim snapshot for reuse as a fixture.
 
-    Aborts the pipeline with EndpointInspectionError on any failure.
+    All-or-nothing: if any endpoint fails, the phase aborts with a single
+    EndpointInspectionError listing every failed endpoint.
     """
 
     @classmethod
@@ -182,75 +319,36 @@ class InspectEndpointPhase(Phase):
             raise ConfigError(f"Phase {phase_id!r} (InspectEndpointPhase) must not declare 'checkpoint'")
 
     async def execute(self, context: dict[str, Any]) -> PhaseOutcome:
-        endpoint_url = context.get("endpoint_url")
-        if not endpoint_url:
-            raise ConfigError(f"Phase {self._phase_id!r}: 'endpoint_url' runtime variable is required")
-
-        limit_mb = RESPONSE_BODY_LIMIT_BYTES // (1024 * 1024)
+        raw = context.get("inspect_input")
+        if not raw:
+            raise ConfigError(f"Phase {self._phase_id!r}: 'inspect_input' runtime variable is required")
         try:
-            async with httpx.AsyncClient(
-                timeout=REQUEST_TIMEOUT_SECONDS,
-                follow_redirects=True,
-                headers={"Accept": DEFAULT_ACCEPT_HEADER},
-            ) as client:
-                async with client.stream("GET", endpoint_url) as response:
-                    if response.status_code != 200:
-                        raise EndpointInspectionError(
-                            f"Endpoint returned HTTP {response.status_code} (expected 200): {endpoint_url}"
-                        )
-                    chunks: list[bytes] = []
-                    received = 0
-                    async for chunk in response.aiter_bytes():
-                        received += len(chunk)
-                        if received > RESPONSE_BODY_LIMIT_BYTES:
-                            raise EndpointInspectionError(f"Response body exceeds {limit_mb} MB limit: {endpoint_url}")
-                        chunks.append(chunk)
-                    body = b"".join(chunks).decode("utf-8", errors="replace")
-                    content_type = response.headers.get("Content-Type", "")
-        except EndpointInspectionError:
-            raise
-        except httpx.TimeoutException as e:
-            raise EndpointInspectionError(f"Endpoint timed out after {REQUEST_TIMEOUT_SECONDS}s: {endpoint_url}") from e
-        except httpx.RequestError as e:
-            raise EndpointInspectionError(f"Request failed for {endpoint_url}: {e}") from e
+            endpoints = InspectInput.model_validate_json(raw).endpoints
+        except ValidationError as e:
+            raise ConfigError(f"Phase {self._phase_id!r}: invalid 'inspect_input': {e}") from e
 
-        try:
-            families, exposition_format = _parse_exposition(body, content_type)
-        except EndpointInspectionError as e:
-            raise EndpointInspectionError(f"{e} ({endpoint_url})") from e
+        memory_dir = self._checkpoint_manager.memory_dir
+        memory_dir.mkdir(parents=True, exist_ok=True)
 
-        rows = _build_jsonl_rows(families)
-        self._checkpoint_manager.memory_dir.mkdir(parents=True, exist_ok=True)
-        jsonl_path = (self._checkpoint_manager.memory_dir / f"{self._phase_id}{JSONL_FILENAME_SUFFIX}").resolve()
-        _write_jsonl(jsonl_path, rows)
+        async with httpx.AsyncClient(
+            timeout=REQUEST_TIMEOUT_SECONDS,
+            follow_redirects=True,
+            headers={"Accept": DEFAULT_ACCEPT_HEADER},
+        ) as client:
+            settled = await asyncio.gather(
+                *(_inspect_one(client, ep.name, ep.url, memory_dir, self._phase_id) for ep in endpoints),
+                return_exceptions=True,
+            )
 
-        exposition_path = (
-            self._checkpoint_manager.memory_dir / f"{self._phase_id}{EXPOSITION_FILENAME_SUFFIX}"
-        ).resolve()
-        _write_exposition(exposition_path, body)
+        failures = [(ep.name, r) for ep, r in zip(endpoints, settled, strict=False) if isinstance(r, Exception)]
+        if failures:
+            detail = "; ".join(f"{name}: {err}" for name, err in failures)
+            raise EndpointInspectionError(f"{len(failures)} endpoint(s) failed to inspect — {detail}")
 
-        metric_count = len(families)
-        memory_text = _build_memory_text(
-            url=endpoint_url,
-            status=response.status_code,
-            content_type=content_type,
-            exposition_format=exposition_format,
-            metric_count=metric_count,
-            jsonl_path=jsonl_path,
-            exposition_path=exposition_path,
-        )
-
+        results = [r for r in settled if not isinstance(r, BaseException)]
         return PhaseOutcome(
-            memory_text=memory_text,
+            memory_text=_build_memory_text(results),
             total_input_tokens=0,
             total_output_tokens=0,
-            checkpoint_data={
-                "endpoint_url": endpoint_url,
-                "status_code": response.status_code,
-                "content_type": content_type,
-                "exposition_format": exposition_format,
-                "metric_count": metric_count,
-                "metrics_jsonl_path": str(jsonl_path),
-                "exposition_path": str(exposition_path),
-            },
+            checkpoint_data={"endpoints": [asdict(r) for r in results]},
         )

--- a/ddev/src/ddev/ai/phases/openmetrics/inspect_endpoint.py
+++ b/ddev/src/ddev/ai/phases/openmetrics/inspect_endpoint.py
@@ -60,7 +60,7 @@ class EndpointSpec(BaseModel):
 
 
 class InspectInput(BaseModel):
-    """Phase 0's structured input contract."""
+    """InspectEndpointPhase's structured input contract."""
 
     model_config = ConfigDict(extra="forbid")
     endpoints: list[EndpointSpec]
@@ -183,7 +183,7 @@ def _write_exposition(path: Path, body: str) -> None:
 
 
 def _fixture_name(name: str, single: bool) -> str:
-    """Intended Phase 2 fixture name for an endpoint (single endpoint → generic metrics.txt)."""
+    """Intended fixture name for an endpoint (single endpoint → generic metrics.txt)."""
     return "tests/fixtures/metrics.txt" if single else f"tests/fixtures/{name}_metrics.txt"
 
 
@@ -250,12 +250,12 @@ async def _fetch(client: httpx.AsyncClient, url: str) -> tuple[str, str, int]:
 
 async def _inspect_one(
     client: httpx.AsyncClient,
-    name: str,
-    url: str,
+    endpoint: EndpointSpec,
     memory_dir: Path,
     phase_id: str,
 ) -> EndpointResult:
     """Fetch, parse, and write the sidecars for a single named endpoint."""
+    name, url = endpoint.name, endpoint.url
     try:
         body, content_type, status_code = await _fetch(client, url)
     except EndpointInspectionError as e:
@@ -306,7 +306,9 @@ class InspectEndpointPhase(Phase):
     4. Writes a ``<phase_id>_<name>_exposition.txt`` verbatim snapshot for reuse as a fixture.
 
     All-or-nothing: if any endpoint fails, the phase aborts with a single
-    EndpointInspectionError listing every failed endpoint.
+    EndpointInspectionError listing every failed endpoint, and any sidecar files
+    already written by endpoints that succeeded before a sibling failure are
+    deleted so no partial output is left behind.
     """
 
     @classmethod
@@ -336,12 +338,16 @@ class InspectEndpointPhase(Phase):
             headers={"Accept": DEFAULT_ACCEPT_HEADER},
         ) as client:
             settled = await asyncio.gather(
-                *(_inspect_one(client, ep.name, ep.url, memory_dir, self._phase_id) for ep in endpoints),
+                *(_inspect_one(client, ep, memory_dir, self._phase_id) for ep in endpoints),
                 return_exceptions=True,
             )
 
         failures = [(ep.name, r) for ep, r in zip(endpoints, settled, strict=False) if isinstance(r, Exception)]
         if failures:
+            for r in settled:
+                if isinstance(r, EndpointResult):
+                    Path(r.metrics_jsonl_path).unlink(missing_ok=True)
+                    Path(r.exposition_path).unlink(missing_ok=True)
             detail = "; ".join(f"{name}: {err}" for name, err in failures)
             raise EndpointInspectionError(f"{len(failures)} endpoint(s) failed to inspect — {detail}")
 

--- a/ddev/src/ddev/ai/phases/openmetrics/inspect_endpoint.py
+++ b/ddev/src/ddev/ai/phases/openmetrics/inspect_endpoint.py
@@ -248,6 +248,14 @@ async def _fetch(client: httpx.AsyncClient, url: str) -> tuple[str, str, int]:
     return body, content_type, response.status_code
 
 
+def _jsonl_sidecar_path(memory_dir: Path, phase_id: str, name: str) -> Path:
+    return (memory_dir / f"{phase_id}_{name}{JSONL_FILENAME_SUFFIX}").resolve()
+
+
+def _exposition_sidecar_path(memory_dir: Path, phase_id: str, name: str) -> Path:
+    return (memory_dir / f"{phase_id}_{name}{EXPOSITION_FILENAME_SUFFIX}").resolve()
+
+
 async def _inspect_one(
     client: httpx.AsyncClient,
     endpoint: EndpointSpec,
@@ -274,10 +282,10 @@ async def _inspect_one(
     }
     rows = _build_jsonl_rows(families)
 
-    jsonl_path = (memory_dir / f"{phase_id}_{name}{JSONL_FILENAME_SUFFIX}").resolve()
+    jsonl_path = _jsonl_sidecar_path(memory_dir, phase_id, name)
     _write_jsonl(jsonl_path, [header, *rows])
 
-    exposition_path = (memory_dir / f"{phase_id}_{name}{EXPOSITION_FILENAME_SUFFIX}").resolve()
+    exposition_path = _exposition_sidecar_path(memory_dir, phase_id, name)
     _write_exposition(exposition_path, body)
 
     return EndpointResult(
@@ -344,10 +352,9 @@ class InspectEndpointPhase(Phase):
 
         failures = [(ep.name, r) for ep, r in zip(endpoints, settled, strict=True) if isinstance(r, BaseException)]
         if failures:
-            for r in settled:
-                if isinstance(r, EndpointResult):
-                    Path(r.metrics_jsonl_path).unlink(missing_ok=True)
-                    Path(r.exposition_path).unlink(missing_ok=True)
+            for ep in endpoints:
+                _jsonl_sidecar_path(memory_dir, self._phase_id, ep.name).unlink(missing_ok=True)
+                _exposition_sidecar_path(memory_dir, self._phase_id, ep.name).unlink(missing_ok=True)
             detail = "; ".join(f"{name}: {err}" for name, err in failures)
             raise EndpointInspectionError(f"{len(failures)} endpoint(s) failed to inspect — {detail}")
 

--- a/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
+++ b/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
@@ -900,6 +900,42 @@ async def test_all_or_nothing_one_endpoint_fails_aborts_phase(flow_dir, message_
     assert not _exposition_path(flow_dir, "agent").exists()
 
 
+async def test_all_or_nothing_cleans_up_partial_write_of_failing_endpoint(flow_dir, message_queue, monkeypatch):
+    """The failing endpoint's own jsonl (written before its exposition write failed) must not be left behind."""
+    url_a = "http://host:9962/metrics"
+    url_b = "http://host:9963/metrics"
+    _install_mock_transport(
+        monkeypatch,
+        _multi_handler(
+            {
+                url_a: (200, PROMETHEUS_BODY, "text/plain"),
+                url_b: (200, PROMETHEUS_BODY_SECOND, "text/plain"),
+            }
+        ),
+    )
+
+    real_replace = os.replace
+
+    def replace_failing_for_operator_exposition(src, dst):
+        if str(dst).endswith("operator_exposition.txt"):
+            raise OSError("simulated exposition write failure")
+        real_replace(src, dst)
+
+    monkeypatch.setattr(inspect_endpoint_module.os, "replace", replace_failing_for_operator_exposition)
+
+    phase, mgr = _make_phase(
+        flow_dir,
+        message_queue,
+        runtime_variables=_inspect_input_var(("agent", url_a), ("operator", url_b)),
+    )
+
+    await _assert_phase_fails(phase, mgr, message_queue, error_contains="endpoint(s) failed to inspect")
+
+    for name in ("agent", "operator"):
+        assert not _jsonl_path(flow_dir, name).exists()
+        assert not _exposition_path(flow_dir, name).exists()
+
+
 async def test_multiple_failures_are_all_reported(flow_dir, message_queue, monkeypatch):
     url_a = "http://host:9962/metrics"
     url_b = "http://host:9963/metrics"

--- a/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
+++ b/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
@@ -776,7 +776,8 @@ def test_inspect_input_invalid_inputs(endpoints, match):
 # ---------------------------------------------------------------------------
 
 
-def _two_endpoint_run(flow_dir, message_queue, monkeypatch):
+@pytest.fixture
+def two_endpoint_run(flow_dir, message_queue, monkeypatch):
     url_a = "http://host:9962/metrics"
     url_b = "http://host:9963/metrics"
     _install_mock_transport(
@@ -796,8 +797,8 @@ def _two_endpoint_run(flow_dir, message_queue, monkeypatch):
     return phase, checkpoint_mgr, url_a, url_b
 
 
-async def test_multi_endpoint_writes_one_jsonl_per_endpoint(flow_dir, message_queue, monkeypatch):
-    phase, _checkpoint_mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+async def test_multi_endpoint_writes_one_jsonl_per_endpoint(flow_dir, two_endpoint_run):
+    phase, _, _, _ = two_endpoint_run
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -807,8 +808,8 @@ async def test_multi_endpoint_writes_one_jsonl_per_endpoint(flow_dir, message_qu
     assert operator_families == {m.name for m in parse_prometheus(PROMETHEUS_BODY_SECOND)}
 
 
-async def test_multi_endpoint_writes_one_exposition_per_endpoint(flow_dir, message_queue, monkeypatch):
-    phase, _checkpoint_mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+async def test_multi_endpoint_writes_one_exposition_per_endpoint(flow_dir, two_endpoint_run):
+    phase, _, _, _ = two_endpoint_run
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -816,8 +817,8 @@ async def test_multi_endpoint_writes_one_exposition_per_endpoint(flow_dir, messa
     assert _exposition_path(flow_dir, "operator").read_text(encoding="utf-8") == PROMETHEUS_BODY_SECOND
 
 
-async def test_jsonl_first_row_is_provenance_header(flow_dir, message_queue, monkeypatch):
-    phase, _checkpoint_mgr, url_a, url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+async def test_jsonl_first_row_is_provenance_header(flow_dir, two_endpoint_run):
+    phase, _, url_a, url_b = two_endpoint_run
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -830,8 +831,8 @@ async def test_jsonl_first_row_is_provenance_header(flow_dir, message_queue, mon
         assert header["metric_families"] == len(_read_family_rows(path))
 
 
-async def test_family_rows_follow_header_unchanged_schema(flow_dir, message_queue, monkeypatch):
-    phase, _checkpoint_mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+async def test_family_rows_follow_header_unchanged_schema(flow_dir, two_endpoint_run):
+    phase, _, _, _ = two_endpoint_run
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -841,8 +842,8 @@ async def test_family_rows_follow_header_unchanged_schema(flow_dir, message_queu
             assert set(row.keys()) == expected_keys
 
 
-async def test_checkpoint_lists_all_endpoints(flow_dir, message_queue, monkeypatch):
-    phase, checkpoint_mgr, url_a, url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+async def test_checkpoint_lists_all_endpoints(two_endpoint_run):
+    phase, checkpoint_mgr, url_a, url_b = two_endpoint_run
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -869,8 +870,8 @@ async def test_checkpoint_lists_all_endpoints(flow_dir, message_queue, monkeypat
         assert os.path.exists(e["exposition_path"])
 
 
-async def test_memory_text_includes_every_endpoint(flow_dir, message_queue, monkeypatch):
-    phase, checkpoint_mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+async def test_memory_text_includes_every_endpoint(flow_dir, two_endpoint_run):
+    phase, checkpoint_mgr, _, _ = two_endpoint_run
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -1000,19 +1001,3 @@ async def test_endpoint_name_normalized_to_snake_case(flow_dir, message_queue, m
     assert _exposition_path(flow_dir, "app_controller").exists()
     checkpoint = checkpoint_mgr.read()[PHASE_ID]
     assert _endpoint_data(checkpoint)["name"] == "app_controller"
-
-
-async def test_multi_endpoint_deterministic_jsonl(flow_dir, message_queue, monkeypatch, tmp_path_factory):
-    phase1, _, _, _ = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
-    await phase1.process_message(PhaseTrigger(id="start", phase_id=None))
-    first = {name: _jsonl_path(flow_dir, name).read_bytes() for name in ("agent", "operator")}
-
-    flow_dir_2 = tmp_path_factory.mktemp("second_run")
-    queue_2 = asyncio.Queue()
-    phase2, _, _, _ = _two_endpoint_run(flow_dir_2, queue_2, monkeypatch)
-    await phase2.process_message(PhaseTrigger(id="start", phase_id=None))
-    second = {name: _jsonl_path(flow_dir_2, name).read_bytes() for name in ("agent", "operator")}
-
-    for name in ("agent", "operator"):
-        assert first[name] == second[name]
-        assert first[name].endswith(b"\n")

--- a/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
+++ b/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
@@ -20,7 +20,6 @@ from ddev.ai.phases.openmetrics import inspect_endpoint as inspect_endpoint_modu
 from ddev.ai.phases.openmetrics.inspect_endpoint import (
     EndpointInspectionError,
     EndpointResult,
-    EndpointSpec,
     InspectEndpointPhase,
     InspectInput,
     _build_jsonl_rows,
@@ -125,7 +124,7 @@ def _make_phase(
     phase_id: str = PHASE_ID,
     runtime_variables: dict[str, str] | None = None,
 ) -> tuple[InspectEndpointPhase, CheckpointManager]:
-    checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
+    checkpoint_mgr = CheckpointManager(flow_dir / "checkpoints.yaml")
     context = FlowContext(
         runtime_variables=(
             runtime_variables if runtime_variables is not None else _inspect_input_var((ENDPOINT_NAME, ENDPOINT_URL))
@@ -136,11 +135,11 @@ def _make_phase(
         phase_id=phase_id,
         dependencies=[],
         config=PhaseConfig(name=phase_id),
-        checkpoint_manager=checkpoint_manager,
+        checkpoint_manager=checkpoint_mgr,
         context=context,
     )
     phase.queue = message_queue
-    return phase, checkpoint_manager
+    return phase, checkpoint_mgr
 
 
 def _install_mock_transport(monkeypatch, handler):
@@ -227,17 +226,17 @@ async def test_success_with_prometheus_body(flow_dir, message_queue, monkeypatch
         monkeypatch,
         _ok_handler(200, PROMETHEUS_BODY, "text/plain; version=0.0.4; charset=utf-8"),
     )
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     expected_families = list(parse_prometheus(PROMETHEUS_BODY))
 
-    memory = mgr.memory_content(PHASE_ID)
+    memory = checkpoint_mgr.memory_content(PHASE_ID)
     assert ENDPOINT_URL in memory
     assert "HTTP status:** 200" in memory
 
-    checkpoint = mgr.read()[PHASE_ID]
+    checkpoint = checkpoint_mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
     endpoint = _endpoint_data(checkpoint)
     assert endpoint["exposition_format"] == "prometheus"
@@ -252,11 +251,11 @@ async def test_success_with_prometheus_body(flow_dir, message_queue, monkeypatch
 async def test_success_with_openmetrics_body(flow_dir, message_queue, monkeypatch):
     content_type = "application/openmetrics-text; version=1.0.0; charset=utf-8"
     _install_mock_transport(monkeypatch, _ok_handler(200, OPENMETRICS_BODY_CLEAN, content_type))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    checkpoint = mgr.read()[PHASE_ID]
+    checkpoint = checkpoint_mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
     endpoint = _endpoint_data(checkpoint)
     assert endpoint["exposition_format"] == "openmetrics"
@@ -269,7 +268,7 @@ async def test_success_with_openmetrics_body(flow_dir, message_queue, monkeypatc
 # ---------------------------------------------------------------------------
 
 
-async def _assert_phase_fails(phase, mgr, message_queue, *, error_contains: str):
+async def _assert_phase_fails(phase, checkpoint_mgr, message_queue, *, error_contains: str):
     """Run process_message, expect failure, drive on_error like the framework would."""
     trigger = PhaseTrigger(id="start", phase_id=None)
     try:
@@ -277,7 +276,7 @@ async def _assert_phase_fails(phase, mgr, message_queue, *, error_contains: str)
     except Exception as raised:
         wrapped = MessageProcessingError(phase._phase_id, trigger, raised)
         await phase.on_error(wrapped)
-        checkpoint = mgr.read()[phase._phase_id]
+        checkpoint = checkpoint_mgr.read()[phase._phase_id]
         assert isinstance(checkpoint, FailedCheckpoint)
         assert error_contains.lower() in checkpoint.error.lower()
         msg = message_queue.get_nowait()
@@ -289,31 +288,31 @@ async def _assert_phase_fails(phase, mgr, message_queue, *, error_contains: str)
 
 async def test_failure_non_200_status(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(503, "service unavailable", "text/plain"))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
-    await _assert_phase_fails(phase, mgr, message_queue, error_contains="HTTP 503")
+    await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="HTTP 503")
 
 
 async def test_failure_body_is_html(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, "<html>not metrics</html>", "text/plain"))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
-    await _assert_phase_fails(phase, mgr, message_queue, error_contains="not valid prometheus exposition")
+    await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="not valid prometheus exposition")
 
 
 async def test_failure_body_is_json(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, '{"hello": "world"}', "text/plain"))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
-    await _assert_phase_fails(phase, mgr, message_queue, error_contains="prometheus")
+    await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="prometheus")
 
 
 async def test_failure_zero_families(flow_dir, message_queue, monkeypatch):
     body = "\n\n# just a stray comment, not a HELP/TYPE\n\n"
     _install_mock_transport(monkeypatch, _ok_handler(200, body, "text/plain"))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
-    await _assert_phase_fails(phase, mgr, message_queue, error_contains="zero metric families")
+    await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="zero metric families")
 
 
 async def test_failure_openmetrics_missing_eof(flow_dir, message_queue, monkeypatch):
@@ -321,27 +320,27 @@ async def test_failure_openmetrics_missing_eof(flow_dir, message_queue, monkeypa
         monkeypatch,
         _ok_handler(200, PROMETHEUS_BODY, "application/openmetrics-text; version=1.0.0"),
     )
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
-    await _assert_phase_fails(phase, mgr, message_queue, error_contains="not valid openmetrics exposition")
+    await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="not valid openmetrics exposition")
 
 
 async def test_failure_timeout(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _raising_handler(httpx.TimeoutException("slow")))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
-    await _assert_phase_fails(phase, mgr, message_queue, error_contains="timed out")
+    await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="timed out")
 
 
 async def test_failure_request_error(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _raising_handler(httpx.ConnectError("refused")))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
-    await _assert_phase_fails(phase, mgr, message_queue, error_contains="request failed")
+    await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="request failed")
 
 
 async def test_failure_missing_inspect_input(flow_dir, message_queue):
-    phase, mgr = _make_phase(flow_dir, message_queue, runtime_variables={})
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue, runtime_variables={})
 
     trigger = PhaseTrigger(id="start", phase_id=None)
     with pytest.raises(ConfigError, match="inspect_input"):
@@ -350,7 +349,7 @@ async def test_failure_missing_inspect_input(flow_dir, message_queue):
     wrapped = MessageProcessingError(phase._phase_id, trigger, ConfigError("inspect_input required"))
     await phase.on_error(wrapped)
 
-    checkpoint = mgr.read()[PHASE_ID]
+    checkpoint = checkpoint_mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, FailedCheckpoint)
     msg = message_queue.get_nowait()
     assert isinstance(msg, PhaseFailedMessage)
@@ -467,11 +466,11 @@ def test_build_memory_text_renders_every_endpoint(tmp_path):
 
 async def test_jsonl_path_in_checkpoint(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    checkpoint = mgr.read()[PHASE_ID]
+    checkpoint = checkpoint_mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
     path_str = _endpoint_data(checkpoint)["metrics_jsonl_path"]
     assert isinstance(path_str, str)
@@ -481,11 +480,11 @@ async def test_jsonl_path_in_checkpoint(flow_dir, message_queue, monkeypatch):
 
 async def test_jsonl_one_row_per_family(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    checkpoint = mgr.read()[PHASE_ID]
+    checkpoint = checkpoint_mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
     rows = _read_family_rows(_jsonl_path(flow_dir))
     expected_families = list(parse_prometheus(PROMETHEUS_BODY))
@@ -494,7 +493,7 @@ async def test_jsonl_one_row_per_family(flow_dir, message_queue, monkeypatch):
 
 async def test_jsonl_row_schema(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, _mgr = _make_phase(flow_dir, message_queue)
+    phase, _checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -509,7 +508,7 @@ async def test_jsonl_row_schema(flow_dir, message_queue, monkeypatch):
 
 async def test_jsonl_counter_total_stripped_prometheus(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, _mgr = _make_phase(flow_dir, message_queue)
+    phase, _checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -524,7 +523,7 @@ async def test_jsonl_counter_total_stripped_openmetrics(flow_dir, message_queue,
         monkeypatch,
         _ok_handler(200, OPENMETRICS_BODY_CLEAN, "application/openmetrics-text; version=1.0.0"),
     )
-    phase, _mgr = _make_phase(flow_dir, message_queue)
+    phase, _checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -536,7 +535,7 @@ async def test_jsonl_counter_total_stripped_openmetrics(flow_dir, message_queue,
 
 async def test_jsonl_histogram_collapses_to_single_row(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, _mgr = _make_phase(flow_dir, message_queue)
+    phase, _checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -553,7 +552,7 @@ async def test_jsonl_summary_collapses_to_single_row(flow_dir, message_queue, mo
         monkeypatch,
         _ok_handler(200, OPENMETRICS_BODY_CLEAN, "application/openmetrics-text; version=1.0.0"),
     )
-    phase, _mgr = _make_phase(flow_dir, message_queue)
+    phase, _checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -570,7 +569,7 @@ async def test_jsonl_unit_populated_for_openmetrics(flow_dir, message_queue, mon
         monkeypatch,
         _ok_handler(200, OPENMETRICS_BODY_WITH_UNIT, "application/openmetrics-text; version=1.0.0"),
     )
-    phase, _mgr = _make_phase(flow_dir, message_queue)
+    phase, _checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -581,7 +580,7 @@ async def test_jsonl_unit_populated_for_openmetrics(flow_dir, message_queue, mon
 
 async def test_jsonl_unit_empty_for_prometheus(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, _mgr = _make_phase(flow_dir, message_queue)
+    phase, _checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -602,7 +601,7 @@ def test_jsonl_label_keys_are_union_across_samples():
 
 async def test_jsonl_sample_count_matches_parser(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, _mgr = _make_phase(flow_dir, message_queue)
+    phase, _checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -615,7 +614,7 @@ async def test_jsonl_sample_count_matches_parser(flow_dir, message_queue, monkey
 
 async def test_jsonl_ordering_matches_parser(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, _mgr = _make_phase(flow_dir, message_queue)
+    phase, _checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -642,13 +641,13 @@ async def test_jsonl_is_deterministic_byte_for_byte(flow_dir, message_queue, mon
 
 async def test_memory_text_includes_jsonl_path(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    checkpoint = mgr.read()[PHASE_ID]
+    checkpoint = checkpoint_mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
-    memory = mgr.memory_content(PHASE_ID)
+    memory = checkpoint_mgr.memory_content(PHASE_ID)
     assert _endpoint_data(checkpoint)["metrics_jsonl_path"] in memory
 
 
@@ -660,21 +659,21 @@ async def test_jsonl_sidecar_atomic_on_os_replace_failure(flow_dir, message_queu
 
     monkeypatch.setattr(inspect_endpoint_module.os, "replace", boom)
 
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
-    await _assert_phase_fails(phase, mgr, message_queue, error_contains="Failed to write metrics catalog")
+    await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="Failed to write metrics catalog")
 
     assert not _jsonl_path(flow_dir).exists()
 
 
 async def test_jsonl_failure_propagates_as_phase_failure(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     blocker = flow_dir / f"{PHASE_ID}_{ENDPOINT_NAME}_metrics.jsonl.tmp"
     blocker.mkdir()
 
-    await _assert_phase_fails(phase, mgr, message_queue, error_contains="Failed to write metrics catalog")
+    await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="Failed to write metrics catalog")
 
 
 # ---------------------------------------------------------------------------
@@ -684,11 +683,11 @@ async def test_jsonl_failure_propagates_as_phase_failure(flow_dir, message_queue
 
 async def test_exposition_path_in_checkpoint(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    checkpoint = mgr.read()[PHASE_ID]
+    checkpoint = checkpoint_mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
     path_str = _endpoint_data(checkpoint)["exposition_path"]
     assert isinstance(path_str, str)
@@ -698,7 +697,7 @@ async def test_exposition_path_in_checkpoint(flow_dir, message_queue, monkeypatc
 
 async def test_exposition_file_holds_verbatim_body(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, _mgr = _make_phase(flow_dir, message_queue)
+    phase, _checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -708,24 +707,26 @@ async def test_exposition_file_holds_verbatim_body(flow_dir, message_queue, monk
 
 async def test_memory_text_includes_exposition_path(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    checkpoint = mgr.read()[PHASE_ID]
+    checkpoint = checkpoint_mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
-    assert _endpoint_data(checkpoint)["exposition_path"] in mgr.memory_content(PHASE_ID)
+    assert _endpoint_data(checkpoint)["exposition_path"] in checkpoint_mgr.memory_content(PHASE_ID)
 
 
 async def test_exposition_failure_propagates_as_phase_failure(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, mgr = _make_phase(flow_dir, message_queue)
+    phase, checkpoint_mgr = _make_phase(flow_dir, message_queue)
 
     # Block only the exposition temp path (the JSONL is written first and succeeds).
     blocker = flow_dir / f"{PHASE_ID}_{ENDPOINT_NAME}_exposition.txt.tmp"
     blocker.mkdir()
 
-    await _assert_phase_fails(phase, mgr, message_queue, error_contains="Failed to write exposition snapshot")
+    await _assert_phase_fails(
+        phase, checkpoint_mgr, message_queue, error_contains="Failed to write exposition snapshot"
+    )
     assert not _exposition_path(flow_dir).exists()
 
 
@@ -741,29 +742,33 @@ def test_normalize_endpoint_name_variants():
     assert normalize_endpoint_name("foo123") == "foo123"
 
 
-def test_normalize_endpoint_name_rejects_leading_digit():
-    with pytest.raises(ValueError, match="not a valid identifier"):
-        normalize_endpoint_name("9metrics")
-
-
-def test_endpoint_spec_rejects_url_without_scheme():
-    with pytest.raises(ValidationError):
-        EndpointSpec(name="main", url="example.com/metrics")
-
-
-def test_inspect_input_rejects_empty_endpoints():
-    with pytest.raises(ValidationError, match="at least one endpoint"):
-        InspectInput(endpoints=[])
-
-
-def test_inspect_input_rejects_duplicate_names():
-    with pytest.raises(ValidationError, match="duplicate endpoint names"):
-        InspectInput(
-            endpoints=[
-                EndpointSpec(name="App Controller", url="http://h:1/m"),
-                EndpointSpec(name="app-controller", url="http://h:2/m"),
-            ]
-        )
+@pytest.mark.parametrize(
+    "endpoints, match",
+    [
+        (
+            [{"name": "9metrics", "url": "http://h/m"}],
+            "not a valid identifier",
+        ),
+        (
+            [{"name": "main", "url": "example.com/metrics"}],
+            "URL must start with",
+        ),
+        (
+            [],
+            "at least one endpoint",
+        ),
+        (
+            [
+                {"name": "App Controller", "url": "http://h:1/m"},
+                {"name": "app-controller", "url": "http://h:2/m"},
+            ],
+            "duplicate endpoint names",
+        ),
+    ],
+)
+def test_inspect_input_invalid_inputs(endpoints, match):
+    with pytest.raises(ValidationError, match=match):
+        InspectInput(endpoints=endpoints)
 
 
 # ---------------------------------------------------------------------------
@@ -783,16 +788,16 @@ def _two_endpoint_run(flow_dir, message_queue, monkeypatch):
             }
         ),
     )
-    phase, mgr = _make_phase(
+    phase, checkpoint_mgr = _make_phase(
         flow_dir,
         message_queue,
         runtime_variables=_inspect_input_var(("agent", url_a), ("operator", url_b)),
     )
-    return phase, mgr, url_a, url_b
+    return phase, checkpoint_mgr, url_a, url_b
 
 
 async def test_multi_endpoint_writes_one_jsonl_per_endpoint(flow_dir, message_queue, monkeypatch):
-    phase, _mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+    phase, _checkpoint_mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -803,7 +808,7 @@ async def test_multi_endpoint_writes_one_jsonl_per_endpoint(flow_dir, message_qu
 
 
 async def test_multi_endpoint_writes_one_exposition_per_endpoint(flow_dir, message_queue, monkeypatch):
-    phase, _mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+    phase, _checkpoint_mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -812,7 +817,7 @@ async def test_multi_endpoint_writes_one_exposition_per_endpoint(flow_dir, messa
 
 
 async def test_jsonl_first_row_is_provenance_header(flow_dir, message_queue, monkeypatch):
-    phase, _mgr, url_a, url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+    phase, _checkpoint_mgr, url_a, url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -826,7 +831,7 @@ async def test_jsonl_first_row_is_provenance_header(flow_dir, message_queue, mon
 
 
 async def test_family_rows_follow_header_unchanged_schema(flow_dir, message_queue, monkeypatch):
-    phase, _mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+    phase, _checkpoint_mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -837,11 +842,11 @@ async def test_family_rows_follow_header_unchanged_schema(flow_dir, message_queu
 
 
 async def test_checkpoint_lists_all_endpoints(flow_dir, message_queue, monkeypatch):
-    phase, mgr, url_a, url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+    phase, checkpoint_mgr, url_a, url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    checkpoint = mgr.read()[PHASE_ID]
+    checkpoint = checkpoint_mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
     endpoints = checkpoint.phase_data["endpoints"]
     assert [e["name"] for e in endpoints] == ["agent", "operator"]
@@ -865,11 +870,11 @@ async def test_checkpoint_lists_all_endpoints(flow_dir, message_queue, monkeypat
 
 
 async def test_memory_text_includes_every_endpoint(flow_dir, message_queue, monkeypatch):
-    phase, mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+    phase, checkpoint_mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    memory = mgr.memory_content(PHASE_ID)
+    memory = checkpoint_mgr.memory_content(PHASE_ID)
     for name in ("agent", "operator"):
         assert name in memory
         assert str(_jsonl_path(flow_dir, name)) in memory
@@ -888,13 +893,13 @@ async def test_all_or_nothing_one_endpoint_fails_aborts_phase(flow_dir, message_
             }
         ),
     )
-    phase, mgr = _make_phase(
+    phase, checkpoint_mgr = _make_phase(
         flow_dir,
         message_queue,
         runtime_variables=_inspect_input_var(("agent", url_a), ("operator", url_b)),
     )
 
-    raised = await _assert_phase_fails(phase, mgr, message_queue, error_contains="[operator]")
+    raised = await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="[operator]")
     assert "HTTP 503" in str(raised)
     assert not _jsonl_path(flow_dir, "agent").exists()
     assert not _exposition_path(flow_dir, "agent").exists()
@@ -923,13 +928,13 @@ async def test_all_or_nothing_cleans_up_partial_write_of_failing_endpoint(flow_d
 
     monkeypatch.setattr(inspect_endpoint_module.os, "replace", replace_failing_for_operator_exposition)
 
-    phase, mgr = _make_phase(
+    phase, checkpoint_mgr = _make_phase(
         flow_dir,
         message_queue,
         runtime_variables=_inspect_input_var(("agent", url_a), ("operator", url_b)),
     )
 
-    await _assert_phase_fails(phase, mgr, message_queue, error_contains="endpoint(s) failed to inspect")
+    await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="endpoint(s) failed to inspect")
 
     for name in ("agent", "operator"):
         assert not _jsonl_path(flow_dir, name).exists()
@@ -948,13 +953,13 @@ async def test_multiple_failures_are_all_reported(flow_dir, message_queue, monke
             }
         ),
     )
-    phase, mgr = _make_phase(
+    phase, checkpoint_mgr = _make_phase(
         flow_dir,
         message_queue,
         runtime_variables=_inspect_input_var(("agent", url_a), ("operator", url_b)),
     )
 
-    raised = await _assert_phase_fails(phase, mgr, message_queue, error_contains="2 endpoint(s) failed")
+    raised = await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="2 endpoint(s) failed")
     text = str(raised)
     assert "agent" in text
     assert "operator" in text
@@ -977,7 +982,7 @@ async def test_multiple_failures_are_all_reported(flow_dir, message_queue, monke
     ],
 )
 async def test_invalid_inspect_input_raises_config_error(flow_dir, message_queue, runtime_variables, match):
-    phase, _mgr = _make_phase(flow_dir, message_queue, runtime_variables=runtime_variables)
+    phase, _checkpoint_mgr = _make_phase(flow_dir, message_queue, runtime_variables=runtime_variables)
     with pytest.raises(ConfigError, match=match):
         await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
@@ -985,24 +990,26 @@ async def test_invalid_inspect_input_raises_config_error(flow_dir, message_queue
 async def test_endpoint_name_normalized_to_snake_case(flow_dir, message_queue, monkeypatch):
     url = "http://host:9962/metrics"
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
-    phase, mgr = _make_phase(flow_dir, message_queue, runtime_variables=_inspect_input_var(("App Controller", url)))
+    phase, checkpoint_mgr = _make_phase(
+        flow_dir, message_queue, runtime_variables=_inspect_input_var(("App Controller", url))
+    )
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     assert _jsonl_path(flow_dir, "app_controller").exists()
     assert _exposition_path(flow_dir, "app_controller").exists()
-    checkpoint = mgr.read()[PHASE_ID]
+    checkpoint = checkpoint_mgr.read()[PHASE_ID]
     assert _endpoint_data(checkpoint)["name"] == "app_controller"
 
 
 async def test_multi_endpoint_deterministic_jsonl(flow_dir, message_queue, monkeypatch, tmp_path_factory):
-    phase1, _mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+    phase1, _, _, _ = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
     await phase1.process_message(PhaseTrigger(id="start", phase_id=None))
     first = {name: _jsonl_path(flow_dir, name).read_bytes() for name in ("agent", "operator")}
 
     flow_dir_2 = tmp_path_factory.mktemp("second_run")
     queue_2 = asyncio.Queue()
-    phase2, _mgr2, _a, _b = _two_endpoint_run(flow_dir_2, queue_2, monkeypatch)
+    phase2, _, _, _ = _two_endpoint_run(flow_dir_2, queue_2, monkeypatch)
     await phase2.process_message(PhaseTrigger(id="start", phase_id=None))
     second = {name: _jsonl_path(flow_dir_2, name).read_bytes() for name in ("agent", "operator")}
 

--- a/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
+++ b/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
@@ -444,6 +444,7 @@ def test_build_memory_text_renders_all_fields(tmp_path):
     assert "prometheus" in text
     assert str(jsonl_path) in text
     assert str(exposition_path) in text
+    assert "tests/fixtures/metrics.txt" in text
 
 
 def test_build_memory_text_renders_every_endpoint(tmp_path):
@@ -455,6 +456,8 @@ def test_build_memory_text_renders_every_endpoint(tmp_path):
         assert r.url in text
         assert r.metrics_jsonl_path in text
         assert r.exposition_path in text
+    assert "tests/fixtures/agent_metrics.txt" in text
+    assert "tests/fixtures/operator_metrics.txt" in text
 
 
 # ---------------------------------------------------------------------------
@@ -893,6 +896,8 @@ async def test_all_or_nothing_one_endpoint_fails_aborts_phase(flow_dir, message_
 
     raised = await _assert_phase_fails(phase, mgr, message_queue, error_contains="[operator]")
     assert "HTTP 503" in str(raised)
+    assert not _jsonl_path(flow_dir, "agent").exists()
+    assert not _exposition_path(flow_dir, "agent").exists()
 
 
 async def test_multiple_failures_are_all_reported(flow_dir, message_queue, monkeypatch):
@@ -921,31 +926,23 @@ async def test_multiple_failures_are_all_reported(flow_dir, message_queue, monke
     assert "timed out" in text
 
 
-async def test_inspect_input_missing_raises_config_error(flow_dir, message_queue):
-    phase, _mgr = _make_phase(flow_dir, message_queue, runtime_variables={})
-    with pytest.raises(ConfigError, match="inspect_input"):
-        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
-
-
-async def test_inspect_input_malformed_json_raises_config_error(flow_dir, message_queue):
-    phase, _mgr = _make_phase(flow_dir, message_queue, runtime_variables={"inspect_input": "not json"})
-    with pytest.raises(ConfigError, match="invalid 'inspect_input'"):
-        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
-
-
-async def test_inspect_input_empty_endpoints_raises_config_error(flow_dir, message_queue):
-    phase, _mgr = _make_phase(flow_dir, message_queue, runtime_variables={"inspect_input": '{"endpoints": []}'})
-    with pytest.raises(ConfigError, match="inspect_input"):
-        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
-
-
-async def test_duplicate_endpoint_names_raise_config_error(flow_dir, message_queue):
-    phase, _mgr = _make_phase(
-        flow_dir,
-        message_queue,
-        runtime_variables=_inspect_input_var(("App Controller", "http://h:1/m"), ("app-controller", "http://h:2/m")),
-    )
-    with pytest.raises(ConfigError, match="duplicate endpoint names"):
+@pytest.mark.parametrize(
+    ("runtime_variables", "match"),
+    [
+        pytest.param({}, "inspect_input", id="missing"),
+        pytest.param({"inspect_input": "not json"}, "invalid 'inspect_input'", id="malformed_json"),
+        pytest.param({"inspect_input": '{"endpoints": []}'}, "inspect_input", id="empty_endpoints"),
+        pytest.param(
+            _inspect_input_var(("App Controller", "http://h:1/m"), ("app-controller", "http://h:2/m")),
+            "duplicate endpoint names",
+            id="duplicate_names",
+        ),
+        pytest.param(_inspect_input_var(("main", "example.com/metrics")), "inspect_input", id="url_without_scheme"),
+    ],
+)
+async def test_invalid_inspect_input_raises_config_error(flow_dir, message_queue, runtime_variables, match):
+    phase, _mgr = _make_phase(flow_dir, message_queue, runtime_variables=runtime_variables)
+    with pytest.raises(ConfigError, match=match):
         await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
 
@@ -960,14 +957,6 @@ async def test_endpoint_name_normalized_to_snake_case(flow_dir, message_queue, m
     assert _exposition_path(flow_dir, "app_controller").exists()
     checkpoint = mgr.read()[PHASE_ID]
     assert _endpoint_data(checkpoint)["name"] == "app_controller"
-
-
-async def test_url_without_scheme_raises_config_error(flow_dir, message_queue):
-    phase, _mgr = _make_phase(
-        flow_dir, message_queue, runtime_variables=_inspect_input_var(("main", "example.com/metrics"))
-    )
-    with pytest.raises(ConfigError, match="inspect_input"):
-        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
 
 async def test_multi_endpoint_deterministic_jsonl(flow_dir, message_queue, monkeypatch, tmp_path_factory):

--- a/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
+++ b/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 from prometheus_client import Metric
 from prometheus_client.parser import text_string_to_metric_families as parse_prometheus
+from pydantic import ValidationError
 
 from ddev.ai.config.errors import ConfigError
 from ddev.ai.config.models import CheckpointConfig, PhaseConfig, TaskConfig
@@ -18,15 +19,20 @@ from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.openmetrics import inspect_endpoint as inspect_endpoint_module
 from ddev.ai.phases.openmetrics.inspect_endpoint import (
     EndpointInspectionError,
+    EndpointResult,
+    EndpointSpec,
     InspectEndpointPhase,
+    InspectInput,
     _build_jsonl_rows,
     _build_memory_text,
     _parse_exposition,
+    normalize_endpoint_name,
 )
 from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointTokenInfo, FailedCheckpoint, SuccessCheckpoint
 from ddev.event_bus.exceptions import MessageProcessingError
 
 ENDPOINT_URL = "http://example.test:9100/metrics"
+ENDPOINT_NAME = "main"
 PHASE_ID = "inspect_endpoint"
 
 PROMETHEUS_BODY = """\
@@ -81,6 +87,16 @@ request_duration_seconds 0.42
 # EOF
 """
 
+# A distinct second body, for multi-endpoint tests where the two catalogs must differ.
+PROMETHEUS_BODY_SECOND = """\
+# HELP queue_depth Current queue depth.
+# TYPE queue_depth gauge
+queue_depth{shard="a"} 3
+# HELP jobs_processed_total Total jobs processed.
+# TYPE jobs_processed_total counter
+jobs_processed_total{shard="a"} 42
+"""
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -97,6 +113,11 @@ def message_queue():
     return asyncio.Queue()
 
 
+def _inspect_input_var(*pairs: tuple[str, str]) -> dict[str, str]:
+    payload = {"endpoints": [{"name": n, "url": u} for n, u in pairs]}
+    return {"inspect_input": json.dumps(payload)}
+
+
 def _make_phase(
     flow_dir,
     message_queue,
@@ -106,7 +127,9 @@ def _make_phase(
 ) -> tuple[InspectEndpointPhase, CheckpointManager]:
     checkpoint_manager = CheckpointManager(flow_dir / "checkpoints.yaml")
     context = FlowContext(
-        runtime_variables=runtime_variables if runtime_variables is not None else {"endpoint_url": ENDPOINT_URL},
+        runtime_variables=(
+            runtime_variables if runtime_variables is not None else _inspect_input_var((ENDPOINT_NAME, ENDPOINT_URL))
+        ),
         flow_variables={},
     )
     phase = InspectEndpointPhase(
@@ -145,8 +168,44 @@ def _raising_handler(exc: Exception):
     return handler
 
 
+def _multi_handler(bodies_by_url: dict[str, tuple[int, str, str]]):
+    """Dispatch by request URL so one mocked run can serve a different body per endpoint.
+
+    A value may also be an ``Exception`` to raise (e.g. a timeout) for that URL.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        entry = bodies_by_url[str(request.url)]
+        if isinstance(entry, Exception):
+            raise entry
+        status, body, ct = entry
+        return httpx.Response(status_code=status, content=body.encode("utf-8"), headers={"Content-Type": ct})
+
+    return handler
+
+
+def _jsonl_path(flow_dir, name: str = ENDPOINT_NAME):
+    return flow_dir / f"{PHASE_ID}_{name}_metrics.jsonl"
+
+
+def _exposition_path(flow_dir, name: str = ENDPOINT_NAME):
+    return flow_dir / f"{PHASE_ID}_{name}_exposition.txt"
+
+
 def _read_jsonl(path) -> list[dict]:
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def _read_header(path) -> dict:
+    return _read_jsonl(path)[0]
+
+
+def _read_family_rows(path) -> list[dict]:
+    return _read_jsonl(path)[1:]
+
+
+def _endpoint_data(checkpoint, index: int = 0) -> dict:
+    return checkpoint.phase_data["endpoints"][index]
 
 
 class _Sample:
@@ -180,11 +239,13 @@ async def test_success_with_prometheus_body(flow_dir, message_queue, monkeypatch
 
     checkpoint = mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
-    assert checkpoint.phase_data["exposition_format"] == "prometheus"
-    assert checkpoint.phase_data["metric_count"] == len(expected_families)
-    assert "sample_metric_names" not in checkpoint.phase_data
-    assert checkpoint.phase_data["status_code"] == 200
-    assert checkpoint.phase_data["endpoint_url"] == ENDPOINT_URL
+    endpoint = _endpoint_data(checkpoint)
+    assert endpoint["exposition_format"] == "prometheus"
+    assert endpoint["metric_count"] == len(expected_families)
+    assert "sample_metric_names" not in endpoint
+    assert endpoint["status_code"] == 200
+    assert endpoint["url"] == ENDPOINT_URL
+    assert endpoint["name"] == ENDPOINT_NAME
     assert checkpoint.tokens == CheckpointTokenInfo(total_input=0, total_output=0)
 
 
@@ -197,9 +258,10 @@ async def test_success_with_openmetrics_body(flow_dir, message_queue, monkeypatc
 
     checkpoint = mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
-    assert checkpoint.phase_data["exposition_format"] == "openmetrics"
-    assert checkpoint.phase_data["content_type"] == content_type
-    assert checkpoint.phase_data["metric_count"] >= 1
+    endpoint = _endpoint_data(checkpoint)
+    assert endpoint["exposition_format"] == "openmetrics"
+    assert endpoint["content_type"] == content_type
+    assert endpoint["metric_count"] >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -278,14 +340,14 @@ async def test_failure_request_error(flow_dir, message_queue, monkeypatch):
     await _assert_phase_fails(phase, mgr, message_queue, error_contains="request failed")
 
 
-async def test_failure_missing_endpoint_url(flow_dir, message_queue):
+async def test_failure_missing_inspect_input(flow_dir, message_queue):
     phase, mgr = _make_phase(flow_dir, message_queue, runtime_variables={})
 
     trigger = PhaseTrigger(id="start", phase_id=None)
-    with pytest.raises(ConfigError, match="endpoint_url"):
+    with pytest.raises(ConfigError, match="inspect_input"):
         await phase.process_message(trigger)
 
-    wrapped = MessageProcessingError(phase._phase_id, trigger, ConfigError("endpoint_url required"))
+    wrapped = MessageProcessingError(phase._phase_id, trigger, ConfigError("inspect_input required"))
     await phase.on_error(wrapped)
 
     checkpoint = mgr.read()[PHASE_ID]
@@ -358,29 +420,45 @@ def test_parse_exposition_raises_on_zero_families():
 # ---------------------------------------------------------------------------
 
 
-def test_build_memory_text_renders_all_fields(tmp_path):
-    jsonl_path = tmp_path / "inspect_endpoint_metrics.jsonl"
-    exposition_path = tmp_path / "inspect_endpoint_exposition.txt"
-    text = _build_memory_text(
-        url="http://example.test:9100/metrics",
-        status=200,
+def _result(name: str, url: str, jsonl_path, exposition_path) -> EndpointResult:
+    return EndpointResult(
+        name=name,
+        url=url,
+        status_code=200,
         content_type="text/plain; version=0.0.4",
         exposition_format="prometheus",
         metric_count=2,
-        jsonl_path=jsonl_path,
-        exposition_path=exposition_path,
+        metrics_jsonl_path=str(jsonl_path),
+        exposition_path=str(exposition_path),
     )
+
+
+def test_build_memory_text_renders_all_fields(tmp_path):
+    jsonl_path = tmp_path / "inspect_endpoint_main_metrics.jsonl"
+    exposition_path = tmp_path / "inspect_endpoint_main_exposition.txt"
+    text = _build_memory_text([_result("main", "http://example.test:9100/metrics", jsonl_path, exposition_path)])
+    assert "main" in text
     assert "http://example.test:9100/metrics" in text
     assert "200" in text
     assert "text/plain; version=0.0.4" in text
     assert "prometheus" in text
-    assert "2" in text
     assert str(jsonl_path) in text
     assert str(exposition_path) in text
 
 
+def test_build_memory_text_renders_every_endpoint(tmp_path):
+    r1 = _result("agent", "http://host:9962/metrics", tmp_path / "a.jsonl", tmp_path / "a.txt")
+    r2 = _result("operator", "http://host:9963/metrics", tmp_path / "o.jsonl", tmp_path / "o.txt")
+    text = _build_memory_text([r1, r2])
+    for r in (r1, r2):
+        assert r.name in text
+        assert r.url in text
+        assert r.metrics_jsonl_path in text
+        assert r.exposition_path in text
+
+
 # ---------------------------------------------------------------------------
-# JSONL + sidecar contract — new tests
+# JSONL + sidecar contract
 # ---------------------------------------------------------------------------
 
 
@@ -392,7 +470,7 @@ async def test_jsonl_path_in_checkpoint(flow_dir, message_queue, monkeypatch):
 
     checkpoint = mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
-    path_str = checkpoint.phase_data["metrics_jsonl_path"]
+    path_str = _endpoint_data(checkpoint)["metrics_jsonl_path"]
     assert isinstance(path_str, str)
     assert os.path.isabs(path_str)
     assert os.path.exists(path_str)
@@ -406,9 +484,9 @@ async def test_jsonl_one_row_per_family(flow_dir, message_queue, monkeypatch):
 
     checkpoint = mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
-    rows = _read_jsonl(flow_dir / f"{PHASE_ID}_metrics.jsonl")
+    rows = _read_family_rows(_jsonl_path(flow_dir))
     expected_families = list(parse_prometheus(PROMETHEUS_BODY))
-    assert len(rows) == checkpoint.phase_data["metric_count"] == len(expected_families)
+    assert len(rows) == _endpoint_data(checkpoint)["metric_count"] == len(expected_families)
 
 
 async def test_jsonl_row_schema(flow_dir, message_queue, monkeypatch):
@@ -418,7 +496,7 @@ async def test_jsonl_row_schema(flow_dir, message_queue, monkeypatch):
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     expected_keys = {"name", "type", "help", "unit", "label_keys", "sample_count"}
-    for row in _read_jsonl(flow_dir / f"{PHASE_ID}_metrics.jsonl"):
+    for row in _read_family_rows(_jsonl_path(flow_dir)):
         assert set(row.keys()) == expected_keys
         assert isinstance(row["label_keys"], list)
         assert all(isinstance(k, str) for k in row["label_keys"])
@@ -432,7 +510,7 @@ async def test_jsonl_counter_total_stripped_prometheus(flow_dir, message_queue, 
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    rows = _read_jsonl(flow_dir / f"{PHASE_ID}_metrics.jsonl")
+    rows = _read_family_rows(_jsonl_path(flow_dir))
     counter_rows = [r for r in rows if r["type"] == "counter"]
     assert len(counter_rows) == 1
     assert counter_rows[0]["name"] == "http_requests"
@@ -447,7 +525,7 @@ async def test_jsonl_counter_total_stripped_openmetrics(flow_dir, message_queue,
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    rows = _read_jsonl(flow_dir / f"{PHASE_ID}_metrics.jsonl")
+    rows = _read_family_rows(_jsonl_path(flow_dir))
     counter_rows = [r for r in rows if r["type"] == "counter"]
     assert len(counter_rows) == 1
     assert counter_rows[0]["name"] == "http_requests"
@@ -459,7 +537,7 @@ async def test_jsonl_histogram_collapses_to_single_row(flow_dir, message_queue, 
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    rows = _read_jsonl(flow_dir / f"{PHASE_ID}_metrics.jsonl")
+    rows = _read_family_rows(_jsonl_path(flow_dir))
     hist_rows = [r for r in rows if r["type"] == "histogram"]
     assert len(hist_rows) == 1
     row = hist_rows[0]
@@ -476,7 +554,7 @@ async def test_jsonl_summary_collapses_to_single_row(flow_dir, message_queue, mo
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    rows = _read_jsonl(flow_dir / f"{PHASE_ID}_metrics.jsonl")
+    rows = _read_family_rows(_jsonl_path(flow_dir))
     summary_rows = [r for r in rows if r["type"] == "summary"]
     assert len(summary_rows) == 1
     row = summary_rows[0]
@@ -493,7 +571,7 @@ async def test_jsonl_unit_populated_for_openmetrics(flow_dir, message_queue, mon
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    rows = _read_jsonl(flow_dir / f"{PHASE_ID}_metrics.jsonl")
+    rows = _read_family_rows(_jsonl_path(flow_dir))
     assert len(rows) == 1
     assert rows[0]["unit"] == "seconds"
 
@@ -504,7 +582,7 @@ async def test_jsonl_unit_empty_for_prometheus(flow_dir, message_queue, monkeypa
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    rows = _read_jsonl(flow_dir / f"{PHASE_ID}_metrics.jsonl")
+    rows = _read_family_rows(_jsonl_path(flow_dir))
     assert all(r["unit"] == "" for r in rows)
 
 
@@ -525,7 +603,7 @@ async def test_jsonl_sample_count_matches_parser(flow_dir, message_queue, monkey
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    rows = _read_jsonl(flow_dir / f"{PHASE_ID}_metrics.jsonl")
+    rows = _read_family_rows(_jsonl_path(flow_dir))
     families = list(parse_prometheus(PROMETHEUS_BODY))
     expected_counts = {m.name: len(m.samples) for m in families}
     actual_counts = {r["name"]: r["sample_count"] for r in rows}
@@ -538,7 +616,7 @@ async def test_jsonl_ordering_matches_parser(flow_dir, message_queue, monkeypatc
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    rows = _read_jsonl(flow_dir / f"{PHASE_ID}_metrics.jsonl")
+    rows = _read_family_rows(_jsonl_path(flow_dir))
     families = list(parse_prometheus(PROMETHEUS_BODY))
     assert [r["name"] for r in rows] == [m.name for m in families]
 
@@ -547,13 +625,13 @@ async def test_jsonl_is_deterministic_byte_for_byte(flow_dir, message_queue, mon
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
     phase1, _ = _make_phase(flow_dir, message_queue)
     await phase1.process_message(PhaseTrigger(id="start", phase_id=None))
-    first_bytes = (flow_dir / f"{PHASE_ID}_metrics.jsonl").read_bytes()
+    first_bytes = _jsonl_path(flow_dir).read_bytes()
 
     flow_dir_2 = tmp_path_factory.mktemp("second_run")
     queue_2 = asyncio.Queue()
     phase2, _ = _make_phase(flow_dir_2, queue_2)
     await phase2.process_message(PhaseTrigger(id="start", phase_id=None))
-    second_bytes = (flow_dir_2 / f"{PHASE_ID}_metrics.jsonl").read_bytes()
+    second_bytes = _jsonl_path(flow_dir_2).read_bytes()
 
     assert first_bytes == second_bytes
     assert first_bytes.endswith(b"\n")
@@ -568,7 +646,7 @@ async def test_memory_text_includes_jsonl_path(flow_dir, message_queue, monkeypa
     checkpoint = mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
     memory = mgr.memory_content(PHASE_ID)
-    assert checkpoint.phase_data["metrics_jsonl_path"] in memory
+    assert _endpoint_data(checkpoint)["metrics_jsonl_path"] in memory
 
 
 async def test_jsonl_sidecar_atomic_on_os_replace_failure(flow_dir, message_queue, monkeypatch):
@@ -583,22 +661,21 @@ async def test_jsonl_sidecar_atomic_on_os_replace_failure(flow_dir, message_queu
 
     await _assert_phase_fails(phase, mgr, message_queue, error_contains="Failed to write metrics catalog")
 
-    final_path = flow_dir / f"{PHASE_ID}_metrics.jsonl"
-    assert not final_path.exists()
+    assert not _jsonl_path(flow_dir).exists()
 
 
 async def test_jsonl_failure_propagates_as_phase_failure(flow_dir, message_queue, monkeypatch):
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
     phase, mgr = _make_phase(flow_dir, message_queue)
 
-    blocker = flow_dir / f"{PHASE_ID}_metrics.jsonl.tmp"
+    blocker = flow_dir / f"{PHASE_ID}_{ENDPOINT_NAME}_metrics.jsonl.tmp"
     blocker.mkdir()
 
     await _assert_phase_fails(phase, mgr, message_queue, error_contains="Failed to write metrics catalog")
 
 
 # ---------------------------------------------------------------------------
-# Raw exposition sidecar — new tests
+# Raw exposition sidecar
 # ---------------------------------------------------------------------------
 
 
@@ -610,7 +687,7 @@ async def test_exposition_path_in_checkpoint(flow_dir, message_queue, monkeypatc
 
     checkpoint = mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
-    path_str = checkpoint.phase_data["exposition_path"]
+    path_str = _endpoint_data(checkpoint)["exposition_path"]
     assert isinstance(path_str, str)
     assert os.path.isabs(path_str)
     assert os.path.exists(path_str)
@@ -622,7 +699,7 @@ async def test_exposition_file_holds_verbatim_body(flow_dir, message_queue, monk
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    exposition = (flow_dir / f"{PHASE_ID}_exposition.txt").read_text(encoding="utf-8")
+    exposition = _exposition_path(flow_dir).read_text(encoding="utf-8")
     assert exposition == PROMETHEUS_BODY
 
 
@@ -634,7 +711,7 @@ async def test_memory_text_includes_exposition_path(flow_dir, message_queue, mon
 
     checkpoint = mgr.read()[PHASE_ID]
     assert isinstance(checkpoint, SuccessCheckpoint)
-    assert checkpoint.phase_data["exposition_path"] in mgr.memory_content(PHASE_ID)
+    assert _endpoint_data(checkpoint)["exposition_path"] in mgr.memory_content(PHASE_ID)
 
 
 async def test_exposition_failure_propagates_as_phase_failure(flow_dir, message_queue, monkeypatch):
@@ -642,8 +719,268 @@ async def test_exposition_failure_propagates_as_phase_failure(flow_dir, message_
     phase, mgr = _make_phase(flow_dir, message_queue)
 
     # Block only the exposition temp path (the JSONL is written first and succeeds).
-    blocker = flow_dir / f"{PHASE_ID}_exposition.txt.tmp"
+    blocker = flow_dir / f"{PHASE_ID}_{ENDPOINT_NAME}_exposition.txt.tmp"
     blocker.mkdir()
 
     await _assert_phase_fails(phase, mgr, message_queue, error_contains="Failed to write exposition snapshot")
-    assert not (flow_dir / f"{PHASE_ID}_exposition.txt").exists()
+    assert not _exposition_path(flow_dir).exists()
+
+
+# ---------------------------------------------------------------------------
+# Input contract — pydantic models
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_endpoint_name_variants():
+    assert normalize_endpoint_name("App Controller") == "app_controller"
+    assert normalize_endpoint_name("api-server") == "api_server"
+    assert normalize_endpoint_name("  Mixed_Case  ") == "mixed_case"
+    assert normalize_endpoint_name("foo123") == "foo123"
+
+
+def test_normalize_endpoint_name_rejects_leading_digit():
+    with pytest.raises(ValueError, match="not a valid identifier"):
+        normalize_endpoint_name("9metrics")
+
+
+def test_endpoint_spec_rejects_url_without_scheme():
+    with pytest.raises(ValidationError):
+        EndpointSpec(name="main", url="example.com/metrics")
+
+
+def test_inspect_input_rejects_empty_endpoints():
+    with pytest.raises(ValidationError, match="at least one endpoint"):
+        InspectInput(endpoints=[])
+
+
+def test_inspect_input_rejects_duplicate_names():
+    with pytest.raises(ValidationError, match="duplicate endpoint names"):
+        InspectInput(
+            endpoints=[
+                EndpointSpec(name="App Controller", url="http://h:1/m"),
+                EndpointSpec(name="app-controller", url="http://h:2/m"),
+            ]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-endpoint
+# ---------------------------------------------------------------------------
+
+
+def _two_endpoint_run(flow_dir, message_queue, monkeypatch):
+    url_a = "http://host:9962/metrics"
+    url_b = "http://host:9963/metrics"
+    _install_mock_transport(
+        monkeypatch,
+        _multi_handler(
+            {
+                url_a: (200, PROMETHEUS_BODY, "text/plain"),
+                url_b: (200, PROMETHEUS_BODY_SECOND, "text/plain"),
+            }
+        ),
+    )
+    phase, mgr = _make_phase(
+        flow_dir,
+        message_queue,
+        runtime_variables=_inspect_input_var(("agent", url_a), ("operator", url_b)),
+    )
+    return phase, mgr, url_a, url_b
+
+
+async def test_multi_endpoint_writes_one_jsonl_per_endpoint(flow_dir, message_queue, monkeypatch):
+    phase, _mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    agent_families = {r["name"] for r in _read_family_rows(_jsonl_path(flow_dir, "agent"))}
+    operator_families = {r["name"] for r in _read_family_rows(_jsonl_path(flow_dir, "operator"))}
+    assert agent_families == {m.name for m in parse_prometheus(PROMETHEUS_BODY)}
+    assert operator_families == {m.name for m in parse_prometheus(PROMETHEUS_BODY_SECOND)}
+
+
+async def test_multi_endpoint_writes_one_exposition_per_endpoint(flow_dir, message_queue, monkeypatch):
+    phase, _mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert _exposition_path(flow_dir, "agent").read_text(encoding="utf-8") == PROMETHEUS_BODY
+    assert _exposition_path(flow_dir, "operator").read_text(encoding="utf-8") == PROMETHEUS_BODY_SECOND
+
+
+async def test_jsonl_first_row_is_provenance_header(flow_dir, message_queue, monkeypatch):
+    phase, _mgr, url_a, url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    for name, url in (("agent", url_a), ("operator", url_b)):
+        path = _jsonl_path(flow_dir, name)
+        header = _read_header(path)
+        assert set(header.keys()) == {"endpoint_name", "endpoint_url", "exposition_format", "metric_families"}
+        assert header["endpoint_name"] == name
+        assert header["endpoint_url"] == url
+        assert header["metric_families"] == len(_read_family_rows(path))
+
+
+async def test_family_rows_follow_header_unchanged_schema(flow_dir, message_queue, monkeypatch):
+    phase, _mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    expected_keys = {"name", "type", "help", "unit", "label_keys", "sample_count"}
+    for name in ("agent", "operator"):
+        for row in _read_family_rows(_jsonl_path(flow_dir, name)):
+            assert set(row.keys()) == expected_keys
+
+
+async def test_checkpoint_lists_all_endpoints(flow_dir, message_queue, monkeypatch):
+    phase, mgr, url_a, url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    checkpoint = mgr.read()[PHASE_ID]
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    endpoints = checkpoint.phase_data["endpoints"]
+    assert [e["name"] for e in endpoints] == ["agent", "operator"]
+    assert [e["url"] for e in endpoints] == [url_a, url_b]
+    expected_fields = {
+        "name",
+        "url",
+        "status_code",
+        "content_type",
+        "exposition_format",
+        "metric_count",
+        "metrics_jsonl_path",
+        "exposition_path",
+    }
+    for e in endpoints:
+        assert set(e.keys()) == expected_fields
+        assert os.path.isabs(e["metrics_jsonl_path"])
+        assert os.path.exists(e["metrics_jsonl_path"])
+        assert os.path.isabs(e["exposition_path"])
+        assert os.path.exists(e["exposition_path"])
+
+
+async def test_memory_text_includes_every_endpoint(flow_dir, message_queue, monkeypatch):
+    phase, mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    memory = mgr.memory_content(PHASE_ID)
+    for name in ("agent", "operator"):
+        assert name in memory
+        assert str(_jsonl_path(flow_dir, name)) in memory
+        assert str(_exposition_path(flow_dir, name)) in memory
+
+
+async def test_all_or_nothing_one_endpoint_fails_aborts_phase(flow_dir, message_queue, monkeypatch):
+    url_a = "http://host:9962/metrics"
+    url_b = "http://host:9963/metrics"
+    _install_mock_transport(
+        monkeypatch,
+        _multi_handler(
+            {
+                url_a: (200, PROMETHEUS_BODY, "text/plain"),
+                url_b: (503, "service unavailable", "text/plain"),
+            }
+        ),
+    )
+    phase, mgr = _make_phase(
+        flow_dir,
+        message_queue,
+        runtime_variables=_inspect_input_var(("agent", url_a), ("operator", url_b)),
+    )
+
+    raised = await _assert_phase_fails(phase, mgr, message_queue, error_contains="[operator]")
+    assert "HTTP 503" in str(raised)
+
+
+async def test_multiple_failures_are_all_reported(flow_dir, message_queue, monkeypatch):
+    url_a = "http://host:9962/metrics"
+    url_b = "http://host:9963/metrics"
+    _install_mock_transport(
+        monkeypatch,
+        _multi_handler(
+            {
+                url_a: (503, "service unavailable", "text/plain"),
+                url_b: httpx.TimeoutException("slow"),
+            }
+        ),
+    )
+    phase, mgr = _make_phase(
+        flow_dir,
+        message_queue,
+        runtime_variables=_inspect_input_var(("agent", url_a), ("operator", url_b)),
+    )
+
+    raised = await _assert_phase_fails(phase, mgr, message_queue, error_contains="2 endpoint(s) failed")
+    text = str(raised)
+    assert "agent" in text
+    assert "operator" in text
+    assert "HTTP 503" in text
+    assert "timed out" in text
+
+
+async def test_inspect_input_missing_raises_config_error(flow_dir, message_queue):
+    phase, _mgr = _make_phase(flow_dir, message_queue, runtime_variables={})
+    with pytest.raises(ConfigError, match="inspect_input"):
+        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+
+async def test_inspect_input_malformed_json_raises_config_error(flow_dir, message_queue):
+    phase, _mgr = _make_phase(flow_dir, message_queue, runtime_variables={"inspect_input": "not json"})
+    with pytest.raises(ConfigError, match="invalid 'inspect_input'"):
+        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+
+async def test_inspect_input_empty_endpoints_raises_config_error(flow_dir, message_queue):
+    phase, _mgr = _make_phase(flow_dir, message_queue, runtime_variables={"inspect_input": '{"endpoints": []}'})
+    with pytest.raises(ConfigError, match="inspect_input"):
+        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+
+async def test_duplicate_endpoint_names_raise_config_error(flow_dir, message_queue):
+    phase, _mgr = _make_phase(
+        flow_dir,
+        message_queue,
+        runtime_variables=_inspect_input_var(("App Controller", "http://h:1/m"), ("app-controller", "http://h:2/m")),
+    )
+    with pytest.raises(ConfigError, match="duplicate endpoint names"):
+        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+
+async def test_endpoint_name_normalized_to_snake_case(flow_dir, message_queue, monkeypatch):
+    url = "http://host:9962/metrics"
+    _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
+    phase, mgr = _make_phase(flow_dir, message_queue, runtime_variables=_inspect_input_var(("App Controller", url)))
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert _jsonl_path(flow_dir, "app_controller").exists()
+    assert _exposition_path(flow_dir, "app_controller").exists()
+    checkpoint = mgr.read()[PHASE_ID]
+    assert _endpoint_data(checkpoint)["name"] == "app_controller"
+
+
+async def test_url_without_scheme_raises_config_error(flow_dir, message_queue):
+    phase, _mgr = _make_phase(
+        flow_dir, message_queue, runtime_variables=_inspect_input_var(("main", "example.com/metrics"))
+    )
+    with pytest.raises(ConfigError, match="inspect_input"):
+        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+
+async def test_multi_endpoint_deterministic_jsonl(flow_dir, message_queue, monkeypatch, tmp_path_factory):
+    phase1, _mgr, _url_a, _url_b = _two_endpoint_run(flow_dir, message_queue, monkeypatch)
+    await phase1.process_message(PhaseTrigger(id="start", phase_id=None))
+    first = {name: _jsonl_path(flow_dir, name).read_bytes() for name in ("agent", "operator")}
+
+    flow_dir_2 = tmp_path_factory.mktemp("second_run")
+    queue_2 = asyncio.Queue()
+    phase2, _mgr2, _a, _b = _two_endpoint_run(flow_dir_2, queue_2, monkeypatch)
+    await phase2.process_message(PhaseTrigger(id="start", phase_id=None))
+    second = {name: _jsonl_path(flow_dir_2, name).read_bytes() for name in ("agent", "operator")}
+
+    for name in ("agent", "operator"):
+        assert first[name] == second[name]
+        assert first[name].endswith(b"\n")


### PR DESCRIPTION
### What does this PR do?

Extends **Phase 0 (`InspectEndpointPhase`)** of the OpenMetrics scaffolding flow so it can inspect **N named endpoints** instead of a single one. Scope is intentionally limited to `inspect_endpoint.py` and its test module — the CLI, orchestrator, flow YAML, and downstream phases are untouched (tracked separately).

**From 1 endpoint to N:**

- **Input.** The phase no longer reads a single `endpoint_url`. It now reads one `inspect_input` runtime variable: a JSON string that deserializes into a pydantic `InspectInput` model holding a list of `{name, url}` endpoints. A single endpoint is just a one-element list. Validation is fully declarative (pydantic) — per-field rules (name normalized to snake_case, URL must carry an `http(s)://` scheme) via `AfterValidator`, and collection-level rules (non-empty, unique names) via a `model_validator`. `ValidationError` is wrapped into the framework's `ConfigError`.
- **Execution.** All endpoints are fetched **concurrently** over one shared `httpx.AsyncClient`. Failure handling is **aggregating all-or-nothing**: every endpoint is allowed to settle (`gather(return_exceptions=True)`), then if any failed the phase aborts with a single error listing *all* failing endpoints (each attributable by its `[name]` prefix) instead of failing one at a time.
- **Output.** Instead of one catalog + one snapshot, the phase writes **per-endpoint** sidecars keyed by name: `<phase_id>_<name>_metrics.jsonl` and `<phase_id>_<name>_exposition.txt`. Each JSONL now starts with a provenance header line (endpoint name/url/format/family count), followed by the unchanged per-family rows. The checkpoint becomes `{"endpoints": [ ... ]}` (one entry per endpoint), and the memory text aggregates all endpoints, exposing every catalog/snapshot path plus the intended fixture name so later phases can locate them.

**What we reuse:**

- The per-endpoint work is a straight extraction of the *old* single-endpoint body into two helpers (`_fetch`, `_inspect_one`) — same fetch semantics (10 MB cap, `follow_redirects`, `Accept: text/plain`, HTTP-200 requirement, timeout, and the httpx→`EndpointInspectionError` translations).
- `_parse_exposition`, `_build_jsonl_rows`, `_write_jsonl`, `_write_exposition`, and `_remove_if_exists` are unchanged. The per-family JSONL row schema is unchanged. `validate_config` is unchanged. The endpoint name is the join key that will thread through renaming → fixtures → scraper config in the follow-up phases.

**Tests:** the test module is long because it does two things. First, it **migrates** every existing single-endpoint test to the new contract (checkpoint reads go through `endpoints[0]`, per-name sidecar filenames, the atomicity/failure cases retargeted). Second, it **adds** multi-endpoint coverage: one catalog/snapshot per endpoint, the provenance header line, unchanged family-row schema, checkpoint lists all endpoints in order, memory text mentions every endpoint, aggregating all-or-nothing (one failure aborts; multiple failures are *all* reported), plus the input-contract cases (missing/malformed/empty input, duplicate names, name normalization, URL without scheme) validated both end-to-end and directly against the pydantic models.

### Motivation

Several real OpenMetrics integrations (rabbitmq, argocd, cilium, istio) scrape more than one endpoint. The generator must be able to inspect each and hand every downstream phase a per-endpoint catalog and fixture. See AI-7019.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
