### PR TITLE
[SDBMON-2665] Cache parameterized-query explain failures caused by ambiguous functions

### DIFF
--- a/postgres/changelog.d/24505.fixed
+++ b/postgres/changelog.d/24505.fixed
@@ -1,0 +1,1 @@
+Cache parameterized-query explain failures caused by ambiguous function calls so they aren't re-attempted on every collection.

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -35,6 +35,7 @@ EXPECTED_PARAMETER_TYPE_ERRORS = (
     psycopg.errors.IndeterminateDatatype,
     psycopg.errors.UndefinedFunction,
     psycopg.errors.DatatypeMismatch,
+    psycopg.errors.AmbiguousFunction,
 )
 
 

--- a/postgres/tests/test_explain_parameterized_queries.py
+++ b/postgres/tests/test_explain_parameterized_queries.py
@@ -210,6 +210,12 @@ def test_explain_parameterized_queries_explain_prepared_statement_no_plan_return
             "SELECT * FROM pg_settings WHERE setting = $1 AND name = $1::int",
             DBExplainError.undefined_function,
         ),
+        # an untyped parameter makes the overloaded `unnest` call ambiguous ("function unnest(unknown)
+        # is not unique")
+        (
+            "SELECT * FROM unnest($1)",
+            DBExplainError.undefined_function,
+        ),
     ],
 )
 def test_parameterized_explain_type_resolution_failure_is_handled(
@@ -319,6 +325,28 @@ def test_create_prepared_statement_datatype_mismatch_maps_to_code(integration_ch
 
     assert result is not None
     assert result[0] == DBExplainError.datatype_mismatch
+
+
+@pytest.mark.unit
+@requires_over_12
+def test_create_prepared_statement_ambiguous_function_maps_to_code(integration_check, dbm_instance):
+    check = integration_check(dbm_instance)
+    epq = check.statement_samples._explain_parameterized_queries
+
+    with mock.patch.object(
+        epq,
+        '_execute_query',
+        side_effect=psycopg.errors.AmbiguousFunction("function unnest(unknown) is not unique"),
+    ):
+        result = epq._create_prepared_statement(
+            None,
+            "SELECT * FROM t WHERE id IN (SELECT id FROM unnest($1) AS p(id))",
+            "SELECT * FROM t WHERE id IN (SELECT id FROM unnest($1) AS p(id))",
+            "test_sig",
+        )
+
+    assert result is not None
+    assert result[0] == DBExplainError.undefined_function
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What does this PR do?

Extends the parameterized-query explain-failure handling from #24102 to also cover `AmbiguousFunction`.

Adds `psycopg.errors.AmbiguousFunction` to `EXPECTED_PARAMETER_TYPE_ERRORS` in `explain_parameterized_queries.py` so that a `PREPARE` failure caused by an untyped parameter making an overloaded function call ambiguous (e.g. `unnest($N)` → `function unnest(unknown) is not unique`) is caught, mapped to a cacheable explain error code (`undefined_function`), and cached per query signature instead of being retried every collection cycle.

### Motivation

Fixes the specific failure reported in #23725. Clients using the extended query protocol (ORMs / codegen) emit queries with untyped array parameters such as `unnest($N)` or `ANY($N)`. Postgres can't resolve the parameter types at `PREPARE` time and raises `AmbiguousFunction` (SQLSTATE 42725). #24102 handled the sibling `IndeterminateDatatype` / `UndefinedFunction` / `DatatypeMismatch` errors but not `AmbiguousFunction`, so this case still surfaced as `failed_to_explain_with_prepared_statement` — a code that is **not** in `PARAMETERIZED_EXPLAIN_ERRORS_TO_CACHE` — and was therefore re-attempted (and re-failed) on every collection cycle, producing log spam and wasted check cycles.

### Testing

Followed a TDD loop, verified end-to-end against real Postgres (PG 12 and 18):

- Added a focused unit test (`test_create_prepared_statement_ambiguous_function_maps_to_code`) that drives `AmbiguousFunction` through the PREPARE phase. Fails before the fix (exception propagates), passes after.
- Added a real-Postgres `unnest($1)` case to `test_parameterized_explain_type_resolution_failure_is_handled`, which asserts the failure is mapped, cached, and short-circuits subsequent attempts. Verified it fails without the fix (`failed_to_explain_with_prepared_statement != undefined_function`) and passes with it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

_Note: changelog entry to follow once the PR number is assigned._

Made with [Cursor](https://cursor.com)