### PR TITLE
Fix CI wrongly validating and testing unrelated integrations on stacked PRs

### DIFF
--- a/.github/workflows/compute-matrix.yml
+++ b/.github/workflows/compute-matrix.yml
@@ -38,9 +38,15 @@ jobs:
     - name: Fetch merge base
       env:
         GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        BASE_REF: "${{ github.event.pull_request.base.ref }}"
+        HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
       run: |-
+        # Compare against the base branch *name* rather than the event payload's cached
+        # `base.sha`, which goes stale (and produces an overly broad diff) whenever the base
+        # branch is a moving/stacked branch that advances without a new push to this PR's head.
+        encoded_base_ref=$(jq -rn --arg ref "$BASE_REF" '$ref | @uri')
         merge_base=$(gh api \
-          repos/${{ github.repository }}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} \
+          "repos/${{ github.repository }}/compare/${encoded_base_ref}...${HEAD_SHA}" \
           --jq '.merge_base_commit.sha')
         echo "MERGE_BASE=$merge_base" >> "$GITHUB_ENV"
         git -c protocol.version=2 fetch --no-tags --no-recurse-submodules --filter=blob:none origin "$merge_base"

--- a/datadog_checks_dev/changelog.d/24543.fixed
+++ b/datadog_checks_dev/changelog.d/24543.fixed
@@ -1,0 +1,1 @@
+Fix changed-file detection ignoring the PR's actual base branch when computing the license-headers validation scope.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -39,20 +39,22 @@ def get_current_branch():
 
 def content_changed(file_glob="*"):
     """
-    Return the content changed in the current branch compared to `master`
+    Return the content changed in the current branch compared to the base branch
     """
     with chdir(get_root()):
-        output = run_command(f'git diff master -U0 -- "{file_glob}"', capture='out')
+        output = run_command(f'git diff {get_base_ref()} -U0 -- "{file_glob}"', capture='out')
     return output.stdout
 
 
 def files_changed(include_uncommitted=True):
     """
-    Return the list of file changed in the current branch compared to `master`
+    Return the list of file changed in the current branch compared to the base branch
     """
+    base_ref = get_base_ref()
+
     with chdir(get_root()):
         # Use `--name-status` to include moved files
-        name_status_result = run_command('git diff --name-status origin/master...', capture='out')
+        name_status_result = run_command(f'git diff --name-status {base_ref}...', capture='out')
 
     name_status_lines = name_status_result.stdout.splitlines()
 
@@ -64,7 +66,7 @@ def files_changed(include_uncommitted=True):
     if include_uncommitted:
         with chdir(get_root()):
             # Use `--name-only` to include uncommitted files
-            name_only_result = run_command('git diff --name-only master', capture='out')
+            name_only_result = run_command(f'git diff --name-only {base_ref}', capture='out')
         name_only_lines = name_only_result.stdout.splitlines()
         changed_files.extend(name_only_lines)
 

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -35,59 +35,74 @@ def test_get_current_branch():
 
 
 def test_files_changed():
-    with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
-        with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
-            name_status_out = mock.MagicMock()
-            name_status_out.stdout = '''
+    with mock.patch('datadog_checks.dev.tooling.git.get_base_ref', return_value='origin/master'):
+        with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
+            with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
+                name_status_out = mock.MagicMock()
+                name_status_out.stdout = '''
 M	foo
 R100	bar	baz
 R100	foo2	foo3
             '''
-            name_only_out = mock.MagicMock()
-            name_only_out.stdout = '''
+                name_only_out = mock.MagicMock()
+                name_only_out.stdout = '''
 file1
 file2
 '''
 
-            run.side_effect = [name_status_out, name_only_out]
-            set_root('/foo/')
-            retval = files_changed()
+                run.side_effect = [name_status_out, name_only_out]
+                set_root('/foo/')
+                retval = files_changed()
 
-            chdir.assert_has_calls(
-                [
-                    # since chdir is a context manager, we need to also assert __enter__/__exit__
-                    mock.call('/foo/'),
-                    mock.call().__enter__(),
-                    mock.call().__exit__(None, None, None),
-                    mock.call('/foo/'),
-                    mock.call().__enter__(),
-                    mock.call().__exit__(None, None, None),
+                chdir.assert_has_calls(
+                    [
+                        # since chdir is a context manager, we need to also assert __enter__/__exit__
+                        mock.call('/foo/'),
+                        mock.call().__enter__(),
+                        mock.call().__exit__(None, None, None),
+                        mock.call('/foo/'),
+                        mock.call().__enter__(),
+                        mock.call().__exit__(None, None, None),
+                    ]
+                )
+                calls = [
+                    mock.call('git diff --name-status origin/master...', capture='out'),
+                    mock.call('git diff --name-only origin/master', capture='out'),
                 ]
-            )
-            calls = [
-                mock.call('git diff --name-status origin/master...', capture='out'),
-                mock.call('git diff --name-only master', capture='out'),
-            ]
-            run.assert_has_calls(calls)
-            assert retval == ['bar', 'baz', 'file1', 'file2', 'foo', 'foo2', 'foo3']
+                run.assert_has_calls(calls)
+                assert retval == ['bar', 'baz', 'file1', 'file2', 'foo', 'foo2', 'foo3']
 
 
 def test_files_changed_not_include_uncommitted():
-    with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
-        with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
-            name_status_out = mock.MagicMock()
-            name_status_out.stdout = '''
+    with mock.patch('datadog_checks.dev.tooling.git.get_base_ref', return_value='origin/master'):
+        with mock.patch('datadog_checks.dev.tooling.git.chdir') as chdir:
+            with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
+                name_status_out = mock.MagicMock()
+                name_status_out.stdout = '''
 M	foo
 R100	bar	baz
 R100	foo2	foo3
             '''
-            run.side_effect = [name_status_out]
-            set_root('/foo/')
-            retval = files_changed(include_uncommitted=False)
+                run.side_effect = [name_status_out]
+                set_root('/foo/')
+                retval = files_changed(include_uncommitted=False)
 
-            chdir.assert_called_once_with('/foo/')
-            run.assert_called_once_with('git diff --name-status origin/master...', capture='out')
-            assert retval == ['bar', 'baz', 'foo', 'foo2', 'foo3']
+                chdir.assert_called_once_with('/foo/')
+                run.assert_called_once_with('git diff --name-status origin/master...', capture='out')
+                assert retval == ['bar', 'baz', 'foo', 'foo2', 'foo3']
+
+
+def test_files_changed_uses_pr_base_ref():
+    with mock.patch('datadog_checks.dev.tooling.git.get_base_ref', return_value='origin/feature-base'):
+        with mock.patch('datadog_checks.dev.tooling.git.chdir'):
+            with mock.patch('datadog_checks.dev.tooling.git.run_command') as run:
+                name_status_out = mock.MagicMock()
+                name_status_out.stdout = ''
+                run.side_effect = [name_status_out]
+                set_root('/foo/')
+                files_changed(include_uncommitted=False)
+
+                run.assert_called_once_with('git diff --name-status origin/feature-base...', capture='out')
 
 
 def test_get_commits_since():


### PR DESCRIPTION
### What does this PR do?

Fixes CI running the full integration test matrix (hundreds of jobs) instead of just the integration a PR actually touches, when the PR's base branch is itself another unmerged (stacked) branch — as seen on https://github.com/DataDog/integrations-core/pull/24487, whose base is `vwhitchurch/docker-run-env-vars-e2e`.

**Confirmed root cause:** `compute-matrix.yml`'s "Fetch merge base" step computes the test matrix's diff base from the `pull_request` event's cached `base.sha`. That value is a snapshot taken the last time *this PR's own head* was synchronized — it does not update when the base branch itself receives new commits. For a PR stacked on a moving/WIP branch, that cached `base.sha` can go stale relative to the base branch's real tip, producing a much wider diff than the PR's own changes and triggering the full integration test matrix.

I verified this directly against #24487's failing run (`29333935437`): the "Fetch merge base" step used `base.sha = 283cdf2` (from 2026-07-10), four days older than the base branch's actual tip at run time, producing a huge diff (`.github`, `datadog_checks_dev`, `gearmand`, `pulsar`, `ray`, `temporal`) and running the full matrix. I then pushed a fresh commit to #24487's head (a diagnostic commit, reverted immediately after) — that refreshed the event's `base.sha` to the base branch's current tip, and the very next run correctly scoped the matrix to just `gearmand`, with no code change needed. That confirms the staleness is the mechanism; this PR removes the dependency on that lucky-timing refresh by resolving the base branch live every run.

Fixed by diffing against the base branch *name* (`github.event.pull_request.base.ref`, percent-encoded) instead of `base.sha`, so GitHub always resolves its current tip rather than a cached value.

**Also included, as an independent correctness fix (not confirmed to have caused the specific validate failure on #24487 — see note below):** `files_changed()`/`content_changed()` in `datadog_checks_dev/datadog_checks/dev/tooling/git.py` hardcoded a diff against `master`/`origin/master` instead of the actual PR base ref, unlike `get_base_ref()` (already defined in the same file) which correctly resolves it via `GITHUB_BASE_REF`. This makes every integration touched by an unmerged base branch look "changed" for `ddev validate all changed`, which is real and reproducible (confirmed via diagnostics on #24487), but in practice it didn't cause a validation failure there — the per-file license-header content comparison already uses the correct base ref and the affected files were identical, so it passed. Still, running full validations against integrations the PR never touched is wasteful and is a latent correctness gap, so it's fixed the same way (`get_base_ref()`).

### Motivation

PR #24487 intermittently ran the full integration test matrix instead of just `gearmand`. Root-caused via a scratch worktree plus temporary, reverted diagnostic commits on #24487 (with the author's OK) to confirm the mechanism against live CI rather than guessing. Note: the `license-headers` failure originally observed on #24487 does not appear to reproduce from the base-ref-selection issue — re-running validate on the same commit passed, so that specific failure looks like a one-off flake rather than something this PR's `files_changed()` change addresses. This PR only changes diffing/base-ref logic; no code under `datadog_checks/` is affected.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged