### PR TITLE
Support Togo runtime and flow inputs

### DIFF
--- a/ddev/src/ddev/ai/agent/build.py
+++ b/ddev/src/ddev/ai/agent/build.py
@@ -14,6 +14,7 @@ from ddev.ai.tools.fs.file_registry import FileRegistry
 from ddev.ai.tools.registry import ToolRegistry
 
 if TYPE_CHECKING:
+    from ddev.ai.agent.scope import AgentScope
     from ddev.ai.react.factory import ReActProcessFactory
 
 
@@ -31,8 +32,8 @@ class AgentRuntimeFactoryProtocol(Protocol):
         *,
         agent_config: AgentConfig,
         system_prompt: str,
-        owner_id: str,
         process_factory: ReActProcessFactory,
+        scope: AgentScope,
     ) -> AgentRuntime: ...
 
 
@@ -44,8 +45,8 @@ class AgentRuntimeBuilder(Protocol):
         *,
         agent_config: AgentConfig,
         system_prompt: str,
-        owner_id: str,
         process_factory: ReActProcessFactory,
+        scope: AgentScope,
     ) -> AgentRuntime: ...
 
 
@@ -66,13 +67,13 @@ class AgentRuntimeFactory:
         *,
         agent_config: AgentConfig,
         system_prompt: str,
-        owner_id: str,
         process_factory: ReActProcessFactory,
+        scope: AgentScope,
     ) -> AgentRuntime:
         """Build an AgentRuntime from the given configuration."""
         tool_registry = ToolRegistry.from_names(
             agent_config.tools,
-            owner_id=owner_id,
+            scope=scope,
             file_registry=self._file_registry,
             agent_config=agent_config,
             # forwarded untouched to tools that spawn child agents
@@ -82,6 +83,6 @@ class AgentRuntimeFactory:
             agent_config,
             tools=tool_registry,
             system_prompt=system_prompt,
-            owner_id=owner_id,
+            owner_id=scope.owner_id,
         )
         return AgentRuntime(agent=agent, tool_registry=tool_registry)

--- a/ddev/src/ddev/ai/agent/exceptions.py
+++ b/ddev/src/ddev/ai/agent/exceptions.py
@@ -2,6 +2,20 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import asyncio
+
+
+def describe_agent_error(error: BaseException) -> str:
+    """Human-readable description of an error raised while running an agent.
+
+    The orchestrator cancels in-flight agent tasks with a message when it stops
+    them because ``max_timeout`` was exceeded, rather than because of a genuine
+    failure. Surface that as a timeout instead of a bare ``CancelledError``.
+    """
+    if isinstance(error, asyncio.CancelledError) and str(error):
+        return f"Timed out: {error}"
+    return f"{type(error).__name__}: {error}"
+
 
 class AgentError(Exception):
     """Base class for all errors raised by an agent."""

--- a/ddev/src/ddev/ai/agent/scope.py
+++ b/ddev/src/ddev/ai/agent/scope.py
@@ -20,3 +20,4 @@ class AgentScope:
 
     owner_id: str
     role: AgentRole
+    phase_id: str

--- a/ddev/src/ddev/ai/callbacks/callbacks.py
+++ b/ddev/src/ddev/ai/callbacks/callbacks.py
@@ -24,7 +24,7 @@ class OnBeforeAgentSendCallback(Protocol):
     """Called immediately before each agent.send() request is issued.
 
     ``prompt`` is the content sent to the agent. When the agent is fed tool
-    results it is a fixed ``"Tool results"`` sentinel."""
+    results it is the tool-results sentinel emitted by ``ReActProcess``."""
 
     async def __call__(self, scope: AgentScope, prompt: str, iteration: int) -> None: ...
 
@@ -85,13 +85,13 @@ class OnPhaseFinishCallback(Protocol):
 class OnBeforeGoalCheckCallback(Protocol):
     """Called immediately before each reviewer agent run for a task with a goal."""
 
-    async def __call__(self, task_name: str, attempt: int) -> None: ...
+    async def __call__(self, phase_id: str, task_name: str, attempt: int) -> None: ...
 
 
 class OnAfterGoalCheckCallback(Protocol):
     """Called after each reviewer agent run, with the parsed verdict."""
 
-    async def __call__(self, task_name: str, attempt: int, valid: bool, reason: str) -> None: ...
+    async def __call__(self, phase_id: str, task_name: str, attempt: int, valid: bool, reason: str) -> None: ...
 
 
 # ---------------------------------------------------------------------------
@@ -210,15 +210,17 @@ class CallbackSet:
         self._on_before_goal_check.append(func)
         return func
 
-    async def fire_before_goal_check(self, task_name: str, attempt: int) -> None:
-        await self._fire(self._on_before_goal_check, task_name, attempt)
+    async def fire_before_goal_check(self, phase_id: str, task_name: str, attempt: int) -> None:
+        await self._fire(self._on_before_goal_check, phase_id, task_name, attempt)
 
     def on_after_goal_check(self, func: OnAfterGoalCheckCallback) -> OnAfterGoalCheckCallback:
         self._on_after_goal_check.append(func)
         return func
 
-    async def fire_after_goal_check(self, task_name: str, attempt: int, valid: bool, reason: str) -> None:
-        await self._fire(self._on_after_goal_check, task_name, attempt, valid, reason)
+    async def fire_after_goal_check(
+        self, phase_id: str, task_name: str, attempt: int, valid: bool, reason: str
+    ) -> None:
+        await self._fire(self._on_after_goal_check, phase_id, task_name, attempt, valid, reason)
 
 
 class Callbacks:
@@ -271,10 +273,12 @@ class Callbacks:
         for s in self._sets:
             await s.fire_phase_finish(phase_id)
 
-    async def fire_before_goal_check(self, task_name: str, attempt: int) -> None:
+    async def fire_before_goal_check(self, phase_id: str, task_name: str, attempt: int) -> None:
         for s in self._sets:
-            await s.fire_before_goal_check(task_name, attempt)
+            await s.fire_before_goal_check(phase_id, task_name, attempt)
 
-    async def fire_after_goal_check(self, task_name: str, attempt: int, valid: bool, reason: str) -> None:
+    async def fire_after_goal_check(
+        self, phase_id: str, task_name: str, attempt: int, valid: bool, reason: str
+    ) -> None:
         for s in self._sets:
-            await s.fire_after_goal_check(task_name, attempt, valid, reason)
+            await s.fire_after_goal_check(phase_id, task_name, attempt, valid, reason)

--- a/ddev/src/ddev/ai/config/models.py
+++ b/ddev/src/ddev/ai/config/models.py
@@ -6,8 +6,11 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
 from enum import StrEnum, auto
-from typing import TYPE_CHECKING, Annotated, Literal
+from os import PathLike
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Mapping, assert_never
 
 from pydantic import AfterValidator, BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
@@ -35,6 +38,58 @@ class VariableDeclaration(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: str = Field(pattern=VARIABLE_NAME_PATTERN)
     default: str | None = None
+
+
+class InputType(StrEnum):
+    STRING = "string"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    PATH = "path"
+
+
+class FlowInput(BaseModel):
+    """Describe a typed value supplied when launching a flow."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    name: str = Field(pattern=VARIABLE_NAME_PATTERN)
+    label: str
+    input_type: InputType = Field(alias="type")
+    default: Any | None = None
+    required: bool = True
+    as_content: bool = False
+
+    @model_validator(mode="after")
+    def validate_input_options(self) -> FlowInput:
+        if self.as_content and self.input_type is not InputType.PATH:
+            raise ValueError("'as_content' may only be used with path inputs")
+        if self.default is not None:
+            match self.input_type:
+                case InputType.STRING | InputType.PATH:
+                    pass
+                case InputType.NUMBER:
+                    _validate_number(self.name, self.default, prefix="Default for number input")
+                case InputType.BOOLEAN:
+                    _convert_boolean(self.name, self.default, prefix="Default for boolean input")
+                case unexpected:
+                    assert_never(unexpected)
+        return self
+
+    def convert_runtime_value(self, value: object) -> str:
+        """Convert one runtime value according to this input's declared type."""
+        match self.input_type:
+            case InputType.STRING:
+                return str(value)
+            case InputType.NUMBER:
+                _validate_number(self.name, value)
+                return str(value)
+            case InputType.BOOLEAN:
+                return _convert_boolean(self.name, value)
+            case InputType.PATH:
+                if self.as_content:
+                    return _read_path_content(self.name, value)
+                return str(value)
+            case unexpected:
+                assert_never(unexpected)
 
 
 class TaskConfig(BaseModel):
@@ -132,8 +187,18 @@ class FlowEntry(BaseModel):
 class FlowConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: str = Field(pattern=NAME_PATTERN)
+    description: str | None = None
+    inputs: list[FlowInput] = Field(default_factory=list)
     variables: Annotated[dict[str, str], AfterValidator(validate_variable_names)] = Field(default_factory=dict)
     flow: list[FlowEntry]
+
+    @field_validator("inputs", mode="after")
+    @classmethod
+    def input_names_must_be_unique(cls, inputs: list[FlowInput]) -> list[FlowInput]:
+        names = [flow_input.name for flow_input in inputs]
+        if len(names) != len(set(names)):
+            raise ValueError("Input names must be unique")
+        return inputs
 
 
 class PhaseEnvelope(BaseModel):
@@ -158,6 +223,57 @@ class ResolvedFlow:
     phases: dict[str, PhaseConfig]
     flow: list[FlowEntry]
     variables: dict[str, str]
+    description: str | None = None
+    inputs: list[FlowInput] = field(default_factory=list)
+
+    def convert_inputs(self, values: Mapping[str, object]) -> dict[str, str]:
+        """Convert declared launch inputs to runtime variable strings."""
+        converted: dict[str, str] = {}
+        for flow_input in self.inputs:
+            value = values.get(flow_input.name)
+            if value is None:
+                if flow_input.required:
+                    raise ValueError(f"Required input {flow_input.name!r} is missing")
+                if flow_input.default is None:
+                    continue
+                value = flow_input.default
+
+            converted[flow_input.name] = flow_input.convert_runtime_value(value)
+        return converted
+
+
+def _convert_boolean(name: str, value: object, *, prefix: str = "Input") -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str) and (lower := value.lower()) in {"true", "false"}:
+        return lower
+    raise ValueError(f"{prefix} {name!r} must be a boolean")
+
+
+def _validate_number(name: str, value: object, *, prefix: str = "Input") -> None:
+    if isinstance(value, bool):
+        raise ValueError(f"{prefix} {name!r} must be a number")
+    try:
+        number = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        raise ValueError(f"{prefix} {name!r} must be a number") from None
+    if not number.is_finite():
+        raise ValueError(f"{prefix} {name!r} must be a number")
+
+
+def _read_path_content(name: str, value: object) -> str:
+    """Read an existing regular UTF-8 file supplied as a path input."""
+    if not isinstance(value, (str, PathLike)) or not str(value):
+        raise ValueError(f"Input {name!r} must be a valid path")
+    path = Path(value)
+    if not path.exists():
+        raise ValueError(f"Input {name!r} path does not exist: {path}")
+    if not path.is_file():
+        raise ValueError(f"Input {name!r} path is not a file: {path}")
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise ValueError(f"Input {name!r} path could not be read: {path}: {error}") from error
 
 
 class ConfigStatus(StrEnum):

--- a/ddev/src/ddev/ai/config/resolving/inlining.py
+++ b/ddev/src/ddev/ai/config/resolving/inlining.py
@@ -24,6 +24,8 @@ def build_resolved_flow(
     """Fold refs into their fields, resolve agents, and topo-sort into a ResolvedFlow."""
     return ResolvedFlow(
         name=flow_name,
+        description=fc.description,
+        inputs=fc.inputs,
         agents={pc.agent: registry.agents[pc.agent] for pc in scheduled_phases if pc.agent is not None},
         phases={pc.name: _inline_phase(registry, pc) for pc in scheduled_phases},
         flow=topological_sort(fc.flow),

--- a/ddev/src/ddev/ai/config/resolving/variables.py
+++ b/ddev/src/ddev/ai/config/resolving/variables.py
@@ -30,8 +30,12 @@ def resolve_variables(
 ) -> tuple[dict[str, str], list[FlowError]]:
     """Gather variable declarations, resolve defaults, and apply ``flow > default``."""
     declared = _gather_variable_declarations(registry, scheduled_phases)
-    defaults, errors = _collect_default_values(declared, supplied=set(flow_config.variables))
-    errors.extend(_find_missing_variables(declared, flow_config))
+    guaranteed_inputs = {
+        flow_input.name for flow_input in flow_config.inputs if flow_input.required or flow_input.default is not None
+    }
+    supplied = set(flow_config.variables) | guaranteed_inputs
+    defaults, errors = _collect_default_values(declared, supplied=supplied)
+    errors.extend(_find_missing_variables(declared, supplied))
     resolved = {**defaults, **flow_config.variables}
     return resolved, errors
 
@@ -82,14 +86,14 @@ def _collect_default_values(declared: list[DeclaredVar], supplied: set[str]) -> 
     return defaults, errors
 
 
-def _find_missing_variables(declared: list[DeclaredVar], flow_config: FlowConfig) -> list[FlowError]:
+def _find_missing_variables(declared: list[DeclaredVar], supplied: set[str]) -> list[FlowError]:
     by_name: dict[str, list[DeclaredVar]] = {}
     for dv in declared:
         by_name.setdefault(dv.name, []).append(dv)
 
     errors: list[FlowError] = []
     for name, entries in by_name.items():
-        if name in flow_config.variables:
+        if name in supplied:
             continue
         if any(dv.default is not None for dv in entries):
             continue

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -82,7 +82,7 @@ class AgenticPhase(Phase):
         )
         self._agent_config = agent_config
         self._process_factory = process_factory
-        self._scope = AgentScope(owner_id=phase_id, role=AgentRole.PHASE)
+        self._scope = AgentScope(owner_id=phase_id, role=AgentRole.PHASE, phase_id=phase_id)
         self._goal_attempt_log: list[GoalValidationRecord] = []
         self._total_input_tokens: int = 0
         self._total_output_tokens: int = 0

--- a/ddev/src/ddev/ai/phases/goal.py
+++ b/ddev/src/ddev/ai/phases/goal.py
@@ -198,6 +198,7 @@ async def _run_reviewer_once(
 
 async def _drive_goal_loop(
     *,
+    phase_id: str,
     task: TaskConfig,
     goal_text: str,
     rendered_task_prompt: str,
@@ -214,7 +215,7 @@ async def _drive_goal_loop(
     try:
         while True:
             attempts += 1
-            await callbacks.fire_before_goal_check(task.name, attempts)
+            await callbacks.fire_before_goal_check(phase_id, task.name, attempts)
 
             user_message = build_reviewer_user_message(
                 rendered_task_prompt=rendered_task_prompt,
@@ -229,7 +230,7 @@ async def _drive_goal_loop(
             total_in += check.input_tokens
             total_out += check.output_tokens
 
-            await callbacks.fire_after_goal_check(task.name, attempts, check.valid, check.reason)
+            await callbacks.fire_after_goal_check(phase_id, task.name, attempts, check.valid, check.reason)
 
             if check.valid:
                 return GoalLoopOutcome(
@@ -279,7 +280,11 @@ async def run_goal_loop(
     is captured by the run-wide logging callbacks bound to ``process_factory``.
     The phase callbacks see only the bracketing before/after_goal_check events.
     """
-    reviewer_scope = AgentScope(owner_id=f"{phase_id}.goal.{task.name}", role=AgentRole.GOAL_REVIEWER)
+    reviewer_scope = AgentScope(
+        owner_id=f"{phase_id}.goal.{task.name}",
+        role=AgentRole.GOAL_REVIEWER,
+        phase_id=phase_id,
+    )
     reviewer_config = parent_agent_config.model_copy(update={"tools": filter_read_only(parent_agent_config.tools)})
     try:
         reviewer_process = process_factory.create(
@@ -291,6 +296,7 @@ async def run_goal_loop(
         raise RuntimeError(f"Failed to create reviewer process for task {task.name}: {e}") from e
 
     return await _drive_goal_loop(
+        phase_id=phase_id,
         task=task,
         goal_text=goal_text,
         rendered_task_prompt=rendered_task_prompt,

--- a/ddev/src/ddev/ai/react/factory.py
+++ b/ddev/src/ddev/ai/react/factory.py
@@ -27,7 +27,7 @@ class ReActProcessFactory:
         runtime = self._runtime_builder(
             agent_config=agent_config,
             system_prompt=system_prompt,
-            owner_id=scope.owner_id,
             process_factory=self,
+            scope=scope,
         )
         return ReActProcess(runtime, callbacks=self._callbacks, scope=scope)

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -12,6 +12,8 @@ from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.react.types import ReActResult
 from ddev.ai.tools.core.types import ToolResult
 
+TOOL_RESULTS_SENTINEL = "Tool results"
+
 # A turn that stops on MAX_TOKENS while a tool call is pending was truncated mid-call: the
 # tool_use block is incomplete and was never executed. We must still answer every tool_use
 # with a tool_result, otherwise the next send() replays a dangling tool_use and the provider
@@ -173,7 +175,7 @@ class ReActProcess:
 
                 messages = [ToolResultMessage(tool_call_id=tc.id, result=result) for tc, result in tool_call_results]
 
-                await self._callbacks.fire_before_agent_send(self._scope, "Tool results", iterations + 1)
+                await self._callbacks.fire_before_agent_send(self._scope, TOOL_RESULTS_SENTINEL, iterations + 1)
 
                 response = await self._agent.send(messages, allowed_tools)
                 iterations += 1

--- a/ddev/src/ddev/ai/runtime/agent_log.py
+++ b/ddev/src/ddev/ai/runtime/agent_log.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TextIO
 
+from ddev.ai.agent.exceptions import describe_agent_error
 from ddev.ai.callbacks.callbacks import CallbackSet
 
 if TYPE_CHECKING:
@@ -142,7 +143,7 @@ class AgentLogger:
 
         @cb.on_agent_error
         async def _on_agent_error(scope: AgentScope, error: BaseException) -> None:
-            detail = f"{type(error).__name__}: {error}"
+            detail = describe_agent_error(error)
             self._emit(scope, {"event": "error", "exception": detail})
             self._emit(scope, {"event": "finish", "success": False, "error": detail})
 

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -66,6 +66,10 @@ class PhaseOrchestrator(EventBusOrchestrator):
         self._failed_phase: str | None = None
         self._failed_error: str | None = None
 
+    @property
+    def failed_phase(self) -> str | None:
+        return self._failed_phase
+
     async def on_initialize(self) -> None:
         """Construct phases from the resolved flow and submit the start PhaseTrigger."""
         checkpoint_manager = CheckpointManager(self._checkpoint_path)

--- a/ddev/src/ddev/ai/tools/agents/base.py
+++ b/ddev/src/ddev/ai/tools/agents/base.py
@@ -42,11 +42,11 @@ class ChildOutcome:
 class BaseSpawnTool[TInput: BaseToolInput](BaseTool[TInput]):
     def __init__(
         self,
-        owner_id: str,
         agent_config: AgentConfig,
         process_factory: ReActProcessFactory,
+        parent_scope: AgentScope,
     ) -> None:
-        self._owner_id = owner_id
+        self._parent_scope = parent_scope
         self._agent_config = agent_config
         self._process_factory = process_factory
         # Parent may itself have a spawn tool; never offer either to children.
@@ -74,7 +74,11 @@ class BaseSpawnTool[TInput: BaseToolInput](BaseTool[TInput]):
         prompt: str,
         tools: list[str],
     ) -> ChildOutcome:
-        child_scope = AgentScope(owner_id=subagent_id, role=AgentRole.SUBAGENT)
+        child_scope = AgentScope(
+            owner_id=subagent_id,
+            role=AgentRole.SUBAGENT,
+            phase_id=self._parent_scope.phase_id,
+        )
         try:
             child_config = self._agent_config.model_copy(update={"tools": tools})
             process = self._process_factory.create(

--- a/ddev/src/ddev/ai/tools/agents/spawn_identical_subagents.py
+++ b/ddev/src/ddev/ai/tools/agents/spawn_identical_subagents.py
@@ -14,6 +14,7 @@ from ddev.ai.tools.core.base import BaseToolInput
 from ddev.ai.tools.core.types import ToolResult
 
 if TYPE_CHECKING:
+    from ddev.ai.agent.scope import AgentScope
     from ddev.ai.config.models import AgentConfig
     from ddev.ai.react.factory import ReActProcessFactory
 
@@ -81,11 +82,15 @@ class SpawnIdenticalSubagentsTool(BaseSpawnTool[SpawnIdenticalSubagentsInput]):
 
     def __init__(
         self,
-        owner_id: str,
         agent_config: AgentConfig,
         process_factory: ReActProcessFactory,
+        parent_scope: AgentScope,
     ) -> None:
-        super().__init__(owner_id, agent_config, process_factory)
+        super().__init__(
+            agent_config=agent_config,
+            process_factory=process_factory,
+            parent_scope=parent_scope,
+        )
         self._call_counter = 0
 
     @property
@@ -104,7 +109,7 @@ class SpawnIdenticalSubagentsTool(BaseSpawnTool[SpawnIdenticalSubagentsInput]):
 
         async def run(index: int, assignment: Assignment) -> ChildOutcome:
             async with semaphore:
-                subagent_id = f"{self._owner_id}.par.{call_id:03d}.{index:03d}-{assignment.name}"
+                subagent_id = f"{self._parent_scope.owner_id}.par.{call_id:03d}.{index:03d}-{assignment.name}"
                 return await self._run_child(
                     subagent_id, assignment.name, system_prompt, assignment.prompt, tool_input.tools
                 )

--- a/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
+++ b/ddev/src/ddev/ai/tools/agents/spawn_subagent.py
@@ -13,6 +13,7 @@ from ddev.ai.tools.core.base import BaseToolInput
 from ddev.ai.tools.core.types import ToolResult
 
 if TYPE_CHECKING:
+    from ddev.ai.agent.scope import AgentScope
     from ddev.ai.config.models import AgentConfig
     from ddev.ai.react.factory import ReActProcessFactory
 
@@ -55,11 +56,15 @@ class SpawnSubagentTool(BaseSpawnTool[SpawnSubagentInput]):
 
     def __init__(
         self,
-        owner_id: str,
         agent_config: AgentConfig,
         process_factory: ReActProcessFactory,
+        parent_scope: AgentScope,
     ) -> None:
-        super().__init__(owner_id, agent_config, process_factory)
+        super().__init__(
+            agent_config=agent_config,
+            process_factory=process_factory,
+            parent_scope=parent_scope,
+        )
         self._counter = 0
 
     @property
@@ -73,7 +78,7 @@ class SpawnSubagentTool(BaseSpawnTool[SpawnSubagentInput]):
             return ToolResult(success=False, error=error)
 
         self._counter += 1
-        subagent_id = f"{self._owner_id}.sub.{self._counter:03d}-{label}"
+        subagent_id = f"{self._parent_scope.owner_id}.sub.{self._counter:03d}-{label}"
         outcome = await self._run_child(
             subagent_id, label, tool_input.system_prompt, tool_input.prompt, tool_input.tools
         )

--- a/ddev/src/ddev/ai/tools/registry.py
+++ b/ddev/src/ddev/ai/tools/registry.py
@@ -17,6 +17,7 @@ from .core.protocol import ToolProtocol
 from .core.types import ToolResult
 
 if TYPE_CHECKING:
+    from ddev.ai.agent.scope import AgentScope
     from ddev.ai.config.models import AgentConfig
     from ddev.ai.react.factory import ReActProcessFactory
 
@@ -26,7 +27,7 @@ class ToolContext:
     """Shared resources passed to every tool factory during construction."""
 
     file_registry: FileRegistry
-    owner_id: str
+    scope: AgentScope
     agent_config: AgentConfig
     process_factory: ReActProcessFactory
 
@@ -40,7 +41,7 @@ def _plain_factory(tool_cls: type[ToolProtocol], ctx: ToolContext) -> ToolProtoc
 
 
 def _file_registry_factory(tool_cls: type, ctx: ToolContext) -> ToolProtocol:
-    return tool_cls(ctx.file_registry, ctx.owner_id)
+    return tool_cls(ctx.file_registry, ctx.scope.owner_id)
 
 
 def _file_policy_factory(tool_cls: type, ctx: ToolContext) -> ToolProtocol:
@@ -48,11 +49,7 @@ def _file_policy_factory(tool_cls: type, ctx: ToolContext) -> ToolProtocol:
 
 
 def _spawn_subagent_factory(tool_cls: type, ctx: ToolContext) -> ToolProtocol:
-    return tool_cls(
-        owner_id=ctx.owner_id,
-        agent_config=ctx.agent_config,
-        process_factory=ctx.process_factory,
-    )
+    return tool_cls(parent_scope=ctx.scope, agent_config=ctx.agent_config, process_factory=ctx.process_factory)
 
 
 @dataclass(frozen=True)
@@ -138,7 +135,7 @@ class ToolRegistry:
         cls,
         tool_names: list[str],
         *,
-        owner_id: str,
+        scope: AgentScope,
         file_registry: FileRegistry,
         agent_config: AgentConfig,
         process_factory: ReActProcessFactory,
@@ -153,7 +150,7 @@ class ToolRegistry:
         """
         ctx = ToolContext(
             file_registry=file_registry,
-            owner_id=owner_id,
+            scope=scope,
             agent_config=agent_config,
             process_factory=process_factory,
         )

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -180,6 +180,15 @@ class EventBusOrchestrator(ABC):
         """
         asyncio.run(self._entry_point())
 
+    async def run_async(self) -> None:
+        """Await the orchestrator on an already-running event loop.
+
+        Use this instead of :meth:`run` when the caller already owns a running loop
+        (e.g. inside a Textual application). Semantics are identical to :meth:`run`;
+        only the entry mechanism differs.
+        """
+        await self._entry_point()
+
     async def _entry_point(self):
         exception = None
         try:

--- a/ddev/tests/ai/agent/test_build.py
+++ b/ddev/tests/ai/agent/test_build.py
@@ -8,10 +8,11 @@ import pytest
 
 from ddev.ai.agent.build import AgentRuntime, AgentRuntimeFactory
 from ddev.ai.agent.registry import AgentProviderRegistry
+from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.config.models import AgentConfig
-from ddev.ai.tools.agents.spawn_subagent import SpawnSubagentTool
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.fs.file_registry import FileRegistry
+from ddev.ai.tools.registry import ToolRegistry
 from tests.ai.config.utils import make_agent_config
 
 
@@ -34,7 +35,7 @@ def test_runtime_factory_delegates_agent_building_and_builds_tools(file_registry
     factory = AgentRuntimeFactory(provider_registry=provider_registry, file_registry=file_registry)
     config = make_agent_config(provider="custom", tools=["read_file"])
 
-    runtime = build_runtime(factory, config)
+    runtime = build_runtime(factory, config, scope=AgentScope("p1", AgentRole.PHASE, "p1"))
 
     assert runtime.agent is agent
     assert runtime.tool_registry.definitions[0]["name"] == "read_file"
@@ -62,41 +63,55 @@ def build_runtime(
     factory: AgentRuntimeFactory,
     config: AgentConfig,
     *,
+    scope: AgentScope,
     system_prompt: str = "system",
-    owner_id: str = "p1",
     process_factory: object = _PROCESS_FACTORY,
 ) -> AgentRuntime:
     return factory.build_runtime(
         agent_config=config,
         system_prompt=system_prompt,
-        owner_id=owner_id,
         process_factory=process_factory,
+        scope=scope,
     )
 
 
 def test_build_runtime_uses_config_tools(file_registry):
     config = make_agent_config(provider="test", tools=["read_file"])
-    runtime = build_runtime(make_factory(file_registry), config)
+    runtime = build_runtime(make_factory(file_registry), config, scope=AgentScope("p1", AgentRole.PHASE, "p1"))
 
     assert len(runtime.tool_registry.definitions) == 1
     assert runtime.tool_registry.definitions[0]["name"] == "read_file"
 
 
-def test_build_runtime_wires_spawn_subagent_tool(file_registry):
-    config = make_agent_config(provider="test", tools=["spawn_subagent"])
+def test_build_runtime_propagates_context_to_tool_registry(file_registry, mocker):
+    config = make_agent_config(provider="test", tools=["spawn_subagent", "spawn_identical_subagents"])
     factory = make_factory(file_registry)
+    scope = AgentScope(owner_id="p1", role=AgentRole.PHASE, phase_id="p1")
     sentinel_process_factory = object()
-    runtime = build_runtime(factory, config, process_factory=sentinel_process_factory)
+    tool_registry = ToolRegistry([])
+    from_names = mocker.patch.object(ToolRegistry, "from_names", return_value=tool_registry)
 
-    tool = runtime.tool_registry._tools["spawn_subagent"]
-    assert isinstance(tool, SpawnSubagentTool)
-    assert tool._agent_config is config
-    assert tool._process_factory is sentinel_process_factory
+    runtime = build_runtime(
+        factory,
+        config,
+        scope=scope,
+        process_factory=sentinel_process_factory,
+    )
+
+    assert runtime.tool_registry is tool_registry
+    from_names.assert_called_once_with(
+        config.tools,
+        scope=scope,
+        file_registry=file_registry,
+        agent_config=config,
+        process_factory=sentinel_process_factory,
+    )
 
 
 def test_build_runtime_reuses_shared_file_registry(file_registry):
     config = make_agent_config(provider="test", tools=["read_file", "edit_file"])
-    runtime = build_runtime(make_factory(file_registry), config, owner_id="owner")
+    scope = AgentScope(owner_id="owner", role=AgentRole.PHASE, phase_id="owner")
+    runtime = build_runtime(make_factory(file_registry), config, scope=scope)
 
     for tool in runtime.tool_registry._tools.values():
         assert tool._registry is file_registry
@@ -105,7 +120,7 @@ def test_build_runtime_reuses_shared_file_registry(file_registry):
 
 def test_build_runtime_native_tool_in_registry(file_registry):
     config = make_agent_config(provider="test", tools=["read_file", "web_search"])
-    runtime = build_runtime(make_factory(file_registry), config)
+    runtime = build_runtime(make_factory(file_registry), config, scope=AgentScope("p1", AgentRole.PHASE, "p1"))
 
     assert runtime.tool_registry.native_tool_names == ("web_search",)
     assert len(runtime.tool_registry.definitions) == 1
@@ -114,7 +129,7 @@ def test_build_runtime_native_tool_in_registry(file_registry):
 
 def test_build_runtime_no_native_tools_empty_list(file_registry):
     config = make_agent_config(provider="test", tools=["read_file"])
-    runtime = build_runtime(make_factory(file_registry), config)
+    runtime = build_runtime(make_factory(file_registry), config, scope=AgentScope("p1", AgentRole.PHASE, "p1"))
 
     assert runtime.tool_registry.native_tool_names == ()
 
@@ -127,7 +142,8 @@ async def test_shared_registry_does_not_share_parent_read_authorization(file_reg
 
     factory = make_factory(file_registry)
     child_config = config.model_copy(update={"tools": ["edit_file"]})
-    runtime = build_runtime(factory, child_config, system_prompt="sys", owner_id="parent.sub.001-child")
+    child_scope = AgentScope(owner_id="parent.sub.001-child", role=AgentRole.SUBAGENT, phase_id="parent")
+    runtime = build_runtime(factory, child_config, system_prompt="sys", scope=child_scope)
     registry = runtime.tool_registry
     result = await registry.run("edit_file", {"path": str(path), "old_string": "before", "new_string": "after"})
 

--- a/ddev/tests/ai/callbacks/test_callbacks.py
+++ b/ddev/tests/ai/callbacks/test_callbacks.py
@@ -17,7 +17,7 @@ from ddev.ai.tools.core.types import ToolResult
 
 @pytest.fixture
 def scope() -> AgentScope:
-    return AgentScope(owner_id="p1", role=AgentRole.PHASE)
+    return AgentScope(owner_id="p1", role=AgentRole.PHASE, phase_id="p1")
 
 
 @pytest.fixture
@@ -494,11 +494,11 @@ async def test_goal_check_callbacks_register_fire_and_swallow_exceptions(event):
         fired.append(args)
 
     if event == "before":
-        await cb.fire_before_goal_check("task-x", 3)
-        assert fired == [("task-x", 3)]
+        await cb.fire_before_goal_check("phase-a", "task-x", 3)
+        assert fired == [("phase-a", "task-x", 3)]
     else:
-        await cb.fire_after_goal_check("task-x", 3, False, "missing y")
-        assert fired == [("task-x", 3, False, "missing y")]
+        await cb.fire_after_goal_check("phase-a", "task-x", 3, False, "missing y")
+        assert fired == [("phase-a", "task-x", 3, False, "missing y")]
 
 
 async def test_callbacks_dispatches_goal_check_to_all_sets():
@@ -506,17 +506,35 @@ async def test_callbacks_dispatches_goal_check_to_all_sets():
     fired: list = []
 
     @s1.on_before_goal_check
-    async def h1(name, attempt):
-        fired.append(("s1", name, attempt))
+    async def h1(phase_id, name, attempt):
+        fired.append(("s1", phase_id, name, attempt))
 
     @s2.on_after_goal_check
-    async def h2(name, attempt, valid, reason):
-        fired.append(("s2", name, attempt, valid, reason))
+    async def h2(phase_id, name, attempt, valid, reason):
+        fired.append(("s2", phase_id, name, attempt, valid, reason))
 
     cb = Callbacks([s1, s2])
-    await cb.fire_before_goal_check("t", 1)
-    await cb.fire_after_goal_check("t", 1, True, "")
-    assert fired == [("s1", "t", 1), ("s2", "t", 1, True, "")]
+    await cb.fire_before_goal_check("phase-a", "t", 1)
+    await cb.fire_after_goal_check("phase-a", "t", 1, True, "")
+    assert fired == [
+        ("s1", "phase-a", "t", 1),
+        ("s2", "phase-a", "t", 1, True, ""),
+    ]
+
+
+async def test_goal_callbacks_distinguish_duplicate_task_names_across_phases():
+    callback_set = CallbackSet()
+    fired: list[tuple[str, str]] = []
+
+    @callback_set.on_before_goal_check
+    async def record(phase_id: str, task_name: str, attempt: int) -> None:
+        fired.append((phase_id, task_name))
+
+    callbacks = Callbacks([callback_set])
+    await callbacks.fire_before_goal_check("phase-a", "review", 1)
+    await callbacks.fire_before_goal_check("phase-b", "review", 1)
+
+    assert fired == [("phase-a", "review"), ("phase-b", "review")]
 
 
 # ---------------------------------------------------------------------------
@@ -538,6 +556,8 @@ async def test_callbacks_empty_is_noop(
     await callbacks.fire_before_agent_send(scope, "p", 1)
     await callbacks.fire_phase_start("p")
     await callbacks.fire_phase_finish("p")
+    await callbacks.fire_before_goal_check("p", "t", 1)
+    await callbacks.fire_after_goal_check("p", "t", 1, True, "")
 
 
 async def test_callbacks_dispatches_to_all_sets(scope: AgentScope, response: AgentResponse) -> None:

--- a/ddev/tests/ai/config/loading/test_discovery.py
+++ b/ddev/tests/ai/config/loading/test_discovery.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-import os
-
-import pytest
+import errno
+from collections.abc import Callable, Iterator
+from pathlib import Path
 
 from ddev.ai.config.loading.discovery import discover
 from ddev.ai.config.loading.files import FileError, MarkdownFile, YamlFile
@@ -121,19 +121,21 @@ def test_symlinked_directory_alias_yields_each_file_once(tmp_path):
     assert len(results) == 1
 
 
-def test_unreadable_directory_yields_file_error(tmp_path):
-    if os.getuid() == 0:
-        pytest.skip("root bypasses directory permissions")
+def test_unreadable_directory_yields_file_error(tmp_path, monkeypatch):
     blocked = tmp_path / "blocked"
-    write(blocked / "a.md", "---\nname: a\n---\nbody")
-    blocked.chmod(0o000)
-    try:
-        results = list(discover([tmp_path]))
-    finally:
-        blocked.chmod(0o755)
 
-    errors = [r for r in results if isinstance(r, FileError)]
-    assert any(r.path == blocked for r in errors)
+    def failing_walk(
+        _path: Path,
+        *,
+        on_error: Callable[[OSError], object],
+        **_kwargs: object,
+    ) -> Iterator[tuple[Path, list[str], list[str]]]:
+        on_error(PermissionError(errno.EACCES, "Permission denied", str(blocked)))
+        return iter(())
+
+    monkeypatch.setattr(Path, "walk", failing_walk)
+
+    assert list(discover([tmp_path])) == [FileError(blocked, "Cannot read directory: Permission denied")]
 
 
 def test_non_overlapping_directories_are_all_walked(tmp_path):

--- a/ddev/tests/ai/config/resolving/test_variables.py
+++ b/ddev/tests/ai/config/resolving/test_variables.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from ddev.ai.config.errors import ErrorKind
-from ddev.ai.config.models import ConfigStatus, FlowEntry, VariableDeclaration
+from ddev.ai.config.models import ConfigStatus, FlowEntry, FlowInput, VariableDeclaration
 from ddev.ai.config.registry import ResourceRegistry
 from ddev.ai.config.resolving.resolver import FlowResolver
 
@@ -86,3 +86,80 @@ def test_flow_variable_overrides_default():
 
     assert diagnostics.status == ConfigStatus.OK
     assert diagnostics.resolved.variables == {"topic": "dogs"}
+
+
+def test_required_runtime_input_satisfies_required_variable_without_static_value():
+    entries = [
+        phase_entry("p", variables=[VariableDeclaration(name="topic")]),
+        flow_entry(
+            "demo",
+            [FlowEntry(phase="p")],
+            inputs=[FlowInput(name="topic", label="Topic", input_type="string", required=True)],
+        ),
+    ]
+    diagnostics = FlowResolver(ResourceRegistry(entries), StubReg()).resolve("demo")
+
+    assert diagnostics.status == ConfigStatus.OK
+    assert diagnostics.resolved.variables == {}
+
+
+def test_required_runtime_input_resolves_default_conflict_without_static_value():
+    entries = [
+        agent_entry("writer", variables=[VariableDeclaration(name="topic", default="agent")]),
+        phase_entry("p", agent="writer", variables=[VariableDeclaration(name="topic", default="phase")]),
+        flow_entry(
+            "demo",
+            [FlowEntry(phase="p")],
+            inputs=[FlowInput(name="topic", label="Topic", input_type="string", required=True)],
+        ),
+    ]
+    diagnostics = FlowResolver(ResourceRegistry(entries), StubReg()).resolve("demo")
+
+    assert diagnostics.status == ConfigStatus.OK
+    assert diagnostics.resolved.variables == {}
+
+
+def test_optional_runtime_input_without_default_does_not_satisfy_required_variable():
+    entries = [
+        phase_entry("p", variables=[VariableDeclaration(name="topic")]),
+        flow_entry(
+            "demo",
+            [FlowEntry(phase="p")],
+            inputs=[FlowInput(name="topic", label="Topic", input_type="string", required=False)],
+        ),
+    ]
+    diagnostics = FlowResolver(ResourceRegistry(entries), StubReg()).resolve("demo")
+
+    assert diagnostics.status == ConfigStatus.BROKEN
+    assert any(error.subject == "topic" and "Required variable" in error.message for error in diagnostics.errors)
+
+
+def test_optional_runtime_input_without_default_does_not_resolve_default_conflict():
+    entries = [
+        agent_entry("writer", variables=[VariableDeclaration(name="topic", default="agent")]),
+        phase_entry("p", agent="writer", variables=[VariableDeclaration(name="topic", default="phase")]),
+        flow_entry(
+            "demo",
+            [FlowEntry(phase="p")],
+            inputs=[FlowInput(name="topic", label="Topic", input_type="string", required=False)],
+        ),
+    ]
+    diagnostics = FlowResolver(ResourceRegistry(entries), StubReg()).resolve("demo")
+
+    assert diagnostics.status == ConfigStatus.BROKEN
+    assert any(error.subject == "topic" and "conflicting defaults" in error.message for error in diagnostics.errors)
+
+
+def test_defaulted_optional_runtime_input_resolves_variable_without_static_value():
+    entries = [
+        phase_entry("p", variables=[VariableDeclaration(name="topic")]),
+        flow_entry(
+            "demo",
+            [FlowEntry(phase="p")],
+            inputs=[FlowInput(name="topic", label="Topic", input_type="string", required=False, default="metrics")],
+        ),
+    ]
+    diagnostics = FlowResolver(ResourceRegistry(entries), StubReg()).resolve("demo")
+
+    assert diagnostics.status == ConfigStatus.OK
+    assert diagnostics.resolved.variables == {}

--- a/ddev/tests/ai/config/test_classify.py
+++ b/ddev/tests/ai/config/test_classify.py
@@ -92,7 +92,7 @@ def test_markdown_with_yaml_only_type_is_file_error(type_):
 
 def test_markdown_non_string_type_is_file_error():
     md = MarkdownFile(path=PATH, meta={"type": ["prompt", "memory_prompt"], "name": "a"}, body="sys")
-    output = classify(md)
+    output = classify_file(md)
 
     assert output.entries == []
     (error,) = output.file_errors
@@ -149,7 +149,15 @@ def test_yaml_phase_happy_path():
 
 
 def test_yaml_flow_happy_path():
-    doc = {"type": "flow", "config": {"name": "f", "flow": [{"phase": "p"}]}}
+    doc = {
+        "type": "flow",
+        "config": {
+            "name": "f",
+            "description": "Flow shown in the launcher",
+            "inputs": [{"name": "topic", "label": "Topic", "type": "string", "default": "metrics"}],
+            "flow": [{"phase": "p"}],
+        },
+    }
     yaml_file = YamlFile(path=YAML_PATH, docs=[doc])
     output = classify_file(yaml_file)
 
@@ -159,6 +167,8 @@ def test_yaml_flow_happy_path():
     assert entry.kind == ResourceKind.FLOW
     assert entry.name == "f"
     assert isinstance(entry.config, FlowConfig)
+    assert entry.config.description == "Flow shown in the launcher"
+    assert entry.config.inputs[0].name == "topic"
 
 
 def test_yaml_non_dict_and_typeless_docs_skipped_silently():
@@ -191,7 +201,7 @@ def test_yaml_markdown_only_type_is_file_error():
 
 def test_yaml_non_string_type_is_file_error():
     yaml_file = YamlFile(path=YAML_PATH, docs=[{"type": ["phase", "flow"], "config": {"name": "x"}}])
-    output = classify(yaml_file)
+    output = classify_file(yaml_file)
 
     assert output.entries == []
     (error,) = output.file_errors
@@ -225,7 +235,7 @@ def test_yaml_nameless_invalid_is_file_error():
 def test_yaml_non_string_name_is_file_error():
     doc = {"type": "phase", "config": {"name": ["p"]}}
     yaml_file = YamlFile(path=YAML_PATH, docs=[doc])
-    output = classify(yaml_file)
+    output = classify_file(yaml_file)
 
     assert output.entries == []
     (error,) = output.file_errors

--- a/ddev/tests/ai/config/test_engine.py
+++ b/ddev/tests/ai/config/test_engine.py
@@ -36,7 +36,9 @@ PHASE_AND_FLOW = (
     "- type: phase\n  config:\n    name: p\n    agent: ag\n"
     "    tasks:\n      - name: t\n        prompt_ref: intro\n        goal_ref: g\n"
     "    checkpoint:\n      memory_prompt_ref: mem\n"
-    "- type: flow\n  config:\n    name: demo\n    variables:\n      x: hi\n"
+    "- type: flow\n  config:\n    name: demo\n    description: Generate an integration\n"
+    "    inputs:\n      - name: topic\n        label: Topic\n        type: string\n        default: metrics\n"
+    "    variables:\n      x: hi\n"
     "    flow:\n      - phase: p\n"
 )
 
@@ -83,6 +85,33 @@ def test_get_flow_resolves_all_refs_and_variables(tmp_path):
     assert rf.phases["p"].checkpoint.memory_prompt_ref is None
     assert rf.variables == {"x": "hi"}
     assert rf.agents["ag"].system_prompt == "sys"
+    assert rf.description == "Generate an integration"
+    assert [flow_input.name for flow_input in rf.inputs] == ["topic"]
+
+
+def test_runtime_input_satisfies_eager_variable_resolution(tmp_path):
+    write(
+        tmp_path / "flow.yaml",
+        "- type: phase\n"
+        "  config:\n"
+        "    name: p\n"
+        "    variables:\n"
+        "      - name: topic\n"
+        "- type: flow\n"
+        "  config:\n"
+        "    name: demo\n"
+        "    inputs:\n"
+        "      - name: topic\n"
+        "        label: Topic\n"
+        "        type: string\n"
+        "    flow:\n"
+        "      - phase: p\n",
+    )
+
+    resolved = ConfigurationEngine(core_dir=tmp_path, user_dirs=[], phase_registry=StubReg()).get_flow("demo")
+
+    assert [flow_input.name for flow_input in resolved.inputs] == ["topic"]
+    assert resolved.variables == {}
 
 
 def test_directory_layout_is_irrelevant(tmp_path):

--- a/ddev/tests/ai/config/test_models.py
+++ b/ddev/tests/ai/config/test_models.py
@@ -10,6 +10,7 @@ import pytest
 from pydantic import ValidationError
 
 from ddev.ai.agent.registry import AgentProviderRegistry
+from ddev.ai.config import models
 from ddev.ai.config.models import (
     AgentConfig,
     CheckpointConfig,
@@ -157,3 +158,183 @@ def test_flow_variables_reject_non_template_identifiers(bad_key):
 def test_flow_variables_accept_template_identifiers():
     fc = FlowConfig(name="demo", variables={"topic": "cats", "_n": "1", "API_KEY": "v"}, flow=[])
     assert fc.variables == {"topic": "cats", "_n": "1", "API_KEY": "v"}
+
+
+def test_flow_config_accepts_tui_metadata():
+    config = FlowConfig.model_validate(
+        {
+            "name": "demo",
+            "description": "Generate an integration",
+            "inputs": [
+                {
+                    "name": "specification",
+                    "label": "Specification",
+                    "type": "path",
+                    "required": True,
+                    "as_content": True,
+                }
+            ],
+            "flow": [],
+        }
+    )
+
+    assert config.description == "Generate an integration"
+    assert config.inputs[0].input_type is models.InputType.PATH
+    assert config.inputs[0].model_dump(by_alias=True)["type"] == "path"
+    assert config.inputs == [
+        models.FlowInput(
+            name="specification",
+            label="Specification",
+            input_type=models.InputType.PATH,
+            required=True,
+            as_content=True,
+        )
+    ]
+
+
+def test_flow_config_rejects_duplicate_input_names():
+    with pytest.raises(ValidationError, match="Input names must be unique"):
+        FlowConfig.model_validate(
+            {
+                "name": "demo",
+                "inputs": [
+                    {"name": "subject", "label": "Subject", "type": "string"},
+                    {"name": "subject", "label": "Other subject", "type": "string"},
+                ],
+                "flow": [],
+            }
+        )
+
+
+def test_flow_input_rejects_as_content_for_non_path():
+    with pytest.raises(ValidationError, match="'as_content' may only be used with path inputs"):
+        models.FlowInput(name="subject", label="Subject", input_type="string", as_content=True)
+
+
+def resolved_with_inputs(*inputs: models.FlowInput) -> models.ResolvedFlow:
+    return models.ResolvedFlow(
+        name="demo",
+        description=None,
+        inputs=list(inputs),
+        agents={},
+        phases={},
+        flow=[],
+        variables={},
+    )
+
+
+def test_resolved_flow_converts_typed_runtime_inputs(tmp_path):
+    source = tmp_path / "spec.md"
+    source.write_text("specification text", encoding="utf-8")
+    resolved = resolved_with_inputs(
+        models.FlowInput(name="name", label="Name", input_type="string"),
+        models.FlowInput(name="count", label="Count", input_type="number"),
+        models.FlowInput(name="enabled", label="Enabled", input_type="boolean"),
+        models.FlowInput(name="source", label="Source", input_type="path", as_content=True),
+    )
+
+    assert resolved.convert_inputs({"name": "example", "count": 3.5, "enabled": True, "source": source}) == {
+        "name": "example",
+        "count": "3.5",
+        "enabled": "true",
+        "source": "specification text",
+    }
+
+
+def test_resolved_flow_boolean_false_is_lowercase():
+    resolved = resolved_with_inputs(models.FlowInput(name="enabled", label="Enabled", input_type="boolean"))
+
+    assert resolved.convert_inputs({"enabled": False}) == {"enabled": "false"}
+
+
+def test_resolved_flow_boolean_string_false_is_false():
+    resolved = resolved_with_inputs(models.FlowInput(name="enabled", label="Enabled", input_type="boolean"))
+
+    assert resolved.convert_inputs({"enabled": "false"}) == {"enabled": "false"}
+
+
+def test_resolved_flow_rejects_invalid_boolean():
+    resolved = resolved_with_inputs(models.FlowInput(name="enabled", label="Enabled", input_type="boolean"))
+
+    with pytest.raises(ValueError, match="Input 'enabled' must be a boolean"):
+        resolved.convert_inputs({"enabled": "sometimes"})
+
+
+def test_resolved_flow_requires_required_input_even_with_default():
+    resolved = resolved_with_inputs(
+        models.FlowInput(name="topic", label="Topic", input_type="string", default="metrics", required=True)
+    )
+
+    with pytest.raises(ValueError, match="Required input 'topic' is missing"):
+        resolved.convert_inputs({})
+
+
+def test_resolved_flow_uses_optional_default_and_omits_unset_optional():
+    resolved = resolved_with_inputs(
+        models.FlowInput(name="topic", label="Topic", input_type="string", default="metrics", required=False),
+        models.FlowInput(name="count", label="Count", input_type="number", default=3, required=False),
+        models.FlowInput(name="enabled", label="Enabled", input_type="boolean", default="false", required=False),
+        models.FlowInput(name="notes", label="Notes", input_type="string", required=False),
+    )
+
+    assert resolved.convert_inputs({}) == {"topic": "metrics", "count": "3", "enabled": "false"}
+
+
+@pytest.mark.parametrize("default", ["many", True])
+def test_flow_input_rejects_invalid_number_default(default):
+    with pytest.raises(ValidationError, match="Default for number input 'count' must be a number"):
+        models.FlowInput(name="count", label="Count", input_type="number", default=default, required=False)
+
+
+def test_resolved_flow_validates_number_values():
+    resolved = resolved_with_inputs(models.FlowInput(name="count", label="Count", input_type="number"))
+
+    assert resolved.convert_inputs({"count": "3.5"}) == {"count": "3.5"}
+    with pytest.raises(ValueError, match="Input 'count' must be a number"):
+        resolved.convert_inputs({"count": "many"})
+
+
+def test_resolved_flow_reads_optional_path_default_as_content(tmp_path):
+    source = tmp_path / "spec.md"
+    source.write_text("default specification", encoding="utf-8")
+    resolved = resolved_with_inputs(
+        models.FlowInput(
+            name="source",
+            label="Source",
+            input_type="path",
+            default=source,
+            required=False,
+            as_content=True,
+        )
+    )
+
+    assert resolved.convert_inputs({}) == {"source": "default specification"}
+
+
+def test_resolved_flow_path_content_reports_missing_file(tmp_path):
+    resolved = resolved_with_inputs(models.FlowInput(name="source", label="Source", input_type="path", as_content=True))
+
+    with pytest.raises(ValueError, match="Input 'source' path does not exist"):
+        resolved.convert_inputs({"source": tmp_path / "missing.md"})
+
+
+def test_resolved_flow_path_content_rejects_directory(tmp_path):
+    resolved = resolved_with_inputs(models.FlowInput(name="source", label="Source", input_type="path", as_content=True))
+
+    with pytest.raises(ValueError, match="Input 'source' path is not a file"):
+        resolved.convert_inputs({"source": tmp_path})
+
+
+def test_flow_input_path_without_content_accepts_nonexistent_path(tmp_path):
+    missing = tmp_path / "output.md"
+    flow_input = models.FlowInput(name="output", label="Output", input_type="path")
+
+    assert flow_input.convert_runtime_value(missing) == str(missing)
+
+
+def test_flow_input_path_as_content_rejects_nonexistent_path(tmp_path):
+    missing = tmp_path / "missing.md"
+    flow_input = models.FlowInput(name="source", label="Source", input_type="path", as_content=True)
+
+    with pytest.raises(ValueError, match="Input 'source' path does not exist"):
+        flow_input.convert_runtime_value(missing)

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -41,7 +41,7 @@ def _memory_process(agent: MockAgent, callbacks: Callbacks | None = None) -> ReA
     return ReActProcess(
         AgentRuntime(agent=agent, tool_registry=ToolRegistry([])),
         callbacks=callbacks,
-        scope=AgentScope(owner_id="p1", role=AgentRole.PHASE),
+        scope=AgentScope(owner_id="p1", role=AgentRole.PHASE, phase_id="p1"),
     )
 
 

--- a/ddev/tests/ai/phases/test_goal.py
+++ b/ddev/tests/ai/phases/test_goal.py
@@ -105,7 +105,7 @@ def test_build_reviewer_user_message_sections():
 def _make_worker_process(responses):
     """ReActProcess wired to a MockAgent — used as the worker."""
     agent = MockAgent(list(responses))
-    scope = AgentScope(owner_id="worker", role=AgentRole.PHASE)
+    scope = AgentScope(owner_id="worker", role=AgentRole.PHASE, phase_id="worker")
     return ReActProcess(AgentRuntime(agent=agent, tool_registry=ToolRegistry([])), scope=scope), agent
 
 
@@ -118,7 +118,14 @@ class ReviewerProcessFactory:
         self._callbacks = callbacks or Callbacks()
 
     def create(self, *, scope, agent_config: AgentConfig, system_prompt: str) -> ReActProcess:
-        self.calls.append({"agent_config": agent_config, "system_prompt": system_prompt, "owner_id": scope.owner_id})
+        self.calls.append(
+            {
+                "agent_config": agent_config,
+                "system_prompt": system_prompt,
+                "owner_id": scope.owner_id,
+                "phase_id": scope.phase_id,
+            }
+        )
         return ReActProcess(
             AgentRuntime(agent=self.agent, tool_registry=ToolRegistry([])),
             callbacks=self._callbacks,
@@ -178,6 +185,7 @@ async def test_run_goal_loop_passes_on_first_attempt(tmp_path):
     assert worker_agent.send_calls == []
     assert builder_calls[0]["owner_id"] == "p1.goal.t1"
     assert builder_calls[0]["system_prompt"] == GOAL_REVIEWER_SYSTEM_PROMPT
+    assert builder_calls[0]["phase_id"] == "p1"
 
     log_path = tmp_path / "goal_reviewer" / "p1.goal.t1.jsonl"
     assert log_path.exists()
@@ -372,12 +380,12 @@ async def test_run_goal_loop_fires_callbacks(tmp_path):
     cb_set = CallbackSet()
 
     @cb_set.on_before_goal_check
-    async def _before(task_name, attempt):
-        events.append(("before", task_name, attempt))
+    async def _before(phase_id: str, task_name: str, attempt: int) -> None:
+        events.append(("before", phase_id, task_name, attempt))
 
     @cb_set.on_after_goal_check
-    async def _after(task_name, attempt, valid, reason):
-        events.append(("after", task_name, attempt, valid, reason))
+    async def _after(phase_id: str, task_name: str, attempt: int, valid: bool, reason: str) -> None:
+        events.append(("after", phase_id, task_name, attempt, valid, reason))
 
     worker_process, _ = _make_worker_process([make_response("attempt 2", 0, 0)])
     initial_result = ReActResult(
@@ -407,8 +415,8 @@ async def test_run_goal_loop_fires_callbacks(tmp_path):
         compact_if_needed=_noop_compact,
     )
     assert events == [
-        ("before", "t1", 1),
-        ("after", "t1", 1, False, "fix X"),
-        ("before", "t1", 2),
-        ("after", "t1", 2, True, ""),
+        ("before", "p1", "t1", 1),
+        ("after", "p1", "t1", 1, False, "fix X"),
+        ("before", "p1", "t1", 2),
+        ("after", "p1", "t1", 2, True, ""),
     ]

--- a/ddev/tests/ai/react/test_factory.py
+++ b/ddev/tests/ai/react/test_factory.py
@@ -28,21 +28,21 @@ class _StubAgent(BaseAgent[Any]):
 def test_create_returns_scoped_process_and_forwards_build_inputs():
     calls: list[dict] = []
 
-    def runtime_builder(*, agent_config, system_prompt, owner_id, process_factory):
+    def runtime_builder(*, agent_config, system_prompt, process_factory, scope):
         calls.append(
             {
                 "agent_config": agent_config,
                 "system_prompt": system_prompt,
-                "owner_id": owner_id,
                 "process_factory": process_factory,
+                "scope": scope,
             }
         )
-        return AgentRuntime(agent=_StubAgent(owner_id), tool_registry=ToolRegistry([]))
+        return AgentRuntime(agent=_StubAgent(scope.owner_id), tool_registry=ToolRegistry([]))
 
     callbacks = Callbacks([CallbackSet()])
     factory = ReActProcessFactory(runtime_builder, callbacks)
 
-    scope = AgentScope(owner_id="p1.sub.001-x", role=AgentRole.SUBAGENT)
+    scope = AgentScope(owner_id="p1.sub.001-x", role=AgentRole.SUBAGENT, phase_id="p1")
     config = make_agent_config(tools=["read_file"])
     process = factory.create(scope=scope, agent_config=config, system_prompt="be helpful")
 
@@ -51,7 +51,7 @@ def test_create_returns_scoped_process_and_forwards_build_inputs():
     assert process._callbacks is callbacks
 
     assert len(calls) == 1
-    assert calls[0]["owner_id"] == "p1.sub.001-x"
+    assert calls[0]["scope"] is scope
     assert calls[0]["agent_config"] is config
     assert calls[0]["system_prompt"] == "be helpful"
     # The factory injects itself so nested spawn tools can create children.

--- a/ddev/tests/ai/react/test_process.py
+++ b/ddev/tests/ai/react/test_process.py
@@ -149,17 +149,20 @@ def make_tool_call(
     return ToolCall(id=call_id, name=name, input=tool_input or {})
 
 
+DEFAULT_SCOPE = AgentScope(owner_id="test", role=AgentRole.PHASE, phase_id="test")
+
+
 def make_process(
     agent: MockAgent,
     registry: ToolRegistry | None = None,
     callbacks: Callbacks | None = None,
     compact_threshold_pct: float | None = None,
-    scope: AgentScope | None = None,
+    scope: AgentScope = DEFAULT_SCOPE,
 ) -> ReActProcess:
     return ReActProcess(
         AgentRuntime(agent=agent, tool_registry=registry or ToolRegistry([])),
         callbacks=callbacks,
-        scope=scope or AgentScope(owner_id="test", role=AgentRole.PHASE),
+        scope=scope,
         compact_threshold_pct=compact_threshold_pct,
     )
 
@@ -508,7 +511,7 @@ async def test_callbacks_invoked_correct_counts(fake_tool: FakeToolFactory) -> N
     )
     recorder = CallbackRecorder()
     agent = MockAgent(responses)
-    scope = AgentScope(owner_id="owner-loop", role=AgentRole.SUBAGENT)
+    scope = AgentScope(owner_id="owner-loop", role=AgentRole.SUBAGENT, phase_id="phase")
 
     result = await make_process(
         agent, registry=registry, callbacks=Callbacks([recorder.callback_set]), scope=scope
@@ -542,7 +545,7 @@ async def test_agent_start_fires_first_with_scope_and_metadata() -> None:
     agent = MockAgent([make_response(StopReason.END_TURN)])
     agent._system_prompt = "you are a tester"
     recorder = CallbackRecorder()
-    scope = AgentScope(owner_id="owner-1", role=AgentRole.SUBAGENT)
+    scope = AgentScope(owner_id="owner-1", role=AgentRole.SUBAGENT, phase_id="phase")
 
     await make_process(agent, callbacks=Callbacks([recorder.callback_set]), scope=scope).start("do it")
 
@@ -562,7 +565,7 @@ async def test_agent_start_fires_first_with_scope_and_metadata() -> None:
 async def test_run_once_sends_with_no_tools_and_fires_scoped_callbacks() -> None:
     agent = MockAgent([make_response(StopReason.END_TURN, input_tokens=7, output_tokens=3)])
     recorder = CallbackRecorder()
-    scope = AgentScope(owner_id="owner-1", role=AgentRole.PHASE)
+    scope = AgentScope(owner_id="owner-1", role=AgentRole.PHASE, phase_id="owner-1")
 
     process = make_process(agent, callbacks=Callbacks([recorder.callback_set]), scope=scope)
     response = await process.run_once("summarize")
@@ -579,7 +582,7 @@ async def test_run_once_sends_with_no_tools_and_fires_scoped_callbacks() -> None
 
 async def test_run_once_error_notifies_and_reraises() -> None:
     recorder = CallbackRecorder()
-    scope = AgentScope(owner_id="owner-1", role=AgentRole.PHASE)
+    scope = AgentScope(owner_id="owner-1", role=AgentRole.PHASE, phase_id="owner-1")
     process = ReActProcess(
         AgentRuntime(agent=ErrorAgent(), tool_registry=ToolRegistry([])),
         scope=scope,
@@ -615,7 +618,7 @@ async def test_agent_error_notifies_and_reraises() -> None:
     recorder = CallbackRecorder()
     process = ReActProcess(
         AgentRuntime(agent=ErrorAgent(), tool_registry=ToolRegistry([])),
-        scope=AgentScope(owner_id="test", role=AgentRole.PHASE),
+        scope=AgentScope(owner_id="test", role=AgentRole.PHASE, phase_id="test"),
         callbacks=Callbacks([recorder.callback_set]),
     )
 
@@ -642,7 +645,7 @@ async def test_keyboard_interrupt_notifies_and_reraises() -> None:
     recorder = CallbackRecorder()
     process = ReActProcess(
         AgentRuntime(agent=InterruptAgent(), tool_registry=ToolRegistry([])),
-        scope=AgentScope(owner_id="test", role=AgentRole.PHASE),
+        scope=AgentScope(owner_id="test", role=AgentRole.PHASE, phase_id="test"),
         callbacks=Callbacks([recorder.callback_set]),
     )
 
@@ -668,7 +671,7 @@ async def test_cancelled_error_notifies_and_reraises() -> None:
     recorder = CallbackRecorder()
     process = ReActProcess(
         AgentRuntime(agent=CancelledAgent(), tool_registry=ToolRegistry([])),
-        scope=AgentScope(owner_id="test", role=AgentRole.PHASE),
+        scope=AgentScope(owner_id="test", role=AgentRole.PHASE, phase_id="test"),
         callbacks=Callbacks([recorder.callback_set]),
     )
 

--- a/ddev/tests/ai/runtime/test_agent_log.py
+++ b/ddev/tests/ai/runtime/test_agent_log.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import asyncio
 import json
 from pathlib import Path
 
@@ -45,8 +46,8 @@ def read_events(path: Path) -> list[dict]:
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
 
 
-PHASE = AgentScope(owner_id="p1", role=AgentRole.PHASE)
-SUB = AgentScope(owner_id="p1.sub.001-x", role=AgentRole.SUBAGENT)
+PHASE = AgentScope(owner_id="p1", role=AgentRole.PHASE, phase_id="p1")
+SUB = AgentScope(owner_id="p1.sub.001-x", role=AgentRole.SUBAGENT, phase_id="p1")
 
 
 async def test_demultiplexes_by_scope_into_separate_files(tmp_path):
@@ -96,6 +97,17 @@ async def test_error_emits_error_then_failed_finish(tmp_path):
     assert events[2]["success"] is False
 
 
+async def test_timeout_cancellation_has_meaningful_error(tmp_path):
+    logger = AgentLogger(tmp_path)
+    cb = logger.as_callback_set()
+
+    await cb.fire_agent_error(PHASE, asyncio.CancelledError("Orchestrator exceeded max_timeout of 10s"))
+
+    events = read_events(tmp_path / "phase" / "p1.jsonl")
+    assert events[0]["exception"] == "Timed out: Orchestrator exceeded max_timeout of 10s"
+    assert events[1]["error"] == "Timed out: Orchestrator exceeded max_timeout of 10s"
+
+
 async def test_compact_events_recorded(tmp_path):
     logger = AgentLogger(tmp_path)
     cb = logger.as_callback_set()
@@ -129,7 +141,7 @@ async def test_close_is_idempotent(tmp_path):
 
 async def test_emit_after_close_is_silently_dropped(tmp_path):
     logger = AgentLogger(tmp_path)
-    scope = AgentScope(owner_id="p1", role=AgentRole.PHASE)
+    scope = AgentScope(owner_id="p1", role=AgentRole.PHASE, phase_id="p1")
     logger.close()
     cb = logger.as_callback_set()
     await cb.fire_agent_start(scope, "sys", [])

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -110,6 +110,8 @@ async def test_on_message_received_fatal_on_phase_failed(core_dir, make_orchestr
     with pytest.raises(FatalProcessingError, match="Phase 'p1' failed"):
         await orchestrator.on_message_received(msg)
 
+    assert orchestrator.failed_phase == "p1"
+
 
 async def test_on_message_received_ignores_other_messages(core_dir, make_orchestrator):
     orchestrator, _, _ = make_orchestrator(core_dir)

--- a/ddev/tests/ai/tools/agents/conftest.py
+++ b/ddev/tests/ai/tools/agents/conftest.py
@@ -97,7 +97,14 @@ class FakeProcessFactory:
         self.calls: list[dict[str, Any]] = []
 
     def create(self, *, scope: AgentScope, agent_config: AgentConfig, system_prompt: str) -> ReActProcess:
-        self.calls.append({"owner_id": scope.owner_id, "agent_config": agent_config, "system_prompt": system_prompt})
+        self.calls.append(
+            {
+                "owner_id": scope.owner_id,
+                "phase_id": scope.phase_id,
+                "agent_config": agent_config,
+                "system_prompt": system_prompt,
+            }
+        )
         if self._build_error is not None:
             raise self._build_error
         runtime = AgentRuntime(agent=self._agent_factory(), tool_registry=self._tool_registry)

--- a/ddev/tests/ai/tools/agents/test_base.py
+++ b/ddev/tests/ai/tools/agents/test_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import pytest
 
+from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.tools.agents.base import SPAWN_IDENTICAL_NAME, SPAWN_SUBAGENT_NAME, BaseSpawnTool
 from ddev.ai.tools.core.base import BaseToolInput
 from ddev.ai.tools.core.types import ToolResult
@@ -21,7 +22,11 @@ class _ConcreteSpawnTool(BaseSpawnTool):
 
 
 def make_tool(tools: list[str]) -> _ConcreteSpawnTool:
-    return _ConcreteSpawnTool(owner_id="p", agent_config=make_agent_config(tools=tools), process_factory=None)
+    return _ConcreteSpawnTool(
+        parent_scope=AgentScope(owner_id="p", role=AgentRole.PHASE, phase_id="p"),
+        agent_config=make_agent_config(tools=tools),
+        process_factory=None,
+    )
 
 
 def test_allowed_tools_excludes_both_spawn_tools():

--- a/ddev/tests/ai/tools/agents/test_spawn_identical_subagents.py
+++ b/ddev/tests/ai/tools/agents/test_spawn_identical_subagents.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.agent.types import StopReason
 from ddev.ai.tools.agents.spawn_identical_subagents import (
     CONCISE_DIRECTIVE,
@@ -26,10 +27,13 @@ if TYPE_CHECKING:
 
 
 def make_tool(
-    factory: FakeProcessFactory, parent_tools: list[str] | None = None, owner_id: str = "parent"
+    factory: FakeProcessFactory,
+    parent_tools: list[str] | None = None,
+    owner_id: str = "parent",
+    phase_id: str = "parent",
 ) -> SpawnIdenticalSubagentsTool:
     return SpawnIdenticalSubagentsTool(
-        owner_id=owner_id,
+        parent_scope=AgentScope(owner_id=owner_id, role=AgentRole.PHASE, phase_id=phase_id),
         agent_config=make_agent_config(tools=parent_tools or ["read_file", "edit_file"]),
         process_factory=factory,
     )
@@ -68,6 +72,19 @@ async def test_happy_path(
         "parent.par.001.002-c",
     ]
     assert result.data.index("## a") < result.data.index("## b") < result.data.index("## c")
+
+
+async def test_child_scopes_inherit_parent_phase_id(
+    process_factory: ProcessFactoryBuilder, mock_agent: type[MockAgent], make_response: ResponseFactory
+):
+    factory = process_factory(lambda: mock_agent([make_response(text="done")]))
+
+    result = await make_tool(factory, phase_id="phase_a")(
+        SpawnIdenticalSubagentsInput(system_prompt="sys", assignments=assignments("a", "b"))
+    )
+
+    assert result.success is True
+    assert [call["phase_id"] for call in factory.calls] == ["phase_a", "phase_a"]
 
 
 async def test_repeated_calls_produce_distinct_owner_ids(

--- a/ddev/tests/ai/tools/agents/test_spawn_subagent.py
+++ b/ddev/tests/ai/tools/agents/test_spawn_subagent.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from ddev.ai.agent.exceptions import AgentError
+from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.agent.types import StopReason, ToolCall
 from ddev.ai.config.models import AgentConfig
 from ddev.ai.tools.agents.spawn_subagent import SpawnSubagentInput, SpawnSubagentTool
@@ -35,10 +36,11 @@ def make_tool(
     factory: FakeProcessFactory,
     parent_tools: list[str] | None = None,
     owner_id: str = "parent",
+    phase_id: str = "parent",
     agent_config: AgentConfig | None = None,
 ) -> SpawnSubagentTool:
     return SpawnSubagentTool(
-        owner_id=owner_id,
+        parent_scope=AgentScope(owner_id=owner_id, role=AgentRole.PHASE, phase_id=phase_id),
         agent_config=agent_config or make_agent_config(tools=parent_tools or ["read_file", "edit_file"]),
         process_factory=factory,
     )
@@ -131,6 +133,20 @@ async def test_child_runtime_config_inherits_parent_settings_and_requested_tools
     assert child_config.tools == ["read_file"]
     assert factory.calls[0]["system_prompt"] == "child system"
     assert factory.calls[0]["owner_id"] == "parent.sub.001-child"
+
+
+async def test_child_scope_inherits_parent_phase_id(
+    process_factory: ProcessFactoryBuilder,
+    mock_agent: type[MockAgent],
+    make_response: ResponseFactory,
+):
+    factory = process_factory(lambda: mock_agent([make_response(text="ok")]))
+    tool = make_tool(factory, phase_id="phase_a")
+
+    result = await tool(SpawnSubagentInput(system_prompt="sys", prompt="go", tools=[], name="child"))
+
+    assert result.success is True
+    assert factory.calls[0]["phase_id"] == "phase_a"
 
 
 async def test_max_tokens_response_prefixed(

--- a/ddev/tests/ai/tools/test_registry.py
+++ b/ddev/tests/ai/tools/test_registry.py
@@ -7,7 +7,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.config.models import AgentConfig
+from ddev.ai.tools.agents.spawn_identical_subagents import SpawnIdenticalSubagentsTool
 from ddev.ai.tools.agents.spawn_subagent import SpawnSubagentTool
 from ddev.ai.tools.core.types import ToolResult
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
@@ -152,18 +154,23 @@ def test_available_tool_names_returns_fresh_copy():
 
 
 OWNER_ID = "test-agent"
-# Exclude spawn_subagent (needs process_factory wiring) and native tools (no ToolProtocol instance).
+SCOPE = AgentScope(owner_id=OWNER_ID, role=AgentRole.PHASE, phase_id=OWNER_ID)
+SPAWN_TOOL_TYPES = (
+    ("spawn_subagent", SpawnSubagentTool),
+    ("spawn_identical_subagents", SpawnIdenticalSubagentsTool),
+)
+# Spawn tools have dedicated runtime-context coverage; native tools have no ToolProtocol instance.
 TOOLS_WITHOUT_EXTRA_DEPS = [
-    n for n in ToolRegistry.available_tool_names() if n not in ("spawn_subagent", *NATIVE_TOOL_NAMES)
+    name for name in ToolRegistry.available_tool_names() if name not in {*dict(SPAWN_TOOL_TYPES), *NATIVE_TOOL_NAMES}
 ]
 
 PROCESS_FACTORY = object()  # opaque sentinel — from_names only stores it on the spawn tool
 
 
-def from_names(tool_names: list[str], tmp_path, *, owner_id: str = OWNER_ID) -> ToolRegistry:
+def from_names(tool_names: list[str], tmp_path, *, scope: AgentScope = SCOPE) -> ToolRegistry:
     return ToolRegistry.from_names(
         tool_names,
-        owner_id=owner_id,
+        scope=scope,
         file_registry=FileRegistry(policy=FileAccessPolicy(write_root=tmp_path)),
         agent_config=AgentConfig.model_construct(tools=tool_names),
         process_factory=PROCESS_FACTORY,
@@ -194,12 +201,14 @@ def test_from_names_all_at_once(tmp_path):
     assert built_names == set(all_names)
 
 
-def test_from_names_spawn_subagent_gets_runtime_context(tmp_path):
-    registry = from_names(["read_file", "spawn_subagent"], tmp_path)
+@pytest.mark.parametrize(("name", "tool_type"), SPAWN_TOOL_TYPES)
+def test_from_names_spawn_tools_get_runtime_context(name, tool_type, tmp_path):
+    registry = from_names(["read_file", name], tmp_path)
 
-    tool = registry._tools["spawn_subagent"]
-    assert isinstance(tool, SpawnSubagentTool)
-    assert tool._agent_config == make_agent_config(tools=["read_file", "spawn_subagent"])
+    tool = registry._tools[name]
+    assert isinstance(tool, tool_type)
+    assert tool._parent_scope is SCOPE
+    assert tool._agent_config == make_agent_config(tools=["read_file", name])
     assert tool._process_factory is PROCESS_FACTORY
     assert tool._allowed_tools == {"read_file"}
 
@@ -303,14 +312,14 @@ def test_from_names_reuses_supplied_file_registry(tmp_path):
     shared = FileRegistry(policy=FileAccessPolicy(write_root=tmp_path))
     reg_a = ToolRegistry.from_names(
         ["read_file", "create_file"],
-        owner_id="a",
+        scope=AgentScope(owner_id="a", role=AgentRole.PHASE, phase_id="a"),
         file_registry=shared,
         agent_config=make_agent_config(tools=["read_file", "create_file"]),
         process_factory=PROCESS_FACTORY,
     )
     reg_b = ToolRegistry.from_names(
         ["read_file", "create_file"],
-        owner_id="b",
+        scope=AgentScope(owner_id="b", role=AgentRole.PHASE, phase_id="b"),
         file_registry=shared,
         agent_config=make_agent_config(tools=["read_file", "create_file"]),
         process_factory=PROCESS_FACTORY,

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -11,6 +11,7 @@ from collections.abc import Generator
 from contextlib import AbstractContextManager, contextmanager, suppress
 from contextlib import nullcontext as does_not_raise
 from dataclasses import dataclass
+from typing import get_type_hints
 
 import pytest
 from pytest_mock import MockerFixture
@@ -943,6 +944,75 @@ def test_should_process_message_conditional_filtering(bare_orchestrator: MockOrc
 
     assert len(analyst.processed) == 1
     assert analyst.processed[0].id == "high_task"
+
+
+# ---------------------------------------------------------------------------
+# run_async tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_async_declares_none_return_type():
+    assert get_type_hints(EventBusOrchestrator.run_async)["return"] is type(None)
+
+
+async def test_run_async_completes_on_running_loop(bare_orchestrator: MockOrchestrator):
+    """run_async() succeeds when awaited inside an already-running event loop."""
+    # asyncio_mode=auto means this function itself runs on a live loop —
+    # no nested asyncio.run() call is made.
+    running_loop = asyncio.get_running_loop()
+
+    await bare_orchestrator.run_async()
+
+    assert "initialize" in bare_orchestrator.events
+    assert "finalize" in bare_orchestrator.events
+    # The loop must be the same one we were called from — no new loop was created.
+    assert asyncio.get_running_loop() is running_loop
+
+
+async def test_run_async_does_not_raise_nested_loop_error(bare_orchestrator: MockOrchestrator):
+    """run_async() must not raise RuntimeError about a running event loop."""
+    try:
+        await bare_orchestrator.run_async()
+    except RuntimeError as exc:
+        if "cannot be called from a running event loop" in str(exc):
+            pytest.fail(f"run_async raised nested-loop RuntimeError: {exc}")
+        raise
+
+
+async def test_run_async_processes_messages(orchestrator: MockOrchestrator, secretary: Secretary):
+    """run_async() processes messages just as run() does."""
+    orchestrator.submit_message(Memo("async_memo"))
+
+    await orchestrator.run_async()
+
+    assert len(secretary.delivered_memos) == 1
+    assert secretary.delivered_memos[0].id == "async_memo"
+    assert orchestrator.finalized_exception is None
+
+
+async def test_run_async_propagates_fatal_error(orchestrator: MockOrchestrator):
+    """run_async() propagates FatalProcessingError just as run() does."""
+    original_on_message = orchestrator.on_message_received
+
+    async def on_message_fatal(message: BaseMessage):
+        await original_on_message(message)
+        raise FatalProcessingError("fatal from run_async")
+
+    orchestrator.on_message_received = on_message_fatal  # type: ignore[method-assign]
+    orchestrator.submit_message(Memo("trigger"))
+
+    with pytest.raises(FatalProcessingError, match="fatal from run_async"):
+        await orchestrator.run_async()
+
+    assert "finalize" in orchestrator.events
+
+
+def test_run_still_works_after_run_async_added(bare_orchestrator: MockOrchestrator):
+    """Synchronous run() continues to work correctly after run_async is introduced."""
+    bare_orchestrator.run()
+
+    assert "initialize" in bare_orchestrator.events
+    assert "finalize" in bare_orchestrator.events
 
 
 def test_should_process_message_is_independent_per_processor(bare_orchestrator: MockOrchestrator, secretary: Secretary):


### PR DESCRIPTION
### What does this PR do?

Adds the reusable runtime and configuration support needed by interactive Togo clients: asynchronous orchestrator execution, phase-scoped callbacks across agents and goal checks, improved failure reporting, and typed launch-input metadata propagated through the distributed configuration engine.

### Motivation

The Togo TUI runs inside Textual's event loop and needs every callback attributed to the correct phase, including concurrent phases. It also needs descriptions and typed launch inputs from the configuration engine without restoring the removed monolithic flow configuration path.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once it is merged