### PR TITLE
Emit untagged telemetry when OpenMetrics reaches its metric limit

### DIFF
--- a/datadog_checks_base/changelog.d/24588.added
+++ b/datadog_checks_base/changelog.d/24588.added
@@ -1,0 +1,1 @@
+Emit untagged OpenMetrics Agent telemetry when ``max_returned_metrics`` is reached.

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -172,6 +172,8 @@ class AgentCheck(object):
     # See https://github.com/DataDog/integrations-core/pull/2093 for more information.
     DEFAULT_METRIC_LIMIT = 0
 
+    EMIT_OPENMETRICS_LIMIT_TELEMETRY = False
+
     # Allow tracing for classic integrations
     def __init_subclass__(cls, *args, **kwargs):
         try:
@@ -1610,6 +1612,20 @@ class AgentCheck(object):
             error_report = json.encode([{'message': message, 'traceback': tb}])
         finally:
             if self.metric_limiter:
+                reached_limit = self.metric_limiter.reached_limit
+                if self.EMIT_OPENMETRICS_LIMIT_TELEMETRY and reached_limit:
+                    try:
+                        emit_agent_telemetry = getattr(datadog_agent, 'emit_agent_telemetry', None)
+                        if callable(emit_agent_telemetry):
+                            emit_agent_telemetry(
+                                'openmetrics',
+                                'max_returned_metrics_reached',
+                                1,
+                                'counter',
+                            )
+                    except Exception:
+                        self.log.debug('Failed to emit OpenMetrics metric limit telemetry', exc_info=True)
+
                 if is_affirmative(self.debug_metrics.get('metric_contexts', False)):
                     debug_metrics = self.metric_limiter.get_debug_metrics()
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -172,8 +172,6 @@ class AgentCheck(object):
     # See https://github.com/DataDog/integrations-core/pull/2093 for more information.
     DEFAULT_METRIC_LIMIT = 0
 
-    EMIT_OPENMETRICS_LIMIT_TELEMETRY = False
-
     # Allow tracing for classic integrations
     def __init_subclass__(cls, *args, **kwargs):
         try:
@@ -1613,18 +1611,8 @@ class AgentCheck(object):
         finally:
             if self.metric_limiter:
                 reached_limit = self.metric_limiter.reached_limit
-                if self.EMIT_OPENMETRICS_LIMIT_TELEMETRY and reached_limit:
-                    try:
-                        emit_agent_telemetry = getattr(datadog_agent, 'emit_agent_telemetry', None)
-                        if callable(emit_agent_telemetry):
-                            emit_agent_telemetry(
-                                'openmetrics',
-                                'max_returned_metrics_reached',
-                                1,
-                                'counter',
-                            )
-                    except Exception:
-                        self.log.debug('Failed to emit OpenMetrics metric limit telemetry', exc_info=True)
+                if reached_limit:
+                    self._on_metric_limit_reached()
 
                 if is_affirmative(self.debug_metrics.get('metric_contexts', False)):
                     debug_metrics = self.metric_limiter.get_debug_metrics()
@@ -1639,6 +1627,22 @@ class AgentCheck(object):
                 self.metric_limiter.reset()
 
         return error_report
+
+    def _on_metric_limit_reached(self) -> None:
+        pass
+
+    def _emit_openmetrics_limit_telemetry(self) -> None:
+        try:
+            emit_agent_telemetry = getattr(datadog_agent, 'emit_agent_telemetry', None)
+            if callable(emit_agent_telemetry):
+                emit_agent_telemetry(
+                    'openmetrics',
+                    'max_returned_metrics_reached',
+                    1,
+                    'counter',
+                )
+        except Exception:
+            self.log.debug('Failed to emit OpenMetrics metric limit telemetry', exc_info=True)
 
     def run_check_initializations(self):
         while self.check_initializations:

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1636,7 +1636,7 @@ class AgentCheck(object):
             emit_agent_telemetry = getattr(datadog_agent, 'emit_agent_telemetry', None)
             if callable(emit_agent_telemetry):
                 emit_agent_telemetry(
-                    'openmetrics',
+                    'checks',
                     'max_returned_metrics_reached',
                     1,
                     'counter',

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -56,7 +56,9 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
     """
 
     DEFAULT_METRIC_LIMIT = 2000
-    EMIT_OPENMETRICS_LIMIT_TELEMETRY = True
+
+    def _on_metric_limit_reached(self) -> None:
+        self._emit_openmetrics_limit_telemetry()
 
     HTTP_CONFIG_REMAPPER = {
         'ssl_verify': {'name': 'tls_verify'},

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -56,6 +56,7 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
     """
 
     DEFAULT_METRIC_LIMIT = 2000
+    EMIT_OPENMETRICS_LIMIT_TELEMETRY = True
 
     HTTP_CONFIG_REMAPPER = {
         'ssl_verify': {'name': 'tls_verify'},

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -41,7 +41,9 @@ class OpenMetricsBaseCheckV2(AgentCheck):
     """
 
     DEFAULT_METRIC_LIMIT = 2000
-    EMIT_OPENMETRICS_LIMIT_TELEMETRY = True
+
+    def _on_metric_limit_reached(self) -> None:
+        self._emit_openmetrics_limit_telemetry()
 
     METRICS_MAP: tuple[MetricsMapping, ...] = ()
     """YAML files with metric name mappings to load automatically.

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -41,6 +41,7 @@ class OpenMetricsBaseCheckV2(AgentCheck):
     """
 
     DEFAULT_METRIC_LIMIT = 2000
+    EMIT_OPENMETRICS_LIMIT_TELEMETRY = True
 
     METRICS_MAP: tuple[MetricsMapping, ...] = ()
     """YAML files with metric name mappings to load automatically.

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 import mock
 import pytest
 
-from datadog_checks.base import AgentCheck, to_native_string
+from datadog_checks.base import AgentCheck, OpenMetricsBaseCheck, OpenMetricsBaseCheckV2, to_native_string
 from datadog_checks.base import __version__ as base_package_version
 
 from .utils import BaseModelTest
@@ -1162,6 +1162,14 @@ class LimitedCheck(AgentCheck):
             self.gauge('foo', i)
 
 
+class TelemetryLimitedCheck(LimitedCheck):
+    EMIT_OPENMETRICS_LIMIT_TELEMETRY = True
+
+
+OPENMETRICS_LIMIT_TELEMETRY = ('openmetrics', 'max_returned_metrics_reached', 1, 'counter')
+METRIC_LIMIT_WARNING = 'Check test exceeded limit of 3 metrics, ignoring next ones'
+
+
 class TestLimits:
     def test_context_uid(self, aggregator):
         check = LimitedCheck()
@@ -1273,6 +1281,98 @@ class TestLimits:
         for _ in range(12):
             check.gauge("metric", 0)
         assert len(aggregator.metrics("metric")) == 10
+
+    def test_openmetrics_limit_telemetry_emitted_once(self, aggregator):
+        check = TelemetryLimitedCheck('test', {}, [{'max_returned_metrics': 3}])
+
+        with patch('datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry') as emit_agent_telemetry:
+            assert check.run() == ''
+
+        emit_agent_telemetry.assert_called_once_with(*OPENMETRICS_LIMIT_TELEMETRY)
+        assert check.get_warnings() == [METRIC_LIMIT_WARNING]
+        assert len(aggregator.metrics('foo')) == 3
+
+    def test_openmetrics_limit_telemetry_not_emitted_before_limit(self, aggregator):
+        check = TelemetryLimitedCheck('test', {}, [{'max_returned_metrics': 5}])
+
+        with patch('datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry') as emit_agent_telemetry:
+            assert check.run() == ''
+
+        emit_agent_telemetry.assert_not_called()
+        assert check.get_warnings() == []
+        assert len(aggregator.metrics('foo')) == 5
+
+    def test_generic_check_does_not_emit_openmetrics_limit_telemetry(self, aggregator):
+        check = LimitedCheck('test', {}, [{'max_returned_metrics': 3}])
+        assert check.EMIT_OPENMETRICS_LIMIT_TELEMETRY is False
+
+        with patch('datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry') as emit_agent_telemetry:
+            assert check.run() == ''
+
+        emit_agent_telemetry.assert_not_called()
+        assert check.get_warnings() == [METRIC_LIMIT_WARNING]
+        assert len(aggregator.metrics('foo')) == 3
+
+    def test_missing_agent_telemetry_method_is_ignored(self, aggregator, datadog_agent, monkeypatch):
+        check = TelemetryLimitedCheck('test', {}, [{'max_returned_metrics': 3}])
+        monkeypatch.delattr(type(datadog_agent), 'emit_agent_telemetry')
+
+        assert check.run() == ''
+        assert check.get_warnings() == [METRIC_LIMIT_WARNING]
+        assert len(aggregator.metrics('foo')) == 3
+        assert check.metric_limiter.get_status() == (0, 3, False)
+
+    def test_agent_telemetry_exception_is_ignored(self, aggregator, caplog):
+        check = TelemetryLimitedCheck('test', {}, [{'max_returned_metrics': 3}])
+        caplog.set_level(logging.DEBUG)
+
+        with patch(
+            'datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry',
+            side_effect=RuntimeError('bridge unavailable'),
+        ) as emit_agent_telemetry:
+            assert check.run() == ''
+
+        emit_agent_telemetry.assert_called_once_with(*OPENMETRICS_LIMIT_TELEMETRY)
+        assert check.get_warnings() == [METRIC_LIMIT_WARNING]
+        assert len(aggregator.metrics('foo')) == 3
+        assert check.metric_limiter.get_status() == (0, 3, False)
+        assert any(
+            record.levelno == logging.DEBUG and record.message == 'Failed to emit OpenMetrics metric limit telemetry'
+            for record in caplog.records
+        )
+
+    def test_openmetrics_limit_telemetry_emitted_once_per_run(self, aggregator):
+        check = TelemetryLimitedCheck('test', {}, [{'max_returned_metrics': 3}])
+
+        with patch('datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry') as emit_agent_telemetry:
+            assert check.run() == ''
+            assert check.run() == ''
+
+        assert emit_agent_telemetry.call_count == 2
+        emit_agent_telemetry.assert_called_with(*OPENMETRICS_LIMIT_TELEMETRY)
+        assert check.get_warnings() == [METRIC_LIMIT_WARNING, METRIC_LIMIT_WARNING]
+        assert len(aggregator.metrics('foo')) == 6
+
+    def test_debug_metrics_do_not_emit_extra_openmetrics_limit_telemetry(self, aggregator):
+        instance = {'debug_metrics': {'metric_contexts': True}, 'max_returned_metrics': 3}
+        check = TelemetryLimitedCheck('test', {}, [instance])
+
+        with patch('datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry') as emit_agent_telemetry:
+            assert check.run() == ''
+
+        emit_agent_telemetry.assert_called_once_with(*OPENMETRICS_LIMIT_TELEMETRY)
+        aggregator.assert_metric('datadog.agent.metrics.contexts.limit', 3)
+        aggregator.assert_metric('datadog.agent.metrics.contexts.total', 5)
+
+    @pytest.mark.parametrize(
+        'openmetrics_base',
+        [
+            pytest.param(OpenMetricsBaseCheck, id='v1'),
+            pytest.param(OpenMetricsBaseCheckV2, id='v2'),
+        ],
+    )
+    def test_openmetrics_base_enables_limit_telemetry(self, openmetrics_base):
+        assert openmetrics_base.EMIT_OPENMETRICS_LIMIT_TELEMETRY is True
 
     def test_debug_metrics_under_limit(self, aggregator, dd_run_check):
         instance = {'debug_metrics': {'metric_contexts': True}}

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -1162,10 +1162,30 @@ class LimitedCheck(AgentCheck):
             self.gauge('foo', i)
 
 
-class TelemetryLimitedCheck(LimitedCheck):
-    EMIT_OPENMETRICS_LIMIT_TELEMETRY = True
+class LimitedOpenMetricsV1Check(OpenMetricsBaseCheck):
+    def check(self, _instance: dict[str, Any]) -> None:
+        for i in range(5):
+            self.gauge('foo', i)
 
 
+class LimitedOpenMetricsV2Check(OpenMetricsBaseCheckV2):
+    def configure_scrapers(self) -> None:
+        pass
+
+    def check(self, _instance: dict[str, Any]) -> None:
+        for i in range(5):
+            self.gauge('foo', i)
+
+
+OPENMETRICS_CHECK_CLASSES = (
+    pytest.param(LimitedOpenMetricsV1Check, id='v1'),
+    pytest.param(LimitedOpenMetricsV2Check, id='v2'),
+)
+OPENMETRICS_INSTANCE = {
+    'prometheus_url': 'http://example.com',
+    'namespace': 'test',
+    'metrics': ['foo'],
+}
 OPENMETRICS_LIMIT_TELEMETRY = ('openmetrics', 'max_returned_metrics_reached', 1, 'counter')
 METRIC_LIMIT_WARNING = 'Check test exceeded limit of 3 metrics, ignoring next ones'
 
@@ -1282,8 +1302,10 @@ class TestLimits:
             check.gauge("metric", 0)
         assert len(aggregator.metrics("metric")) == 10
 
-    def test_openmetrics_limit_telemetry_emitted_once(self, aggregator):
-        check = TelemetryLimitedCheck('test', {}, [{'max_returned_metrics': 3}])
+    @pytest.mark.parametrize('openmetrics_check_class', OPENMETRICS_CHECK_CLASSES)
+    def test_openmetrics_limit_telemetry_emitted_once(self, aggregator, openmetrics_check_class):
+        instance = {**OPENMETRICS_INSTANCE, 'max_returned_metrics': 3}
+        check = openmetrics_check_class('test', {}, [instance])
 
         with patch('datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry') as emit_agent_telemetry:
             assert check.run() == ''
@@ -1292,8 +1314,10 @@ class TestLimits:
         assert check.get_warnings() == [METRIC_LIMIT_WARNING]
         assert len(aggregator.metrics('foo')) == 3
 
-    def test_openmetrics_limit_telemetry_not_emitted_before_limit(self, aggregator):
-        check = TelemetryLimitedCheck('test', {}, [{'max_returned_metrics': 5}])
+    @pytest.mark.parametrize('openmetrics_check_class', OPENMETRICS_CHECK_CLASSES)
+    def test_openmetrics_limit_telemetry_not_emitted_before_limit(self, aggregator, openmetrics_check_class):
+        instance = {**OPENMETRICS_INSTANCE, 'max_returned_metrics': 5}
+        check = openmetrics_check_class('test', {}, [instance])
 
         with patch('datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry') as emit_agent_telemetry:
             assert check.run() == ''
@@ -1304,7 +1328,6 @@ class TestLimits:
 
     def test_generic_check_does_not_emit_openmetrics_limit_telemetry(self, aggregator):
         check = LimitedCheck('test', {}, [{'max_returned_metrics': 3}])
-        assert check.EMIT_OPENMETRICS_LIMIT_TELEMETRY is False
 
         with patch('datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry') as emit_agent_telemetry:
             assert check.run() == ''
@@ -1313,8 +1336,12 @@ class TestLimits:
         assert check.get_warnings() == [METRIC_LIMIT_WARNING]
         assert len(aggregator.metrics('foo')) == 3
 
-    def test_missing_agent_telemetry_method_is_ignored(self, aggregator, datadog_agent, monkeypatch):
-        check = TelemetryLimitedCheck('test', {}, [{'max_returned_metrics': 3}])
+    @pytest.mark.parametrize('openmetrics_check_class', OPENMETRICS_CHECK_CLASSES)
+    def test_missing_agent_telemetry_method_is_ignored(
+        self, aggregator, datadog_agent, monkeypatch, openmetrics_check_class
+    ):
+        instance = {**OPENMETRICS_INSTANCE, 'max_returned_metrics': 3}
+        check = openmetrics_check_class('test', {}, [instance])
         monkeypatch.delattr(type(datadog_agent), 'emit_agent_telemetry')
 
         assert check.run() == ''
@@ -1322,8 +1349,10 @@ class TestLimits:
         assert len(aggregator.metrics('foo')) == 3
         assert check.metric_limiter.get_status() == (0, 3, False)
 
-    def test_agent_telemetry_exception_is_ignored(self, aggregator, caplog):
-        check = TelemetryLimitedCheck('test', {}, [{'max_returned_metrics': 3}])
+    @pytest.mark.parametrize('openmetrics_check_class', OPENMETRICS_CHECK_CLASSES)
+    def test_agent_telemetry_exception_is_ignored(self, aggregator, caplog, openmetrics_check_class):
+        instance = {**OPENMETRICS_INSTANCE, 'max_returned_metrics': 3}
+        check = openmetrics_check_class('test', {}, [instance])
         caplog.set_level(logging.DEBUG)
 
         with patch(
@@ -1341,8 +1370,10 @@ class TestLimits:
             for record in caplog.records
         )
 
-    def test_openmetrics_limit_telemetry_emitted_once_per_run(self, aggregator):
-        check = TelemetryLimitedCheck('test', {}, [{'max_returned_metrics': 3}])
+    @pytest.mark.parametrize('openmetrics_check_class', OPENMETRICS_CHECK_CLASSES)
+    def test_openmetrics_limit_telemetry_emitted_once_per_run(self, aggregator, openmetrics_check_class):
+        instance = {**OPENMETRICS_INSTANCE, 'max_returned_metrics': 3}
+        check = openmetrics_check_class('test', {}, [instance])
 
         with patch('datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry') as emit_agent_telemetry:
             assert check.run() == ''
@@ -1353,9 +1384,14 @@ class TestLimits:
         assert check.get_warnings() == [METRIC_LIMIT_WARNING, METRIC_LIMIT_WARNING]
         assert len(aggregator.metrics('foo')) == 6
 
-    def test_debug_metrics_do_not_emit_extra_openmetrics_limit_telemetry(self, aggregator):
-        instance = {'debug_metrics': {'metric_contexts': True}, 'max_returned_metrics': 3}
-        check = TelemetryLimitedCheck('test', {}, [instance])
+    @pytest.mark.parametrize('openmetrics_check_class', OPENMETRICS_CHECK_CLASSES)
+    def test_debug_metrics_do_not_emit_extra_openmetrics_limit_telemetry(self, aggregator, openmetrics_check_class):
+        instance = {
+            **OPENMETRICS_INSTANCE,
+            'debug_metrics': {'metric_contexts': True},
+            'max_returned_metrics': 3,
+        }
+        check = openmetrics_check_class('test', {}, [instance])
 
         with patch('datadog_checks.base.checks.base.datadog_agent.emit_agent_telemetry') as emit_agent_telemetry:
             assert check.run() == ''
@@ -1363,16 +1399,6 @@ class TestLimits:
         emit_agent_telemetry.assert_called_once_with(*OPENMETRICS_LIMIT_TELEMETRY)
         aggregator.assert_metric('datadog.agent.metrics.contexts.limit', 3)
         aggregator.assert_metric('datadog.agent.metrics.contexts.total', 5)
-
-    @pytest.mark.parametrize(
-        'openmetrics_base',
-        [
-            pytest.param(OpenMetricsBaseCheck, id='v1'),
-            pytest.param(OpenMetricsBaseCheckV2, id='v2'),
-        ],
-    )
-    def test_openmetrics_base_enables_limit_telemetry(self, openmetrics_base):
-        assert openmetrics_base.EMIT_OPENMETRICS_LIMIT_TELEMETRY is True
 
     def test_debug_metrics_under_limit(self, aggregator, dd_run_check):
         instance = {'debug_metrics': {'metric_contexts': True}}

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -1186,7 +1186,7 @@ OPENMETRICS_INSTANCE = {
     'namespace': 'test',
     'metrics': ['foo'],
 }
-OPENMETRICS_LIMIT_TELEMETRY = ('openmetrics', 'max_returned_metrics_reached', 1, 'counter')
+OPENMETRICS_LIMIT_TELEMETRY = ('checks', 'max_returned_metrics_reached', 1, 'counter')
 METRIC_LIMIT_WARNING = 'Check test exceeded limit of 3 metrics, ignoring next ones'
 
 


### PR DESCRIPTION
### What does this PR do?

Emits the untagged `openmetrics.max_returned_metrics_reached` Agent telemetry counter once per OpenMetrics check run when the existing metric limiter reaches `max_returned_metrics`.

The producer checks the limiter's structured `reached_limit` state before reset, then uses the existing four-argument `datadog_agent.emit_agent_telemetry` API. OpenMetrics v1 and v2 opt in; generic `AgentCheck` limiters do not. Emission is best-effort and cannot alter warning, drop, or reset behavior.

The metric intentionally carries no tags, including no `check_name`.

### Motivation

AI-7012 asks for a fleet-wide COAT signal for silent OpenMetrics drops after `max_returned_metrics` is reached. An untagged first version provides that signal while avoiding warning-text parsing, new rtloader callbacks, and a generic labeled telemetry bridge.

Validation included focused metric-limiter tests covering v1/v2 opt-in, once-per-run emission, generic-check exclusion, old-Agent compatibility, bridge failure behavior, and debug metric contexts. The complete `datadog_checks_base` format/lint target also passed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
