### PR TITLE
[SINT-5468] Change the GitLab id_token audience

### DIFF
--- a/.gitlab/software_composition_analysis.yaml
+++ b/.gitlab/software_composition_analysis.yaml
@@ -10,7 +10,7 @@ datadog-sca-ci:
   needs: []
   id_tokens:
     DD_STS_OIDC_TOKEN:
-      aud: rapid-seceng-sit
+      aud: dd-sts
   script:
     - |
       set +o xtrace


### PR DESCRIPTION
### What does this PR do?
We switch from rapid-seceng-sit to dd-sts audience in the dd-sts id_token from GitLab to be able to restrict this token claim to this service and not the other APIs SDLC Security team owns.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
See [this user guide](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5769659435/User+guide+dd-sts#Gitlab-CI-job)
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
