### PR TITLE
Update Anthropic cost data latency to 24-48 hours

### DIFF
--- a/anthropic_usage_and_costs/README.md
+++ b/anthropic_usage_and_costs/README.md
@@ -49,7 +49,7 @@ Copy the API key to a secure location after you generate it.
 3. (Optional) Enable **Cost data ingestion** to send cost data to [Cloud Cost Management][6]. This requires Cloud Cost Management to be enabled on your Datadog account.
 4. Click **Save Configuration**.
 
-After you save the configuration, Datadog begins polling the appropriate Anthropic usage and cost endpoints and populates metrics in your environment. Usage metrics typically appear within 10 minutes, and cost data appears in Cloud Cost Management within 24 hours.
+After you save the configuration, Datadog begins polling the appropriate Anthropic usage and cost endpoints and populates metrics in your environment. Usage metrics typically appear within 10 minutes, and cost data appears in Cloud Cost Management within 24-48 hours.
 
 ## Data Collected
 


### PR DESCRIPTION
### What does this PR do?
Updates the Anthropic Usage and Costs integration README to say cost data appears in Cloud Cost Management within 24-48 hours, instead of 24 hours.

### Motivation
Fixes DOCS-15132

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged