### PR TITLE
Show context clears in AI run logs

### DIFF
--- a/ddev/src/ddev/ai/callbacks/callbacks.py
+++ b/ddev/src/ddev/ai/callbacks/callbacks.py
@@ -53,6 +53,12 @@ class AfterCompactCallback(Protocol):
     async def __call__(self, scope: AgentScope) -> None: ...
 
 
+class OnContextClearedCallback(Protocol):
+    """Called immediately after the agent's conversation history is cleared."""
+
+    async def __call__(self, scope: AgentScope) -> None: ...
+
+
 class OnAgentFinishCallback(Protocol):
     """Called when the ReAct loop exits cleanly."""
 
@@ -122,6 +128,7 @@ class CallbackSet:
         self._on_tool_call: list[OnToolCallCallback] = []
         self._before_compact: list[BeforeCompactCallback] = []
         self._after_compact: list[AfterCompactCallback] = []
+        self._on_context_cleared: list[OnContextClearedCallback] = []
         self._on_agent_finish: list[OnAgentFinishCallback] = []
         self._on_agent_error: list[OnAgentErrorCallback] = []
         self._on_phase_start: list[OnPhaseStartCallback] = []
@@ -177,6 +184,13 @@ class CallbackSet:
 
     async def fire_after_compact(self, scope: AgentScope) -> None:
         await self._fire(self._after_compact, scope)
+
+    def on_context_cleared(self, func: OnContextClearedCallback) -> OnContextClearedCallback:
+        self._on_context_cleared.append(func)
+        return func
+
+    async def fire_context_cleared(self, scope: AgentScope) -> None:
+        await self._fire(self._on_context_cleared, scope)
 
     def on_agent_finish(self, func: OnAgentFinishCallback) -> OnAgentFinishCallback:
         self._on_agent_finish.append(func)
@@ -256,6 +270,10 @@ class Callbacks:
     async def fire_after_compact(self, scope: AgentScope) -> None:
         for s in self._sets:
             await s.fire_after_compact(scope)
+
+    async def fire_context_cleared(self, scope: AgentScope) -> None:
+        for s in self._sets:
+            await s.fire_context_cleared(scope)
 
     async def fire_agent_finish(self, scope: AgentScope, result: ReActResult) -> None:
         for s in self._sets:

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -168,7 +168,7 @@ class AgenticPhase(Phase):
         last_result: ReActResult | None,
     ) -> None:
         if task.clear_context_before:
-            process.reset()
+            await process.reset()
             return
 
         if task.compact_context_before:

--- a/ddev/src/ddev/ai/phases/goal.py
+++ b/ddev/src/ddev/ai/phases/goal.py
@@ -224,7 +224,7 @@ async def _drive_goal_loop(
             )
 
             if attempts > 1:
-                reviewer_process.reset()
+                await reviewer_process.reset()
 
             check = await _run_reviewer_once(reviewer_process, user_message)
             total_in += check.input_tokens

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -61,9 +61,10 @@ class ReActProcess:
         self._scope = scope
         self._compact_threshold_pct = compact_threshold_pct
 
-    def reset(self) -> None:
+    async def reset(self) -> None:
         """Clear the agent's conversation history."""
         self._agent.reset()
+        await self._callbacks.fire_context_cleared(self._scope)
 
     async def compact(self, response: AgentResponse | None = None) -> tuple[int, int]:
         """Compact the agent's conversation history unconditionally.

--- a/ddev/src/ddev/ai/runtime/agent_log.py
+++ b/ddev/src/ddev/ai/runtime/agent_log.py
@@ -127,6 +127,10 @@ class AgentLogger:
         async def _on_after_compact(scope: AgentScope) -> None:
             self._emit(scope, {"event": "after_compact"})
 
+        @cb.on_context_cleared
+        async def _on_context_cleared(scope: AgentScope) -> None:
+            self._emit(scope, {"event": "context_cleared"})
+
         @cb.on_agent_finish
         async def _on_agent_finish(scope: AgentScope, result: ReActResult) -> None:
             self._emit(

--- a/ddev/src/ddev/cli/meta/ai/rendering.py
+++ b/ddev/src/ddev/cli/meta/ai/rendering.py
@@ -277,6 +277,11 @@ def render_compact_notice() -> Text:
     return Text("  ⋯ compacting context", style="dim")
 
 
+def render_context_cleared_notice() -> Text:
+    """Build the context-cleared notice line."""
+    return Text("  ↻ context cleared", style="dim")
+
+
 def render_agent_finish_line(scope: AgentScope, result: ReActResult) -> Text:
     """Build the ``✓ <owner_id> — N iters, X in / Y out`` summary line."""
     return Text(

--- a/ddev/src/ddev/cli/meta/ai/tui/app.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/app.py
@@ -30,6 +30,7 @@ from ddev.cli.meta.ai.tui.messages import (
     AgentToolCalled,
     BeforeCompact,
     BeforeGoalCheck,
+    ContextCleared,
     PhaseFinished,
     PhaseStarted,
 )
@@ -166,6 +167,9 @@ class TogoApp(App):
         self._record(msg)
 
     async def on_after_compact(self, msg: AfterCompact) -> None:
+        self._record(msg)
+
+    async def on_context_cleared(self, msg: ContextCleared) -> None:
         self._record(msg)
 
     async def on_before_goal_check(self, msg: BeforeGoalCheck) -> None:

--- a/ddev/src/ddev/cli/meta/ai/tui/bridge.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/bridge.py
@@ -29,6 +29,7 @@ from ddev.cli.meta.ai.tui.messages import (
     AgentToolCalled,
     BeforeCompact,
     BeforeGoalCheck,
+    ContextCleared,
     PhaseFinished,
     PhaseStarted,
 )
@@ -89,6 +90,10 @@ def build_app_callback_set(app: BridgeApp) -> CallbackSet:
     @cb.on_after_compact
     async def _(scope: AgentScope) -> None:
         _target().post_message(AfterCompact(scope))
+
+    @cb.on_context_cleared
+    async def _(scope: AgentScope) -> None:
+        _target().post_message(ContextCleared(scope))
 
     @cb.on_agent_finish
     async def _(scope: AgentScope, result: ReActResult) -> None:

--- a/ddev/src/ddev/cli/meta/ai/tui/messages.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/messages.py
@@ -106,6 +106,14 @@ class AfterCompact(Message):
         self.scope = scope
 
 
+class ContextCleared(Message):
+    """Fired immediately after the agent's conversation history is cleared."""
+
+    def __init__(self, scope: AgentScope) -> None:
+        super().__init__()
+        self.scope = scope
+
+
 class AgentBeforeSend(Message):
     """Fired just before each agent.send() with the prompt content (sentinel excluded)."""
 

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -25,6 +25,7 @@ from ddev.cli.meta.ai.rendering import (
     render_agent_start_header,
     render_agent_tools_line,
     render_compact_notice,
+    render_context_cleared_notice,
     render_prompt_panel,
     render_response_header,
     render_response_text,
@@ -44,6 +45,7 @@ from ddev.cli.meta.ai.tui.messages import (
     AgentToolCalled,
     BeforeCompact,
     BeforeGoalCheck,
+    ContextCleared,
     ExecutionFailed,
     PhaseFinished,
     PhaseStarted,
@@ -323,6 +325,9 @@ class ExecutionScreen(TogoScreen):
 
     def on_before_compact(self, msg: BeforeCompact) -> None:
         self._write_output(render_compact_notice(), phase_id=msg.scope.phase_id)
+
+    def on_context_cleared(self, msg: ContextCleared) -> None:
+        self._write_output(render_context_cleared_notice(), phase_id=msg.scope.phase_id)
 
     def on_agent_finished(self, msg: AgentFinished) -> None:
         phase_id = msg.scope.phase_id

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -357,6 +357,7 @@ MarkdownH3 {
 
 .task-prompt-scroll {
     height: 1fr;
+    min-height: 13;
     overflow-y: auto;
 }
 

--- a/ddev/tests/ai/callbacks/test_callbacks.py
+++ b/ddev/tests/ai/callbacks/test_callbacks.py
@@ -237,6 +237,34 @@ async def test_after_compact_registered_and_fired(scope: AgentScope) -> None:
     assert fired == [scope]
 
 
+async def test_context_cleared_registered_and_fired(scope: AgentScope) -> None:
+    cb = CallbackSet()
+    fired: list[AgentScope] = []
+
+    @cb.on_context_cleared
+    async def h(scope: AgentScope) -> None:
+        fired.append(scope)
+
+    await cb.fire_context_cleared(scope)
+    assert fired == [scope]
+
+
+async def test_context_cleared_callback_exception_is_swallowed(scope: AgentScope) -> None:
+    cb = CallbackSet()
+    fired: list[bool] = []
+
+    @cb.on_context_cleared
+    async def bad(scope: AgentScope) -> None:
+        raise RuntimeError("boom")
+
+    @cb.on_context_cleared
+    async def good(scope: AgentScope) -> None:
+        fired.append(True)
+
+    await cb.fire_context_cleared(scope)
+    assert fired == [True]
+
+
 async def test_compact_callback_exception_is_swallowed(scope: AgentScope) -> None:
     cb = CallbackSet()
     fired: list[bool] = []
@@ -553,6 +581,7 @@ async def test_callbacks_empty_is_noop(
     await callbacks.fire_agent_error(scope, RuntimeError("boom"))
     await callbacks.fire_before_compact(scope)
     await callbacks.fire_after_compact(scope)
+    await callbacks.fire_context_cleared(scope)
     await callbacks.fire_before_agent_send(scope, "p", 1)
     await callbacks.fire_phase_start("p")
     await callbacks.fire_phase_finish("p")

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -628,7 +628,7 @@ async def test_clear_context_before_resets_history(flow_dir, monkeypatch, messag
             make_response("summary", 10, 5),
         ]
     )
-    phase, _ = make_agent_phase(
+    phase, mgr = make_agent_phase(
         flow_dir,
         mock_agent,
         monkeypatch,
@@ -643,6 +643,8 @@ async def test_clear_context_before_resets_history(flow_dir, monkeypatch, messag
 
     assert mock_agent.reset_call_count == 1
     assert mock_agent.compact_call_count == 0
+    events = read_jsonl(mgr.root / "phase" / "p1.jsonl")
+    assert "context_cleared" in {event["event"] for event in events}
 
 
 async def test_clear_context_before_skips_auto_compact(flow_dir, monkeypatch, message_queue):

--- a/ddev/tests/ai/react/test_process.py
+++ b/ddev/tests/ai/react/test_process.py
@@ -86,6 +86,7 @@ class CallbackRecorder:
         self.errors: list[BaseException] = []
         self.before_compacts: int = 0
         self.after_compacts: int = 0
+        self.context_clears: list[AgentScope] = []
 
         self.callback_set = CallbackSet()
 
@@ -120,6 +121,10 @@ class CallbackRecorder:
         @self.callback_set.on_after_compact
         async def _record_after_compact(scope: AgentScope) -> None:
             self.after_compacts += 1
+
+        @self.callback_set.on_context_cleared
+        async def _record_context_cleared(scope: AgentScope) -> None:
+            self.context_clears.append(scope)
 
 
 def make_response(
@@ -748,11 +753,13 @@ async def test_context_usage_propagated(context_usage: ContextUsage | None) -> N
 # ---------------------------------------------------------------------------
 
 
-async def test_reset_delegates_to_agent() -> None:
+async def test_reset_delegates_to_agent_and_fires_callback() -> None:
     agent = MockAgent([])
-    make_process(agent).reset()
+    recorder = CallbackRecorder()
+    await make_process(agent, callbacks=Callbacks([recorder.callback_set])).reset()
     assert agent.reset_calls == 1
     assert agent.history == []
+    assert recorder.context_clears == [DEFAULT_SCOPE]
 
 
 async def test_compact_delegates_to_agent_returns_zero_when_no_op() -> None:

--- a/ddev/tests/ai/runtime/test_agent_log.py
+++ b/ddev/tests/ai/runtime/test_agent_log.py
@@ -119,6 +119,16 @@ async def test_compact_events_recorded(tmp_path):
     assert [e["event"] for e in events] == ["before_compact", "after_compact"]
 
 
+async def test_context_cleared_event_recorded(tmp_path):
+    logger = AgentLogger(tmp_path)
+    cb = logger.as_callback_set()
+
+    await cb.fire_context_cleared(PHASE)
+
+    events = read_events(tmp_path / "phase" / "p1.jsonl")
+    assert [e["event"] for e in events] == ["context_cleared"]
+
+
 async def test_reused_scope_appends_to_same_file(tmp_path):
     logger = AgentLogger(tmp_path)
     cb = logger.as_callback_set()

--- a/ddev/tests/cli/meta/ai/test_rendering.py
+++ b/ddev/tests/cli/meta/ai/test_rendering.py
@@ -38,6 +38,7 @@ from ddev.cli.meta.ai.rendering import (
     render_agent_start_header,
     render_agent_tools_line,
     render_compact_notice,
+    render_context_cleared_notice,
     render_prompt_panel,
     render_response_header,
     render_response_text,
@@ -439,6 +440,12 @@ def test_render_compact_notice_returns_text():
     result = render_compact_notice()
     assert isinstance(result, Text)
     assert "compact" in result.plain.lower()
+
+
+def test_render_context_cleared_notice_returns_text():
+    result = render_context_cleared_notice()
+    assert isinstance(result, Text)
+    assert "context cleared" in result.plain.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/cli/meta/ai/tui/test_bridge.py
+++ b/ddev/tests/cli/meta/ai/tui/test_bridge.py
@@ -25,6 +25,7 @@ from ddev.cli.meta.ai.tui.messages import (
     AgentToolCalled,
     BeforeCompact,
     BeforeGoalCheck,
+    ContextCleared,
     PhaseFinished,
     PhaseStarted,
 )
@@ -78,6 +79,7 @@ class StubOrchestrator:
         await self.cb_set.fire_tool_call(SCOPE, tool_call, result, 1)
         await self.cb_set.fire_before_compact(SCOPE)
         await self.cb_set.fire_after_compact(SCOPE)
+        await self.cb_set.fire_context_cleared(SCOPE)
         await self.cb_set.fire_agent_finish(SCOPE, _make_react_result())
         await self.cb_set.fire_agent_error(SCOPE, ValueError("boom"))
         await self.cb_set.fire_before_goal_check("phase1", "task1", 1)
@@ -175,6 +177,12 @@ async def test_after_compact_payload(received_from_stub):
     assert msgs[0].scope is SCOPE
 
 
+async def test_context_cleared_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, ContextCleared)]
+    assert len(msgs) == 1
+    assert msgs[0].scope is SCOPE
+
+
 async def test_agent_finished_payload(received_from_stub):
     msgs = [m for m in received_from_stub if isinstance(m, AgentFinished)]
     assert len(msgs) == 1
@@ -207,8 +215,8 @@ async def test_after_goal_check_payload(received_from_stub):
     assert msgs[0].reason == "looks good"
 
 
-async def test_all_11_messages_delivered(make_togo_app):
-    """Every one of the 11 bridge event types delivers exactly one message to the sink."""
+async def test_all_12_messages_delivered(make_togo_app):
+    """Every bridge event type delivers exactly one message to the sink."""
     app = make_togo_app([])
     async with app.run_test() as pilot:
         cb = build_app_callback_set(app)
@@ -216,7 +224,7 @@ async def test_all_11_messages_delivered(make_togo_app):
         app.run_flow(stub)
         await pilot.pause(0.3)
 
-    assert len(app.received) == 11
+    assert len(app.received) == 12
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -643,6 +643,22 @@ def test_scoped_goal_event_only_mutates_identified_phase() -> None:
     assert screen._task_statuses[("phase_2", "shared_task")] is RunStatus.FAILED
 
 
+def test_context_cleared_notice_is_written_to_scoped_phase_log() -> None:
+    from ddev.ai.agent.scope import AgentRole, AgentScope
+    from ddev.cli.meta.ai.tui.messages import ContextCleared
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    screen = ExecutionScreen(flow)
+    scope = AgentScope(owner_id="phase_1", role=AgentRole.PHASE, phase_id="phase_1")
+
+    screen.on_context_cleared(ContextCleared(scope))
+
+    assert len(screen._phase_logs["phase_1"]) == 1
+    assert "context cleared" in screen._phase_logs["phase_1"][0].plain.lower()
+    assert screen._phase_logs["phase_2"] == []
+
+
 async def test_pipeline_phase_running_during_execution():
     """A phase being run by _FakeOrchestrator transitions through 'running'."""
     from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet


### PR DESCRIPTION
### What does this PR do?

Adds a context-cleared callback that fires whenever a ReAct process resets its conversation history. The event is recorded in the agent JSONL log and shown in the Togo phase log as `↻ context cleared`.

**UX screenshot:**

<img width="676" height="46" alt="image (1)" src="https://github.com/user-attachments/assets/6514cb63-1f21-4a5f-8dcf-17261f386314" />


### Motivation

Make context resets visible during AI runs, especially between tasks that use `clear_context_before`, so users can understand why the next task starts with fresh context.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged