### PR TITLE
Bump datadog-checks-base floor for integrations with config discovery

### DIFF
--- a/cockroachdb/changelog.d/24545.fixed
+++ b/cockroachdb/changelog.d/24545.fixed
@@ -1,0 +1,1 @@
+Require `datadog-checks-base>=37.41.0` since config discovery relies on it.

--- a/cockroachdb/pyproject.toml
+++ b/cockroachdb/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/flink/changelog.d/24545.fixed
+++ b/flink/changelog.d/24545.fixed
@@ -1,0 +1,1 @@
+Require `datadog-checks-base>=37.41.0` since config discovery relies on it.

--- a/flink/pyproject.toml
+++ b/flink/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/kong/changelog.d/24545.fixed
+++ b/kong/changelog.d/24545.fixed
@@ -1,0 +1,1 @@
+Require `datadog-checks-base>=37.41.0` since config discovery relies on it.

--- a/kong/pyproject.toml
+++ b/kong/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/krakend/changelog.d/24545.fixed
+++ b/krakend/changelog.d/24545.fixed
@@ -1,0 +1,1 @@
+Require `datadog-checks-base>=37.41.0` since config discovery relies on it.

--- a/krakend/pyproject.toml
+++ b/krakend/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: System :: Monitoring",
 ]
-dependencies = ["datadog-checks-base>=37.33.0"]
+dependencies = ["datadog-checks-base>=37.41.0"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/milvus/changelog.d/24545.fixed
+++ b/milvus/changelog.d/24545.fixed
@@ -1,0 +1,1 @@
+Require `datadog-checks-base>=37.41.0` since config discovery relies on it.

--- a/milvus/pyproject.toml
+++ b/milvus/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/n8n/changelog.d/24545.fixed
+++ b/n8n/changelog.d/24545.fixed
@@ -1,0 +1,1 @@
+Require `datadog-checks-base>=37.41.0` since config discovery relies on it.

--- a/n8n/pyproject.toml
+++ b/n8n/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/prefect/changelog.d/24545.fixed
+++ b/prefect/changelog.d/24545.fixed
@@ -1,0 +1,1 @@
+Require `datadog-checks-base>=37.41.0` since config discovery relies on it.

--- a/prefect/pyproject.toml
+++ b/prefect/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/pulsar/changelog.d/24545.fixed
+++ b/pulsar/changelog.d/24545.fixed
@@ -1,0 +1,1 @@
+Require `datadog-checks-base>=37.41.0` since config discovery relies on it.

--- a/pulsar/pyproject.toml
+++ b/pulsar/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/ray/changelog.d/24545.fixed
+++ b/ray/changelog.d/24545.fixed
@@ -1,0 +1,1 @@
+Require `datadog-checks-base>=37.41.0` since config discovery relies on it.

--- a/ray/pyproject.toml
+++ b/ray/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/scylla/changelog.d/24545.fixed
+++ b/scylla/changelog.d/24545.fixed
@@ -1,0 +1,1 @@
+Require `datadog-checks-base>=37.41.0` since config discovery relies on it.

--- a/scylla/pyproject.toml
+++ b/scylla/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/teleport/changelog.d/24545.fixed
+++ b/teleport/changelog.d/24545.fixed
@@ -1,0 +1,1 @@
+Require `datadog-checks-base>=37.41.0` since config discovery relies on it.

--- a/teleport/pyproject.toml
+++ b/teleport/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",

--- a/temporal/changelog.d/24545.fixed
+++ b/temporal/changelog.d/24545.fixed
@@ -1,0 +1,1 @@
+Require `datadog-checks-base>=37.41.0` since config discovery relies on it.

--- a/temporal/pyproject.toml
+++ b/temporal/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=37.41.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?

Bumps the minimum allowed `datadog-checks-base` version from `>=37.33.0` to `>=37.41.0` in `pyproject.toml` for the integrations that already ship generated container-based config discovery support: cockroachdb, flink, kong, krakend, milvus, n8n, prefect, pulsar, ray, scylla, teleport, temporal.

### Motivation

Each of these integrations' generated `config_models/discovery.py` imports `Service` and `candidate_ports` from `datadog_checks.base.utils.discovery`, which was only added in `datadog-checks-base` 37.41.0 (#23963). Their `pyproject.toml` still allowed `datadog-checks-base>=37.33.0`, so an environment pinned to an older allowed base version would install a package that advertises discovery support but can't actually load it. Flagged by Codex review on #24494 for boundary; this PR applies the same fix to every integration on `master` that already merged discovery support.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged