### PR TITLE
[Backport 7.81.x] Kafka consumer broker timestamps and earliest offsets caching

### DIFF
--- a/kafka_consumer/changelog.d/24472.fixed
+++ b/kafka_consumer/changelog.d/24472.fixed
@@ -1,0 +1,1 @@
+Reduce cluster-check-runner memory churn by persisting the DSM broker timestamps cache in a compact binary format (marshal) instead of serializing it as JSON on every run.

--- a/kafka_consumer/changelog.d/24515.fixed
+++ b/kafka_consumer/changelog.d/24515.fixed
@@ -1,0 +1,1 @@
+Cache the earliest (log-start) offset used for `kafka.topic.size` and `kafka.partition.size` across collection intervals instead of refetching it from the broker on every run.

--- a/kafka_consumer/changelog.d/24515.fixed
+++ b/kafka_consumer/changelog.d/24515.fixed
@@ -1,1 +1,0 @@
-Cache the earliest (log-start) offset used for `kafka.topic.size` and `kafka.partition.size` across collection intervals instead of refetching it from the broker on every run.

--- a/kafka_consumer/changelog.d/24537.1.fixed
+++ b/kafka_consumer/changelog.d/24537.1.fixed
@@ -1,0 +1,1 @@
+Cache the earliest (log-start) offset used for `kafka.topic.size` and `kafka.partition.size` across collection intervals instead of refetching it from the broker on every run.

--- a/kafka_consumer/changelog.d/24537.2.fixed
+++ b/kafka_consumer/changelog.d/24537.2.fixed
@@ -1,0 +1,1 @@
+Reuse the Kafka AdminClient and Consumer across check runs to prevent unbounded agent memory growth from librdkafka thread churn.

--- a/kafka_consumer/changelog.d/24537.3.fixed
+++ b/kafka_consumer/changelog.d/24537.3.fixed
@@ -1,0 +1,1 @@
+Call malloc_trim after each run to return librdkafka's per-arena free memory to the OS and curb agent memory growth.

--- a/kafka_consumer/changelog.d/24537.4.fixed
+++ b/kafka_consumer/changelog.d/24537.4.fixed
@@ -1,0 +1,1 @@
+Keep the DSM broker_timestamps cache in memory and persist it at most every 5 minutes to reduce per-run allocation churn and memory growth.

--- a/kafka_consumer/changelog.d/24537.fixed
+++ b/kafka_consumer/changelog.d/24537.fixed
@@ -1,0 +1,1 @@
+Cap the total DSM broker timestamps history per cluster with a memory budget that scales the per-partition depth by partition count, bounding cluster-check-runner memory on large clusters.

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -42,6 +42,10 @@ class KafkaClient:
         return self._kafka_client
 
     def open_consumer(self, consumer_group):
+        # Reuse the consumer across runs so its per-broker threads (and their glibc arenas) persist.
+        if self._consumer is not None:
+            return
+
         config = {
             "bootstrap.servers": self.config._kafka_connect_str,
             "group.id": consumer_group,
@@ -55,8 +59,11 @@ class KafkaClient:
         self.log.debug("Consumer instance %s created for group %s", self._consumer, consumer_group)
 
     def close_consumer(self):
+        if self._consumer is None:
+            return
         self.log.debug("Closing consumer instance %s", self._consumer)
         self._consumer.close()
+        self._consumer = None
 
     def __get_authentication_config(self):
         config = {

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -70,8 +70,16 @@ class ClusterMetadataCollector:
         self.SCHEMA_COMPATIBILITY_FETCH_CACHE_MAX_SIZE = 20_000
         self.SCHEMA_ID_CACHE_MAX_SIZE = 20_000
 
+        # Earliest offsets only move via the broker's log-cleaner cycle (log.retention.check.interval.ms),
+        # so the result is cached across runs instead of refetched on every collection interval.
+        self.EARLIEST_OFFSETS_DEFAULT_TTL = 300  # 5 minutes, matches Kafka's own broker default
+        self.EARLIEST_OFFSETS_MIN_TTL = 60
+        self.EARLIEST_OFFSETS_MAX_TTL = 1800
+        self._log_retention_check_interval_s: float | None = None
+
         self.BROKER_CONFIG_CACHE_KEY = 'kafka_broker_config_cache'
         self.BROKER_CONFIG_FETCH_CACHE_KEY = 'kafka_broker_config_fetch_cache'
+        self.EARLIEST_OFFSETS_CACHE_KEY = 'kafka_earliest_offsets_cache'
         self.TOPIC_CONFIG_CACHE_KEY = 'kafka_topic_config_cache'
         self.TOPIC_CONFIG_FETCH_CACHE_KEY = 'kafka_topic_config_fetch_cache'
         self.TOPIC_HWM_SUM_CACHE_KEY = 'kafka_topic_hwm_sum_cache'
@@ -473,6 +481,7 @@ class ClusterMetadataCollector:
                 for config_name in [
                     'log.retention.bytes',
                     'log.retention.ms',
+                    'log.retention.check.interval.ms',
                     'log.segment.bytes',
                     'num.partitions',
                     'num.network.threads',
@@ -485,6 +494,11 @@ class ClusterMetadataCollector:
                             value = float(config_data[config_name]) if config_data[config_name] else 0
                             metric_name = f"broker.config.{config_name.replace('.', '_')}"
                             self.check.gauge(metric_name, value, tags=metric_tags)
+                            if config_name == 'log.retention.check.interval.ms' and value > 0:
+                                interval_s = value / 1000
+                                self._log_retention_check_interval_s = min(
+                                    interval_s, self._log_retention_check_interval_s or interval_s
+                                )
                         except (ValueError, TypeError):
                             self.log.debug(
                                 "Could not convert broker %s config %s value %r to float",
@@ -531,7 +545,59 @@ class ClusterMetadataCollector:
                 "data-streams-message",
             )
 
+    def _topic_partition_pairs(self, topic_partitions):
+        return {
+            (topic, partition)
+            for topic, partitions in topic_partitions.items()
+            if topic not in KAFKA_INTERNAL_TOPICS
+            for partition in partitions
+        }
+
+    def _earliest_offsets_ttl(self) -> float:
+        """TTL for the earliest-offsets cache, derived from the broker's log-cleaner cycle."""
+        ttl = self._log_retention_check_interval_s or self.EARLIEST_OFFSETS_DEFAULT_TTL
+        return max(self.EARLIEST_OFFSETS_MIN_TTL, min(self.EARLIEST_OFFSETS_MAX_TTL, ttl))
+
+    def _load_earliest_offsets_cache(self) -> dict[str, Any] | None:
+        try:
+            cached_str = self.check.read_persistent_cache(self.EARLIEST_OFFSETS_CACHE_KEY)
+            if not cached_str:
+                return None
+            data = json.loads(cached_str)
+            return {
+                'expire_at': data['expire_at'],
+                'offsets': {(topic, partition): offset for topic, partition, offset in data['offsets']},
+            }
+        except Exception as e:
+            self.log.debug("Could not read earliest offsets cache: %s", e)
+            return None
+
+    def _save_earliest_offsets_cache(self, offsets: dict[tuple[str, int], int]) -> None:
+        try:
+            payload = {
+                'expire_at': time.time() + self._earliest_offsets_ttl(),
+                'offsets': [[topic, partition, offset] for (topic, partition), offset in offsets.items()],
+            }
+            self.check.write_persistent_cache(self.EARLIEST_OFFSETS_CACHE_KEY, json.dumps(payload))
+        except Exception as e:
+            self.log.debug("Could not write earliest offsets cache: %s", e)
+
     def _fetch_earliest_offsets(self, topic_partitions):
+        """Return cached log-start offsets, refetching from the broker only once the TTL expires."""
+        requested = self._topic_partition_pairs(topic_partitions)
+        if not requested:
+            return {}
+
+        cached = self._load_earliest_offsets_cache()
+        if cached is not None and time.time() < cached['expire_at']:
+            return {tp: offset for tp, offset in cached['offsets'].items() if tp in requested}
+
+        result = self._fetch_earliest_offsets_from_broker(topic_partitions)
+        if result:
+            self._save_earliest_offsets_cache(result)
+        return result
+
+    def _fetch_earliest_offsets_from_broker(self, topic_partitions):
         """Batch-fetch log-start offsets via AdminClient.list_offsets(earliest).
 
         Uses ListOffsets with the EARLIEST_TIMESTAMP sentinel, which the broker
@@ -542,9 +608,7 @@ class ClusterMetadataCollector:
         """
         requests = {
             TopicPartition(topic, partition): OffsetSpec.earliest()
-            for topic, partitions in topic_partitions.items()
-            if topic not in KAFKA_INTERNAL_TOPICS
-            for partition in partitions
+            for topic, partition in self._topic_partition_pairs(topic_partitions)
         }
         if not requests:
             return {}

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -70,8 +70,6 @@ class ClusterMetadataCollector:
         self.SCHEMA_COMPATIBILITY_FETCH_CACHE_MAX_SIZE = 20_000
         self.SCHEMA_ID_CACHE_MAX_SIZE = 20_000
 
-        # Earliest offsets only move via the broker's log-cleaner cycle (log.retention.check.interval.ms),
-        # so the result is cached across runs instead of refetched on every collection interval.
         self.EARLIEST_OFFSETS_DEFAULT_TTL = 300  # 5 minutes, matches Kafka's own broker default
         self.EARLIEST_OFFSETS_MIN_TTL = 60
         self.EARLIEST_OFFSETS_MAX_TTL = 1800

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -479,7 +479,6 @@ class ClusterMetadataCollector:
                 for config_name in [
                     'log.retention.bytes',
                     'log.retention.ms',
-                    'log.retention.check.interval.ms',
                     'log.segment.bytes',
                     'num.partitions',
                     'num.network.threads',
@@ -492,11 +491,6 @@ class ClusterMetadataCollector:
                             value = float(config_data[config_name]) if config_data[config_name] else 0
                             metric_name = f"broker.config.{config_name.replace('.', '_')}"
                             self.check.gauge(metric_name, value, tags=metric_tags)
-                            if config_name == 'log.retention.check.interval.ms' and value > 0:
-                                interval_s = value / 1000
-                                self._log_retention_check_interval_s = min(
-                                    interval_s, self._log_retention_check_interval_s or interval_s
-                                )
                         except (ValueError, TypeError):
                             self.log.debug(
                                 "Could not convert broker %s config %s value %r to float",
@@ -504,6 +498,21 @@ class ClusterMetadataCollector:
                                 config_name,
                                 config_data[config_name],
                             )
+
+                retention_check_interval_ms = config_data.get('log.retention.check.interval.ms')
+                if retention_check_interval_ms:
+                    try:
+                        interval_s = float(retention_check_interval_ms) / 1000
+                        if interval_s > 0:
+                            self._log_retention_check_interval_s = min(
+                                interval_s, self._log_retention_check_interval_s or interval_s
+                            )
+                    except (ValueError, TypeError):
+                        self.log.debug(
+                            "Could not convert broker %s config log.retention.check.interval.ms value %r to float",
+                            broker_id_str,
+                            retention_check_interval_ms,
+                        )
 
                 truncated_config = self._truncate_config_for_event(config_data, max_configs=50)
                 event_text = json.dumps(truncated_config, indent=2, sort_keys=True)
@@ -570,10 +579,10 @@ class ClusterMetadataCollector:
             self.log.debug("Could not read earliest offsets cache: %s", e)
             return None
 
-    def _save_earliest_offsets_cache(self, offsets: dict[tuple[str, int], int]) -> None:
+    def _save_earliest_offsets_cache(self, offsets: dict[tuple[str, int], int], expire_at: float | None = None) -> None:
         try:
             payload = {
-                'expire_at': time.time() + self._earliest_offsets_ttl(),
+                'expire_at': expire_at if expire_at is not None else time.time() + self._earliest_offsets_ttl(),
                 'offsets': [[topic, partition, offset] for (topic, partition), offset in offsets.items()],
             }
             self.check.write_persistent_cache(self.EARLIEST_OFFSETS_CACHE_KEY, json.dumps(payload))
@@ -588,7 +597,14 @@ class ClusterMetadataCollector:
 
         cached = self._load_earliest_offsets_cache()
         if cached is not None and time.time() < cached['expire_at']:
-            return {tp: offset for tp, offset in cached['offsets'].items() if tp in requested}
+            cached_offsets = {tp: offset for tp, offset in cached['offsets'].items() if tp in requested}
+            if cached_offsets.keys() == requested:
+                return cached_offsets
+
+            result = self._fetch_earliest_offsets_from_broker(topic_partitions)
+            if result:
+                self._save_earliest_offsets_cache(result, expire_at=cached['expire_at'])
+            return result
 
         result = self._fetch_earliest_offsets_from_broker(topic_partitions)
         if result:

--- a/kafka_consumer/datadog_checks/kafka_consumer/config.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config.py
@@ -34,7 +34,10 @@ class KafkaConfig:
         # Optimization to avoid OOM kill:
         # https://github.com/confluentinc/confluent-kafka-python/issues/759
         self._consumer_queued_max_messages_kbytes = instance.get('consumer_queued_max_messages_kbytes', 1024)
-        self._close_admin_client = instance.get('close_admin_client', True)
+        # Reuse the AdminClient across runs by default so librdkafka's per-broker threads (and the
+        # glibc arenas they are bound to) stay alive and their memory is recycled in place instead of
+        # being stranded on every run. Set close_admin_client: true to restore the old churning behavior.
+        self._close_admin_client = instance.get('close_admin_client', False)
 
         self._kafka_connect_str = instance.get('kafka_connect_str')
         self._kafka_version = instance.get('kafka_client_api_version')

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -19,6 +19,10 @@ from datadog_checks.kafka_consumer.constants import (
 
 MAX_TIMESTAMPS = 1000
 
+# Total broker-timestamp entries retained per cluster, ~0.5 GiB at ~89 bytes/entry. The
+# per-partition history is scaled down from this budget as the partition count grows.
+MAX_TIMESTAMP_ENTRIES = 6_000_000
+
 
 class KafkaCheck(AgentCheck):
     __NAMESPACE__ = 'kafka'
@@ -249,7 +253,14 @@ class KafkaCheck(AgentCheck):
             self.log.warning('Could not read broker timestamps from cache: %s', str(e))
         return broker_timestamps
 
+    def _max_history(self, num_partitions):
+        """Per-partition timestamp cap, scaled so total retained entries stay within the budget."""
+        if num_partitions <= 0:
+            return self._max_timestamps
+        return max(2, min(self._max_timestamps, MAX_TIMESTAMP_ENTRIES // num_partitions))
+
     def _add_broker_timestamps(self, broker_timestamps, highwater_offsets):
+        max_history = self._max_history(len(highwater_offsets))
         for (topic, partition), highwater_offset in highwater_offsets.items():
             timestamps = broker_timestamps["{}_{}".format(topic, partition)]
             # If the highwater offset went backwards (topic recreated,
@@ -263,7 +274,7 @@ class KafkaCheck(AgentCheck):
             # If there's too many timestamps, we delete the oldest one (by
             # timestamp, not by offset — evicting by min offset would discard
             # the fresh post-reset entries and keep poisonous stale ones).
-            if len(timestamps) > self._max_timestamps:
+            if len(timestamps) > max_history:
                 del timestamps[min(timestamps, key=timestamps.get)]
 
     def _save_broker_timestamps(self, broker_timestamps, persistent_cache_key):

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -1,7 +1,9 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import base64
 import json
+import marshal
 from collections import defaultdict
 from time import time
 
@@ -242,9 +244,7 @@ class KafkaCheck(AgentCheck):
         """Loads broker timestamps from persistent cache."""
         broker_timestamps = defaultdict(dict)
         try:
-            for topic_partition, content in json.loads(self.read_persistent_cache(persistent_cache_key)).items():
-                for offset, timestamp in content.items():
-                    broker_timestamps[topic_partition][int(offset)] = timestamp
+            broker_timestamps.update(marshal.loads(base64.b64decode(self.read_persistent_cache(persistent_cache_key))))
         except Exception as e:
             self.log.warning('Could not read broker timestamps from cache: %s', str(e))
         return broker_timestamps
@@ -268,7 +268,8 @@ class KafkaCheck(AgentCheck):
 
     def _save_broker_timestamps(self, broker_timestamps, persistent_cache_key):
         """Saves broker timestamps to persistent cache."""
-        self.write_persistent_cache(persistent_cache_key, json.dumps(broker_timestamps))
+        blob = marshal.dumps(dict(broker_timestamps))
+        self.write_persistent_cache(persistent_cache_key, base64.b64encode(blob).decode('ascii'))
 
     def report_highwater_offsets(self, highwater_offsets, contexts_limit, cluster_id):
         """Report the broker highwater offsets."""

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -2,8 +2,11 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import base64
+import ctypes
+import ctypes.util
 import json
 import marshal
+import platform
 from collections import defaultdict
 from time import time
 
@@ -23,6 +26,33 @@ MAX_TIMESTAMPS = 1000
 # per-partition history is scaled down from this budget as the partition count grows.
 MAX_TIMESTAMP_ENTRIES = 6_000_000
 
+# Persist the in-memory broker-timestamps cache to disk at most this often (seconds), instead of
+# marshalling the whole (growing) structure on every run.
+BROKER_TIMESTAMPS_SAVE_INTERVAL = 300
+
+
+def _load_malloc_trim():
+    """Return glibc's ``malloc_trim`` on Linux, or ``None`` where it is unavailable (macOS, musl)."""
+    if platform.system() != 'Linux':
+        return None
+    try:
+        libc = ctypes.CDLL(ctypes.util.find_library('c') or 'libc.so.6', use_errno=True)
+        trim = libc.malloc_trim
+    except (OSError, AttributeError):
+        return None
+    trim.argtypes = [ctypes.c_size_t]
+    trim.restype = ctypes.c_int
+    return trim
+
+
+MALLOC_TRIM = _load_malloc_trim()
+
+
+def _malloc_trim():
+    """Return glibc per-arena free memory to the OS after a run; no-op where unavailable."""
+    if MALLOC_TRIM is not None:
+        MALLOC_TRIM(0)
+
 
 class KafkaCheck(AgentCheck):
     __NAMESPACE__ = 'kafka'
@@ -35,6 +65,10 @@ class KafkaCheck(AgentCheck):
         self._max_timestamps = int(self.instance.get('timestamp_history_size', MAX_TIMESTAMPS))
         self.client = KafkaClient(self.config, self.log)
         self.topic_partition_cache = {}
+        # DSM broker-timestamps history kept in memory across runs (loaded from disk once on first
+        # run) so we don't marshal-load/dump the whole growing structure every run.
+        self._broker_timestamps = None
+        self._broker_timestamps_last_save = 0
         self.check_initializations.insert(0, self.config.validate_config)
 
         # Initialize cluster metadata collector
@@ -42,6 +76,12 @@ class KafkaCheck(AgentCheck):
 
     def check(self, _):
         """The main entrypoint of the check."""
+        try:
+            self._run_check()
+        finally:
+            _malloc_trim()
+
+    def _run_check(self):
         # Fetch Kafka consumer offsets
 
         consumer_offsets = {}
@@ -245,13 +285,17 @@ class KafkaCheck(AgentCheck):
         return self.client.list_consumer_group_offsets(groups)
 
     def _load_broker_timestamps(self, persistent_cache_key):
-        """Loads broker timestamps from persistent cache."""
+        """Return the in-memory broker timestamps, loading from persistent cache once on first run."""
+        if self._broker_timestamps is not None:
+            return self._broker_timestamps
+
         broker_timestamps = defaultdict(dict)
         try:
             broker_timestamps.update(marshal.loads(base64.b64decode(self.read_persistent_cache(persistent_cache_key))))
         except Exception as e:
             self.log.warning('Could not read broker timestamps from cache: %s', str(e))
-        return broker_timestamps
+        self._broker_timestamps = broker_timestamps
+        return self._broker_timestamps
 
     def _max_history(self, num_partitions):
         """Per-partition timestamp cap, scaled so total retained entries stay within the budget."""
@@ -278,9 +322,13 @@ class KafkaCheck(AgentCheck):
                 del timestamps[min(timestamps, key=timestamps.get)]
 
     def _save_broker_timestamps(self, broker_timestamps, persistent_cache_key):
-        """Saves broker timestamps to persistent cache."""
+        """Persist broker timestamps to disk, but only periodically to avoid per-run marshal churn."""
+        now = time()
+        if now - self._broker_timestamps_last_save < BROKER_TIMESTAMPS_SAVE_INTERVAL:
+            return
         blob = marshal.dumps(dict(broker_timestamps))
         self.write_persistent_cache(persistent_cache_key, base64.b64encode(blob).decode('ascii'))
+        self._broker_timestamps_last_save = now
 
     def report_highwater_offsets(self, highwater_offsets, contexts_limit, cluster_id):
         """Report the broker highwater offsets."""
@@ -432,19 +480,17 @@ class KafkaCheck(AgentCheck):
 
         dd_consumer_group = "datadog-agent"
 
+        # Reuse the consumer across runs (do not close it) so its per-broker threads persist.
         self.client.open_consumer(dd_consumer_group)
-        try:
-            cluster_id, _ = self.client.consumer_get_cluster_id_and_list_topics(dd_consumer_group)
+        cluster_id, _ = self.client.consumer_get_cluster_id_and_list_topics(dd_consumer_group)
 
-            self.log.debug('Querying %s highwater offsets', len(topic_partitions_to_check))
+        self.log.debug('Querying %s highwater offsets', len(topic_partitions_to_check))
 
-            result = {}
-            for topic, partition, offset in self.client.consumer_offsets_for_times(
-                partitions=topic_partitions_to_check, offset=HIGH_WATERMARK
-            ):
-                result[(topic, partition)] = offset
-        finally:
-            self.client.close_consumer()
+        result = {}
+        for topic, partition, offset in self.client.consumer_offsets_for_times(
+            partitions=topic_partitions_to_check, offset=HIGH_WATERMARK
+        ):
+            result[(topic, partition)] = offset
 
         self.log.debug('Got %s highwater offsets', len(result))
         return result, cluster_id

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1132,6 +1132,32 @@ def test_fetch_earliest_offsets_cached_across_calls(check):
     assert mock_kafka_client.kafka_client.list_offsets.call_count == 1
 
 
+def test_fetch_earliest_offsets_refetches_when_cache_missing_partitions(check):
+    """A fresh cache that doesn't cover every requested partition triggers a full refetch, keeping the same TTL."""
+    instance = {
+        'kafka_connect_str': 'localhost:9092',
+        'enable_cluster_monitoring': True,
+    }
+    kafka_consumer_check = check(instance)
+    mock_kafka_client = seed_mock_kafka_client()
+    kafka_consumer_check.client = mock_kafka_client
+    kafka_consumer_check.metadata_collector.client = mock_kafka_client
+
+    collector = kafka_consumer_check.metadata_collector
+    expire_at = time.time() + 300
+    seed_payload = json.dumps({'expire_at': expire_at, 'offsets': [['test-topic', 0, 10]]})
+    _wire_cache(kafka_consumer_check, seed={collector.EARLIEST_OFFSETS_CACHE_KEY: seed_payload})
+
+    topic_partitions = {'test-topic': [0, 1]}
+    result = collector._fetch_earliest_offsets(topic_partitions)
+
+    assert result == {('test-topic', 0): 10, ('test-topic', 1): 20}
+    assert mock_kafka_client.kafka_client.list_offsets.call_count == 1
+
+    saved = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    assert saved['expire_at'] == expire_at
+
+
 def test_schema_registry_oauth_oidc_token(check, dd_run_check, aggregator):
     """Test that OIDC OAuth token is fetched and passed as Bearer header for Schema Registry."""
     instance = {

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1107,6 +1107,31 @@ def test_kafka_configs_refresh_interval(check, interval, expected_interval, expe
     assert collector.CONFIGS_REFRESH_JITTER == expected_jitter
 
 
+def test_fetch_earliest_offsets_cached_across_calls(check):
+    """fetch_earliest_offsets should hit the broker once, then serve later calls from cache."""
+    instance = {
+        'kafka_connect_str': 'localhost:9092',
+        'enable_cluster_monitoring': True,
+    }
+    kafka_consumer_check = check(instance)
+    mock_kafka_client = seed_mock_kafka_client()
+    kafka_consumer_check.client = mock_kafka_client
+    kafka_consumer_check.metadata_collector.client = mock_kafka_client
+
+    _wire_cache(kafka_consumer_check)
+
+    collector = kafka_consumer_check.metadata_collector
+    topic_partitions = {'test-topic': [0, 1]}
+
+    first = collector._fetch_earliest_offsets(topic_partitions)
+    second = collector._fetch_earliest_offsets(topic_partitions)
+
+    expected = {('test-topic', 0): 10, ('test-topic', 1): 20}
+    assert first == expected
+    assert second == expected
+    assert mock_kafka_client.kafka_client.list_offsets.call_count == 1
+
+
 def test_schema_registry_oauth_oidc_token(check, dd_run_check, aggregator):
     """Test that OIDC OAuth token is fetched and passed as Bearer header for Schema Registry."""
     instance = {

--- a/kafka_consumer/tests/test_integration.py
+++ b/kafka_consumer/tests/test_integration.py
@@ -1,8 +1,9 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import json
+import base64
 import logging
+import marshal
 from collections import defaultdict
 from contextlib import nullcontext as does_not_raise
 
@@ -27,7 +28,7 @@ def mocked_read_persistent_cache(cache_key):
     cached_offsets["dc_0"][40] = 200
     cached_offsets["dc_1"][25] = 150
     cached_offsets["dc_1"][40] = 200
-    return json.dumps(cached_offsets)
+    return base64.b64encode(marshal.dumps(dict(cached_offsets))).decode('ascii')
 
 
 def mocked_time():

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
 import logging
+from collections import defaultdict
 from contextlib import nullcontext as does_not_raise
 
 import mock
@@ -528,6 +529,33 @@ def test_add_broker_timestamps_evicts_by_oldest_timestamp(kafka_instance, check)
     assert 500 not in timestamps  # oldest by timestamp
     assert 400 in timestamps
     assert 600 in timestamps
+
+
+def test_max_history_scales_with_partition_count(check, kafka_instance):
+    kafka_consumer_check = check(kafka_instance)  # default timestamp_history_size = 1000
+    assert kafka_consumer_check._max_history(0) == 1000
+    assert kafka_consumer_check._max_history(1) == 1000
+    assert kafka_consumer_check._max_history(6000) == 1000  # 6M / 6000 = 1000 (breakeven)
+    assert kafka_consumer_check._max_history(60000) == 100  # 6M / 60000
+    assert kafka_consumer_check._max_history(6_000_000) == 2  # floored at 2
+
+
+def test_add_broker_timestamps_caps_total_by_budget(check, kafka_instance, monkeypatch):
+    import datadog_checks.kafka_consumer.kafka_consumer as kc
+
+    monkeypatch.setattr(kc, 'MAX_TIMESTAMP_ENTRIES', 1000)
+    kafka_consumer_check = check(kafka_instance)
+    # 100 partitions against a 1000-entry budget -> per-partition cap of 10.
+    highwater_offsets = {("topic1", p): 0 for p in range(100)}
+    broker_timestamps = defaultdict(dict)
+
+    # One new offset per simulated check run, as in real usage: eviction removes
+    # a single oldest entry per call, so the cap is only reached after enough runs.
+    for offset in range(1, 61):
+        highwater_offsets[("topic1", 0)] = offset
+        kafka_consumer_check._add_broker_timestamps(broker_timestamps, highwater_offsets)
+
+    assert len(broker_timestamps["topic1_0"]) <= 11
 
 
 def test_count_consumer_contexts(check, kafka_instance):


### PR DESCRIPTION
### What does this PR do?
Backports six kafka_consumer changes to the `7.81.x` branch:
- #24472: Persist the DSM broker timestamps cache using `marshal` instead of JSON, to reduce cluster-check-runner memory churn.
- #24508: Cap the retained `broker_timestamps` history per cluster by a per-partition budget derived from `MAX_TIMESTAMP_ENTRIES`, so memory use no longer grows unbounded with partition count.
- #24515: Cache earliest (log-start) offsets per broker-config-derived TTL instead of fetching them on every check run, and refetch from the broker (without extending the TTL) if a fresh cache doesn't cover every requested partition.
- #24552: Reuse the librdkafka `AdminClient` and `Consumer` across runs (default `close_admin_client` to false, idempotent `open_consumer`, stop closing the cluster-id consumer) so per-broker threads and their glibc arenas persist and their memory is recycled in place instead of stranded each run.
- #24553: Call `malloc_trim(0)` after each run (glibc/Linux only) to return per-arena free memory to the OS.
- #24554: Keep the DSM `broker_timestamps` cache in memory across runs and persist it to disk at most every 5 minutes, removing the per-run marshal load/dump churn that scaled with cache size.

The #24508 and #24515 changes were adapted during the backport: #24508 was built on master's newer bulk-pruning `_add_broker_timestamps` (with `prune_floors`/`_visvalingam_whyatt`), so it was reimplemented on top of the 7.81.x branch's older single-oldest-eviction logic while preserving the same budget-scaling behavior. #24515's public `fetch_earliest_offsets` method was kept as the 7.81.x branch's existing private `_fetch_earliest_offsets` name to avoid an unrelated naming change.

### Motivation
Bring memory-usage and caching improvements already merged/in review on `master` to the `7.81.x` release branch.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
