### PR TITLE
fix(incident-io): rename api key field to api_token to match crawler

### DIFF
--- a/incident_io/assets/account_config.json
+++ b/incident_io/assets/account_config.json
@@ -4,7 +4,7 @@
       "auth_name": "API Key",
       "bearer_token": {
         "password_setting": {
-          "key": "incident_io_api_key",
+          "key": "api_token",
           "label": "API key",
           "help": "incident.io API Key",
           "required": true,


### PR DESCRIPTION
### What does this PR do?

Inline api key field naming with cralwer sdk
