### PR TITLE
Fix false-positive discovery-candidate stability failures from log concatenation

### DIFF
--- a/datadog_checks_dev/changelog.d/24536.fixed
+++ b/datadog_checks_dev/changelog.d/24536.fixed
@@ -1,0 +1,1 @@
+Fix false-positive discovery-candidate stability failures caused by incorrectly diffing concatenated stdout/stderr container logs.

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -72,7 +72,7 @@ def assert_all_discovery_candidates_stable(
     compose_service = compose_service or _get_default_compose_service()
     container_id = _get_compose_container_id(compose_file, compose_service, project_name=project_name)
     initial_state = _inspect_container(container_id)
-    previous_logs = _get_container_logs(container_id)
+    previous_stdout, previous_stderr = _get_container_logs(container_id)
 
     ports = tuple(SimpleNamespace(number=port, name='') for port in _get_container_ports(initial_state))
     service = SimpleNamespace(
@@ -100,12 +100,14 @@ def assert_all_discovery_candidates_stable(
         current_state = _inspect_container(current_container_id)
         _assert_container_stable(initial_state, current_state, index)
 
-        current_logs = _get_container_logs(current_container_id)
-        new_logs = current_logs[len(previous_logs) :] if current_logs.startswith(previous_logs) else current_logs
+        current_stdout, current_stderr = _get_container_logs(current_container_id)
+        new_stdout = _diff_logs(previous_stdout, current_stdout)
+        new_stderr = _diff_logs(previous_stderr, current_stderr)
+        new_logs = new_stdout + new_stderr
         for line in new_logs.splitlines():
             logging.debug('New log line: %s', line)
         _assert_no_log_patterns(new_logs, log_patterns, index)
-        previous_logs = current_logs
+        previous_stdout, previous_stderr = current_stdout, current_stderr
 
 
 def _get_compose_container_id(
@@ -188,9 +190,19 @@ def _get_container_ports(inspect_data: Mapping[str, Any]) -> list[int]:
     return sorted(ports)
 
 
-def _get_container_logs(container_id: str) -> str:
+def _get_container_logs(container_id: str) -> tuple[str, str]:
     result = run_command(['docker', 'logs', container_id], capture=True)
-    return result.stdout + result.stderr
+    return result.stdout, result.stderr
+
+
+def _diff_logs(previous: str, current: str) -> str:
+    """Return the portion of `current` appended since `previous`.
+
+    stdout and stderr must be diffed separately and then combined, rather than diffing their
+    concatenation: interleaving between the two streams isn't fixed across `docker logs` calls, so
+    concatenating first breaks the `startswith` prefix check and replays already-seen lines as new.
+    """
+    return current[len(previous) :] if current.startswith(previous) else current
 
 
 def _assert_container_stable(

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -101,6 +101,7 @@ def assert_all_discovery_candidates_stable(
         _assert_container_stable(initial_state, current_state, index)
 
         current_stdout, current_stderr = _get_container_logs(current_container_id)
+        # Diffed separately: stdout/stderr interleaving varies across calls, breaking a combined diff.
         new_stdout = _diff_logs(previous_stdout, current_stdout)
         new_stderr = _diff_logs(previous_stderr, current_stderr)
         new_logs = new_stdout + new_stderr
@@ -196,12 +197,7 @@ def _get_container_logs(container_id: str) -> tuple[str, str]:
 
 
 def _diff_logs(previous: str, current: str) -> str:
-    """Return the portion of `current` appended since `previous`.
-
-    stdout and stderr must be diffed separately and then combined, rather than diffing their
-    concatenation: interleaving between the two streams isn't fixed across `docker logs` calls, so
-    concatenating first breaks the `startswith` prefix check and replays already-seen lines as new.
-    """
+    """Return the portion of `current` appended since `previous`."""
     return current[len(previous) :] if current.startswith(previous) else current
 
 

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -397,11 +397,7 @@ def test_assert_all_discovery_candidates_stable_detects_new_crash_logs():
 
 
 def test_assert_all_discovery_candidates_stable_ignores_old_stderr_when_new_stdout_arrives():
-    # Regression test: containers that split access logs (stdout) from error logs (stderr), like Kong,
-    # previously caused stale stderr content to be re-flagged as new whenever fresh stdout arrived, because
-    # the diff compared the *concatenation* of stdout+stderr against the previous concatenation. Any new
-    # stdout content shifts the position of the unchanged stderr tail, breaking the `startswith` check and
-    # replaying the entire log (old errors included) as "new".
+    # Regression test: new stdout previously shifted unchanged stderr, replaying it as new.
     class DiscoveryCheck:
         @classmethod
         def generate_configs(cls, service):

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -394,3 +394,39 @@ def test_assert_all_discovery_candidates_stable_detects_new_crash_logs():
                 '/tmp/docker-compose.yml',
                 'service',
             )
+
+
+def test_assert_all_discovery_candidates_stable_ignores_old_stderr_when_new_stdout_arrives():
+    # Regression test: containers that split access logs (stdout) from error logs (stderr), like Kong,
+    # previously caused stale stderr content to be re-flagged as new whenever fresh stdout arrived, because
+    # the diff compared the *concatenation* of stdout+stderr against the previous concatenation. Any new
+    # stdout content shifts the position of the unchanged stderr tail, breaking the `startswith` check and
+    # replaying the entire log (old errors included) as "new".
+    class DiscoveryCheck:
+        @classmethod
+        def generate_configs(cls, service):
+            yield {'init_config': {}, 'instances': [{'url': f'http://{service.host}:8080/metrics'}]}
+
+    logs = iter(
+        [
+            _docker_result(stdout='', stderr='old startup error\n'),
+            _docker_result(stdout='new access log line\n', stderr='old startup error\n'),
+        ]
+    )
+
+    def fake_run_command(command, **kwargs):
+        if command[:2] == ['docker', 'compose']:
+            return _docker_result(stdout='container-id\n')
+        if command[:2] == ['docker', 'inspect']:
+            return _docker_result(stdout=json.dumps([_container_inspect()]))
+        if command[:2] == ['docker', 'logs']:
+            return next(logs)
+        raise AssertionError(f'Unexpected command: {command}')
+
+    with mock.patch('datadog_checks.dev.docker.run_command', side_effect=fake_run_command):
+        assert_all_discovery_candidates_stable(
+            mock.Mock(),
+            DiscoveryCheck,
+            '/tmp/docker-compose.yml',
+            'service',
+        )


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in `assert_all_discovery_candidates_stable` (used by config-discovery E2E tests) where it diffed container logs incorrectly, causing intermittent false-positive test failures. `_get_container_logs` concatenated a container's stdout and stderr into a single string, and the diffing logic compared that concatenation against the previous snapshot using `startswith`. Whenever new stdout content arrived between two snapshots (e.g. a new access-log line), it shifted where the unchanged stderr tail sat in the concatenated string, breaking the `startswith` prefix check. This caused the *entire* historical log — including old, already-seen stderr content — to be replayed as "new" on every subsequent probe.

The fix captures stdout and stderr separately from `docker logs` and diffs each stream independently against its own previous snapshot, then combines only the genuinely new portions before pattern-matching.

### Motivation

Kong's `test_e2e_discovery_all_candidates` E2E test flaked in CI ([run](https://github.com/DataDog/integrations-core/actions/runs/29262964228/job/86860798554?pr=24494)) with:
```
AssertionError: Container logs matched 'error' after probing candidate #1: 'error'
```
Kong routes its access logs to stdout and its error/notice logs to stderr (a common pattern for containers that split these streams). Investigation with `--log-cli-level=DEBUG` showed that a benign nginx/migrations startup message that had *already* happened before the test began — and was therefore already accounted for in the initial log snapshot — was incorrectly re-reported as new stderr content once the test's own HTTP probes generated new stdout lines. This is exactly the concatenation bug described above, reproduced locally 8/8 times before the fix and passing 5/5 times after.

This bug affects every integration that uses `assert_all_discovery_candidates_stable` and separates its stdout/stderr streams, not just Kong.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
