### PR TITLE
Migrate openstack_controller to the backend-neutral HTTP protocol

### DIFF
--- a/openstack_controller/changelog.d/24594.fixed
+++ b/openstack_controller/changelog.d/24594.fixed
@@ -1,1 +1,0 @@
-Build the keystoneauth session through the backend-neutral HTTP client protocol instead of the raw requests session.

--- a/openstack_controller/changelog.d/24594.fixed
+++ b/openstack_controller/changelog.d/24594.fixed
@@ -1,0 +1,1 @@
+Build the keystoneauth session through the backend-neutral HTTP client protocol instead of the raw requests session.

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
@@ -64,6 +64,16 @@ class ApiSdk(Api):
     def component_in_catalog(self, component_types):
         return self._catalog.has_component(component_types)
 
+    def _build_keystone_session(self, auth):
+        # keystoneauth builds its own transport; mirror the TLS config and headers from our HTTP
+        # client via the backend-neutral protocol surface instead of handing it the requests session.
+        return session.Session(
+            auth=auth,
+            verify=self.http.options['verify'],
+            cert=self.http.options['cert'],
+            additional_headers=self.http.options['headers'],
+        )
+
     def authorize_user(self):
         v3_auth = v3.Password(
             auth_url=self.cloud_config.get_auth_args().get('auth_url'),
@@ -71,7 +81,7 @@ class ApiSdk(Api):
             password=self.cloud_config.get_auth_args().get('password'),
             user_domain_name=self.cloud_config.get_auth_args().get('user_domain_name', DEFAULT_DOMAIN_ID),
         )
-        keystone_session = session.Session(auth=v3_auth, session=self.http.session)
+        keystone_session = self._build_keystone_session(v3_auth)
         self.connection = connection.Connection(
             cloud=self.config.openstack_cloud_name, session=keystone_session, region_name=self._region_id
         )
@@ -88,7 +98,7 @@ class ApiSdk(Api):
             user_domain_name=self.cloud_config.get_auth_args().get('user_domain_name', DEFAULT_DOMAIN_ID),
             system_scope="all",
         )
-        keystone_session = session.Session(auth=v3_auth, session=self.http.session)
+        keystone_session = self._build_keystone_session(v3_auth)
         self.connection = connection.Connection(
             cloud=self.config.openstack_cloud_name, session=keystone_session, region_name=self._region_id
         )
@@ -106,7 +116,7 @@ class ApiSdk(Api):
             project_id=project_id,
             project_domain_name=self.cloud_config.get_auth_args().get('project_domain_name', DEFAULT_DOMAIN_ID),
         )
-        keystone_session = session.Session(auth=v3_auth, session=self.http.session)
+        keystone_session = self._build_keystone_session(v3_auth)
         self.connection = connection.Connection(
             cloud=self.config.openstack_cloud_name, session=keystone_session, region_name=self._region_id
         )

--- a/openstack_controller/tests/conftest.py
+++ b/openstack_controller/tests/conftest.py
@@ -213,9 +213,10 @@ def openstack_v3_password(request, mock_responses):
 
 @pytest.fixture
 def openstack_session(openstack_v3_password, microversion_headers):
-    def session(auth, session):
-        microversion_headers[0] = session.headers.get('X-OpenStack-Nova-API-Version')
-        microversion_headers[1] = session.headers.get('X-OpenStack-Ironic-API-Version')
+    def session(auth, verify=None, cert=None, additional_headers=None):
+        headers = additional_headers or {}
+        microversion_headers[0] = headers.get('X-OpenStack-Nova-API-Version')
+        microversion_headers[1] = headers.get('X-OpenStack-Ironic-API-Version')
         return mock.MagicMock(
             project_id=auth.project_id,
             auth=auth,


### PR DESCRIPTION
### What does this PR do?

Migrates `openstack_controller` off the raw `requests.Session` and onto the backend-neutral `HTTPClient` protocol introduced in #24516. The three `authorize_*` methods in `api_sdk.py` no longer hand keystoneauth `self.http.session`; a new `_build_keystone_session` helper constructs keystoneauth's own `Session` from the protocol surface (`self.http.options['verify']`, `['cert']`, `['headers']`).

The keystone session's `additional_headers` carries the Nova and Ironic microversion headers so the openstacksdk data-plane connection keeps selecting the configured microversions. The test fixture `openstack_session` is updated to match the new session factory signature.

The requests backend is still in use underneath; this change only ensures openstack_controller talks to it exclusively through the neutral protocol.

### Motivation

Stacked on #24516. That PR left `openstack_controller` as the last in-tree consumer reaching into `self.http.session`, because keystoneauth needs to build its own transport and there was no protocol-native way to feed it TLS config and headers. This PR closes that gap so the integration no longer couples to `requests`.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged