### PR TITLE
[lustre] Use `lctl get_param -n` instead of `-ny` for Lustre 2.15.x compatibility

### DIFF
--- a/lustre/CHANGELOG.md
+++ b/lustre/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- towncrier release notes start -->
 
+## 1.5.1b1 / 2026-07-10
+
+***Fixed***:
+
+* Collect client stat metrics on Lustre 2.15.x clients (e.g. AWS FSx for Lustre) by calling `lctl get_param -n` instead of `-ny`. The `-y` (YAML) flag was only added in Lustre 2.16, so on 2.15.x every stats-based family (llite/mdc/osc/ldlm) was silently collected as empty. ([#24501](https://github.com/DataDog/integrations-core/pull/24501))
+* Log `lctl`/`lnetctl` command failures at WARNING instead of DEBUG so silent data gaps are visible in the check status. ([#24501](https://github.com/DataDog/integrations-core/pull/24501))
+
 ## 1.5.0 / 2026-04-01 / Agent 7.78.1
 
 ***Added***:

--- a/lustre/changelog.d/24501.fixed
+++ b/lustre/changelog.d/24501.fixed
@@ -1,1 +1,0 @@
-Fix client stats collection on Lustre 2.15.x clients (e.g. AWS FSx for Lustre) by calling `lctl get_param -n` instead of `-ny`; the `-y` flag was only added in Lustre 2.16, so on 2.15.x every stats-based family (llite/mdc/osc/ldlm) was silently collected as empty.

--- a/lustre/changelog.d/24501.fixed
+++ b/lustre/changelog.d/24501.fixed
@@ -1,0 +1,1 @@
+Fix client stats collection on Lustre 2.15.x clients (e.g. AWS FSx for Lustre) by calling `lctl get_param -n` instead of `-ny`; the `-y` flag was only added in Lustre 2.16, so on 2.15.x every stats-based family (llite/mdc/osc/ldlm) was silently collected as empty.

--- a/lustre/datadog_checks/lustre/__about__.py
+++ b/lustre/datadog_checks/lustre/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.5.0'
+__version__ = '1.5.1b1'

--- a/lustre/datadog_checks/lustre/check.py
+++ b/lustre/datadog_checks/lustre/check.py
@@ -238,7 +238,7 @@ class LustreCheck(AgentCheck):
 
     @AgentCheck.metadata_entrypoint
     def _update_metadata(self):
-        version = self._run_command("lctl", 'get_param', '-ny', 'version').strip()
+        version = self._run_command("lctl", 'get_param', '-n', 'version').strip()
         if version:
             self.log.debug("Setting version %s for Lustre", version)
             self.set_metadata("version", version)
@@ -293,7 +293,7 @@ class LustreCheck(AgentCheck):
             return
         param_names = self._get_jobstats_params_list(jobstats_param)
         jobid_config_tags = [
-            f'{param.regex}:{self._run_command("lctl", "get_param", "-ny", param.regex, sudo=True).strip()}'
+            f'{param.regex}:{self._run_command("lctl", "get_param", "-n", param.regex, sudo=True).strip()}'
             for param in JOBID_TAG_PARAMS
         ]
         for param_name in param_names:
@@ -339,7 +339,7 @@ class LustreCheck(AgentCheck):
         '''
         Get the jobstats metrics for a given jobstats param.
         '''
-        jobstats_output = self._run_command('lctl', 'get_param', '-ny', jobstats_param, sudo=True)
+        jobstats_output = self._run_command('lctl', 'get_param', '-n', jobstats_param, sudo=True)
         try:
             return yaml.safe_load(jobstats_output) or {}
         except Exception as e:
@@ -454,7 +454,7 @@ class LustreCheck(AgentCheck):
                     tags = self.tags + self._extract_tags_from_param(param.regex, param_name, param.wildcards)
                 except IgnoredFilesystemName:
                     continue
-                raw_stats = self._run_command('lctl', 'get_param', '-ny', param_name, sudo=True)
+                raw_stats = self._run_command('lctl', 'get_param', '-n', param_name, sudo=True)
                 if not param.regex.endswith('.stats'):
                     self._submit_param(param.prefix, param_name, tags)
                     continue
@@ -467,7 +467,7 @@ class LustreCheck(AgentCheck):
         Submit a single parameter.
         '''
         try:
-            output = int(self._run_command('lctl', 'get_param', '-ny', param_name, sudo=True))
+            output = int(self._run_command('lctl', 'get_param', '-n', param_name, sudo=True))
             suffix = param_name.split('.')[-1]
         except (ValueError, TypeError):
             self.log.debug('No output found for %s', param_name)

--- a/lustre/datadog_checks/lustre/check.py
+++ b/lustre/datadog_checks/lustre/check.py
@@ -260,7 +260,10 @@ class LustreCheck(AgentCheck):
                 cmd, timeout=5, shell=False, capture_output=True, text=True
             )  # Explicitly disable shell invocation to prevent command injection
             if not output.returncode == 0 and output.stderr:
-                self.log.debug(
+                # Surface command failures at WARNING (not DEBUG) so data gaps are visible.
+                # A silent DEBUG here is what let the `get_param -y` incompatibility (#24475)
+                # empty out client stats while the check still reported [OK].
+                self.log.warning(
                     'Command %s exited with returncode %s. Captured stderr: %s', cmd, output.returncode, output.stderr
                 )
                 return ''

--- a/lustre/tests/conftest.py
+++ b/lustre/tests/conftest.py
@@ -47,7 +47,7 @@ def mock_lustre_commands():
     Usage:
         def test_something(mock_lustre_commands):
             mapping = {
-                'lctl get_param -ny version': 'all_version.txt',
+                'lctl get_param -n version': 'all_version.txt',
                 'lctl dl': 'client_dl_yaml.txt',
             }
             with mock_lustre_commands(mapping):

--- a/lustre/tests/test_unit.py
+++ b/lustre/tests/test_unit.py
@@ -65,7 +65,7 @@ def test_check(dd_run_check, aggregator, mock_lustre_commands, node_type, dl_fix
     }
     filesystem_tag_metric_prefixes = set()
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': dl_fixture,
         'lnetctl stats show': 'all_lnet_stats.txt',
         'lnetctl net show': 'all_lnet_net.txt',
@@ -73,7 +73,7 @@ def test_check(dd_run_check, aggregator, mock_lustre_commands, node_type, dl_fix
     }
     for param in DEFAULT_STATS + EXTRA_STATS + JOBSTATS_PARAMS + JOBID_TAG_PARAMS + CURATED_PARAMS:
         mapping[f'lctl list_param {param.regex}'] = param.regex
-        mapping[f'lctl get_param -ny {param.regex}'] = param.fixture
+        mapping[f'lctl get_param -n {param.regex}'] = param.fixture
         if any(wildcard in TAGS_WITH_FILESYSTEM for wildcard in param.wildcards):
             filesystem_tag_metric_prefixes.add(f"lustre.{param.prefix}")
 
@@ -99,10 +99,10 @@ def test_check(dd_run_check, aggregator, mock_lustre_commands, node_type, dl_fix
 def test_jobstats(aggregator, mock_lustre_commands, node_type, fixture_file, expected_metrics):
     instance = {'node_type': node_type, 'filesystems': ['lustre']}
 
-    jobid_tag_commands = {f'lctl get_param -ny {param.regex}': f'{param.fixture}' for param in JOBID_TAG_PARAMS}
+    jobid_tag_commands = {f'lctl get_param -n {param.regex}': f'{param.fixture}' for param in JOBID_TAG_PARAMS}
     mapping = ChainMap(
         {
-            'lctl get_param -ny version': 'all_version.txt',
+            'lctl get_param -n version': 'all_version.txt',
             'lctl dl': f'{node_type}_dl_yaml.txt',
             'lctl list_param': "all_list_param.txt",
             'lctl get_param': fixture_file,
@@ -128,7 +128,7 @@ def test_jobstats(aggregator, mock_lustre_commands, node_type, fixture_file, exp
 )
 def test_lnet(aggregator, instance, mock_lustre_commands, method, fixture_file, expected_metrics):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lnetctl': fixture_file,
     }
@@ -141,7 +141,7 @@ def test_lnet(aggregator, instance, mock_lustre_commands, method, fixture_file, 
 
 def test_device_health(aggregator, instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
     with mock_lustre_commands(mapping):
@@ -187,7 +187,7 @@ def test_device_health(aggregator, instance, mock_lustre_commands):
 )
 def test_node_type(mock_lustre_commands, fixture_file, expected_node_type):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': fixture_file,
     }
     with mock_lustre_commands(mapping):
@@ -198,7 +198,7 @@ def test_node_type(mock_lustre_commands, fixture_file, expected_node_type):
 
 def test_submit_changelogs(instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lfs changelog': 'client_changelogs.txt',
     }
@@ -226,7 +226,7 @@ def test_submit_changelogs(instance, mock_lustre_commands):
 
 def test_get_changelog(instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lfs changelog': 'client_changelogs.txt',
     }
@@ -251,10 +251,10 @@ def test_get_changelog(instance, mock_lustre_commands):
 
 def test_submit_param_data(aggregator, instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lctl list_param llite.*.stats': 'llite.lustre.stats',
-        'lctl get_param -ny llite': 'client_llite_stats.txt',
+        'lctl get_param -n llite': 'client_llite_stats.txt',
     }
     with mock_lustre_commands(mapping):
         check = LustreCheck('lustre', {}, [instance])
@@ -273,7 +273,7 @@ def test_submit_param_data(aggregator, instance, mock_lustre_commands):
 
 def test_extract_tags_from_param(mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
     with mock_lustre_commands(mapping):
@@ -306,7 +306,7 @@ def test_extract_tags_from_param(mock_lustre_commands):
 
 def test_parse_stats(mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
     with mock_lustre_commands(mapping):
@@ -350,7 +350,7 @@ short_line 1
 
 def test_update_filesystems(mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'mds_dl_yaml.txt',
         'lctl list_param mdt.*.job_stats': 'mdt.lustre-MDT0000.job_stats\nmdt.lustre2-MDT0000.job_stats',
     }
@@ -365,7 +365,7 @@ def test_update_filesystems(mock_lustre_commands):
 
 def test_update_changelog_targets(mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
     with mock_lustre_commands(mapping):
@@ -387,7 +387,7 @@ def test_update_changelog_targets(mock_lustre_commands):
 
 def test_lnet_group_filtering(aggregator, instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lnetctl net show': 'all_lnet_net.txt',
     }
@@ -406,7 +406,7 @@ def test_lnet_group_filtering(aggregator, instance, mock_lustre_commands):
 
 def test_metric_type_assignment(aggregator, instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
     with mock_lustre_commands(mapping):
@@ -427,8 +427,8 @@ def test_metric_type_assignment(aggregator, instance, mock_lustre_commands):
 
 def test_empty_command_outputs(instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
-        'lctl get_param -ny mdt': '',
+        'lctl get_param -n version': 'all_version.txt',
+        'lctl get_param -n mdt': '',
         'lctl dl': 'client_dl_yaml.txt',
     }
     with mock_lustre_commands(mapping):
@@ -445,7 +445,7 @@ def test_empty_command_outputs(instance, mock_lustre_commands):
 def test_exception_handling(mock_lustre_commands):
     """Test various exception handling scenarios."""
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
 
@@ -505,7 +505,7 @@ def test_run_command_exceptions():
 def test_node_type_determination_logging(caplog, mock_lustre_commands):
     """Test logging for node type determination errors."""
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
 
@@ -522,7 +522,7 @@ def test_filesystem_discovery_logging(caplog, mock_lustre_commands):
     """Test logging for filesystem discovery."""
     filesystem = 'testfilesystem'
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lctl list_param mdt.*.job_stats': f'mdt.{filesystem}-MDT0000.job_stats',
     }
@@ -553,7 +553,7 @@ def test_filesystem_discovery_logging(caplog, mock_lustre_commands):
 def test_lnet_error_logging(caplog, mock_lustre_commands):
     """Test logging for LNET data retrieval errors."""
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lnetctl stats show': 'invalid yaml',
     }
@@ -572,7 +572,7 @@ def test_parameter_filtering_logging(caplog, mock_lustre_commands):
     """Test logging for parameter filtering based on node type and filesystem."""
     wrong_filesystem_param = 'some.wrongfilesystem-MDT0000.param.mds'
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lctl list_param some.*.param.mds': wrong_filesystem_param,
     }
@@ -606,7 +606,7 @@ def test_parameter_filtering_logging(caplog, mock_lustre_commands):
 def test_changelog_logging(caplog, mock_lustre_commands):
     """Test logging for changelog operations."""
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lfs changelog': 'test_changelog',
     }
@@ -666,7 +666,7 @@ def test_sanitize_command(bin_path, should_pass):
 def test_device_discovery(mock_lustre_commands, yaml_fixture, non_yaml_fixture):
     """Devices should be discovered regardless of Lustre version"""
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl -y': yaml_fixture,
         'lctl dl': non_yaml_fixture,
         'lfs changelog': 'test_changelog',

--- a/lustre/tests/test_unit.py
+++ b/lustre/tests/test_unit.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import logging
+import subprocess
 from typing import ChainMap
 
 import mock
@@ -729,3 +730,27 @@ def test_device_discovery(mock_lustre_commands, yaml_fixture, non_yaml_fixture):
         ]
 
         assert actual_devices == expected_devices
+
+
+def test_run_command_warns_on_failure(caplog, mock_lustre_commands):
+    """A command that exits non-zero with stderr is surfaced at WARNING, not DEBUG (#24475)."""
+    with mock_lustre_commands(
+        {
+            'lctl get_param -n version': 'all_version.txt',
+            'lctl dl': 'client_dl_yaml.txt',
+        }
+    ):
+        check = LustreCheck('lustre', {}, [{}])
+
+    failed = subprocess.CompletedProcess(
+        args=[], returncode=4, stdout='', stderr="get_param: invalid option -- 'y'"
+    )
+    with caplog.at_level(logging.WARNING):
+        with mock.patch('subprocess.run', return_value=failed):
+            result = check._run_command('lctl', 'get_param', '-n', 'llite.lustrefs.stats')
+
+    assert result == ''
+    assert any(
+        record.levelno == logging.WARNING and 'exited with returncode 4' in record.getMessage()
+        for record in caplog.records
+    ), caplog.text


### PR DESCRIPTION
### What does this PR do?

Changes the Lustre check to invoke `lctl get_param -n <param>` instead of `lctl get_param -ny <param>` (all 5 call sites in `check.py`), and updates the unit-test command mocks accordingly.

### Motivation

Fixes #24475.

The `-y` (YAML) flag for `get_param` was **only added in Lustre 2.16**. Every client shipping `lctl` 2.15.x — notably **AWS FSx for Lustre** (PERSISTENT_2), the largest managed-Lustre install base — rejects it:

```
$ lctl get_param -ny llite.<fs>.stats
get_param: invalid option -- 'y'   # returncode 4
```

`_run_command` logs the failure at **DEBUG** and returns `''`, so the check status stays `[OK]` while **every stats-based family silently collects nothing** — `llite`/filesystem, `mdc`, `osc`, `ldlm`, and everything gated by `enable_extra_params`. Only the non-`get_param` paths survive: `lustre.net.*` (via `lnetctl`) and `lustre.device.health` (via `lctl dl`). Users see a mostly-empty *Lustre - Overview* dashboard with no visible error.

`-n` emits the classic plaintext value format that the check's `_parse_stats`, `_submit_param` (`int(...)`), and jobstats (`yaml.safe_load`, whose `.get('job_stats')` already assumes the top-level `-n` shape) paths already consume — and `-n` is supported across **all** Lustre versions, so this works on both 2.15.x and 2.16+.

### Reproduction / verification

Reproduced on a self-hosted **Lustre 2.15.6** two-node lab (ldiskfs MGS/MDS/OSS + client, `node_type: client`), matching the issue's root cause:

| check.py | flag | categories | unique metrics |
|---|---|---|---|
| before | `get_param -ny` | `net` only | 17 |
| after  | `get_param -n`  | filesystem, osc, mdc, ldlm, net | 265+ |

Debug log before the fix (identical to the report):
```
Running command: ['sudo', '/usr/sbin/lctl', 'get_param', '-ny', 'llite.lustrefs-….file_heat']
Command [...] exited with returncode 4. Captured stderr: get_param: invalid option -- 'y'
```

`ddev test lustre`: **44 passed, 1 skipped**.

### Follow-up (not in this PR)

The issue also notes the failure is invisible (DEBUG-only). A separate improvement could surface stats-collection failures as a check WARNING / service check so future flag/format gaps aren't silent. Left out here to keep the fix focused and low-risk; happy to add if maintainers prefer.

### Review checklist (to be filled by the reviewer)

- [ ] Feature or bugfix MUST have tests (updated the `check.py` command mocks; the exact-match mocks act as a regression guard against reintroducing `-ny`)
- [ ] Changelog entry — added as `lustre/changelog.d/<pr>.fixed` (added after PR number is known)
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.