### PR TITLE
kafka_consumer: cap total broker_timestamps history by a per-cluster memory budget

### DIFF
--- a/kafka_consumer/changelog.d/24508.fixed
+++ b/kafka_consumer/changelog.d/24508.fixed
@@ -1,0 +1,1 @@
+Cap the total DSM broker timestamps history per cluster with a memory budget that scales the per-partition depth by partition count, bounding cluster-check-runner memory on large clusters.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -21,6 +21,10 @@ from datadog_checks.kafka_consumer.constants import (
 
 MAX_TIMESTAMPS = 1000
 
+# Total broker-timestamp entries retained per cluster, ~0.5 GiB at ~89 bytes/entry. The
+# per-partition history is scaled down from this budget as the partition count grows.
+MAX_TIMESTAMP_ENTRIES = 6_000_000
+
 LAG_EXTRAPOLATION_LIMIT_SECONDS = 600
 
 
@@ -297,8 +301,15 @@ class KafkaCheck(AgentCheck):
                     earliest[topic_partition] = offset
         return earliest
 
+    def _max_history(self, num_partitions):
+        """Per-partition timestamp cap, scaled so total retained entries stay within the budget."""
+        if num_partitions <= 0:
+            return self._max_timestamps
+        return max(2, min(self._max_timestamps, MAX_TIMESTAMP_ENTRIES // num_partitions))
+
     def _add_broker_timestamps(self, broker_timestamps, highwater_offsets, prune_floors=None):
         prune_floors = prune_floors or {}
+        max_history = self._max_history(len(highwater_offsets))
         for (topic, partition), highwater_offset in highwater_offsets.items():
             timestamps = broker_timestamps["{}_{}".format(topic, partition)]
             # Reset detected: clear the whole cache. Low-offset survivors are from the
@@ -306,11 +317,11 @@ class KafkaCheck(AgentCheck):
             if any(o > highwater_offset for o in timestamps):
                 timestamps.clear()
             timestamps[highwater_offset] = time()
-            if len(timestamps) >= self._max_timestamps:
+            if len(timestamps) >= max_history:
                 prune_floor = prune_floors.get((topic, partition))
                 if prune_floor is not None:
                     _prune_below_anchor(timestamps, prune_floor)
-                _visvalingam_whyatt(timestamps, max(2, self._max_timestamps // 2))
+                _visvalingam_whyatt(timestamps, max(2, max_history // 2))
 
     def _save_broker_timestamps(self, broker_timestamps, persistent_cache_key):
         """Saves broker timestamps to persistent cache."""

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -5,6 +5,7 @@ import base64
 import json
 import logging
 import marshal
+from collections import defaultdict
 from contextlib import nullcontext as does_not_raise
 
 import mock
@@ -526,6 +527,30 @@ def test_check_clears_cache_on_partial_reset(kafka_instance, check, dd_run_check
     timestamps = written["topic1_0"]
     assert len(timestamps) == 1
     assert 100 in timestamps
+
+
+def test_max_history_scales_with_partition_count(check, kafka_instance):
+    kafka_consumer_check = check(kafka_instance)  # default timestamp_history_size = 1000
+    assert kafka_consumer_check._max_history(0) == 1000
+    assert kafka_consumer_check._max_history(1) == 1000
+    assert kafka_consumer_check._max_history(6000) == 1000  # 6M / 6000 = 1000 (breakeven)
+    assert kafka_consumer_check._max_history(60000) == 100  # 6M / 60000
+    assert kafka_consumer_check._max_history(6_000_000) == 2  # floored at 2
+
+
+def test_add_broker_timestamps_caps_total_by_budget(check, kafka_instance, monkeypatch):
+    import datadog_checks.kafka_consumer.kafka_consumer as kc
+
+    monkeypatch.setattr(kc, 'MAX_TIMESTAMP_ENTRIES', 1000)
+    kafka_consumer_check = check(kafka_instance)
+    # 100 partitions against a 1000-entry budget -> per-partition cap of 10.
+    highwater_offsets = {("topic1", p): 500 for p in range(100)}
+    broker_timestamps = defaultdict(dict)
+    broker_timestamps["topic1_0"] = {i: float(i) for i in range(60)}
+
+    kafka_consumer_check._add_broker_timestamps(broker_timestamps, highwater_offsets)
+
+    assert len(broker_timestamps["topic1_0"]) <= 10
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

Bounds the total number of DSM `broker_timestamps` entries the `kafka_consumer` check retains, with a fixed per-cluster memory budget. The per-partition history depth is derived each run from the partition count:

```
effective_history = clamp(MAX_TIMESTAMP_ENTRIES // num_partitions, 2, timestamp_history_size)
```

`MAX_TIMESTAMP_ENTRIES = 6_000_000` (≈ 0.5 GiB at ~89 bytes/entry). Small clusters keep the full `timestamp_history_size` (1000) history; large clusters scale the depth down (e.g. 6,000 partitions → 1000, 60,000 → 100, 100,000 → 60), so total retained history stays within the budget instead of growing with partition count.

### Motivation

With `enable_cluster_monitoring`, the check tracks broker timestamps for every partition to estimate consumer lag in seconds. `broker_timestamps` accumulates up to `timestamp_history_size` samples per partition, so on large clusters it grows to tens of millions of entries — multiple GiB of live memory — and was a top contributor to cluster-check-runner OOMs (#incident-57455). Measured on a repro (3 clusters, ~68k partitions): the dict reached 24.8M entries (~2.2 GiB) and was still climbing toward ~50M / ~4.5 GiB. The cap holds it to ~0.5 GiB/cluster while preserving lag-interpolation accuracy (Visvalingam–Whyatt downsampling keeps the most significant samples within the reduced depth).

This complements the marshal storage change (#24471) and is independent of it.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests — added `test_max_history_scales_with_partition_count` and `test_add_broker_timestamps_caps_total_by_budget`. Full unit suite passes; lint clean.
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. → `qa/required` (agent-impacting; validate memory reduction + no `estimated_consumer_lag` regression on a live large cluster).
- [ ] If you need to backport this PR to another branch, add the `backport/<branch-name>` label.
