### PR TITLE
Use Kueue v1beta2 Workload API

### DIFF
--- a/kueue/changelog.d/24563.fixed
+++ b/kueue/changelog.d/24563.fixed
@@ -1,0 +1,1 @@
+Use the current Kueue Workload API for workload event collection, with fallback support for older clusters.

--- a/kueue/datadog_checks/kueue/check.py
+++ b/kueue/datadog_checks/kueue/check.py
@@ -334,7 +334,9 @@ class KueueCheck(OpenMetricsBaseCheckV2, ConfigMixin):
         priority = spec.get('priority')
         if priority is not None:
             tags.append(f'kueue_workload_priority:{priority}')
-        if priority_class := spec.get('priorityClassName'):
+        priority_class_ref = spec.get('priorityClassRef') or {}
+        priority_class = priority_class_ref.get('name') or spec.get('priorityClassName')
+        if priority_class:
             tags.append(f'kueue_workload_priority_class:{priority_class}')
 
         admission = status.get('admission', {})

--- a/kueue/datadog_checks/kueue/kube_client.py
+++ b/kueue/datadog_checks/kueue/kube_client.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from kubernetes import client, config
+from kubernetes.client.exceptions import ApiException
 
 
 class KubernetesAPIClient:
@@ -22,17 +23,25 @@ class KubernetesAPIClient:
             self.custom_obj_client = client.CustomObjectsApi()
 
     def list_workloads(self, namespace: str | None = None) -> list[dict]:
+        try:
+            return self.list_workloads_for_version('v1beta2', namespace)
+        except ApiException as e:
+            if e.status != 404:
+                raise
+            return self.list_workloads_for_version('v1beta1', namespace)
+
+    def list_workloads_for_version(self, version: str, namespace: str | None) -> list[dict]:
         if namespace:
             return self.custom_obj_client.list_namespaced_custom_object(
                 group='kueue.x-k8s.io',
-                version='v1beta1',
+                version=version,
                 namespace=namespace,
                 plural='workloads',
             )['items']
 
         return self.custom_obj_client.list_cluster_custom_object(
             group='kueue.x-k8s.io',
-            version='v1beta1',
+            version=version,
             plural='workloads',
         )['items']
 

--- a/kueue/tests/fixtures/workloads/admitted.json
+++ b/kueue/tests/fixtures/workloads/admitted.json
@@ -9,7 +9,9 @@
     "spec": {
       "queueName": "gpu",
       "priority": 100,
-      "priorityClassName": "high"
+      "priorityClassRef": {
+        "name": "high"
+      }
     },
     "status": {
       "admission": {

--- a/kueue/tests/test_unit.py
+++ b/kueue/tests/test_unit.py
@@ -216,6 +216,21 @@ def test_workload_events_suppress_first_poll(dd_run_check, aggregator, instance,
     assert not aggregator.events
 
 
+@pytest.mark.parametrize(
+    ('spec', 'priority_class'),
+    [
+        ({'priorityClassName': 'v1beta1'}, 'v1beta1'),
+        ({'priorityClassName': 'v1beta1', 'priorityClassRef': {'name': 'v1beta2'}}, 'v1beta2'),
+    ],
+)
+def test_workload_event_tags_priority_class(instance, spec, priority_class):
+    check = KueueCheck('kueue', {}, [instance])
+
+    tags = check.workload_event_tags('admitted', {'spec': spec}, None)
+
+    assert f'kueue_workload_priority_class:{priority_class}' in tags
+
+
 def test_workload_events_transitions(dd_run_check, aggregator, instance, mock_http_response):
     mock_http_response(file_path=get_fixture_path('metrics.txt'))
     tagger.reset()

--- a/kueue/tests/test_unit.py
+++ b/kueue/tests/test_unit.py
@@ -6,6 +6,7 @@ import json
 from unittest.mock import Mock
 
 import pytest
+from kubernetes.client.exceptions import ApiException
 
 from datadog_checks.base.stubs import tagger
 from datadog_checks.dev.utils import get_metadata_metrics
@@ -13,7 +14,6 @@ from datadog_checks.kueue import KueueCheck
 from datadog_checks.kueue.check import OTHER_RESOURCE_NAME, RESOURCE_NAME_MAP
 from datadog_checks.kueue.kube_client import KubernetesAPIClient
 from datadog_checks.kueue.metrics import LOCAL_QUEUE_METRIC_MAP, METRIC_MAP, RESOURCE_METRIC_MAP
-from kubernetes.client.exceptions import ApiException
 
 from .common import EXPECTED_METRIC_TAGS, UNIT_METRICS, get_fixture_path
 

--- a/kueue/tests/test_unit.py
+++ b/kueue/tests/test_unit.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import json
+from unittest.mock import Mock
 
 import pytest
 
@@ -10,7 +11,9 @@ from datadog_checks.base.stubs import tagger
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.kueue import KueueCheck
 from datadog_checks.kueue.check import OTHER_RESOURCE_NAME, RESOURCE_NAME_MAP
+from datadog_checks.kueue.kube_client import KubernetesAPIClient
 from datadog_checks.kueue.metrics import LOCAL_QUEUE_METRIC_MAP, METRIC_MAP, RESOURCE_METRIC_MAP
+from kubernetes.client.exceptions import ApiException
 
 from .common import EXPECTED_METRIC_TAGS, UNIT_METRICS, get_fixture_path
 
@@ -148,6 +151,23 @@ def test_workload_events_config_can_be_parsed_before_check(instance):
     check._parse_workload_events_config()
 
     assert check.collect_workload_events is True
+
+
+@pytest.mark.parametrize(
+    ('namespace', 'method_name'),
+    [
+        (None, 'list_cluster_custom_object'),
+        ('default', 'list_namespaced_custom_object'),
+    ],
+)
+def test_workload_api_version_fallback(namespace, method_name):
+    kube_client = object.__new__(KubernetesAPIClient)
+    kube_client.custom_obj_client = Mock()
+    method = getattr(kube_client.custom_obj_client, method_name)
+    method.side_effect = [ApiException(status=404), {'items': []}]
+
+    assert kube_client.list_workloads(namespace) == []
+    assert [call.kwargs['version'] for call in method.call_args_list] == ['v1beta2', 'v1beta1']
 
 
 class FakeKubernetesAPIClient:


### PR DESCRIPTION
### What does this PR do?
Queries Kueue Workloads through v1beta2, with v1beta1 fallback for older clusters.

### Motivation
Some Kueue clusters no longer serve the v1beta1 Workload endpoint.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged