### PR TITLE
Document single_endpoint_mode per-node metrics for ClickHouse Cloud

### DIFF
--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -39,7 +39,9 @@ To configure this check for an Agent running on a host:
 
 *Note*: This integration uses the official `clickhouse-connect` client to connect over HTTP.
 
-*Note*: For a ClickHouse Cloud service reached through a single load-balanced endpoint, set `single_endpoint_mode: true`. The Agent then collects system-table metrics from all nodes behind the endpoint using `clusterAllReplicas()` and tags each series with `clickhouse_node`. Without this setting, cumulative per-node counters (such as the counter behind `clickhouse.query.failed.count`) can be read from different nodes on consecutive collections, producing inaccurate values. Per-node collection requires Agent version 7.83.0 or later.
+*Note*: If your ClickHouse Cloud service sits behind a single load-balanced endpoint, set `single_endpoint_mode: true`. This tells the Agent (version 7.83.0 or later) to query system-table metrics across all nodes behind that endpoint using `clusterAllReplicas()`, tagging each resulting series with `clickhouse_node` so you can still distinguish per-node data.
+
+Without this setting, the Agent may hit a different node on each collection cycle. For cumulative per-node counters like `clickhouse.query.failed.count`, that inconsistency produces inaccurate values, since the counter isn't being read from the same source each time.
 
 2. [Restart the Agent][5].
 

--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -39,7 +39,7 @@ To configure this check for an Agent running on a host:
 
 *Note*: This integration uses the official `clickhouse-connect` client to connect over HTTP.
 
-*Note*: For a ClickHouse Cloud service reached through a single load-balanced endpoint, set `single_endpoint_mode: true`. The Agent then collects system-table metrics from all nodes behind the endpoint using `clusterAllReplicas()` and tags each series with `clickhouse_node`. Without this setting, cumulative per-node counters (such as the counter behind `clickhouse.query.failed.count`) can be read from different nodes on consecutive collections, producing inaccurate values. Per-node collection requires Agent version 7.82.0 or later.
+*Note*: For a ClickHouse Cloud service reached through a single load-balanced endpoint, set `single_endpoint_mode: true`. The Agent then collects system-table metrics from all nodes behind the endpoint using `clusterAllReplicas()` and tags each series with `clickhouse_node`. Without this setting, cumulative per-node counters (such as the counter behind `clickhouse.query.failed.count`) can be read from different nodes on consecutive collections, producing inaccurate values. Per-node collection requires Agent version 7.83.0 or later.
 
 2. [Restart the Agent][5].
 

--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -39,6 +39,8 @@ To configure this check for an Agent running on a host:
 
 *Note*: This integration uses the official `clickhouse-connect` client to connect over HTTP.
 
+*Note*: For a ClickHouse Cloud service reached through a single load-balanced endpoint, set `single_endpoint_mode: true`. The Agent then collects system-table metrics from all nodes behind the endpoint using `clusterAllReplicas()` and tags each series with `clickhouse_node`. Without this setting, cumulative per-node counters (such as the counter behind `clickhouse.query.failed.count`) can be read from different nodes on consecutive collections, producing inaccurate values. Per-node collection requires Agent version 7.82.0 or later.
+
 2. [Restart the Agent][5].
 
 ##### Log collection


### PR DESCRIPTION
### What does this PR do?
Adds a note to the ClickHouse integration README (Host setup) explaining `single_endpoint_mode` for ClickHouse Cloud. When enabled, the Agent collects system-table metrics from all nodes behind the single endpoint using `clusterAllReplicas()` and tags each series with `clickhouse_node`. Documents that per-node collection requires Agent 7.82.0 or later.

### Motivation
Without `single_endpoint_mode`, cumulative per-node counters (such as the counter behind `clickhouse.query.failed.count`) can be read from different nodes on consecutive collections through a load balancer, producing inaccurate metric values. The README did not previously mention this setting.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)