### PR TITLE
Fix mount_logs container startup on macOS Colima

### DIFF
--- a/datadog_checks_dev/changelog.d/24593.fixed
+++ b/datadog_checks_dev/changelog.d/24593.fixed
@@ -1,1 +1,1 @@
-Anchor ``mount_logs`` shared log files under ``$HOME`` on macOS so container bind mounts resolve to files on Colima.
+Fix test environments that mount logs (``mount_logs``) failing to start on macOS when Docker runs through Colima.

--- a/datadog_checks_dev/changelog.d/24593.fixed
+++ b/datadog_checks_dev/changelog.d/24593.fixed
@@ -1,0 +1,1 @@
+Anchor ``mount_logs`` shared log files under ``$HOME`` on macOS so container bind mounts resolve to files on Colima.

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -281,11 +281,7 @@ def using_windows_containers():
 
 
 def shared_logs_base_dir():
-    # On macOS the Docker daemon runs inside a VM. Colima shares only the user's home directory
-    # by default, so files created under $TMPDIR (/var/folders) are invisible to the daemon and a
-    # bind mount of such a file silently becomes an empty directory instead. Anchor shared log
-    # files under $HOME (shared by both Colima and Docker Desktop) so the bind source stays a real
-    # file. On Linux the daemon is local, so the default temp location works and we return None.
+    # macOS runs the daemon in a VM; Colima shares only $HOME, so keep bind sources there.
     if sys.platform != 'darwin':
         return None
 

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+import sys
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -13,7 +14,7 @@ from urllib.parse import urlparse
 
 from .conditions import CheckDockerLogs
 from .env import environment_run, get_state, save_state
-from .fs import create_file, file_exists
+from .fs import create_file, ensure_dir_exists, file_exists
 from .spec import load_spec
 from .structures import EnvVars, LazyFunction, TempDir
 from .subprocess import run_command
@@ -279,6 +280,20 @@ def using_windows_containers():
     return os_type == 'windows'
 
 
+def shared_logs_base_dir():
+    # On macOS the Docker daemon runs inside a VM. Colima shares only the user's home directory
+    # by default, so files created under $TMPDIR (/var/folders) are invisible to the daemon and a
+    # bind mount of such a file silently becomes an empty directory instead. Anchor shared log
+    # files under $HOME (shared by both Colima and Docker Desktop) so the bind source stays a real
+    # file. On Linux the daemon is local, so the default temp location works and we return None.
+    if sys.platform != 'darwin':
+        return None
+
+    base = os.path.join(os.path.expanduser('~'), '.cache', 'datadog-checks-dev', 'shared-logs')
+    ensure_dir_exists(base)
+    return base
+
+
 @contextmanager
 def shared_logs(example_log_configs, mount_whitelist=None):
     log_source = example_log_configs[0].get('source', 'check')
@@ -289,6 +304,7 @@ def shared_logs(example_log_configs, mount_whitelist=None):
 
     env_vars = {}
     docker_volumes = get_state('docker_volumes', [])
+    base_directory = shared_logs_base_dir()
 
     with ExitStack() as stack:
         for i, example_log_config in enumerate(example_log_configs, 1):
@@ -296,7 +312,7 @@ def shared_logs(example_log_configs, mount_whitelist=None):
                 continue
 
             log_name = 'dd_log_{}'.format(i)
-            d = stack.enter_context(TempDir(log_name))
+            d = stack.enter_context(TempDir(log_name, base_directory=base_directory))
 
             # Create the file that will ultimately be shared by containers
             shared_log_file = os.path.join(d, '{}_{}.log'.format(log_source, log_name))


### PR DESCRIPTION
### What does this PR do?

Anchors the shared log files created by `mount_logs` (in `datadog_checks_dev`'s `docker_run`) under `$HOME` on macOS instead of the default `$TMPDIR` (`/var/folders`).

### Motivation

On macOS the Docker daemon runs inside a VM. Colima, a common local Docker setup, shares only the user's home directory by default. The file that `shared_logs` creates under `$TMPDIR` is therefore invisible to the daemon, so Docker materializes the missing bind-mount source as an empty **directory**. Any container expecting a **file** at that mount path then breaks.

Concretely, this makes `ddev test <integration>` fail for any integration that uses `mount_logs=True` on Colima. For VoltDB it manifests as the `voltdb0` container crashing on startup: its log4j `DailyRollingFileAppender` targets `/var/log/voltdb.log` (bind-mounted from `${DD_LOG_1}`), finds a directory instead of a file, and dies with `java.io.FileNotFoundException: /var/log/voltdb.log (Is a directory)` followed by a `NullPointerException`. The environment fixture then exhausts its retries and every integration test errors during setup.

`$HOME` is shared by both Colima and Docker Desktop, so anchoring the shared-logs temp directory there fixes Colima without affecting Docker Desktop. Linux is unchanged (the daemon is local, so `$TMPDIR` is already daemon-visible), so CI behavior is unaffected.

Validation:
- `ddev test datadog_checks_dev` lint clean; `ddev test datadog_checks_dev -- -k docker` -> 28 passed.
- Before: `ddev test voltdb` on Colima -> `voltdb0` crashes with `(Is a directory)` NPE, all integration tests error at setup.
- After (code fix only, no `TMPDIR` override): `voltdb0` boots, no log4j crash, integration test passes (18s).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
