### PR TITLE
Propagate docker_run env vars to discovery-stability check's compose command

### DIFF
--- a/datadog_checks_dev/changelog.d/24533.fixed
+++ b/datadog_checks_dev/changelog.d/24533.fixed
@@ -1,0 +1,1 @@
+Preserve ``docker_run`` environment variables across e2e process boundaries so ``assert_all_discovery_candidates_stable`` can invoke ``docker compose`` without requiring fallback defaults in the compose file.

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -448,15 +448,29 @@ def docker_run(
                 )
 
     if compose_file is not None:
+        env_snapshot = dict(os.environ)
+
         save_state(
             'docker_compose_metadata',
             {
                 'compose_file': compose_file,
                 'project_name': (env_vars or {}).get('COMPOSE_PROJECT_NAME') or os.getenv('COMPOSE_PROJECT_NAME'),
                 'service_name': service_name,
-                'env_vars': env_vars or {},
             },
         )
+
+        # Runs after every other wrapper (docker_run's own `env_vars`, `mount_logs`'s `shared_logs`,
+        # and any caller-supplied `wrappers`) so it captures whatever env vars they added to interpolate
+        # into the compose file, for `assert_all_discovery_candidates_stable` to reuse in later processes.
+        @contextmanager
+        def _persist_compose_env_vars():
+            new_env_vars = {key: value for key, value in os.environ.items() if env_snapshot.get(key) != value}
+            docker_metadata = get_state('docker_compose_metadata', {})
+            docker_metadata['env_vars'] = new_env_vars
+            save_state('docker_compose_metadata', docker_metadata)
+            yield
+
+        wrappers.append(_persist_compose_env_vars())
 
     with environment_run(
         up=set_up,

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -122,7 +122,9 @@ def _get_compose_container_id(
         command.extend(['-p', project_name])
     command.extend(['-f', os.fspath(compose_file), 'ps', '-q', compose_service])
 
-    container_id = run_command(command, capture='out', check=True).stdout.strip()
+    container_id = run_command(
+        command, capture='out', check=True, env={**os.environ, **_get_default_compose_env_vars()}
+    ).stdout.strip()
     if not container_id:
         raise AssertionError(f'No container found for compose service {compose_service!r}')
 
@@ -154,6 +156,11 @@ def _get_default_compose_file() -> str:
 def _get_default_compose_project_name() -> str | None:
     docker_metadata = get_state('docker_compose_metadata', {})
     return docker_metadata.get('project_name') or os.getenv('COMPOSE_PROJECT_NAME')
+
+
+def _get_default_compose_env_vars() -> dict[str, str]:
+    docker_metadata = get_state('docker_compose_metadata', {})
+    return docker_metadata.get('env_vars') or {}
 
 
 def _inspect_container(container_id: str) -> dict[str, Any]:
@@ -447,6 +454,7 @@ def docker_run(
                 'compose_file': compose_file,
                 'project_name': (env_vars or {}).get('COMPOSE_PROJECT_NAME') or os.getenv('COMPOSE_PROJECT_NAME'),
                 'service_name': service_name,
+                'env_vars': env_vars or {},
             },
         )
 

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -463,14 +463,14 @@ def docker_run(
         # and any caller-supplied `wrappers`) so it captures whatever env vars they added to interpolate
         # into the compose file, for `assert_all_discovery_candidates_stable` to reuse in later processes.
         @contextmanager
-        def _persist_compose_env_vars():
+        def persist_compose_env_vars():
             new_env_vars = {key: value for key, value in os.environ.items() if env_snapshot.get(key) != value}
             docker_metadata = get_state('docker_compose_metadata', {})
             docker_metadata['env_vars'] = new_env_vars
             save_state('docker_compose_metadata', docker_metadata)
             yield
 
-        wrappers.append(_persist_compose_env_vars())
+        wrappers.append(persist_compose_env_vars())
 
     with environment_run(
         up=set_up,

--- a/pulsar/tests/docker/docker-compose.yaml
+++ b/pulsar/tests/docker/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
     - '6650:6650'
     - '8080:8080'
     volumes:
-    - ${DD_LOG_1:-/dev/null}:/var/log/pulsar.log
+    - ${DD_LOG_1}:/var/log/pulsar.log
     # Not everything is documented:
     # https://pulsar.apache.org/docs/en/reference-configuration/
     environment:

--- a/ray/tests/docker/docker-compose.yaml
+++ b/ray/tests/docker/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
     volumes:
       - ./ping.py:/home/ray/ping.py
       - ./serve_tasks:/home/ray/serve
-      - ${RAY_LOG_FOLDER:-/tmp}:/tmp/logs
+      - ${RAY_LOG_FOLDER}:/tmp/logs
   ray-worker-1:
     container_name: ray-worker-1
     hostname: ray-worker-1

--- a/temporal/tests/compose/docker-compose.yaml
+++ b/temporal/tests/compose/docker-compose.yaml
@@ -65,7 +65,7 @@ services:
     volumes:
       - ./config:/etc/temporal/config/dynamicconfig
       - ./template/config_template.yaml:/etc/temporal/config/config_template.yaml
-      - ${TEMPORAL_LOG_FOLDER:-/tmp}:/var/log/temporal
+      - ${TEMPORAL_LOG_FOLDER}:/var/log/temporal
     healthcheck:
       test:
         [


### PR DESCRIPTION
### What does this PR do?
Makes the env vars used to interpolate a `docker_run` compose file (whether passed via `env_vars=`, set by `shared_logs()`, or set by any other wrapper) available to the `docker compose ps`/`logs` commands that `assert_all_discovery_candidates_stable` shells out to, even when that call happens in a separate `ddev env test` process from the one that started the environment. Also removes the per-integration `docker-compose.yaml` fallback defaults (temporal, pulsar, ray) that were added last week as workarounds for this same issue.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-614

During `ddev env test`, the `dd_environment` fixture that calls `docker_run` is replaced with a no-op, since the environment was already started by a separate `ddev env start` process. Any env vars used to interpolate the compose file were therefore missing from `os.environ` in that later process. When `assert_all_discovery_candidates_stable` shelled out to `docker compose ps`/`logs` to inspect the running container, compose would reject the file with errors like `invalid spec: empty section between colons` for any referenced variable with no value and no fallback default.

Rather than have every integration that adopts `assert_all_discovery_candidates_stable` add `:-<default>` fallbacks to its compose file, `docker_run` now snapshots the env vars introduced by any of its wrappers and persists them alongside the compose metadata it already saves across process boundaries (compose file, service name, project name). `_get_compose_container_id` then passes those env vars through explicitly to the subprocess it invokes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged