### PR TITLE
Emit a per-node clickhouse_node tag across all node-scoped ClickHouse checks

### DIFF
--- a/clickhouse/changelog.d/24579.changed
+++ b/clickhouse/changelog.d/24579.changed
@@ -1,0 +1,1 @@
+Emit a per-node ``clickhouse_node`` tag on all node-scoped ClickHouse checks; query metrics are no longer merged across nodes and are emitted per node.

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -292,9 +292,12 @@ class ClickhouseCheck(DatabaseCheck):
                     pick(queries.SystemEventsToDeprecate),
                     pick(queries.SystemEvents),
                     pick(queries.SystemAsynchronousMetrics),
+                    # SystemParts is left plain: it has a GROUP BY, so cluster_aware_query would
+                    # emit hostName() outside the GROUP BY (invalid SQL). Per-node parts data is
+                    # covered by the DBM parts_and_merges check instead.
                     queries.SystemParts,
-                    queries.SystemReplicas,
-                    queries.SystemDictionaries,
+                    pick(queries.SystemReplicas),
+                    pick(queries.SystemDictionaries),
                 ]
             )
 

--- a/clickhouse/datadog_checks/clickhouse/parts_and_merges.py
+++ b/clickhouse/datadog_checks/clickhouse/parts_and_merges.py
@@ -31,6 +31,7 @@ from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
+from datadog_checks.clickhouse.utils import node_tag
 
 DBM_TYPE = "storage_health"
 
@@ -680,6 +681,7 @@ class ClickhousePartsAndMerges(DBMAsyncJob):
                     f'database:{database}',
                     f'table:{table}',
                     f'server_node:{server_node}',
+                    node_tag(server_node),
                     f'partition:{partition}',
                 ]
             else:
@@ -688,6 +690,7 @@ class ClickhousePartsAndMerges(DBMAsyncJob):
                     f'database:{database}',
                     f'table:{table}',
                     f'server_node:{server_node}',
+                    node_tag(server_node),
                 ]
             self._check.gauge('table.parts.active', agg['active'], tags=tags)
             self._check.gauge('table.parts.level_zero', agg['level_zero'], tags=tags)
@@ -736,6 +739,7 @@ class ClickhousePartsAndMerges(DBMAsyncJob):
                 f'database:{database}',
                 f'table:{table}',
                 f'server_node:{server_node}',
+                node_tag(server_node),
             ]
             avg_progress = agg['progress_sum'] / agg['progress_count'] if agg['progress_count'] > 0 else 0.0
             self._check.gauge('merges.active', agg['active'], tags=tags)
@@ -751,6 +755,7 @@ class ClickhousePartsAndMerges(DBMAsyncJob):
                 f'database:{row["database"]}',
                 f'table:{row["table"]}',
                 f'server_node:{row.get("server_node", "")}',
+                node_tag(row.get("server_node", "")),
             ]
             oldest_create_time = row.get('oldest_create_time')
             oldest_age = now - oldest_create_time if oldest_create_time is not None else 0
@@ -765,6 +770,7 @@ class ClickhousePartsAndMerges(DBMAsyncJob):
                 f'database:{row["database"]}',
                 f'table:{row["table"]}',
                 f'server_node:{row.get("server_node", "")}',
+                node_tag(row.get("server_node", "")),
             ]
             self._check.gauge('replication.queue_depth', row['depth'], tags=tags)
             self._check.gauge('replication.stuck_tasks', row['stuck'], tags=tags)
@@ -789,6 +795,7 @@ class ClickhousePartsAndMerges(DBMAsyncJob):
                 f'database:{database}',
                 f'table:{table}',
                 f'server_node:{server_node}',
+                node_tag(server_node),
             ]
             self._check.gauge('table.detached_parts.count', agg['total'], tags=tags)
             self._check.gauge('table.detached_parts.manual', agg['manual'], tags=tags)
@@ -798,7 +805,7 @@ class ClickhousePartsAndMerges(DBMAsyncJob):
         # --- Thresholds (server-level MergeTree settings) ---
         for row in thresholds or []:
             server_node = row.get('server_node', '')
-            tags = self.tags + [f'server_node:{server_node}']
+            tags = self.tags + [f'server_node:{server_node}', node_tag(server_node)]
             if row['name'] == 'parts_to_delay_insert':
                 self._check.gauge('parts.threshold.delay_insert', row['value'], tags=tags)
             elif row['name'] == 'parts_to_throw_insert':

--- a/clickhouse/datadog_checks/clickhouse/query_completions.py
+++ b/clickhouse/datadog_checks/clickhouse/query_completions.py
@@ -19,6 +19,7 @@ from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.clickhouse.explain_plans import ClickhouseExplainPlans
 from datadog_checks.clickhouse.query_log_job import ClickhouseQueryLogJob, agent_check_getter
+from datadog_checks.clickhouse.utils import node_tag
 
 # Query to fetch individual completed queries from system.query_log.
 # Unlike statements.py which aggregates, this returns individual query executions.
@@ -118,22 +119,23 @@ class ClickhouseQueryCompletions(ClickhouseQueryLogJob):
             except Exception:
                 self._log.exception("Failed to collect explain plans")
 
-            # Step 3: Apply rate limiting and create payload
-            payload = self._create_batched_payload(rows)
+            # Step 3: Apply rate limiting and create one payload per node
+            payloads = self._create_batched_payloads(rows)
 
-            if not payload or not payload.get('clickhouse_query_completions'):
+            if not payloads:
                 self._log.debug("No query completions after rate limiting")
                 return
 
-            # Step 4: Submit payload
-            payload_data = json.dumps(payload, default=default_json_event_encoding)
-            num_completions = len(payload.get('clickhouse_query_completions', []))
-            self._log.debug(
-                "Submitting query completions payload: %d bytes, %d completions",
-                len(payload_data),
-                num_completions,
-            )
-            self._check.database_monitoring_query_activity(payload_data)
+            # Step 4: Submit one payload per node
+            for payload in payloads:
+                payload_data = json.dumps(payload, default=default_json_event_encoding)
+                num_completions = len(payload.get('clickhouse_query_completions', []))
+                self._log.debug(
+                    "Submitting query completions payload: %d bytes, %d completions",
+                    len(payload_data),
+                    num_completions,
+                )
+                self._check.database_monitoring_query_activity(payload_data)
 
             if self._current_checkpoint_microseconds is not None:
                 self._log.debug(
@@ -269,15 +271,19 @@ class ClickhouseQueryCompletions(ClickhouseQueryLogJob):
             # Checkpoint will still advance to avoid duplicates on retry.
             raise
 
-    def _create_batched_payload(self, rows):
+    def _create_batched_payloads(self, rows):
         """
-        Create a batched payload following SQL Server query_completion pattern.
-        Apply rate limiting and filter out rate-limited queries.
+        Create one batched payload per ClickHouse node, following the SQL Server
+        query_completion pattern.
+
+        Applies rate limiting, filters out rate-limited queries, and groups the
+        surviving completions by node so each payload carries its own
+        ``clickhouse_node`` tag.
 
         Returns:
-            dict: Batched payload with array of query completion details
+            list[dict]: one payload per node (empty list if nothing to submit)
         """
-        query_completions = []
+        completions_by_node = {}
 
         for row in rows:
             query_signature = row.get('query_signature')
@@ -320,24 +326,27 @@ class ClickhouseQueryCompletions(ClickhouseQueryLogJob):
                 },
             }
 
-            query_completions.append({'query_details': query_details})
+            server_node = row.get('hostname', '')
+            completions_by_node.setdefault(server_node, []).append({'query_details': query_details})
 
-        if not query_completions:
-            return None
+        payloads = []
+        for server_node, query_completions in completions_by_node.items():
+            ddtags = self._tags_no_db + [node_tag(server_node)] if server_node else self._tags_no_db
+            # Create payload following SQL Server pattern
+            payloads.append(
+                {
+                    'host': self._check.reported_hostname,
+                    'database_instance': self._check.database_identifier,
+                    'ddagentversion': datadog_agent.get_version(),
+                    'ddsource': 'clickhouse',
+                    'dbm_type': 'query_completion',
+                    'collection_interval': self._collection_interval,
+                    'ddtags': ddtags,
+                    'timestamp': time.time() * 1000,
+                    'clickhouse_version': self._check.dbms_version,
+                    'service': getattr(self._check, 'service', None),
+                    'clickhouse_query_completions': query_completions,
+                }
+            )
 
-        # Create payload following SQL Server pattern
-        payload = {
-            'host': self._check.reported_hostname,
-            'database_instance': self._check.database_identifier,
-            'ddagentversion': datadog_agent.get_version(),
-            'ddsource': 'clickhouse',
-            'dbm_type': 'query_completion',
-            'collection_interval': self._collection_interval,
-            'ddtags': self._tags_no_db,
-            'timestamp': time.time() * 1000,
-            'clickhouse_version': self._check.dbms_version,
-            'service': getattr(self._check, 'service', None),
-            'clickhouse_query_completions': query_completions,
-        }
-
-        return payload
+        return payloads

--- a/clickhouse/datadog_checks/clickhouse/query_errors.py
+++ b/clickhouse/datadog_checks/clickhouse/query_errors.py
@@ -20,6 +20,7 @@ from datadog_checks.base.utils.db.utils import RateLimitingTTLCache, default_jso
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.clickhouse.query_log_job import ClickhouseQueryLogJob, agent_check_getter
+from datadog_checks.clickhouse.utils import node_tag
 
 # Query to fetch failed queries from system.query_log.
 # Collects ExceptionBeforeStart (type=3) and ExceptionWhileProcessing (type=4) events.
@@ -110,21 +111,22 @@ class ClickhouseQueryErrors(ClickhouseQueryLogJob):
                 self._log.debug("No new query errors")
                 return
 
-            payload = self._create_batched_payload(rows)
+            payloads = self._create_batched_payloads(rows)
 
-            if not payload or not payload.get('clickhouse_query_errors'):
+            if not payloads:
                 self._log.debug("No query errors after rate limiting")
                 return
 
             try:
-                payload_data = json.dumps(payload, default=default_json_event_encoding)
-                num_errors = len(payload.get('clickhouse_query_errors', []))
-                self._log.debug(
-                    "Submitting query errors payload: %d bytes, %d errors",
-                    len(payload_data),
-                    num_errors,
-                )
-                self._check.database_monitoring_query_activity(payload_data)
+                for payload in payloads:
+                    payload_data = json.dumps(payload, default=default_json_event_encoding)
+                    num_errors = len(payload.get('clickhouse_query_errors', []))
+                    self._log.debug(
+                        "Submitting query errors payload: %d bytes, %d errors",
+                        len(payload_data),
+                        num_errors,
+                    )
+                    self._check.database_monitoring_query_activity(payload_data)
                 self._log.debug(
                     "Successfully submitted. Checkpoint: %d microseconds", self._current_checkpoint_microseconds
                 )
@@ -261,9 +263,13 @@ class ClickhouseQueryErrors(ClickhouseQueryLogJob):
 
             raise
 
-    def _create_batched_payload(self, rows: list) -> dict | None:
-        """Create a batched payload with rate limiting applied."""
-        query_errors = []
+    def _create_batched_payloads(self, rows: list) -> list[dict]:
+        """Create one batched payload per node, with rate limiting applied.
+
+        Errors are grouped by node so each payload carries its own
+        ``clickhouse_node`` tag. Returns an empty list if nothing to submit.
+        """
+        errors_by_node = {}
 
         for row in rows:
             query_signature = row.get('query_signature')
@@ -308,23 +314,26 @@ class ClickhouseQueryErrors(ClickhouseQueryLogJob):
                 },
             }
 
-            query_errors.append({'query_details': query_details})
+            server_node = row.get('hostname', '')
+            errors_by_node.setdefault(server_node, []).append({'query_details': query_details})
 
-        if not query_errors:
-            return None
+        payloads = []
+        for server_node, query_errors in errors_by_node.items():
+            ddtags = self._tags_no_db + [node_tag(server_node)] if server_node else self._tags_no_db
+            payloads.append(
+                {
+                    'host': self._check.reported_hostname,
+                    'database_instance': self._check.database_identifier,
+                    'ddagentversion': datadog_agent.get_version(),
+                    'ddsource': 'clickhouse',
+                    'dbm_type': 'query_error',
+                    'collection_interval': self._collection_interval,
+                    'ddtags': ddtags,
+                    'timestamp': time.time() * 1000,
+                    'clickhouse_version': self._check.dbms_version,
+                    'service': self._check._config.service,
+                    'clickhouse_query_errors': query_errors,
+                }
+            )
 
-        payload = {
-            'host': self._check.reported_hostname,
-            'database_instance': self._check.database_identifier,
-            'ddagentversion': datadog_agent.get_version(),
-            'ddsource': 'clickhouse',
-            'dbm_type': 'query_error',
-            'collection_interval': self._collection_interval,
-            'ddtags': self._tags_no_db,
-            'timestamp': time.time() * 1000,
-            'clickhouse_version': self._check.dbms_version,
-            'service': self._check._config.service,
-            'clickhouse_query_errors': query_errors,
-        }
-
-        return payload
+        return payloads

--- a/clickhouse/datadog_checks/clickhouse/statement_samples.py
+++ b/clickhouse/datadog_checks/clickhouse/statement_samples.py
@@ -32,6 +32,7 @@ from datadog_checks.base.utils.db.utils import (
 )
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
+from datadog_checks.clickhouse.utils import node_tag
 
 # Query to get currently running/active queries from system.processes
 # This is the ClickHouse equivalent of Postgres pg_stat_activity
@@ -66,7 +67,8 @@ SELECT
     port,
     client_hostname,
     is_cancelled,
-    http_user_agent
+    http_user_agent,
+    hostName() as server_node
 FROM {processes_table}
 WHERE query NOT LIKE '%system.processes%'
   AND query NOT LIKE '%system.query_log%'
@@ -80,10 +82,11 @@ SELECT
     user,
     query_kind,
     current_database,
-    count(*) as connections
+    count(*) as connections,
+    hostName() as server_node
 FROM {processes_table}
 WHERE query NOT LIKE '%system.processes%'
-GROUP BY user, query_kind, current_database
+GROUP BY user, query_kind, current_database, server_node
 """
 
 
@@ -239,6 +242,7 @@ class ClickhouseStatementSamples(DBMAsyncJob):
                 client_hostname,
                 is_cancelled,
                 http_user_agent,
+                server_node,
             ) = row
 
             normalized_row = {
@@ -268,6 +272,7 @@ class ClickhouseStatementSamples(DBMAsyncJob):
                 'client_hostname': str(client_hostname) if client_hostname else None,
                 'is_cancelled': bool(is_cancelled) if is_cancelled is not None else False,
                 'http_user_agent': str(http_user_agent) if http_user_agent else None,
+                'server_node': str(server_node) if server_node else '',
             }
 
             return self._obfuscate_query(normalized_row)
@@ -347,6 +352,7 @@ class ClickhouseStatementSamples(DBMAsyncJob):
                         'query_kind': row[1],
                         'current_database': row[2],
                         'connections': row[3],
+                        'server_node': str(row[4]) if row[4] else '',
                     }
                 )
 
@@ -381,26 +387,47 @@ class ClickhouseStatementSamples(DBMAsyncJob):
             if session_count >= self._payload_row_limit:
                 break
 
-    def _create_samples_event(self, rows, active_connections):
+    def _create_samples_events(self, rows, active_connections):
         """
-        Create a database monitoring samples event payload.
+        Create one database monitoring samples event per ClickHouse node.
+
+        Active sessions and connections are grouped by node so each event carries
+        its own clickhouse_node tag. When there is no data at all, a single
+        cluster-level (untagged) empty snapshot is still emitted.
         """
         active_sessions = list(self._create_active_sessions(rows))
 
-        event = {
-            "host": self._check.reported_hostname,
-            "database_instance": self._check.database_identifier,
-            "ddagentversion": datadog_agent.get_version(),
-            "ddsource": "clickhouse",
-            "dbm_type": "activity",
-            "collection_interval": self._collection_interval,
-            "ddtags": self._tags_no_db,
-            "timestamp": time.time() * 1000,
-            "service": getattr(self._check._config, 'service', None),
-            "clickhouse_activity": active_sessions,
-            "clickhouse_connections": active_connections,
-        }
-        return event
+        sessions_by_node = {}
+        for session in active_sessions:
+            sessions_by_node.setdefault(session.get('server_node', ''), []).append(session)
+
+        connections_by_node = {}
+        for connection in active_connections:
+            connections_by_node.setdefault(connection.get('server_node', ''), []).append(connection)
+
+        node_keys = set(sessions_by_node) | set(connections_by_node)
+        if not node_keys:
+            node_keys = {''}  # still emit an empty cluster-level snapshot
+
+        events = []
+        for server_node in sorted(node_keys):
+            ddtags = self._tags_no_db + [node_tag(server_node)] if server_node else self._tags_no_db
+            events.append(
+                {
+                    "host": self._check.reported_hostname,
+                    "database_instance": self._check.database_identifier,
+                    "ddagentversion": datadog_agent.get_version(),
+                    "ddsource": "clickhouse",
+                    "dbm_type": "activity",
+                    "collection_interval": self._collection_interval,
+                    "ddtags": ddtags,
+                    "timestamp": time.time() * 1000,
+                    "service": getattr(self._check._config, 'service', None),
+                    "clickhouse_activity": sessions_by_node.get(server_node, []),
+                    "clickhouse_connections": connections_by_node.get(server_node, []),
+                }
+            )
+        return events
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_samples(self):
@@ -420,10 +447,13 @@ class ClickhouseStatementSamples(DBMAsyncJob):
         # Get active connections aggregation
         active_connections = self._get_active_connections()
 
-        # Create and submit samples event
-        samples_event = self._create_samples_event(rows, active_connections)
+        # Create and submit one samples event per node
+        samples_events = self._create_samples_events(rows, active_connections)
 
-        self._check.database_monitoring_query_activity(json.dumps(samples_event, default=default_json_event_encoding))
+        for samples_event in samples_events:
+            self._check.database_monitoring_query_activity(
+                json.dumps(samples_event, default=default_json_event_encoding)
+            )
 
         elapsed_ms = (time.time() - start_time) * 1000
         self._check.histogram(
@@ -434,9 +464,10 @@ class ClickhouseStatementSamples(DBMAsyncJob):
         )
 
         self._log.debug(
-            "Samples snapshot collected: sessions=%s, connections=%s, elapsed_ms=%.2f",
-            len(samples_event.get('clickhouse_activity', [])),
-            len(samples_event.get('clickhouse_connections', [])),
+            "Samples snapshot collected: events=%s, sessions=%s, connections=%s, elapsed_ms=%.2f",
+            len(samples_events),
+            sum(len(e.get('clickhouse_activity', [])) for e in samples_events),
+            sum(len(e.get('clickhouse_connections', [])) for e in samples_events),
             elapsed_ms,
         )
 

--- a/clickhouse/datadog_checks/clickhouse/statements.py
+++ b/clickhouse/datadog_checks/clickhouse/statements.py
@@ -21,6 +21,7 @@ from datadog_checks.base.utils.db.utils import default_json_event_encoding
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.clickhouse.query_log_job import ClickhouseQueryLogJob, agent_check_getter
+from datadog_checks.clickhouse.utils import node_tag
 
 # Query to fetch aggregated metrics from system.query_log using checkpoint-based collection.
 #
@@ -82,7 +83,7 @@ def _row_key(row):
     :param row: a normalized row from system.query_log
     :return: a tuple uniquely identifying this row
     """
-    return row['query_signature'], row.get('user', ''), row.get('databases', '')
+    return row['query_signature'], row.get('user', ''), row.get('databases', ''), row.get('server_node', '')
 
 
 class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
@@ -138,30 +139,38 @@ class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
             for event in self._rows_to_fqt_events(rows):
                 self._check.database_monitoring_query_sample(json.dumps(event, default=default_json_event_encoding))
 
-            # Prepare metrics payload wrapper
-            payload_wrapper = {
+            # Base metrics payload wrapper; the per-node clickhouse_node tag is added per group below.
+            base_wrapper = {
                 'host': self._check.reported_hostname,
                 'database_instance': self._check.database_identifier,
                 'timestamp': time.time() * 1000,
                 'min_collection_interval': self._collection_interval,
-                'tags': self._tags_no_db,
                 'ddagentversion': datadog_agent.get_version(),
                 'clickhouse_version': self._check.dbms_version,
             }
 
-            # Get query metrics payloads (may be split into multiple if too large)
-            payloads = self._get_query_metrics_payloads(payload_wrapper, rows)
-
-            for payload in payloads:
-                payload_data = json.loads(payload)
-                num_rows = len(payload_data.get('clickhouse_rows', []))
-                self._log.info(
-                    "Submitting query metrics payload: %d bytes, %d rows, database_instance=%s",
-                    len(payload),
-                    num_rows,
-                    payload_data.get('database_instance', 'MISSING'),
+            # Emit one payload set per node so each carries its own clickhouse_node tag.
+            # In single-node deployments this is a single group with no node tag.
+            for server_node, node_rows in self._group_rows_by_node(rows).items():
+                payload_wrapper = dict(base_wrapper)
+                payload_wrapper['tags'] = (
+                    self._tags_no_db + [node_tag(server_node)] if server_node else self._tags_no_db
                 )
-                self._check.database_monitoring_query_metrics(payload)
+
+                # Get query metrics payloads (may be split into multiple if too large)
+                payloads = self._get_query_metrics_payloads(payload_wrapper, node_rows)
+
+                for payload in payloads:
+                    payload_data = json.loads(payload)
+                    num_rows = len(payload_data.get('clickhouse_rows', []))
+                    self._log.info(
+                        "Submitting query metrics payload: %d bytes, %d rows, database_instance=%s, node=%s",
+                        len(payload),
+                        num_rows,
+                        payload_data.get('database_instance', 'MISSING'),
+                        server_node or 'N/A',
+                    )
+                    self._check.database_monitoring_query_metrics(payload)
 
             if self._current_checkpoint_microseconds is not None:
                 self._log.info("Collection complete. Checkpoint saved: %d", self._current_checkpoint_microseconds)
@@ -275,6 +284,7 @@ class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
 
                 result_row = {
                     'normalized_query_hash': str(normalized_query_hash),
+                    'server_node': str(server_node) if server_node else '',
                     'query': str(query_text) if query_text else '',
                     'user': str(query_user) if query_user else '',
                     'query_type': str(query_type) if query_type else '',
@@ -299,9 +309,7 @@ class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
 
             self._set_checkpoint_from_event_time(global_max_event_time)
 
-            if result_rows:
-                result_rows = self._merge_rows_across_nodes(result_rows)
-
+            # Rows are kept per (query, node); node grouping/tagging happens at emit time.
             return result_rows
 
         except Exception as e:
@@ -315,57 +323,17 @@ class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
             raise
 
     @staticmethod
-    def _merge_rows_across_nodes(node_rows):
+    def _group_rows_by_node(rows):
         """
-        Merge per-(query, node) rows into per-query rows.
+        Group query-metric rows by their ClickHouse node (``server_node``).
 
-        Summable metrics (count, total_time, …) are summed.
-        peak_memory_usage takes the max.
-        Non-metric fields are taken from the node with the highest execution count.
+        Each group is emitted as its own payload tagged with ``clickhouse_node``.
+        Rows without a node value are grouped under '' (single-node / direct connection).
         """
         groups = {}
-        for row in node_rows:
-            key = row['normalized_query_hash']
-            if key not in groups:
-                groups[key] = []
-            groups[key].append(row)
-
-        result = []
-        for rows in groups.values():
-            if len(rows) == 1:
-                result.append(rows[0])
-                continue
-
-            base = max(rows, key=lambda r: r.get('count', 0))
-            merged = dict(base)
-
-            sum_fields = [
-                'count',
-                'total_time',
-                'read_rows',
-                'read_bytes',
-                'written_rows',
-                'written_bytes',
-                'result_rows',
-                'result_bytes',
-                'memory_usage',
-                'cpu_us',
-                'cpu_wait_us',
-            ]
-            for field in sum_fields:
-                merged[field] = sum(r.get(field, 0) for r in rows)
-
-            merged['peak_memory_usage'] = max(r.get('peak_memory_usage', 0) for r in rows)
-
-            total_count = merged['count']
-            if total_count > 0:
-                merged['mean_time'] = merged['total_time'] / total_count
-            else:
-                merged['mean_time'] = 0.0
-
-            result.append(merged)
-
-        return result
+        for row in rows:
+            groups.setdefault(row.get('server_node', ''), []).append(row)
+        return groups
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _collect_metrics_rows(self):
@@ -448,6 +416,9 @@ class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
                 "db:{}".format(db),
                 "user:{}".format(user),
             ]
+            server_node = row.get('server_node')
+            if server_node:
+                row_tags.append(node_tag(server_node))
 
             yield {
                 "timestamp": time.time() * 1000,

--- a/clickhouse/datadog_checks/clickhouse/table_metrics.py
+++ b/clickhouse/datadog_checks/clickhouse/table_metrics.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
 from datadog_checks.base.utils.tracking import tracked_method
+from datadog_checks.clickhouse.utils import node_tag
 
 DEFAULT_COLLECTION_INTERVAL = 60
 
@@ -140,7 +141,7 @@ class ClickhouseTableMetrics(DBMAsyncJob):
         # per-view series carries exactly one `db:` tag — the view's own database.
         base_tags = [t for t in self._check.tags if not t.startswith('db:')]
         for database, view_name, host, status, _exception, last_time, next_time, written_rows, written_bytes in rows:
-            view_tags = base_tags + [f'db:{database}', f'view:{view_name}', f'host:{host}']
+            view_tags = base_tags + [f'db:{database}', f'view:{view_name}', f'host:{host}', node_tag(host)]
             refresh_status = _VIEW_REFRESH_STATUS_MAP.get(status, AgentCheck.UNKNOWN)
             self._check.gauge('view.refresh.status', refresh_status, tags=view_tags)
             self._check.gauge('view.refresh.last_time', int(last_time or 0), tags=view_tags)

--- a/clickhouse/datadog_checks/clickhouse/utils.py
+++ b/clickhouse/datadog_checks/clickhouse/utils.py
@@ -31,6 +31,11 @@ def compact_query(query):
 CLUSTER_NODE_TAG = 'clickhouse_node'
 
 
+def node_tag(node: str) -> str:
+    """Build the per-node tag (``clickhouse_node:<node>``) attached to node-scoped data."""
+    return f"{CLUSTER_NODE_TAG}:{node}"
+
+
 def cluster_aware_query(base: dict) -> dict:
     """Build a cluster-aware variant that reads all replicas and tags each row per node.
 

--- a/clickhouse/tests/test_dbm_integration.py
+++ b/clickhouse/tests/test_dbm_integration.py
@@ -298,8 +298,10 @@ def test_samples_event_structure(instance):
 
     with mock.patch('datadog_checks.clickhouse.statement_samples.datadog_agent') as mock_agent:
         mock_agent.get_version.return_value = '7.64.0'
-        event = samples._create_samples_event(rows, active_connections)
+        events = samples._create_samples_events(rows, active_connections)
 
+    assert len(events) == 1
+    event = events[0]
     assert event['ddsource'] == 'clickhouse'
     assert event['dbm_type'] == 'activity'
     assert 'host' in event

--- a/clickhouse/tests/test_parts_and_merges.py
+++ b/clickhouse/tests/test_parts_and_merges.py
@@ -388,6 +388,7 @@ def test_emit_gauges_thresholds(check):
     for _, tags in by_name.values():
         assert not any(t.startswith('database:') or t.startswith('table:') for t in tags)
         assert 'server_node:node-1' in tags
+        assert 'clickhouse_node:node-1' in tags
 
 
 def test_collect_detached_parts_normalizes(check):

--- a/clickhouse/tests/test_query_completions.py
+++ b/clickhouse/tests/test_query_completions.py
@@ -151,10 +151,11 @@ def test_create_batched_payload_query_details(check_with_dbm):
 
     with mock.patch('datadog_checks.clickhouse.query_completions.datadog_agent') as mock_agent:
         mock_agent.get_version.return_value = '7.64.0'
-        payload = query_completions._create_batched_payload(rows)
+        payloads = query_completions._create_batched_payloads(rows)
 
-    # Verify payload has completions
-    assert payload is not None
+    # Single-node collection produces exactly one payload
+    assert len(payloads) == 1
+    payload = payloads[0]
     assert len(payload['clickhouse_query_completions']) == 1
 
     # Verify query_details structure
@@ -199,7 +200,10 @@ def test_create_batched_payload_structure(check_with_dbm):
 
     with mock.patch('datadog_checks.clickhouse.query_completions.datadog_agent') as mock_agent:
         mock_agent.get_version.return_value = '7.64.0'
-        payload = query_completions._create_batched_payload(rows)
+        payloads = query_completions._create_batched_payloads(rows)
+
+    assert len(payloads) == 1
+    payload = payloads[0]
 
     # Verify payload structure
     assert payload['ddsource'] == 'clickhouse'
@@ -212,6 +216,48 @@ def test_create_batched_payload_structure(check_with_dbm):
     assert len(payload['clickhouse_query_completions']) == 2
     assert payload['clickhouse_query_completions'][0]['query_details']['statement'] == 'SELECT * FROM users'
     assert payload['clickhouse_query_completions'][1]['query_details']['statement'] == 'INSERT INTO events VALUES (?)'
+
+
+def test_create_batched_payloads_splits_per_node(check_with_dbm):
+    """Completions from different nodes are split into one payload per node, each node-tagged."""
+    query_completions = check_with_dbm.query_completions
+    query_completions._tags_no_db = ['test:clickhouse']
+
+    rows = [
+        {
+            'statement': 'SELECT * FROM users',
+            'query_signature': 'sig-node-1',
+            'query_duration_ms': 100.0,
+            'databases': 'default',
+            'user': 'default',
+            'hostname': 'node-1',
+        },
+        {
+            'statement': 'SELECT * FROM events',
+            'query_signature': 'sig-node-2',
+            'query_duration_ms': 200.0,
+            'databases': 'default',
+            'user': 'default',
+            'hostname': 'node-2',
+        },
+    ]
+
+    with mock.patch('datadog_checks.clickhouse.query_completions.datadog_agent') as mock_agent:
+        mock_agent.get_version.return_value = '7.64.0'
+        payloads = query_completions._create_batched_payloads(rows)
+
+    assert len(payloads) == 2
+    by_node = {}
+    for payload in payloads:
+        node_tags = [t for t in payload['ddtags'] if t.startswith('clickhouse_node:')]
+        assert len(node_tags) == 1, payload['ddtags']
+        node = node_tags[0].split(':', 1)[1]
+        by_node[node] = payload
+        assert payload['database_instance'] == check_with_dbm.database_identifier
+        for completion in payload['clickhouse_query_completions']:
+            assert completion['query_details']['hostname'] == node
+
+    assert set(by_node) == {'node-1', 'node-2'}
 
 
 def test_rate_limiting(check_with_dbm):

--- a/clickhouse/tests/test_query_errors.py
+++ b/clickhouse/tests/test_query_errors.py
@@ -152,9 +152,10 @@ def test_create_batched_payload_error_fields(check_with_dbm):
 
     with mock.patch('datadog_checks.clickhouse.query_errors.datadog_agent') as mock_agent:
         mock_agent.get_version.return_value = '7.64.0'
-        payload = query_errors._create_batched_payload(rows)
+        payloads = query_errors._create_batched_payloads(rows)
 
-    assert payload is not None
+    assert len(payloads) == 1
+    payload = payloads[0]
     assert len(payload['clickhouse_query_errors']) == 1
 
     query_details = payload['clickhouse_query_errors'][0]['query_details']
@@ -185,8 +186,10 @@ def test_create_batched_payload_structure(check_with_dbm):
 
     with mock.patch('datadog_checks.clickhouse.query_errors.datadog_agent') as mock_agent:
         mock_agent.get_version.return_value = '7.64.0'
-        payload = query_errors._create_batched_payload(rows)
+        payloads = query_errors._create_batched_payloads(rows)
 
+    assert len(payloads) == 1
+    payload = payloads[0]
     assert payload['ddsource'] == 'clickhouse'
     assert payload['dbm_type'] == 'query_error'
     assert 'clickhouse_query_errors' in payload
@@ -198,6 +201,46 @@ def test_create_batched_payload_structure(check_with_dbm):
     assert payload['collection_interval'] == query_errors._collection_interval
     assert 'clickhouse_version' in payload
     assert 'service' in payload
+
+
+def test_create_batched_payloads_splits_per_node(check_with_dbm):
+    """Errors from different nodes are split into one payload per node, each node-tagged."""
+    query_errors = check_with_dbm.query_errors
+    query_errors._tags_no_db = ['test:clickhouse']
+
+    rows = [
+        {
+            'statement': 'SELECT * FROM t1',
+            'query_signature': 'sig-node-1',
+            'exception': 'boom',
+            'exception_code': 60,
+            'hostname': 'node-1',
+        },
+        {
+            'statement': 'SELECT * FROM t2',
+            'query_signature': 'sig-node-2',
+            'exception': 'boom',
+            'exception_code': 60,
+            'hostname': 'node-2',
+        },
+    ]
+
+    with mock.patch('datadog_checks.clickhouse.query_errors.datadog_agent') as mock_agent:
+        mock_agent.get_version.return_value = '7.64.0'
+        payloads = query_errors._create_batched_payloads(rows)
+
+    assert len(payloads) == 2
+    by_node = {}
+    for payload in payloads:
+        node_tags = [t for t in payload['ddtags'] if t.startswith('clickhouse_node:')]
+        assert len(node_tags) == 1, payload['ddtags']
+        node = node_tags[0].split(':', 1)[1]
+        by_node[node] = payload
+        assert payload['database_instance'] == check_with_dbm.database_identifier
+        for error in payload['clickhouse_query_errors']:
+            assert error['query_details']['hostname'] == node
+
+    assert set(by_node) == {'node-1', 'node-2'}
 
 
 def test_query_errors_sql_query_format():
@@ -278,7 +321,7 @@ def test_collect_and_submit_no_rows(check_with_dbm):
     with (
         mock.patch.object(query_errors, '_collect_query_errors', return_value=[]) as mock_collect,
         mock.patch.object(query_errors, '_advance_checkpoint') as mock_advance,
-        mock.patch.object(query_errors, '_create_batched_payload') as mock_payload,
+        mock.patch.object(query_errors, '_create_batched_payloads') as mock_payload,
     ):
         query_errors._collect_and_submit()
 
@@ -294,7 +337,7 @@ def test_collect_and_submit_all_rate_limited(check_with_dbm):
 
     with (
         mock.patch.object(query_errors, '_collect_query_errors', return_value=rows),
-        mock.patch.object(query_errors, '_create_batched_payload', return_value=None) as mock_payload,
+        mock.patch.object(query_errors, '_create_batched_payloads', return_value=[]) as mock_payload,
         mock.patch.object(query_errors, '_advance_checkpoint') as mock_advance,
         mock.patch.object(query_errors._check, 'database_monitoring_query_activity') as mock_submit,
     ):

--- a/clickhouse/tests/test_statement_metrics.py
+++ b/clickhouse/tests/test_statement_metrics.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from unittest import mock
+
 import pytest
 
 from datadog_checks.base.utils.db.sql import compute_sql_signature
@@ -512,127 +514,83 @@ def test_statements_query_format():
     assert "ProfileEvents['OSCPUWaitMicroseconds']" in STATEMENTS_QUERY
 
 
-def test_merge_rows_across_nodes_single_node():
-    """When a query only appears on one node, it should pass through unchanged."""
-    from datadog_checks.clickhouse.statements import ClickhouseStatementMetrics
-
+def test_group_rows_by_node_single_node():
+    """Rows from a single node are grouped under that node."""
     rows = [
-        {
+        {'normalized_query_hash': 'hash1', 'server_node': 'node-1', 'count': 10},
+        {'normalized_query_hash': 'hash2', 'server_node': 'node-1', 'count': 5},
+    ]
+
+    groups = ClickhouseStatementMetrics._group_rows_by_node(rows)
+    assert set(groups) == {'node-1'}
+    assert len(groups['node-1']) == 2
+
+
+def test_group_rows_by_node_keeps_nodes_separate():
+    """Per-(query, node) rows are kept separate — never summed across nodes."""
+    rows = [
+        {'normalized_query_hash': 'hash1', 'server_node': 'node-1', 'count': 100},
+        {'normalized_query_hash': 'hash1', 'server_node': 'node-2', 'count': 50},
+    ]
+
+    groups = ClickhouseStatementMetrics._group_rows_by_node(rows)
+    assert set(groups) == {'node-1', 'node-2'}
+    assert groups['node-1'][0]['count'] == 100
+    assert groups['node-2'][0]['count'] == 50
+
+
+def test_group_rows_by_node_without_node():
+    """Rows without a server_node (single-node / direct connection) group under ''."""
+    rows = [{'normalized_query_hash': 'hash1', 'count': 10}]
+    groups = ClickhouseStatementMetrics._group_rows_by_node(rows)
+    assert set(groups) == {''}
+
+
+def test_collect_and_submit_emits_one_payload_per_node(check_with_dbm):
+    """Query metrics are emitted as one payload per node, each carrying clickhouse_node."""
+    metrics = check_with_dbm.statement_metrics
+    metrics._tags_no_db = ['test:clickhouse']
+
+    def make_row(node, count):
+        return {
             'normalized_query_hash': 'hash1',
+            'server_node': node,
             'query': 'SELECT 1',
-            'count': 10,
-            'total_time': 100.0,
-            'mean_time': 10.0,
-            'read_rows': 100,
-            'read_bytes': 1000,
-            'written_rows': 0,
-            'written_bytes': 0,
-            'result_rows': 10,
-            'result_bytes': 500,
-            'memory_usage': 5000,
-            'peak_memory_usage': 8000,
-            'cpu_us': 80000,
-            'cpu_wait_us': 8000,
+            'query_signature': 'sig1',
+            'user': 'default',
+            'databases': 'mydb',
+            'dd_tables': [],
+            'dd_commands': [],
+            'dd_comments': None,
+            'count': count,
+            'total_time': float(count),
         }
-    ]
 
-    result = ClickhouseStatementMetrics._merge_rows_across_nodes(rows)
-    assert len(result) == 1
-    assert result[0]['count'] == 10
-    assert result[0]['total_time'] == 100.0
-    assert result[0]['cpu_us'] == 80000
-    assert result[0]['cpu_wait_us'] == 8000
+    rows = [make_row('node-1', 10), make_row('node-2', 20)]
 
+    submitted = []
+    with (
+        mock.patch.object(metrics, '_collect_metrics_rows', return_value=rows),
+        mock.patch.object(metrics, '_advance_checkpoint'),
+        mock.patch.object(metrics._check, 'database_monitoring_query_sample'),
+        mock.patch.object(metrics._check, 'database_monitoring_query_metrics', side_effect=submitted.append),
+    ):
+        metrics._collect_and_submit()
 
-def test_merge_rows_across_nodes_sums_counts():
-    """Summable metrics should be added across nodes."""
-    from datadog_checks.clickhouse.statements import ClickhouseStatementMetrics
+    payloads = [json.loads(p) for p in submitted]
+    tags_by_node = {}
+    for payload in payloads:
+        node_tags = [t for t in payload['tags'] if t.startswith('clickhouse_node:')]
+        assert len(node_tags) == 1, payload['tags']
+        node = node_tags[0].split(':', 1)[1]
+        tags_by_node[node] = payload
+        # database_instance (cluster-level) is present on every split payload
+        assert payload['database_instance'] == check_with_dbm.database_identifier
+        # each payload only carries rows from its own node
+        for row in payload['clickhouse_rows']:
+            assert row['server_node'] == node
 
-    rows = [
-        {
-            'normalized_query_hash': 'hash1',
-            'query': 'SELECT 1',
-            'count': 100,
-            'total_time': 500.0,
-            'mean_time': 5.0,
-            'read_rows': 1000,
-            'read_bytes': 10000,
-            'written_rows': 0,
-            'written_bytes': 0,
-            'result_rows': 100,
-            'result_bytes': 5000,
-            'memory_usage': 50000,
-            'peak_memory_usage': 80000,
-            'cpu_us': 500000,
-            'cpu_wait_us': 50000,
-        },
-        {
-            'normalized_query_hash': 'hash1',
-            'query': 'SELECT 1',
-            'count': 50,
-            'total_time': 300.0,
-            'mean_time': 6.0,
-            'read_rows': 500,
-            'read_bytes': 5000,
-            'written_rows': 10,
-            'written_bytes': 100,
-            'result_rows': 50,
-            'result_bytes': 2500,
-            'memory_usage': 30000,
-            'peak_memory_usage': 90000,
-            'cpu_us': 300000,
-            'cpu_wait_us': 30000,
-        },
-    ]
-
-    result = ClickhouseStatementMetrics._merge_rows_across_nodes(rows)
-    assert len(result) == 1
-
-    merged = result[0]
-    assert merged['count'] == 150
-    assert merged['total_time'] == 800.0
-    assert merged['read_rows'] == 1500
-    assert merged['read_bytes'] == 15000
-    assert merged['written_rows'] == 10
-    assert merged['written_bytes'] == 100
-    assert merged['result_rows'] == 150
-    assert merged['result_bytes'] == 7500
-    assert merged['memory_usage'] == 80000
-    assert merged['peak_memory_usage'] == 90000
-    assert merged['cpu_us'] == 800000
-    assert merged['cpu_wait_us'] == 80000
-    assert merged['mean_time'] == 800.0 / 150
-
-
-def test_merge_rows_across_nodes_different_queries():
-    """Rows with different query hashes should not be merged."""
-    from datadog_checks.clickhouse.statements import ClickhouseStatementMetrics
-
-    base = {
-        'query': 'q',
-        'count': 10,
-        'total_time': 100.0,
-        'mean_time': 10.0,
-        'read_rows': 0,
-        'read_bytes': 0,
-        'written_rows': 0,
-        'written_bytes': 0,
-        'result_rows': 0,
-        'result_bytes': 0,
-        'memory_usage': 0,
-        'peak_memory_usage': 0,
-        'cpu_us': 80000,
-        'cpu_wait_us': 8000,
-    }
-
-    rows = [
-        {**base, 'normalized_query_hash': 'hash1'},
-        {**base, 'normalized_query_hash': 'hash2'},
-        {**base, 'normalized_query_hash': 'hash3'},
-    ]
-
-    result = ClickhouseStatementMetrics._merge_rows_across_nodes(rows)
-    assert len(result) == 3
+    assert set(tags_by_node) == {'node-1', 'node-2'}
 
 
 def test_metrics_row_with_empty_values(check_with_dbm):

--- a/clickhouse/tests/test_statement_samples.py
+++ b/clickhouse/tests/test_statement_samples.py
@@ -125,7 +125,11 @@ def test_create_samples_event(check_with_dbm):
 
     with mock.patch('datadog_checks.clickhouse.statement_samples.datadog_agent') as mock_agent:
         mock_agent.get_version.return_value = '7.64.0'
-        event = samples._create_samples_event(rows, active_connections)
+        events = samples._create_samples_events(rows, active_connections)
+
+    # Without node info this is a single cluster-level event
+    assert len(events) == 1
+    event = events[0]
 
     # Verify event structure
     assert event['ddsource'] == 'clickhouse'
@@ -141,6 +145,52 @@ def test_create_samples_event(check_with_dbm):
     # Verify connections payload
     assert 'clickhouse_connections' in event
     assert len(event['clickhouse_connections']) == 1
+
+
+def test_create_samples_events_splits_per_node(check_with_dbm):
+    """Sessions and connections from different nodes are split into one event per node."""
+    samples = check_with_dbm.statement_samples
+    samples._tags_no_db = ['test:clickhouse']
+
+    rows = [
+        {'statement': 'SELECT 1', 'query_signature': 'sig1', 'user': 'default', 'server_node': 'node-1'},
+        {'statement': 'SELECT 2', 'query_signature': 'sig2', 'user': 'default', 'server_node': 'node-2'},
+    ]
+    active_connections = [
+        {
+            'user': 'default',
+            'query_kind': 'Select',
+            'current_database': 'default',
+            'connections': 5,
+            'server_node': 'node-1',
+        },
+        {
+            'user': 'default',
+            'query_kind': 'Select',
+            'current_database': 'default',
+            'connections': 3,
+            'server_node': 'node-2',
+        },
+    ]
+
+    with mock.patch('datadog_checks.clickhouse.statement_samples.datadog_agent') as mock_agent:
+        mock_agent.get_version.return_value = '7.64.0'
+        events = samples._create_samples_events(rows, active_connections)
+
+    assert len(events) == 2
+    by_node = {}
+    for event in events:
+        node_tags = [t for t in event['ddtags'] if t.startswith('clickhouse_node:')]
+        assert len(node_tags) == 1, event['ddtags']
+        node = node_tags[0].split(':', 1)[1]
+        by_node[node] = event
+        assert event['database_instance'] == check_with_dbm.database_identifier
+        for session in event['clickhouse_activity']:
+            assert session['server_node'] == node
+        for connection in event['clickhouse_connections']:
+            assert connection['server_node'] == node
+
+    assert set(by_node) == {'node-1', 'node-2'}
 
 
 def test_active_queries_query_format():
@@ -168,6 +218,9 @@ def test_active_queries_query_format():
     assert 'thread_ids' in ACTIVE_QUERIES_QUERY
     assert 'is_cancelled' in ACTIVE_QUERIES_QUERY
 
+    # Per-node identity
+    assert 'hostName() as server_node' in ACTIVE_QUERIES_QUERY
+
 
 def test_active_connections_query_format():
     """Test that the active connections query is properly formatted"""
@@ -179,6 +232,10 @@ def test_active_connections_query_format():
     # Verify aggregation
     assert 'count(*)' in ACTIVE_CONNECTIONS_QUERY
     assert 'GROUP BY' in ACTIVE_CONNECTIONS_QUERY
+
+    # Per-node identity in SELECT and GROUP BY
+    assert 'hostName() as server_node' in ACTIVE_CONNECTIONS_QUERY
+    assert 'GROUP BY user, query_kind, current_database, server_node' in ACTIVE_CONNECTIONS_QUERY
 
 
 def test_get_debug_tags(check_with_dbm):
@@ -195,7 +252,7 @@ def test_normalize_row_with_all_fields(check_with_dbm):
     """Test that all fields are properly normalized from system.processes"""
     samples = check_with_dbm.statement_samples
 
-    # Create a mock row with all 26 fields from ACTIVE_QUERIES_QUERY
+    # Create a mock row with all 27 fields from ACTIVE_QUERIES_QUERY
     mock_row = (
         1.234,  # elapsed
         'abc-123-def',  # query_id
@@ -223,6 +280,7 @@ def test_normalize_row_with_all_fields(check_with_dbm):
         'app-server-01',  # client_hostname
         0,  # is_cancelled
         'python-requests/2.28.0',  # http_user_agent
+        'clickhouse-node-1',  # server_node
     )
 
     normalized_row = samples._normalize_row(mock_row)
@@ -261,6 +319,9 @@ def test_normalize_row_with_all_fields(check_with_dbm):
 
     # Verify HTTP field
     assert normalized_row['http_user_agent'] == 'python-requests/2.28.0'
+
+    # Verify per-node field
+    assert normalized_row['server_node'] == 'clickhouse-node-1'
 
     # Verify obfuscation happened
     assert 'statement' in normalized_row

--- a/clickhouse/tests/test_table_metrics.py
+++ b/clickhouse/tests/test_table_metrics.py
@@ -200,6 +200,7 @@ def test_collect_view_refresh_emits_gauges(check):
     assert 'db:mydb' in by_name['view.refresh.status'][1]
     assert 'view:mv_orders' in by_name['view.refresh.status'][1]
     assert 'host:replica-1' in by_name['view.refresh.status'][1]
+    assert 'clickhouse_node:replica-1' in by_name['view.refresh.status'][1]
     assert by_name['view.refresh.rows'][0] == 500
     assert by_name['view.refresh.bytes'][0] == 4096
 

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -438,9 +438,14 @@ def test_get_queries_tags_system_tables_per_node_in_single_endpoint_mode(instanc
         assert 'hostName() AS clickhouse_node' in query['query']
         assert query['columns'][-1] == {'name': 'clickhouse_node', 'type': 'tag'}
 
-    # system.parts/replicas/dictionaries use GROUP BY and are intentionally left untouched here.
+    # system.parts uses GROUP BY, so cluster_aware_query would put hostName() outside the
+    # GROUP BY (invalid SQL) — it is intentionally left un-wrapped. system.replicas and
+    # system.dictionaries have no GROUP BY and are wrapped for per-node tagging.
     if not use_advanced_queries:
         assert any(q is queries.SystemParts for q in check.get_queries())
+        cluster_aware_tables = ' '.join(q['query'] for q in cluster_aware)
+        assert "clusterAllReplicas('default', system.replicas)" in cluster_aware_tables
+        assert "clusterAllReplicas('default', system.dictionaries)" in cluster_aware_tables
 
 
 @pytest.mark.parametrize('use_advanced_queries', [True, False])

--- a/clickhouse/tests/test_utils.py
+++ b/clickhouse/tests/test_utils.py
@@ -34,3 +34,40 @@ class TestErrorSanitizer:
 )
 def test_parse_version(version: str, expected: list[int]):
     expected == utils.parse_version(version)
+
+
+@pytest.mark.unit
+def test_node_tag():
+    assert utils.node_tag('node-1') == 'clickhouse_node:node-1'
+    assert utils.CLUSTER_NODE_TAG == 'clickhouse_node'
+
+
+@pytest.mark.unit
+def test_cluster_aware_query_adds_node_tag():
+    base = {
+        'name': 'system.metrics',
+        'query': 'SELECT value, metric FROM system.metrics',
+        'columns': [{'name': 'value', 'type': 'gauge'}, {'name': 'metric', 'type': 'tag'}],
+    }
+
+    result = utils.cluster_aware_query(base)
+
+    # Reads all replicas and selects hostName() as the per-node tag
+    assert "clusterAllReplicas('default', system.metrics)" in result['query']
+    assert 'hostName() AS clickhouse_node' in result['query']
+    # The node column is appended as a tag column
+    assert result['columns'][-1] == {'name': 'clickhouse_node', 'type': 'tag'}
+
+
+@pytest.mark.unit
+def test_cluster_aware_query_preserves_trailing_clause():
+    base = {
+        'name': 'system.errors',
+        'query': 'SELECT value, name FROM system.errors WHERE value > 0',
+        'columns': [{'name': 'value', 'type': 'gauge'}, {'name': 'name', 'type': 'tag'}],
+    }
+
+    result = utils.cluster_aware_query(base)
+
+    assert "clusterAllReplicas('default', system.errors)" in result['query']
+    assert 'WHERE value > 0' in result['query']


### PR DESCRIPTION
### What does this PR do?

Adds a uniform, additive per-node tag (`clickhouse_node`, value = ClickHouse `hostName()`) to every ClickHouse check that carries node-specific data, so metrics/samples/etc. can be sliced (and billed) per node. `database_instance` stays cluster-level, so existing cluster grouping/filtering is unaffected.

Changes by area:
- **utils**: new `node_tag()` helper (reuses the existing `CLUSTER_NODE_TAG = 'clickhouse_node'`).
- **Standard metrics** (`get_queries`): `system.replicas` and `system.dictionaries` are now read via `clusterAllReplicas` and tagged per node in single-endpoint mode. `system.parts` is intentionally left plain — its `GROUP BY` is incompatible with the `cluster_aware_query` rewrite; per-node parts data comes from the DBM parts/merges check.
- **Query metrics** (`statements.py`): rows are no longer merged across nodes (`_merge_rows_across_nodes` removed). Rows are grouped by node and emitted as **one payload per node**, each carrying `clickhouse_node`. FQT events are node-tagged too.
- **Query completions / errors / samples**: payloads are split per node, each tagged `clickhouse_node`. `ACTIVE_QUERIES_QUERY` / `ACTIVE_CONNECTIONS_QUERY` now select `hostName()`.
- **parts_and_merges / table_metrics (view refreshes)**: `clickhouse_node` added alongside the existing `server_node:` / `host:` tags (kept for backward compatibility).

### Motivation

ClickHouse Cloud billing is moving to per-node. Today the resource primary key is `database_instance`, which is cluster-level, and most check data is aggregated across nodes before it leaves the Agent — so there is no reliable way to attribute metrics to a node. This makes every node-scoped check emit a consistent per-node tag.

**Breaking behavior:** query-metrics per-query series change from cluster-summed to per-node; cluster totals must be re-aggregated across `clickhouse_node`. Acceptable while the feature is in preview.

**Open dependency:** the per-node approach emits multiple `database_monitoring_query_metrics` / `query_activity` payloads for the same `(database_instance, timestamp)`. This assumes the DBM intake does not dedupe on that key — needs confirmation with the dbm-metrics-processor team before merge.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged