### PR TITLE
Add discovery port name helper

### DIFF
--- a/datadog_checks_base/changelog.d/24555.added
+++ b/datadog_checks_base/changelog.d/24555.added
@@ -1,0 +1,1 @@
+Add a discovery helper for selecting service ports by name.

--- a/datadog_checks_base/datadog_checks/base/utils/discovery/__init__.pyi
+++ b/datadog_checks_base/datadog_checks/base/utils/discovery/__init__.pyi
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from .discovery import Discovery, Port, Service, candidate_ports
+from .discovery import Discovery, Port, Service, candidate_ports, candidate_ports_by_name
 from .strategies import discovery_strategy
 
-__all__ = ['Discovery', 'Port', 'Service', 'candidate_ports', 'discovery_strategy']
+__all__ = ['Discovery', 'Port', 'Service', 'candidate_ports', 'candidate_ports_by_name', 'discovery_strategy']

--- a/datadog_checks_base/datadog_checks/base/utils/discovery/discovery.py
+++ b/datadog_checks_base/datadog_checks/base/utils/discovery/discovery.py
@@ -67,6 +67,8 @@ def candidate_ports_by_name(service: Service, names: Iterable[str]) -> Iterator[
     seen: set[int] = set()
 
     for name in dict.fromkeys(names):
+        if not name:
+            continue
         for port in service.ports:
             if port.name == name and port.number not in seen:
                 seen.add(port.number)

--- a/datadog_checks_base/datadog_checks/base/utils/discovery/discovery.py
+++ b/datadog_checks_base/datadog_checks/base/utils/discovery/discovery.py
@@ -63,7 +63,7 @@ def candidate_ports(service: Service, hints: Iterable[int]) -> Iterator[Port]:
 
 
 def candidate_ports_by_name(service: Service, names: Iterable[str]) -> Iterator[Port]:
-    """Yield service ports matching one of the provided names."""
+    """Yield ports matching each name in order, with no fallback to unmatched ports."""
     seen: set[int] = set()
 
     for name in dict.fromkeys(names):

--- a/datadog_checks_base/datadog_checks/base/utils/discovery/discovery.py
+++ b/datadog_checks_base/datadog_checks/base/utils/discovery/discovery.py
@@ -60,3 +60,14 @@ def candidate_ports(service: Service, hints: Iterable[int]) -> Iterator[Port]:
         if port.number not in seen:
             seen.add(port.number)
             yield port
+
+
+def candidate_ports_by_name(service: Service, names: Iterable[str]) -> Iterator[Port]:
+    """Yield service ports matching one of the provided names."""
+    seen: set[int] = set()
+
+    for name in dict.fromkeys(names):
+        for port in service.ports:
+            if port.name == name and port.number not in seen:
+                seen.add(port.number)
+                yield port

--- a/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
+++ b/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
@@ -209,78 +209,68 @@ def test_candidate_ports_prefers_hints_and_deduplicates():
     ]
 
 
-def test_candidate_ports_by_name_only_yields_matching_ports():
-    service = Service(
-        id='svc',
-        host='127.0.0.1',
-        ports=(
-            Port(number=8080, name='http'),
-            Port(number=9090, name='metrics'),
-            Port(number=8081, name='admin'),
+@pytest.mark.parametrize(
+    "ports, names, expected",
+    [
+        pytest.param(
+            (
+                Port(number=8080, name='http'),
+                Port(number=9090, name='metrics'),
+                Port(number=8081, name='admin'),
+            ),
+            ['metrics', 'http-prom'],
+            [Port(number=9090, name='metrics')],
+            id="only_yields_matching_ports",
         ),
-    )
-
-    assert list(candidate_ports_by_name(service, ['metrics', 'http-prom'])) == [Port(number=9090, name='metrics')]
-
-
-def test_candidate_ports_by_name_respects_name_priority():
-    service = Service(
-        id='svc',
-        host='127.0.0.1',
-        ports=(
-            Port(number=8080, name='bar'),
-            Port(number=9090, name='foo'),
-            Port(number=8081, name='bar'),
-            Port(number=9091, name='foo'),
+        pytest.param(
+            (
+                Port(number=8080, name='bar'),
+                Port(number=9090, name='foo'),
+                Port(number=8081, name='bar'),
+                Port(number=9091, name='foo'),
+            ),
+            ['foo', 'bar'],
+            [
+                Port(number=9090, name='foo'),
+                Port(number=9091, name='foo'),
+                Port(number=8080, name='bar'),
+                Port(number=8081, name='bar'),
+            ],
+            id="respects_name_priority",
         ),
-    )
-
-    assert list(candidate_ports_by_name(service, ['foo', 'bar'])) == [
-        Port(number=9090, name='foo'),
-        Port(number=9091, name='foo'),
-        Port(number=8080, name='bar'),
-        Port(number=8081, name='bar'),
-    ]
-
-
-def test_candidate_ports_by_name_does_not_fallback_to_other_ports():
-    service = Service(
-        id='svc',
-        host='127.0.0.1',
-        ports=(
-            Port(number=8080, name='http'),
-            Port(number=8081, name='admin'),
+        pytest.param(
+            (
+                Port(number=8080, name='http'),
+                Port(number=8081, name='admin'),
+            ),
+            ['metrics'],
+            [],
+            id="does_not_fallback_to_other_ports",
         ),
-    )
-
-    assert list(candidate_ports_by_name(service, ['metrics'])) == []
-
-
-def test_candidate_ports_by_name_deduplicates_matching_port_numbers():
-    service = Service(
-        id='svc',
-        host='127.0.0.1',
-        ports=(
-            Port(number=8443, name='metrics'),
-            Port(number=8443, name='http-metrics'),
-            Port(number=9443, name='metrics'),
+        pytest.param(
+            (
+                Port(number=8443, name='metrics'),
+                Port(number=8443, name='http-metrics'),
+                Port(number=9443, name='metrics'),
+            ),
+            ['http-metrics', 'metrics'],
+            [
+                Port(number=8443, name='http-metrics'),
+                Port(number=9443, name='metrics'),
+            ],
+            id="deduplicates_matching_port_numbers",
         ),
-    )
-
-    assert list(candidate_ports_by_name(service, ['http-metrics', 'metrics'])) == [
-        Port(number=8443, name='http-metrics'),
-        Port(number=9443, name='metrics'),
-    ]
-
-
-def test_candidate_ports_by_name_ignores_empty_names():
-    service = Service(
-        id='svc',
-        host='127.0.0.1',
-        ports=(Port(number=8080, name=''),),
-    )
-
-    assert list(candidate_ports_by_name(service, [''])) == []
+        pytest.param(
+            (Port(number=8080, name=''),),
+            [''],
+            [],
+            id="ignores_empty_names",
+        ),
+    ],
+)
+def test_candidate_ports_by_name(ports, names, expected):
+    service = Service(id='svc', host='127.0.0.1', ports=ports)
+    assert list(candidate_ports_by_name(service, names)) == expected
 
 
 def test_dev_placeholder_field_constants_match_models():

--- a/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
+++ b/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
@@ -273,6 +273,16 @@ def test_candidate_ports_by_name_deduplicates_matching_port_numbers():
     ]
 
 
+def test_candidate_ports_by_name_ignores_empty_names():
+    service = Service(
+        id='svc',
+        host='127.0.0.1',
+        ports=(Port(number=8080, name=''),),
+    )
+
+    assert list(candidate_ports_by_name(service, [''])) == []
+
+
 def test_dev_placeholder_field_constants_match_models():
     """Guard the one fact datadog_checks_dev must hand-copy from base.
 

--- a/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
+++ b/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
@@ -6,7 +6,7 @@ import re
 import mock
 import pytest
 
-from datadog_checks.base.utils.discovery import Discovery, Port, Service, candidate_ports
+from datadog_checks.base.utils.discovery import Discovery, Port, Service, candidate_ports, candidate_ports_by_name
 
 
 def test_include_empty():
@@ -206,6 +206,70 @@ def test_candidate_ports_prefers_hints_and_deduplicates():
         Port(number=9090, name='metrics'),
         Port(number=8080, name='http'),
         Port(number=8081, name='admin'),
+    ]
+
+
+def test_candidate_ports_by_name_only_yields_matching_ports():
+    service = Service(
+        id='svc',
+        host='127.0.0.1',
+        ports=(
+            Port(number=8080, name='http'),
+            Port(number=9090, name='metrics'),
+            Port(number=8081, name='admin'),
+        ),
+    )
+
+    assert list(candidate_ports_by_name(service, ['metrics', 'http-prom'])) == [Port(number=9090, name='metrics')]
+
+
+def test_candidate_ports_by_name_respects_name_priority():
+    service = Service(
+        id='svc',
+        host='127.0.0.1',
+        ports=(
+            Port(number=8080, name='bar'),
+            Port(number=9090, name='foo'),
+            Port(number=8081, name='bar'),
+            Port(number=9091, name='foo'),
+        ),
+    )
+
+    assert list(candidate_ports_by_name(service, ['foo', 'bar'])) == [
+        Port(number=9090, name='foo'),
+        Port(number=9091, name='foo'),
+        Port(number=8080, name='bar'),
+        Port(number=8081, name='bar'),
+    ]
+
+
+def test_candidate_ports_by_name_does_not_fallback_to_other_ports():
+    service = Service(
+        id='svc',
+        host='127.0.0.1',
+        ports=(
+            Port(number=8080, name='http'),
+            Port(number=8081, name='admin'),
+        ),
+    )
+
+    assert list(candidate_ports_by_name(service, ['metrics'])) == []
+
+
+def test_candidate_ports_by_name_deduplicates_matching_port_numbers():
+    service = Service(
+        id='svc',
+        host='127.0.0.1',
+        ports=(
+            Port(number=8443, name='metrics'),
+            Port(number=8443, name='http-metrics'),
+            Port(number=9443, name='metrics'),
+        ),
+    )
+
+    assert list(candidate_ports_by_name(service, ['http-metrics', 'metrics'])) == [
+        Port(number=8443, name='http-metrics'),
+        Port(number=9443, name='metrics'),
     ]
 
 


### PR DESCRIPTION
### What does this PR do?

Add a discovery helper to get ports by name. This will be used in a new strategy which will allow ports to be selected using the name specified in the Kubernetes deployment. This strategy can be re-used by multiple integrations whose services use named ports for their metrics port, such as `velero` or `argo_rollouts`.

This helper is unused in this PR except for tests but is added in a separate PR following the example of earlier PRs where it was requested to keep changes to `datadog_checks_base` separate from other changes.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged