### PR TITLE
kafka_consumer: keep broker_timestamps in memory and persist every 5 minutes

### DIFF
--- a/kafka_consumer/changelog.d/24554.fixed
+++ b/kafka_consumer/changelog.d/24554.fixed
@@ -1,0 +1,1 @@
+Keep the DSM broker_timestamps cache in memory and persist it at most every 5 minutes to reduce per-run allocation churn and memory growth.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -27,8 +27,6 @@ MAX_TIMESTAMP_ENTRIES = 6_000_000
 
 LAG_EXTRAPOLATION_LIMIT_SECONDS = 600
 
-# Persist the in-memory broker-timestamps cache to disk at most this often (seconds), instead of
-# marshalling the whole (growing) structure on every run.
 BROKER_TIMESTAMPS_SAVE_INTERVAL = 300
 
 
@@ -43,10 +41,8 @@ class KafkaCheck(AgentCheck):
         self._max_timestamps = int(self.instance.get('timestamp_history_size', MAX_TIMESTAMPS))
         self.client = KafkaClient(self.config, self.log)
         self.topic_partition_cache = {}
-        # DSM broker-timestamps history kept in memory across runs (loaded from disk once on first
-        # run) so we don't marshal-load/dump the whole growing structure every run.
-        self._broker_timestamps = None
-        self._broker_timestamps_last_save = 0
+        self.broker_timestamps = None
+        self.broker_timestamps_last_save = 0
         self.check_initializations.insert(0, self.config.validate_config)
 
         # Initialize cluster metadata collector
@@ -293,16 +289,16 @@ class KafkaCheck(AgentCheck):
 
     def _load_broker_timestamps(self, persistent_cache_key):
         """Return the in-memory broker timestamps, loading from persistent cache once on first run."""
-        if self._broker_timestamps is not None:
-            return self._broker_timestamps
+        if self.broker_timestamps is not None:
+            return self.broker_timestamps
 
         broker_timestamps = defaultdict(dict)
         try:
             broker_timestamps.update(marshal.loads(base64.b64decode(self.read_persistent_cache(persistent_cache_key))))
         except Exception as e:
             self.log.warning('Could not read broker timestamps from cache: %s', str(e))
-        self._broker_timestamps = broker_timestamps
-        return self._broker_timestamps
+        self.broker_timestamps = broker_timestamps
+        return self.broker_timestamps
 
     def _earliest_consumer_offsets(self, consumer_offsets):
         """Return the lowest committed offset per (topic, partition) across all consumer groups."""
@@ -338,11 +334,11 @@ class KafkaCheck(AgentCheck):
     def _save_broker_timestamps(self, broker_timestamps, persistent_cache_key):
         """Persist broker timestamps to disk, but only periodically to avoid per-run marshal churn."""
         now = time()
-        if now - self._broker_timestamps_last_save < BROKER_TIMESTAMPS_SAVE_INTERVAL:
+        if now - self.broker_timestamps_last_save < BROKER_TIMESTAMPS_SAVE_INTERVAL:
             return
         blob = marshal.dumps(dict(broker_timestamps))
         self.write_persistent_cache(persistent_cache_key, base64.b64encode(blob).decode('ascii'))
-        self._broker_timestamps_last_save = now
+        self.broker_timestamps_last_save = now
 
     def report_highwater_offsets(self, highwater_offsets, contexts_limit, cluster_id):
         """Report the broker highwater offsets."""

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -27,6 +27,10 @@ MAX_TIMESTAMP_ENTRIES = 6_000_000
 
 LAG_EXTRAPOLATION_LIMIT_SECONDS = 600
 
+# Persist the in-memory broker-timestamps cache to disk at most this often (seconds), instead of
+# marshalling the whole (growing) structure on every run.
+BROKER_TIMESTAMPS_SAVE_INTERVAL = 300
+
 
 class KafkaCheck(AgentCheck):
     __NAMESPACE__ = 'kafka'
@@ -39,6 +43,10 @@ class KafkaCheck(AgentCheck):
         self._max_timestamps = int(self.instance.get('timestamp_history_size', MAX_TIMESTAMPS))
         self.client = KafkaClient(self.config, self.log)
         self.topic_partition_cache = {}
+        # DSM broker-timestamps history kept in memory across runs (loaded from disk once on first
+        # run) so we don't marshal-load/dump the whole growing structure every run.
+        self._broker_timestamps = None
+        self._broker_timestamps_last_save = 0
         self.check_initializations.insert(0, self.config.validate_config)
 
         # Initialize cluster metadata collector
@@ -284,13 +292,17 @@ class KafkaCheck(AgentCheck):
         return self.client.list_consumer_group_offsets(groups)
 
     def _load_broker_timestamps(self, persistent_cache_key):
-        """Loads broker timestamps from persistent cache."""
+        """Return the in-memory broker timestamps, loading from persistent cache once on first run."""
+        if self._broker_timestamps is not None:
+            return self._broker_timestamps
+
         broker_timestamps = defaultdict(dict)
         try:
             broker_timestamps.update(marshal.loads(base64.b64decode(self.read_persistent_cache(persistent_cache_key))))
         except Exception as e:
             self.log.warning('Could not read broker timestamps from cache: %s', str(e))
-        return broker_timestamps
+        self._broker_timestamps = broker_timestamps
+        return self._broker_timestamps
 
     def _earliest_consumer_offsets(self, consumer_offsets):
         """Return the lowest committed offset per (topic, partition) across all consumer groups."""
@@ -324,9 +336,13 @@ class KafkaCheck(AgentCheck):
                 _visvalingam_whyatt(timestamps, max(2, max_history // 2))
 
     def _save_broker_timestamps(self, broker_timestamps, persistent_cache_key):
-        """Saves broker timestamps to persistent cache."""
+        """Persist broker timestamps to disk, but only periodically to avoid per-run marshal churn."""
+        now = time()
+        if now - self._broker_timestamps_last_save < BROKER_TIMESTAMPS_SAVE_INTERVAL:
+            return
         blob = marshal.dumps(dict(broker_timestamps))
         self.write_persistent_cache(persistent_cache_key, base64.b64encode(blob).decode('ascii'))
+        self._broker_timestamps_last_save = now
 
     def report_highwater_offsets(self, highwater_offsets, contexts_limit, cluster_id):
         """Report the broker highwater offsets."""


### PR DESCRIPTION
### What does this PR do?

Keep the DSM `broker_timestamps` history in memory across check runs (loaded from the persistent cache only once, on the first run) and persist it back to disk at most once every 5 minutes, instead of marshal-loading and marshal-dumping the whole structure on every run.

### Motivation

With Data Streams enabled, the `broker_timestamps` cache grows toward its per-cluster entry cap. Loading it from disk (`base64` + `marshal.loads` into a dict of millions of small objects) and re-dumping it on every run created a large transient allocation each cycle that scales with the cache size, fragmenting the heap and driving agent RSS up. Holding the structure in memory removes the per-run load/dump churn; periodic persistence (every 5 min) preserves restart durability while keeping write churn low. On agent restart at most a few minutes of timestamp history is lost, which is acceptable for lag-in-seconds interpolation.

See #incident-57455 for the impact on memory fragmentation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
