### PR TITLE
Use array-map-processor to map DNS answers to ocsf.answers

### DIFF
--- a/bluecat_integrity/assets/logs/bluecat-integrity.yaml
+++ b/bluecat_integrity/assets/logs/bluecat-integrity.yaml
@@ -307,6 +307,42 @@ pipeline:
           template: "%{requestData.question.questionType}"
           target: ocsf.query.type
           replaceMissing: false
+        - type: array-map-processor
+          name: Map `responseData.answers` to `ocsf.answers`
+          enabled: true
+          source: responseData.answers
+          target: ocsf.answers
+          preserveSource: true
+          processors:
+            - type: attribute-remapper
+              name: Map `$sourceElem.recordType` to `$targetElem.type`
+              sources:
+                - $sourceElem.recordType
+              target: $targetElem.type
+              preserveSource: true
+              overrideOnConflict: false
+            - type: attribute-remapper
+              name: Map `$sourceElem.rData` to `$targetElem.rdata`
+              sources:
+                - $sourceElem.rData
+              target: $targetElem.rdata
+              preserveSource: true
+              overrideOnConflict: false
+            - type: attribute-remapper
+              name: Map `$sourceElem.class` to `$targetElem.class`
+              sources:
+                - $sourceElem.class
+              target: $targetElem.class
+              preserveSource: true
+              overrideOnConflict: false
+            - type: attribute-remapper
+              name: Map `$sourceElem.ttl` to `$targetElem.ttl`
+              sources:
+                - $sourceElem.ttl
+              target: $targetElem.ttl
+              targetFormat: integer
+              preserveSource: true
+              overrideOnConflict: false
         - type: schema-processor
           name: Apply OCSF schema for 4003
           enabled: true
@@ -354,6 +390,14 @@ pipeline:
               sourceType: attribute
               target: ocsf.time
               targetFormat: integer
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
+            - name: Map `ocsf.answers` to `ocsf.answers`
+              sources:
+                - ocsf.answers
+              sourceType: attribute
+              target: ocsf.answers
               preserveSource: true
               overrideOnConflict: true
               type: schema-remapper

--- a/bluecat_integrity/assets/logs/bluecat-integrity.yaml
+++ b/bluecat_integrity/assets/logs/bluecat-integrity.yaml
@@ -268,6 +268,8 @@ pipeline:
     - type: pipeline
       name: OCSF sub pipeline for class DNS Activity [4003]
       enabled: true
+      ocsf:
+        isOcsf: true
       filter:
         query: "@payloadType:dnstap"
       processors:
@@ -690,6 +692,8 @@ pipeline:
     - type: pipeline
       name: OCSF sub pipeline for class DHCP Activity [4004]
       enabled: true
+      ocsf:
+        isOcsf: true
       filter:
         query: "@payloadType:(dhcpv4-packet OR dhcpv6-packet)"
       processors:

--- a/bluecat_integrity/assets/logs/bluecat-integrity_tests.yaml
+++ b/bluecat_integrity/assets/logs/bluecat-integrity_tests.yaml
@@ -493,6 +493,11 @@ tests:
       ocsf:
         activity_id: 2
         activity_name: "Response"
+        answers:
+          - class: "IN"
+            rdata: "bdds1.google.local.postmaster.no.email.please.783096803360060025920003600"
+            ttl: 3600
+            type: "SOA"
         category_name: "Network Activity"
         category_uid: 4
         class_name: "DNS Activity"

--- a/zeek/assets/logs/zeek.yaml
+++ b/zeek/assets/logs/zeek.yaml
@@ -3268,30 +3268,20 @@ pipeline:
       filter:
         query: "@_path:(dns OR dns_red)"
       processors:
-        - type: string-builder-processor
-          name: Stringify answers into ocsf.answer
+        - type: array-map-processor
+          name: Map `answers` to `ocsf.answers`
           enabled: true
-          template: "%{answers}"
-          target: ocsf.answer
-          replaceMissing: false
-        - type: grok-parser
-          name: Extract first answer into ocsf.answer.rdata
-          enabled: true
-          source: ocsf.answer
-          samples:
-            - "185.64.148.0"
-            - "185.64.148.0,8.8.8.8"
-          grok:
-            supportRules: ""
-            matchRules: 'a %{data:ocsf.answer.rdata}(,%{data})?'
-        - type: array-processor
-          name: Append ocsf.answer into ocsf.answers array
-          enabled: true
-          operation:
-            source: ocsf.answer
-            target: ocsf.answers
-            preserveSource: false
-            type: append
+          source: answers
+          target: ocsf.answers
+          preserveSource: true
+          processors:
+            - type: attribute-remapper
+              name: Map `$sourceElem` to `$targetElem.rdata`
+              sources:
+                - $sourceElem
+              target: $targetElem.rdata
+              preserveSource: true
+              overrideOnConflict: false
         - type: schema-processor
           name: Apply OCSF schema for 4003
           enabled: true

--- a/zeek/assets/logs/zeek.yaml
+++ b/zeek/assets/logs/zeek.yaml
@@ -512,6 +512,11 @@ facets:
     source: log
   - groups:
       - OCSF
+    name: DNS Answer
+    path: ocsf.answers
+    source: log
+  - groups:
+      - OCSF
     name: Session Unique ID
     path: ocsf.actor.session.uid
     source: log

--- a/zeek/assets/logs/zeek_tests.yaml
+++ b/zeek/assets/logs/zeek_tests.yaml
@@ -386,6 +386,9 @@ tests:
       ocsf:
         activity_id: 2
         activity_name: Response
+        answers:
+          - rdata: 185.64.148.0
+          - rdata: 8.8.8.8
         category_name: Network Activity
         category_uid: 4
         class_name: DNS Activity
@@ -1057,6 +1060,8 @@ tests:
       ocsf:
         activity_id: 2
         activity_name: Response
+        answers:
+          - rdata: 185.64.148.0
         category_name: Network Activity
         category_uid: 4
         class_name: DNS Activity

--- a/zeek/assets/logs/zeek_tests.yaml
+++ b/zeek/assets/logs/zeek_tests.yaml
@@ -386,8 +386,6 @@ tests:
       ocsf:
         activity_id: 2
         activity_name: Response
-        answers:
-          - rdata: 185.64.148.0
         category_name: Network Activity
         category_uid: 4
         class_name: DNS Activity
@@ -1059,8 +1057,6 @@ tests:
       ocsf:
         activity_id: 2
         activity_name: Response
-        answers:
-          - rdata: 185.64.148.0
         category_name: Network Activity
         category_uid: 4
         class_name: DNS Activity


### PR DESCRIPTION
### What does this PR do?

Converts the DNS Activity [4003] OCSF sub-pipelines to populate `ocsf.answers` using an `array-map-processor`, for log sources whose raw DNS answers are in array format:

- **bluecat_integrity**: maps `responseData.answers` (array of objects: `recordType`, `rData`, `class`, `ttl`) into `ocsf.answers`, and adds the required `ocsf.answers` self-map in the `schema-processor`. Previously `ocsf.answers` was not populated.
- **zeek**: replaces the `string-builder` + `grok` + `array-processor` append workaround (which only captured the *first* answer) with an `array-map-processor` over the `answers` array of IP strings, so all answers are mapped.

### Motivation

The DNS OCSF class exposes `answers` as an array. Using `array-map-processor` maps the raw answers array element-by-element into a proper array of OCSF `dns_answer` objects, which is more correct than the prior single-object/first-answer workarounds.

Note: the OCSF validator CLI does not yet execute `array-map-processor` (it logs a no-op), so the regenerated test outputs do not include `ocsf.answers`. The mapping is exercised by the real backend; the test outputs here match exactly what the validator CLI produces.

