### PR TITLE
Rename mem_pool_index tag to mem in cisco-firepower-asa profile

### DIFF
--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-firepower-asa.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-firepower-asa.yaml
@@ -52,7 +52,7 @@ metrics:
         symbol:
           OID: 1.3.6.1.4.1.9.9.221.1.1.1.1.3
           name: cempMemPoolName
-      - tag: mem_pool_index
+      - tag: mem
         index: 1
   - MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
     symbol:

--- a/snmp/tests/test_e2e_core_profiles/test_profile_cisco_firepower_asa.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_cisco_firepower_asa.py
@@ -49,7 +49,7 @@ def test_e2e_profile_cisco_firepower_asa(dd_agent_check):
     aggregator.assert_metric('snmp.crasNumSetupFailInsufResources', metric_type=aggregator.COUNT, tags=common_tags)
     aggregator.assert_metric('snmp.crasNumUsers', metric_type=aggregator.GAUGE, tags=common_tags)
     mem_tag_rows = [
-        ['mem_pool_index:1', 'mem_pool_name:System memory'],
+        ['mem:1', 'mem_pool_name:System memory'],
     ]
     for tag_row in mem_tag_rows:
         aggregator.assert_metric('snmp.memory.free', metric_type=aggregator.GAUGE, tags=common_tags + tag_row)


### PR DESCRIPTION
### What does this PR do?
Renames the `mem_pool_index` metric tag to `mem` in the `cisco-firepower-asa` SNMP profile's memory metrics (`CISCO-ENHANCED-MEMPOOL-MIB`).

### Motivation
This tag name is inconsistent with other profiles using the same `CISCO-ENHANCED-MEMPOOL-MIB`/`cempMemPoolTable`, such as `cisco-nexus`, which tags the same index as `mem`. This PR aligns `cisco-firepower-asa` with that convention.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged