### PR TITLE
Add configuration-driven Togo TUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,9 @@ benchmark_*.svg
 ## Local overrides for ddev
 .ddev.toml
 
+## AI flow run artifacts (ddev ai)
+.ddev/ai-runs/
+
 ## Size metrics
 size-uncompressed.txt
 size-compressed.txt

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -52,6 +52,9 @@ dynamic = ["version"]
 ai = [
     "prometheus-client",
     "python-frontmatter",
+    "pyperclip>=1.11.0",
+    "textual>=8.2.0",
+    "textual-autocomplete>=4.0.0",
 ]
 
 [project.urls]

--- a/ddev/src/ddev/cli/meta/__init__.py
+++ b/ddev/src/ddev/cli/meta/__init__.py
@@ -12,6 +12,7 @@ from datadog_checks.dev.tooling.commands.meta.prometheus import prom
 from datadog_checks.dev.tooling.commands.meta.snmp import snmp
 from datadog_checks.dev.tooling.commands.meta.windows import windows
 
+from ddev.cli.meta.ai import ai_group
 from ddev.cli.meta.scripts import scripts
 
 
@@ -24,6 +25,7 @@ def meta():
     """
 
 
+meta.add_command(ai_group)
 meta.add_command(catalog)
 meta.add_command(changes)
 meta.add_command(create_example_commits)

--- a/ddev/src/ddev/cli/meta/ai/__init__.py
+++ b/ddev/src/ddev/cli/meta/ai/__init__.py
@@ -1,0 +1,65 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""
+``ddev meta ai`` command group.
+
+Launches the Togo interface for browsing, configuring, running, and resuming
+AI flows.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from ddev.cli.application import Application
+
+
+# The command name is set explicitly to `ai` so the function can be named `ai_group`,
+# avoiding a clash with the `ddev.cli.meta.ai` package when imported into `ddev.cli.meta`.
+@click.group('ai', short_help='Open the Togo AI flow interface', invoke_without_command=True)
+@click.pass_context
+def ai_group(ctx: click.Context) -> None:
+    """Browse, configure, and run AI flows in Togo."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    app: Application = ctx.obj
+
+    from ddev.ai.agent.registry import build_agent_provider_registry
+    from ddev.ai.config.engine import ConfigurationEngine
+    from ddev.ai.config.errors import ConfigError
+    from ddev.ai.constants import CORE_FLOWS_DIR, CORE_PHASES_DIR, CORE_PHASES_PACKAGE
+    from ddev.ai.phases.registry import PhaseRegistry
+    from ddev.cli.meta.ai.tui.app import TogoApp
+
+    phase_registry = PhaseRegistry()
+    phase_registry.register_from(CORE_PHASES_DIR, CORE_PHASES_PACKAGE)
+    provider_registry = build_agent_provider_registry(app.config.ai)
+    try:
+        engine = ConfigurationEngine(
+            core_dir=CORE_FLOWS_DIR,
+            user_dirs=app.config.ai.flow_dirs,
+            phase_registry=phase_registry,
+            provider_registry=provider_registry,
+        )
+    except ConfigError as error:
+        app.abort(str(error))
+
+    togo = TogoApp(
+        engine=engine,
+        phase_registry=phase_registry,
+        provider_registry=provider_registry,
+        ddev_app=app,
+    )
+    httpx_logger = logging.getLogger('httpx')
+    previous_level = httpx_logger.level
+    httpx_logger.setLevel(logging.WARNING)
+    try:
+        togo.run()
+    finally:
+        httpx_logger.setLevel(previous_level)

--- a/ddev/src/ddev/cli/meta/ai/palette.py
+++ b/ddev/src/ddev/cli/meta/ai/palette.py
@@ -1,0 +1,46 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Togo design-system color palette.
+
+Single source of truth for every color used to render an AI flow run. The
+Togo TUI delegates its Rich rendering and Textual theme to these constants
+so neither reaches for arbitrary named colors outside this set.
+
+All colors are deliberately muted/pastel rather than fully saturated: the
+TUI log view is read at length against a dark background, and a fully
+saturated palette reads as visually loud over long sessions.
+"""
+
+from __future__ import annotations
+
+PRIMARY = "#8874C9"
+SECONDARY = "#C3B5E8"
+ACCENT = "#A38FD1"
+
+FOREGROUND = "#E9E8EC"
+BACKGROUND = "#17161C"
+SURFACE = "#1D1C23"
+PANEL = "#201F28"
+
+BORDER = "#34323B"
+TEXT_MUTED = "#8A8891"
+
+SUCCESS = "#85C09A"
+WARNING = "#E0B36A"
+ERROR = "#E08A93"
+
+STATUS_RUNNING = "#86B8DE"
+STATUS_PENDING = "#8F8B94"
+STATUS_DONE = SUCCESS
+STATUS_FAILED = ERROR
+STATUS_CONNECTOR = "#4A4650"
+
+# Per-role identity colors used to tell speakers apart in the log.
+ROLE_PHASE = "#7FC4C4"
+ROLE_SUBAGENT = WARNING
+ROLE_GOAL_REVIEWER = "#D99BB3"
+
+# Tool-activity colors, distinct from role identity colors.
+TOOL_CALL = WARNING
+TOOL_SEARCH = "#A98FD9"

--- a/ddev/src/ddev/cli/meta/ai/rendering.py
+++ b/ddev/src/ddev/cli/meta/ai/rendering.py
@@ -1,0 +1,291 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Pure rendering helpers for AI flow run events.
+
+All functions return ``rich`` renderables (``Text``, ``Panel``, or ``str``)
+and have no side-effects: no ``Console``, no ``Application``, no Textual
+widgets. The TUI execution view delegates to this module for consistent
+visual output across phase logs.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING, Any
+
+from rich.markdown import Markdown, TableElement
+from rich.panel import Panel
+from rich.text import Text
+
+from ddev.ai.agent.exceptions import describe_agent_error
+from ddev.ai.agent.scope import AgentRole
+from ddev.cli.meta.ai.palette import (
+    ERROR,
+    ROLE_GOAL_REVIEWER,
+    ROLE_PHASE,
+    ROLE_SUBAGENT,
+    STATUS_DONE,
+    STATUS_RUNNING,
+    TOOL_CALL,
+    TOOL_SEARCH,
+)
+
+if TYPE_CHECKING:
+    from rich.console import Console, ConsoleOptions, RenderResult
+
+    from ddev.ai.agent.scope import AgentScope
+    from ddev.ai.agent.types import ToolCall, WebFetchCall, WebSearchCall
+    from ddev.ai.react.types import ReActResult
+    from ddev.ai.tools.core.types import ToolResult
+
+# Input field values longer than this are summarized as ``<N chars>`` instead of dumped.
+MAX_INLINE_VALUE = 60
+
+# Prompts longer than ``PROMPT_HEAD_CHARS + PROMPT_TAIL_CHARS`` are middle-truncated
+# in the console/TUI; the full text is always written verbatim to the JSONL log.
+PROMPT_HEAD_CHARS = 1200
+PROMPT_TAIL_CHARS = 400
+TABLE_MIN_COLUMN_WIDTH = 8
+
+# Per-role visual identity so the reader can tell who is speaking at a glance.
+ROLE_STYLES: dict[AgentRole, dict[str, str]] = {
+    AgentRole.PHASE: {"label": "agent", "color": ROLE_PHASE, "prompt_border": STATUS_RUNNING},
+    AgentRole.SUBAGENT: {"label": "subagent", "color": ROLE_SUBAGENT, "prompt_border": ROLE_SUBAGENT},
+    AgentRole.GOAL_REVIEWER: {
+        "label": "goal reviewer",
+        "color": ROLE_GOAL_REVIEWER,
+        "prompt_border": ROLE_GOAL_REVIEWER,
+    },
+}
+
+
+def _ellipsize_cell(value: str, width: int) -> str:
+    if len(value) <= width:
+        return value.ljust(width)
+    if width <= 1:
+        return "…"[:width]
+    return f"{value[: width - 1]}…"
+
+
+def _table_column_widths(rows: list[list[str]], max_width: int) -> list[int]:
+    column_count = len(rows[0])
+    separator_width = 3 * (column_count - 1)
+    available_width = max(TABLE_MIN_COLUMN_WIDTH * column_count, max_width - separator_width)
+    desired_widths = [max(len(row[index]) for row in rows) for index in range(column_count)]
+    base_width = max(TABLE_MIN_COLUMN_WIDTH, available_width // column_count)
+    widths = [min(width, base_width) for width in desired_widths]
+
+    remaining = available_width - sum(widths)
+    while remaining > 0:
+        expandable = [index for index, width in enumerate(widths) if width < desired_widths[index]]
+        if not expandable:
+            break
+        for index in expandable:
+            if remaining <= 0:
+                break
+            widths[index] += 1
+            remaining -= 1
+
+    return widths
+
+
+def _format_table_row(row: list[str], widths: list[int]) -> str:
+    return " | ".join(_ellipsize_cell(value, width) for value, width in zip(row, widths, strict=True))
+
+
+def _wrap_table_cell(value: str, width: int) -> list[str]:
+    wrapped = textwrap.wrap(
+        value,
+        width=max(1, width),
+        break_long_words=True,
+        break_on_hyphens=False,
+        replace_whitespace=True,
+        drop_whitespace=True,
+    )
+    return wrapped or [""]
+
+
+def _format_wrapped_table_row(row: list[str], widths: list[int]) -> list[str]:
+    wrapped_cells = [_wrap_table_cell(value, width) for value, width in zip(row, widths, strict=True)]
+    row_height = max(len(lines) for lines in wrapped_cells)
+    rendered_lines: list[str] = []
+
+    for line_number in range(row_height):
+        cells = [
+            (lines[line_number] if line_number < len(lines) else "").ljust(width)
+            for lines, width in zip(wrapped_cells, widths, strict=True)
+        ]
+        rendered_lines.append(" | ".join(cells))
+
+    return rendered_lines
+
+
+class AgentTableElement(TableElement):
+    """Markdown table renderer tuned for narrow TUI log panes."""
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        rows: list[list[str]] = []
+        if self.header is not None and self.header.row is not None:
+            rows.append([cell.content.plain for cell in self.header.row.cells])
+        if self.body is not None:
+            rows.extend([[cell.content.plain for cell in row.cells] for row in self.body.rows])
+        if not rows:
+            return
+
+        column_count = max(len(row) for row in rows)
+        normalized_rows = [row + [""] * (column_count - len(row)) for row in rows]
+        widths = _table_column_widths(normalized_rows, options.max_width)
+
+        lines = [_format_wrapped_table_row(normalized_rows[0], widths)[0]]
+        lines.append(_format_table_row(["-" * width for width in widths], widths))
+        for row in normalized_rows[1:]:
+            lines.extend(_format_wrapped_table_row(row, widths))
+
+        yield Text("\n".join(lines), style="markdown.table.border", no_wrap=True, overflow="ellipsis")
+
+
+class AgentMarkdown(Markdown):
+    """Markdown renderable for agent prompts and responses."""
+
+    elements = {**Markdown.elements, "table_open": AgentTableElement}
+
+
+def _role_style(role: AgentRole) -> dict[str, str]:
+    """Return the visual style dict for *role*, defaulting to PHASE."""
+    return ROLE_STYLES.get(role, ROLE_STYLES[AgentRole.PHASE])
+
+
+def _truncate_middle(text: str, head: int, tail: int, log_hint: str) -> str:
+    """Keep the start and end of *text*, eliding the middle with a pointer to the full log."""
+    if len(text) <= head + tail:
+        return text
+    omitted = len(text) - head - tail
+    return f'{text[:head]}\n\n[... {omitted} chars omitted — full prompt in {log_hint} ...]\n\n{text[-tail:]}'
+
+
+def _summarize_input(tool_input: dict[str, Any]) -> str:
+    """Render a tool call's input as a compact ``k=v`` line, eliding bulky values."""
+    parts: list[str] = []
+    for key, value in tool_input.items():
+        if isinstance(value, str):
+            rendered = f"<{len(value)} chars>" if len(value) > MAX_INLINE_VALUE else value
+        elif isinstance(value, (list, dict)):
+            rendered = f"<{len(value)} items>"
+        else:
+            rendered = str(value)
+        parts.append(f"{key}={rendered}")
+    return " ".join(parts)
+
+
+def _tokens(input_tokens: int, output_tokens: int) -> str:
+    """Format a token pair as a compact ``N in / M out`` string."""
+
+    def short(n: int) -> str:
+        return f"{n / 1000:.0f}k" if n >= 1000 else str(n)
+
+    return f"{short(input_tokens)} in / {short(output_tokens)} out"
+
+
+# ---------------------------------------------------------------------------
+# Rich renderable builders
+# ---------------------------------------------------------------------------
+
+
+def render_agent_start_header(scope: AgentScope) -> Text:
+    """Build the ``▸ <owner_id> [<label>]`` header shown when an agent starts."""
+    style = _role_style(scope.role)
+    header = Text(f"▸ {scope.owner_id} ", style=f"bold {style['color']}")
+    header.append(f"[{style['label']}]", style=f"dim {style['color']}")
+    return header
+
+
+def render_agent_tools_line(tools: list[str]) -> Text:
+    """Build the ``tools: t1, t2, …`` line shown below the agent start header."""
+    return Text(f"  tools: {', '.join(tools)}", style="dim")
+
+
+def render_prompt_panel(scope: AgentScope, prompt: str, log_hint: str) -> Panel:
+    """Build a ``Panel`` wrapping the (possibly middle-truncated) *prompt*."""
+    style = _role_style(scope.role)
+    body = _truncate_middle(prompt, PROMPT_HEAD_CHARS, PROMPT_TAIL_CHARS, log_hint)
+    title = f"prompt · {style['label']} ({scope.owner_id})"
+    return Panel(AgentMarkdown(body), title=title, title_align="left", border_style=style["prompt_border"])
+
+
+def render_response_header(scope: AgentScope) -> Text:
+    """Build the ``◂ response · <label> (<owner_id>)`` header."""
+    style = _role_style(scope.role)
+    return Text(f"◂ response · {style['label']} ({scope.owner_id})", style=f"bold {style['color']}")
+
+
+def render_response_text(text: str) -> AgentMarkdown:
+    """Render an agent response as Markdown."""
+    return AgentMarkdown(text)
+
+
+def render_tool_call_line(tool_call: ToolCall) -> Text:
+    """Build the ``→ <tool> k=v …`` line for a tool call in an agent response."""
+    line = Text("  → ", style=TOOL_CALL)
+    line.append(tool_call.name, style=f"bold {TOOL_CALL}")
+    summary = _summarize_input(tool_call.input)
+    if summary:
+        line.append(f" {summary}", style="dim")
+    return line
+
+
+def render_web_search_line(search: WebSearchCall) -> Text:
+    """Build the ``🔍 web_search <query> (N results)`` line."""
+    line = Text("  🔍 ", style=TOOL_SEARCH)
+    line.append("web_search", style=f"bold {TOOL_SEARCH}")
+    line.append(f" {search.query}", style="dim")
+    if search.error:
+        line.append(f" — {search.error}", style=ERROR)
+    else:
+        line.append(f" ({search.result_count} results)", style="dim")
+    return line
+
+
+def render_web_fetch_line(fetch: WebFetchCall) -> Text:
+    """Build the ``📄 web_fetch <url> (retrieved …)`` line."""
+    line = Text("  📄 ", style=TOOL_SEARCH)
+    line.append("web_fetch", style=f"bold {TOOL_SEARCH}")
+    line.append(f" {fetch.url}", style="dim")
+    if fetch.error:
+        line.append(f" — {fetch.error}", style=ERROR)
+    elif fetch.retrieved_at:
+        line.append(f" (retrieved {fetch.retrieved_at})", style="dim")
+    return line
+
+
+def render_tool_result_line(tool_call: ToolCall, result: ToolResult) -> Text:
+    """Build the ``✓/✗ <tool>`` result line shown after a tool call completes."""
+    if result.success:
+        line = Text("    ✓ ", style=STATUS_DONE)
+        line.append(tool_call.name, style="dim")
+        if result.truncated:
+            line.append(" (truncated)", style="dim")
+    else:
+        line = Text("    ✗ ", style=ERROR)
+        line.append(tool_call.name, style="dim")
+        line.append(f" — {result.error}", style=ERROR)
+    return line
+
+
+def render_compact_notice() -> Text:
+    """Build the ``⋯ compacting context`` notice line."""
+    return Text("  ⋯ compacting context", style="dim")
+
+
+def render_agent_finish_line(scope: AgentScope, result: ReActResult) -> Text:
+    """Build the ``✓ <owner_id> — N iters, X in / Y out`` summary line."""
+    return Text(
+        f"✓ {scope.owner_id} — {result.iterations} iters, "
+        f"{_tokens(result.total_input_tokens, result.total_output_tokens)}",
+        style=f"dim {STATUS_DONE}",
+    )
+
+
+def render_agent_error_line(scope: AgentScope, error: BaseException) -> Text:
+    """Build the ``✗ <owner_id> — ErrorType: message`` error line."""
+    return Text(f"✗ {scope.owner_id} — {describe_agent_error(error)}", style=ERROR)

--- a/ddev/src/ddev/cli/meta/ai/tui/__init__.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/ddev/src/ddev/cli/meta/ai/tui/app.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/app.py
@@ -1,0 +1,175 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""TogoApp — themed shell for the Togo AI harness."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+from textual import events, on, work
+from textual.app import App
+from textual.binding import Binding
+from textual.message import Message
+from textual.message_pump import MessagePump
+
+from ddev.ai.agent.registry import AgentProviderRegistry
+from ddev.ai.phases.registry import PhaseRegistry
+from ddev.cli.meta.ai.palette import STATUS_DONE, STATUS_FAILED, STATUS_PENDING, STATUS_RUNNING
+from ddev.cli.meta.ai.tui.messages import (
+    AfterCompact,
+    AfterGoalCheck,
+    AgentBeforeSend,
+    AgentErrored,
+    AgentFinished,
+    AgentResponseReceived,
+    AgentStarted,
+    AgentToolCalled,
+    BeforeCompact,
+    BeforeGoalCheck,
+    PhaseFinished,
+    PhaseStarted,
+)
+from ddev.cli.meta.ai.tui.theme import togo_markdown_theme, togo_theme
+
+if TYPE_CHECKING:
+    from ddev.ai.config.engine import ConfigurationEngine
+    from ddev.cli.application import Application
+
+
+class OrchestratorLike(Protocol):
+    """Object that can be run by the TUI shell."""
+
+    @property
+    def failed_phase(self) -> str | None: ...
+
+    async def run_async(self) -> None: ...
+
+
+class TogoApp(App):
+    """Textual application shell for the Togo AI harness.
+
+    Registers and activates the ``togo`` theme on mount.  Exposes:
+
+    - ``engine``: the configuration engine whose validated flow results are displayed.
+    - ``bridge_target``: the MessagePump that bridge callbacks post to.
+      Defaults to the app itself; later phases can swap in a screen.
+    - ``run_flow(orchestrator)``: async worker that awaits
+      ``orchestrator.run_async()``.
+    - ``received``: list of every bridge message received — used as a test
+      sink.
+    """
+
+    CSS_PATH = str(Path(__file__).parent / "togo.tcss")
+    ENABLE_COMMAND_PALETTE = False
+
+    BINDINGS = [
+        Binding("ctrl+q", "quit", "Quit"),
+    ]
+
+    def __init__(
+        self,
+        *,
+        engine: ConfigurationEngine,
+        phase_registry: PhaseRegistry,
+        provider_registry: AgentProviderRegistry,
+        ddev_app: Application,
+    ) -> None:
+        super().__init__()
+        self.engine = engine
+        self.phase_registry = phase_registry
+        self.provider_registry = provider_registry
+        self.received: list[Message] = []
+        self.bridge_target: MessagePump = self
+        self.ddev_app: Application = ddev_app
+        self.console.push_theme(togo_markdown_theme)
+
+    def get_theme_variable_defaults(self) -> dict[str, str]:
+        """Provide parse-time defaults for status variables so $status-* resolves in CSS."""
+        return {
+            "status-running": STATUS_RUNNING,
+            "status-pending": STATUS_PENDING,
+            "status-done": STATUS_DONE,
+            "status-failed": STATUS_FAILED,
+        }
+
+    def on_mount(self) -> None:
+        from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+        self.register_theme(togo_theme)
+        self.theme = "togo"
+        self.push_screen(MainScreen())
+
+    def copy_to_clipboard(self, text: str) -> None:
+        """Copy through system APIs when available and always fall back to OSC 52."""
+        try:
+            import pyperclip
+
+            pyperclip.copy(text)
+        except Exception:
+            if sys.platform == "darwin":
+                try:
+                    subprocess.run(["/usr/bin/pbcopy"], input=text, text=True, check=True)
+                except Exception:
+                    pass
+        try:
+            super().copy_to_clipboard(text)
+        except Exception:
+            pass
+
+    @on(events.TextSelected)
+    def on_text_selected(self) -> None:
+        selection = self.screen.get_selected_text()
+        if selection:
+            self.copy_to_clipboard(selection)
+
+    def _record(self, msg: Message) -> None:
+        self.received.append(msg)
+
+    @work
+    async def run_flow(self, orchestrator: OrchestratorLike) -> None:
+        """Run the orchestrator on the app's event loop."""
+        await orchestrator.run_async()
+
+    # ------------------------------------------------------------------
+    # Sink handlers — record every bridge message for headless assertions
+    # ------------------------------------------------------------------
+
+    async def on_agent_before_send(self, msg: AgentBeforeSend) -> None:
+        self._record(msg)
+
+    async def on_phase_started(self, msg: PhaseStarted) -> None:
+        self._record(msg)
+
+    async def on_phase_finished(self, msg: PhaseFinished) -> None:
+        self._record(msg)
+
+    async def on_agent_started(self, msg: AgentStarted) -> None:
+        self._record(msg)
+
+    async def on_agent_response_received(self, msg: AgentResponseReceived) -> None:
+        self._record(msg)
+
+    async def on_agent_tool_called(self, msg: AgentToolCalled) -> None:
+        self._record(msg)
+
+    async def on_agent_finished(self, msg: AgentFinished) -> None:
+        self._record(msg)
+
+    async def on_agent_errored(self, msg: AgentErrored) -> None:
+        self._record(msg)
+
+    async def on_before_compact(self, msg: BeforeCompact) -> None:
+        self._record(msg)
+
+    async def on_after_compact(self, msg: AfterCompact) -> None:
+        self._record(msg)
+
+    async def on_before_goal_check(self, msg: BeforeGoalCheck) -> None:
+        self._record(msg)
+
+    async def on_after_goal_check(self, msg: AfterGoalCheck) -> None:
+        self._record(msg)

--- a/ddev/src/ddev/cli/meta/ai/tui/bridge.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/bridge.py
@@ -1,0 +1,109 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Bridge between the orchestrator callback system and the Textual message pump.
+
+No widget or screen imports — this module only depends on callbacks and messages.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from textual.message import Message
+from textual.message_pump import MessagePump
+
+from ddev.ai.agent.scope import AgentScope
+from ddev.ai.agent.types import AgentResponse, ToolCall
+from ddev.ai.callbacks.callbacks import CallbackSet
+from ddev.ai.react.types import ReActResult
+from ddev.ai.tools.core.types import ToolResult
+from ddev.cli.meta.ai.tui.messages import (
+    AfterCompact,
+    AfterGoalCheck,
+    AgentBeforeSend,
+    AgentErrored,
+    AgentFinished,
+    AgentResponseReceived,
+    AgentStarted,
+    AgentToolCalled,
+    BeforeCompact,
+    BeforeGoalCheck,
+    PhaseFinished,
+    PhaseStarted,
+)
+
+
+class BridgeApp(Protocol):
+    """App contract required by callback-to-message bridging."""
+
+    bridge_target: MessagePump
+
+    def post_message(self, message: Message) -> bool: ...
+
+
+def build_app_callback_set(app: BridgeApp) -> CallbackSet:
+    """Return a CallbackSet whose handlers post Textual messages to app.bridge_target.
+
+    ``app.bridge_target`` is read on every callback invocation so the target can be
+    changed at runtime (e.g. a screen registers itself after startup).
+
+    The returned CallbackSet can be composed with others::
+
+        app_set = build_app_callback_set(app)
+        callbacks = Callbacks([app_set, *extra_sets])
+    """
+    cb = CallbackSet()
+
+    def _target() -> MessagePump:
+        return app.bridge_target
+
+    @cb.on_phase_start
+    async def _(phase_id: str) -> None:
+        _target().post_message(PhaseStarted(phase_id))
+
+    @cb.on_phase_finish
+    async def _(phase_id: str) -> None:
+        _target().post_message(PhaseFinished(phase_id))
+
+    @cb.on_before_agent_send
+    async def _(scope: AgentScope, prompt: str, iteration: int) -> None:
+        _target().post_message(AgentBeforeSend(scope, prompt, iteration))
+
+    @cb.on_agent_start
+    async def _(scope: AgentScope, system_prompt: str, tools: list[str]) -> None:
+        _target().post_message(AgentStarted(scope, system_prompt, tools))
+
+    @cb.on_agent_response
+    async def _(scope: AgentScope, response: AgentResponse, iteration: int) -> None:
+        _target().post_message(AgentResponseReceived(scope, response, iteration))
+
+    @cb.on_tool_call
+    async def _(scope: AgentScope, tool_call: ToolCall, result: ToolResult, iteration: int) -> None:
+        _target().post_message(AgentToolCalled(scope, tool_call, result, iteration))
+
+    @cb.on_before_compact
+    async def _(scope: AgentScope) -> None:
+        _target().post_message(BeforeCompact(scope))
+
+    @cb.on_after_compact
+    async def _(scope: AgentScope) -> None:
+        _target().post_message(AfterCompact(scope))
+
+    @cb.on_agent_finish
+    async def _(scope: AgentScope, result: ReActResult) -> None:
+        _target().post_message(AgentFinished(scope, result))
+
+    @cb.on_agent_error
+    async def _(scope: AgentScope, error: BaseException) -> None:
+        _target().post_message(AgentErrored(scope, error))
+
+    @cb.on_before_goal_check
+    async def _(phase_id: str, task_name: str, attempt: int) -> None:
+        _target().post_message(BeforeGoalCheck(phase_id, task_name, attempt))
+
+    @cb.on_after_goal_check
+    async def _(phase_id: str, task_name: str, attempt: int, valid: bool, reason: str) -> None:
+        _target().post_message(AfterGoalCheck(phase_id, task_name, attempt, valid, reason))
+
+    return cb

--- a/ddev/src/ddev/cli/meta/ai/tui/messages.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/messages.py
@@ -1,0 +1,145 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Custom Textual Message subclasses mirroring the orchestrator callback events.
+
+No widget imports — this module is safe to import anywhere in the TUI package.
+"""
+
+from __future__ import annotations
+
+from textual.message import Message
+
+from ddev.ai.agent.scope import AgentScope
+from ddev.ai.agent.types import AgentResponse, ToolCall
+from ddev.ai.react.types import ReActResult
+from ddev.ai.tools.core.types import ToolResult
+
+
+class PhaseStarted(Message):
+    """Fired when a phase begins executing."""
+
+    def __init__(self, phase_id: str) -> None:
+        super().__init__()
+        self.phase_id = phase_id
+
+
+class PhaseFinished(Message):
+    """Fired when a phase completes successfully."""
+
+    def __init__(self, phase_id: str) -> None:
+        super().__init__()
+        self.phase_id = phase_id
+
+
+class ExecutionFailed(Message):
+    """Fired when orchestration exits with an exception."""
+
+    def __init__(self, error: BaseException, phase_id: str | None) -> None:
+        super().__init__()
+        self.error = error
+        self.phase_id = phase_id
+
+
+class AgentStarted(Message):
+    """Fired once when an agent run begins, before the first send."""
+
+    def __init__(self, scope: AgentScope, system_prompt: str, tools: list[str]) -> None:
+        super().__init__()
+        self.scope = scope
+        self.system_prompt = system_prompt
+        self.tools = tools
+
+
+class AgentResponseReceived(Message):
+    """Fired after every agent.send() returns."""
+
+    def __init__(self, scope: AgentScope, response: AgentResponse, iteration: int) -> None:
+        super().__init__()
+        self.scope = scope
+        self.response = response
+        self.iteration = iteration
+
+
+class AgentToolCalled(Message):
+    """Fired once per (tool_call, result) pair after tools execute."""
+
+    def __init__(self, scope: AgentScope, tool_call: ToolCall, result: ToolResult, iteration: int) -> None:
+        super().__init__()
+        self.scope = scope
+        self.tool_call = tool_call
+        self.result = result
+        self.iteration = iteration
+
+
+class AgentFinished(Message):
+    """Fired when the ReAct loop exits cleanly."""
+
+    def __init__(self, scope: AgentScope, result: ReActResult) -> None:
+        super().__init__()
+        self.scope = scope
+        self.result = result
+
+
+class AgentErrored(Message):
+    """Fired when the ReAct loop aborts with an exception."""
+
+    def __init__(self, scope: AgentScope, error: BaseException) -> None:
+        super().__init__()
+        self.scope = scope
+        self.error = error
+
+
+class BeforeCompact(Message):
+    """Fired immediately before the agent's history is compacted."""
+
+    def __init__(self, scope: AgentScope) -> None:
+        super().__init__()
+        self.scope = scope
+
+
+class AfterCompact(Message):
+    """Fired immediately after the agent's history has been compacted."""
+
+    def __init__(self, scope: AgentScope) -> None:
+        super().__init__()
+        self.scope = scope
+
+
+class AgentBeforeSend(Message):
+    """Fired just before each agent.send() with the prompt content (sentinel excluded)."""
+
+    def __init__(self, scope: AgentScope, prompt: str, iteration: int) -> None:
+        super().__init__()
+        self.scope = scope
+        self.prompt = prompt
+        self.iteration = iteration
+
+
+class BeforeGoalCheck(Message):
+    """Fired immediately before each reviewer agent run for a task with a goal."""
+
+    def __init__(self, phase_id: str, task_name: str, attempt: int) -> None:
+        super().__init__()
+        self.phase_id = phase_id
+        self.task_name = task_name
+        self.attempt = attempt
+
+
+class AfterGoalCheck(Message):
+    """Fired after each reviewer agent run, with the parsed verdict."""
+
+    def __init__(
+        self,
+        phase_id: str,
+        task_name: str,
+        attempt: int,
+        valid: bool,
+        reason: str,
+    ) -> None:
+        super().__init__()
+        self.phase_id = phase_id
+        self.task_name = task_name
+        self.attempt = attempt
+        self.valid = valid
+        self.reason = reason

--- a/ddev/src/ddev/cli/meta/ai/tui/runs.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/runs.py
@@ -1,0 +1,68 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Run-directory helpers: detect whether a resumable run exists for a flow."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+from ddev.ai.config.errors import ConfigError
+from ddev.ai.config.models import ResolvedFlow
+from ddev.ai.runtime.checkpoints import CheckpointManager, resolve_resume_state
+
+
+def flow_slug(flow: ResolvedFlow) -> str:
+    """Return a readable, collision-resistant filesystem slug for a flow."""
+    name = flow.name or "unnamed"
+    readable = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or "unnamed"
+    digest = hashlib.sha256(name.encode("utf-8")).hexdigest()[:8]
+    return f"{readable}-{digest}"
+
+
+def ai_runs_dir(repo_root: str | Path) -> Path:
+    """Return the shared run root below a repository."""
+    return Path(repo_root) / ".ddev" / "ai-runs"
+
+
+def has_resumable_run(flow: ResolvedFlow, runs_dir: Path) -> bool:
+    """Return True if an incomplete run exists for *flow*.
+
+    A run is resumable when ``checkpoints.yaml`` exists inside the flow's run
+    directory, is non-empty, and ``resolve_resume_state`` (the same logic the
+    orchestrator uses to resume) finds at least one scheduled phase that
+    hasn't reached a dependency-closed success.
+
+    Args:
+        flow: The flow to check.
+        runs_dir: Base directory that contains per-flow run sub-directories.
+    """
+    checkpoints_path = runs_dir / flow_slug(flow) / "checkpoints.yaml"
+    if not checkpoints_path.exists():
+        return False
+
+    manager = CheckpointManager(checkpoints_path)
+    try:
+        checkpoints = manager.read()
+    except Exception:
+        return False
+
+    if not checkpoints:
+        return False
+
+    try:
+        completed, _frontier = resolve_resume_state(flow, manager)
+    except ConfigError:
+        return False
+
+    scheduled = {entry.phase for entry in flow.flow}
+    return completed != scheduled
+
+
+def resume_completed_phases(flow: ResolvedFlow, runs_dir: Path) -> set[str]:
+    """Return dependency-closed completed phases from the flow checkpoint."""
+    manager = CheckpointManager(runs_dir / flow_slug(flow) / "checkpoints.yaml")
+    completed, _frontier = resolve_resume_state(flow, manager)
+    return completed

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/__init__.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/base.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/base.py
@@ -1,0 +1,50 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""TogoScreen — base screen providing the shared chrome (header + rule + body + footer)."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import Iterator
+from typing import cast
+
+from textual.app import ComposeResult
+from textual.containers import Container
+from textual.screen import Screen
+from textual.widget import Widget
+from textual.widgets import Footer
+
+from ddev.cli.meta.ai.tui.app import TogoApp
+from ddev.cli.meta.ai.tui.widgets.header import TogoHeader
+
+
+class TogoScreen(Screen):
+    """Base screen composing TogoHeader + compose_body() + Footer."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._togo_title: str | None = None
+
+    def compose(self) -> ComposeResult:
+        yield TogoHeader(title=self._togo_title or self.TITLE or "")
+        with Container(id="screen-body"):
+            yield from self.compose_body()
+        yield Footer()
+
+    @property
+    def togo_app(self) -> TogoApp:
+        """Return the concrete app this screen is mounted under."""
+        return cast(TogoApp, self.app)
+
+    def copy_selection(self) -> bool:
+        """Copy the current screen selection, returning whether text was available."""
+        selection = self.get_selected_text()
+        if not selection:
+            return False
+        self.app.copy_to_clipboard(selection)
+        return True
+
+    @abstractmethod
+    def compose_body(self) -> Iterator[Widget]:
+        """Yield the screen-specific body widgets."""

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/diagnostics_modal.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/diagnostics_modal.py
@@ -1,0 +1,59 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widget import Widget
+from textual.widgets import Button, Static
+
+from ddev.ai.config.errors import FlowError
+from ddev.ai.config.models import FlowResult
+
+
+class FlowDiagnosticsModal(ModalScreen[None]):
+    """Read-only details for a flow that could not be resolved."""
+
+    BINDINGS = [Binding("escape", "dismiss_modal", "Close")]
+
+    def __init__(self, result: FlowResult) -> None:
+        super().__init__()
+        self.result = result
+
+    def compose(self) -> ComposeResult:
+        dialog = Widget(id="dialog", classes="diagnostics")
+        dialog.border_title = f"diagnostics · {self.result.name}"
+        with dialog:
+            yield Static("This flow cannot be launched until these configuration errors are fixed.", classes="desc")
+            with VerticalScroll(id="diagnostic-errors"):
+                for index, error in enumerate(self.result.errors, start=1):
+                    yield self._error_widget(index, error)
+            with Horizontal(classes="modal-actions"):
+                yield Button("Close", id="btn-close", variant="primary")
+
+    def _error_widget(self, index: int, error: FlowError) -> Widget:
+        details = Text(f"{index:02d} · {error.kind.value}", style="bold")
+        details.append(f"\n{error.message}")
+        context = []
+        if error.phase:
+            context.append(f"phase: {error.phase}")
+        if error.subject:
+            context.append(f"subject: {error.subject}")
+        if context:
+            details.append("\n" + " · ".join(context), style="dim")
+        if error.sources:
+            details.append("\nsources:", style="dim")
+            for source in error.sources:
+                details.append(f"\n  {source}")
+        return Static(details, classes="diagnostic-error")
+
+    def action_dismiss_modal(self) -> None:
+        self.dismiss(None)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-close":
+            self.dismiss(None)

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -1,0 +1,350 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""ExecutionScreen — live execution view with a pipeline graph and per-phase drill-down logs."""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from textual import events, work
+from textual.binding import Binding
+from textual.widget import Widget
+from textual.widgets import Static
+from textual.worker import Worker
+
+from ddev.ai.callbacks.callbacks import Callbacks
+from ddev.ai.config.models import ResolvedFlow
+from ddev.ai.react.process import TOOL_RESULTS_SENTINEL
+from ddev.cli.meta.ai.rendering import (
+    render_agent_error_line,
+    render_agent_finish_line,
+    render_agent_start_header,
+    render_agent_tools_line,
+    render_compact_notice,
+    render_prompt_panel,
+    render_response_header,
+    render_response_text,
+    render_tool_call_line,
+    render_tool_result_line,
+    render_web_fetch_line,
+    render_web_search_line,
+)
+from ddev.cli.meta.ai.tui.app import OrchestratorLike
+from ddev.cli.meta.ai.tui.messages import (
+    AfterGoalCheck,
+    AgentBeforeSend,
+    AgentErrored,
+    AgentFinished,
+    AgentResponseReceived,
+    AgentStarted,
+    AgentToolCalled,
+    BeforeCompact,
+    BeforeGoalCheck,
+    ExecutionFailed,
+    PhaseFinished,
+    PhaseStarted,
+)
+from ddev.cli.meta.ai.tui.runs import ai_runs_dir, flow_slug, resume_completed_phases
+from ddev.cli.meta.ai.tui.screens.base import TogoScreen
+from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogEntry, PhaseLogScreen
+from ddev.cli.meta.ai.tui.status import RunStatus
+from ddev.cli.meta.ai.tui.widgets.header import TogoHeader
+from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseSelected, PipelineGraph
+
+if TYPE_CHECKING:
+    from ddev.ai.runtime.orchestrator import PhaseOrchestrator
+
+
+type OrchestratorBuilder = Callable[[Callbacks], OrchestratorLike]
+
+
+class ExecutionScreen(TogoScreen):
+    """Live execution screen: pipeline graph plus per-phase drill-down logs."""
+
+    BINDINGS = [
+        Binding("escape", "back", "Back", priority=True),
+        Binding("ctrl+c", "copy_or_cancel_run", "Copy / Cancel"),
+    ]
+
+    def __init__(
+        self,
+        flow: ResolvedFlow,
+        runtime_variables: dict[str, str] | None = None,
+        resume: bool = False,
+        runs_dir: Path | None = None,
+        orchestrator_builder: OrchestratorBuilder | None = None,
+    ) -> None:
+        super().__init__()
+        self.flow = flow
+        self.runtime_variables = runtime_variables
+        self.resume = resume
+        self._runs_dir = runs_dir
+        self._orchestrator_builder = orchestrator_builder
+        self._togo_title = flow.name or "Execution"
+
+        self._phase_statuses: dict[str, RunStatus] = {entry.phase: RunStatus.PENDING for entry in flow.flow}
+        self._task_statuses: dict[tuple[str, str], RunStatus] = {
+            (entry.phase, task.name): RunStatus.PENDING
+            for entry in flow.flow
+            for task in flow.phases[entry.phase].tasks
+        }
+        self._phase_logs: dict[str, list[PhaseLogEntry]] = {entry.phase: [] for entry in flow.flow}
+        self._open_phase_log_screens: dict[str, list[PhaseLogScreen]] = {entry.phase: [] for entry in flow.flow}
+        self._active_thinking: dict[str, dict[str, str]] = {entry.phase: {} for entry in flow.flow}
+        self._orchestrator: OrchestratorLike | None = None
+        self._run_worker: Worker[None] | None = None
+        # Records every renderable produced by the run — used by tests and to
+        # populate phase log screens opened after the fact.
+        self._output_renders: list[PhaseLogEntry] = []
+        self._output_write_count: int = 0
+
+    def compose_body(self) -> Iterator[Widget]:
+        error = Static("", id="execution-error")
+        error.display = False
+        yield error
+        pipeline = PipelineGraph(self.flow, self._phase_statuses, id="pipeline")
+        pipeline.border_title = "Pipeline"
+        yield pipeline
+
+    def on_mount(self) -> None:
+        self.togo_app.bridge_target = self
+        if self.resume:
+            runs_dir = self._runs_dir or ai_runs_dir(self.togo_app.ddev_app.repo.path)
+            for phase_id in resume_completed_phases(self.flow, runs_dir):
+                self._phase_statuses[phase_id] = RunStatus.DONE
+                for task_phase, task_name in self._task_statuses:
+                    if task_phase == phase_id:
+                        self._task_statuses[(task_phase, task_name)] = RunStatus.DONE
+        self._update_display()
+        self._run_worker = self._run_orchestrator()
+
+    def on_unmount(self) -> None:
+        if self._run_worker is not None:
+            self._run_worker.cancel()
+        if self.togo_app.bridge_target is self:
+            self.togo_app.bridge_target = self.togo_app
+
+    def action_cancel_run(self) -> None:
+        """Cancel the running orchestrator worker."""
+        if self._run_worker is not None:
+            self._run_worker.cancel()
+
+    def action_copy_or_cancel_run(self) -> None:
+        if not self.copy_selection():
+            self.action_cancel_run()
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def on_key(self, event: events.Key) -> None:
+        if event.key == "escape":
+            event.stop()
+            self.action_back()
+
+    @work(exit_on_error=False)
+    async def _run_orchestrator(self) -> None:
+        from ddev.cli.meta.ai.tui.bridge import build_app_callback_set
+
+        callbacks = Callbacks([build_app_callback_set(self.togo_app)])
+        orchestrator: OrchestratorLike | None = None
+
+        try:
+            if self._orchestrator_builder is not None:
+                orchestrator = self._orchestrator_builder(callbacks)
+            else:
+                orchestrator = self._build_real_orchestrator(callbacks)
+            self._orchestrator = orchestrator
+            self.query_one(TogoHeader).running = True
+            await orchestrator.run_async()
+        except Exception as error:
+            failed_phase = orchestrator.failed_phase if orchestrator is not None else None
+            self.post_message(ExecutionFailed(error, failed_phase))
+        finally:
+            try:
+                self.query_one(TogoHeader).running = False
+            except Exception:
+                pass
+
+    def _build_real_orchestrator(self, callbacks: Callbacks) -> PhaseOrchestrator:
+        """Construct the real PhaseOrchestrator for production use."""
+        from ddev.ai.runtime.orchestrator import PhaseOrchestrator
+        from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
+
+        write_root = Path(self.togo_app.ddev_app.repo.path)
+        run_root = ai_runs_dir(write_root)
+        if not run_root.resolve().is_relative_to(write_root.resolve()):
+            raise ValueError(f"Refusing to use AI run directory outside repository: {run_root}")
+        run_dir = run_root / flow_slug(self.flow)
+        if not self.resume:
+            if run_dir.is_symlink():
+                run_dir.unlink()
+            elif run_dir.exists():
+                shutil.rmtree(run_dir)
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        return PhaseOrchestrator(
+            resolved_flow=self.flow,
+            phase_registry=self.togo_app.phase_registry,
+            checkpoint_path=run_dir / "checkpoints.yaml",
+            runtime_variables=self.runtime_variables or {},
+            provider_registry=self.togo_app.provider_registry,
+            file_access_policy=FileAccessPolicy(write_root=write_root),
+            callbacks=callbacks,
+            resume=self.resume,
+        )
+
+    # ── Display helpers ──────────────────────────────────────────────────
+
+    def _update_display(self) -> None:
+        try:
+            self.query_one("#pipeline", PipelineGraph).update_statuses(self._phase_statuses)
+        except Exception:
+            pass
+
+    def _show_execution_error(self, error: BaseException) -> None:
+        message = f"Execution failed: {type(error).__name__}: {error}"
+        try:
+            widget = self.query_one("#execution-error", Static)
+            widget.update(message)
+            widget.display = True
+        except Exception:
+            pass
+
+    def _mark_phase_failed(self, phase_id: str) -> None:
+        self._phase_statuses[phase_id] = RunStatus.FAILED
+        for (task_phase, task_name), status in list(self._task_statuses.items()):
+            if task_phase == phase_id and status in (RunStatus.RUNNING, RunStatus.PENDING):
+                self._task_statuses[(task_phase, task_name)] = RunStatus.FAILED
+
+    def register_phase_log_screen(self, screen: PhaseLogScreen) -> None:
+        self._open_phase_log_screens.setdefault(screen.phase_id, []).append(screen)
+        for key, label in self._active_thinking.get(screen.phase_id, {}).items():
+            screen.start_thinking(key, label)
+
+    def unregister_phase_log_screen(self, screen: PhaseLogScreen) -> None:
+        screens = self._open_phase_log_screens.get(screen.phase_id, [])
+        if screen in screens:
+            screens.remove(screen)
+
+    def _write_output(self, renderable: PhaseLogEntry, phase_id: str | None = None) -> None:
+        """Write a renderable to phase logs and record it for tests."""
+        self._output_renders.append(renderable)
+        self._output_write_count += 1
+        if phase_id is not None:
+            self._phase_logs.setdefault(phase_id, []).append(renderable)
+            for screen in list(self._open_phase_log_screens.get(phase_id, [])):
+                screen.write(renderable)
+
+    def _thinking_key(self, owner_id: str, role: str, iteration: int) -> str:
+        return f"{owner_id}:{role}:{iteration}"
+
+    def _start_thinking(self, phase_id: str | None, key: str, label: str) -> None:
+        if phase_id is None:
+            return
+        self._active_thinking.setdefault(phase_id, {})[key] = label
+        for screen in list(self._open_phase_log_screens.get(phase_id, [])):
+            screen.start_thinking(key, label)
+
+    def _stop_thinking(self, phase_id: str | None, key: str) -> None:
+        if phase_id is None:
+            return
+        self._active_thinking.setdefault(phase_id, {}).pop(key, None)
+        for screen in list(self._open_phase_log_screens.get(phase_id, [])):
+            screen.stop_thinking(key)
+
+    def _stop_agent_thinking(self, phase_id: str | None, owner_id: str, role: str) -> None:
+        if phase_id is None:
+            return
+        prefix = f"{owner_id}:{role}:"
+        for key in list(self._active_thinking.setdefault(phase_id, {})):
+            if key.startswith(prefix):
+                self._stop_thinking(phase_id, key)
+
+    # ── Bridge message handlers ──────────────────────────────────────────
+
+    def on_phase_started(self, msg: PhaseStarted) -> None:
+        self._phase_statuses[msg.phase_id] = RunStatus.RUNNING
+        self._update_display()
+
+    def on_phase_finished(self, msg: PhaseFinished) -> None:
+        self._phase_statuses[msg.phase_id] = RunStatus.DONE
+        for (p, t), status in list(self._task_statuses.items()):
+            if p == msg.phase_id and status in (RunStatus.RUNNING, RunStatus.PENDING):
+                self._task_statuses[(p, t)] = RunStatus.DONE
+        self._update_display()
+
+    def on_execution_failed(self, msg: ExecutionFailed) -> None:
+        self._show_execution_error(msg.error)
+        if msg.phase_id in self._phase_statuses:
+            self._mark_phase_failed(msg.phase_id)
+            self._update_display()
+
+    def on_phase_selected(self, msg: PhaseSelected) -> None:
+        status = self._phase_statuses.get(msg.phase_id, RunStatus.PENDING)
+        if status.has_started:
+            self.app.push_screen(PhaseLogScreen(self.flow, msg.phase_id, self._phase_logs[msg.phase_id], source=self))
+        else:
+            self.app.push_screen(PhaseConfigScreen(self.flow, msg.phase_id))
+
+    def on_agent_started(self, msg: AgentStarted) -> None:
+        phase_id = msg.scope.phase_id
+        self._write_output(render_agent_start_header(msg.scope), phase_id=phase_id)
+        if msg.tools:
+            self._write_output(render_agent_tools_line(msg.tools), phase_id=phase_id)
+
+    def on_agent_before_send(self, msg: AgentBeforeSend) -> None:
+        phase_id = msg.scope.phase_id
+        if msg.prompt != TOOL_RESULTS_SENTINEL:
+            self._write_output(render_prompt_panel(msg.scope, msg.prompt, "run artifacts"), phase_id=phase_id)
+        key = self._thinking_key(msg.scope.owner_id, msg.scope.role.value, msg.iteration)
+        self._start_thinking(phase_id, key, f"{msg.scope.owner_id} · {msg.scope.role.value}")
+
+    def on_agent_response_received(self, msg: AgentResponseReceived) -> None:
+        phase_id = msg.scope.phase_id
+        key = self._thinking_key(msg.scope.owner_id, msg.scope.role.value, msg.iteration)
+        self._stop_thinking(phase_id, key)
+        self._write_output(render_response_header(msg.scope), phase_id=phase_id)
+        if msg.response.text.strip():
+            self._write_output(render_response_text(msg.response.text), phase_id=phase_id)
+        for tool_call in msg.response.tool_calls:
+            self._write_output(render_tool_call_line(tool_call), phase_id=phase_id)
+        for search in msg.response.web_activity.searches:
+            self._write_output(render_web_search_line(search), phase_id=phase_id)
+        for fetch in msg.response.web_activity.fetches:
+            self._write_output(render_web_fetch_line(fetch), phase_id=phase_id)
+
+    def on_agent_tool_called(self, msg: AgentToolCalled) -> None:
+        self._write_output(render_tool_result_line(msg.tool_call, msg.result), phase_id=msg.scope.phase_id)
+
+    def on_before_compact(self, msg: BeforeCompact) -> None:
+        self._write_output(render_compact_notice(), phase_id=msg.scope.phase_id)
+
+    def on_agent_finished(self, msg: AgentFinished) -> None:
+        phase_id = msg.scope.phase_id
+        self._stop_agent_thinking(phase_id, msg.scope.owner_id, msg.scope.role.value)
+        self._write_output(render_agent_finish_line(msg.scope, msg.result), phase_id=phase_id)
+
+    def on_agent_errored(self, msg: AgentErrored) -> None:
+        phase_id = msg.scope.phase_id
+        self._stop_agent_thinking(phase_id, msg.scope.owner_id, msg.scope.role.value)
+        self._write_output(render_agent_error_line(msg.scope, msg.error), phase_id=phase_id)
+        if phase_id is not None:
+            self._mark_phase_failed(phase_id)
+        self._update_display()
+
+    def on_before_goal_check(self, msg: BeforeGoalCheck) -> None:
+        key = (msg.phase_id, msg.task_name)
+        if key in self._task_statuses:
+            self._task_statuses[key] = RunStatus.RUNNING
+            self._update_display()
+
+    def on_after_goal_check(self, msg: AfterGoalCheck) -> None:
+        key = (msg.phase_id, msg.task_name)
+        if key in self._task_statuses:
+            self._task_statuses[key] = RunStatus.DONE if msg.valid else RunStatus.FAILED
+            self._update_display()

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
@@ -1,0 +1,139 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""FlowScreen — flow overview, pipeline preview, and launch/resume actions."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widget import Widget
+from textual.widgets import Button, Static
+
+from ddev.ai.config.models import AgentConfig, ResolvedFlow
+from ddev.cli.meta.ai.tui.screens.base import TogoScreen
+from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchInputValues
+from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+from ddev.cli.meta.ai.tui.status import RunStatus
+from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseSelected, PipelineGraph
+
+
+class FlowScreen(TogoScreen):
+    """Show resolved flow details and controls for launching or resuming execution."""
+
+    BINDINGS = [
+        Binding("escape", "app.pop_screen", "Back"),
+        Binding("l", "launch", "Launch"),
+    ]
+
+    def __init__(
+        self,
+        flow: ResolvedFlow,
+        runs_dir: Path | None = None,
+    ) -> None:
+        super().__init__()
+        self.flow = flow
+        self._runs_dir = runs_dir
+        self._togo_title = flow.name or "Flow"
+
+    def compose_body(self) -> Iterator[Widget]:
+        with Horizontal(id="flow-body"):
+            yield from self._compose_overview()
+
+            graph = PipelineGraph(
+                self.flow,
+                {entry.phase: RunStatus.PENDING for entry in self.flow.flow},
+                id="flow-pipeline",
+            )
+            graph.border_title = "Pipeline"
+            yield graph
+
+        with Horizontal(id="actions"):
+            yield Button("Back", id="back")
+            yield Button("Launch ▶", id="launch-btn", variant="primary")
+            resume_btn = Button("Resume", id="resume", variant="warning")
+            resume_btn.display = False
+            yield resume_btn
+
+    def _compose_overview(self) -> Iterator[Widget]:
+        overview = VerticalScroll(id="flow-overview", classes="panel")
+        overview.border_title = "overview"
+        with overview:
+            if self.flow.description:
+                yield Static(self.flow.description, id="flow-description", classes="desc")
+
+            if self.flow.agents:
+                yield Static("AGENTS", classes="eyebrow")
+                with Vertical(id="flow-agents"):
+                    for name, config in self.flow.agents.items():
+                        yield from self._compose_agent_summary(name, config)
+
+            if self.flow.inputs:
+                yield Static("INPUTS", classes="eyebrow")
+                with Vertical(id="flow-inputs"):
+                    for flow_input in self.flow.inputs:
+                        marker = "required" if flow_input.required else "optional"
+                        yield Static(f"○ {flow_input.label} · {marker}", classes="flow-input-row")
+
+    def _compose_agent_summary(self, name: str, config: AgentConfig) -> Iterator[Widget]:
+        row = Vertical(classes="flow-agent-row")
+        with row:
+            yield Static(f"◆ {name} · {config.model or config.provider}", classes="flow-agent-heading")
+            if config.tools:
+                yield Static(" · ".join(config.tools), classes="flow-agent-tools")
+
+    def on_mount(self) -> None:
+        from ddev.cli.meta.ai.tui.runs import ai_runs_dir, has_resumable_run
+
+        runs_dir = self._runs_dir or ai_runs_dir(self.togo_app.ddev_app.repo.path)
+        if has_resumable_run(self.flow, runs_dir):
+            try:
+                self.query_one("#resume").display = True
+            except Exception:
+                pass
+
+    def on_phase_selected(self, event: PhaseSelected) -> None:
+        self.app.push_screen(PhaseConfigScreen(self.flow, event.phase_id))
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        match event.button.id:
+            case "back":
+                self.app.pop_screen()
+            case "launch-btn":
+                self.action_launch()
+            case "resume":
+                self._do_resume()
+
+    def action_launch(self) -> None:
+        from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+        from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchModal
+
+        def _on_dismiss(values: LaunchInputValues | None) -> None:
+            if values is not None:
+                self.app.push_screen(ExecutionScreen(self.flow, runtime_variables=values, runs_dir=self._runs_dir))
+
+        self.app.push_screen(LaunchModal(self.flow), _on_dismiss)
+
+    def _do_resume(self) -> None:
+        from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+        from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchModal
+
+        if not self.flow.inputs:
+            self.app.push_screen(ExecutionScreen(self.flow, runtime_variables={}, resume=True, runs_dir=self._runs_dir))
+            return
+
+        def _on_dismiss(values: LaunchInputValues | None) -> None:
+            if values is not None:
+                self.app.push_screen(
+                    ExecutionScreen(
+                        self.flow,
+                        runtime_variables=values,
+                        resume=True,
+                        runs_dir=self._runs_dir,
+                    )
+                )
+
+        self.app.push_screen(LaunchModal(self.flow), _on_dismiss)

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/launch_modal.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/launch_modal.py
@@ -1,0 +1,203 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""LaunchModal — collects typed flow inputs and dismisses with a validated payload."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Literal
+
+from textual import events
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal
+from textual.content import Content
+from textual.screen import ModalScreen
+from textual.validation import Number
+from textual.widget import Widget
+from textual.widgets import Button, Input, Label, Static, Switch
+from textual_autocomplete import DropdownItem, PathAutoComplete, TargetState
+
+from ddev.ai.config.models import FlowInput, InputType, ResolvedFlow
+
+type LaunchInputValue = str | bool
+type LaunchInputValues = dict[str, str]
+
+
+class TogoPathAutoComplete(PathAutoComplete):
+    """PathAutoComplete that expands a leading ``~`` and skips emoji prefixes.
+
+    The typed value is never rewritten to an existing entry: Enter always
+    submits the field's literal text (including paths that don't exist yet,
+    e.g. an output directory to be created), and only Tab accepts a
+    suggestion from the dropdown.
+    """
+
+    def __init__(self, target: Input | str) -> None:
+        super().__init__(
+            target,
+            folder_prefix=Content(""),
+            file_prefix=Content(""),
+        )
+
+    def get_candidates(self, target_state: TargetState) -> list[DropdownItem]:
+        current_input = target_state.text[: target_state.cursor_position]
+        if current_input.startswith("~"):
+            expanded = str(Path(current_input).expanduser())
+            if current_input.endswith("/") and not expanded.endswith("/"):
+                expanded += "/"
+            target_state = TargetState(text=expanded, cursor_position=len(expanded))
+        return super().get_candidates(target_state)
+
+    def _listen_to_messages(self, event: events.Event) -> None:
+        """Handle enter/escape ourselves instead of delegating to the base class.
+
+        The base implementation only runs its enter/escape handling when the dropdown
+        currently has at least one candidate (``option_list.option_count`` — it auto-hides
+        with zero matches), and even then it applies the highlighted completion on enter
+        regardless of ``prevent_default_enter``. Neither behavior is what we want for a
+        path field that must accept freely typed, possibly nonexistent paths: typing a new
+        output directory (no matching candidates) left enter/escape unhandled by the
+        dropdown entirely, so escape fell through to the modal's own ``escape`` binding and
+        dismissed the whole dialog, discarding whatever was typed. We handle both keys
+        directly based on whether the path field itself has focus (not on the dropdown's
+        visibility, which can't be relied on), so the typed text is never silently
+        overwritten or discarded.
+        """
+        if isinstance(event, events.Key) and self.target.has_focus:
+            if event.key == "enter":
+                if self.display:
+                    self.action_hide()
+                return
+            if event.key == "escape":
+                event.prevent_default()
+                event.stop()
+                if self.display:
+                    self.action_hide()
+                return
+        super()._listen_to_messages(event)
+
+
+class LaunchModal(ModalScreen):
+    """Collect and convert a flow's typed runtime inputs."""
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    def __init__(self, flow: ResolvedFlow) -> None:
+        super().__init__()
+        self.flow = flow
+
+    # ------------------------------------------------------------------
+    # Compose
+    # ------------------------------------------------------------------
+
+    def compose(self) -> ComposeResult:
+        dialog = Widget(id="dialog", classes="launch")
+        dialog.border_title = f"launch · {self.flow.name or 'flow'}"
+        with dialog:
+            yield Static("Provide inputs for this run, then start.", classes="desc")
+            with Widget(id="launch-fields"):
+                yield from self._compose_inputs()
+            yield Static("", id="launch-error")
+            with Horizontal(classes="modal-actions"):
+                yield Button("Cancel", id="btn-cancel")
+                yield Button("Launch ▶", id="btn-launch", variant="primary")
+
+    def _compose_inputs(self) -> Iterator[Widget]:
+        for inp in self.flow.inputs:
+            yield Label(inp.label.upper(), classes="eyebrow")
+            yield from self._widget_for(inp)
+
+    def _widget_for(self, inp: FlowInput) -> Iterator[Widget]:
+        widget_id = f"input-{inp.name}"
+        if inp.input_type == InputType.BOOLEAN:
+            default_enabled = inp.default if isinstance(inp.default, bool) else str(inp.default).lower() == "true"
+            yield Switch(value=default_enabled, id=widget_id)
+        elif inp.input_type == InputType.NUMBER:
+            default_text = str(inp.default) if inp.default is not None else ""
+            yield Input(value=default_text, id=widget_id, validators=[Number()])
+        elif inp.input_type == InputType.PATH:
+            default_text = str(inp.default) if inp.default is not None else ""
+            path_input = Input(value=default_text, id=widget_id)
+            yield path_input
+            yield TogoPathAutoComplete(target=f"#{widget_id}")
+        else:
+            # STRING (default)
+            default_text = str(inp.default) if inp.default is not None else ""
+            yield Input(value=default_text, id=widget_id)
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-cancel":
+            self.dismiss(None)
+        elif event.button.id == "btn-launch":
+            self._try_launch()
+
+    # ------------------------------------------------------------------
+    # Validation + dismiss
+    # ------------------------------------------------------------------
+
+    def _try_launch(self) -> None:
+        values: dict[str, LaunchInputValue] = {}
+        for inp in self.flow.inputs:
+            widget_id = f"input-{inp.name}"
+            ok, value = self._read_value(inp, widget_id)
+            if not ok:
+                return
+            if value is None:
+                continue
+            values[inp.name] = value
+        try:
+            converted = self.flow.convert_inputs(values)
+        except ValueError as error:
+            self._show_error(str(error))
+            return
+        self.dismiss(converted)
+
+    def _read_value(
+        self, inp: FlowInput, widget_id: str
+    ) -> tuple[Literal[True], LaunchInputValue | None] | tuple[Literal[False], None]:
+        """Read and validate the value for one input.
+
+        Returns (success, value); on failure shows an inline error.
+        """
+        if inp.input_type == InputType.BOOLEAN:
+            sw = self.query_one(f"#{widget_id}", Switch)
+            return True, sw.value
+
+        widget = self.query_one(f"#{widget_id}", Input)
+        text = widget.value.strip()
+
+        if inp.required and not text:
+            self._show_error(f"{inp.label}: required field cannot be empty.")
+            return False, None
+        if not text:
+            return True, None
+
+        if inp.input_type == InputType.NUMBER:
+            try:
+                float(text)
+            except ValueError:
+                self._show_error(f"{inp.label}: must be a valid number.")
+                return False, None
+
+        return True, text
+
+    def _show_error(self, message: str) -> None:
+        try:
+            err = self.query_one("#launch-error", Static)
+            err.update(f"[red]{message}[/red]")
+        except Exception:
+            pass

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/main.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/main.py
@@ -1,0 +1,46 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""MainScreen — lists valid and broken configuration-engine flow results."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from textual.containers import VerticalScroll
+from textual.widget import Widget
+from textual.widgets import Static
+
+from ddev.cli.meta.ai.tui.runs import ai_runs_dir, has_resumable_run
+from ddev.cli.meta.ai.tui.screens.base import TogoScreen
+from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+
+class MainScreen(TogoScreen):
+    """Main dashboard screen listing all available flows."""
+
+    TITLE = "Flows"
+
+    @property
+    def runs_dir(self) -> Path:
+        return ai_runs_dir(self.togo_app.ddev_app.repo.path)
+
+    def compose_body(self) -> Iterator[Widget]:
+        results = sorted(self.togo_app.engine.flows.values(), key=lambda result: result.name.casefold())
+        yield Static(f"DISCOVERED FLOWS · {len(results)}", classes="eyebrow")
+        grid = VerticalScroll(id="flow-grid")
+        for i, result in enumerate(results):
+            resumable = result.resolved is not None and has_resumable_run(result.resolved, self.runs_dir)
+            grid.compose_add_child(FlowCard(result=result, index=i, resumable=resumable))
+        yield grid
+
+    def on_flow_card_selected(self, event: FlowCard.Selected) -> None:
+        if event.result.resolved is not None:
+            from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+
+            self.app.push_screen(FlowScreen(event.result.resolved, runs_dir=self.runs_dir))
+        else:
+            from ddev.cli.meta.ai.tui.screens.diagnostics_modal import FlowDiagnosticsModal
+
+            self.app.push_screen(FlowDiagnosticsModal(event.result))

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/phase_config.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/phase_config.py
@@ -1,0 +1,99 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Full-screen phase configuration view."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widget import Widget
+from textual.widgets import Button, Collapsible, Markdown, Static
+
+from ddev.ai.config.models import AgentConfig, ResolvedFlow, TaskConfig
+from ddev.cli.meta.ai.tui.screens.base import TogoScreen
+
+
+class PhaseConfigScreen(TogoScreen):
+    """Shows the full configuration for one phase."""
+
+    BINDINGS = [Binding("escape", "app.pop_screen", "Back")]
+
+    def __init__(self, flow: ResolvedFlow, phase_id: str) -> None:
+        super().__init__()
+        self.flow = flow
+        self.phase_id = phase_id
+        self._togo_title = f"{flow.name or 'Flow'} · {phase_id}"
+
+    def compose_body(self) -> Iterator[Widget]:
+        phase = self.flow.phases[self.phase_id]
+        phase_index = next(index for index, entry in enumerate(self.flow.flow) if entry.phase == self.phase_id)
+        dependencies = next(entry.dependencies for entry in self.flow.flow if entry.phase == self.phase_id)
+
+        config_panel = Widget(id="phase-configuration", classes="panel")
+        config_panel.border_title = "phase configuration"
+        with config_panel:
+            with Horizontal(id="phase-summary"):
+                with Vertical(id="phase-heading"):
+                    yield Static(f"Phase {phase_index:02d}", id="phase-index", classes="eyebrow")
+                    yield Static(self.phase_id, id="phase-title")
+                with Vertical(id="phase-dependencies-summary"):
+                    yield Static("DEPENDENCIES", classes="eyebrow")
+                    yield Static(
+                        ", ".join(dependencies) if dependencies else "none",
+                        id="phase-dependencies",
+                        classes="desc",
+                    )
+
+            with Horizontal(id="phase-config-grid"):
+                tasks_card = VerticalScroll(id="phase-tasks-card", classes="phase-config-card")
+                tasks_card.border_title = "tasks"
+                with tasks_card:
+                    with Vertical(id="phase-tasks"):
+                        for index, task in enumerate(phase.tasks):
+                            yield from self._compose_task(task, collapsed=index > 0)
+
+                agent_card = Widget(id="phase-agent-card", classes="phase-config-card")
+                agent_card.border_title = "agent"
+                with agent_card:
+                    if phase.agent and phase.agent in self.flow.agents:
+                        yield from self._compose_agent(phase.agent, self.flow.agents[phase.agent])
+                    else:
+                        yield Static("No agent configured for this phase.", classes="desc")
+
+        with Horizontal(id="phase-actions"):
+            yield Button("Back", id="back")
+
+    def _compose_task(self, task: TaskConfig, *, collapsed: bool) -> Iterator[Widget]:
+        with Collapsible(title=task.name, collapsed=collapsed, classes="phase-task"):
+            yield Static("resolved prompt", classes="eyebrow task-prompt-source")
+            with VerticalScroll(classes="task-prompt-scroll"):
+                yield Markdown(self._resolve_task_prompt(task), classes="task-prompt")
+
+    def _resolve_task_prompt(self, task: TaskConfig) -> str:
+        return task.prompt or "_No task prompt configured._"
+
+    def _compose_agent(self, agent_name: str, config: AgentConfig) -> Iterator[Widget]:
+        yield Static(agent_name, id="phase-agent-name")
+        with Horizontal(id="phase-agent-meta"):
+            yield Static(f"provider · {config.provider}", id="phase-agent-provider", classes="badge")
+            if config.model:
+                yield Static(f"model · {config.model}", id="phase-agent-model", classes="badge")
+        yield Static("TOOLS", classes="eyebrow")
+        if config.tools:
+            yield Static(" · ".join(config.tools), id="phase-agent-tools", classes="tools-box")
+        else:
+            yield Static("No tools configured", id="phase-agent-tools-empty", classes="desc")
+        yield Static("SYSTEM PROMPT", classes="eyebrow")
+        yield Markdown(config.system_prompt or "_No system prompt configured._", id="phase-agent-prompt")
+
+    def on_collapsible_expanded(self, event: Collapsible.Expanded) -> None:
+        for task in self.query(Collapsible):
+            if task is not event.collapsible:
+                task.collapsed = True
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "back":
+            self.app.pop_screen()

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/phase_log.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/phase_log.py
@@ -1,0 +1,179 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Full-screen phase log view."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from typing import Protocol
+
+from rich.console import RenderableType
+from rich.markdown import Markdown as RichMarkdown
+from rich.panel import Panel
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical, VerticalScroll
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Markdown, Static
+
+from ddev.ai.config.models import ResolvedFlow
+from ddev.cli.meta.ai.tui.screens.base import TogoScreen
+from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+
+type PhaseLogEntry = str | Text | Panel | RichMarkdown
+
+SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+
+
+def _selectable_widget(renderable: RenderableType) -> Widget:
+    if isinstance(renderable, RichMarkdown):
+        return Markdown(renderable.markup, classes="phase-log-markdown")
+    if isinstance(renderable, Panel):
+        return PhaseLogPanel(renderable)
+    return Static(renderable)
+
+
+class PhaseLogPanel(Vertical):
+    """Selectable Textual equivalent of a Rich panel."""
+
+    def __init__(self, panel: Panel) -> None:
+        super().__init__(classes="phase-log-panel")
+        self._panel = panel
+        if panel.title is not None:
+            self.border_title = str(panel.title)
+        if str(panel.border_style) != "none":
+            self.styles.border = ("round", str(panel.border_style))
+
+    def compose(self) -> ComposeResult:
+        yield _selectable_widget(self._panel.renderable)
+
+
+class PhaseLogBlock(Vertical):
+    """A single rendered block in the phase log."""
+
+    def __init__(self, renderable: PhaseLogEntry) -> None:
+        super().__init__(classes="phase-log-block")
+        self._renderable = renderable
+
+    def compose(self) -> ComposeResult:
+        yield _selectable_widget(self._renderable)
+
+
+class ThinkingBlock(Static):
+    """Transient block shown while an agent response is pending."""
+
+    frame: reactive[int] = reactive(0)
+
+    def __init__(self, key: str, label: str) -> None:
+        super().__init__("", classes="phase-log-block phase-log-thinking")
+        self.key = key
+        self._label = label
+
+    def on_mount(self) -> None:
+        self.set_interval(0.1, self._tick)
+        self._update()
+
+    def watch_frame(self, frame: int) -> None:
+        self._update()
+
+    def _tick(self) -> None:
+        self.frame = (self.frame + 1) % len(SPINNER_FRAMES)
+
+    def _update(self) -> None:
+        self.update(f"{SPINNER_FRAMES[self.frame]} thinking · {self._label}")
+
+
+class PhaseLogSource(Protocol):
+    """Object that tracks open phase log screens for live writes."""
+
+    def register_phase_log_screen(self, screen: PhaseLogScreen) -> None: ...
+
+    def unregister_phase_log_screen(self, screen: PhaseLogScreen) -> None: ...
+
+
+class PhaseLogScreen(TogoScreen):
+    """Shows the live log for one running phase."""
+
+    BINDINGS = [
+        Binding("escape", "app.pop_screen", "Back"),
+        Binding("ctrl+c", "copy_or_show_config", "Copy / Config"),
+    ]
+
+    def __init__(
+        self,
+        flow: ResolvedFlow,
+        phase_id: str,
+        entries: Sequence[PhaseLogEntry],
+        source: PhaseLogSource | None = None,
+    ) -> None:
+        super().__init__()
+        self.flow = flow
+        self.phase_id = phase_id
+        self._entries = entries
+        self._source = source
+        self._replayed_entries = False
+        self._written_entry_ids: set[int] = set()
+        self._thinking_blocks: dict[str, ThinkingBlock] = {}
+        self._togo_title = f"{flow.name or 'Flow'} · {phase_id} log"
+
+    def compose_body(self) -> Iterator[Widget]:
+        yield VerticalScroll(id="phase-log-output")
+
+    def on_mount(self) -> None:
+        self._replay_entries()
+        if self._source is not None:
+            self._source.register_phase_log_screen(self)
+
+    def on_unmount(self) -> None:
+        if self._source is not None:
+            self._source.unregister_phase_log_screen(self)
+
+    def write(self, renderable: PhaseLogEntry) -> None:
+        try:
+            output = self.query_one("#phase-log-output", VerticalScroll)
+            should_scroll = output.is_vertical_scroll_end
+            output.mount(PhaseLogBlock(renderable))
+            if should_scroll:
+                output.call_after_refresh(output.scroll_end, animate=False)
+            self._written_entry_ids.add(id(renderable))
+        except Exception:
+            pass
+
+    def start_thinking(self, key: str, label: str) -> None:
+        try:
+            output = self.query_one("#phase-log-output", VerticalScroll)
+        except Exception:
+            return
+        if key in self._thinking_blocks:
+            return
+        block = ThinkingBlock(key, label)
+        self._thinking_blocks[key] = block
+        should_scroll = output.is_vertical_scroll_end
+        output.mount(block)
+        if should_scroll:
+            output.call_after_refresh(output.scroll_end, animate=False)
+
+    def stop_thinking(self, key: str) -> None:
+        block = self._thinking_blocks.pop(key, None)
+        if block is not None and block.is_mounted:
+            block.remove()
+
+    def _replay_entries(self, retry: bool = True) -> bool:
+        if self._replayed_entries:
+            return True
+
+        for entry in self._entries:
+            if id(entry) not in self._written_entry_ids:
+                self.write(entry)
+        self._replayed_entries = True
+        return True
+
+    def action_show_config(self) -> None:
+        self.app.push_screen(PhaseConfigScreen(self.flow, self.phase_id))
+
+    def action_copy_or_show_config(self) -> None:
+        if not self.copy_selection():
+            self.action_show_config()

--- a/ddev/src/ddev/cli/meta/ai/tui/status.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/status.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Execution status values used by the AI TUI."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class RunStatus(StrEnum):
+    """Finite phase/task execution states shown in the TUI."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+
+    @property
+    def has_started(self) -> bool:
+        return self is not RunStatus.PENDING

--- a/ddev/src/ddev/cli/meta/ai/tui/theme.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/theme.py
@@ -1,0 +1,75 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Togo design-system theme."""
+
+from rich.theme import Theme as RichTheme
+from textual.theme import Theme
+
+from ddev.cli.meta.ai.palette import (
+    ACCENT,
+    BACKGROUND,
+    BORDER,
+    ERROR,
+    FOREGROUND,
+    PANEL,
+    PRIMARY,
+    ROLE_GOAL_REVIEWER,
+    ROLE_PHASE,
+    SECONDARY,
+    STATUS_DONE,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_RUNNING,
+    SUCCESS,
+    SURFACE,
+    TEXT_MUTED,
+    WARNING,
+)
+
+togo_theme = Theme(
+    name="togo",
+    primary=PRIMARY,
+    secondary=SECONDARY,
+    accent=ACCENT,
+    foreground=FOREGROUND,
+    background=BACKGROUND,
+    surface=SURFACE,
+    panel=PANEL,
+    success=SUCCESS,
+    warning=WARNING,
+    error=ERROR,
+    dark=True,
+    variables={
+        "border": BORDER,
+        "border-blurred": BORDER,
+        "text-muted": TEXT_MUTED,
+        "block-cursor-background": ACCENT,
+        "block-cursor-foreground": BACKGROUND,
+        "block-cursor-text-style": "bold",
+        "footer-key-foreground": SECONDARY,
+        "status-running": STATUS_RUNNING,
+        "status-pending": STATUS_PENDING,
+        "status-done": STATUS_DONE,
+        "status-failed": STATUS_FAILED,
+    },
+)
+
+# Rich's built-in Markdown element styles (``markdown.code``, ``markdown.block_quote``, etc.)
+# default to fully saturated named colors (bright cyan, magenta, yellow) on a literal black
+# background — agent responses and fetched docs render as Markdown, so those defaults show up
+# directly in the log view regardless of the app's own theme. Push this over Rich's console
+# theme so Markdown content stays inside the same muted palette as everything else.
+togo_markdown_theme = RichTheme(
+    {
+        "markdown.code": f"bold {ROLE_PHASE} on {SURFACE}",
+        "markdown.code_block": f"{ROLE_PHASE} on {SURFACE}",
+        "markdown.block_quote": ROLE_GOAL_REVIEWER,
+        "markdown.list": TEXT_MUTED,
+        "markdown.item.bullet": f"bold {WARNING}",
+        "markdown.item.number": f"bold {WARNING}",
+        "markdown.hr": WARNING,
+        "markdown.link": STATUS_RUNNING,
+        "markdown.link_url": f"underline {STATUS_RUNNING}",
+    }
+)

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -1,0 +1,623 @@
+/* Togo TUI design-system stylesheet */
+
+/* ── Screen / scrollbars ──────────────────────────────────────────────── */
+
+Screen {
+    background: $background;
+    color: $foreground;
+    layout: vertical;
+}
+
+* {
+    scrollbar-color: $primary;
+    scrollbar-color-hover: $accent;
+    scrollbar-background: $surface;
+}
+
+#screen-body {
+    height: 1fr;
+    padding: 1 2;
+    overflow-y: hidden;
+}
+
+/* ── Utility classes ──────────────────────────────────────────────────── */
+
+.eyebrow {
+    color: $text-muted;
+    text-style: bold;
+}
+
+.desc {
+    color: $text-muted;
+}
+
+.panel {
+    background: $surface;
+    border: round $border;
+    border-title-color: $secondary;
+    border-title-align: left;
+    padding: 1 2;
+}
+
+.panel.dashed {
+    border: dashed $border;
+}
+
+Button {
+    border: round $border;
+    background: $panel;
+    color: $foreground;
+    min-width: 12;
+}
+
+Button:hover {
+    border: round $primary;
+    background: $panel-lighten-1;
+}
+
+Button:focus {
+    border: round $accent;
+    background: $panel-lighten-1;
+}
+
+Button.-primary {
+    border: round $secondary;
+    background: $panel;
+    color: $secondary;
+}
+
+Button.-primary:hover,
+Button.-primary:focus {
+    border: round $secondary;
+    background: $panel-lighten-1;
+    color: $secondary;
+}
+
+Button.-warning {
+    border: round $warning;
+}
+
+/* ── TogoHeader ───────────────────────────────────────────────────────── */
+
+TogoHeader {
+    layout: horizontal;
+    align-vertical: middle;
+    width: 100%;
+    height: 7;
+    background: $panel;
+    color: $foreground;
+    padding: 1 2;
+}
+
+#header-info {
+    width: 1fr;
+    height: 5;
+    padding-top: 1;
+    margin-left: 2;
+}
+
+#header-info > Static {
+    width: 100%;
+    height: 1;
+    text-overflow: ellipsis;
+    text-wrap: nowrap;
+}
+
+#header-repo {
+    color: $text-muted;
+}
+
+#header-right {
+    width: auto;
+    color: $status-running;
+    text-style: bold;
+}
+
+#header-badge {
+    color: $status-running;
+    text-style: bold;
+    padding: 0 1;
+}
+
+#header-mascot {
+    width: 11;
+    height: 5;
+    color: $primary;
+}
+
+/* ── Footer ───────────────────────────────────────────────────────────── */
+
+Footer {
+    background: $panel;
+    color: $text-muted;
+}
+
+/* ── Flow grid / FlowCard ─────────────────────────────────────────────── */
+
+#flow-grid {
+    layout: grid;
+    grid-size: 3;
+    grid-gutter: 1 2;
+    padding: 1 0;
+    height: 1fr;
+    overflow-y: auto;
+}
+
+FlowCard {
+    background: $panel;
+    border: solid $border;
+    padding: 1 3;
+    height: 10;
+    min-width: 36;
+}
+
+FlowCard:hover {
+    border: solid $primary;
+}
+
+FlowCard:focus {
+    border: solid $accent;
+    background: $panel-lighten-1;
+}
+
+FlowCard.broken {
+    border: solid $error;
+}
+
+FlowCard.broken:hover {
+    border: solid $warning;
+}
+
+FlowCard.broken:focus {
+    border: solid $accent;
+    background: $panel-lighten-1;
+}
+
+FlowCard > .eyebrow {
+    margin-bottom: 1;
+}
+
+/* ── Collapsible / actions ─────────────────────────────────────────────── */
+
+Collapsible {
+    border: none;
+    background: transparent;
+    padding: 0 1;
+    margin: 0 0 1 0;
+}
+
+#configuration {
+    height: 1fr;
+    margin: 0 0 1 0;
+    overflow-y: auto;
+}
+
+#flow-body {
+    layout: horizontal;
+    height: 1fr;
+    margin: 0 0 1 0;
+}
+
+#flow-overview {
+    width: 20%;
+    min-width: 40;
+    height: 1fr;
+    margin: 0 2 0 0;
+}
+
+#flow-description {
+    margin: 0 0 1 0;
+}
+
+#flow-agents {
+    height: auto;
+    margin: 0 0 1 0;
+}
+
+.flow-agent-row {
+    height: auto;
+    margin: 0 0 1 0;
+}
+
+.flow-agent-heading {
+    color: $foreground;
+    text-style: bold;
+}
+
+.flow-agent-tools {
+    color: $status-running;
+}
+
+#flow-inputs {
+    height: auto;
+}
+
+.flow-input-row {
+    color: $text-muted;
+    height: auto;
+}
+
+#flow-pipeline {
+    layers: connectors nodes;
+    width: 1fr;
+    height: 1fr;
+    margin: 0 0 1 0;
+    border: round $border;
+    border-title-color: $secondary;
+    border-title-align: left;
+    background: $surface;
+    padding: 1 2;
+    overflow: auto auto;
+}
+
+#phase-configuration {
+    height: 1fr;
+    margin: 0 0 1 0;
+    border: round $border;
+    border-title-color: $secondary;
+    border-title-align: left;
+    background: $surface;
+    padding: 1 3;
+    overflow: hidden hidden;
+}
+
+#phase-summary {
+    layout: horizontal;
+    height: auto;
+    margin: 0 0 1 0;
+}
+
+#phase-heading {
+    width: 2fr;
+    height: auto;
+}
+
+#phase-dependencies-summary {
+    width: 1fr;
+    height: auto;
+    border: round $border;
+    border-title-color: $secondary;
+    border-title-align: left;
+    background: $panel;
+    padding: 1 2;
+}
+
+#phase-title {
+    color: $foreground;
+    text-style: bold;
+    margin-top: 1;
+}
+
+#phase-config-grid {
+    layout: horizontal;
+    height: 1fr;
+    margin: 1 0;
+}
+
+.phase-config-card {
+    height: 1fr;
+    border: round $border;
+    border-title-color: $secondary;
+    border-title-align: left;
+    background: $panel;
+    padding: 1 2;
+    margin: 0 1 1 0;
+    overflow-y: auto;
+}
+
+#phase-tasks-card {
+    width: 2fr;
+}
+
+#phase-tasks {
+    height: 1fr;
+}
+
+.phase-task {
+    height: 1fr;
+    min-height: 3;
+    border: dashed $border;
+    border-title-color: $secondary;
+    border-title-align: left;
+    background: $surface;
+    padding: 1 2;
+    margin: 0 0 1 0;
+    overflow: hidden hidden;
+}
+
+.phase-task.-collapsed {
+    height: auto;
+}
+
+Collapsible.phase-task > CollapsibleTitle {
+    width: 1fr;
+}
+
+Collapsible.phase-task > Contents {
+    height: 1fr;
+    overflow: hidden hidden;
+}
+
+.task-prompt-source {
+    margin-bottom: 1;
+}
+
+.task-prompt {
+    color: $foreground;
+    height: auto;
+}
+
+/* Textual's built-in MarkdownH3 defaults to `width: auto`, which stops long
+   headings from wrapping and lets them run off the right edge of the pane
+   (task/agent system prompts render as Markdown and can contain headings of
+   any length). Force it back to a wrapping block like every other level. */
+MarkdownH3 {
+    width: 1fr;
+}
+
+.task-prompt-scroll {
+    height: 1fr;
+    overflow-y: auto;
+}
+
+#phase-agent-card {
+    width: 1fr;
+    margin-top: 0;
+}
+
+#phase-agent-name {
+    color: $foreground;
+    text-style: bold;
+    margin-bottom: 1;
+}
+
+#phase-agent-meta {
+    layout: horizontal;
+    height: auto;
+    margin: 0 0 1 0;
+}
+
+#phase-agent-tools {
+    width: 1fr;
+    height: auto;
+    border: round $border;
+    color: $status-running;
+    padding: 1 2;
+    margin: 0 0 1 0;
+    text-style: bold;
+}
+
+#phase-agent-prompt {
+    margin-top: 1;
+}
+
+#actions {
+    layout: horizontal;
+    dock: bottom;
+    height: auto;
+    padding: 1;
+    align-horizontal: right;
+    background: transparent;
+    border: none;
+}
+
+#actions Button {
+    margin-left: 2;
+}
+
+#phase-actions {
+    layout: horizontal;
+    dock: bottom;
+    height: auto;
+    padding: 1;
+    align-horizontal: right;
+    background: transparent;
+    border: none;
+}
+
+/* ── Execution view ───────────────────────────────────────────────────── */
+
+#execution-error {
+    display: none;
+    height: auto;
+    border: round $error;
+    background: $panel;
+    color: $error;
+    text-style: bold;
+    padding: 1 2;
+    margin: 0 0 1 0;
+}
+
+#pipeline {
+    layers: connectors nodes;
+    width: 1fr;
+    height: 1fr;
+    margin: 0 0 1 0;
+    border: round $border;
+    border-title-color: $secondary;
+    border-title-align: left;
+    background: $surface;
+    padding: 1 2;
+    overflow: auto auto;
+}
+
+#pipeline-connectors {
+    layer: connectors;
+    color: $text-muted;
+    background: transparent;
+    width: 1fr;
+    height: 1fr;
+}
+
+.phase-node {
+    layer: nodes;
+    width: auto;
+    height: 3;
+    min-width: 16;
+    border: round $border;
+    background: $panel;
+    color: $text-muted;
+    padding: 0 1;
+}
+
+.phase-node.status-running {
+    border: round $status-running;
+    color: $status-running;
+}
+
+.phase-node.status-done {
+    border: round $status-done;
+    color: $status-done;
+}
+
+.phase-node.status-failed {
+    border: round $status-failed;
+    color: $status-failed;
+}
+
+#phase-log-output {
+    width: 1fr;
+    height: 1fr;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+.phase-log-block {
+    width: 1fr;
+    height: auto;
+    margin: 0 0 1 0;
+}
+
+.phase-log-block > Static,
+.phase-log-block > Markdown,
+.phase-log-panel,
+.phase-log-panel > Static,
+.phase-log-panel > Markdown {
+    width: 1fr;
+    height: auto;
+}
+
+.phase-log-panel {
+    border: round $border;
+    padding: 0 1;
+}
+
+.phase-log-thinking {
+    color: $status-running;
+    text-style: bold;
+    border: round $status-running;
+    padding: 0 1;
+    background: $surface;
+}
+
+/* ── Modal / dialog / badge / prompt ──────────────────────────────────── */
+
+ModalScreen {
+    align: center middle;
+    background: $background 60%;
+}
+
+#dialog {
+    layout: vertical;
+    background: $surface;
+    border: round $primary;
+    border-title-color: $secondary;
+    border-title-align: left;
+    padding: 1 2;
+    width: 84;
+    min-width: 50%;
+    max-width: 90%;
+    height: auto;
+    min-height: 50%;
+    max-height: 90%;
+    overflow: hidden;
+}
+
+#dialog.launch {
+    width: 96;
+}
+
+#dialog.diagnostics {
+    width: 96;
+}
+
+#diagnostic-errors {
+    height: 1fr;
+    margin-top: 1;
+}
+
+.diagnostic-error {
+    height: auto;
+    border: round $error;
+    background: $panel;
+    padding: 1 2;
+    margin-bottom: 1;
+}
+
+#agent-meta {
+    layout: horizontal;
+    height: auto;
+    margin: 0 0 1 0;
+}
+
+#agent-tools {
+    height: auto;
+    margin: 0 0 1 0;
+}
+
+#agent-tool-list {
+    layout: horizontal;
+    height: auto;
+}
+
+#launch-fields {
+    height: 1fr;
+    overflow-y: auto;
+}
+
+#launch-fields > Label.eyebrow {
+    margin-top: 1;
+}
+
+.badge {
+    border: round $border;
+    color: $foreground;
+    text-style: bold;
+    padding: 0 1;
+    margin-right: 1;
+}
+
+.badge.tool {
+    color: $status-running;
+}
+
+#prompt {
+    border: round $border;
+    background: $panel;
+    padding: 1 2;
+    height: 1fr;
+    max-height: 18;
+    overflow-y: auto;
+}
+
+.modal-actions {
+    dock: bottom;
+    layout: horizontal;
+    align-horizontal: right;
+    height: auto;
+    padding-top: 1;
+}
+
+.modal-actions Button {
+    margin-left: 2;
+}
+
+/* ── Input / Select focus ─────────────────────────────────────────────── */
+
+Input:focus {
+    border: tall $accent;
+}
+
+Select:focus {
+    border: tall $accent;
+}

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/__init__.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/flow_card.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/flow_card.py
@@ -1,0 +1,77 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""FlowCard widget — focusable card representing a single flow."""
+
+from __future__ import annotations
+
+from rich.text import Text
+from textual.binding import Binding
+from textual.message import Message
+from textual.widgets import Static
+
+from ddev.ai.config.models import ConfigStatus, FlowResult
+from ddev.cli.meta.ai.palette import ERROR, SUCCESS
+from ddev.cli.meta.ai.tui.widgets.pipeline_graph import COLOR_RUNNING
+
+
+class FlowCard(Static):
+    """Focusable card for one validated or broken flow result."""
+
+    can_focus = True
+
+    BINDINGS = [Binding("enter", "select", "Select")]
+
+    class Selected(Message):
+        """Posted when the card is activated (Enter or click)."""
+
+        def __init__(self, result: FlowResult) -> None:
+            super().__init__()
+            self.result = result
+
+    def __init__(self, result: FlowResult, index: int, *, resumable: bool = False) -> None:
+        classes = "broken" if result.status is ConfigStatus.BROKEN else "valid"
+        super().__init__(classes=classes)
+        self.result = result
+        self.flow = result.resolved
+        self.index = index
+        self.resumable = resumable
+
+    @property
+    def phase_count(self) -> int:
+        """Number of phases in the flow."""
+        return len(self.flow.flow) if self.flow is not None else 0
+
+    def render(self) -> Text:
+        name = self.result.name or "(unnamed)"
+        desc = self.flow.description if self.flow is not None and self.flow.description else ""
+        if self.result.status is ConfigStatus.BROKEN:
+            desc = self.result.errors[0].message if self.result.errors else "Invalid flow configuration"
+        n = self.phase_count
+        content = Text(name, style="bold", no_wrap=True, overflow="ellipsis")
+        if desc:
+            content.append("\n")
+            content.append(desc, style="dim")
+        content.append("\n\n")
+        if self.result.status is ConfigStatus.BROKEN:
+            count = len(self.result.errors)
+            content.append(
+                f"✕ broken · {count} {'error' if count == 1 else 'errors'}",
+                style=f"bold {ERROR}",
+            )
+            content.append("\nEnter to inspect diagnostics", style="dim")
+        else:
+            phase_word = "phase" if n == 1 else "phases"
+            content.append("●", style=SUCCESS)
+            content.append(f" {n} {phase_word}")
+            if self.resumable:
+                content.append("\n↻ resumable run available", style=COLOR_RUNNING)
+        return content
+
+    def action_select(self) -> None:
+        self.post_message(self.Selected(self.result))
+
+    def on_click(self) -> None:
+        if self.screen.get_selected_text():
+            return
+        self.post_message(self.Selected(self.result))

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/header.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/header.py
@@ -1,0 +1,87 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""TogoHeader widget — wordmark, screen title, optional running badge, clock."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static
+
+from ddev.ai.config.models import ConfigStatus
+from ddev.cli.meta.ai.palette import ERROR, PRIMARY
+
+if TYPE_CHECKING:
+    from ddev.cli.meta.ai.tui.app import TogoApp
+
+TOGO_HUSKY = """█▀▄     ▄▀█
+███████████
+██ ▀ █ ▀ ██
+█▀▄▄▄█▄▄▄▀█
+  ▀▀███▀▀"""
+
+
+class TogoHeader(Widget):
+    """App header with the Togo mascot, flow summary, repository, and run state."""
+
+    DEFAULT_CSS = ""
+
+    running: reactive[bool] = reactive(False)
+    _pulse_on: reactive[bool] = reactive(True)
+
+    def __init__(self, title: str = "", running: bool = False) -> None:
+        super().__init__()
+        self._title = title
+        self.running = running
+
+    def compose(self) -> ComposeResult:
+        yield Static(TOGO_HUSKY, id="header-mascot")
+        with Vertical(id="header-info"):
+            product = Text("Togo", style=f"bold {PRIMARY}")
+            product.append(" ◆ Agent Integrations")
+            yield Static(product, id="header-product")
+            yield Static("", id="header-flow-summary")
+            yield Static("", id="header-repo")
+        yield Static("", id="header-right")
+
+    def on_mount(self) -> None:
+        self.set_interval(0.6, self._tick_pulse)
+        self._update_context()
+        self._update_running_badge()
+
+    def watch_running(self, running: bool) -> None:
+        self._update_running_badge()
+
+    def watch__pulse_on(self, pulse_on: bool) -> None:
+        self._update_running_badge()
+
+    def _tick_pulse(self) -> None:
+        if self.running:
+            self._pulse_on = not self._pulse_on
+
+    def _update_context(self) -> None:
+        app = cast("TogoApp", self.app)
+        results = app.engine.flows.values()
+        broken_count = sum(result.status is ConfigStatus.BROKEN for result in results)
+        summary = Text(f"{len(app.engine.flows)} Flows Discovered")
+        if broken_count:
+            summary.append(f" / {broken_count} flows need attention", style=ERROR)
+        self.query_one("#header-flow-summary", Static).update(summary)
+        self.query_one("#header-repo", Static).update(str(app.ddev_app.repo.path))
+
+    def _update_running_badge(self) -> None:
+        try:
+            right = self.query_one("#header-right", Static)
+        except Exception:
+            return
+        if not self.running:
+            right.update("")
+            return
+        marker = "●" if self._pulse_on else "○"
+        right.update(f"{marker} running")

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/pipeline_graph.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/pipeline_graph.py
@@ -1,0 +1,411 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Reusable pipeline DAG graph widgets."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import TypedDict, Unpack
+
+from rich.text import Text
+from textual.binding import Binding
+from textual.css.query import NoMatches
+from textual.geometry import Offset
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import Static
+
+from ddev.ai.config.models import ResolvedFlow
+from ddev.cli.meta.ai.palette import STATUS_CONNECTOR, STATUS_DONE, STATUS_FAILED, STATUS_PENDING, STATUS_RUNNING
+from ddev.cli.meta.ai.tui.status import RunStatus
+
+COLOR_DONE = STATUS_DONE
+COLOR_RUNNING = STATUS_RUNNING
+COLOR_PENDING = STATUS_PENDING
+COLOR_FAILED = STATUS_FAILED
+COLOR_CONNECTOR = STATUS_CONNECTOR
+GRAPH_COLUMN_GAP = 6
+GRAPH_ROW_GAP = 5
+NODE_HEIGHT = 3  # keep in sync with the `.phase-node` height in togo.tcss
+
+
+class WidgetKwargs(TypedDict, total=False):
+    name: str | None
+    id: str | None
+    classes: str | None
+    disabled: bool
+    markup: bool
+
+
+NODE_GLYPHS: dict[RunStatus, tuple[str, str]] = {
+    RunStatus.DONE: ("○", COLOR_DONE),
+    RunStatus.RUNNING: ("◉", COLOR_RUNNING),
+    RunStatus.FAILED: ("✕", COLOR_FAILED),
+}
+
+
+@dataclass(frozen=True)
+class _GraphNode:
+    phase_id: str
+    status: RunStatus
+    label: str
+    color: str
+    x: int
+    y: int
+
+
+@dataclass(frozen=True)
+class _PipelineLayout:
+    connectors: Text
+    nodes: list[_GraphNode]
+
+
+class PhaseSelected(Message):
+    """Posted when a graph phase node is activated."""
+
+    def __init__(self, phase_id: str) -> None:
+        super().__init__()
+        self.phase_id = phase_id
+
+
+def _phase_label(phase_id: str, statuses: dict[str, RunStatus]) -> tuple[str, str]:
+    status = statuses.get(phase_id, RunStatus.PENDING)
+    glyph, color = NODE_GLYPHS.get(status, ("●", COLOR_PENDING))
+    return f"{glyph} {phase_id}", color
+
+
+def _pad_labels(labels: dict[str, tuple[str, str]]) -> dict[str, tuple[str, str]]:
+    """Right-pad every label to the same width so all boxes render at a uniform size."""
+    if not labels:
+        return labels
+    width = max(len(text) for text, _ in labels.values())
+    return {phase_id: (text.ljust(width), color) for phase_id, (text, color) in labels.items()}
+
+
+def _display_dependencies(flow: ResolvedFlow) -> dict[str, list[str]]:
+    deps_by_phase = {entry.phase: entry.dependencies for entry in flow.flow}
+
+    def depends_on(phase_id: str, dependency: str, seen: set[str] | None = None) -> bool:
+        if seen is None:
+            seen = set()
+        if phase_id in seen:
+            return False
+        seen.add(phase_id)
+        deps = deps_by_phase.get(phase_id, [])
+        return dependency in deps or any(depends_on(dep, dependency, seen) for dep in deps)
+
+    display_deps: dict[str, list[str]] = {}
+    for entry in flow.flow:
+        deps = entry.dependencies
+        display_deps[entry.phase] = [
+            dep for dep in deps if not any(other != dep and depends_on(other, dep) for other in deps)
+        ]
+    return display_deps
+
+
+def _phase_levels(flow: ResolvedFlow, deps_by_phase: dict[str, list[str]]) -> dict[str, int]:
+    levels: dict[str, int] = {}
+
+    def level_for(phase_id: str) -> int:
+        if phase_id in levels:
+            return levels[phase_id]
+        deps = deps_by_phase.get(phase_id, [])
+        level = 0 if not deps else 1 + max(level_for(dep) for dep in deps)
+        levels[phase_id] = level
+        return level
+
+    for entry in flow.flow:
+        level_for(entry.phase)
+    return levels
+
+
+def _phase_positions(
+    flow: ResolvedFlow,
+    levels: dict[str, int],
+    deps_by_phase: dict[str, list[str]],
+    labels: dict[str, tuple[str, str]],
+) -> dict[str, tuple[int, int]]:
+    """Lay phases out in an evenly spaced grid, then center parents over children.
+
+    ``labels`` are pre-padded to a common width (see ``_pad_labels``), so every
+    box is the same size and a plain left-edge x is interchangeable with a
+    box center for averaging purposes. The layout runs in two passes:
+
+    1. Top-down: seed each level with an evenly spaced, left-to-right row in
+       the flow's declared order.
+    2. Bottom-up: starting at the deepest level, pull every node toward the
+       mean x of its direct children (the phases that depend on it), then
+       re-sweep the level left-to-right to restore the minimum column gap
+       that centering may have collapsed. This settles parents over the
+       midpoint of their children instead of hugging whichever sibling
+       happened to be laid out first.
+    """
+    entries_by_level: dict[int, list[str]] = {}
+    for entry in flow.flow:
+        entries_by_level.setdefault(levels[entry.phase], []).append(entry.phase)
+
+    if not entries_by_level:
+        return {}
+
+    box_width = len(next(iter(labels.values()))[0])
+    step = box_width + GRAPH_COLUMN_GAP
+
+    children_of: dict[str, list[str]] = {phase_id: [] for phase_id in labels}
+    for phase_id, deps in deps_by_phase.items():
+        for dep in deps:
+            children_of[dep].append(phase_id)
+
+    x: dict[str, float] = {}
+    for level in sorted(entries_by_level):
+        for index, phase_id in enumerate(entries_by_level[level]):
+            x[phase_id] = float(index * step)
+
+    for level in sorted(entries_by_level, reverse=True):
+        row = entries_by_level[level]
+        for phase_id in row:
+            kids = children_of[phase_id]
+            if kids:
+                x[phase_id] = sum(x[kid] for kid in kids) / len(kids)
+
+        previous_edge: float | None = None
+        for phase_id in sorted(row, key=lambda phase_id: x[phase_id]):
+            if previous_edge is not None and x[phase_id] < previous_edge:
+                x[phase_id] = previous_edge
+            previous_edge = x[phase_id] + step
+
+    min_x = min(x.values())
+    return {
+        phase_id: (round(x[phase_id] - min_x), level * GRAPH_ROW_GAP)
+        for level, row in entries_by_level.items()
+        for phase_id in row
+    }
+
+
+def _draw_char(grid: list[list[str]], y: int, x: int, char: str) -> None:
+    if y < 0 or x < 0 or y >= len(grid) or x >= len(grid[y]):
+        return
+    existing = grid[y][x]
+    corners = {"┐", "┘", "┌", "└"}
+    if existing == " " or existing == char:
+        grid[y][x] = char
+    elif char in {"▶", "▼"}:
+        grid[y][x] = char
+    elif existing in {"▶", "▼"}:
+        return
+    elif existing in corners and char == "─":
+        grid[y][x] = "┬" if existing in {"┐", "┌"} else "┴"
+    elif existing in {"┬", "┴"} and char in {"│", "─"}:
+        return
+    elif existing in corners and char == "│":
+        return
+    elif char in corners and existing == "─":
+        grid[y][x] = "┬" if char in {"┐", "┌"} else "┴"
+    elif char in corners and existing == "│":
+        grid[y][x] = char
+    elif {existing, char} <= {"─", "│"}:
+        grid[y][x] = "┼"
+    else:
+        grid[y][x] = "┼"
+
+
+def _draw_horizontal(grid: list[list[str]], y: int, start_x: int, end_x: int) -> None:
+    if end_x < start_x:
+        return
+    for x in range(start_x, end_x + 1):
+        _draw_char(grid, y, x, "─")
+
+
+def _draw_vertical(grid: list[list[str]], x: int, start_y: int, end_y: int) -> None:
+    if end_y < start_y:
+        start_y, end_y = end_y, start_y
+    for y in range(start_y, end_y + 1):
+        _draw_char(grid, y, x, "│")
+
+
+def _draw_edge(grid: list[list[str]], start: tuple[int, int], end: tuple[int, int]) -> None:
+    start_x, start_y = start
+    end_x, end_y = end
+    if end_y <= start_y:
+        return
+
+    arrow_y = end_y - 1
+    if start_x == end_x:
+        _draw_vertical(grid, start_x, start_y, arrow_y - 1)
+        _draw_char(grid, arrow_y, start_x, "▼")
+        return
+
+    mid_y = start_y + 1
+    _draw_vertical(grid, start_x, start_y, mid_y - 1)
+    _draw_char(grid, mid_y, start_x, "└" if end_x > start_x else "┘")
+    _draw_horizontal(grid, mid_y, min(start_x, end_x) + 1, max(start_x, end_x) - 1)
+    _draw_char(grid, mid_y, end_x, "┐" if end_x > start_x else "┌")
+    _draw_vertical(grid, end_x, mid_y + 1, arrow_y - 1)
+    _draw_char(grid, arrow_y, end_x, "▼")
+
+
+def render_pipeline(flow: ResolvedFlow, statuses: dict[str, RunStatus]) -> Text:
+    """Build a Rich Text dependency graph from declared flow edges."""
+    layout = _build_pipeline_layout(flow, statuses)
+    lines = layout.connectors.plain.splitlines() or [""]
+    grid = [list(line) for line in lines]
+    width = max((len(line) for line in lines), default=0)
+    for line in grid:
+        line.extend(" " for _ in range(width - len(line)))
+
+    node_ranges: list[tuple[int, int, int, str]] = []
+    for node in layout.nodes:
+        while node.y >= len(grid):
+            grid.append([" " for _ in range(width)])
+        if node.x + len(node.label) > width:
+            for line in grid:
+                line.extend(" " for _ in range(node.x + len(node.label) - width))
+            width = node.x + len(node.label)
+        for offset, char in enumerate(node.label):
+            grid[node.y][node.x + offset] = char
+        node_ranges.append((node.y, node.x, node.x + len(node.label), node.color))
+
+    result_lines = ["".join(line).rstrip() for line in grid]
+    result = Text("\n".join(result_lines))
+    offset = 0
+    for line_number, result_line in enumerate(result_lines):
+        for node_y, start_x, end_x, color in node_ranges:
+            if node_y == line_number:
+                result.stylize(color, offset + start_x, offset + end_x)
+        for index, char in enumerate(result_line):
+            if char in "─│┐┘┌└┼▶▼┬┴":
+                result.stylize(COLOR_CONNECTOR, offset + index, offset + index + 1)
+        offset += len(result_line) + 1
+    return result
+
+
+def _build_pipeline_layout(flow: ResolvedFlow, statuses: dict[str, RunStatus]) -> _PipelineLayout:
+    entries = flow.flow
+    if not entries:
+        return _PipelineLayout(Text(), [])
+
+    deps_by_phase = _display_dependencies(flow)
+    levels = _phase_levels(flow, deps_by_phase)
+    labels = _pad_labels({entry.phase: _phase_label(entry.phase, statuses) for entry in entries})
+    node_positions = _phase_positions(flow, levels, deps_by_phase, labels)
+    height = max(y for _, y in node_positions.values()) + 1
+    width = max(x + len(labels[entry.phase][0]) for entry in entries for x, _ in [node_positions[entry.phase]])
+    grid = [[" " for _ in range(width)] for _ in range(height)]
+
+    for entry in entries:
+        end_x, end_y = node_positions[entry.phase]
+        end_label = labels[entry.phase][0]
+        for dep in deps_by_phase[entry.phase]:
+            start_x, start_y = node_positions[dep]
+            start_label = labels[dep][0]
+            _draw_edge(
+                grid,
+                # Anchor at the node's bottom border row rather than its middle: any
+                # segment drawn inside the box's own rows is invisible anyway (nodes
+                # render on top of the connector canvas), and bends need to land on a
+                # row that's actually clear of both boxes to render properly.
+                (start_x + len(start_label) // 2, start_y + NODE_HEIGHT - 1),
+                (end_x + len(end_label) // 2, end_y),
+            )
+
+    lines = ["".join(line).rstrip() for line in grid]
+    connectors = Text("\n".join(lines), style=COLOR_CONNECTOR)
+    nodes = [
+        _GraphNode(
+            phase_id=entry.phase,
+            status=statuses.get(entry.phase, RunStatus.PENDING),
+            label=labels[entry.phase][0],
+            color=labels[entry.phase][1],
+            x=node_positions[entry.phase][0],
+            y=node_positions[entry.phase][1],
+        )
+        for entry in entries
+    ]
+    return _PipelineLayout(connectors, nodes)
+
+
+class PhaseNode(Static):
+    """Native Textual node for one phase in the execution pipeline graph."""
+
+    can_focus = True
+    BINDINGS = [Binding("enter", "select", "Select phase")]
+
+    def __init__(self, phase_id: str, status: RunStatus, label: str) -> None:
+        super().__init__(label, classes=f"phase-node status-{status.value}")
+        self.phase_id = phase_id
+        self.status = status
+
+    def action_select(self) -> None:
+        self.post_message(PhaseSelected(self.phase_id))
+
+    def on_click(self) -> None:
+        if self.screen.get_selected_text():
+            return
+        self.action_select()
+
+
+class PipelineGraph(Widget):
+    """Pipeline graph with native phase-node widgets and a connector canvas.
+
+    The DAG is laid out from the origin (see ``_build_pipeline_layout``), then
+    re-centered within whatever space this widget is given — otherwise small
+    graphs look lost in the top-left corner of a much larger pane.
+    """
+
+    def __init__(self, flow: ResolvedFlow, statuses: dict[str, RunStatus], **kwargs: Unpack[WidgetKwargs]) -> None:
+        super().__init__(**kwargs)
+        self.flow = flow
+        self._statuses = dict(statuses)
+        self._layout: _PipelineLayout = _PipelineLayout(Text(), [])
+
+    def compose(self) -> Iterator[Widget]:
+        self._layout = _build_pipeline_layout(self.flow, self._statuses)
+
+        connectors = Static(self._layout.connectors, id="pipeline-connectors")
+        connectors.styles.position = "absolute"
+        connectors.styles.layer = "connectors"
+        yield connectors
+
+        for node in self._layout.nodes:
+            phase_node = PhaseNode(node.phase_id, node.status, node.label)
+            phase_node.styles.position = "absolute"
+            phase_node.styles.layer = "nodes"
+            yield phase_node
+
+        self.call_after_refresh(self._recenter)
+
+    def on_resize(self) -> None:
+        self._recenter()
+
+    def _content_size(self) -> tuple[int, int]:
+        lines = self._layout.connectors.plain.splitlines()
+        width = max((len(line) for line in lines), default=0)
+        if self._layout.nodes:
+            width = max(width, max(node.x + len(node.label) for node in self._layout.nodes))
+            height = max(node.y for node in self._layout.nodes) + 1
+        else:
+            height = len(lines)
+        return width, height
+
+    def _recenter(self) -> None:
+        if not self._layout.nodes and not self._layout.connectors.plain:
+            return
+        content_width, content_height = self._content_size()
+        offset_x = max(0, (self.size.width - content_width) // 2)
+        offset_y = max(0, (self.size.height - content_height) // 2)
+
+        try:
+            self.query_one("#pipeline-connectors", Static).styles.offset = Offset(offset_x, offset_y)
+        except NoMatches:
+            pass
+
+        nodes_by_id = {node.phase_id: node for node in self._layout.nodes}
+        for phase_node in self.query(PhaseNode):
+            node = nodes_by_id.get(phase_node.phase_id)
+            if node is not None:
+                phase_node.styles.offset = Offset(node.x + offset_x, node.y + offset_y)
+
+    def update_statuses(self, statuses: dict[str, RunStatus]) -> None:
+        self._statuses = dict(statuses)
+        self.refresh(recompose=True, layout=True)

--- a/ddev/tests/cli/meta/ai/__init__.py
+++ b/ddev/tests/cli/meta/ai/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/ddev/tests/cli/meta/ai/conftest.py
+++ b/ddev/tests/cli/meta/ai/conftest.py
@@ -1,0 +1,57 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def no_anthropic_env(monkeypatch):
+    """Keep the developer's real keys out of the test so the no-key path is reachable."""
+    monkeypatch.delenv('DD_ANTHROPIC_API_KEY', raising=False)
+    monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+
+
+@pytest.fixture(autouse=True)
+def restore_cwd():
+    """The command chdirs into the repo root on the orchestrator path; undo it for the next test."""
+    cwd = os.getcwd()
+    yield
+    os.chdir(cwd)
+
+
+@pytest.fixture
+def docker_dir(tmp_path):
+    """A valid `--docker-path` directory."""
+    path = tmp_path / 'docker'
+    path.mkdir()
+    (path / 'docker-compose.yaml').write_text('services: {}\n')
+    return path
+
+
+@pytest.fixture
+def prd_file(tmp_path):
+    """A valid, non-empty `--prd` file."""
+    path = tmp_path / 'prd.md'
+    path.write_text('Drop the foo_total metric.\n')
+    return path
+
+
+@pytest.fixture
+def ai_repo(tmp_path_factory, config_file):
+    """An empty repo that `app.repo.path` resolves to, isolated from the real checkout."""
+    repo_path = tmp_path_factory.mktemp('ai-repo')
+    config_file.model.repos['core'] = str(repo_path)
+    config_file.save()
+    return repo_path
+
+
+@pytest.fixture
+def with_api_key(config_file):
+    """Set an Anthropic key in config so validation gets past the key check."""
+    config_file.model.ai.anthropic_api_key = 'sk-test'
+    config_file.save()
+    return config_file

--- a/ddev/tests/cli/meta/ai/test_entry.py
+++ b/ddev/tests/cli/meta/ai/test_entry.py
@@ -1,0 +1,140 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for the `ddev meta ai` entry point (TOGOTUI-10)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def no_anthropic_env(monkeypatch):
+    """Keep the developer's real keys out of tests so the no-key path is reachable."""
+    monkeypatch.delenv('DD_ANTHROPIC_API_KEY', raising=False)
+    monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+
+
+@pytest.fixture
+def with_api_key(config_file):
+    """Set an Anthropic key in config so validation gets past the key check."""
+    config_file.model.ai.anthropic_api_key = 'sk-test'
+    config_file.save()
+    return config_file
+
+
+# ---------------------------------------------------------------------------
+# Help / registration
+# ---------------------------------------------------------------------------
+
+
+def test_ai_help_resolves(ddev):
+    result = ddev('meta', 'ai', '--help')
+
+    assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# No-subcommand path: TogoApp construction
+# ---------------------------------------------------------------------------
+
+
+def test_no_subcommand_builds_shared_configuration_components(ddev, mocker, with_api_key):
+    """The composition root injects one engine and the same registries into the TUI."""
+    from ddev.cli.meta.ai.tui.app import TogoApp
+
+    run_mock = mocker.patch.object(TogoApp, 'run', return_value=None)
+    spy = mocker.spy(TogoApp, '__init__')
+    engine = mocker.patch('ddev.ai.config.engine.ConfigurationEngine')
+
+    result = ddev('meta', 'ai')
+
+    assert result.exit_code == 0, result.output
+    assert run_mock.called
+    spy.assert_called_once()
+    kwargs = spy.call_args.kwargs
+    assert kwargs['engine'] is engine.return_value
+    assert kwargs['phase_registry'] is not None
+    assert kwargs['provider_registry'] is not None
+
+
+def test_no_subcommand_passes_ddev_app(ddev, mocker, with_api_key):
+    """Invoking the ai group with no subcommand passes the ddev Application as ddev_app."""
+    from ddev.cli.meta.ai.tui.app import TogoApp
+
+    mocker.patch.object(TogoApp, 'run', return_value=None)
+    spy = mocker.spy(TogoApp, '__init__')
+
+    result = ddev('meta', 'ai')
+
+    assert result.exit_code == 0, result.output
+    spy.assert_called_once()
+    kwargs = spy.call_args.kwargs
+    assert 'ddev_app' in kwargs
+    assert kwargs['ddev_app'] is not None
+
+
+def test_no_subcommand_suppresses_httpx_info_logs_while_togo_runs(ddev, mocker, with_api_key):
+    """HTTP request logs do not write over the Textual display."""
+    from ddev.cli.meta.ai.tui.app import TogoApp
+
+    httpx_logger = logging.getLogger('httpx')
+    previous_level = httpx_logger.level
+    observed_levels = []
+
+    def observe_level() -> None:
+        observed_levels.append(httpx_logger.level)
+
+    try:
+        httpx_logger.setLevel(logging.INFO)
+        mocker.patch.object(TogoApp, 'run', side_effect=observe_level)
+
+        result = ddev('meta', 'ai')
+
+        assert result.exit_code == 0, result.output
+        assert observed_levels == [logging.WARNING]
+        assert httpx_logger.level == logging.INFO
+    finally:
+        httpx_logger.setLevel(previous_level)
+
+
+def test_no_subcommand_no_api_key_opens_dashboard(ddev, mocker):
+    """Browsing flows does not require provider credentials up front."""
+    from ddev.cli.meta.ai.tui.app import TogoApp
+
+    mocker.patch('ddev.ai.config.engine.ConfigurationEngine')
+    run_mock = mocker.patch.object(TogoApp, 'run', return_value=None)
+
+    result = ddev('meta', 'ai', catch_exceptions=True)
+
+    assert result.exit_code == 0, result.output
+    run_mock.assert_called_once()
+
+
+def test_no_subcommand_reports_configuration_error(ddev, mocker):
+    mocker.patch(
+        'ddev.ai.config.engine.ConfigurationEngine',
+        side_effect=__import__('ddev.ai.config.errors', fromlist=['ConfigError']).ConfigError('bad flow directory'),
+    )
+
+    result = ddev('meta', 'ai', catch_exceptions=True)
+
+    assert result.exit_code == 1
+    assert 'bad flow directory' in result.output
+
+
+def test_no_subcommand_construction_error(ddev, mocker, with_api_key):
+    """`ddev meta ai` surfaces an unexpected error when TogoApp.__init__ raises."""
+    from ddev.cli.meta.ai.tui.app import TogoApp
+
+    mocker.patch.object(TogoApp, '__init__', side_effect=RuntimeError('construction failed'))
+
+    result = ddev('meta', 'ai', catch_exceptions=True)
+
+    assert result.exit_code != 0

--- a/ddev/tests/cli/meta/ai/test_rendering.py
+++ b/ddev/tests/cli/meta/ai/test_rendering.py
@@ -1,0 +1,525 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.text import Text
+
+from ddev.ai.agent.scope import AgentRole, AgentScope
+from ddev.ai.agent.types import (
+    AgentResponse,
+    StopReason,
+    TokenUsage,
+    ToolCall,
+    WebActivity,
+    WebFetchCall,
+    WebSearchCall,
+)
+from ddev.ai.react.types import ReActResult
+from ddev.ai.tools.core.types import ToolResult
+from ddev.cli.meta.ai.palette import ROLE_GOAL_REVIEWER, ROLE_PHASE, ROLE_SUBAGENT
+from ddev.cli.meta.ai.rendering import (
+    MAX_INLINE_VALUE,
+    PROMPT_HEAD_CHARS,
+    PROMPT_TAIL_CHARS,
+    ROLE_STYLES,
+    AgentMarkdown,
+    _role_style,
+    _summarize_input,
+    _tokens,
+    _truncate_middle,
+    render_agent_error_line,
+    render_agent_finish_line,
+    render_agent_start_header,
+    render_agent_tools_line,
+    render_compact_notice,
+    render_prompt_panel,
+    render_response_header,
+    render_response_text,
+    render_tool_call_line,
+    render_tool_result_line,
+    render_web_fetch_line,
+    render_web_search_line,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers: constants
+# ---------------------------------------------------------------------------
+
+
+def test_role_styles_covers_all_roles():
+    for role in AgentRole:
+        assert role in ROLE_STYLES
+        style = ROLE_STYLES[role]
+        assert "label" in style
+        assert "color" in style
+        assert "prompt_border" in style
+
+
+def test_rendering_uses_no_raw_named_colors():
+    """Every color in this module must come from ddev.cli.meta.ai.palette, not a bare Rich color name.
+
+    A raw name like "cyan" or "magenta" bypasses the Togo palette and reads as a
+    jarringly saturated color against the app's muted theme.
+    """
+    import re
+    from pathlib import Path
+
+    from ddev.cli.meta.ai import rendering as rendering_module
+
+    source = Path(rendering_module.__file__).read_text(encoding="utf-8")
+    forbidden = {"black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"}
+    found = {name for name in forbidden if re.search(rf'"[^"]*\b{name}\b[^"]*"', source)}
+    assert not found, f"Found raw named color(s) {found} in rendering.py; use ddev.cli.meta.ai.palette instead"
+
+
+# ---------------------------------------------------------------------------
+# _role_style
+# ---------------------------------------------------------------------------
+
+
+def test_role_style_phase():
+    style = _role_style(AgentRole.PHASE)
+    assert style["label"] == "agent"
+    assert style["color"] == ROLE_PHASE
+
+
+def test_role_style_subagent():
+    style = _role_style(AgentRole.SUBAGENT)
+    assert style["label"] == "subagent"
+    assert style["color"] == ROLE_SUBAGENT
+
+
+def test_role_style_goal_reviewer():
+    style = _role_style(AgentRole.GOAL_REVIEWER)
+    assert style["label"] == "goal reviewer"
+    assert style["color"] == ROLE_GOAL_REVIEWER
+
+
+def test_role_style_unknown_falls_back_to_phase():
+    """An unexpected role value falls back gracefully to the PHASE style."""
+    fake_role = MagicMock(spec=AgentRole)
+    # MagicMock is not in ROLE_STYLES, so .get() returns the default
+    style = _role_style(fake_role)
+    assert style == ROLE_STYLES[AgentRole.PHASE]
+
+
+# ---------------------------------------------------------------------------
+# _truncate_middle
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_middle_short_text_unchanged():
+    text = "hello world"
+    assert _truncate_middle(text, 100, 100, "run.log") == text
+
+
+def test_truncate_middle_exactly_at_boundary():
+    text = "a" * 10
+    # head=5, tail=5 → exactly len(text), no truncation
+    assert _truncate_middle(text, 5, 5, "run.log") == text
+
+
+def test_truncate_middle_long_text_is_truncated():
+    text = "A" * 200 + "B" * 200
+    result = _truncate_middle(text, 100, 50, "run.log")
+    assert result.startswith("A" * 100)
+    assert result.endswith("B" * 50)
+    assert "250 chars omitted" in result
+    assert "run.log" in result
+
+
+def test_truncate_middle_preserves_log_hint():
+    text = "x" * 2000
+    hint = "/some/path/to/run.jsonl"
+    result = _truncate_middle(text, PROMPT_HEAD_CHARS, PROMPT_TAIL_CHARS, hint)
+    assert hint in result
+
+
+# ---------------------------------------------------------------------------
+# _summarize_input
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_input_short_string_inline():
+    result = _summarize_input({"key": "short"})
+    assert "key=short" in result
+
+
+def test_summarize_input_long_string_elided():
+    long_value = "x" * (MAX_INLINE_VALUE + 1)
+    result = _summarize_input({"code": long_value})
+    assert f"code=<{len(long_value)} chars>" in result
+
+
+def test_summarize_input_list_value():
+    result = _summarize_input({"items": [1, 2, 3]})
+    assert "items=<3 items>" in result
+
+
+def test_summarize_input_dict_value():
+    result = _summarize_input({"opts": {"a": 1}})
+    assert "opts=<1 items>" in result
+
+
+def test_summarize_input_integer_value():
+    result = _summarize_input({"count": 42})
+    assert "count=42" in result
+
+
+def test_summarize_input_multiple_keys():
+    result = _summarize_input({"a": "x", "b": "y"})
+    assert "a=x" in result
+    assert "b=y" in result
+
+
+def test_summarize_input_empty():
+    assert _summarize_input({}) == ""
+
+
+def test_summarize_input_none_value():
+    """_summarize_input does not raise when a value is None."""
+    result = _summarize_input({"key": None})
+    assert "key" in result
+
+
+# ---------------------------------------------------------------------------
+# _tokens
+# ---------------------------------------------------------------------------
+
+
+def test_tokens_small_numbers():
+    assert _tokens(500, 300) == "500 in / 300 out"
+
+
+def test_tokens_thousands_formatted():
+    assert _tokens(1500, 2000) == "2k in / 2k out"
+
+
+def test_tokens_mixed():
+    assert _tokens(999, 1000) == "999 in / 1k out"
+
+
+def test_tokens_zero():
+    assert _tokens(0, 0) == "0 in / 0 out"
+
+
+# ---------------------------------------------------------------------------
+# render_agent_start_header
+# ---------------------------------------------------------------------------
+
+
+def test_render_agent_start_header_returns_text():
+    scope = AgentScope(owner_id="phase_agent", role=AgentRole.PHASE, phase_id="phase_agent")
+    result = render_agent_start_header(scope)
+    assert isinstance(result, Text)
+    plain = result.plain
+    assert "phase_agent" in plain
+    assert "agent" in plain
+
+
+def test_render_agent_start_header_subagent():
+    scope = AgentScope(owner_id="sub_1", role=AgentRole.SUBAGENT, phase_id="phase_agent")
+    result = render_agent_start_header(scope)
+    assert "sub_1" in result.plain
+    assert "subagent" in result.plain
+
+
+# ---------------------------------------------------------------------------
+# render_agent_tools_line
+# ---------------------------------------------------------------------------
+
+
+def test_render_agent_tools_line_returns_text():
+    result = render_agent_tools_line(["bash", "read_file"])
+    assert isinstance(result, Text)
+    assert "bash" in result.plain
+    assert "read_file" in result.plain
+
+
+# ---------------------------------------------------------------------------
+# render_prompt_panel
+# ---------------------------------------------------------------------------
+
+
+def test_render_prompt_panel_returns_panel():
+    scope = AgentScope(owner_id="phase_agent", role=AgentRole.PHASE, phase_id="phase_agent")
+    panel = render_prompt_panel(scope, "Say hello.", "/run/log.jsonl")
+    assert isinstance(panel, Panel)
+
+
+def test_render_prompt_panel_short_prompt_verbatim():
+    scope = AgentScope(owner_id="phase_agent", role=AgentRole.PHASE, phase_id="phase_agent")
+    prompt = "Short prompt."
+    panel = render_prompt_panel(scope, prompt, "/run/log.jsonl")
+    assert isinstance(panel.renderable, Markdown)
+    assert prompt in panel.renderable.markup
+
+
+def test_render_prompt_panel_long_prompt_truncated():
+    scope = AgentScope(owner_id="phase_agent", role=AgentRole.PHASE, phase_id="phase_agent")
+    long_prompt = "A" * (PROMPT_HEAD_CHARS + PROMPT_TAIL_CHARS + 100)
+    panel = render_prompt_panel(scope, long_prompt, "/run/log.jsonl")
+    assert isinstance(panel.renderable, Markdown)
+    assert "omitted" in panel.renderable.markup
+
+
+def test_render_prompt_panel_title_contains_owner_id():
+    scope = AgentScope(owner_id="my_agent", role=AgentRole.PHASE, phase_id="my_agent")
+    panel = render_prompt_panel(scope, "hi", "/run/log")
+    assert "my_agent" in panel.title
+
+
+# ---------------------------------------------------------------------------
+# render_response_header
+# ---------------------------------------------------------------------------
+
+
+def test_render_response_header_returns_text():
+    scope = AgentScope(owner_id="phase_agent", role=AgentRole.PHASE, phase_id="phase_agent")
+    result = render_response_header(scope)
+    assert isinstance(result, Text)
+    assert "phase_agent" in result.plain
+    assert "response" in result.plain
+
+
+# ---------------------------------------------------------------------------
+# render_response_text
+# ---------------------------------------------------------------------------
+
+
+def test_render_response_text_returns_markdown():
+    result = render_response_text("## Hello from the model.")
+    assert isinstance(result, Markdown)
+    assert "## Hello from the model." in result.markup
+
+
+def test_agent_markdown_tables_wrap_cells_with_aligned_columns():
+    table = (
+        "| Flag | Purpose | Notes |\n"
+        "| --- | --- | --- |\n"
+        '| `--search "created:>=YYYY-MM-DD"` | Date filter | '
+        "The created qualifier supports >=, <=, and range formats such as created:>=2025-06-21. |\n"
+    )
+    console = Console(width=50, record=True, force_terminal=False, color_system=None)
+    console.print(AgentMarkdown(table))
+
+    rendered = console.export_text()
+
+    assert "Purpose" in rendered
+    assert "Date filter" in rendered
+    assert "The created" in rendered
+    assert "formats such as" in rendered
+    assert rendered.count("--search") == 1
+    body_lines = [line for line in rendered.splitlines() if line.strip() and not set(line.strip()) <= {"-", "|", " "}]
+    assert all(line.count(" | ") == 2 for line in body_lines)
+
+
+def test_agent_markdown_tables_align_wrapped_cell_continuations():
+    table = (
+        "| Path | Glossary | Subtheme |\n"
+        "| --- | --- | --- |\n"
+        "| `/tmp/example` | "
+        "This glossary entry has enough words to wrap onto several continuation lines in a narrow pane. | "
+        "Short note |\n"
+    )
+    console = Console(width=64, record=True, force_terminal=False, color_system=None)
+    console.print(AgentMarkdown(table))
+
+    rendered = console.export_text()
+    lines = [line for line in rendered.splitlines() if line.strip()]
+    body_lines = [line for line in lines if "glossary" in line or "continuation" in line or "narrow pane" in line]
+
+    assert len(body_lines) >= 2
+    assert all(line.count(" | ") == 2 for line in body_lines)
+    assert all(len(line) <= 64 for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# render_tool_call_line
+# ---------------------------------------------------------------------------
+
+
+def test_render_tool_call_line_returns_text():
+    tool_call = ToolCall(id="c1", name="read_file", input={"path": "foo.py"})
+    result = render_tool_call_line(tool_call)
+    assert isinstance(result, Text)
+    assert "read_file" in result.plain
+    assert "path=foo.py" in result.plain
+
+
+def test_render_tool_call_line_no_input():
+    tool_call = ToolCall(id="c2", name="list_dir", input={})
+    result = render_tool_call_line(tool_call)
+    assert isinstance(result, Text)
+    assert "list_dir" in result.plain
+
+
+# ---------------------------------------------------------------------------
+# render_web_search_line
+# ---------------------------------------------------------------------------
+
+
+def test_render_web_search_line_success():
+    search = WebSearchCall(query="datadog metrics", result_count=5)
+    result = render_web_search_line(search)
+    assert isinstance(result, Text)
+    assert "datadog metrics" in result.plain
+    assert "5" in result.plain
+
+
+def test_render_web_search_line_error():
+    search = WebSearchCall(query="bad query", result_count=0, error="timeout")
+    result = render_web_search_line(search)
+    assert isinstance(result, Text)
+    assert "timeout" in result.plain
+
+
+# ---------------------------------------------------------------------------
+# render_web_fetch_line
+# ---------------------------------------------------------------------------
+
+
+def test_render_web_fetch_line_success():
+    fetch = WebFetchCall(url="https://example.com", retrieved_at="2026-01-01")
+    result = render_web_fetch_line(fetch)
+    assert isinstance(result, Text)
+    assert "https://example.com" in result.plain
+    assert "2026-01-01" in result.plain
+
+
+def test_render_web_fetch_line_error():
+    fetch = WebFetchCall(url="https://bad.com", error="404")
+    result = render_web_fetch_line(fetch)
+    assert isinstance(result, Text)
+    assert "404" in result.plain
+
+
+# ---------------------------------------------------------------------------
+# render_tool_result_line
+# ---------------------------------------------------------------------------
+
+
+def test_render_tool_result_line_success():
+    tool_call = ToolCall(id="c1", name="read_file", input={})
+    result_obj = ToolResult(success=True)
+    line = render_tool_result_line(tool_call, result_obj)
+    assert isinstance(line, Text)
+    assert "✓" in line.plain
+    assert "read_file" in line.plain
+
+
+def test_render_tool_result_line_failure():
+    tool_call = ToolCall(id="c1", name="read_file", input={})
+    result_obj = ToolResult(success=False, error="file not found")
+    line = render_tool_result_line(tool_call, result_obj)
+    assert isinstance(line, Text)
+    assert "✗" in line.plain
+    assert "file not found" in line.plain
+
+
+def test_render_tool_result_line_truncated():
+    tool_call = ToolCall(id="c1", name="read_file", input={})
+    result_obj = ToolResult(success=True, truncated=True)
+    line = render_tool_result_line(tool_call, result_obj)
+    assert "truncated" in line.plain
+
+
+# ---------------------------------------------------------------------------
+# render_compact_notice
+# ---------------------------------------------------------------------------
+
+
+def test_render_compact_notice_returns_text():
+    result = render_compact_notice()
+    assert isinstance(result, Text)
+    assert "compact" in result.plain.lower()
+
+
+# ---------------------------------------------------------------------------
+# render_agent_finish_line
+# ---------------------------------------------------------------------------
+
+
+def _make_react_result(iterations: int = 3, input_tokens: int = 500, output_tokens: int = 200) -> ReActResult:
+    usage = TokenUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
+    response = AgentResponse(
+        stop_reason=StopReason.END_TURN,
+        text="done",
+        tool_calls=[],
+        usage=usage,
+        web_activity=WebActivity(),
+    )
+    return ReActResult(
+        final_response=response,
+        iterations=iterations,
+        total_input_tokens=input_tokens,
+        total_output_tokens=output_tokens,
+        context_usage=None,
+    )
+
+
+def test_render_agent_finish_line_returns_text():
+    scope = AgentScope(owner_id="phase_agent", role=AgentRole.PHASE, phase_id="phase_agent")
+    result_obj = _make_react_result()
+    line = render_agent_finish_line(scope, result_obj)
+    assert isinstance(line, Text)
+    assert "phase_agent" in line.plain
+    assert "3 iters" in line.plain
+    assert "500 in / 200 out" in line.plain
+
+
+def test_render_agent_finish_line_single_iteration():
+    """singular 'iter' (not 'iters') is used when iterations == 1."""
+    scope = AgentScope(owner_id="phase_agent", role=AgentRole.PHASE, phase_id="phase_agent")
+    result_obj = _make_react_result(iterations=1)
+    line = render_agent_finish_line(scope, result_obj)
+    assert isinstance(line, Text)
+    # Verify the iteration count is rendered (singular or plural form)
+    assert "1 iter" in line.plain
+
+
+# ---------------------------------------------------------------------------
+# render_agent_error_line
+# ---------------------------------------------------------------------------
+
+
+def test_render_agent_error_line_returns_text():
+    scope = AgentScope(owner_id="phase_agent", role=AgentRole.PHASE, phase_id="phase_agent")
+    error = ValueError("something broke")
+    line = render_agent_error_line(scope, error)
+    assert isinstance(line, Text)
+    assert "phase_agent" in line.plain
+    assert "ValueError" in line.plain
+    assert "something broke" in line.plain
+
+
+# ---------------------------------------------------------------------------
+# Smoke: rendering module has no Console/Application/Textual dependency
+# ---------------------------------------------------------------------------
+
+
+def test_rendering_module_has_no_console_import():
+    import importlib
+    import sys
+
+    # Importing rendering must not pull in any Textual or Console objects
+    mod = sys.modules.get("ddev.cli.meta.ai.rendering")
+    if mod is None:
+        mod = importlib.import_module("ddev.cli.meta.ai.rendering")
+    source_file = mod.__file__
+    with open(source_file, encoding="utf-8") as f:
+        source = f.read()
+    assert "Console(" not in source
+    assert "from textual" not in source
+    assert "import textual" not in source

--- a/ddev/tests/cli/meta/ai/tui/__init__.py
+++ b/ddev/tests/cli/meta/ai/tui/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/ddev/tests/cli/meta/ai/tui/conftest.py
+++ b/ddev/tests/cli/meta/ai/tui/conftest.py
@@ -1,0 +1,186 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from textual.app import App, ComposeResult
+
+from ddev.ai.agent.registry import AgentProviderRegistry
+from ddev.ai.config.models import (
+    AgentConfig,
+    ConfigStatus,
+    FlowEntry,
+    FlowInput,
+    FlowResult,
+    InputType,
+    PhaseConfig,
+    ResolvedFlow,
+    TaskConfig,
+)
+from ddev.ai.phases.registry import PhaseRegistry
+from ddev.cli.meta.ai.tui.app import TogoApp
+from ddev.cli.meta.ai.tui.theme import togo_theme
+
+LARGE_TERMINAL = (120, 50)
+STATUS_VARIABLE_KEYS = ("status-running", "status-pending", "status-done", "status-failed")
+
+
+def make_test_ddev_app(api_key: str | None = None, repo_path: Path | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        config=SimpleNamespace(ai=SimpleNamespace(anthropic_api_key=api_key, flow_dirs=[])),
+        repo=SimpleNamespace(path=str(repo_path or Path.cwd())),
+    )
+
+
+class StaticConfigurationEngine:
+    def __init__(self, flows: list[ResolvedFlow], results: list[FlowResult] | None = None) -> None:
+        self.flows = (
+            {result.name: result for result in results}
+            if results is not None
+            else {flow.name: FlowResult(flow.name, ConfigStatus.OK, resolved=flow) for flow in flows}
+        )
+
+    def get_flow(self, name: str) -> ResolvedFlow:
+        result = self.flows[name]
+        assert result.resolved is not None
+        return result.resolved
+
+
+class TogoModalTestApp(App):
+    CSS_PATH = TogoApp.CSS_PATH
+
+    def get_theme_variable_defaults(self) -> dict[str, str]:
+        return {key: togo_theme.variables[key] for key in STATUS_VARIABLE_KEYS}
+
+
+class LaunchModalTestApp(TogoModalTestApp):
+    """Minimal app that pushes LaunchModal immediately on mount."""
+
+    def __init__(self, flow: ResolvedFlow) -> None:
+        super().__init__()
+        self.flow = flow
+        self.dismiss_result: Any = "NOT_SET"
+
+    def compose(self) -> ComposeResult:
+        yield from []
+
+    def on_mount(self) -> None:
+        from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchModal
+
+        self.register_theme(togo_theme)
+        self.theme = "togo"
+
+        def on_dismiss(result: Any) -> None:
+            self.dismiss_result = result
+
+        self.push_screen(LaunchModal(self.flow), on_dismiss)
+
+
+@pytest.fixture
+def large_terminal() -> tuple[int, int]:
+    """A viewport large enough for modal button click tests."""
+    return LARGE_TERMINAL
+
+
+@pytest.fixture
+def ddev_app() -> SimpleNamespace:
+    return make_test_ddev_app()
+
+
+@pytest.fixture
+def make_flow() -> Callable[..., ResolvedFlow]:
+    def factory(
+        name: str = "Test Flow",
+        n_phases: int = 2,
+        *,
+        inputs: list[FlowInput] | None = None,
+        agents: dict[str, AgentConfig] | None = None,
+    ) -> ResolvedFlow:
+        flow_agents = agents or {"agent_a": AgentConfig.model_construct(provider="anthropic", tools=[])}
+        agent_name = next(iter(flow_agents))
+        phases = {
+            f"phase_{i}": PhaseConfig(
+                name=f"phase_{i}",
+                agent=agent_name,
+                tasks=[TaskConfig(name=f"task_{i}", prompt="do something")],
+            )
+            for i in range(n_phases)
+        }
+        flow = [FlowEntry(phase=f"phase_{i}") for i in range(n_phases)]
+        return ResolvedFlow(
+            name=name,
+            description=f"Description for {name}",
+            inputs=inputs or [],
+            agents=flow_agents,
+            phases=phases,
+            flow=flow,
+            variables={},
+        )
+
+    return factory
+
+
+@pytest.fixture
+def make_flow_with_tools() -> Callable[..., ResolvedFlow]:
+    def factory(name: str = "Tool Flow") -> ResolvedFlow:
+        agents = {
+            "analyst": AgentConfig.model_construct(provider="anthropic", model="claude-3-sonnet", tools=["read_file"])
+        }
+        phases = {
+            "analyse": PhaseConfig(
+                name="analyse",
+                agent="analyst",
+                tasks=[TaskConfig(name="read_task", prompt="analyse something")],
+            )
+        }
+        return ResolvedFlow(
+            name=name,
+            description="Tool flow",
+            agents=agents,
+            phases=phases,
+            flow=[FlowEntry(phase="analyse")],
+            variables={},
+        )
+
+    return factory
+
+
+@pytest.fixture
+def all_flow_inputs() -> list[FlowInput]:
+    return [
+        FlowInput(name="my_string", label="My String", input_type=InputType.STRING, default="hello", required=True),
+        FlowInput(name="my_number", label="My Number", input_type=InputType.NUMBER, default=42, required=True),
+        FlowInput(name="my_bool", label="My Bool", input_type=InputType.BOOLEAN, default=True, required=False),
+        FlowInput(name="my_path", label="My Path", input_type=InputType.PATH, default="/tmp", required=False),
+    ]
+
+
+@pytest.fixture
+def make_togo_app(make_flow: Callable[..., ResolvedFlow], ddev_app: SimpleNamespace) -> Callable[..., TogoApp]:
+    def factory(
+        flows: list[ResolvedFlow] | None = None,
+        *,
+        results: list[FlowResult] | None = None,
+    ) -> TogoApp:
+        return TogoApp(
+            engine=StaticConfigurationEngine([make_flow()] if flows is None else flows, results),
+            phase_registry=PhaseRegistry(),
+            provider_registry=AgentProviderRegistry(),
+            ddev_app=ddev_app,
+        )
+
+    return factory
+
+
+@pytest.fixture
+def make_launch_modal_app(make_flow: Callable[..., ResolvedFlow]) -> Callable[..., LaunchModalTestApp]:
+    def factory(inputs: list[FlowInput]) -> LaunchModalTestApp:
+        return LaunchModalTestApp(make_flow(name="Test Flow", n_phases=1, inputs=inputs))
+
+    return factory

--- a/ddev/tests/cli/meta/ai/tui/test_app.py
+++ b/ddev/tests/cli/meta/ai/tui/test_app.py
@@ -1,0 +1,111 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for tui/app.py: TogoApp structural and behavioral properties."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import SimpleNamespace
+
+from textual.app import App
+
+
+async def test_togo_app_boots_with_main_screen(make_togo_app):
+    """The app pushes MainScreen on mount so it is the active screen."""
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    app = make_togo_app([])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+
+
+async def test_togo_app_does_not_offer_command_palette(make_togo_app):
+    """The footer and keyboard shortcuts expose only Togo actions."""
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    app = make_togo_app([])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert "palette" not in app.export_screenshot().lower()
+
+        await pilot.press("ctrl+p")
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+
+
+async def test_bridge_target_defaults_to_app(make_togo_app):
+    app = make_togo_app([])
+    async with app.run_test():
+        assert app.bridge_target is app
+
+
+async def test_received_sink_starts_empty(make_togo_app):
+    app = make_togo_app([])
+    async with app.run_test():
+        assert app.received == []
+
+
+async def test_copy_to_clipboard_uses_system_and_textual_clipboards(monkeypatch, make_togo_app):
+    copied: list[str] = []
+    monkeypatch.setitem(sys.modules, "pyperclip", SimpleNamespace(copy=copied.append))
+
+    app = make_togo_app([])
+    async with app.run_test():
+        app.copy_to_clipboard("selected output")
+
+        assert copied == ["selected output"]
+        assert app.clipboard == "selected output"
+
+
+async def test_copy_to_clipboard_ignores_textual_clipboard_failure(monkeypatch, make_togo_app):
+    copied: list[str] = []
+    monkeypatch.setitem(sys.modules, "pyperclip", SimpleNamespace(copy=copied.append))
+
+    def fail_textual_copy(_app: App, _text: str) -> None:
+        raise RuntimeError("OSC 52 unavailable")
+
+    monkeypatch.setattr(App, "copy_to_clipboard", fail_textual_copy)
+    app = make_togo_app([])
+    async with app.run_test():
+        app.copy_to_clipboard("selected output")
+
+        assert copied == ["selected output"]
+
+
+async def test_copy_to_clipboard_falls_back_when_system_clipboard_fails(monkeypatch, make_togo_app):
+    native_copies: list[tuple[list[str], str]] = []
+
+    def fail_system_copy(_text: str) -> None:
+        raise RuntimeError("system clipboard unavailable")
+
+    def native_copy(command: list[str], *, input: str, text: bool, check: bool) -> None:
+        assert text is True
+        assert check is True
+        native_copies.append((command, input))
+
+    app_module = importlib.import_module("ddev.cli.meta.ai.tui.app")
+    monkeypatch.setitem(sys.modules, "pyperclip", SimpleNamespace(copy=fail_system_copy))
+    monkeypatch.setattr(app_module.subprocess, "run", native_copy)
+    monkeypatch.setattr(app_module.sys, "platform", "darwin")
+    app = make_togo_app([])
+    async with app.run_test():
+        app.copy_to_clipboard("selected output")
+
+        assert native_copies == [(["/usr/bin/pbcopy"], "selected output")]
+        assert app.clipboard == "selected output"
+
+
+async def test_text_selection_is_copied_automatically(monkeypatch, make_togo_app):
+    copied: list[str] = []
+    app = make_togo_app([])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        monkeypatch.setattr(app.screen, "get_selected_text", lambda: "selected output")
+        monkeypatch.setattr(app, "copy_to_clipboard", copied.append)
+
+        app.on_text_selected()
+
+        assert copied == ["selected output"]

--- a/ddev/tests/cli/meta/ai/tui/test_bridge.py
+++ b/ddev/tests/cli/meta/ai/tui/test_bridge.py
@@ -1,0 +1,279 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for tui/bridge.py: build_app_callback_set delivers the right Textual messages."""
+
+from __future__ import annotations
+
+import pytest
+
+from ddev.ai.agent.scope import AgentRole, AgentScope
+from ddev.ai.agent.types import AgentResponse as AgentResponsePayload
+from ddev.ai.agent.types import StopReason, TokenUsage, ToolCall
+from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
+from ddev.ai.react.types import ReActResult
+from ddev.ai.tools.core.types import ToolResult
+from ddev.cli.meta.ai.tui.bridge import build_app_callback_set
+from ddev.cli.meta.ai.tui.messages import (
+    AfterCompact,
+    AfterGoalCheck,
+    AgentBeforeSend,
+    AgentErrored,
+    AgentFinished,
+    AgentResponseReceived,
+    AgentStarted,
+    AgentToolCalled,
+    BeforeCompact,
+    BeforeGoalCheck,
+    PhaseFinished,
+    PhaseStarted,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+SCOPE = AgentScope(owner_id="test_agent", role=AgentRole.PHASE, phase_id="test_agent")
+
+
+def _make_response() -> AgentResponsePayload:
+    usage = TokenUsage(
+        input_tokens=10,
+        output_tokens=5,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
+    return AgentResponsePayload(
+        stop_reason=StopReason.END_TURN,
+        text="hello",
+        tool_calls=[],
+        usage=usage,
+    )
+
+
+def _make_react_result() -> ReActResult:
+    return ReActResult(
+        final_response=_make_response(),
+        iterations=3,
+        total_input_tokens=30,
+        total_output_tokens=15,
+        context_usage=None,
+    )
+
+
+class StubOrchestrator:
+    """Fires one of every callback event so each bridge handler is exercised exactly once."""
+
+    def __init__(self, cb_set: CallbackSet) -> None:
+        self.cb_set = cb_set
+
+    async def run_async(self) -> None:
+        tool_call = ToolCall(id="tc1", name="bash", input={"cmd": "ls"})
+        result = ToolResult(success=True, data="file.txt")
+
+        await self.cb_set.fire_phase_start("phase1")
+        await self.cb_set.fire_phase_finish("phase1")
+        await self.cb_set.fire_agent_start(SCOPE, "sys_prompt", ["bash", "python"])
+        await self.cb_set.fire_agent_response(SCOPE, _make_response(), 1)
+        await self.cb_set.fire_tool_call(SCOPE, tool_call, result, 1)
+        await self.cb_set.fire_before_compact(SCOPE)
+        await self.cb_set.fire_after_compact(SCOPE)
+        await self.cb_set.fire_agent_finish(SCOPE, _make_react_result())
+        await self.cb_set.fire_agent_error(SCOPE, ValueError("boom"))
+        await self.cb_set.fire_before_goal_check("phase1", "task1", 1)
+        await self.cb_set.fire_after_goal_check("phase1", "task1", 1, True, "looks good")
+
+
+# ---------------------------------------------------------------------------
+# Factory: type, composition, and basic wiring
+# ---------------------------------------------------------------------------
+
+
+async def test_build_app_callback_set_wires_correctly(make_togo_app):
+    """build_app_callback_set returns a wired CallbackSet that routes events to the app sink."""
+    app = make_togo_app([])
+    async with app.run_test() as pilot:
+        cb = build_app_callback_set(app)
+        assert isinstance(cb, CallbackSet)
+        combined = Callbacks([cb])
+        assert isinstance(combined, Callbacks)
+        # Fire one real event to confirm the wiring delivers a message
+        await combined.fire_phase_start("wiring_phase")
+        await pilot.pause(0.1)
+    phase_started = [m for m in app.received if isinstance(m, PhaseStarted)]
+    assert len(phase_started) == 1
+    assert phase_started[0].phase_id == "wiring_phase"
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture: run StubOrchestrator once and expose app.received
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def received_from_stub(make_togo_app):
+    """Run StubOrchestrator once and return the full app.received list."""
+    app = make_togo_app([])
+    async with app.run_test() as pilot:
+        cb = build_app_callback_set(app)
+        stub = StubOrchestrator(cb)
+        app.run_flow(stub)
+        await pilot.pause(0.3)
+    return app.received
+
+
+# ---------------------------------------------------------------------------
+# Bridge → app sink: each event type delivers the right message
+# ---------------------------------------------------------------------------
+
+
+async def test_phase_started_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, PhaseStarted)]
+    assert len(msgs) == 1
+    assert msgs[0].phase_id == "phase1"
+
+
+async def test_phase_finished_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, PhaseFinished)]
+    assert len(msgs) == 1
+    assert msgs[0].phase_id == "phase1"
+
+
+async def test_agent_started_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, AgentStarted)]
+    assert len(msgs) == 1
+    assert msgs[0].scope.owner_id == "test_agent"
+    assert msgs[0].system_prompt == "sys_prompt"
+    assert msgs[0].tools == ["bash", "python"]
+
+
+async def test_agent_response_received_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, AgentResponseReceived)]
+    assert len(msgs) == 1
+    assert msgs[0].response.text == "hello"
+    assert msgs[0].iteration == 1
+    assert msgs[0].scope is SCOPE
+
+
+async def test_agent_tool_called_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, AgentToolCalled)]
+    assert len(msgs) == 1
+    assert msgs[0].tool_call.name == "bash"
+    assert msgs[0].result.data == "file.txt"
+    assert msgs[0].iteration == 1
+
+
+async def test_before_compact_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, BeforeCompact)]
+    assert len(msgs) == 1
+    assert msgs[0].scope is SCOPE
+
+
+async def test_after_compact_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, AfterCompact)]
+    assert len(msgs) == 1
+    assert msgs[0].scope is SCOPE
+
+
+async def test_agent_finished_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, AgentFinished)]
+    assert len(msgs) == 1
+    assert msgs[0].result.iterations == 3
+    assert msgs[0].scope is SCOPE
+
+
+async def test_agent_errored_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, AgentErrored)]
+    assert len(msgs) == 1
+    assert isinstance(msgs[0].error, ValueError)
+    assert str(msgs[0].error) == "boom"
+
+
+async def test_before_goal_check_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, BeforeGoalCheck)]
+    assert len(msgs) == 1
+    assert msgs[0].phase_id == "phase1"
+    assert msgs[0].task_name == "task1"
+    assert msgs[0].attempt == 1
+
+
+async def test_after_goal_check_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, AfterGoalCheck)]
+    assert len(msgs) == 1
+    assert msgs[0].phase_id == "phase1"
+    assert msgs[0].task_name == "task1"
+    assert msgs[0].attempt == 1
+    assert msgs[0].valid is True
+    assert msgs[0].reason == "looks good"
+
+
+async def test_all_11_messages_delivered(make_togo_app):
+    """Every one of the 11 bridge event types delivers exactly one message to the sink."""
+    app = make_togo_app([])
+    async with app.run_test() as pilot:
+        cb = build_app_callback_set(app)
+        stub = StubOrchestrator(cb)
+        app.run_flow(stub)
+        await pilot.pause(0.3)
+
+    assert len(app.received) == 11
+
+
+# ---------------------------------------------------------------------------
+# AgentBeforeSend: new bridge event for on_before_agent_send
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_before_send_non_sentinel_delivered(make_togo_app):
+    """AgentBeforeSend is posted when the prompt is not TOOL_RESULTS_SENTINEL."""
+    app = make_togo_app([])
+    async with app.run_test() as pilot:
+        cb = build_app_callback_set(app)
+        combined = Callbacks([cb])
+        await combined.fire_before_agent_send(SCOPE, "Analyze the metrics.", 1)
+        await pilot.pause(0.2)
+
+    msgs = [m for m in app.received if isinstance(m, AgentBeforeSend)]
+    assert len(msgs) == 1
+    assert msgs[0].scope is SCOPE
+    assert msgs[0].prompt == "Analyze the metrics."
+    assert msgs[0].iteration == 1
+
+
+async def test_agent_before_send_sentinel_delivered(make_togo_app):
+    """AgentBeforeSend is posted for tool-result sends so the TUI can show thinking state."""
+    from ddev.ai.react.process import TOOL_RESULTS_SENTINEL
+
+    app = make_togo_app([])
+    async with app.run_test() as pilot:
+        cb = build_app_callback_set(app)
+        combined = Callbacks([cb])
+        await combined.fire_before_agent_send(SCOPE, TOOL_RESULTS_SENTINEL, 2)
+        await pilot.pause(0.2)
+
+    msgs = [m for m in app.received if isinstance(m, AgentBeforeSend)]
+    assert len(msgs) == 1
+    assert msgs[0].scope is SCOPE
+    assert msgs[0].prompt == TOOL_RESULTS_SENTINEL
+    assert msgs[0].iteration == 2
+
+
+async def test_agent_before_send_payload_scope_and_iteration(make_togo_app):
+    """AgentBeforeSend carries the correct scope, prompt, and iteration."""
+    from ddev.ai.agent.scope import AgentRole, AgentScope
+
+    scope = AgentScope(owner_id="phase_x", role=AgentRole.SUBAGENT, phase_id="phase_x")
+
+    app = make_togo_app([])
+    async with app.run_test() as pilot:
+        cb = build_app_callback_set(app)
+        combined = Callbacks([cb])
+        await combined.fire_before_agent_send(scope, "Inspect the endpoint.", 3)
+        await pilot.pause(0.2)
+
+    msgs = [m for m in app.received if isinstance(m, AgentBeforeSend)]
+    assert len(msgs) == 1
+    assert msgs[0].scope.owner_id == "phase_x"
+    assert msgs[0].scope.role.value == "subagent"
+    assert msgs[0].prompt == "Inspect the endpoint."
+    assert msgs[0].iteration == 3

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -1,0 +1,1689 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for ExecutionScreen live wiring and fake orchestrator (test-internal only)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from textual.app import ComposeResult
+from textual.screen import Screen
+from textual.widget import Widget
+
+from ddev.ai.agent.registry import AgentProviderRegistry
+from ddev.ai.config.models import AgentConfig, FlowEntry, PhaseConfig, ResolvedFlow, TaskConfig
+from ddev.ai.phases.registry import PhaseRegistry
+from ddev.cli.meta.ai.tui.app import TogoApp
+from ddev.cli.meta.ai.tui.status import RunStatus
+
+from .conftest import StaticConfigurationEngine
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+DEMO_PHASES = [
+    ("phase_1", ["task_one"]),
+    ("phase_2", ["task_two"]),
+]
+
+
+def _make_flow(
+    name: str = "Test Flow",
+    phases: list[tuple[str, list[str]]] | None = None,
+) -> ResolvedFlow:
+    """Build a ResolvedFlow matching the given (phase_id, task_names) list."""
+    if phases is None:
+        phases = DEMO_PHASES
+    agents = {"agent_a": AgentConfig.model_construct(provider="anthropic", tools=[])}
+    phase_configs = {
+        phase_id: PhaseConfig(
+            name=phase_id,
+            agent="agent_a",
+            tasks=[TaskConfig(name=task_name, prompt="do it") for task_name in task_names],
+        )
+        for phase_id, task_names in phases
+    }
+    flow_entries = [FlowEntry(phase=phase_id) for phase_id, _ in phases]
+    return ResolvedFlow(
+        name=name,
+        description="A test flow",
+        agents=agents,
+        phases=phase_configs,
+        flow=flow_entries,
+        variables={},
+    )
+
+
+def _make_dag_flow() -> ResolvedFlow:
+    """Build a flow with branching and fan-in dependencies."""
+    agents = {"agent_a": AgentConfig.model_construct(provider="anthropic", tools=[])}
+    phase_ids = ["research", "write_readme", "write_script", "write_tests", "final_review"]
+    phase_configs = {
+        phase_id: PhaseConfig(
+            name=phase_id,
+            agent="agent_a",
+            tasks=[TaskConfig(name=f"{phase_id}_task", prompt="do it")],
+        )
+        for phase_id in phase_ids
+    }
+    return ResolvedFlow(
+        name="DAG Flow",
+        description="A dependency graph test flow",
+        agents=agents,
+        phases=phase_configs,
+        flow=[
+            FlowEntry(phase="research"),
+            FlowEntry(phase="write_readme", dependencies=["research"]),
+            FlowEntry(phase="write_script", dependencies=["research"]),
+            FlowEntry(phase="write_tests", dependencies=["write_script"]),
+            FlowEntry(phase="final_review", dependencies=["write_readme", "write_script", "write_tests"]),
+        ],
+        variables={},
+    )
+
+
+def _demo_dir() -> Path:
+    import ddev.ai
+
+    return Path(ddev.ai.__file__).parent / "flows" / "demo"
+
+
+# ---------------------------------------------------------------------------
+# Test-only fake orchestrator — scripted, no API key, no real agents.
+# This is a test double that lives ONLY in the test module.
+# The shipped tui/ package contains no fake/demo orchestrators.
+# ---------------------------------------------------------------------------
+
+
+def _make_token_usage() -> Any:
+    from ddev.ai.agent.types import TokenUsage
+
+    return TokenUsage(
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
+
+
+def _make_agent_response(text: str) -> Any:
+    from ddev.ai.agent.types import AgentResponse, StopReason, WebActivity
+
+    return AgentResponse(
+        stop_reason=StopReason.END_TURN,
+        text=text,
+        tool_calls=[],
+        usage=_make_token_usage(),
+        web_activity=WebActivity(),
+    )
+
+
+def _make_react_result(response: Any) -> Any:
+    from ddev.ai.react.types import ReActResult
+
+    return ReActResult(
+        final_response=response,
+        iterations=2,
+        total_input_tokens=200,
+        total_output_tokens=100,
+        context_usage=None,
+    )
+
+
+class _FakeOrchestrator:
+    """Scripted fake orchestrator for tests — no API key, no real agents.
+
+    Fires a deterministic sequence of callback events (phase/agent/tool/goal)
+    through a supplied ``Callbacks`` object without any API key or real agents.
+    Tests inject it into ``ExecutionScreen`` via the ``orchestrator_builder``
+    parameter to verify pipeline, task, and output rendering.
+    """
+
+    def __init__(
+        self,
+        callbacks: Any,
+        phases: list[tuple[str, list[str]]],
+        *,
+        fail_on_phase: str | None = None,
+    ) -> None:
+        self._callbacks = callbacks
+        self._phases = phases
+        self._fail_on_phase = fail_on_phase
+        self.failed_phase: str | None = None
+
+    async def run_async(self) -> None:
+        """Fire the scripted event sequence through the callbacks."""
+        for phase_id, task_names in self._phases:
+            await self._run_phase(phase_id, task_names)
+
+    async def _run_phase(self, phase_id: str, task_names: list[str]) -> None:
+        from ddev.ai.agent.scope import AgentRole, AgentScope
+        from ddev.ai.agent.types import ToolCall
+        from ddev.ai.react.process import TOOL_RESULTS_SENTINEL
+        from ddev.ai.tools.core.types import ToolResult
+
+        scope = AgentScope(owner_id=phase_id, role=AgentRole.PHASE, phase_id=phase_id)
+        await self._callbacks.fire_phase_start(phase_id)
+        await self._callbacks.fire_agent_start(scope, f"You are the agent for {phase_id}.", ["bash"])
+
+        # First iteration: real prompt
+        await self._callbacks.fire_before_agent_send(scope, f"Complete the work for {phase_id}.", 1)
+        resp1 = _make_agent_response("I'll start working on this.")
+        await self._callbacks.fire_agent_response(scope, resp1, 1)
+
+        # Tool call
+        tool_call = ToolCall(id=f"{phase_id}_tc1", name="bash", input={"cmd": "echo done"})
+        tool_result = ToolResult(success=True, data="done\n")
+        await self._callbacks.fire_tool_call(scope, tool_call, tool_result, 1)
+
+        # Second iteration: sentinel prompt (bridge skips this, no AgentBeforeSend posted)
+        await self._callbacks.fire_before_agent_send(scope, TOOL_RESULTS_SENTINEL, 2)
+        resp2 = _make_agent_response("Work complete.")
+        await self._callbacks.fire_agent_response(scope, resp2, 2)
+
+        # Failure mode: fire error and raise before goal checks
+        if self._fail_on_phase == phase_id:
+            error = RuntimeError(f"Simulated failure in phase {phase_id!r}")
+            await self._callbacks.fire_agent_error(scope, error)
+            self.failed_phase = phase_id
+            raise error
+
+        # Goal validation for each task
+        for task_name in task_names:
+            await self._callbacks.fire_before_goal_check(phase_id, task_name, 1)
+            await self._callbacks.fire_after_goal_check(phase_id, task_name, 1, True, "Goal achieved.")
+
+        react_result = _make_react_result(resp2)
+        await self._callbacks.fire_agent_finish(scope, react_result)
+        await self._callbacks.fire_phase_finish(phase_id)
+
+
+def _make_builder(
+    phases: list[tuple[str, list[str]]] | None = None,
+    *,
+    fail_on_phase: str | None = None,
+) -> Any:
+    """Return an orchestrator builder that creates a _FakeOrchestrator."""
+    if phases is None:
+        phases = DEMO_PHASES
+
+    def builder(callbacks: Any) -> _FakeOrchestrator:
+        return _FakeOrchestrator(callbacks, phases, fail_on_phase=fail_on_phase)
+
+    return builder
+
+
+def _app(flow: ResolvedFlow | None = None) -> TogoApp:
+    flow = flow or _make_flow()
+
+    ddev_app = SimpleNamespace(
+        config=SimpleNamespace(ai=SimpleNamespace(anthropic_api_key=None, flow_dirs=[])),
+        repo=SimpleNamespace(path=str(Path.cwd())),
+    )
+    return TogoApp(
+        engine=StaticConfigurationEngine([flow]),
+        phase_registry=PhaseRegistry(),
+        provider_registry=AgentProviderRegistry(),
+        ddev_app=ddev_app,
+    )
+
+
+class _GraphHarness(Screen):
+    def __init__(self, graph: Widget) -> None:
+        super().__init__()
+        self._graph = graph
+        self.selected_phases: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        yield self._graph
+
+    def on_phase_selected(self, event: Any) -> None:
+        self.selected_phases.append(event.phase_id)
+
+
+# ---------------------------------------------------------------------------
+# _FakeOrchestrator unit tests (no Textual App needed)
+# ---------------------------------------------------------------------------
+
+
+async def test_fake_orchestrator_success_completes():
+    """_FakeOrchestrator.run_async() completes without raising on success."""
+    from ddev.ai.callbacks.callbacks import Callbacks
+
+    cb = Callbacks()
+    demo = _FakeOrchestrator(cb, DEMO_PHASES)
+    await demo.run_async()
+    assert demo.failed_phase is None
+
+
+async def test_fake_orchestrator_fires_phase_events():
+    """_FakeOrchestrator fires phase_start and phase_finish for each phase."""
+    from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
+
+    started: list[str] = []
+    finished: list[str] = []
+    cb_set = CallbackSet()
+
+    @cb_set.on_phase_start
+    async def _(phase_id: str) -> None:
+        started.append(phase_id)
+
+    @cb_set.on_phase_finish
+    async def _(phase_id: str) -> None:
+        finished.append(phase_id)
+
+    demo = _FakeOrchestrator(Callbacks([cb_set]), DEMO_PHASES)
+    await demo.run_async()
+    assert started == ["phase_1", "phase_2"]
+    assert finished == ["phase_1", "phase_2"]
+
+
+async def test_fake_orchestrator_fires_agent_events():
+    """_FakeOrchestrator fires agent_start, agent_response, agent_finish per phase."""
+    from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
+
+    owner_ids: list[str] = []
+    cb_set = CallbackSet()
+
+    @cb_set.on_agent_start
+    async def _(scope: Any, system_prompt: str, tools: list[str]) -> None:
+        owner_ids.append(scope.owner_id)
+
+    demo = _FakeOrchestrator(Callbacks([cb_set]), DEMO_PHASES)
+    await demo.run_async()
+    assert owner_ids == ["phase_1", "phase_2"]
+
+
+async def test_fake_orchestrator_fires_before_agent_send_non_sentinel():
+    """_FakeOrchestrator fires before_agent_send with a non-sentinel prompt."""
+    from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
+    from ddev.ai.react.process import TOOL_RESULTS_SENTINEL
+
+    non_sentinel_prompts: list[str] = []
+    cb_set = CallbackSet()
+
+    @cb_set.on_before_agent_send
+    async def _(scope: Any, prompt: str, iteration: int) -> None:
+        if prompt != TOOL_RESULTS_SENTINEL:
+            non_sentinel_prompts.append(prompt)
+
+    demo = _FakeOrchestrator(Callbacks([cb_set]), DEMO_PHASES)
+    await demo.run_async()
+    assert len(non_sentinel_prompts) >= len(DEMO_PHASES)
+
+
+async def test_fake_orchestrator_fires_sentinel_prompt():
+    """_FakeOrchestrator fires before_agent_send with TOOL_RESULTS_SENTINEL."""
+    from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
+    from ddev.ai.react.process import TOOL_RESULTS_SENTINEL
+
+    all_prompts: list[str] = []
+    cb_set = CallbackSet()
+
+    @cb_set.on_before_agent_send
+    async def _(scope: Any, prompt: str, iteration: int) -> None:
+        all_prompts.append(prompt)
+
+    demo = _FakeOrchestrator(Callbacks([cb_set]), DEMO_PHASES)
+    await demo.run_async()
+    assert TOOL_RESULTS_SENTINEL in all_prompts
+
+
+async def test_fake_orchestrator_fires_goal_check_events():
+    """_FakeOrchestrator fires before/after_goal_check for each task."""
+    from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
+
+    goal_results: list[tuple[str, str, bool]] = []
+    cb_set = CallbackSet()
+
+    @cb_set.on_after_goal_check
+    async def _(phase_id: str, task_name: str, attempt: int, valid: bool, reason: str) -> None:
+        goal_results.append((phase_id, task_name, valid))
+
+    demo = _FakeOrchestrator(Callbacks([cb_set]), DEMO_PHASES)
+    await demo.run_async()
+    assert ("phase_1", "task_one", True) in goal_results
+    assert ("phase_2", "task_two", True) in goal_results
+
+
+async def test_fake_orchestrator_failure_raises():
+    """_FakeOrchestrator in failure mode raises from run_async()."""
+    from ddev.ai.callbacks.callbacks import Callbacks
+
+    demo = _FakeOrchestrator(Callbacks(), DEMO_PHASES, fail_on_phase="phase_1")
+    with pytest.raises(RuntimeError):
+        await demo.run_async()
+
+
+async def test_fake_orchestrator_failure_sets_failed_phase():
+    """_FakeOrchestrator sets failed_phase on failure."""
+    from ddev.ai.callbacks.callbacks import Callbacks
+
+    demo = _FakeOrchestrator(Callbacks(), DEMO_PHASES, fail_on_phase="phase_1")
+    try:
+        await demo.run_async()
+    except RuntimeError:
+        pass
+    assert demo.failed_phase == "phase_1"
+
+
+async def test_fake_orchestrator_failure_fires_agent_error():
+    """_FakeOrchestrator in failure mode fires on_agent_error before raising."""
+    from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
+
+    errors: list[BaseException] = []
+    cb_set = CallbackSet()
+
+    @cb_set.on_agent_error
+    async def _(scope: Any, error: BaseException) -> None:
+        errors.append(error)
+
+    demo = _FakeOrchestrator(Callbacks([cb_set]), DEMO_PHASES, fail_on_phase="phase_1")
+    try:
+        await demo.run_async()
+    except RuntimeError:
+        pass
+    assert len(errors) == 1
+    assert isinstance(errors[0], RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# ExecutionScreen: builder injection and wiring
+# ---------------------------------------------------------------------------
+
+
+async def test_execution_screen_uses_injectable_builder():
+    """ExecutionScreen passes Callbacks to the provided builder."""
+    from ddev.ai.callbacks.callbacks import Callbacks
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    received_callbacks: list[Callbacks] = []
+
+    def _builder(cb: Callbacks) -> Any:
+        received_callbacks.append(cb)
+
+        class _Noop:
+            async def run_async(self) -> None:
+                pass
+
+        return _Noop()
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.push_screen(ExecutionScreen(flow, orchestrator_builder=_builder))
+        await pilot.pause(0.3)
+
+    assert len(received_callbacks) == 1
+    assert isinstance(received_callbacks[0], Callbacks)
+
+
+async def test_execution_screen_sets_bridge_target_on_mount():
+    """ExecutionScreen sets app.bridge_target = itself on mount."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder())
+        await app.push_screen(screen)
+        await pilot.pause(0.1)
+        assert app.bridge_target is screen
+
+
+async def test_execution_screen_resets_bridge_target_on_unmount():
+    """Popping ExecutionScreen resets app.bridge_target to the app."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.push_screen(ExecutionScreen(flow, orchestrator_builder=_make_builder()))
+        await pilot.pause(0.3)
+        app.pop_screen()
+        await pilot.pause(0.1)
+        assert app.bridge_target is app
+
+
+# ---------------------------------------------------------------------------
+# ExecutionScreen: pipeline status transitions
+# ---------------------------------------------------------------------------
+
+
+async def test_pipeline_graph_renders_native_phase_nodes():
+    """PipelineGraph renders phases as native widgets so TCSS can style each status."""
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PipelineGraph
+
+    graph = PipelineGraph(_make_dag_flow(), {"research": RunStatus.RUNNING})
+    app = _app(_make_dag_flow())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.push_screen(_GraphHarness(graph))
+        await pilot.pause()
+        nodes = {node.phase_id: node for node in graph.query("PhaseNode")}
+        assert set(nodes) == {"research", "write_readme", "write_script", "write_tests", "final_review"}
+        assert "status-running" in nodes["research"].classes
+        assert "status-pending" in nodes["write_readme"].classes
+        graph.query_one("#pipeline-connectors")
+
+
+async def test_pipeline_graph_updates_phase_node_status_classes():
+    """PipelineGraph updates native node classes when phase statuses change."""
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PipelineGraph
+
+    graph = PipelineGraph(_make_dag_flow(), {"research": RunStatus.PENDING})
+    app = _app(_make_dag_flow())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.push_screen(_GraphHarness(graph))
+        await pilot.pause()
+        graph.update_statuses({"research": RunStatus.DONE})
+        await pilot.pause()
+        node = {node.phase_id: node for node in graph.query("PhaseNode")}["research"]
+        assert "status-done" in node.classes
+        assert "status-pending" not in node.classes
+
+
+async def test_pipeline_graph_phase_node_selection_posts_phase_id():
+    """Activating a phase node emits the selected phase id."""
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseNode, PipelineGraph
+
+    graph = PipelineGraph(_make_dag_flow(), {"research": RunStatus.PENDING})
+    harness = _GraphHarness(graph)
+    app = _app(_make_dag_flow())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.push_screen(harness)
+        await pilot.pause()
+        graph.query_one(PhaseNode).action_select()
+        await pilot.pause()
+        assert harness.selected_phases == ["research"]
+
+
+async def test_pipeline_graph_phase_node_click_ignores_text_selection(monkeypatch):
+    """Releasing a drag selection over a phase node does not activate it."""
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseNode, PipelineGraph
+
+    graph = PipelineGraph(_make_dag_flow(), {"research": RunStatus.PENDING})
+    harness = _GraphHarness(graph)
+    app = _app(_make_dag_flow())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.push_screen(harness)
+        await pilot.pause()
+        monkeypatch.setattr(harness, "get_selected_text", lambda: "selected phase text")
+
+        graph.query_one(PhaseNode).on_click()
+        await pilot.pause()
+
+        assert harness.selected_phases == []
+
+
+async def test_pipeline_nodes_start_pending():
+    """All pipeline nodes start in 'pending' status."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    screen = ExecutionScreen(flow)
+    for phase_id, _ in DEMO_PHASES:
+        assert screen._phase_statuses[phase_id] is RunStatus.PENDING
+
+
+def test_render_pipeline_draws_vertical_layered_dag():
+    """Pipeline graph renders phase levels top-to-bottom with downward arrows."""
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import render_pipeline
+
+    flow = _make_dag_flow()
+    rendered = render_pipeline(flow, {entry.phase: RunStatus.PENDING for entry in flow.flow}).plain
+    lines = rendered.splitlines()
+
+    assert rendered.count("● research") == 1
+    assert rendered.count("● write_readme") == 1
+    assert rendered.count("● write_script") == 1
+    assert rendered.count("● write_tests") == 1
+    assert rendered.count("● final_review") == 1
+    assert "▼" in rendered
+    assert "▶" not in rendered
+    assert next(i for i, line in enumerate(lines) if "● research" in line) < next(
+        i for i, line in enumerate(lines) if "● final_review" in line
+    )
+    assert not any("● research" in line and "● write_readme" in line for line in lines)
+
+
+async def test_pipeline_transitions_to_done_on_success():
+    """All pipeline nodes reach 'done' after a successful _FakeOrchestrator run."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder())
+        await app.push_screen(screen)
+        await pilot.pause(0.5)
+
+    for phase_id, _ in DEMO_PHASES:
+        assert screen._phase_statuses[phase_id] is RunStatus.DONE, (
+            f"Expected phase {phase_id!r} to be 'done', got {screen._phase_statuses[phase_id]!r}"
+        )
+
+
+async def test_pipeline_failed_phase_shows_failed_status():
+    """A phase that raises shows 'failed' status; subsequent phases remain 'pending'."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder(fail_on_phase="phase_1"))
+        await app.push_screen(screen)
+        await pilot.pause(0.5)
+
+    assert screen._phase_statuses["phase_1"] is RunStatus.FAILED
+    assert screen._phase_statuses["phase_2"] is RunStatus.PENDING
+
+
+def test_interleaved_phase_error_only_mutates_scoped_phase() -> None:
+    """An error from phase A cannot be attributed to concurrently running phase B."""
+    from ddev.ai.agent.scope import AgentRole, AgentScope
+    from ddev.cli.meta.ai.tui.messages import AgentBeforeSend, AgentErrored, PhaseStarted
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    screen = ExecutionScreen(_make_flow())
+    screen.on_phase_started(PhaseStarted("phase_1"))
+    screen.on_phase_started(PhaseStarted("phase_2"))
+    phase_a_scope = AgentScope(owner_id="phase_1", role=AgentRole.PHASE, phase_id="phase_1")
+    phase_b_scope = AgentScope(owner_id="phase_2", role=AgentRole.PHASE, phase_id="phase_2")
+    screen.on_agent_before_send(AgentBeforeSend(phase_a_scope, "phase A prompt", 1))
+    screen.on_agent_before_send(AgentBeforeSend(phase_b_scope, "phase B prompt", 1))
+
+    screen.on_agent_errored(AgentErrored(phase_a_scope, RuntimeError("phase A failed")))
+
+    assert screen._phase_statuses["phase_1"] is RunStatus.FAILED
+    assert screen._task_statuses[("phase_1", "task_one")] is RunStatus.FAILED
+    assert screen._phase_statuses["phase_2"] is RunStatus.RUNNING
+    assert screen._task_statuses[("phase_2", "task_two")] is RunStatus.PENDING
+    assert any("phase A failed" in str(entry) for entry in screen._phase_logs["phase_1"])
+    assert not any("phase A failed" in str(entry) for entry in screen._phase_logs["phase_2"])
+
+
+def test_scoped_goal_event_only_mutates_identified_phase() -> None:
+    """A goal verdict for phase A cannot update the same-named task in phase B."""
+    from ddev.cli.meta.ai.tui.messages import AfterGoalCheck, BeforeGoalCheck, PhaseStarted
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow(phases=[("phase_1", ["shared_task"]), ("phase_2", ["shared_task"])])
+    screen = ExecutionScreen(flow)
+    screen.on_phase_started(PhaseStarted("phase_1"))
+    screen.on_phase_started(PhaseStarted("phase_2"))
+
+    screen.on_before_goal_check(BeforeGoalCheck("phase_1", "shared_task", 1))
+    screen.on_before_goal_check(BeforeGoalCheck("phase_2", "shared_task", 1))
+    screen.on_after_goal_check(AfterGoalCheck("phase_1", "shared_task", 1, True, "done"))
+
+    assert screen._task_statuses[("phase_1", "shared_task")] is RunStatus.DONE
+    assert screen._task_statuses[("phase_2", "shared_task")] is RunStatus.RUNNING
+
+    screen.on_after_goal_check(AfterGoalCheck("phase_2", "shared_task", 1, False, "failed"))
+
+    assert screen._task_statuses[("phase_1", "shared_task")] is RunStatus.DONE
+    assert screen._task_statuses[("phase_2", "shared_task")] is RunStatus.FAILED
+
+
+async def test_pipeline_phase_running_during_execution():
+    """A phase being run by _FakeOrchestrator transitions through 'running'."""
+    from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+
+    cb_seen: list[str] = []
+
+    def _builder_with_tracking(cb: Callbacks) -> Any:
+        tracking = CallbackSet()
+
+        @tracking.on_phase_start
+        async def _(phase_id: str) -> None:
+            cb_seen.append(f"start:{phase_id}")
+
+        @tracking.on_phase_finish
+        async def _(phase_id: str) -> None:
+            cb_seen.append(f"finish:{phase_id}")
+
+        combined = Callbacks([*cb._sets, tracking])  # type: ignore[attr-defined]
+        return _FakeOrchestrator(combined, DEMO_PHASES)
+
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=_builder_with_tracking)
+        await app.push_screen(screen)
+        await pilot.pause(0.5)
+
+    assert "start:phase_1" in cb_seen
+    assert "finish:phase_1" in cb_seen
+    assert "start:phase_2" in cb_seen
+    assert "finish:phase_2" in cb_seen
+
+
+async def test_execution_phase_activation_opens_config_for_pending_phase():
+    """Pending phase activation opens the shared phase configuration screen."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+    from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseSelected
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder(phases=[]))
+        await app.push_screen(screen)
+        await pilot.pause()
+        screen.on_phase_selected(PhaseSelected("phase_1"))
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, PhaseConfigScreen)
+
+
+@pytest.mark.parametrize("status", [RunStatus.RUNNING, RunStatus.DONE, RunStatus.FAILED])
+async def test_execution_phase_activation_opens_log_for_started_phase(status: RunStatus):
+    """Started phase activation opens a full-screen phase log."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseSelected
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder(phases=[]))
+        await app.push_screen(screen)
+        await pilot.pause()
+        screen._phase_statuses["phase_1"] = status
+        screen.on_phase_selected(PhaseSelected("phase_1"))
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, PhaseLogScreen)
+        assert pilot.app.screen.phase_id == "phase_1"
+
+
+async def test_phase_log_screen_ctrl_c_pushes_config_screen():
+    """PhaseLogScreen exposes the shared config screen via ctrl+c."""
+    from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.push_screen(PhaseLogScreen(flow, "phase_1", []))
+        await pilot.pause()
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, PhaseConfigScreen)
+        await pilot.press("escape")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, PhaseLogScreen)
+
+
+async def test_phase_log_screen_ctrl_c_copies_selection_before_opening_config(monkeypatch):
+    """Ctrl+C copies selected log text without navigating away."""
+    from textual.geometry import Offset
+    from textual.selection import Selection
+    from textual.widgets import Static
+
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogBlock, PhaseLogScreen
+
+    copied: list[str] = []
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = PhaseLogScreen(flow, "phase_1", ["selected log output"])
+        await app.push_screen(screen)
+        await pilot.pause()
+        text = screen.query_one(PhaseLogBlock).query_one(Static)
+        screen.selections = {text: Selection(Offset(0, 0), None)}
+        monkeypatch.setattr(app, "copy_to_clipboard", copied.append)
+
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+        assert app.screen is screen
+        assert copied == ["selected log output"]
+
+
+async def test_phase_log_screen_replays_entries_as_blocks_once():
+    """Saved phase log entries are replayed as mounted block widgets."""
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogBlock, PhaseLogScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = PhaseLogScreen(flow, "phase_1", ["first log line"])
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        assert len(screen.query(PhaseLogBlock)) == 1
+
+        assert screen._replay_entries() is True
+        await pilot.pause()
+        assert len(screen.query(PhaseLogBlock)) == 1
+
+
+async def test_phase_log_renders_rich_markdown_as_selectable_textual_markdown():
+    """Rich Markdown log entries become native Textual Markdown widgets."""
+    from rich.markdown import Markdown as RichMarkdown
+    from textual.geometry import Offset
+    from textual.selection import Selection
+    from textual.widgets import Markdown
+    from textual.widgets.markdown import MarkdownBlock
+
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogBlock, PhaseLogScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = PhaseLogScreen(flow, "phase_1", [RichMarkdown("copy **this response**")])
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        markdown = screen.query_one(PhaseLogBlock).query_one(Markdown)
+        assert markdown.source == "copy **this response**"
+        markdown_block = markdown.query_one(MarkdownBlock)
+        screen.selections = {markdown_block: Selection(Offset(0, 0), None)}
+        assert screen.get_selected_text() == "copy this response"
+
+
+async def test_phase_log_renders_rich_panel_as_selectable_textual_panel():
+    """Rich Panel log entries become bordered widgets with native selectable content."""
+    from rich.markdown import Markdown as RichMarkdown
+    from rich.panel import Panel
+    from textual.geometry import Offset
+    from textual.selection import Selection
+    from textual.widgets import Markdown
+    from textual.widgets.markdown import MarkdownBlock
+
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogBlock, PhaseLogPanel, PhaseLogScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = PhaseLogScreen(
+            flow,
+            "phase_1",
+            [Panel(RichMarkdown("copy the **prompt**"), title="prompt · agent")],
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        panel = screen.query_one(PhaseLogBlock).query_one(PhaseLogPanel)
+        assert panel.border_title == "prompt · agent"
+        markdown = panel.query_one(Markdown)
+        assert markdown.source == "copy the **prompt**"
+        markdown_block = markdown.query_one(MarkdownBlock)
+        screen.selections = {markdown_block: Selection(Offset(0, 0), None)}
+        assert screen.get_selected_text() == "copy the prompt"
+
+
+async def test_agent_output_routes_to_phase_logs_by_scope_phase_id():
+    """Agent renderables are partitioned by AgentScope.phase_id."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder())
+        await app.push_screen(screen)
+        await pilot.pause(0.5)
+
+    assert screen._phase_logs["phase_1"]
+    assert screen._phase_logs["phase_2"]
+    assert screen._phase_logs["phase_1"] is not screen._phase_logs["phase_2"]
+
+
+async def test_phase_log_shows_thinking_block_until_agent_response():
+    """Open phase logs show a transient component while an agent response is pending."""
+    from ddev.ai.agent.scope import AgentRole, AgentScope
+    from ddev.cli.meta.ai.tui.messages import AgentBeforeSend, AgentResponseReceived
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen, ThinkingBlock
+
+    class _IdleOrchestrator:
+        async def run_async(self) -> None:
+            pass
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=lambda _callbacks: _IdleOrchestrator())
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        phase_log = PhaseLogScreen(flow, "phase_1", screen._phase_logs["phase_1"], source=screen)
+        await app.push_screen(phase_log)
+        await pilot.pause()
+
+        scope = AgentScope(owner_id="phase_1", role=AgentRole.PHASE, phase_id="phase_1")
+        screen.on_agent_before_send(AgentBeforeSend(scope, "do the work", 1))
+        await pilot.pause()
+
+        thinking_blocks = phase_log.query(ThinkingBlock)
+        assert len(thinking_blocks) == 1
+        assert "phase_1:phase:1" in screen._active_thinking["phase_1"]
+
+        screen.on_agent_response_received(AgentResponseReceived(scope, _make_agent_response("done"), 1))
+        await pilot.pause()
+
+        assert len(phase_log.query(ThinkingBlock)) == 0
+        assert "phase_1:phase:1" not in screen._active_thinking["phase_1"]
+
+
+async def test_sentinel_send_shows_thinking_without_prompt_block():
+    """Sending tool results back to the model shows thinking without logging a fake prompt."""
+    from ddev.ai.agent.scope import AgentRole, AgentScope
+    from ddev.ai.react.process import TOOL_RESULTS_SENTINEL
+    from ddev.cli.meta.ai.tui.messages import AgentBeforeSend, AgentResponseReceived
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen, ThinkingBlock
+
+    class _IdleOrchestrator:
+        async def run_async(self) -> None:
+            pass
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=lambda _callbacks: _IdleOrchestrator())
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        phase_log = PhaseLogScreen(flow, "phase_1", screen._phase_logs["phase_1"], source=screen)
+        await app.push_screen(phase_log)
+        await pilot.pause()
+
+        scope = AgentScope(owner_id="phase_1", role=AgentRole.PHASE, phase_id="phase_1")
+        screen.on_agent_before_send(AgentBeforeSend(scope, TOOL_RESULTS_SENTINEL, 2))
+        await pilot.pause()
+
+        assert screen._phase_logs["phase_1"] == []
+        assert len(phase_log.query(ThinkingBlock)) == 1
+
+        screen.on_agent_response_received(AgentResponseReceived(scope, _make_agent_response("done"), 2))
+        await pilot.pause()
+
+        assert len(phase_log.query(ThinkingBlock)) == 0
+
+
+async def test_phase_log_replays_entries_before_active_thinking_block():
+    """Opening a log mid-turn appends transient state after historical entries."""
+    from ddev.ai.agent.scope import AgentRole, AgentScope
+    from ddev.cli.meta.ai.tui.messages import AgentBeforeSend
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogBlock, PhaseLogScreen, ThinkingBlock
+
+    class _IdleOrchestrator:
+        async def run_async(self) -> None:
+            pass
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=lambda _callbacks: _IdleOrchestrator())
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        scope = AgentScope(owner_id="phase_1", role=AgentRole.PHASE, phase_id="phase_1")
+        screen.on_agent_before_send(AgentBeforeSend(scope, "do the work", 1))
+        await pilot.pause()
+
+        phase_log = PhaseLogScreen(flow, "phase_1", screen._phase_logs["phase_1"], source=screen)
+        await app.push_screen(phase_log)
+        await pilot.pause()
+
+        output_children = list(phase_log.query_one("#phase-log-output").children)
+        assert isinstance(output_children[-2], PhaseLogBlock)
+        assert isinstance(output_children[-1], ThinkingBlock)
+
+
+# ---------------------------------------------------------------------------
+# ExecutionScreen: tasks panel
+# ---------------------------------------------------------------------------
+
+
+async def test_tasks_start_pending():
+    """All tasks start in 'pending' status."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    screen = ExecutionScreen(flow)
+    for phase_id, task_names in DEMO_PHASES:
+        for task_name in task_names:
+            assert screen._task_statuses[(phase_id, task_name)] is RunStatus.PENDING
+
+
+async def test_tasks_done_after_success_run():
+    """All tasks reach 'done' after a successful _FakeOrchestrator run."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder())
+        await app.push_screen(screen)
+        await pilot.pause(0.5)
+
+    for phase_id, task_names in DEMO_PHASES:
+        for task_name in task_names:
+            key = (phase_id, task_name)
+            assert screen._task_statuses[key] is RunStatus.DONE, (
+                f"Expected task {key!r} to be 'done', got {screen._task_statuses[key]!r}"
+            )
+
+
+async def test_tasks_failed_when_phase_fails():
+    """Tasks in a failed phase reach 'failed' status."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder(fail_on_phase="phase_1"))
+        await app.push_screen(screen)
+        await pilot.pause(0.5)
+
+    # phase_1 task should be failed
+    assert screen._task_statuses[("phase_1", "task_one")] is RunStatus.FAILED
+    # phase_2 task should remain pending
+    assert screen._task_statuses[("phase_2", "task_two")] is RunStatus.PENDING
+
+
+# ---------------------------------------------------------------------------
+# ExecutionScreen: renderable output produced by the orchestrator
+# ---------------------------------------------------------------------------
+
+
+async def test_output_records_rendered_output():
+    """Output renderables are recorded as the orchestrator runs."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder())
+        await app.push_screen(screen)
+        await pilot.pause(0.5)
+
+    assert screen._output_write_count > 0
+
+
+async def test_phase_log_output_uses_block_scroll_container():
+    """Phase log output is a component container, not an append-only RichLog."""
+    from textual.containers import VerticalScroll
+
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        await app.push_screen(PhaseLogScreen(flow, "phase_1", []))
+        await pilot.pause()
+        output = pilot.app.screen.query_one("#phase-log-output", VerticalScroll)
+        assert output.border_title is None
+
+
+async def test_output_includes_prompt_panel():
+    """Recorded output includes a Rich Panel with Markdown prompt content."""
+    from rich.markdown import Markdown
+    from rich.panel import Panel
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder())
+        await app.push_screen(screen)
+        await pilot.pause(0.5)
+
+    panels = [r for r in screen._output_renders if isinstance(r, Panel)]
+    assert len(panels) >= len(DEMO_PHASES), (
+        f"Expected at least {len(DEMO_PHASES)} Panel(s) in output, got {len(panels)}"
+    )
+    assert all(isinstance(panel.renderable, Markdown) for panel in panels)
+
+
+async def test_output_renders_agent_responses_as_markdown():
+    """Agent response bodies are written as Markdown renderables."""
+    from rich.markdown import Markdown
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder())
+        await app.push_screen(screen)
+        await pilot.pause(0.5)
+
+    responses = [r for r in screen._output_renders if isinstance(r, Markdown)]
+    assert len(responses) >= len(DEMO_PHASES)
+
+
+async def test_output_contains_agent_start_header():
+    """Recorded output includes agent start headers (Rich Text objects)."""
+    from rich.text import Text
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder())
+        await app.push_screen(screen)
+        await pilot.pause(0.5)
+
+    texts = [r for r in screen._output_renders if isinstance(r, Text)]
+    assert len(texts) > 0
+
+
+# ---------------------------------------------------------------------------
+# ExecutionScreen: header running badge
+# ---------------------------------------------------------------------------
+
+
+async def test_header_shows_running_badge_during_run():
+    """Header running badge is shown while the orchestrator runs."""
+    import asyncio
+
+    from textual.widgets import Static
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    running_states: list[bool] = []
+    badge_states: list[str] = []
+
+    class _SlowDemo:
+        failed_phase = None
+
+        def __init__(self, cb: Any) -> None:
+            self._cb = cb
+
+        async def run_async(self) -> None:
+            await asyncio.sleep(0.2)
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=lambda cb: _SlowDemo(cb))
+        await app.push_screen(screen)
+        await pilot.pause(0.05)
+        from ddev.cli.meta.ai.tui.widgets.header import TogoHeader
+
+        header = screen.query_one(TogoHeader)
+        badge = header.query_one("#header-right", Static)
+        running_states.append(header.running)
+        badge_states.append(str(badge.content))
+        await pilot.pause(0.3)
+        running_states.append(header.running)
+        badge_states.append(str(badge.content))
+
+    assert True in running_states
+    assert running_states[-1] is False
+    assert any(state in {"● running", "○ running"} for state in badge_states)
+    assert badge_states[-1] == ""
+
+
+# ---------------------------------------------------------------------------
+# ExecutionScreen: cancellation
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_stops_worker_without_crash():
+    """Pressing ctrl+c cancels the worker without crashing the app."""
+    import asyncio
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    class _InfiniteDemo:
+        failed_phase = None
+
+        def __init__(self, cb: Any) -> None:
+            self._cb = cb
+
+        async def run_async(self) -> None:
+            await asyncio.sleep(999)
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=lambda cb: _InfiniteDemo(cb))
+        await app.push_screen(screen)
+        await pilot.pause(0.05)
+        await pilot.press("ctrl+c")
+        await pilot.pause(0.1)
+        assert pilot.app.is_running
+
+
+async def test_execution_ctrl_c_copies_selection_before_cancelling(monkeypatch):
+    """Ctrl+C copies selected text without cancelling the active run."""
+    import asyncio
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    class _InfiniteDemo:
+        async def run_async(self) -> None:
+            await asyncio.sleep(999)
+
+    copied: list[str] = []
+    cancelled: list[bool] = []
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=lambda _callbacks: _InfiniteDemo())
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert screen._run_worker is not None
+        monkeypatch.setattr(screen, "get_selected_text", lambda: "selected pipeline output")
+        monkeypatch.setattr(screen._run_worker, "cancel", lambda: cancelled.append(True))
+        monkeypatch.setattr(app, "copy_to_clipboard", copied.append)
+
+        screen.action_copy_or_cancel_run()
+
+        assert copied == ["selected pipeline output"]
+        assert cancelled == []
+
+
+async def test_unmount_cancels_worker():
+    """Popping ExecutionScreen cancels the worker."""
+    import asyncio
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    class _InfiniteDemo:
+        failed_phase = None
+
+        def __init__(self, cb: Any) -> None:
+            self._cb = cb
+
+        async def run_async(self) -> None:
+            await asyncio.sleep(999)
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=lambda cb: _InfiniteDemo(cb))
+        await app.push_screen(screen)
+        await pilot.pause(0.05)
+        app.pop_screen()
+        await pilot.pause(0.1)
+        assert isinstance(pilot.app.screen, MainScreen)
+        assert pilot.app.is_running
+
+
+# ---------------------------------------------------------------------------
+# ExecutionScreen: failing orchestrator does not crash the app
+# ---------------------------------------------------------------------------
+
+
+async def test_failing_orchestrator_no_app_crash():
+    """A raising orchestrator surfaces failure in UI without crashing the app."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder(fail_on_phase="phase_1"))
+        await app.push_screen(screen)
+        await pilot.pause(0.5)
+        assert pilot.app.is_running
+        assert isinstance(pilot.app.screen, ExecutionScreen)
+
+    assert screen._phase_statuses["phase_1"] is RunStatus.FAILED
+
+
+async def test_orchestrator_build_failure_is_visible_and_screen_stays_stable() -> None:
+    """Startup failures are rendered even though the worker does not exit on error."""
+    from textual.widgets import Static
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    def fail_to_build(_callbacks: Any) -> Any:
+        raise RuntimeError("constructor exploded")
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=fail_to_build)
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        error = screen.query_one("#execution-error", Static)
+        assert error.display
+        assert "constructor exploded" in str(error.render())
+        assert app.screen is screen
+        assert app.is_running
+
+
+async def test_orchestrator_exception_only_marks_reported_failed_phase() -> None:
+    """A concurrent sibling stays running when the orchestrator identifies the failed phase."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    class ConcurrentFailure:
+        failed_phase = "phase_1"
+
+        def __init__(self, callbacks: Any) -> None:
+            self.callbacks = callbacks
+
+        async def run_async(self) -> None:
+            await self.callbacks.fire_phase_start("phase_1")
+            await self.callbacks.fire_phase_start("phase_2")
+            raise RuntimeError("phase 1 crashed")
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=ConcurrentFailure)
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        assert screen._phase_statuses["phase_1"] is RunStatus.FAILED
+        assert screen._task_statuses[("phase_1", "task_one")] is RunStatus.FAILED
+        assert screen._phase_statuses["phase_2"] is RunStatus.RUNNING
+        assert screen._task_statuses[("phase_2", "task_two")] is RunStatus.PENDING
+
+
+async def test_orchestrator_exception_without_failed_phase_is_not_attributed() -> None:
+    """An unknown orchestration failure is visible without failing concurrent phases."""
+    from textual.widgets import Static
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    class UnknownFailure:
+        failed_phase = None
+
+        def __init__(self, callbacks: Any) -> None:
+            self.callbacks = callbacks
+
+        async def run_async(self) -> None:
+            await self.callbacks.fire_phase_start("phase_1")
+            await self.callbacks.fire_phase_start("phase_2")
+            raise RuntimeError("scheduler crashed")
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=UnknownFailure)
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        assert screen._phase_statuses["phase_1"] is RunStatus.RUNNING
+        assert screen._phase_statuses["phase_2"] is RunStatus.RUNNING
+        assert screen._task_statuses[("phase_1", "task_one")] is RunStatus.PENDING
+        assert screen._task_statuses[("phase_2", "task_two")] is RunStatus.PENDING
+        assert "scheduler crashed" in str(screen.query_one("#execution-error", Static).render())
+
+
+# ---------------------------------------------------------------------------
+# ExecutionScreen: resume mode skips completed phases
+# ---------------------------------------------------------------------------
+
+
+async def test_resume_flag_passed_to_orchestrator():
+    """ExecutionScreen stores resume=True and passes it to the builder."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+
+    def _builder(cb: Any) -> Any:
+        class _Noop:
+            async def run_async(self) -> None:
+                pass
+
+        return _Noop()
+
+    screen = ExecutionScreen(flow, resume=True, orchestrator_builder=_builder)
+    assert screen.resume is True
+
+
+async def test_resume_initializes_completed_phase_statuses(tmp_path: Path) -> None:
+    """Dependency-closed checkpoint successes render done before resumed work starts."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_dag_flow()
+    run_dir = tmp_path / flow_slug(flow)
+    run_dir.mkdir()
+    (run_dir / "checkpoints.yaml").write_text(
+        """research:
+  status: success
+  started_at: '2024-01-01T00:00:00'
+  finished_at: '2024-01-01T00:01:00'
+  tokens: {total_input: 1, total_output: 1}
+  memory_path: research_memory.md
+final_review:
+  status: success
+  started_at: '2024-01-01T00:00:00'
+  finished_at: '2024-01-01T00:01:00'
+  tokens: {total_input: 1, total_output: 1}
+  memory_path: final_review_memory.md
+"""
+    )
+
+    class Noop:
+        failed_phase = None
+
+        async def run_async(self) -> None:
+            pass
+
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, resume=True, runs_dir=tmp_path, orchestrator_builder=lambda _: Noop())
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        assert screen._phase_statuses["research"] is RunStatus.DONE
+        assert screen._phase_statuses["final_review"] is RunStatus.PENDING
+
+
+# ---------------------------------------------------------------------------
+# NEW: Default builder constructs real PhaseOrchestrator — TDD tests
+# These tests verify end-to-end wiring of the real orchestrator path.
+# ---------------------------------------------------------------------------
+
+
+def _setup_default_builder_mocks(tmp_path: Path):
+    """Return (fake_ddev_app, mock_orch_instance) for default-builder tests."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    fake_ddev_app = MagicMock()
+    fake_ddev_app.config.ai.anthropic_api_key = "test_api_key_abc"
+    fake_ddev_app.repo.path = str(tmp_path)
+
+    mock_orch_instance = MagicMock()
+    mock_orch_instance.run_async = AsyncMock()
+    return fake_ddev_app, mock_orch_instance
+
+
+def _app_with_repo(flow: ResolvedFlow, ddev_app: Any) -> TogoApp:
+    return TogoApp(
+        engine=StaticConfigurationEngine([flow]),
+        phase_registry=PhaseRegistry(),
+        provider_registry=AgentProviderRegistry(),
+        ddev_app=ddev_app,
+    )
+
+
+async def test_default_builder_constructs_real_phase_orchestrator(tmp_path: Path) -> None:
+    """Default builder constructs a real PhaseOrchestrator wired with correct params."""
+    from unittest.mock import patch
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    fake_ddev_app, mock_orch_instance = _setup_default_builder_mocks(tmp_path)
+
+    with patch("ddev.ai.runtime.orchestrator.PhaseOrchestrator") as MockOrch:
+        MockOrch.return_value = mock_orch_instance
+        togo_app = _app_with_repo(flow, fake_ddev_app)
+        async with togo_app.run_test() as pilot:
+            await pilot.pause()
+            screen = ExecutionScreen(flow)
+            await togo_app.push_screen(screen)
+            await pilot.pause(0.3)
+
+    MockOrch.assert_called_once()
+    call_kwargs = MockOrch.call_args.kwargs
+    assert call_kwargs["resolved_flow"] is flow
+    assert call_kwargs["phase_registry"] is togo_app.phase_registry
+    assert call_kwargs["provider_registry"] is togo_app.provider_registry
+    assert call_kwargs["resume"] is False
+
+    from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
+
+    assert isinstance(call_kwargs["file_access_policy"], FileAccessPolicy)
+    assert call_kwargs["file_access_policy"].write_root == tmp_path
+
+
+async def test_default_builder_resume_flag_forwarded(tmp_path: Path) -> None:
+    """Default builder forwards resume=True to PhaseOrchestrator."""
+    from unittest.mock import patch
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    fake_ddev_app, mock_orch_instance = _setup_default_builder_mocks(tmp_path)
+
+    with patch("ddev.ai.runtime.orchestrator.PhaseOrchestrator") as MockOrch:
+        MockOrch.return_value = mock_orch_instance
+        togo_app = _app_with_repo(flow, fake_ddev_app)
+        async with togo_app.run_test() as pilot:
+            await pilot.pause()
+            screen = ExecutionScreen(flow, resume=True)
+            await togo_app.push_screen(screen)
+            await pilot.pause(0.3)
+
+    call_kwargs = MockOrch.call_args.kwargs
+    assert call_kwargs["resume"] is True
+
+
+async def test_fresh_real_run_clears_only_computed_flow_directory(tmp_path: Path) -> None:
+    """A fresh run removes stale state for its flow without touching sibling runs."""
+    from unittest.mock import patch
+
+    from ddev.cli.meta.ai.tui.runs import ai_runs_dir, flow_slug
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    run_root = ai_runs_dir(tmp_path)
+    run_dir = run_root / flow_slug(flow)
+    sibling = run_root / "other-flow"
+    run_dir.mkdir(parents=True)
+    sibling.mkdir()
+    (run_dir / "checkpoints.yaml").write_text("stale")
+    (run_dir / "phase_1_memory.md").write_text("secret")
+    (run_dir / "agent.log").write_text("old")
+    (sibling / "keep.txt").write_text("keep")
+    fake_ddev_app, mock_orch_instance = _setup_default_builder_mocks(tmp_path)
+
+    with patch("ddev.ai.runtime.orchestrator.PhaseOrchestrator", return_value=mock_orch_instance):
+        app = _app_with_repo(flow, fake_ddev_app)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app.push_screen(ExecutionScreen(flow))
+            await pilot.pause()
+
+    assert run_dir.is_dir()
+    assert list(run_dir.iterdir()) == []
+    assert (sibling / "keep.txt").read_text() == "keep"
+
+
+async def test_resume_real_run_preserves_existing_flow_directory(tmp_path: Path) -> None:
+    """Resume never clears checkpoint, memory, or agent-log state."""
+    from unittest.mock import patch
+
+    from ddev.cli.meta.ai.tui.runs import ai_runs_dir, flow_slug
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    run_dir = ai_runs_dir(tmp_path) / flow_slug(flow)
+    run_dir.mkdir(parents=True)
+    stale = run_dir / "agent.log"
+    stale.write_text("keep")
+    fake_ddev_app, mock_orch_instance = _setup_default_builder_mocks(tmp_path)
+
+    with patch("ddev.ai.runtime.orchestrator.PhaseOrchestrator", return_value=mock_orch_instance):
+        app = _app_with_repo(flow, fake_ddev_app)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app.push_screen(ExecutionScreen(flow, resume=True))
+            await pilot.pause()
+
+    assert stale.read_text() == "keep"
+
+
+async def test_fresh_real_run_refuses_run_root_symlink_outside_repo(tmp_path: Path) -> None:
+    """Cleanup cannot follow a repository run-root symlink into another directory."""
+    from unittest.mock import patch
+
+    from ddev.cli.meta.ai.tui.runs import flow_slug
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside_run = outside / flow_slug(flow)
+    outside_run.mkdir(parents=True)
+    keep = outside_run / "keep.txt"
+    keep.write_text("keep")
+    (tmp_path / ".ddev").mkdir()
+    (tmp_path / ".ddev" / "ai-runs").symlink_to(outside, target_is_directory=True)
+    fake_ddev_app, mock_orch_instance = _setup_default_builder_mocks(tmp_path)
+
+    with patch("ddev.ai.runtime.orchestrator.PhaseOrchestrator", return_value=mock_orch_instance) as mock_orch:
+        app = _app_with_repo(flow, fake_ddev_app)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app.push_screen(ExecutionScreen(flow))
+            await pilot.pause()
+
+    assert keep.read_text() == "keep"
+    mock_orch.assert_not_called()
+
+
+async def test_launch_from_flow_screen_no_runtime_error(tmp_path: Path) -> None:
+    """Launching from FlowScreen passes the resolved flow into execution."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+
+    flow = _make_flow()
+
+    fake_ddev_app = MagicMock()
+    fake_ddev_app.config.ai.anthropic_api_key = "launch_test_key"
+    fake_ddev_app.repo.path = str(tmp_path)
+
+    mock_orch_instance = MagicMock()
+    mock_orch_instance.run_async = AsyncMock()
+
+    with patch("ddev.ai.runtime.orchestrator.PhaseOrchestrator") as MockOrch:
+        MockOrch.return_value = mock_orch_instance
+        togo_app = _app_with_repo(flow, fake_ddev_app)
+        async with togo_app.run_test(size=(120, 50)) as pilot:
+            await pilot.pause()
+            await togo_app.push_screen(FlowScreen(flow))
+            await pilot.pause()
+            await pilot.click("#launch-btn")
+            await pilot.pause()
+            await pilot.click("#btn-launch")
+            await pilot.pause(0.3)
+            assert isinstance(pilot.app.screen, ExecutionScreen)
+            assert pilot.app.is_running
+
+    # The real orchestrator was constructed (not a RuntimeError path)
+    MockOrch.assert_called_once()
+
+
+async def test_phase_config_renders_inlined_agent_prompt() -> None:
+    """PhaseConfigScreen shows the system prompt already inlined by resolution."""
+    from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+
+    flow = _make_flow()
+    first_phase = flow.flow[0].phase
+    first_agent = flow.phases[first_phase].agent
+    assert first_agent is not None
+    flow.agents[first_agent].system_prompt = "Inlined system prompt"
+
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.push_screen(PhaseConfigScreen(flow, first_phase))
+        await pilot.pause()
+
+        prompt_widget = pilot.app.screen.query_one("#phase-agent-prompt")
+        assert "Inlined system prompt" in prompt_widget.source
+
+
+# ---------------------------------------------------------------------------
+# Missing edge case: ExecutionScreen with zero phases
+# ---------------------------------------------------------------------------
+
+
+async def test_execution_screen_empty_flow() -> None:
+    """ExecutionScreen with zero phases mounts without error."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = _make_flow(phases=[])
+    app = _app(flow)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder(phases=[]))
+        await app.push_screen(screen)
+        await pilot.pause(0.5)
+        assert pilot.app.is_running
+
+    # No phases → statuses dict is empty and all phases are trivially "done"
+    assert screen._phase_statuses == {}

--- a/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
@@ -1,0 +1,635 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for FlowScreen content, agent modal activation, launch wiring, and resume affordance."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+from textual.containers import Horizontal
+from textual.widgets import Button
+
+from ddev.ai.agent.registry import AgentProviderRegistry
+from ddev.ai.config.models import (
+    AgentConfig,
+    FlowEntry,
+    FlowInput,
+    InputType,
+    PhaseConfig,
+    ResolvedFlow,
+    TaskConfig,
+)
+from ddev.ai.phases.registry import PhaseRegistry
+from ddev.cli.meta.ai.tui.app import TogoApp
+
+from .conftest import StaticConfigurationEngine
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_flow(name: str = "Test Flow", n_phases: int = 2) -> ResolvedFlow:
+    """Create a minimal ResolvedFlow with *n_phases* entries."""
+    agents = {"agent_a": AgentConfig.model_construct(provider="anthropic", tools=[])}
+    phases = {
+        f"phase_{i}": PhaseConfig(
+            name=f"phase_{i}",
+            agent="agent_a",
+            tasks=[TaskConfig(name=f"task_{i}", prompt="do something")],
+        )
+        for i in range(n_phases)
+    }
+    flow = [FlowEntry(phase=f"phase_{i}") for i in range(n_phases)]
+    return ResolvedFlow(
+        name=name,
+        description=f"Description for {name}",
+        agents=agents,
+        phases=phases,
+        flow=flow,
+        variables={},
+    )
+
+
+def _make_flow_with_tools(name: str = "Tool Flow") -> ResolvedFlow:
+    """Create a flow whose agent has tools."""
+    agents = {
+        "analyst": AgentConfig.model_construct(provider="anthropic", model="claude-3-sonnet", tools=["read_file"])
+    }
+    phases = {
+        "analyse": PhaseConfig(
+            name="analyse",
+            agent="analyst",
+            tasks=[TaskConfig(name="read_task", prompt="analyse something")],
+        )
+    }
+    flow = [FlowEntry(phase="analyse")]
+    return ResolvedFlow(
+        name=name,
+        description="Tool flow",
+        agents=agents,
+        phases=phases,
+        flow=flow,
+        variables={},
+    )
+
+
+def _app() -> TogoApp:
+    flow = _make_flow()
+    ddev_app = SimpleNamespace(
+        config=SimpleNamespace(ai=SimpleNamespace(anthropic_api_key=None, flow_dirs=[])),
+        repo=SimpleNamespace(path=str(Path.cwd())),
+    )
+    return TogoApp(
+        engine=StaticConfigurationEngine([flow]),
+        phase_registry=PhaseRegistry(),
+        provider_registry=AgentProviderRegistry(),
+        ddev_app=ddev_app,
+    )
+
+
+def _incomplete_checkpoints_yaml(flow: ResolvedFlow) -> str:
+    """Return YAML with only the first scheduled phase as success."""
+    first_phase = flow.flow[0].phase
+    return f"""{first_phase}:
+  status: success
+  started_at: '2024-01-01T00:00:00'
+  finished_at: '2024-01-01T00:01:00'
+  tokens:
+    total_input: 100
+    total_output: 100
+  memory_path: {first_phase}_memory.md
+"""
+
+
+def _write_incomplete_run(tmp_path: Path, flow: ResolvedFlow) -> Path:
+    """Create a run dir under tmp_path with an incomplete checkpoints.yaml."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug
+
+    run_dir = tmp_path / flow_slug(flow)
+    run_dir.mkdir(parents=True)
+    (run_dir / "checkpoints.yaml").write_text(_incomplete_checkpoints_yaml(flow))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Resumable-run helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_flow_slug_distinguishes_case_sensitive_names() -> None:
+    """Case-distinct flow names cannot share persisted run state."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug
+
+    upper = flow_slug(_make_flow(name="Build"))
+    lower = flow_slug(_make_flow(name="build"))
+    assert upper != lower
+    assert upper.startswith("build-")
+    assert lower.startswith("build-")
+
+
+def test_has_resumable_run_no_dir(tmp_path: Path) -> None:
+    """No run dir → not resumable."""
+    from ddev.cli.meta.ai.tui.runs import has_resumable_run
+
+    flow = _make_flow()
+    assert not has_resumable_run(flow, runs_dir=tmp_path)
+
+
+def test_has_resumable_run_incomplete_checkpoints(tmp_path: Path) -> None:
+    """Run dir with incomplete checkpoints → resumable."""
+    from ddev.cli.meta.ai.tui.runs import has_resumable_run
+
+    flow = _make_flow(n_phases=2)
+    _write_incomplete_run(tmp_path, flow)
+    assert has_resumable_run(flow, runs_dir=tmp_path)
+
+
+def test_has_resumable_run_all_phases_complete(tmp_path: Path) -> None:
+    """All scheduled phases at success → not resumable."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug, has_resumable_run
+
+    flow = _make_flow(n_phases=2)
+    run_dir = tmp_path / flow_slug(flow)
+    run_dir.mkdir()
+    # Both phases complete
+    checkpoints_yaml = ""
+    for entry in flow.flow:
+        checkpoints_yaml += f"""{entry.phase}:
+  status: success
+  started_at: '2024-01-01T00:00:00'
+  finished_at: '2024-01-01T00:01:00'
+  tokens:
+    total_input: 100
+    total_output: 100
+  memory_path: {entry.phase}_memory.md
+"""
+    (run_dir / "checkpoints.yaml").write_text(checkpoints_yaml)
+    assert not has_resumable_run(flow, runs_dir=tmp_path)
+
+
+def test_has_resumable_run_no_checkpoints_file(tmp_path: Path) -> None:
+    """Run dir exists but no checkpoints.yaml → not resumable."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug, has_resumable_run
+
+    flow = _make_flow()
+    run_dir = tmp_path / flow_slug(flow)
+    run_dir.mkdir()
+    assert not has_resumable_run(flow, runs_dir=tmp_path)
+
+
+def test_has_resumable_run_uses_resolve_resume_state(tmp_path: Path, monkeypatch) -> None:
+    """has_resumable_run must decide via resolve_resume_state, not its own bespoke check.
+
+    This keeps the "should we show Resume?" decision and the orchestrator's actual
+    skip-already-done-phases decision on the exact same code path, so they can't
+    silently drift apart.
+    """
+    from ddev.cli.meta.ai.tui import runs
+
+    flow = _make_flow(n_phases=2)
+    _write_incomplete_run(tmp_path, flow)
+
+    calls = []
+
+    def _spy(config, checkpoint_manager):
+        calls.append(config)
+        return {flow.flow[0].phase}, {flow.flow[1].phase}
+
+    monkeypatch.setattr(runs, "resolve_resume_state", _spy)
+
+    assert runs.has_resumable_run(flow, runs_dir=tmp_path)
+    assert calls == [flow]
+
+
+def test_has_resumable_run_failed_checkpoint(tmp_path: Path) -> None:
+    """A phase checkpoint with status: failed is resumable (not complete)."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug, has_resumable_run
+
+    flow = _make_flow(n_phases=2)
+    run_dir = tmp_path / flow_slug(flow)
+    run_dir.mkdir()
+    # Write a failed checkpoint for the first phase only
+    first_phase = flow.flow[0].phase
+    (run_dir / "checkpoints.yaml").write_text(
+        f"{first_phase}:\n"
+        "  status: failed\n"
+        "  started_at: '2024-01-01T00:00:00'\n"
+        "  finished_at: '2024-01-01T00:01:00'\n"
+        "  error: Simulated failure\n"
+        "  tokens:\n"
+        "    total_input: 0\n"
+        "    total_output: 0\n"
+    )
+    # A failed phase means the run is not successfully complete → resumable
+    assert has_resumable_run(flow, runs_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# FlowScreen structure
+# ---------------------------------------------------------------------------
+
+
+async def test_flow_screen_is_togo_screen() -> None:
+    """FlowScreen is a TogoScreen subclass."""
+    from ddev.cli.meta.ai.tui.screens.base import TogoScreen
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+
+    assert issubclass(FlowScreen, TogoScreen)
+
+
+async def test_flow_screen_renders_expected_regions_and_actions() -> None:
+    """FlowScreen renders its durable regions and action controls."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PipelineGraph
+
+    flow = _make_flow()
+    app = _app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow))
+        await pilot.pause()
+        pilot.app.screen.query_one("#flow-pipeline", PipelineGraph)
+        actions = pilot.app.screen.query_one("#actions", Horizontal)
+        button_ids = {button.id for button in actions.query(Button)}
+        assert button_ids == {"back", "launch-btn", "resume"}
+        assert actions.query_one("#launch-btn", Button).variant == "primary"
+
+
+async def test_flow_overview_scales_with_wide_viewport() -> None:
+    """The overview uses a proportional width on large screens."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+
+    flow = _make_flow()
+    app = _app()
+    async with app.run_test(size=(240, 60)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow))
+        await pilot.pause()
+
+        flow_body = pilot.app.screen.query_one("#flow-body")
+        overview = pilot.app.screen.query_one("#flow-overview")
+
+        assert overview.region.width >= flow_body.content_region.width * 0.19
+
+
+async def test_flow_screen_renders_one_phase_node_per_phase() -> None:
+    """FlowScreen renders exactly one graph node per phase."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseNode
+
+    flow = _make_flow(n_phases=3)
+    app = _app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow))
+        await pilot.pause()
+        nodes = pilot.app.screen.query(PhaseNode)
+        assert len(nodes) == 3
+
+
+async def test_flow_screen_phase_nodes_show_phase_names() -> None:
+    """Each graph node includes the phase ID."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseNode
+
+    flow = _make_flow(n_phases=2)
+    app = _app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow))
+        await pilot.pause()
+        labels = [str(node.render()) for node in pilot.app.screen.query(PhaseNode)]
+        assert any("phase_0" in label for label in labels)
+        assert any("phase_1" in label for label in labels)
+
+
+async def test_flow_screen_phase_activation_pushes_config_screen() -> None:
+    """Activating a phase node pushes a full-screen phase configuration view."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseNode
+
+    flow = _make_flow(n_phases=2)
+    app = _app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow))
+        await pilot.pause()
+        pilot.app.screen.query(PhaseNode).first().action_select()
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, PhaseConfigScreen)
+        assert pilot.app.screen.phase_id == "phase_0"
+
+
+async def test_phase_config_screen_renders_phase_info_and_agent_details() -> None:
+    """PhaseConfigScreen renders phase config, task prompts, and agent details inline."""
+    from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+
+    flow = _make_flow(n_phases=2)
+    app = _app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(PhaseConfigScreen(flow, "phase_0"))
+        await pilot.pause()
+        screen = pilot.app.screen
+        screen.query_one("#phase-configuration")
+        screen.query_one("#phase-config-grid")
+        screen.query_one("#phase-tasks-card")
+        screen.query_one("#phase-agent-card")
+        assert "phase_0" in str(screen.query_one("#phase-title").render())
+        task_prompt = screen.query(".task-prompt").first()
+        assert "do something" in task_prompt.source
+        assert "agent_a" in str(screen.query_one("#phase-agent-name").render())
+        assert "provider · anthropic" in str(screen.query_one("#phase-agent-provider").render())
+        assert "_No system prompt configured._" in screen.query_one("#phase-agent-prompt").source
+
+
+async def test_phase_config_screen_renders_resolved_task_prompt() -> None:
+    """PhaseConfigScreen renders the prompt already inlined by the engine."""
+    from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+
+    flow = ResolvedFlow(
+        name="Resolved Prompt Flow",
+        agents={"agent_a": AgentConfig.model_construct(provider="anthropic", tools=[])},
+        phases={
+            "review": PhaseConfig(
+                name="review",
+                agent="agent_a",
+                tasks=[TaskConfig(name="inspect", prompt="Read the pull request and summarize the risk.")],
+            )
+        },
+        flow=[FlowEntry(phase="review")],
+        variables={},
+    )
+    app = _app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(PhaseConfigScreen(flow, "review"))
+        await pilot.pause()
+
+        task_prompt = pilot.app.screen.query(".task-prompt").first()
+        assert "Read the pull request" in task_prompt.source
+        assert "resolved prompt" in str(pilot.app.screen.query(".task-prompt-source").first().render())
+
+
+async def test_phase_config_task_prompt_is_scrollable() -> None:
+    """Long task prompts are hosted in their own scroll container."""
+    from textual.containers import VerticalScroll
+    from textual.widgets import Collapsible
+
+    from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+
+    flow = _make_flow()
+    phase = flow.phases[flow.flow[0].phase]
+    phase.tasks = [
+        TaskConfig(name="first", prompt="\n\n".join(["First task prompt."] * 40)),
+        TaskConfig(name="second", prompt="\n\n".join(["Second task prompt."] * 40)),
+    ]
+    app = _app()
+    async with app.run_test(size=(200, 60)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(PhaseConfigScreen(flow, flow.flow[0].phase))
+        await pilot.pause()
+
+        pilot.app.screen.query_one("#phase-tasks-card", VerticalScroll)
+        tasks = list(pilot.app.screen.query(Collapsible))
+        titles = list(pilot.app.screen.query("CollapsibleTitle"))
+        assert [task.collapsed for task in tasks] == [False, True]
+        assert tasks[0].query_one(".task-prompt-scroll", VerticalScroll).max_scroll_y > 0
+        assert titles[0].region.right == tasks[0].content_region.right
+
+        await pilot.click("CollapsibleTitle", offset=(titles[0].region.width - 2, 0))
+        await pilot.pause()
+        assert tasks[0].collapsed is True
+
+        tasks[1].collapsed = False
+        await pilot.pause()
+
+        assert [task.collapsed for task in tasks] == [True, False]
+        assert tasks[1].query_one(".task-prompt-scroll", VerticalScroll).max_scroll_y > 0
+
+
+# ---------------------------------------------------------------------------
+# Back / escape navigation
+# ---------------------------------------------------------------------------
+
+
+async def test_back_button_pops_to_main() -> None:
+    """Pressing Back on FlowScreen returns to MainScreen."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = _make_flow()
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow))
+        await pilot.pause()
+        await pilot.click("#back")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+
+
+async def test_escape_pops_to_main() -> None:
+    """Pressing Escape on FlowScreen returns to MainScreen."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = _make_flow()
+    app = _app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow))
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+
+
+# ---------------------------------------------------------------------------
+# Resume button visibility
+# ---------------------------------------------------------------------------
+
+
+async def test_resume_button_hidden_with_no_run(tmp_path: Path) -> None:
+    """Resume button is not visible when no run dir exists."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+
+    flow = _make_flow()
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        resume_btn = pilot.app.screen.query_one("#resume", Button)
+        assert not resume_btn.display
+
+
+async def test_resume_button_shown_with_incomplete_run(tmp_path: Path) -> None:
+    """Resume button is visible when an incomplete run exists."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+
+    flow = _make_flow(n_phases=2)
+    _write_incomplete_run(tmp_path, flow)
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        resume_btn = pilot.app.screen.query_one("#resume", Button)
+        assert resume_btn.display
+
+
+async def test_phase_config_agent_panel_renders_tools_and_prompt() -> None:
+    """PhaseConfigScreen shows agent tools and system prompt inline."""
+    from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+
+    flow = ResolvedFlow(
+        name="Agent Detail Flow",
+        agents={
+            "analyst": AgentConfig.model_construct(
+                provider="anthropic",
+                model="claude-3-sonnet",
+                tools=["read_file", "create_file", "ddev_test"],
+                system_prompt="You are the inline analyst.",
+            )
+        },
+        phases={
+            "analyse": PhaseConfig(
+                name="analyse",
+                agent="analyst",
+                tasks=[TaskConfig(name="inspect", prompt="inspect this")],
+            )
+        },
+        flow=[FlowEntry(phase="analyse")],
+        variables={},
+    )
+    app = _app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(PhaseConfigScreen(flow, "analyse"))
+        await pilot.pause()
+
+        assert "analyst" in str(pilot.app.screen.query_one("#phase-agent-name").render())
+        assert "claude-3-sonnet" in str(pilot.app.screen.query_one("#phase-agent-model").render())
+        rendered_tools = str(pilot.app.screen.query_one("#phase-agent-tools").render())
+        assert rendered_tools == "read_file · create_file · ddev_test"
+        assert "inline analyst" in pilot.app.screen.query_one("#phase-agent-prompt").source
+
+
+# ---------------------------------------------------------------------------
+# Launch ▶ → LaunchModal → ExecutionScreen
+# ---------------------------------------------------------------------------
+
+
+async def test_launch_button_opens_launch_modal() -> None:
+    """Pressing Launch ▶ pushes LaunchModal."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchModal
+
+    flow = _make_flow()
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow))
+        await pilot.pause()
+        await pilot.click("#launch-btn")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, LaunchModal)
+
+
+async def test_valid_launch_dismissal_pushes_execution_screen() -> None:
+    """After LaunchModal dismisses with values, ExecutionScreen is pushed."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchModal
+
+    # Flow with no inputs so LaunchModal dismisses immediately on click
+    flow = _make_flow()
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow))
+        await pilot.pause()
+        await pilot.click("#launch-btn")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, LaunchModal)
+        # Flow has no inputs → clicking Launch ▶ dismisses immediately
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, ExecutionScreen)
+
+
+async def test_launch_dismissal_passes_runtime_variables() -> None:
+    """ExecutionScreen receives runtime_variables from the dismissed LaunchModal."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+
+    flow = _make_flow()  # no inputs → runtime_variables will be {}
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow))
+        await pilot.pause()
+        await pilot.click("#launch-btn")
+        await pilot.pause()
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+        screen: ExecutionScreen = pilot.app.screen  # type: ignore[assignment]
+        assert screen.runtime_variables is not None
+
+
+# ---------------------------------------------------------------------------
+# Resume → ExecutionScreen
+# ---------------------------------------------------------------------------
+
+
+async def test_resume_pushes_execution_screen_with_resume_flag(tmp_path: Path) -> None:
+    """Pressing Resume pushes ExecutionScreen with resume=True."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+
+    flow = _make_flow(n_phases=2)
+    _write_incomplete_run(tmp_path, flow)
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        await pilot.click("#resume")
+        await pilot.pause()
+        screen = pilot.app.screen
+        assert isinstance(screen, ExecutionScreen)
+        assert screen.resume is True
+
+
+async def test_resume_with_inputs_reopens_modal_and_passes_converted_values(tmp_path: Path) -> None:
+    """Resume recollects runtime inputs without persisting their contents."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchModal
+
+    flow = replace(
+        _make_flow(n_phases=2),
+        inputs=[FlowInput(name="token", label="Token", input_type=InputType.STRING, default="fresh-value")],
+    )
+    _write_incomplete_run(tmp_path, flow)
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        await pilot.click("#resume")
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, LaunchModal)
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+        screen = pilot.app.screen
+        assert isinstance(screen, ExecutionScreen)
+        assert screen.resume is True
+        assert screen.runtime_variables == {"token": "fresh-value"}

--- a/ddev/tests/cli/meta/ai/tui/test_launch_modal.py
+++ b/ddev/tests/cli/meta/ai/tui/test_launch_modal.py
@@ -1,0 +1,377 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for LaunchModal — typed input widgets, validation, and dismiss payload."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from textual import events
+from textual.containers import Horizontal
+from textual.widgets import Button, Input, Static, Switch
+
+from ddev.ai.config.models import FlowInput, InputType
+
+# ---------------------------------------------------------------------------
+# Widget rendering per InputType
+# ---------------------------------------------------------------------------
+
+
+async def test_launch_modal_occupies_at_least_half_viewport(make_launch_modal_app) -> None:
+    viewport = (240, 100)
+    app = make_launch_modal_app([])
+
+    async with app.run_test(size=viewport) as pilot:
+        await pilot.pause()
+        dialog = app.screen.query_one("#dialog")
+        actions = app.screen.query_one(".modal-actions")
+        launch_button = app.screen.query_one("#btn-launch")
+
+        assert dialog.region.width >= viewport[0] / 2
+        assert dialog.region.height >= viewport[1] / 2
+        assert actions.region.bottom == dialog.content_region.bottom
+        assert launch_button.region.right == dialog.content_region.right
+
+
+@pytest.mark.parametrize(
+    "flow_input,widget_type,expected_value",
+    [
+        (FlowInput(name="s", label="S", input_type=InputType.STRING, default="hello"), Input, "hello"),
+        (FlowInput(name="n", label="N", input_type=InputType.NUMBER, default=42), Input, "42"),
+        (FlowInput(name="p", label="P", input_type=InputType.PATH, default="/tmp"), Input, "/tmp"),
+    ],
+)
+async def test_textual_input_widgets_prefill_defaults(
+    make_launch_modal_app, flow_input, widget_type, expected_value
+) -> None:
+    """String, number, and path inputs render as Textual Inputs with defaults."""
+    app = make_launch_modal_app([flow_input])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        widget = modal.query_one(f"#input-{flow_input.name}", widget_type)
+        assert widget.value == expected_value
+
+
+async def test_number_input_has_number_validator(make_launch_modal_app) -> None:
+    """number Input carries at least one validator."""
+    app = make_launch_modal_app([FlowInput(name="n", label="N", input_type=InputType.NUMBER, default=7)])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        inp = modal.query_one("#input-n", Input)
+        assert len(inp.validators) >= 1
+
+
+async def test_text_input_accepts_terminal_paste(make_launch_modal_app) -> None:
+    """Bracketed terminal paste is inserted into the focused launch input."""
+    app = make_launch_modal_app([FlowInput(name="s", label="S", input_type=InputType.STRING)])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inp = app.screen.query_one("#input-s", Input)
+        inp.focus()
+        inp.post_message(events.Paste("pasted value"))
+        await pilot.pause()
+
+        assert inp.value == "pasted value"
+
+
+@pytest.mark.parametrize("default,expected", [(True, True), (False, False), ("true", True), ("false", False)])
+async def test_boolean_switch_prefilled(make_launch_modal_app, default, expected) -> None:
+    """boolean Switch state matches the default value."""
+    app = make_launch_modal_app([FlowInput(name="b", label="B", input_type=InputType.BOOLEAN, default=default)])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        sw = modal.query_one("#input-b", Switch)
+        assert sw.value is expected
+
+
+# ---------------------------------------------------------------------------
+# Cancel / escape closes modal with no result
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_button_dismisses_with_none(make_launch_modal_app, all_flow_inputs, large_terminal) -> None:
+    """Pressing Cancel dismisses the modal without a value."""
+    app = make_launch_modal_app(all_flow_inputs)
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        await pilot.click("#btn-cancel")
+        await pilot.pause()
+        assert app.dismiss_result is None
+
+
+async def test_escape_dismisses_with_none(make_launch_modal_app, all_flow_inputs) -> None:
+    """Pressing Escape dismisses the modal without a value."""
+    app = make_launch_modal_app(all_flow_inputs)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.dismiss_result is None
+
+
+# ---------------------------------------------------------------------------
+# Validation: invalid number blocks Launch
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_number_blocks_launch(make_launch_modal_app, large_terminal) -> None:
+    """An unparseable number value prevents dismiss from being called."""
+    app = make_launch_modal_app([FlowInput(name="n", label="N", input_type=InputType.NUMBER, default=1, required=True)])
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        inp = app.screen.query_one("#input-n", Input)
+        await pilot.click(inp)
+        # Clear and type invalid value
+        for _ in range(10):
+            await pilot.press("backspace")
+        await pilot.press(*"notanumber")
+        await pilot.pause()
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+        assert app.dismiss_result == "NOT_SET"
+
+
+async def test_non_finite_number_conversion_error_stays_inline(make_launch_modal_app, large_terminal) -> None:
+    """Numbers accepted by float but rejected by ResolvedFlow remain in the modal."""
+    app = make_launch_modal_app([FlowInput(name="n", label="N", input_type=InputType.NUMBER, default=1)])
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        app.screen.query_one("#input-n", Input).value = "NaN"
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert app.dismiss_result == "NOT_SET"
+        assert "must be a number" in str(app.screen.query_one("#launch-error", Static).render())
+
+
+async def test_missing_as_content_path_error_stays_inline(make_launch_modal_app, tmp_path, large_terminal) -> None:
+    """Unreadable content paths are reported without dismissing the modal."""
+    missing = tmp_path / "missing.txt"
+    app = make_launch_modal_app(
+        [FlowInput(name="source", label="Source", input_type=InputType.PATH, default=str(missing), as_content=True)]
+    )
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert app.dismiss_result == "NOT_SET"
+        assert "does not exist" in str(app.screen.query_one("#launch-error", Static).render())
+
+
+# ---------------------------------------------------------------------------
+# Validation: missing required field blocks Launch
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_required_string_blocks_launch(make_launch_modal_app, large_terminal) -> None:
+    """An empty required string field prevents dismiss from being called."""
+    app = make_launch_modal_app(
+        [FlowInput(name="s", label="S", input_type=InputType.STRING, default="", required=True)]
+    )
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        # Ensure field is empty
+        inp = app.screen.query_one("#input-s", Input)
+        await pilot.click(inp)
+        for _ in range(20):
+            await pilot.press("backspace")
+        await pilot.pause()
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+        assert app.dismiss_result == "NOT_SET"
+
+
+# ---------------------------------------------------------------------------
+# Valid submission: dismiss with correct payload
+# ---------------------------------------------------------------------------
+
+
+async def test_valid_submission_dismisses_with_payload(make_launch_modal_app, large_terminal) -> None:
+    """Valid inputs produce a dismiss payload matching runtime_variables output."""
+    inputs = [
+        FlowInput(name="s", label="S", input_type=InputType.STRING, default="world", required=True),
+        FlowInput(name="b", label="B", input_type=InputType.BOOLEAN, default=False, required=False),
+    ]
+    app = make_launch_modal_app(inputs)
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+        assert app.dismiss_result is not None
+        assert app.dismiss_result != "NOT_SET"
+        assert app.dismiss_result == {"s": "world", "b": "false"}
+
+
+async def test_valid_number_submission_dismisses(make_launch_modal_app, large_terminal) -> None:
+    """A valid number value produces a dismissal."""
+    app = make_launch_modal_app(
+        [FlowInput(name="n", label="N", input_type=InputType.NUMBER, default=99, required=True)]
+    )
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+        assert app.dismiss_result is not None
+        assert app.dismiss_result != "NOT_SET"
+        assert app.dismiss_result == {"n": "99"}
+
+
+@pytest.mark.parametrize(
+    "flow_input",
+    [
+        FlowInput(name="s", label="S", input_type=InputType.STRING, default=None, required=False),
+        FlowInput(name="n", label="N", input_type=InputType.NUMBER, default=None, required=False),
+        FlowInput(
+            name="p",
+            label="P",
+            input_type=InputType.PATH,
+            default=None,
+            required=False,
+            as_content=True,
+        ),
+    ],
+    ids=["string", "number", "path-as-content"],
+)
+async def test_optional_empty_field_is_omitted(make_launch_modal_app, large_terminal, flow_input: FlowInput) -> None:
+    """An empty optional field is omitted from the launch payload."""
+    app = make_launch_modal_app([flow_input])
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert app.dismiss_result == {}
+
+
+# ---------------------------------------------------------------------------
+# Modal structure
+# ---------------------------------------------------------------------------
+
+
+async def test_launch_modal_has_dialog_launch_id(make_launch_modal_app, all_flow_inputs) -> None:
+    """LaunchModal contains a #dialog element with .launch class."""
+    from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchModal
+
+    app = make_launch_modal_app(all_flow_inputs)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, LaunchModal)
+        dialog = modal.query_one("#dialog")
+        assert "launch" in dialog.classes
+
+
+async def test_launch_modal_has_scrollable_fields_region(make_launch_modal_app, all_flow_inputs) -> None:
+    """LaunchModal groups inputs in a dedicated scrollable fields region."""
+    app = make_launch_modal_app(all_flow_inputs)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        fields = app.screen.query_one("#launch-fields")
+        assert fields.query_one("#input-my_string", Input)
+        assert fields.query_one("#input-my_bool", Switch)
+
+
+async def test_launch_modal_actions_are_horizontal(make_launch_modal_app, all_flow_inputs) -> None:
+    """LaunchModal renders its actions in one row without coupling to button order."""
+    app = make_launch_modal_app(all_flow_inputs)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        actions = app.screen.query_one(".modal-actions", Horizontal)
+        button_ids = [button.id for button in actions.query(Button)]
+        assert set(button_ids) == {"btn-cancel", "btn-launch"}
+        assert app.screen.query_one("#btn-launch", Button).variant == "primary"
+
+
+async def test_launch_modal_is_modal_screen() -> None:
+    """LaunchModal extends ModalScreen."""
+    from textual.screen import ModalScreen
+
+    from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchModal
+
+    assert issubclass(LaunchModal, ModalScreen)
+
+
+# ---------------------------------------------------------------------------
+# Missing edge case: required path field blocks launch
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_required_path_blocks_launch(make_launch_modal_app, large_terminal) -> None:
+    """An empty required path field prevents dismiss from being called."""
+    app = make_launch_modal_app(
+        [FlowInput(name="p", label="P", input_type=InputType.PATH, default=None, required=True)]
+    )
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        # Ensure the path field is empty (no default)
+        inp = app.screen.query_one("#input-p", Input)
+        assert inp.value == ""
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+        assert app.dismiss_result == "NOT_SET"
+
+
+# ---------------------------------------------------------------------------
+# Path autocomplete: home-dir expansion, no forced completion on Enter
+# ---------------------------------------------------------------------------
+
+
+async def test_path_autocomplete_expands_home_directory(make_launch_modal_app, large_terminal) -> None:
+    """A leading ``~`` is expanded to the home directory when listing candidates."""
+    from textual_autocomplete import TargetState
+
+    app = make_launch_modal_app(
+        [FlowInput(name="p", label="P", input_type=InputType.PATH, default=None, required=False)]
+    )
+    async with app.run_test(size=large_terminal):
+        from ddev.cli.meta.ai.tui.screens.launch_modal import TogoPathAutoComplete
+
+        autocomplete = app.screen.query_one(TogoPathAutoComplete)
+        home_candidates = autocomplete.get_candidates(
+            TargetState(text=str(Path.home()) + "/", cursor_position=len(str(Path.home())) + 1)
+        )
+        tilde_candidates = autocomplete.get_candidates(TargetState(text="~/", cursor_position=2))
+        assert {c.main for c in tilde_candidates} == {c.main for c in home_candidates}
+
+
+async def test_path_autocomplete_does_not_force_completion_on_enter(
+    make_launch_modal_app, large_terminal, tmp_path, monkeypatch
+) -> None:
+    """Enter keeps the field's literal text even when the dropdown has a matching suggestion."""
+    (tmp_path / "sandbox").mkdir()
+    monkeypatch.chdir(tmp_path)
+    app = make_launch_modal_app(
+        [FlowInput(name="p", label="P", input_type=InputType.PATH, default=None, required=False)]
+    )
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        inp = app.screen.query_one("#input-p", Input)
+        await pilot.click(inp)
+        await pilot.press(*"sand")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert inp.value == "sand"
+
+
+async def test_path_autocomplete_keeps_text_on_escape_with_no_candidates(make_launch_modal_app, large_terminal) -> None:
+    """Escape must not fall through to the modal's cancel binding while the path field has focus."""
+    app = make_launch_modal_app(
+        [FlowInput(name="p", label="P", input_type=InputType.PATH, default=None, required=False)]
+    )
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        inp = app.screen.query_one("#input-p", Input)
+        await pilot.click(inp)
+        await pilot.press(*"nonexistent-output-dir")
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.dismiss_result == "NOT_SET"
+        assert inp.value == "nonexistent-output-dir"

--- a/ddev/tests/cli/meta/ai/tui/test_main_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_main_screen.py
@@ -1,0 +1,330 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for MainScreen and FlowCard engine results, layout, and interactions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ddev.ai.config.errors import ErrorKind, FlowError
+from ddev.ai.config.models import ConfigStatus, FlowResult
+
+# ---------------------------------------------------------------------------
+# TogoApp: screen stack after mount
+# ---------------------------------------------------------------------------
+
+
+async def test_app_screen_stack_has_two_screens_after_mount(make_flow, make_togo_app):
+    """After mount, screen_stack has the default screen + MainScreen."""
+    app = make_togo_app([make_flow("Alpha Flow", n_phases=3), make_flow("Beta Flow", n_phases=1)])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert len(app.screen_stack) == 2
+
+
+# ---------------------------------------------------------------------------
+# FlowCard widget
+# ---------------------------------------------------------------------------
+
+
+async def test_main_screen_renders_provider_flows(make_flow, make_togo_app):
+    """MainScreen renders one FlowCard per provider flow with the expected metadata."""
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+    app = make_togo_app([make_flow("Alpha Flow", n_phases=3), make_flow("Beta Flow", n_phases=1)])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        cards = list(pilot.app.screen.query(FlowCard))
+        assert len(cards) == 2
+        names = [c.flow.name for c in cards]
+        assert names == ["Alpha Flow", "Beta Flow"]
+        phase_counts = {c.flow.name: c.phase_count for c in cards}
+        assert phase_counts["Alpha Flow"] == 3
+        assert phase_counts["Beta Flow"] == 1
+
+
+async def test_main_screen_sorts_valid_and_broken_results(make_flow, make_togo_app):
+    broken = FlowResult(
+        "Alpha Broken",
+        ConfigStatus.BROKEN,
+        [FlowError(ErrorKind.AGENT, "provider unavailable", subject="writer")],
+    )
+    valid = make_flow("Zulu Valid", n_phases=1)
+    app = make_togo_app([valid], results=[FlowResult(valid.name, ConfigStatus.OK, resolved=valid), broken])
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        cards = list(app.screen.query("FlowCard"))
+
+    assert [card.result.name for card in cards] == ["Alpha Broken", "Zulu Valid"]
+    assert "broken" in cards[0].classes
+    assert "valid" in cards[1].classes
+
+
+async def test_broken_flow_keyboard_opens_grouped_diagnostics(make_flow, make_togo_app):
+    broken = FlowResult(
+        "Broken Flow",
+        ConfigStatus.BROKEN,
+        [
+            FlowError(
+                ErrorKind.AGENT,
+                "provider unavailable",
+                subject="writer",
+                phase="review",
+                sources=[Path("/tmp/agent.yaml")],
+            ),
+            FlowError(ErrorKind.PROMPT, "prompt missing", phase="review"),
+        ],
+    )
+    app = make_togo_app([], results=[broken])
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        card = app.screen.query_one("FlowCard")
+        card.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        from ddev.cli.meta.ai.tui.screens.diagnostics_modal import FlowDiagnosticsModal
+
+        assert isinstance(app.screen, FlowDiagnosticsModal)
+        assert len(app.screen.query(".diagnostic-error")) == 2
+        rendered = " ".join(str(widget.render()) for widget in app.screen.query("Static"))
+        assert "provider unavailable" in rendered
+        assert "writer" in rendered
+        assert "review" in rendered
+        assert str(Path("/tmp/agent.yaml")) in rendered
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.screen.__class__.__name__ == "MainScreen"
+
+
+async def test_diagnostics_display_complete_error_report(make_togo_app):
+    validation_message = (
+        "Input should be a valid string "
+        "[type=string_type, input_value={'name': 'integration', 'type': 'string'}, input_type=dict]"
+    )
+    broken = FlowResult(
+        "Broken Flow",
+        ConfigStatus.BROKEN,
+        [
+            FlowError(
+                ErrorKind.FLOW,
+                validation_message,
+                subject="inputs",
+                sources=[Path("/tmp/flow.yaml")],
+            ),
+            FlowError(ErrorKind.PROMPT, "Referenced prompt was not found", phase="generate"),
+        ],
+    )
+    app = make_togo_app([], results=[broken])
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.screen.query_one("FlowCard").on_click()
+        await pilot.pause()
+
+        rendered = " ".join(str(widget.render()) for widget in app.screen.query(".diagnostic-error"))
+        assert "01 · flow" in rendered
+        assert validation_message in rendered
+        assert "subject: inputs" in rendered
+        assert str(Path("/tmp/flow.yaml")) in rendered
+        assert "02 · prompt" in rendered
+        assert "Referenced prompt was not found" in rendered
+        assert "phase: generate" in rendered
+
+
+async def test_diagnostics_modal_occupies_at_least_half_viewport(make_togo_app):
+    viewport = (240, 100)
+    broken = FlowResult(
+        "Broken Flow",
+        ConfigStatus.BROKEN,
+        [FlowError(ErrorKind.FLOW, "Invalid flow")],
+    )
+    app = make_togo_app([], results=[broken])
+
+    async with app.run_test(size=viewport) as pilot:
+        await pilot.pause()
+        app.screen.query_one("FlowCard").on_click()
+        await pilot.pause()
+        dialog = app.screen.query_one("#dialog")
+        actions = app.screen.query_one(".modal-actions")
+        close_button = app.screen.query_one("#btn-close")
+
+        assert dialog.region.width >= viewport[0] / 2
+        assert dialog.region.height >= viewport[1] / 2
+        assert actions.region.bottom == dialog.content_region.bottom
+        assert close_button.region.right == dialog.content_region.right
+
+
+async def test_broken_flow_click_opens_diagnostics(make_togo_app):
+    broken = FlowResult(
+        "Broken Flow",
+        ConfigStatus.BROKEN,
+        [FlowError(ErrorKind.FLOW, "invalid flow")],
+    )
+    app = make_togo_app([], results=[broken])
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.screen.query_one("FlowCard").on_click()
+        await pilot.pause()
+
+        assert app.screen.__class__.__name__ == "FlowDiagnosticsModal"
+
+
+async def test_broken_flow_drag_selection_does_not_open_diagnostics(monkeypatch, make_togo_app):
+    broken = FlowResult(
+        "Broken Flow",
+        ConfigStatus.BROKEN,
+        [FlowError(ErrorKind.FLOW, "invalid flow")],
+    )
+    app = make_togo_app([], results=[broken])
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        monkeypatch.setattr(app.screen, "get_selected_text", lambda: "selected diagnostics")
+        app.screen.query_one("FlowCard").on_click()
+        await pilot.pause()
+
+        assert app.screen.__class__.__name__ == "MainScreen"
+
+
+async def test_flow_card_is_focusable(make_flow):
+    """FlowCard is a focusable widget."""
+    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+    flow = make_flow("Test", n_phases=2)
+    card = FlowCard(result=FlowResult(flow.name, ConfigStatus.OK, resolved=flow), index=0)
+    assert card.can_focus is True
+
+
+async def test_flow_card_carries_flow_config(make_flow):
+    """FlowCard exposes the ResolvedFlow it was built from."""
+    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+    flow = make_flow("Carrier", n_phases=2)
+    card = FlowCard(result=FlowResult(flow.name, ConfigStatus.OK, resolved=flow), index=0)
+    assert card.flow is flow
+
+
+async def test_valid_flow_marker_uses_success_palette(make_flow):
+    """The valid marker uses the established success color."""
+    from ddev.cli.meta.ai.palette import SUCCESS
+    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+    flow = make_flow("Valid", n_phases=1)
+    card = FlowCard(result=FlowResult(flow.name, ConfigStatus.OK, resolved=flow), index=0)
+    rendered = card.render()
+    marker_index = rendered.plain.index("●")
+    assert any(span.start <= marker_index < span.end and span.style == SUCCESS for span in rendered.spans)
+
+
+async def test_flow_card_uses_available_width_before_truncating(make_flow, make_togo_app):
+    name = "Openmetrics Integration Generator"
+    flow = make_flow(name, n_phases=1)
+    app = make_togo_app([flow])
+
+    async with app.run_test(size=(240, 50)) as pilot:
+        await pilot.pause()
+        card = app.screen.query_one("FlowCard")
+
+        assert card.content_region.width > len(name)
+        assert card.render().plain.splitlines()[0] == name
+
+
+async def test_flow_card_click_does_not_navigate_when_text_is_selected(monkeypatch, make_togo_app):
+    """Releasing a drag selection over a card does not activate the card."""
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+    app = make_togo_app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        card = app.screen.query_one(FlowCard)
+        monkeypatch.setattr(app.screen, "get_selected_text", lambda: "selected card text")
+
+        card.on_click()
+        await pilot.pause()
+
+        assert isinstance(app.screen, MainScreen)
+
+
+# ---------------------------------------------------------------------------
+# MainScreen
+# ---------------------------------------------------------------------------
+
+
+async def test_main_screen_title():
+    """MainScreen TITLE is set to the expected value."""
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    assert MainScreen.TITLE == "Flows"
+
+
+async def test_main_screen_renders_flow_grid(make_flow, make_togo_app):
+    """MainScreen includes a container with the #flow-grid id."""
+    from textual.containers import VerticalScroll
+
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    app = make_togo_app([make_flow("Alpha Flow", n_phases=3), make_flow("Beta Flow", n_phases=1)])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        pilot.app.screen.query_one("#flow-grid", VerticalScroll)
+
+
+async def test_main_screen_empty_provider_no_cards(make_togo_app):
+    """MainScreen with zero flows renders zero FlowCards."""
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+    app = make_togo_app([])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        assert len(pilot.app.screen.query(FlowCard)) == 0
+
+
+async def test_resume_discovery_uses_repository_root_when_cwd_differs(tmp_path, monkeypatch, make_flow, make_togo_app):
+    """Dashboard and flow details discover runs below the configured repository."""
+    from textual.widgets import Button
+
+    from ddev.cli.meta.ai.tui.runs import flow_slug
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+    repo_path = tmp_path / "repo"
+    other_cwd = tmp_path / "elsewhere"
+    repo_path.mkdir()
+    other_cwd.mkdir()
+    flow = make_flow("Repo Flow", n_phases=2)
+    run_dir = repo_path / ".ddev" / "ai-runs" / flow_slug(flow)
+    run_dir.mkdir(parents=True)
+    (run_dir / "checkpoints.yaml").write_text(
+        """phase_0:
+  status: success
+  started_at: '2024-01-01T00:00:00'
+  finished_at: '2024-01-01T00:01:00'
+  tokens:
+    total_input: 1
+    total_output: 1
+  memory_path: phase_0_memory.md
+"""
+    )
+    app = make_togo_app([flow])
+    app.ddev_app.repo.path = str(repo_path)
+    monkeypatch.chdir(other_cwd)
+
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        card = app.screen.query_one(FlowCard)
+        assert card.resumable
+        card.action_select()
+        await pilot.pause()
+        assert isinstance(app.screen, FlowScreen)
+        assert app.screen.query_one("#resume", Button).display

--- a/ddev/tests/cli/meta/ai/tui/test_navigation.py
+++ b/ddev/tests/cli/meta/ai/tui/test_navigation.py
@@ -1,0 +1,136 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for screen navigation and screen skeletons: FlowScreen, ExecutionScreen."""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Navigation: FlowCard → FlowScreen
+# ---------------------------------------------------------------------------
+
+
+async def test_enter_on_flow_card_pushes_flow_screen(make_flow, make_togo_app):
+    """Pressing Enter on a focused FlowCard pushes FlowScreen."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+    app = make_togo_app([make_flow("Alpha Flow", n_phases=3), make_flow("Beta Flow", n_phases=1)])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        card = pilot.app.screen.query(FlowCard).first()
+        card.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, FlowScreen)
+
+
+async def test_flow_screen_receives_correct_flow(make_flow, make_togo_app):
+    """FlowScreen is pushed with the ResolvedFlow matching the selected card."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+    app = make_togo_app([make_flow("Alpha Flow", n_phases=3), make_flow("Beta Flow", n_phases=1)])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        cards = list(pilot.app.screen.query(FlowCard))
+        first_card = cards[0]
+        expected_flow = first_card.flow
+        first_card.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        flow_screen: FlowScreen = pilot.app.screen  # type: ignore[assignment]
+        assert flow_screen.flow is expected_flow
+
+
+# ---------------------------------------------------------------------------
+# FlowScreen skeleton
+# ---------------------------------------------------------------------------
+
+
+async def test_flow_screen_mounts_on_shell(make_flow, make_togo_app):
+    """FlowScreen can be pushed onto the app and mounts without error."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    flow = make_flow("Push Test", n_phases=2)
+    app = make_togo_app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        await pilot.app.push_screen(FlowScreen(flow))
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, FlowScreen)
+
+
+async def test_flow_screen_carries_flow_config(make_flow):
+    """FlowScreen exposes the ResolvedFlow it was constructed with."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+
+    flow = make_flow("Config Carrier", n_phases=2)
+    screen = FlowScreen(flow)
+    assert screen.flow is flow
+
+
+# ---------------------------------------------------------------------------
+# ExecutionScreen skeleton
+# ---------------------------------------------------------------------------
+
+
+async def test_execution_screen_is_togo_screen():
+    """ExecutionScreen extends TogoScreen."""
+    from ddev.cli.meta.ai.tui.screens.base import TogoScreen
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    assert issubclass(ExecutionScreen, TogoScreen)
+
+
+async def test_execution_screen_accepts_flow_and_defaults(make_flow):
+    """ExecutionScreen.__init__ accepts flow with runtime_variables=None, resume=False."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = make_flow("Exec", n_phases=2)
+    screen = ExecutionScreen(flow)
+    assert screen.flow is flow
+    assert screen.runtime_variables is None
+    assert screen.resume is False
+
+
+async def test_execution_screen_accepts_runtime_variables(make_flow):
+    """ExecutionScreen stores runtime_variables when supplied."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = make_flow("Exec Vars", n_phases=1)
+    rv = {"target": "World"}
+    screen = ExecutionScreen(flow, runtime_variables=rv)
+    assert screen.runtime_variables == rv
+
+
+async def test_execution_screen_accepts_resume_flag(make_flow):
+    """ExecutionScreen stores resume=True when supplied."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = make_flow("Exec Resume", n_phases=1)
+    screen = ExecutionScreen(flow, resume=True)
+    assert screen.resume is True
+
+
+async def test_execution_screen_mounts_with_placeholder_regions(make_flow, make_togo_app):
+    """ExecutionScreen mounts with a full graph region."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PipelineGraph
+
+    flow = make_flow("Exec Mount", n_phases=2)
+    app = make_togo_app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        await pilot.app.push_screen(ExecutionScreen(flow))
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, ExecutionScreen)
+        pilot.app.screen.query_one("#pipeline", PipelineGraph)

--- a/ddev/tests/cli/meta/ai/tui/test_shell.py
+++ b/ddev/tests/cli/meta/ai/tui/test_shell.py
@@ -1,0 +1,157 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for the app shell: bindings, dependency injection, shared chrome, and header."""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Footer
+
+from ddev.ai.agent.registry import AgentProviderRegistry
+from ddev.ai.config.errors import ErrorKind, FlowError
+from ddev.ai.config.models import ConfigStatus, FlowResult
+from ddev.ai.phases.registry import PhaseRegistry
+from ddev.cli.meta.ai.tui.app import TogoApp
+from ddev.cli.meta.ai.tui.screens.base import TogoScreen
+from ddev.cli.meta.ai.tui.widgets.header import TogoHeader
+
+from .conftest import StaticConfigurationEngine
+
+
+def _app_kwargs(ddev_app):
+    return {
+        "engine": StaticConfigurationEngine([]),
+        "phase_registry": PhaseRegistry(),
+        "provider_registry": AgentProviderRegistry(),
+        "ddev_app": ddev_app,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Global bindings
+# ---------------------------------------------------------------------------
+
+
+async def test_ctrl_q_is_bound_globally(ddev_app):
+    """ctrl+q is bound at the App level."""
+    app = TogoApp(**_app_kwargs(ddev_app))
+    async with app.run_test():
+        keys = {b.key for b in app.BINDINGS}
+        assert "ctrl+q" in keys
+
+
+# ---------------------------------------------------------------------------
+# Configuration dependency injection
+# ---------------------------------------------------------------------------
+
+
+async def test_togo_app_accepts_configuration_dependencies(ddev_app):
+    """TogoApp stores the injected engine and registries."""
+    kwargs = _app_kwargs(ddev_app)
+    app = TogoApp(**kwargs)
+    async with app.run_test():
+        assert app.engine is kwargs["engine"]
+        assert app.phase_registry is kwargs["phase_registry"]
+        assert app.provider_registry is kwargs["provider_registry"]
+
+
+# ---------------------------------------------------------------------------
+# TogoScreen base chrome
+# ---------------------------------------------------------------------------
+
+
+class _DummyScreen(TogoScreen):
+    """Minimal concrete TogoScreen for testing the base class chrome."""
+
+    TITLE = "Test Screen"
+
+    def compose_body(self):
+        from textual.widgets import Label
+
+        yield Label("body content", id="dummy-body-content")
+
+
+class _DummyApp(TogoApp):
+    """TogoApp variant that boots directly into _DummyScreen."""
+
+    def on_mount(self) -> None:
+        from ddev.cli.meta.ai.tui.theme import togo_theme
+
+        self.register_theme(togo_theme)
+        self.theme = "togo"
+        self.push_screen(_DummyScreen())
+
+
+@pytest.mark.parametrize("widget_cls", [TogoHeader, Footer], ids=["header", "footer"])
+async def test_togo_screen_contains_chrome_widget(widget_cls, ddev_app):
+    """TogoScreen renders header and footer chrome widgets."""
+    async with _DummyApp(**_app_kwargs(ddev_app)).run_test() as pilot:
+        await pilot.pause()
+        assert pilot.app.screen.query_one(widget_cls)
+
+
+async def test_togo_screen_wraps_body_in_shared_region(ddev_app):
+    """TogoScreen renders screen-specific content inside the shared padded body."""
+    async with TogoApp(**_app_kwargs(ddev_app)).run_test() as pilot:
+        await pilot.pause()
+        body = pilot.app.screen.query_one("#screen-body")
+        assert body.query_one("#flow-grid")
+
+
+# ---------------------------------------------------------------------------
+# TogoHeader widget
+# ---------------------------------------------------------------------------
+
+
+async def test_togo_header_displays_husky_mascot(ddev_app):
+    """The application header visibly identifies Togo and its repository."""
+    async with _DummyApp(**_app_kwargs(ddev_app)).run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screenshot = pilot.app.export_screenshot()
+
+        assert "█▀▄" in screenshot
+        assert "▀▀███▀▀" in screenshot
+        assert "Togo" in screenshot
+        assert "Agent&#160;Integrations" in screenshot
+        assert "0&#160;Flows&#160;Discovered" in screenshot
+        assert str(ddev_app.repo.path) in screenshot
+
+
+async def test_togo_header_calls_attention_to_broken_flows(ddev_app):
+    """Broken flows are summarized prominently in the application header."""
+    kwargs = _app_kwargs(ddev_app)
+    kwargs["engine"] = StaticConfigurationEngine(
+        [],
+        results=[
+            FlowResult(
+                "Broken Flow",
+                ConfigStatus.BROKEN,
+                [FlowError(ErrorKind.FLOW, "invalid configuration")],
+            )
+        ],
+    )
+    async with _DummyApp(**kwargs).run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+
+        assert "1&#160;flows&#160;need&#160;attention" in pilot.app.export_screenshot()
+
+
+async def test_togo_header_running_badge_pulses(ddev_app):
+    """The running badge is visible and alternates its marker."""
+    from textual.widgets import Static
+
+    async with _DummyApp(**_app_kwargs(ddev_app)).run_test() as pilot:
+        await pilot.pause()
+        header = pilot.app.screen.query_one(TogoHeader)
+        badge = header.query_one("#header-right", Static)
+
+        header.running = True
+        await pilot.pause(0.1)
+        first = str(badge.content)
+        await pilot.pause(0.7)
+        second = str(badge.content)
+
+    assert first in {"● running", "○ running"}
+    assert second in {"● running", "○ running"}
+    assert first != second

--- a/ddev/tests/cli/meta/ai/tui/test_theme.py
+++ b/ddev/tests/cli/meta/ai/tui/test_theme.py
@@ -1,0 +1,138 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for tui/theme.py: togo_theme tokens and CSS stylesheet loading."""
+
+from __future__ import annotations
+
+import pytest
+
+from ddev.cli.meta.ai.palette import ACCENT, PRIMARY, SECONDARY
+from ddev.cli.meta.ai.tui.app import TogoApp
+from ddev.cli.meta.ai.tui.theme import togo_theme
+
+
+def test_togo_theme_tokens():
+    """The togo theme exposes the design-system tokens used by the TUI."""
+    assert togo_theme.name == "togo"
+    assert togo_theme.primary == PRIMARY
+    assert togo_theme.secondary == SECONDARY
+    assert togo_theme.accent == ACCENT
+    assert togo_theme.dark is True
+    assert {"status-running", "status-pending", "status-done", "status-failed"} <= set(togo_theme.variables)
+
+
+def test_togo_app_css_path_set():
+    """TogoApp declares togo.tcss as its CSS_PATH."""
+    from pathlib import Path
+
+    assert Path(TogoApp.CSS_PATH).name == "togo.tcss"
+    assert Path(TogoApp.CSS_PATH).exists()
+
+
+async def test_togo_app_registers_togo_theme(make_togo_app):
+    """The togo theme is registered and active after mount."""
+    app = make_togo_app([])
+    async with app.run_test():
+        assert "togo" in app.available_themes
+        assert app.theme == "togo"
+
+
+async def test_togo_app_css_loads_without_error(make_togo_app):
+    """The app boots without raising CSS parse errors."""
+    app = make_togo_app([])
+    async with app.run_test():
+        # If CSS_PATH contains a parse error, run_test() raises; reaching here
+        # means the stylesheet was loaded successfully.
+        pass
+
+
+# ---------------------------------------------------------------------------
+# get_theme_variable_defaults — TOGOTUI-12
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("key", ["status-running", "status-pending", "status-done", "status-failed"])
+def test_get_theme_variable_defaults_returns_status_key(key, make_togo_app):
+    """TogoApp.get_theme_variable_defaults() includes all four status keys."""
+    defaults = make_togo_app([]).get_theme_variable_defaults()
+    assert key in defaults
+
+
+def test_get_theme_variable_defaults_values_match_theme(make_togo_app):
+    """Default values match the corresponding togo_theme variables."""
+    defaults = make_togo_app([]).get_theme_variable_defaults()
+    for key in ("status-running", "status-pending", "status-done", "status-failed"):
+        assert defaults[key] == togo_theme.variables[key]
+
+
+async def test_css_uses_status_running_variable_not_hardcoded():
+    """togo.tcss must not contain the hardcoded status-running hex; use $status-running instead."""
+    from pathlib import Path
+
+    from ddev.cli.meta.ai.palette import STATUS_RUNNING
+
+    tcss = Path(TogoApp.CSS_PATH).read_text()
+    assert STATUS_RUNNING not in tcss, f"Replace hardcoded {STATUS_RUNNING} with $status-running in togo.tcss"
+
+
+def test_border_titles_use_visible_accent_color():
+    """Titled boxes should not use muted grey for their border titles."""
+    from pathlib import Path
+
+    tcss = Path(TogoApp.CSS_PATH).read_text()
+    assert "border-title-color: $text-muted" not in tcss
+
+
+def test_flow_cards_use_consistent_height_and_round_border():
+    """Flow cards should render as grid cards with a shared standard height."""
+    from pathlib import Path
+
+    tcss = Path(TogoApp.CSS_PATH).read_text()
+    assert "FlowCard {\n    background: $panel;\n    border: solid $border;" in tcss
+    assert "height: 10;" in tcss
+
+
+def test_flow_grid_scrolls_vertically():
+    """Large flow result sets stay reachable within the dashboard."""
+    from pathlib import Path
+
+    tcss = Path(TogoApp.CSS_PATH).read_text()
+    assert "#flow-grid {\n    layout: grid;" in tcss
+    assert "height: 1fr;" in tcss
+    assert "overflow-y: auto;" in tcss
+
+
+def test_launch_fields_have_vertical_spacing():
+    """Launch modal fields must not render cramped against each other."""
+    from pathlib import Path
+
+    tcss = Path(TogoApp.CSS_PATH).read_text()
+    assert "#launch-fields > Label.eyebrow {\n    margin-top: 1;\n}" in tcss
+
+
+def test_input_focus_uses_muted_accent_not_bold_primary():
+    """Focused inputs should use a subtle accent outline, not a bold filled primary border."""
+    from pathlib import Path
+
+    tcss = Path(TogoApp.CSS_PATH).read_text()
+    assert "Input:focus {\n    border: tall $accent;\n}" in tcss
+    assert "Input:focus {\n    border: round $primary;\n}" not in tcss
+
+
+def test_markdown_h3_headings_wrap_instead_of_overflowing():
+    """Textual's built-in MarkdownH3 defaults to `width: auto`, which stops long headings
+    (e.g. in agent system prompts) from wrapping and lets them run off the right edge of
+    the pane instead of flowing onto multiple lines like every other Markdown block."""
+    from pathlib import Path
+
+    tcss = Path(TogoApp.CSS_PATH).read_text()
+    assert "MarkdownH3 {\n    width: 1fr;\n}" in tcss
+
+
+async def test_togo_theme_status_running_matches_default(make_togo_app):
+    """The active togo theme's status-running matches get_theme_variable_defaults."""
+    app = make_togo_app([])
+    async with app.run_test():
+        defaults = app.get_theme_variable_defaults()
+        assert app.current_theme.variables["status-running"] == defaults["status-running"]


### PR DESCRIPTION
### What does this PR do?

Adds the `ddev meta ai` Togo interface backed directly by the distributed configuration engine. The dashboard lists valid and broken flows, presents styled configuration diagnostics, collects typed launch inputs, runs and resumes flows with phase-aware live status, and supports selectable output and clipboard copying.

### Motivation

Flow discovery, validation, and resolution now have a single entry point. The TUI should consume that engine directly so configured user flows, validation failures, provider availability, and resolved execution all use the same phase and provider registries as the runtime.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once it is merged