### PR TITLE
[SNMP] Add use_remote_config_profiles to the config spec

### DIFF
--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -96,6 +96,15 @@ files:
               definition_file: cisco-asr.yaml
         hidden: true
         fleet_configurable: false
+      - name: use_remote_config_profiles
+        description: |
+          Whether to apply device profiles from the SNMP Profile Manager, managed through Remote Configuration.
+          When enabled, any locally defined profiles are ignored in favor of the remotely-managed profiles.
+        value:
+          type: boolean
+          example: true
+          display_default: false
+        fleet_configurable: true
       - name: refresh_oids_cache_interval
         legacy: true
         description: |

--- a/snmp/changelog.d/24528.added
+++ b/snmp/changelog.d/24528.added
@@ -1,0 +1,1 @@
+Add the `use_remote_config_profiles` option to the SNMP configuration spec so it is accepted by config validation and Remote Configuration.

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -55,6 +55,12 @@ init_config:
     #     metric_tags:
     #     - TCP
 
+    ## @param use_remote_config_profiles - boolean - optional - default: false
+    ## Whether to apply device profiles from the SNMP Profile Manager, managed through Remote Configuration.
+    ## When enabled, any locally defined profiles are ignored in favor of the remotely-managed profiles.
+    #
+    # use_remote_config_profiles: true
+
     ## @param refresh_oids_cache_interval - integer - optional - default: 0
     ## Note: Beta feature, only available using python SNMP integration.
     ## Set this option to enable caching of OIDs. The value is the number of seconds before the


### PR DESCRIPTION
This PR adds the `use_remote_config_profiles` option to `init_config` in the SNMP `spec.yaml`, and regenerates `conf.yaml.example`.

It is already shipped in the Agent's SNMP autodiscovery template (`cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml`) and accepted by the corecheck (`InitConfig`), but it was never in this integration's spec. Since the config schema is generated from `spec.yaml`, Remote Configuration rejected it with "Property use_remote_config_profiles is not allowed".

https://datadoghq.atlassian.net/browse/AGENT-16536

## Validation
- `ddev -x validate config -s snmp` and `ddev -x validate models -s snmp` pass.
- Regenerated `conf.yaml.example` shows `use_remote_config_profiles` (default `false`) under `init_config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
