### PR TITLE
kafka_consumer: return freed memory to the OS with malloc_trim after each run

### DIFF
--- a/kafka_consumer/changelog.d/24553.fixed
+++ b/kafka_consumer/changelog.d/24553.fixed
@@ -1,0 +1,1 @@
+Call malloc_trim after each run to return librdkafka's per-arena free memory to the OS and curb agent memory growth.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -31,7 +31,7 @@ MAX_TIMESTAMP_ENTRIES = 6_000_000
 LAG_EXTRAPOLATION_LIMIT_SECONDS = 600
 
 
-def _load_malloc_trim():
+def load_malloc_trim():
     """Return glibc's ``malloc_trim`` on Linux, or ``None`` where it is unavailable (macOS, musl)."""
     if platform.system() != 'Linux':
         return None
@@ -45,13 +45,10 @@ def _load_malloc_trim():
     return trim
 
 
-# librdkafka runs one thread per broker, so allocations spread across many glibc arenas whose freed
-# memory is retained per-arena rather than returned to the OS. Trimming after each run hands that
-# free memory back and keeps RSS from growing unbounded on high-core hosts.
-MALLOC_TRIM = _load_malloc_trim()
+MALLOC_TRIM = load_malloc_trim()
 
 
-def _malloc_trim():
+def malloc_trim():
     """Return glibc per-arena free memory to the OS after a run; no-op where unavailable."""
     if MALLOC_TRIM is not None:
         MALLOC_TRIM(0)
@@ -81,7 +78,7 @@ class KafkaCheck(AgentCheck):
         try:
             self._run_check()
         finally:
-            _malloc_trim()
+            malloc_trim()
 
     def _run_check(self):
         # Fetch Kafka consumer offsets

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -2,9 +2,12 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import base64
+import ctypes
+import ctypes.util
 import heapq
 import json
 import marshal
+import platform
 from collections import defaultdict
 from time import time
 
@@ -28,6 +31,32 @@ MAX_TIMESTAMP_ENTRIES = 6_000_000
 LAG_EXTRAPOLATION_LIMIT_SECONDS = 600
 
 
+def _load_malloc_trim():
+    """Return glibc's ``malloc_trim`` on Linux, or ``None`` where it is unavailable (macOS, musl)."""
+    if platform.system() != 'Linux':
+        return None
+    try:
+        libc = ctypes.CDLL(ctypes.util.find_library('c') or 'libc.so.6', use_errno=True)
+        trim = libc.malloc_trim
+    except (OSError, AttributeError):
+        return None
+    trim.argtypes = [ctypes.c_size_t]
+    trim.restype = ctypes.c_int
+    return trim
+
+
+# librdkafka runs one thread per broker, so allocations spread across many glibc arenas whose freed
+# memory is retained per-arena rather than returned to the OS. Trimming after each run hands that
+# free memory back and keeps RSS from growing unbounded on high-core hosts.
+MALLOC_TRIM = _load_malloc_trim()
+
+
+def _malloc_trim():
+    """Return glibc per-arena free memory to the OS after a run; no-op where unavailable."""
+    if MALLOC_TRIM is not None:
+        MALLOC_TRIM(0)
+
+
 class KafkaCheck(AgentCheck):
     __NAMESPACE__ = 'kafka'
 
@@ -49,6 +78,12 @@ class KafkaCheck(AgentCheck):
 
     def check(self, _):
         """The main entrypoint of the check."""
+        try:
+            self._run_check()
+        finally:
+            _malloc_trim()
+
+    def _run_check(self):
         # Fetch Kafka consumer offsets
 
         consumer_offsets = {}


### PR DESCRIPTION
### What does this PR do?

Call glibc `malloc_trim(0)` after every check run (in a `finally`), so per-arena free memory is returned to the OS each cycle. It is resolved once at import via `ctypes` and is a no-op on platforms without it (macOS, musl).

### Motivation

librdkafka runs roughly one thread per broker, and on high-core hosts glibc spreads allocations across many per-thread arenas (default cap `8 x ncpu`). glibc only ever returns memory from the top of an arena's heap and never coalesces free chunks across arenas, so the transient allocations each run leaves behind accumulate as retained-but-unused memory and agent RSS ratchets upward. `malloc_trim(0)` walks the arenas and hands their free memory back to the OS, keeping RSS bounded without requiring a `MALLOC_ARENA_MAX` environment variable. Overhead is negligible for this check (runs are network-bound at several seconds).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
