### PR TITLE
bump requests version in ddev

### DIFF
--- a/ddev/changelog.d/24534.fixed
+++ b/ddev/changelog.d/24534.fixed
@@ -1,0 +1,1 @@
+Bump requests to 2.34.2 to match datadog-checks-base.

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "tomli-w",
     "tomlkit",
     "tqdm",
-    "requests==2.33.0",
+    "requests==2.34.2",
     "matplotlib",
     "squarify",
     "datadog",


### PR DESCRIPTION
### What does this PR do?
Bump requests version in ddev

### Motivation
requests was bumped in the base check here: https://github.com/DataDog/integrations-core/pull/24321/changes and it needs to be compatible with ddev. This causes the "Cache Python dependencies" job to fail:

```
Run uv pip install --system ./ddev ./datadog_checks_dev[cli] ./datadog_checks_base[deps]
Using Python 3.13.14 environment at: /opt/hostedtoolcache/Python/3.13.14/x64
  × No solution found when resolving dependencies:
  ╰─▶ Because only ddev==0.0.1.dev1 is available and ddev==0.0.1.dev1 depends
      on requests==2.33.0, we can conclude that all versions of ddev depend
      on requests==2.33.0.
      And because datadog-checks-base[deps]==37.42.0 depends on
      requests==2.34.2 and only datadog-checks-base[deps]==37.42.0 is
      available, we can conclude that all versions of ddev and all versions of
      datadog-checks-base[deps] are incompatible.
      And because you require ddev and datadog-checks-base[deps], we can
      conclude that your requirements are unsatisfiable.
Error: Process completed with exit code 1.
```
https://github.com/DataDog/integrations-core/actions/runs/29261316541/job/86855054904

and thus blocks tests from running on master. This is needed to start running tests on master

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
