### PR TITLE
kafka_consumer: reuse AdminClient and Consumer connections across runs

### DIFF
--- a/kafka_consumer/changelog.d/24552.fixed
+++ b/kafka_consumer/changelog.d/24552.fixed
@@ -1,1 +1,1 @@
-Reuse the Kafka AdminClient and Consumer across check runs to prevent unbounded agent memory growth from librdkafka thread churn.
+Allow reusing the Kafka AdminClient and Consumer across check runs (via close_admin_client: false) to avoid unbounded agent memory growth from librdkafka thread churn.

--- a/kafka_consumer/changelog.d/24552.fixed
+++ b/kafka_consumer/changelog.d/24552.fixed
@@ -1,0 +1,1 @@
+Reuse the Kafka AdminClient and Consumer across check runs to prevent unbounded agent memory growth from librdkafka thread churn.

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -42,6 +42,10 @@ class KafkaClient:
         return self._kafka_client
 
     def open_consumer(self, consumer_group):
+        # Reuse the consumer across runs so its per-broker threads (and their glibc arenas) persist.
+        if self._consumer is not None:
+            return
+
         config = {
             "bootstrap.servers": self.config._kafka_connect_str,
             "group.id": consumer_group,
@@ -55,8 +59,11 @@ class KafkaClient:
         self.log.debug("Consumer instance %s created for group %s", self._consumer, consumer_group)
 
     def close_consumer(self):
+        if self._consumer is None:
+            return
         self.log.debug("Closing consumer instance %s", self._consumer)
         self._consumer.close()
+        self._consumer = None
 
     def __get_authentication_config(self):
         config = {

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -42,7 +42,6 @@ class KafkaClient:
         return self._kafka_client
 
     def open_consumer(self, consumer_group):
-        # Reuse the consumer across runs so its per-broker threads (and their glibc arenas) persist.
         if self._consumer is not None:
             return
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/config.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config.py
@@ -34,9 +34,6 @@ class KafkaConfig:
         # Optimization to avoid OOM kill:
         # https://github.com/confluentinc/confluent-kafka-python/issues/759
         self._consumer_queued_max_messages_kbytes = instance.get('consumer_queued_max_messages_kbytes', 1024)
-        # Reuse the AdminClient across runs by default so librdkafka's per-broker threads (and the
-        # glibc arenas they are bound to) stay alive and their memory is recycled in place instead of
-        # being stranded on every run. Set close_admin_client: true to restore the old churning behavior.
         self._close_admin_client = instance.get('close_admin_client', False)
 
         self._kafka_connect_str = instance.get('kafka_connect_str')

--- a/kafka_consumer/datadog_checks/kafka_consumer/config.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config.py
@@ -34,7 +34,7 @@ class KafkaConfig:
         # Optimization to avoid OOM kill:
         # https://github.com/confluentinc/confluent-kafka-python/issues/759
         self._consumer_queued_max_messages_kbytes = instance.get('consumer_queued_max_messages_kbytes', 1024)
-        self._close_admin_client = instance.get('close_admin_client', False)
+        self._close_admin_client = instance.get('close_admin_client', True)
 
         self._kafka_connect_str = instance.get('kafka_connect_str')
         self._kafka_version = instance.get('kafka_client_api_version')

--- a/kafka_consumer/datadog_checks/kafka_consumer/config.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config.py
@@ -34,7 +34,10 @@ class KafkaConfig:
         # Optimization to avoid OOM kill:
         # https://github.com/confluentinc/confluent-kafka-python/issues/759
         self._consumer_queued_max_messages_kbytes = instance.get('consumer_queued_max_messages_kbytes', 1024)
-        self._close_admin_client = instance.get('close_admin_client', True)
+        # Reuse the AdminClient across runs by default so librdkafka's per-broker threads (and the
+        # glibc arenas they are bound to) stay alive and their memory is recycled in place instead of
+        # being stranded on every run. Set close_admin_client: true to restore the old churning behavior.
+        self._close_admin_client = instance.get('close_admin_client', False)
 
         self._kafka_connect_str = instance.get('kafka_connect_str')
         self._kafka_version = instance.get('kafka_client_api_version')

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -499,7 +499,6 @@ class KafkaCheck(AgentCheck):
             ):
                 result[(topic, partition)] = offset
         finally:
-            # Reuse the consumer across runs unless close_admin_client is set (which reuses neither client).
             if self.config._close_admin_client:
                 self.client.close_consumer()
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -488,15 +488,20 @@ class KafkaCheck(AgentCheck):
         dd_consumer_group = "datadog-agent"
 
         self.client.open_consumer(dd_consumer_group)
-        cluster_id, _ = self.client.consumer_get_cluster_id_and_list_topics(dd_consumer_group)
+        try:
+            cluster_id, _ = self.client.consumer_get_cluster_id_and_list_topics(dd_consumer_group)
 
-        self.log.debug('Querying %s highwater offsets', len(topic_partitions_to_check))
+            self.log.debug('Querying %s highwater offsets', len(topic_partitions_to_check))
 
-        result = {}
-        for topic, partition, offset in self.client.get_partition_offsets(
-            partitions=topic_partitions_to_check, offset=HIGH_WATERMARK
-        ):
-            result[(topic, partition)] = offset
+            result = {}
+            for topic, partition, offset in self.client.get_partition_offsets(
+                partitions=topic_partitions_to_check, offset=HIGH_WATERMARK
+            ):
+                result[(topic, partition)] = offset
+        finally:
+            # Reuse the consumer across runs unless close_admin_client is set (which reuses neither client).
+            if self.config._close_admin_client:
+                self.client.close_consumer()
 
         self.log.debug('Got %s highwater offsets', len(result))
         return result, cluster_id

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -487,7 +487,6 @@ class KafkaCheck(AgentCheck):
 
         dd_consumer_group = "datadog-agent"
 
-        # Reuse the consumer across runs (do not close it) so its per-broker threads persist.
         self.client.open_consumer(dd_consumer_group)
         cluster_id, _ = self.client.consumer_get_cluster_id_and_list_topics(dd_consumer_group)
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -487,19 +487,17 @@ class KafkaCheck(AgentCheck):
 
         dd_consumer_group = "datadog-agent"
 
+        # Reuse the consumer across runs (do not close it) so its per-broker threads persist.
         self.client.open_consumer(dd_consumer_group)
-        try:
-            cluster_id, _ = self.client.consumer_get_cluster_id_and_list_topics(dd_consumer_group)
+        cluster_id, _ = self.client.consumer_get_cluster_id_and_list_topics(dd_consumer_group)
 
-            self.log.debug('Querying %s highwater offsets', len(topic_partitions_to_check))
+        self.log.debug('Querying %s highwater offsets', len(topic_partitions_to_check))
 
-            result = {}
-            for topic, partition, offset in self.client.get_partition_offsets(
-                partitions=topic_partitions_to_check, offset=HIGH_WATERMARK
-            ):
-                result[(topic, partition)] = offset
-        finally:
-            self.client.close_consumer()
+        result = {}
+        for topic, partition, offset in self.client.get_partition_offsets(
+            partitions=topic_partitions_to_check, offset=HIGH_WATERMARK
+        ):
+            result[(topic, partition)] = offset
 
         self.log.debug('Got %s highwater offsets', len(result))
         return result, cluster_id


### PR DESCRIPTION
### What does this PR do?

Allow the librdkafka `AdminClient` and `Consumer` to be reused across check runs instead of recreated every collection, gated by the existing `close_admin_client` flag (default unchanged):

- `close_admin_client` keeps its previous default of `true` — default behavior is unchanged. Set `close_admin_client: false` to opt into reuse of **both** clients.
- Make `KafkaClient.open_consumer` idempotent and have `close_consumer` clear the handle.
- In `get_highwater_offsets`, only close the cluster-id consumer when `close_admin_client` is set, so the consumer is reused (or not) under the same flag as the AdminClient.

### Motivation

librdkafka runs roughly one thread per broker. Tearing the clients down and recreating them on every run (every `min_collection_interval`) kills and respawns those threads each time. On high-core hosts glibc's default arena cap is `8 x ncpu`, so the churned threads spread allocations across hundreds of per-thread arenas whose freed memory is retained per-arena rather than reused or returned to the OS — driving unbounded agent RSS growth (observed climbing multiple GB toward OOM on a 3-cluster, ~70k-partition target). Setting `close_admin_client: false` keeps the clients — and therefore the threads and their arenas — alive so each run reuses the same memory in place. The default is left unchanged so existing deployments are not affected unless they opt in.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
