### PR TITLE
[lustre] Fix client stats on Lustre 2.15.x (`get_param -y` unsupported)

### DIFF
--- a/lustre/README.md
+++ b/lustre/README.md
@@ -100,7 +100,7 @@ The Lustre integration requires elevated privileges to run Lustre commands. Ensu
 
 ```bash
 # Check if the Agent user can run Lustre commands
-sudo -u dd-agent lctl dl
+sudo -u dd-agent sudo lctl dl
 sudo -u dd-agent sudo lnetctl net show
 ```
 

--- a/lustre/changelog.d/24501.fixed
+++ b/lustre/changelog.d/24501.fixed
@@ -1,1 +1,0 @@
-Fix client stats collection on Lustre 2.15.x clients (e.g. AWS FSx for Lustre) by calling `lctl get_param -n` instead of `-ny`; the `-y` flag was only added in Lustre 2.16, so on 2.15.x every stats-based family (llite/mdc/osc/ldlm) was silently collected as empty.

--- a/lustre/changelog.d/24501.fixed
+++ b/lustre/changelog.d/24501.fixed
@@ -1,0 +1,1 @@
+Fix client stats collection on Lustre 2.15.x clients (e.g. AWS FSx for Lustre) by calling `lctl get_param -n` instead of `-ny`; the `-y` flag was only added in Lustre 2.16, so on 2.15.x every stats-based family (llite/mdc/osc/ldlm) was silently collected as empty.

--- a/lustre/changelog.d/24504.fixed
+++ b/lustre/changelog.d/24504.fixed
@@ -1,0 +1,1 @@
+Fix silent client metric gaps on Lustre 2.15.x clients (e.g. AWS FSx for Lustre): use `lctl get_param -n` instead of `-ny` (the `-y` YAML flag was only added in Lustre 2.16) so llite/mdc/osc/ldlm stats are collected, and run `lctl dl` with sudo so device.health/refcount are collected. Command failures are now logged at WARNING instead of DEBUG so future gaps are visible.

--- a/lustre/datadog_checks/lustre/check.py
+++ b/lustre/datadog_checks/lustre/check.py
@@ -177,7 +177,7 @@ class LustreCheck(AgentCheck):
         devices = []
         if self._use_yaml:
             try:
-                output = self._run_command('lctl', 'dl', '-y', sudo=True)
+                output = self._run_command('lctl', 'dl', '-y', sudo=True, warn_on_error=False)
                 device_data = yaml.safe_load(output)
                 devices = device_data.get('devices', [])
             except AttributeError:
@@ -243,9 +243,13 @@ class LustreCheck(AgentCheck):
             self.log.debug("Setting version %s for Lustre", version)
             self.set_metadata("version", version)
 
-    def _run_command(self, bin: str, *args: str, sudo: bool = False) -> str:
+    def _run_command(self, bin: str, *args: str, sudo: bool = False, warn_on_error: bool = True) -> str:
         '''
         Run a command using the given binary.
+
+        Set warn_on_error=False for commands whose failure is expected and handled
+        by the caller (e.g. a capability probe with a fallback), to avoid logging a
+        WARNING on every check run.
         '''
         if bin not in self._bin_mapping:
             raise ValueError('Unknown binary: {}'.format(bin))
@@ -260,9 +264,8 @@ class LustreCheck(AgentCheck):
                 cmd, timeout=5, shell=False, capture_output=True, text=True
             )  # Explicitly disable shell invocation to prevent command injection
             if not output.returncode == 0 and output.stderr:
-                self.log.warning(
-                    'Command %s exited with returncode %s. Captured stderr: %s', cmd, output.returncode, output.stderr
-                )
+                log = self.log.warning if warn_on_error else self.log.debug
+                log('Command %s exited with returncode %s. Captured stderr: %s', cmd, output.returncode, output.stderr)
                 return ''
             if output.stdout is None:
                 self.log.debug(

--- a/lustre/datadog_checks/lustre/check.py
+++ b/lustre/datadog_checks/lustre/check.py
@@ -238,7 +238,7 @@ class LustreCheck(AgentCheck):
 
     @AgentCheck.metadata_entrypoint
     def _update_metadata(self):
-        version = self._run_command("lctl", 'get_param', '-ny', 'version').strip()
+        version = self._run_command("lctl", 'get_param', '-n', 'version').strip()
         if version:
             self.log.debug("Setting version %s for Lustre", version)
             self.set_metadata("version", version)
@@ -293,7 +293,7 @@ class LustreCheck(AgentCheck):
             return
         param_names = self._get_jobstats_params_list(jobstats_param)
         jobid_config_tags = [
-            f'{param.regex}:{self._run_command("lctl", "get_param", "-ny", param.regex, sudo=True).strip()}'
+            f'{param.regex}:{self._run_command("lctl", "get_param", "-n", param.regex, sudo=True).strip()}'
             for param in JOBID_TAG_PARAMS
         ]
         for param_name in param_names:
@@ -339,7 +339,7 @@ class LustreCheck(AgentCheck):
         '''
         Get the jobstats metrics for a given jobstats param.
         '''
-        jobstats_output = self._run_command('lctl', 'get_param', '-ny', jobstats_param, sudo=True)
+        jobstats_output = self._run_command('lctl', 'get_param', '-n', jobstats_param, sudo=True)
         try:
             return yaml.safe_load(jobstats_output) or {}
         except Exception as e:
@@ -454,7 +454,7 @@ class LustreCheck(AgentCheck):
                     tags = self.tags + self._extract_tags_from_param(param.regex, param_name, param.wildcards)
                 except IgnoredFilesystemName:
                     continue
-                raw_stats = self._run_command('lctl', 'get_param', '-ny', param_name, sudo=True)
+                raw_stats = self._run_command('lctl', 'get_param', '-n', param_name, sudo=True)
                 if not param.regex.endswith('.stats'):
                     self._submit_param(param.prefix, param_name, tags)
                     continue
@@ -467,7 +467,7 @@ class LustreCheck(AgentCheck):
         Submit a single parameter.
         '''
         try:
-            output = int(self._run_command('lctl', 'get_param', '-ny', param_name, sudo=True))
+            output = int(self._run_command('lctl', 'get_param', '-n', param_name, sudo=True))
             suffix = param_name.split('.')[-1]
         except (ValueError, TypeError):
             self.log.debug('No output found for %s', param_name)

--- a/lustre/datadog_checks/lustre/check.py
+++ b/lustre/datadog_checks/lustre/check.py
@@ -177,14 +177,14 @@ class LustreCheck(AgentCheck):
         devices = []
         if self._use_yaml:
             try:
-                output = self._run_command('lctl', 'dl', '-y')
+                output = self._run_command('lctl', 'dl', '-y', sudo=True)
                 device_data = yaml.safe_load(output)
                 devices = device_data.get('devices', [])
             except AttributeError:
                 self.log.debug('Device update failed with yaml flag, retrying without it.')
                 self._use_yaml = False
         if not self._use_yaml:
-            output = self._run_command('lctl', 'dl')
+            output = self._run_command('lctl', 'dl', sudo=True)
             for device_line in output.splitlines():
                 device_attr = device_line.split()
                 if not len(device_attr) == len(DEVICE_ATTR_NAMES):
@@ -260,9 +260,6 @@ class LustreCheck(AgentCheck):
                 cmd, timeout=5, shell=False, capture_output=True, text=True
             )  # Explicitly disable shell invocation to prevent command injection
             if not output.returncode == 0 and output.stderr:
-                # Surface command failures at WARNING (not DEBUG) so data gaps are visible.
-                # A silent DEBUG here is what let the `get_param -y` incompatibility (#24475)
-                # empty out client stats while the check still reported [OK].
                 self.log.warning(
                     'Command %s exited with returncode %s. Captured stderr: %s', cmd, output.returncode, output.stderr
                 )

--- a/lustre/datadog_checks/lustre/check.py
+++ b/lustre/datadog_checks/lustre/check.py
@@ -260,7 +260,10 @@ class LustreCheck(AgentCheck):
                 cmd, timeout=5, shell=False, capture_output=True, text=True
             )  # Explicitly disable shell invocation to prevent command injection
             if not output.returncode == 0 and output.stderr:
-                self.log.debug(
+                # Surface command failures at WARNING (not DEBUG) so data gaps are visible.
+                # A silent DEBUG here is what let the `get_param -y` incompatibility (#24475)
+                # empty out client stats while the check still reported [OK].
+                self.log.warning(
                     'Command %s exited with returncode %s. Captured stderr: %s', cmd, output.returncode, output.stderr
                 )
                 return ''

--- a/lustre/tests/conftest.py
+++ b/lustre/tests/conftest.py
@@ -47,7 +47,7 @@ def mock_lustre_commands():
     Usage:
         def test_something(mock_lustre_commands):
             mapping = {
-                'lctl get_param -ny version': 'all_version.txt',
+                'lctl get_param -n version': 'all_version.txt',
                 'lctl dl': 'client_dl_yaml.txt',
             }
             with mock_lustre_commands(mapping):

--- a/lustre/tests/test_unit.py
+++ b/lustre/tests/test_unit.py
@@ -65,7 +65,7 @@ def test_check(dd_run_check, aggregator, mock_lustre_commands, node_type, dl_fix
     }
     filesystem_tag_metric_prefixes = set()
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': dl_fixture,
         'lnetctl stats show': 'all_lnet_stats.txt',
         'lnetctl net show': 'all_lnet_net.txt',
@@ -73,7 +73,7 @@ def test_check(dd_run_check, aggregator, mock_lustre_commands, node_type, dl_fix
     }
     for param in DEFAULT_STATS + EXTRA_STATS + JOBSTATS_PARAMS + JOBID_TAG_PARAMS + CURATED_PARAMS:
         mapping[f'lctl list_param {param.regex}'] = param.regex
-        mapping[f'lctl get_param -ny {param.regex}'] = param.fixture
+        mapping[f'lctl get_param -n {param.regex}'] = param.fixture
         if any(wildcard in TAGS_WITH_FILESYSTEM for wildcard in param.wildcards):
             filesystem_tag_metric_prefixes.add(f"lustre.{param.prefix}")
 
@@ -99,10 +99,10 @@ def test_check(dd_run_check, aggregator, mock_lustre_commands, node_type, dl_fix
 def test_jobstats(aggregator, mock_lustre_commands, node_type, fixture_file, expected_metrics):
     instance = {'node_type': node_type, 'filesystems': ['lustre']}
 
-    jobid_tag_commands = {f'lctl get_param -ny {param.regex}': f'{param.fixture}' for param in JOBID_TAG_PARAMS}
+    jobid_tag_commands = {f'lctl get_param -n {param.regex}': f'{param.fixture}' for param in JOBID_TAG_PARAMS}
     mapping = ChainMap(
         {
-            'lctl get_param -ny version': 'all_version.txt',
+            'lctl get_param -n version': 'all_version.txt',
             'lctl dl': f'{node_type}_dl_yaml.txt',
             'lctl list_param': "all_list_param.txt",
             'lctl get_param': fixture_file,
@@ -128,7 +128,7 @@ def test_jobstats(aggregator, mock_lustre_commands, node_type, fixture_file, exp
 )
 def test_lnet(aggregator, instance, mock_lustre_commands, method, fixture_file, expected_metrics):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lnetctl': fixture_file,
     }
@@ -141,7 +141,7 @@ def test_lnet(aggregator, instance, mock_lustre_commands, method, fixture_file, 
 
 def test_device_health(aggregator, instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
     with mock_lustre_commands(mapping):
@@ -187,7 +187,7 @@ def test_device_health(aggregator, instance, mock_lustre_commands):
 )
 def test_node_type(mock_lustre_commands, fixture_file, expected_node_type):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': fixture_file,
     }
     with mock_lustre_commands(mapping):
@@ -198,7 +198,7 @@ def test_node_type(mock_lustre_commands, fixture_file, expected_node_type):
 
 def test_submit_changelogs(instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lfs changelog': 'client_changelogs.txt',
     }
@@ -226,7 +226,7 @@ def test_submit_changelogs(instance, mock_lustre_commands):
 
 def test_get_changelog(instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lfs changelog': 'client_changelogs.txt',
     }
@@ -251,10 +251,10 @@ def test_get_changelog(instance, mock_lustre_commands):
 
 def test_submit_param_data(aggregator, instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lctl list_param llite.*.stats': 'llite.lustre.stats',
-        'lctl get_param -ny llite': 'client_llite_stats.txt',
+        'lctl get_param -n llite': 'client_llite_stats.txt',
     }
     with mock_lustre_commands(mapping):
         check = LustreCheck('lustre', {}, [instance])
@@ -273,7 +273,7 @@ def test_submit_param_data(aggregator, instance, mock_lustre_commands):
 
 def test_extract_tags_from_param(mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
     with mock_lustre_commands(mapping):
@@ -306,7 +306,7 @@ def test_extract_tags_from_param(mock_lustre_commands):
 
 def test_parse_stats(mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
     with mock_lustre_commands(mapping):
@@ -350,7 +350,7 @@ short_line 1
 
 def test_update_filesystems(mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'mds_dl_yaml.txt',
         'lctl list_param mdt.*.job_stats': 'mdt.lustre-MDT0000.job_stats\nmdt.lustre2-MDT0000.job_stats',
     }
@@ -365,7 +365,7 @@ def test_update_filesystems(mock_lustre_commands):
 
 def test_update_changelog_targets(mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
     with mock_lustre_commands(mapping):
@@ -387,7 +387,7 @@ def test_update_changelog_targets(mock_lustre_commands):
 
 def test_lnet_group_filtering(aggregator, instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lnetctl net show': 'all_lnet_net.txt',
     }
@@ -406,7 +406,7 @@ def test_lnet_group_filtering(aggregator, instance, mock_lustre_commands):
 
 def test_metric_type_assignment(aggregator, instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
     with mock_lustre_commands(mapping):
@@ -427,8 +427,8 @@ def test_metric_type_assignment(aggregator, instance, mock_lustre_commands):
 
 def test_empty_command_outputs(instance, mock_lustre_commands):
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
-        'lctl get_param -ny mdt': '',
+        'lctl get_param -n version': 'all_version.txt',
+        'lctl get_param -n mdt': '',
         'lctl dl': 'client_dl_yaml.txt',
     }
     with mock_lustre_commands(mapping):
@@ -445,7 +445,7 @@ def test_empty_command_outputs(instance, mock_lustre_commands):
 def test_exception_handling(mock_lustre_commands):
     """Test various exception handling scenarios."""
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
 
@@ -505,7 +505,7 @@ def test_run_command_exceptions():
 def test_node_type_determination_logging(caplog, mock_lustre_commands):
     """Test logging for node type determination errors."""
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
     }
 
@@ -522,7 +522,7 @@ def test_filesystem_discovery_logging(caplog, mock_lustre_commands):
     """Test logging for filesystem discovery."""
     filesystem = 'testfilesystem'
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lctl list_param mdt.*.job_stats': f'mdt.{filesystem}-MDT0000.job_stats',
     }
@@ -553,7 +553,7 @@ def test_filesystem_discovery_logging(caplog, mock_lustre_commands):
 def test_lnet_error_logging(caplog, mock_lustre_commands):
     """Test logging for LNET data retrieval errors."""
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lnetctl stats show': 'invalid yaml',
     }
@@ -572,7 +572,7 @@ def test_parameter_filtering_logging(caplog, mock_lustre_commands):
     """Test logging for parameter filtering based on node type and filesystem."""
     wrong_filesystem_param = 'some.wrongfilesystem-MDT0000.param.mds'
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lctl list_param some.*.param.mds': wrong_filesystem_param,
     }
@@ -606,7 +606,7 @@ def test_parameter_filtering_logging(caplog, mock_lustre_commands):
 def test_changelog_logging(caplog, mock_lustre_commands):
     """Test logging for changelog operations."""
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl': 'client_dl_yaml.txt',
         'lfs changelog': 'test_changelog',
     }
@@ -666,7 +666,7 @@ def test_sanitize_command(bin_path, should_pass):
 def test_device_discovery(mock_lustre_commands, yaml_fixture, non_yaml_fixture):
     """Devices should be discovered regardless of Lustre version"""
     mapping = {
-        'lctl get_param -ny version': 'all_version.txt',
+        'lctl get_param -n version': 'all_version.txt',
         'lctl dl -y': yaml_fixture,
         'lctl dl': non_yaml_fixture,
         'lfs changelog': 'test_changelog',

--- a/lustre/tests/test_unit.py
+++ b/lustre/tests/test_unit.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import logging
+import subprocess
 from typing import ChainMap
 
 import mock
@@ -729,3 +730,27 @@ def test_device_discovery(mock_lustre_commands, yaml_fixture, non_yaml_fixture):
         ]
 
         assert actual_devices == expected_devices
+
+
+def test_run_command_warns_on_failure(caplog, mock_lustre_commands):
+    """A command that exits non-zero with stderr is surfaced at WARNING, not DEBUG (#24475)."""
+    with mock_lustre_commands(
+        {
+            'lctl get_param -n version': 'all_version.txt',
+            'lctl dl': 'client_dl_yaml.txt',
+        }
+    ):
+        check = LustreCheck('lustre', {}, [{}])
+
+    failed = subprocess.CompletedProcess(
+        args=[], returncode=4, stdout='', stderr="get_param: invalid option -- 'y'"
+    )
+    with caplog.at_level(logging.WARNING):
+        with mock.patch('subprocess.run', return_value=failed):
+            result = check._run_command('lctl', 'get_param', '-n', 'llite.lustrefs.stats')
+
+    assert result == ''
+    assert any(
+        record.levelno == logging.WARNING and 'exited with returncode 4' in record.getMessage()
+        for record in caplog.records
+    ), caplog.text

--- a/lustre/tests/test_unit.py
+++ b/lustre/tests/test_unit.py
@@ -742,9 +742,7 @@ def test_run_command_warns_on_failure(caplog, mock_lustre_commands):
     ):
         check = LustreCheck('lustre', {}, [{}])
 
-    failed = subprocess.CompletedProcess(
-        args=[], returncode=4, stdout='', stderr="get_param: invalid option -- 'y'"
-    )
+    failed = subprocess.CompletedProcess(args=[], returncode=4, stdout='', stderr="get_param: invalid option -- 'y'")
     with caplog.at_level(logging.WARNING):
         with mock.patch('subprocess.run', return_value=failed):
             result = check._run_command('lctl', 'get_param', '-n', 'llite.lustrefs.stats')
@@ -752,5 +750,28 @@ def test_run_command_warns_on_failure(caplog, mock_lustre_commands):
     assert result == ''
     assert any(
         record.levelno == logging.WARNING and 'exited with returncode 4' in record.getMessage()
+        for record in caplog.records
+    ), caplog.text
+
+
+def test_run_command_warn_on_error_false_stays_debug(caplog, mock_lustre_commands):
+    """An expected/handled failure (warn_on_error=False) logs at DEBUG, not WARNING, to avoid per-run noise."""
+    with mock_lustre_commands(
+        {
+            'lctl get_param -n version': 'all_version.txt',
+            'lctl dl': 'client_dl_yaml.txt',
+        }
+    ):
+        check = LustreCheck('lustre', {}, [{}])
+
+    failed = subprocess.CompletedProcess(args=[], returncode=4, stdout='', stderr="dl: invalid option -- 'y'")
+    with caplog.at_level(logging.DEBUG):
+        with mock.patch('subprocess.run', return_value=failed):
+            result = check._run_command('lctl', 'dl', '-y', warn_on_error=False)
+
+    assert result == ''
+    assert not any(record.levelno == logging.WARNING for record in caplog.records), caplog.text
+    assert any(
+        record.levelno == logging.DEBUG and 'exited with returncode 4' in record.getMessage()
         for record in caplog.records
     ), caplog.text


### PR DESCRIPTION
### What

Three fixes so the Lustre check works on Lustre **2.15.x** clients (e.g. AWS FSx for Lustre):
1. `lctl get_param -ny` → `-n` at all 5 call sites — `-y` (YAML) was only added in Lustre 2.16.
2. `lctl dl` / `lctl dl -y` now run with `sudo` — device discovery was the only Lustre command not elevated.
3. Command failures log at WARNING instead of DEBUG, so silent data gaps are visible.

### Why — #24475

On `lctl` 2.15.x, `get_param -y` fails with `invalid option -- 'y'` (rc=4), swallowed at DEBUG — so the check stayed `[OK]` while every stats family (llite/mdc/osc/ldlm) silently collected nothing. `-n` emits the plaintext/native-YAML the parsers already consume (`_parse_stats`, `int()`, jobstats `yaml.safe_load(...).get('job_stats')`) and works on all versions.

Separately, `_update_devices` ran `lctl dl` **without sudo**, so as `dd-agent` it failed with `Permission denied` (rc=13) → `device.health`/`refcount` dropped out. Whether it worked depended on the OS's non-root access to `lctl dl` (permitted on EL9.4, denied on EL8.10). The README already documents the required `dd-agent` sudoers grant for `lctl`, so this just makes device discovery consistent with the stats calls.

### Verification (live labs)

| | Lustre 2.15.6 (EL8.10) | Lustre 2.16.1 (EL9.4) |
|---|---|---|
| stats families before | net only (17) | — |
| after fix | filesystem/mdc/osc/ldlm/net (265+) | 278, no errors |
| device metrics | **0 → 5** after `dl` sudo fix | 5 |

- 2.16.1 client ↔ 2.15.6 server interop confirmed (regression check: `get_param -n` output identical on 2.16).
- `ddev test lustre`: **45 passed**.