### PR TITLE
Backport #24554 to 7.82.x: keep broker_timestamps in memory and persist every 5 minutes

### DIFF
--- a/kafka_consumer/changelog.d/24554.fixed
+++ b/kafka_consumer/changelog.d/24554.fixed
@@ -1,0 +1,1 @@
+Keep the DSM broker_timestamps cache in memory and persist it at most every 5 minutes to reduce per-run allocation churn and memory growth.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -21,6 +21,8 @@ MAX_TIMESTAMPS = 1000
 
 LAG_EXTRAPOLATION_LIMIT_SECONDS = 600
 
+BROKER_TIMESTAMPS_SAVE_INTERVAL = 300
+
 
 class KafkaCheck(AgentCheck):
     __NAMESPACE__ = 'kafka'
@@ -33,6 +35,8 @@ class KafkaCheck(AgentCheck):
         self._max_timestamps = int(self.instance.get('timestamp_history_size', MAX_TIMESTAMPS))
         self.client = KafkaClient(self.config, self.log)
         self.topic_partition_cache = {}
+        self.broker_timestamps = None
+        self.broker_timestamps_last_save = 0
         self.check_initializations.insert(0, self.config.validate_config)
 
         # Initialize cluster metadata collector
@@ -278,7 +282,10 @@ class KafkaCheck(AgentCheck):
         return self.client.list_consumer_group_offsets(groups)
 
     def _load_broker_timestamps(self, persistent_cache_key):
-        """Loads broker timestamps from persistent cache."""
+        """Return the in-memory broker timestamps, loading from persistent cache once on first run."""
+        if self.broker_timestamps is not None:
+            return self.broker_timestamps
+
         broker_timestamps = defaultdict(dict)
         try:
             for topic_partition, content in json.loads(self.read_persistent_cache(persistent_cache_key)).items():
@@ -286,7 +293,8 @@ class KafkaCheck(AgentCheck):
                     broker_timestamps[topic_partition][int(offset)] = timestamp
         except Exception as e:
             self.log.warning('Could not read broker timestamps from cache: %s', str(e))
-        return broker_timestamps
+        self.broker_timestamps = broker_timestamps
+        return self.broker_timestamps
 
     def _earliest_consumer_offsets(self, consumer_offsets):
         """Return the lowest committed offset per (topic, partition) across all consumer groups."""
@@ -313,8 +321,12 @@ class KafkaCheck(AgentCheck):
                 _visvalingam_whyatt(timestamps, max(2, self._max_timestamps // 2))
 
     def _save_broker_timestamps(self, broker_timestamps, persistent_cache_key):
-        """Saves broker timestamps to persistent cache."""
+        """Persist broker timestamps to disk, but only periodically to avoid per-run json churn."""
+        now = time()
+        if now - self.broker_timestamps_last_save < BROKER_TIMESTAMPS_SAVE_INTERVAL:
+            return
         self.write_persistent_cache(persistent_cache_key, json.dumps(broker_timestamps))
+        self.broker_timestamps_last_save = now
 
     def report_highwater_offsets(self, highwater_offsets, contexts_limit, cluster_id):
         """Report the broker highwater offsets."""


### PR DESCRIPTION
### What does this PR do?
Backports #24554 to the `7.82.x` branch. Keeps the DSM `broker_timestamps` history in memory across check runs (loaded from the persistent cache only once, on the first run) and persists it back to disk at most once every 5 minutes, instead of loading and dumping the whole structure on every run.

### Motivation
With Data Streams enabled, the `broker_timestamps` cache grows toward its per-cluster entry cap. Loading it from disk and re-dumping it on every run created a large transient allocation each cycle that scales with the cache size, fragmenting the heap and driving agent RSS up. Holding the structure in memory removes the per-run load/dump churn; periodic persistence (every 5 min) preserves restart durability while keeping write churn low. On agent restart at most a few minutes of timestamp history is lost, which is acceptable for lag-in-seconds interpolation.

See #incident-57455 for the impact on memory fragmentation.

Note: the `7.82.x` branch still persists `broker_timestamps` via `json.dumps`/`json.loads`, since the switch to `base64`+`marshal` serialization landed on `master` in a separate, later commit not covered by #24554. This backport applies the same in-memory/periodic-persistence behavior on top of the existing json-based read/write, and does not pull in the marshal/base64 change.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged