### PR TITLE
kafka_consumer: cache earliest offsets across collection intervals

### DIFF
--- a/kafka_consumer/changelog.d/24515.fixed
+++ b/kafka_consumer/changelog.d/24515.fixed
@@ -1,0 +1,1 @@
+Cache the earliest (log-start) offset used for `kafka.topic.size` and `kafka.partition.size` across collection intervals instead of refetching it from the broker on every run.

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -68,8 +68,6 @@ class ClusterMetadataCollector:
         self.SCHEMA_COMPATIBILITY_FETCH_CACHE_MAX_SIZE = 20_000
         self.SCHEMA_ID_CACHE_MAX_SIZE = 20_000
 
-        # Earliest offsets only move via the broker's log-cleaner cycle (log.retention.check.interval.ms),
-        # so the result is cached across runs instead of refetched on every collection interval.
         self.EARLIEST_OFFSETS_DEFAULT_TTL = 300  # 5 minutes, matches Kafka's own broker default
         self.EARLIEST_OFFSETS_MIN_TTL = 60
         self.EARLIEST_OFFSETS_MAX_TTL = 1800
@@ -438,14 +436,7 @@ class ClusterMetadataCollector:
             self.log.debug("Could not write earliest offsets cache: %s", e)
 
     def fetch_earliest_offsets(self, topic_partitions):
-        """Return cached log-start offsets, refetching from the broker only once the TTL expires.
-
-        The log start offset only moves via the broker's log-cleaner cycle
-        (log.retention.check.interval.ms), so there's no point refetching it on every
-        collection interval. The TTL is derived from that broker config when known
-        (clamped to [EARLIEST_OFFSETS_MIN_TTL, EARLIEST_OFFSETS_MAX_TTL]), else defaults
-        to EARLIEST_OFFSETS_DEFAULT_TTL.
-        """
+        """Return cached log-start offsets, refetching from the broker only once the TTL expires."""
         requested = self._topic_partition_pairs(topic_partitions)
         if not requested:
             return {}

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -334,7 +334,6 @@ class ClusterMetadataCollector:
                 for config_name in [
                     'log.retention.bytes',
                     'log.retention.ms',
-                    'log.retention.check.interval.ms',
                     'log.segment.bytes',
                     'num.partitions',
                     'num.network.threads',
@@ -347,11 +346,6 @@ class ClusterMetadataCollector:
                             value = float(config_data[config_name]) if config_data[config_name] else 0
                             metric_name = f"broker.config.{config_name.replace('.', '_')}"
                             self.check.gauge(metric_name, value, tags=metric_tags)
-                            if config_name == 'log.retention.check.interval.ms' and value > 0:
-                                interval_s = value / 1000
-                                self._log_retention_check_interval_s = min(
-                                    interval_s, self._log_retention_check_interval_s or interval_s
-                                )
                         except (ValueError, TypeError):
                             self.log.debug(
                                 "Could not convert broker %s config %s value %r to float",
@@ -359,6 +353,21 @@ class ClusterMetadataCollector:
                                 config_name,
                                 config_data[config_name],
                             )
+
+                retention_check_interval_ms = config_data.get('log.retention.check.interval.ms')
+                if retention_check_interval_ms:
+                    try:
+                        interval_s = float(retention_check_interval_ms) / 1000
+                        if interval_s > 0:
+                            self._log_retention_check_interval_s = min(
+                                interval_s, self._log_retention_check_interval_s or interval_s
+                            )
+                    except (ValueError, TypeError):
+                        self.log.debug(
+                            "Could not convert broker %s config log.retention.check.interval.ms value %r to float",
+                            broker_id_str,
+                            retention_check_interval_ms,
+                        )
 
                 truncated_config = self._truncate_config_for_event(config_data, max_configs=50)
                 event_text = json.dumps(truncated_config, indent=2, sort_keys=True)
@@ -425,10 +434,10 @@ class ClusterMetadataCollector:
             self.log.debug("Could not read earliest offsets cache: %s", e)
             return None
 
-    def _save_earliest_offsets_cache(self, offsets: dict[tuple[str, int], int]) -> None:
+    def _save_earliest_offsets_cache(self, offsets: dict[tuple[str, int], int], expire_at: float | None = None) -> None:
         try:
             payload = {
-                'expire_at': time.time() + self._earliest_offsets_ttl(),
+                'expire_at': expire_at if expire_at is not None else time.time() + self._earliest_offsets_ttl(),
                 'offsets': [[topic, partition, offset] for (topic, partition), offset in offsets.items()],
             }
             self.check.write_persistent_cache(self.EARLIEST_OFFSETS_CACHE_KEY, json.dumps(payload))
@@ -443,7 +452,14 @@ class ClusterMetadataCollector:
 
         cached = self._load_earliest_offsets_cache()
         if cached is not None and time.time() < cached['expire_at']:
-            return {tp: offset for tp, offset in cached['offsets'].items() if tp in requested}
+            cached_offsets = {tp: offset for tp, offset in cached['offsets'].items() if tp in requested}
+            if cached_offsets.keys() == requested:
+                return cached_offsets
+
+            result = self._fetch_earliest_offsets_from_broker(topic_partitions)
+            if result:
+                self._save_earliest_offsets_cache(result, expire_at=cached['expire_at'])
+            return result
 
         result = self._fetch_earliest_offsets_from_broker(topic_partitions)
         if result:

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -68,8 +68,16 @@ class ClusterMetadataCollector:
         self.SCHEMA_COMPATIBILITY_FETCH_CACHE_MAX_SIZE = 20_000
         self.SCHEMA_ID_CACHE_MAX_SIZE = 20_000
 
+        # Earliest offsets only move via the broker's log-cleaner cycle (log.retention.check.interval.ms),
+        # so the result is cached across runs instead of refetched on every collection interval.
+        self.EARLIEST_OFFSETS_DEFAULT_TTL = 300  # 5 minutes, matches Kafka's own broker default
+        self.EARLIEST_OFFSETS_MIN_TTL = 60
+        self.EARLIEST_OFFSETS_MAX_TTL = 1800
+        self._log_retention_check_interval_s: float | None = None
+
         self.BROKER_CONFIG_CACHE_KEY = 'kafka_broker_config_cache'
         self.BROKER_CONFIG_FETCH_CACHE_KEY = 'kafka_broker_config_fetch_cache'
+        self.EARLIEST_OFFSETS_CACHE_KEY = 'kafka_earliest_offsets_cache'
         self.TOPIC_CONFIG_CACHE_KEY = 'kafka_topic_config_cache'
         self.TOPIC_CONFIG_FETCH_CACHE_KEY = 'kafka_topic_config_fetch_cache'
         self.TOPIC_HWM_SUM_CACHE_KEY = 'kafka_topic_hwm_sum_cache'
@@ -328,6 +336,7 @@ class ClusterMetadataCollector:
                 for config_name in [
                     'log.retention.bytes',
                     'log.retention.ms',
+                    'log.retention.check.interval.ms',
                     'log.segment.bytes',
                     'num.partitions',
                     'num.network.threads',
@@ -340,6 +349,11 @@ class ClusterMetadataCollector:
                             value = float(config_data[config_name]) if config_data[config_name] else 0
                             metric_name = f"broker.config.{config_name.replace('.', '_')}"
                             self.check.gauge(metric_name, value, tags=metric_tags)
+                            if config_name == 'log.retention.check.interval.ms' and value > 0:
+                                interval_s = value / 1000
+                                self._log_retention_check_interval_s = min(
+                                    interval_s, self._log_retention_check_interval_s or interval_s
+                                )
                         except (ValueError, TypeError):
                             self.log.debug(
                                 "Could not convert broker %s config %s value %r to float",
@@ -386,7 +400,66 @@ class ClusterMetadataCollector:
                 "data-streams-message",
             )
 
+    def _topic_partition_pairs(self, topic_partitions):
+        return {
+            (topic, partition)
+            for topic, partitions in topic_partitions.items()
+            if topic not in KAFKA_INTERNAL_TOPICS
+            for partition in partitions
+        }
+
+    def _earliest_offsets_ttl(self) -> float:
+        """TTL for the earliest-offsets cache, derived from the broker's log-cleaner cycle."""
+        ttl = self._log_retention_check_interval_s or self.EARLIEST_OFFSETS_DEFAULT_TTL
+        return max(self.EARLIEST_OFFSETS_MIN_TTL, min(self.EARLIEST_OFFSETS_MAX_TTL, ttl))
+
+    def _load_earliest_offsets_cache(self) -> dict[str, Any] | None:
+        try:
+            cached_str = self.check.read_persistent_cache(self.EARLIEST_OFFSETS_CACHE_KEY)
+            if not cached_str:
+                return None
+            data = json.loads(cached_str)
+            return {
+                'expire_at': data['expire_at'],
+                'offsets': {(topic, partition): offset for topic, partition, offset in data['offsets']},
+            }
+        except Exception as e:
+            self.log.debug("Could not read earliest offsets cache: %s", e)
+            return None
+
+    def _save_earliest_offsets_cache(self, offsets: dict[tuple[str, int], int]) -> None:
+        try:
+            payload = {
+                'expire_at': time.time() + self._earliest_offsets_ttl(),
+                'offsets': [[topic, partition, offset] for (topic, partition), offset in offsets.items()],
+            }
+            self.check.write_persistent_cache(self.EARLIEST_OFFSETS_CACHE_KEY, json.dumps(payload))
+        except Exception as e:
+            self.log.debug("Could not write earliest offsets cache: %s", e)
+
     def fetch_earliest_offsets(self, topic_partitions):
+        """Return cached log-start offsets, refetching from the broker only once the TTL expires.
+
+        The log start offset only moves via the broker's log-cleaner cycle
+        (log.retention.check.interval.ms), so there's no point refetching it on every
+        collection interval. The TTL is derived from that broker config when known
+        (clamped to [EARLIEST_OFFSETS_MIN_TTL, EARLIEST_OFFSETS_MAX_TTL]), else defaults
+        to EARLIEST_OFFSETS_DEFAULT_TTL.
+        """
+        requested = self._topic_partition_pairs(topic_partitions)
+        if not requested:
+            return {}
+
+        cached = self._load_earliest_offsets_cache()
+        if cached is not None and time.time() < cached['expire_at']:
+            return {tp: offset for tp, offset in cached['offsets'].items() if tp in requested}
+
+        result = self._fetch_earliest_offsets_from_broker(topic_partitions)
+        if result:
+            self._save_earliest_offsets_cache(result)
+        return result
+
+    def _fetch_earliest_offsets_from_broker(self, topic_partitions):
         """Batch-fetch log-start offsets via AdminClient.list_offsets(earliest).
 
         Uses ListOffsets with the EARLIEST_TIMESTAMP sentinel, which the broker
@@ -397,9 +470,7 @@ class ClusterMetadataCollector:
         """
         requests = {
             TopicPartition(topic, partition): OffsetSpec.earliest()
-            for topic, partitions in topic_partitions.items()
-            if topic not in KAFKA_INTERNAL_TOPICS
-            for partition in partitions
+            for topic, partition in self._topic_partition_pairs(topic_partitions)
         }
         if not requests:
             return {}

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1135,6 +1135,31 @@ def test_kafka_configs_refresh_interval(check, interval, expected_interval, expe
     assert collector.cache.refresh_jitter == expected_jitter
 
 
+def test_fetch_earliest_offsets_cached_across_calls(check):
+    """fetch_earliest_offsets should hit the broker once, then serve later calls from cache."""
+    instance = {
+        'kafka_connect_str': 'localhost:9092',
+        'enable_cluster_monitoring': True,
+    }
+    kafka_consumer_check = check(instance)
+    mock_kafka_client = seed_mock_kafka_client()
+    kafka_consumer_check.client = mock_kafka_client
+    kafka_consumer_check.metadata_collector.client = mock_kafka_client
+
+    _wire_cache(kafka_consumer_check)
+
+    collector = kafka_consumer_check.metadata_collector
+    topic_partitions = {'test-topic': [0, 1]}
+
+    first = collector.fetch_earliest_offsets(topic_partitions)
+    second = collector.fetch_earliest_offsets(topic_partitions)
+
+    expected = {('test-topic', 0): 10, ('test-topic', 1): 20}
+    assert first == expected
+    assert second == expected
+    assert mock_kafka_client.kafka_client.list_offsets.call_count == 1
+
+
 def test_schema_registry_oauth_oidc_token(check, dd_run_check, aggregator):
     """Test that OIDC OAuth token is fetched and passed as Bearer header for Schema Registry."""
     instance = {

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1160,6 +1160,32 @@ def test_fetch_earliest_offsets_cached_across_calls(check):
     assert mock_kafka_client.kafka_client.list_offsets.call_count == 1
 
 
+def test_fetch_earliest_offsets_refetches_when_cache_missing_partitions(check):
+    """A fresh cache that doesn't cover every requested partition triggers a full refetch, keeping the same TTL."""
+    instance = {
+        'kafka_connect_str': 'localhost:9092',
+        'enable_cluster_monitoring': True,
+    }
+    kafka_consumer_check = check(instance)
+    mock_kafka_client = seed_mock_kafka_client()
+    kafka_consumer_check.client = mock_kafka_client
+    kafka_consumer_check.metadata_collector.client = mock_kafka_client
+
+    collector = kafka_consumer_check.metadata_collector
+    expire_at = time.time() + 300
+    seed_payload = json.dumps({'expire_at': expire_at, 'offsets': [['test-topic', 0, 10]]})
+    _wire_cache(kafka_consumer_check, seed={collector.EARLIEST_OFFSETS_CACHE_KEY: seed_payload})
+
+    topic_partitions = {'test-topic': [0, 1]}
+    result = collector.fetch_earliest_offsets(topic_partitions)
+
+    assert result == {('test-topic', 0): 10, ('test-topic', 1): 20}
+    assert mock_kafka_client.kafka_client.list_offsets.call_count == 1
+
+    saved = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    assert saved['expire_at'] == expire_at
+
+
 def test_schema_registry_oauth_oidc_token(check, dd_run_check, aggregator):
     """Test that OIDC OAuth token is fetched and passed as Bearer header for Schema Registry."""
     instance = {


### PR DESCRIPTION
### What does this PR do?
Caches the per-partition earliest (log-start) offset used to compute `kafka.topic.size` and `kafka.partition.size`, instead of refetching it from the broker on every collection interval. The cache TTL is derived from the broker's `log.retention.check.interval.ms` config when available, clamped to `[60s, 1800s]`, defaulting to 300s.

### Motivation
The earliest offset only moves forward via the broker's log-cleaner cycle, so refetching it every check run adds unnecessary `ListOffsets` load on the broker without the value ever changing between cleaner cycles. Caching it across runs, with a TTL tied to that cycle, removes that redundant load while keeping the reported values accurate.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged