### PR TITLE
Mark integration spec fields as fleet_configurable

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -242,7 +242,7 @@ files:
           value:
             type: boolean
             example: true
-          fleet_configurable: false
+          fleet_configurable: true
         - name: collection_interval
           description: |
             Set the operation samples collection interval in seconds. Each collection involves capturing
@@ -275,7 +275,7 @@ files:
           value:
             type: boolean
             example: true
-          fleet_configurable: false
+          fleet_configurable: true
         - name: collection_interval
           description: |
             Set the slow operations collection interval in seconds. Each collection involves capturing
@@ -283,7 +283,7 @@ files:
           value:
             type: number
             example: 10
-          fleet_configurable: false
+          fleet_configurable: true
         - name: max_operations
           description: |
             Set the maximum number of slow operations to collect per interval.
@@ -304,7 +304,7 @@ files:
           value:
             type: string
             example: queryPlanner
-          fleet_configurable: false
+          fleet_configurable: true
     - name: collect_schemas
       description: Configure collection of MongoDB schemas (inferred) by sampling documents.
       fleet_configurable: true
@@ -315,7 +315,7 @@ files:
           value:
             type: boolean
             example: true
-          fleet_configurable: false
+          fleet_configurable: true
         - name: collection_interval
           description: |
             Set the schemas collection interval in seconds. Each collection involves sampling documents
@@ -323,7 +323,7 @@ files:
           value:
             type: number
             example: 3600
-          fleet_configurable: false
+          fleet_configurable: true
         - name: sample_size
           description: |
             Set the sample size for each collection. The sample size is the number of documents to sample
@@ -343,7 +343,7 @@ files:
             type: number
             display_default: null
             example: 300
-          fleet_configurable: false
+          fleet_configurable: true
         - name: max_depth
           description: |
             Set the maximum depth of nested documents to sample.
@@ -436,7 +436,7 @@ files:
             type: boolean
             example: false
             display_default: false
-          fleet_configurable: false
+          fleet_configurable: true
         - name: collection_interval
           description: |
             Set the query metrics collection interval in seconds.
@@ -444,7 +444,7 @@ files:
             type: number
             example: 10
             display_default: 10
-          fleet_configurable: false
+          fleet_configurable: true
         - name: full_statement_text_cache_max_size
           description: |
             Maximum size of the cache for full query text events.
@@ -452,7 +452,7 @@ files:
             type: number
             example: 10000
             display_default: 10000
-          fleet_configurable: false
+          fleet_configurable: true
         - name: full_statement_text_samples_per_hour_per_query
           description: |
             Maximum number of full query text events per query per hour.
@@ -460,7 +460,7 @@ files:
             type: number
             example: 1
             display_default: 1
-          fleet_configurable: false
+          fleet_configurable: true
     - name: replica_check
       description: |
         Whether or not to read from available replicas.
@@ -554,7 +554,7 @@ files:
           value:
             type: integer
             example: 300
-          fleet_configurable: false
+          fleet_configurable: true
         - name: collections_indexes_stats
           description: |
             The interval in seconds at which to collect collection indexes stats metrics.

--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -242,7 +242,6 @@ files:
           value:
             type: boolean
             example: true
-          fleet_configurable: true
         - name: collection_interval
           description: |
             Set the operation samples collection interval in seconds. Each collection involves capturing
@@ -275,7 +274,6 @@ files:
           value:
             type: boolean
             example: true
-          fleet_configurable: true
         - name: collection_interval
           description: |
             Set the slow operations collection interval in seconds. Each collection involves capturing
@@ -283,7 +281,6 @@ files:
           value:
             type: number
             example: 10
-          fleet_configurable: true
         - name: max_operations
           description: |
             Set the maximum number of slow operations to collect per interval.
@@ -304,7 +301,6 @@ files:
           value:
             type: string
             example: queryPlanner
-          fleet_configurable: true
     - name: collect_schemas
       description: Configure collection of MongoDB schemas (inferred) by sampling documents.
       fleet_configurable: true
@@ -315,7 +311,6 @@ files:
           value:
             type: boolean
             example: true
-          fleet_configurable: true
         - name: collection_interval
           description: |
             Set the schemas collection interval in seconds. Each collection involves sampling documents
@@ -323,7 +318,6 @@ files:
           value:
             type: number
             example: 3600
-          fleet_configurable: true
         - name: sample_size
           description: |
             Set the sample size for each collection. The sample size is the number of documents to sample
@@ -343,7 +337,6 @@ files:
             type: number
             display_default: null
             example: 300
-          fleet_configurable: true
         - name: max_depth
           description: |
             Set the maximum depth of nested documents to sample.
@@ -436,7 +429,6 @@ files:
             type: boolean
             example: false
             display_default: false
-          fleet_configurable: true
         - name: collection_interval
           description: |
             Set the query metrics collection interval in seconds.
@@ -444,7 +436,6 @@ files:
             type: number
             example: 10
             display_default: 10
-          fleet_configurable: true
         - name: full_statement_text_cache_max_size
           description: |
             Maximum size of the cache for full query text events.
@@ -452,7 +443,6 @@ files:
             type: number
             example: 10000
             display_default: 10000
-          fleet_configurable: true
         - name: full_statement_text_samples_per_hour_per_query
           description: |
             Maximum number of full query text events per query per hour.
@@ -460,7 +450,6 @@ files:
             type: number
             example: 1
             display_default: 1
-          fleet_configurable: true
     - name: replica_check
       description: |
         Whether or not to read from available replicas.
@@ -554,7 +543,6 @@ files:
           value:
             type: integer
             example: 300
-          fleet_configurable: true
         - name: collections_indexes_stats
           description: |
             The interval in seconds at which to collect collection indexes stats metrics.

--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -367,7 +367,6 @@ files:
           value:
             type: boolean
             example: true
-          fleet_configurable: false
         - name: collection_interval
           description: |
             Set the schemas collection interval in seconds. Each collection involves sampling documents
@@ -375,7 +374,6 @@ files:
           value:
             type: number
             example: 3600
-          fleet_configurable: false
         - name: sample_size
           description: |
             Set the sample size for each collection. The sample size is the number of documents to sample
@@ -384,7 +382,6 @@ files:
           value:
             type: number
             example: 10
-          fleet_configurable: false
         - name: max_collections
           description: |
             Set the maximum number of collections to collect schemas from per interval. The maxium number of collections
@@ -395,14 +392,12 @@ files:
             type: number
             display_default: null
             example: 300
-          fleet_configurable: false
         - name: max_depth
           description: |
             Set the maximum depth of nested documents to sample.
           value:
             type: number
             example: 5
-          fleet_configurable: false
         - name: collect_search_indexes
           description: |
             Set to `true` to collect search indexes for each collection.
@@ -410,7 +405,6 @@ files:
           value:
             type: boolean
             example: false
-          fleet_configurable: false
     - name: query_metrics
       description: |
         Query metrics provide aggregated performance statistics for normalized queries.

--- a/oracle/assets/configuration/spec.yaml
+++ b/oracle/assets/configuration/spec.yaml
@@ -11,7 +11,7 @@ files:
       value:
         example: false
         type: boolean
-      fleet_configurable: false
+      fleet_configurable: true
     - template: init_config/db
     - template: init_config/default
   - template: instances
@@ -22,7 +22,7 @@ files:
       value:
         type: string
         example: localhost:1521
-      fleet_configurable: false
+      fleet_configurable: true
     - name: service_name
       description: |
         The Oracle Database service name. To view the services available on your server,
@@ -30,7 +30,7 @@ files:
       required: true
       value:
         type: string
-      fleet_configurable: false
+      fleet_configurable: true
     - name: protocol
       description: |
         The protocol to connect to the Oracle Database Server. Valid protocols include TCP and TCPS.
@@ -43,20 +43,20 @@ files:
       value:
         type: string
         example: TCP
-      fleet_configurable: false
+      fleet_configurable: true
     - name: username
       description: The username for the Datadog user account.
       required: true
       value:
         type: string
-      fleet_configurable: false
+      fleet_configurable: true
     - name: password
       description: The password for the Datadog user account.
       required: true
       secret: true
       value:
         type: string
-      fleet_configurable: false
+      fleet_configurable: true
     - name: jdbc_driver_path
       description: |
         Set this parameter if you are not using the Oracle native client or Instant Client.

--- a/oracle/assets/configuration/spec.yaml
+++ b/oracle/assets/configuration/spec.yaml
@@ -11,7 +11,6 @@ files:
       value:
         example: false
         type: boolean
-      fleet_configurable: true
     - template: init_config/db
     - template: init_config/default
   - template: instances
@@ -22,7 +21,6 @@ files:
       value:
         type: string
         example: localhost:1521
-      fleet_configurable: true
     - name: service_name
       description: |
         The Oracle Database service name. To view the services available on your server,
@@ -30,7 +28,6 @@ files:
       required: true
       value:
         type: string
-      fleet_configurable: true
     - name: protocol
       description: |
         The protocol to connect to the Oracle Database Server. Valid protocols include TCP and TCPS.
@@ -43,20 +40,17 @@ files:
       value:
         type: string
         example: TCP
-      fleet_configurable: true
     - name: username
       description: The username for the Datadog user account.
       required: true
       value:
         type: string
-      fleet_configurable: true
     - name: password
       description: The password for the Datadog user account.
       required: true
       secret: true
       value:
         type: string
-      fleet_configurable: true
     - name: jdbc_driver_path
       description: |
         Set this parameter if you are not using the Oracle native client or Instant Client.

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -801,6 +801,7 @@ files:
           value:
             type: boolean
             example: false
+          fleet_configurable: false
         - name: batch_max_content_size
           hidden: true
           description: |
@@ -809,6 +810,7 @@ files:
           value:
             type: integer
             example: 20_000_000
+          fleet_configurable: false
     - name: query_samples
       display_priority: 0
       fleet_configurable: true
@@ -894,6 +896,7 @@ files:
           value:
             type: boolean
             example: false
+          fleet_configurable: false
     - name: query_activity
       display_priority: 0
       fleet_configurable: true

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -573,7 +573,6 @@ files:
             type: integer
             example: 600
             display_default: 600
-          fleet_configurable: true
     - name: application_name
       display_priority: 0
       fleet_configurable: true
@@ -770,7 +769,6 @@ files:
           value:
             type: number
             default: 10000
-          fleet_configurable: true
         - name: full_statement_text_cache_max_size
           hidden: true
           description: |
@@ -778,7 +776,6 @@ files:
           value:
             type: number
             default: 10000
-          fleet_configurable: true
         - name: full_statement_text_samples_per_hour_per_query
           hidden: true
           description: |
@@ -786,7 +783,6 @@ files:
           value:
             type: number
             default: 1
-          fleet_configurable: true
         - name: incremental_query_metrics
           hidden: true
           description: |
@@ -797,7 +793,6 @@ files:
             type: boolean
             display_default: true
             example: true
-          fleet_configurable: true
         - name: run_sync
           hidden: true
           description: |
@@ -806,7 +801,6 @@ files:
           value:
             type: boolean
             example: false
-          fleet_configurable: true
         - name: batch_max_content_size
           hidden: true
           description: |
@@ -815,7 +809,6 @@ files:
           value:
             type: integer
             example: 20_000_000
-          fleet_configurable: true
     - name: query_samples
       display_priority: 0
       fleet_configurable: true
@@ -849,7 +842,6 @@ files:
           value:
             type: integer
             example: 60
-          fleet_configurable: true
         - name: samples_per_hour_per_query
           description: |
             Set the rate limit for how many explain plan events will be ingested per hour per normalized explain
@@ -857,7 +849,6 @@ files:
           value:
             type: integer
             example: 15
-          fleet_configurable: true
         - name: explained_queries_cache_maxsize
           description: |
             Set the max size of the cache used for the explained_queries_per_hour_per_query rate limit. This should
@@ -866,7 +857,6 @@ files:
           value:
             type: integer
             example: 5000
-          fleet_configurable: true
         - name: seen_samples_cache_maxsize
           description: |
             Set the max size of the cache used for the samples_per_hour_per_query rate limit. This should be increased
@@ -874,7 +864,6 @@ files:
           value:
             type: integer
             example: 10000
-          fleet_configurable: true
         - name: explain_parameterized_queries
           fleet_configurable: true
           description: |
@@ -890,7 +879,6 @@ files:
           value:
             type: integer
             default: 5000
-          fleet_configurable: true
         - name: explain_errors_cache_ttl
           hidden: true
           description: |
@@ -898,7 +886,6 @@ files:
           value:
             type: integer
             default: 86400
-          fleet_configurable: true
         - name: run_sync
           hidden: true
           description: |
@@ -907,7 +894,6 @@ files:
           value:
             type: boolean
             example: false
-          fleet_configurable: true
     - name: query_activity
       display_priority: 0
       fleet_configurable: true

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -573,7 +573,7 @@ files:
             type: integer
             example: 600
             display_default: 600
-          fleet_configurable: false
+          fleet_configurable: true
     - name: application_name
       display_priority: 0
       fleet_configurable: true
@@ -770,7 +770,7 @@ files:
           value:
             type: number
             default: 10000
-          fleet_configurable: false
+          fleet_configurable: true
         - name: full_statement_text_cache_max_size
           hidden: true
           description: |
@@ -778,7 +778,7 @@ files:
           value:
             type: number
             default: 10000
-          fleet_configurable: false
+          fleet_configurable: true
         - name: full_statement_text_samples_per_hour_per_query
           hidden: true
           description: |
@@ -786,7 +786,7 @@ files:
           value:
             type: number
             default: 1
-          fleet_configurable: false
+          fleet_configurable: true
         - name: incremental_query_metrics
           hidden: true
           description: |
@@ -797,7 +797,7 @@ files:
             type: boolean
             display_default: true
             example: true
-          fleet_configurable: false
+          fleet_configurable: true
         - name: run_sync
           hidden: true
           description: |
@@ -806,7 +806,7 @@ files:
           value:
             type: boolean
             example: false
-          fleet_configurable: false
+          fleet_configurable: true
         - name: batch_max_content_size
           hidden: true
           description: |
@@ -815,7 +815,7 @@ files:
           value:
             type: integer
             example: 20_000_000
-          fleet_configurable: false
+          fleet_configurable: true
     - name: query_samples
       display_priority: 0
       fleet_configurable: true
@@ -849,7 +849,7 @@ files:
           value:
             type: integer
             example: 60
-          fleet_configurable: false
+          fleet_configurable: true
         - name: samples_per_hour_per_query
           description: |
             Set the rate limit for how many explain plan events will be ingested per hour per normalized explain
@@ -857,7 +857,7 @@ files:
           value:
             type: integer
             example: 15
-          fleet_configurable: false
+          fleet_configurable: true
         - name: explained_queries_cache_maxsize
           description: |
             Set the max size of the cache used for the explained_queries_per_hour_per_query rate limit. This should
@@ -866,7 +866,7 @@ files:
           value:
             type: integer
             example: 5000
-          fleet_configurable: false
+          fleet_configurable: true
         - name: seen_samples_cache_maxsize
           description: |
             Set the max size of the cache used for the samples_per_hour_per_query rate limit. This should be increased
@@ -874,7 +874,7 @@ files:
           value:
             type: integer
             example: 10000
-          fleet_configurable: false
+          fleet_configurable: true
         - name: explain_parameterized_queries
           fleet_configurable: true
           description: |
@@ -890,7 +890,7 @@ files:
           value:
             type: integer
             default: 5000
-          fleet_configurable: false
+          fleet_configurable: true
         - name: explain_errors_cache_ttl
           hidden: true
           description: |
@@ -898,7 +898,7 @@ files:
           value:
             type: integer
             default: 86400
-          fleet_configurable: false
+          fleet_configurable: true
         - name: run_sync
           hidden: true
           description: |
@@ -907,7 +907,7 @@ files:
           value:
             type: boolean
             example: false
-          fleet_configurable: false
+          fleet_configurable: true
     - name: query_activity
       display_priority: 0
       fleet_configurable: true

--- a/rabbitmq/assets/configuration/spec.yaml
+++ b/rabbitmq/assets/configuration/spec.yaml
@@ -45,7 +45,6 @@ files:
             value:
               type: boolean
               example: true
-            fleet_configurable: true
           - name: unaggregated_endpoint
             description: |
               Specify an endpoint without aggregation to collect more detailed metrics.
@@ -65,7 +64,6 @@ files:
             value:
               type: string
               example: "detailed"
-            fleet_configurable: true
       - template: instances/openmetrics
         overrides:
           openmetrics_endpoint.required: false

--- a/rabbitmq/assets/configuration/spec.yaml
+++ b/rabbitmq/assets/configuration/spec.yaml
@@ -45,7 +45,7 @@ files:
             value:
               type: boolean
               example: true
-            fleet_configurable: false
+            fleet_configurable: true
           - name: unaggregated_endpoint
             description: |
               Specify an endpoint without aggregation to collect more detailed metrics.
@@ -65,7 +65,7 @@ files:
             value:
               type: string
               example: "detailed"
-            fleet_configurable: false
+            fleet_configurable: true
       - template: instances/openmetrics
         overrides:
           openmetrics_endpoint.required: false

--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -76,7 +76,6 @@ files:
               name: tcpPassiveOpens
               metric_tags:
                 - TCP
-        fleet_configurable: true
       - name: profiles
         description: |
           Specify profiles to be able to reference a set of metrics by name.

--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -46,7 +46,7 @@ files:
         value:
           example: 10
           type: integer
-        fleet_configurable: false
+        fleet_configurable: true
       - name: min_collection_interval
         value:
           example: 15
@@ -76,7 +76,7 @@ files:
               name: tcpPassiveOpens
               metric_tags:
                 - TCP
-        fleet_configurable: false
+        fleet_configurable: true
       - name: profiles
         description: |
           Specify profiles to be able to reference a set of metrics by name.
@@ -623,7 +623,7 @@ files:
           value:
             type: integer
             example: 20
-          fleet_configurable: false
+          fleet_configurable: true
         - name: linux
           description: Linux-specific configuration
           options:

--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -46,7 +46,7 @@ files:
         value:
           example: 10
           type: integer
-        fleet_configurable: true
+        fleet_configurable: false
       - name: min_collection_interval
         value:
           example: 15
@@ -623,7 +623,7 @@ files:
           value:
             type: integer
             example: 20
-          fleet_configurable: true
+          fleet_configurable: false
         - name: linux
           description: Linux-specific configuration
           options:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -612,7 +612,6 @@ files:
             type: boolean
             example: false
           hidden: true
-          fleet_configurable: true
         - name: collection_interval
           description: |
             Set the query metric collection interval (in seconds). Each collection involves one or more queries to
@@ -621,14 +620,12 @@ files:
           value:
             type: number
             example: 60
-          fleet_configurable: true
         - name: dm_exec_query_stats_row_limit
           description: |
             Set the maximum number of query stats rows that can be retrieved in a single check run.
           value:
             type: integer
             example: 10000
-          fleet_configurable: true
         - name: samples_per_hour_per_query
           description: |
             Set the rate limit for the number of query sample events that are ingested per hour and per normalized
@@ -636,7 +633,6 @@ files:
           value:
             type: integer
             example: 4
-          fleet_configurable: true
         - name: enforce_collection_interval_deadline
           description: |
             By default, plan collection stops if it is time for the next run of the query metrics & plans loop. This
@@ -647,7 +643,6 @@ files:
             type: boolean
             example: True
           hidden: true
-          fleet_configurable: true
         - name: max_queries
           description: |
             Limit the number of queries sent to the backend.
@@ -658,7 +653,6 @@ files:
             example: 250
             display_default: 250
           hidden: true
-          fleet_configurable: true
         - name: lookback_window
           description: |
             Queries whose last execution completed after the lookback window are excluded from
@@ -668,7 +662,6 @@ files:
             type: integer
             display_default: 2 * collection_interval
             example: 600
-          fleet_configurable: true
         - name: collect_plans
           description: |
             Set to `false` to disable collection of query execution plans while keeping query
@@ -726,7 +719,6 @@ files:
           value:
             type: boolean
             example: true
-          fleet_configurable: true
         - name: collection_interval
           description: |
             Set the activity collection interval in seconds. Each collection involves querying several
@@ -737,7 +729,6 @@ files:
             type: number
             example: 10
           hidden: true
-          fleet_configurable: true
     - name: stored_procedure_characters_limit
       description: |
         Limit the number of characters of the text of a stored procedure that is collected.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -612,7 +612,7 @@ files:
             type: boolean
             example: false
           hidden: true
-          fleet_configurable: false
+          fleet_configurable: true
         - name: collection_interval
           description: |
             Set the query metric collection interval (in seconds). Each collection involves one or more queries to
@@ -621,14 +621,14 @@ files:
           value:
             type: number
             example: 60
-          fleet_configurable: false
+          fleet_configurable: true
         - name: dm_exec_query_stats_row_limit
           description: |
             Set the maximum number of query stats rows that can be retrieved in a single check run.
           value:
             type: integer
             example: 10000
-          fleet_configurable: false
+          fleet_configurable: true
         - name: samples_per_hour_per_query
           description: |
             Set the rate limit for the number of query sample events that are ingested per hour and per normalized
@@ -636,7 +636,7 @@ files:
           value:
             type: integer
             example: 4
-          fleet_configurable: false
+          fleet_configurable: true
         - name: enforce_collection_interval_deadline
           description: |
             By default, plan collection stops if it is time for the next run of the query metrics & plans loop. This
@@ -647,7 +647,7 @@ files:
             type: boolean
             example: True
           hidden: true
-          fleet_configurable: false
+          fleet_configurable: true
         - name: max_queries
           description: |
             Limit the number of queries sent to the backend.
@@ -658,7 +658,7 @@ files:
             example: 250
             display_default: 250
           hidden: true
-          fleet_configurable: false
+          fleet_configurable: true
         - name: lookback_window
           description: |
             Queries whose last execution completed after the lookback window are excluded from
@@ -668,7 +668,7 @@ files:
             type: integer
             display_default: 2 * collection_interval
             example: 600
-          fleet_configurable: false
+          fleet_configurable: true
         - name: collect_plans
           description: |
             Set to `false` to disable collection of query execution plans while keeping query
@@ -726,7 +726,7 @@ files:
           value:
             type: boolean
             example: true
-          fleet_configurable: false
+          fleet_configurable: true
         - name: collection_interval
           description: |
             Set the activity collection interval in seconds. Each collection involves querying several
@@ -737,7 +737,7 @@ files:
             type: number
             example: 10
           hidden: true
-          fleet_configurable: false
+          fleet_configurable: true
     - name: stored_procedure_characters_limit
       description: |
         Limit the number of characters of the text of a stored procedure that is collected.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Enable fleet management for fields that were present in RC schemas but incorrectly excluded by fleet_configurable: false in the source specs. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
