### PR TITLE
Emit telemetry when OpenMetrics reaches its metric limit

### DIFF
--- a/datadog_checks_base/changelog.d/24577.added
+++ b/datadog_checks_base/changelog.d/24577.added
@@ -1,0 +1,1 @@
+Emit `checks.max_returned_metrics_reached` and cumulative `checks.max_returned_metrics_dropped` Agent telemetry, tagged with `check_name`, when a check run reaches `max_returned_metrics` and starts dropping metrics.

--- a/datadog_checks_base/changelog.d/24577.added
+++ b/datadog_checks_base/changelog.d/24577.added
@@ -1,1 +1,1 @@
-Emit `checks.max_returned_metrics_reached` and cumulative `checks.max_returned_metrics_dropped` Agent telemetry, tagged with `check_name`, when a check run reaches `max_returned_metrics` and starts dropping metrics.
+Emit `checks.max_returned_metrics_reached` and cumulative `checks.max_returned_metrics_dropped` Agent telemetry, tagged with `check_name` and the effective `limit_type`, when a check run reaches `max_returned_metrics` and starts dropping metrics.

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1610,6 +1610,9 @@ class AgentCheck(object):
             error_report = json.encode([{'message': message, 'traceback': tb}])
         finally:
             if self.metric_limiter:
+                reached_metric_limit = self.metric_limiter.reached_limit
+                dropped_metric_count = max(0, self.metric_limiter.count - self.metric_limiter.limit)
+
                 if is_affirmative(self.debug_metrics.get('metric_contexts', False)):
                     debug_metrics = self.metric_limiter.get_debug_metrics()
 
@@ -1622,7 +1625,34 @@ class AgentCheck(object):
 
                 self.metric_limiter.reset()
 
+                if reached_metric_limit:
+                    self._emit_metric_limit_telemetry(dropped_metric_count)
+
         return error_report
+
+    def _emit_metric_limit_telemetry(self, dropped_metric_count):
+        # type: (int) -> None
+        try:
+            datadog_agent.emit_agent_telemetry(
+                'checks',
+                'max_returned_metrics_reached',
+                1,
+                'counter',
+                labels={'check_name': self.name},
+            )
+        except Exception:
+            self.log.debug('Failed to emit max_returned_metrics_reached Agent telemetry', exc_info=True)
+
+        try:
+            datadog_agent.emit_agent_telemetry(
+                'checks',
+                'max_returned_metrics_dropped',
+                dropped_metric_count,
+                'counter',
+                labels={'check_name': self.name},
+            )
+        except Exception:
+            self.log.debug('Failed to emit max_returned_metrics_dropped Agent telemetry', exc_info=True)
 
     def run_check_initializations(self):
         while self.check_initializations:

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1612,6 +1612,7 @@ class AgentCheck(object):
             if self.metric_limiter:
                 reached_metric_limit = self.metric_limiter.reached_limit
                 dropped_metric_count = max(0, self.metric_limiter.count - self.metric_limiter.limit)
+                limit_type = 'default' if self.metric_limiter.limit == self.DEFAULT_METRIC_LIMIT else 'custom'
 
                 if is_affirmative(self.debug_metrics.get('metric_contexts', False)):
                     debug_metrics = self.metric_limiter.get_debug_metrics()
@@ -1626,19 +1627,19 @@ class AgentCheck(object):
                 self.metric_limiter.reset()
 
                 if reached_metric_limit:
-                    self._emit_metric_limit_telemetry(dropped_metric_count)
+                    self._emit_metric_limit_telemetry(dropped_metric_count, limit_type)
 
         return error_report
 
-    def _emit_metric_limit_telemetry(self, dropped_metric_count):
-        # type: (int) -> None
+    def _emit_metric_limit_telemetry(self, dropped_metric_count, limit_type):
+        # type: (int, str) -> None
         try:
             datadog_agent.emit_agent_telemetry(
                 'checks',
                 'max_returned_metrics_reached',
                 1,
                 'counter',
-                labels={'check_name': self.name},
+                labels={'check_name': self.name, 'limit_type': limit_type},
             )
         except Exception:
             self.log.debug('Failed to emit max_returned_metrics_reached Agent telemetry', exc_info=True)
@@ -1649,7 +1650,7 @@ class AgentCheck(object):
                 'max_returned_metrics_dropped',
                 dropped_metric_count,
                 'counter',
-                labels={'check_name': self.name},
+                labels={'check_name': self.name, 'limit_type': limit_type},
             )
         except Exception:
             self.log.debug('Failed to emit max_returned_metrics_dropped Agent telemetry', exc_info=True)

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -3,8 +3,17 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
 from collections import defaultdict
+from collections.abc import Mapping
 
 from datadog_checks.base.utils.format import json
+
+
+def validate_telemetry_labels(labels):
+    if not isinstance(labels, Mapping):
+        raise TypeError('Agent telemetry labels must be a mapping, got {}.'.format(type(labels).__name__))
+    for key, value in labels.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise TypeError('Agent telemetry labels must map strings to strings, got {!r}: {!r}.'.format(key, value))
 
 
 class DatadogAgentStub(object):
@@ -27,6 +36,7 @@ class DatadogAgentStub(object):
         self._external_tags = []
         self._host_tags = "{}"
         self._sent_telemetry = defaultdict(list)
+        self._sent_labeled_telemetry = defaultdict(list)
         self._sent_reported_issues = defaultdict(list)
         self._sent_resolved_issues = []
 
@@ -41,6 +51,8 @@ class DatadogAgentStub(object):
         self._process_start_time = 0
         self._external_tags = []
         self._host_tags = "{}"
+        self._sent_telemetry.clear()
+        self._sent_labeled_telemetry.clear()
         self._sent_reported_issues.clear()
         self._sent_resolved_issues.clear()
 
@@ -90,6 +102,24 @@ class DatadogAgentStub(object):
         values = self._sent_telemetry[(check_name, metric_name, metric_type)]
         assert metric_value in values, 'Expected value {} for check {}, metric {}, type {}. Found {}.'.format(
             metric_value, check_name, metric_name, metric_type, values
+        )
+
+    def labeled_telemetry(self, check_name, metric_name, metric_type):
+        """Return the ``(value, labels)`` pairs emitted for a labeled telemetry metric."""
+        return list(self._sent_labeled_telemetry[(check_name, metric_name, metric_type)])
+
+    def assert_labeled_telemetry(self, check_name, metric_name, metric_type, metric_value, labels):
+        emitted = self.labeled_telemetry(check_name, metric_name, metric_type)
+        assert (metric_value, labels) in emitted, (
+            'Expected value {} with labels {} for check {}, metric {}, type {}. Found {}.'.format(
+                metric_value, labels, check_name, metric_name, metric_type, emitted
+            )
+        )
+
+    def assert_no_labeled_telemetry(self, check_name, metric_name, metric_type):
+        emitted = self.labeled_telemetry(check_name, metric_name, metric_type)
+        assert not emitted, 'Expected no telemetry for check {}, metric {}, type {}. Found {}.'.format(
+            check_name, metric_name, metric_type, emitted
         )
 
     def assert_reported_issue(self, check_name, issue_id, issue):
@@ -173,8 +203,11 @@ class DatadogAgentStub(object):
         # Passthrough stub: obfuscation implementation is in Go code.
         return command
 
-    def emit_agent_telemetry(self, check_name, metric_name, metric_value, metric_type):
+    def emit_agent_telemetry(self, check_name, metric_name, metric_value, metric_type, labels=None):
         self._sent_telemetry[(check_name, metric_name, metric_type)].append(metric_value)
+        if labels is not None:
+            validate_telemetry_labels(labels)
+            self._sent_labeled_telemetry[(check_name, metric_name, metric_type)].append((metric_value, dict(labels)))
 
     def report_issue(self, check_name, report_json):
         self._sent_reported_issues[check_name].append(json.decode(report_json))

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -1162,6 +1162,12 @@ class LimitedCheck(AgentCheck):
             self.gauge('foo', i)
 
 
+class UnlimitedCheck(LimitedCheck):
+    """Mirrors the product-specific OpenMetrics packages that disable the limiter with a zero default."""
+
+    DEFAULT_METRIC_LIMIT = 0
+
+
 class TestLimits:
     def test_context_uid(self, aggregator):
         check = LimitedCheck()
@@ -1293,6 +1299,78 @@ class TestLimits:
         assert len(aggregator.metrics('foo')) == 3
         aggregator.assert_metric('datadog.agent.metrics.contexts.limit', 3)
         aggregator.assert_metric('datadog.agent.metrics.contexts.total', 5)
+
+    @pytest.fixture
+    def emit_agent_telemetry(self, monkeypatch):
+        emit = mock.MagicMock()
+        monkeypatch.setattr('datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry', emit)
+        return emit
+
+    @staticmethod
+    def expected_telemetry_calls(check_name, dropped):
+        return [
+            mock.call('checks', 'max_returned_metrics_reached', 1, 'counter', labels={'check_name': check_name}),
+            mock.call('checks', 'max_returned_metrics_dropped', dropped, 'counter', labels={'check_name': check_name}),
+        ]
+
+    @pytest.mark.parametrize('debug_metrics', [False, True])
+    def test_metric_limit_telemetry_once_per_run(self, aggregator, dd_run_check, debug_metrics, emit_agent_telemetry):
+        """The debug path resets the limiter early, so both signals must be read before it is cleared."""
+        instance = {'max_returned_metrics': 3}
+        if debug_metrics:
+            instance['debug_metrics'] = {'metric_contexts': True}
+        check = LimitedCheck('a_check', {}, [instance])
+
+        dd_run_check(check)
+        dd_run_check(check)
+
+        assert emit_agent_telemetry.call_args_list == self.expected_telemetry_calls('a_check', 2) * 2
+        assert len(aggregator.metrics('foo')) == 6
+
+    @pytest.mark.parametrize(
+        'check_class, instance',
+        [
+            pytest.param(LimitedCheck, {'max_returned_metrics': 10}, id='under-limit'),
+            pytest.param(UnlimitedCheck, {}, id='no-limiter'),
+        ],
+    )
+    def test_metric_limit_telemetry_not_emitted_when_limit_not_reached(
+        self, dd_run_check, emit_agent_telemetry, check_class, instance
+    ):
+        check = check_class('a_check', {}, [instance])
+
+        dd_run_check(check)
+
+        emit_agent_telemetry.assert_not_called()
+        assert not check.get_warnings()
+
+    def test_metric_limit_telemetry_attempts_dropped_signal_when_reached_signal_fails(self, dd_run_check, monkeypatch):
+        """Each signal is guarded separately, so losing the first one must not cost the second."""
+        emit_agent_telemetry = mock.MagicMock(side_effect=[RuntimeError('bridge failure'), None])
+        monkeypatch.setattr('datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry', emit_agent_telemetry)
+        check = LimitedCheck('a_check', {}, [{'max_returned_metrics': 3}])
+
+        dd_run_check(check)
+
+        assert emit_agent_telemetry.call_args_list == self.expected_telemetry_calls('a_check', 2)
+
+    @pytest.mark.parametrize(
+        'broken_bridge',
+        [
+            pytest.param(mock.MagicMock(side_effect=RuntimeError('bridge failure')), id='bridge-raises'),
+            pytest.param(lambda check_name, metric_name, metric_value, metric_type: None, id='bridge-without-labels'),
+        ],
+    )
+    def test_metric_limit_telemetry_failure_leaves_the_check_intact(
+        self, aggregator, dd_run_check, monkeypatch, broken_bridge
+    ):
+        monkeypatch.setattr('datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry', broken_bridge)
+        check = LimitedCheck('a_check', {}, [{'max_returned_metrics': 3}])
+
+        dd_run_check(check)
+        dd_run_check(check)
+
+        assert len(aggregator.metrics('foo')) == 6
 
 
 class TestCheckInitializations:

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -1168,6 +1168,10 @@ class UnlimitedCheck(LimitedCheck):
     DEFAULT_METRIC_LIMIT = 0
 
 
+class DefaultLimitedCheck(LimitedCheck):
+    DEFAULT_METRIC_LIMIT = 3
+
+
 class TestLimits:
     def test_context_uid(self, aggregator):
         check = LimitedCheck()
@@ -1307,10 +1311,11 @@ class TestLimits:
         return emit
 
     @staticmethod
-    def expected_telemetry_calls(check_name, dropped):
+    def expected_telemetry_calls(check_name, dropped, limit_type='custom'):
+        labels = {'check_name': check_name, 'limit_type': limit_type}
         return [
-            mock.call('checks', 'max_returned_metrics_reached', 1, 'counter', labels={'check_name': check_name}),
-            mock.call('checks', 'max_returned_metrics_dropped', dropped, 'counter', labels={'check_name': check_name}),
+            mock.call('checks', 'max_returned_metrics_reached', 1, 'counter', labels=labels),
+            mock.call('checks', 'max_returned_metrics_dropped', dropped, 'counter', labels=labels),
         ]
 
     @pytest.mark.parametrize('debug_metrics', [False, True])
@@ -1326,6 +1331,13 @@ class TestLimits:
 
         assert emit_agent_telemetry.call_args_list == self.expected_telemetry_calls('a_check', 2) * 2
         assert len(aggregator.metrics('foo')) == 6
+
+    def test_metric_limit_telemetry_default_limit_type(self, dd_run_check, emit_agent_telemetry):
+        check = DefaultLimitedCheck('a_check', {}, [{}])
+
+        dd_run_check(check)
+
+        assert emit_agent_telemetry.call_args_list == self.expected_telemetry_calls('a_check', 2, 'default')
 
     @pytest.mark.parametrize(
         'check_class, instance',

--- a/datadog_checks_base/tests/stubs/test_datadog_agent.py
+++ b/datadog_checks_base/tests/stubs/test_datadog_agent.py
@@ -76,3 +76,26 @@ def test_assert_external_tags_count(datadog_agent, external_tags, count, raise_e
     except AssertionError:
         if not raise_exception:
             raise
+
+
+@pytest.mark.parametrize(
+    'labels',
+    [
+        pytest.param({'key': 1}, id='non-string value'),
+        pytest.param([('key', 'value')], id='not a mapping'),
+    ],
+)
+def test_emit_agent_telemetry_rejects_invalid_labels(datadog_agent, labels):
+    with pytest.raises(TypeError):
+        datadog_agent.emit_agent_telemetry('checks', 'a_metric', 1, 'counter', labels=labels)
+
+
+def test_emit_agent_telemetry_records_labels(datadog_agent):
+    datadog_agent.emit_agent_telemetry('checks', 'a_metric', 1, 'counter', labels={'check_name': 'a_check'})
+    datadog_agent.emit_agent_telemetry('checks', 'another_metric', 1, 'counter')
+
+    datadog_agent.assert_telemetry('checks', 'a_metric', 'counter', 1)
+    datadog_agent.assert_labeled_telemetry('checks', 'a_metric', 'counter', 1, {'check_name': 'a_check'})
+
+    datadog_agent.assert_telemetry('checks', 'another_metric', 'counter', 1)
+    datadog_agent.assert_no_labeled_telemetry('checks', 'another_metric', 'counter')

--- a/openmetrics/tests/test_metric_limit_telemetry.py
+++ b/openmetrics/tests/test_metric_limit_telemetry.py
@@ -45,5 +45,6 @@ def test_metric_limit_telemetry_emitted_when_limit_reached(
     dd_run_check(check)
 
     assert len(check.get_warnings()) == 1
-    datadog_agent.assert_labeled_telemetry(*REACHED_TELEMETRY, 1, {'check_name': 'openmetrics'})
-    datadog_agent.assert_labeled_telemetry(*DROPPED_TELEMETRY, expected_dropped, {'check_name': 'openmetrics'})
+    labels = {'check_name': 'openmetrics', 'limit_type': 'custom'}
+    datadog_agent.assert_labeled_telemetry(*REACHED_TELEMETRY, 1, labels)
+    datadog_agent.assert_labeled_telemetry(*DROPPED_TELEMETRY, expected_dropped, labels)

--- a/openmetrics/tests/test_metric_limit_telemetry.py
+++ b/openmetrics/tests/test_metric_limit_telemetry.py
@@ -1,0 +1,49 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+"""Agent telemetry emitted when a check drops metrics after reaching ``max_returned_metrics``.
+
+The generic ``openmetrics`` package is the only shipped OpenMetrics package that keeps the
+positive ``2000`` base default in ``integrations-core``, so it is the dominant producer of this
+signal. ``OpenMetricsCheck.__new__`` dispatches to OpenMetrics v2 for ``openmetrics_endpoint``
+and to OpenMetrics v1 for ``prometheus_url``; both paths are covered here.
+"""
+
+import pytest
+
+from datadog_checks.openmetrics import OpenMetricsCheck
+
+REACHED_TELEMETRY = ('checks', 'max_returned_metrics_reached', 'counter')
+DROPPED_TELEMETRY = ('checks', 'max_returned_metrics_dropped', 'counter')
+
+V2_INSTANCE = {
+    'openmetrics_endpoint': 'http://localhost:10249/metrics',
+    'namespace': 'openmetrics',
+    'metrics': [{'metric1': 'renamed.metric1'}, 'metric2', 'counter1', 'counter2'],
+}
+
+V1_INSTANCE = {
+    'prometheus_url': 'http://localhost:10249/metrics',
+    'namespace': 'openmetrics',
+    'metrics': [{'metric1': 'renamed.metric1'}, 'metric2', 'counter1_total'],
+}
+
+LIMIT_VERSIONS = [
+    pytest.param(V2_INSTANCE, 'openmetrics_poll_mock', 5, id='v2'),
+    pytest.param(V1_INSTANCE, 'prometheus_poll_mock', 2, id='v1'),
+]
+
+
+@pytest.mark.parametrize('instance, poll_mock_fixture, expected_dropped', LIMIT_VERSIONS)
+def test_metric_limit_telemetry_emitted_when_limit_reached(
+    dd_run_check, datadog_agent, request, instance, poll_mock_fixture, expected_dropped
+):
+    request.getfixturevalue(poll_mock_fixture)
+    check = OpenMetricsCheck('openmetrics', {}, [dict(instance, max_returned_metrics=1)])
+
+    dd_run_check(check)
+
+    assert len(check.get_warnings()) == 1
+    datadog_agent.assert_labeled_telemetry(*REACHED_TELEMETRY, 1, {'check_name': 'openmetrics'})
+    datadog_agent.assert_labeled_telemetry(*DROPPED_TELEMETRY, expected_dropped, {'check_name': 'openmetrics'})


### PR DESCRIPTION
### What does this PR do?

- Emit two best-effort Agent telemetry counter increments for each check run that reaches its configured metric limit:
  - `checks.max_returned_metrics_reached += 1`
  - `checks.max_returned_metrics_dropped += max(0, limiter.count - limiter.limit)`
- Tag both counters with bounded `check_name` and `limit_type:default|custom` dimensions.

Companion changes:

- Agent bridge and COAT allowlist: https://github.com/DataDog/datadog-agent/pull/53751
- Public telemetry disclosure: https://github.com/DataDog/documentation/pull/38477
- Tracking issue: https://datadoghq.atlassian.net/browse/AI-7012

### Motivation

OpenMetrics drops metric contexts beyond `max_returned_metrics` for the remainder of a check run. Today this is visible only in logs through a one-per-run warning.

The occurrence counter measures how often checks are limited, while the dropped-volume counter measures severity. `limit_type` distinguishes checks exceeding their effective class default—normally `2000` for generic OpenMetrics and Prometheus—from checks exceeding an operator-customized effective limit.

### Metric contract

Both metrics are cumulative counters tagged with `check_name` and `limit_type`:

- `checks.max_returned_metrics_reached`: incremented by `1` at most once per affected check run.
- `checks.max_returned_metrics_dropped`: incremented once per affected run by the number of limiter-counted contexts beyond the effective limit.
- `limit_type=default` when the effective limiter value equals the check class default; otherwise `limit_type=custom`. Values are bounded to those two literals.

### Validation

- Focused `datadog_checks_base` limiter and telemetry-stub tests, including one default-limit classification case.
- OpenMetrics v1/v2 metric-limit tests.
- Formatting and lint for the affected packages.
- Staging validation is available; contact the author for the dashboard link.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label and it will automatically open a backport PR after merge
