### PR TITLE
Backport #24553 to 7.82.x: return freed memory to the OS with malloc_trim after each run

### DIFF
--- a/kafka_consumer/changelog.d/24553.fixed
+++ b/kafka_consumer/changelog.d/24553.fixed
@@ -1,0 +1,1 @@
+Call malloc_trim after each run to return librdkafka's per-arena free memory to the OS and curb agent memory growth.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -1,8 +1,11 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import ctypes
+import ctypes.util
 import heapq
 import json
+import platform
 from collections import defaultdict
 from time import time
 
@@ -20,6 +23,29 @@ from datadog_checks.kafka_consumer.constants import (
 MAX_TIMESTAMPS = 1000
 
 LAG_EXTRAPOLATION_LIMIT_SECONDS = 600
+
+
+def load_malloc_trim():
+    """Return glibc's ``malloc_trim`` on Linux, or ``None`` where it is unavailable (macOS, musl)."""
+    if platform.system() != 'Linux':
+        return None
+    try:
+        libc = ctypes.CDLL(ctypes.util.find_library('c') or 'libc.so.6', use_errno=True)
+        trim = libc.malloc_trim
+    except (OSError, AttributeError):
+        return None
+    trim.argtypes = [ctypes.c_size_t]
+    trim.restype = ctypes.c_int
+    return trim
+
+
+MALLOC_TRIM = load_malloc_trim()
+
+
+def malloc_trim():
+    """Return glibc per-arena free memory to the OS after a run; no-op where unavailable."""
+    if MALLOC_TRIM is not None:
+        MALLOC_TRIM(0)
 
 
 class KafkaCheck(AgentCheck):
@@ -43,6 +69,12 @@ class KafkaCheck(AgentCheck):
 
     def check(self, _):
         """The main entrypoint of the check."""
+        try:
+            self._run_check()
+        finally:
+            malloc_trim()
+
+    def _run_check(self):
         # Fetch Kafka consumer offsets
 
         consumer_offsets = {}


### PR DESCRIPTION
### What does this PR do?
Backports #24553 to the `7.82.x` branch. Calls glibc `malloc_trim(0)` after every kafka_consumer check run (in a `finally`), so per-arena free memory is returned to the OS each cycle. It is resolved once at import via `ctypes` and is a no-op on platforms without it (macOS, musl).

### Motivation
librdkafka runs roughly one thread per broker, and on high-core hosts glibc spreads allocations across many per-thread arenas (default cap `8 x ncpu`). glibc only ever returns memory from the top of an arena's heap and never coalesces free chunks across arenas, so the transient allocations each run leaves behind accumulate as retained-but-unused memory and agent RSS ratchets upward. `malloc_trim(0)` walks the arenas and hands their free memory back to the OS, keeping RSS bounded without requiring a `MALLOC_ARENA_MAX` environment variable. Overhead is negligible for this check (runs are network-bound at several seconds).

The automated backport to `7.82.x` failed on a cherry-pick conflict (7.82.x lacks unrelated `base64`/`marshal` imports and constants added to `master` by other commits). Resolved manually, keeping only this PR's changes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged