### PR TITLE
show flow input types

### DIFF
--- a/ddev/src/ddev/cli/meta/ai/tui/screens/launch_modal.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/launch_modal.py
@@ -107,7 +107,7 @@ class LaunchModal(ModalScreen):
 
     def _compose_inputs(self) -> Iterator[Widget]:
         for inp in self.flow.inputs:
-            yield Label(inp.label.upper(), classes="eyebrow")
+            yield Label(f"{inp.label.upper()} ({inp.input_type.value})", classes="eyebrow")
             yield from self._widget_for(inp)
 
     def _widget_for(self, inp: FlowInput) -> Iterator[Widget]:

--- a/ddev/tests/cli/meta/ai/tui/test_launch_modal.py
+++ b/ddev/tests/cli/meta/ai/tui/test_launch_modal.py
@@ -35,6 +35,22 @@ async def test_launch_modal_occupies_at_least_half_viewport(make_launch_modal_ap
         assert launch_button.region.right == dialog.content_region.right
 
 
+async def test_input_labels_show_declared_types(make_launch_modal_app, all_flow_inputs) -> None:
+    app = make_launch_modal_app(all_flow_inputs)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        labels = [label.render().plain for label in app.screen.query("#launch-fields > Label.eyebrow")]
+
+        assert labels == [
+            "MY STRING (string)",
+            "MY NUMBER (number)",
+            "MY BOOL (boolean)",
+            "MY PATH (path)",
+        ]
+
+
 @pytest.mark.parametrize(
     "flow_input,widget_type,expected_value",
     [


### PR DESCRIPTION
### What does this PR do?
Adds type label for inputs:
<img width="1262" height="652" alt="image (2)" src="https://github.com/user-attachments/assets/79502406-0a1f-456e-a1dd-2f6ffe564083" />

### Motivation
Input types weren't shown so it was difficult to know when to provide a str and when to provide a Path or a number.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
