### PR TITLE
[kafka_consumer] Emit consumer_membership DSM events

### DIFF
--- a/kafka_consumer/changelog.d/24601.added
+++ b/kafka_consumer/changelog.d/24601.added
@@ -1,0 +1,1 @@
+Emit a `consumer_membership` data-streams-message per consumer group with the Kafka cluster id, group id and current member ids.

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -22,7 +22,7 @@ from datadog_checks.kafka_consumer.constants import KAFKA_INTERNAL_TOPICS
 CONSUMER_GROUP_REBALANCING_STATES = frozenset({'PREPARING_REBALANCING', 'COMPLETING_REBALANCING'})
 
 
-def _str_attr(obj, attr):
+def _str_attr(obj: Any, attr: str) -> str:
     return getattr(obj, attr, '') or ''
 
 
@@ -808,20 +808,7 @@ class ClusterMetadataCollector:
             member_hash = hashlib.sha256(json.dumps(member_ids, separators=(',', ':')).encode()).hexdigest()
             current_member_hashes[group_id] = member_hash
 
-            self.check.event_platform_event(
-                json.dumps(
-                    {
-                        'collection_timestamp': int(time.time() * 1000),
-                        'kafka_cluster_id': cluster_id,
-                        **self.config._original_cluster_id_field(),
-                        'config_type': 'consumer_membership',
-                        'group_id': group_id,
-                        'member_ids': member_ids,
-                        'members': self._build_members_detail(members),
-                    }
-                ),
-                "data-streams-message",
-            )
+            self._emit_consumer_membership_event(cluster_id, group_id, member_ids, members)
 
             if prev_member_hashes is not None:
                 prev_hash = prev_member_hashes.get(group_id)
@@ -832,8 +819,9 @@ class ClusterMetadataCollector:
                 client_id = member.client_id
                 host = member.host
 
-                if hasattr(member, 'assignment') and member.assignment:
-                    partition_count = len(member.assignment.topic_partitions)
+                assignment = getattr(member, 'assignment', None)
+                if assignment:
+                    partition_count = len(assignment.topic_partitions)
 
                     # Member-level gauges deliberately use state_tags, not group_meta_tags: the
                     # group-level dimensional tags are omitted here to keep per-member cardinality bounded.
@@ -848,7 +836,23 @@ class ClusterMetadataCollector:
 
         self._save_member_hashes_cache(current_member_hashes)
 
-    def _build_members_detail(self, members):
+    def _emit_consumer_membership_event(self, cluster_id, group_id, member_ids, members) -> None:
+        self.check.event_platform_event(
+            json.dumps(
+                {
+                    'collection_timestamp': int(time.time() * 1000),
+                    'kafka_cluster_id': cluster_id,
+                    **self.config._original_cluster_id_field(),
+                    'config_type': 'consumer_membership',
+                    'group_id': group_id,
+                    'member_ids': member_ids,
+                    'members': self._build_members_detail(members),
+                }
+            ),
+            "data-streams-message",
+        )
+
+    def _build_members_detail(self, members) -> list[dict[str, Any]]:
         members_detail = []
         for member in members:
             assignment = getattr(member, 'assignment', None)

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -804,8 +804,6 @@ class ClusterMetadataCollector:
             member_hash = hashlib.sha256(json.dumps(member_ids, separators=(',', ':')).encode()).hexdigest()
             current_member_hashes[group_id] = member_hash
 
-            # Per-member detail. client_id and host come back on the describe response for free, so
-            # include them alongside the member id for DSM to correlate.
             members_detail = sorted(
                 (
                     {
@@ -818,9 +816,6 @@ class ClusterMetadataCollector:
                 key=lambda m: m['member_id'],
             )
 
-            # Emit the current membership of the group so DSM can reconcile members with infra tags
-            # (members reported by the tracer carry infra tags; this list lets DSM drop departed
-            # members and seed tagless rows for members the tracer has not reported).
             self.check.event_platform_event(
                 json.dumps(
                     {

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -804,6 +804,20 @@ class ClusterMetadataCollector:
             member_hash = hashlib.sha256(json.dumps(member_ids, separators=(',', ':')).encode()).hexdigest()
             current_member_hashes[group_id] = member_hash
 
+            # Per-member detail. client_id and host come back on the describe response for free, so
+            # include them alongside the member id for DSM to correlate.
+            members_detail = sorted(
+                (
+                    {
+                        'member_id': getattr(m, 'member_id', '') or '',
+                        'client_id': getattr(m, 'client_id', '') or '',
+                        'member_host': getattr(m, 'host', '') or '',
+                    }
+                    for m in members
+                ),
+                key=lambda m: m['member_id'],
+            )
+
             # Emit the current membership of the group so DSM can reconcile members with infra tags
             # (members reported by the tracer carry infra tags; this list lets DSM drop departed
             # members and seed tagless rows for members the tracer has not reported).
@@ -816,6 +830,7 @@ class ClusterMetadataCollector:
                         'config_type': 'consumer_membership',
                         'group_id': group_id,
                         'member_ids': member_ids,
+                        'members': members_detail,
                     }
                 ),
                 "data-streams-message",

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -22,6 +22,10 @@ from datadog_checks.kafka_consumer.constants import KAFKA_INTERNAL_TOPICS
 CONSUMER_GROUP_REBALANCING_STATES = frozenset({'PREPARING_REBALANCING', 'COMPLETING_REBALANCING'})
 
 
+def _str_attr(obj, attr):
+    return getattr(obj, attr, '') or ''
+
+
 class SchemaDefinition(TypedDict):
     schema: str
     schema_type: str
@@ -800,27 +804,9 @@ class ClusterMetadataCollector:
                 tags=group_meta_tags,
             )
 
-            member_ids = sorted(getattr(m, 'member_id', '') or '' for m in members)
+            member_ids = sorted(_str_attr(member, 'member_id') for member in members)
             member_hash = hashlib.sha256(json.dumps(member_ids, separators=(',', ':')).encode()).hexdigest()
             current_member_hashes[group_id] = member_hash
-
-            members_detail = []
-            for m in members:
-                assignment = getattr(m, 'assignment', None)
-                topic_partitions = (
-                    [{'topic': tp.topic, 'partition': tp.partition} for tp in assignment.topic_partitions]
-                    if assignment
-                    else []
-                )
-                members_detail.append(
-                    {
-                        'member_id': getattr(m, 'member_id', '') or '',
-                        'client_id': getattr(m, 'client_id', '') or '',
-                        'member_host': getattr(m, 'host', '') or '',
-                        'topic_partitions': topic_partitions,
-                    }
-                )
-            members_detail.sort(key=lambda x: x['member_id'])
 
             self.check.event_platform_event(
                 json.dumps(
@@ -831,7 +817,7 @@ class ClusterMetadataCollector:
                         'config_type': 'consumer_membership',
                         'group_id': group_id,
                         'member_ids': member_ids,
-                        'members': members_detail,
+                        'members': self._build_members_detail(members),
                     }
                 ),
                 "data-streams-message",
@@ -861,6 +847,26 @@ class ClusterMetadataCollector:
                     self.check.gauge('consumer_group.member.partitions', partition_count, tags=member_tags)
 
         self._save_member_hashes_cache(current_member_hashes)
+
+    def _build_members_detail(self, members):
+        members_detail = []
+        for member in members:
+            assignment = getattr(member, 'assignment', None)
+            topic_partitions = (
+                [{'topic': tp.topic, 'partition': tp.partition} for tp in assignment.topic_partitions]
+                if assignment
+                else []
+            )
+            members_detail.append(
+                {
+                    'member_id': _str_attr(member, 'member_id'),
+                    'client_id': _str_attr(member, 'client_id'),
+                    'member_host': _str_attr(member, 'host'),
+                    'topic_partitions': topic_partitions,
+                }
+            )
+        members_detail.sort(key=lambda x: x['member_id'])
+        return members_detail
 
     def _load_member_hashes_cache(self) -> dict[str, str] | None:
         """Return the previous member-hash map, or None if unreadable."""

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -804,17 +804,23 @@ class ClusterMetadataCollector:
             member_hash = hashlib.sha256(json.dumps(member_ids, separators=(',', ':')).encode()).hexdigest()
             current_member_hashes[group_id] = member_hash
 
-            members_detail = sorted(
-                (
+            members_detail = []
+            for m in members:
+                assignment = getattr(m, 'assignment', None)
+                topic_partitions = (
+                    [{'topic': tp.topic, 'partition': tp.partition} for tp in assignment.topic_partitions]
+                    if assignment
+                    else []
+                )
+                members_detail.append(
                     {
                         'member_id': getattr(m, 'member_id', '') or '',
                         'client_id': getattr(m, 'client_id', '') or '',
                         'member_host': getattr(m, 'host', '') or '',
+                        'topic_partitions': topic_partitions,
                     }
-                    for m in members
-                ),
-                key=lambda m: m['member_id'],
-            )
+                )
+            members_detail.sort(key=lambda x: x['member_id'])
 
             self.check.event_platform_event(
                 json.dumps(

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -804,6 +804,23 @@ class ClusterMetadataCollector:
             member_hash = hashlib.sha256(json.dumps(member_ids, separators=(',', ':')).encode()).hexdigest()
             current_member_hashes[group_id] = member_hash
 
+            # Emit the current membership of the group so DSM can reconcile members with infra tags
+            # (members reported by the tracer carry infra tags; this list lets DSM drop departed
+            # members and seed tagless rows for members the tracer has not reported).
+            self.check.event_platform_event(
+                json.dumps(
+                    {
+                        'collection_timestamp': int(time.time() * 1000),
+                        'kafka_cluster_id': cluster_id,
+                        **self.config._original_cluster_id_field(),
+                        'config_type': 'consumer_membership',
+                        'group_id': group_id,
+                        'member_ids': member_ids,
+                    }
+                ),
+                "data-streams-message",
+            )
+
             if prev_member_hashes is not None:
                 prev_hash = prev_member_hashes.get(group_id)
                 if prev_hash is not None and prev_hash != member_hash:

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -227,16 +227,20 @@ def mock_compatibility_methods(collector, global_compat='BACKWARD', subject_comp
     collector._get_schema_registry_subject_compatibility = mock.Mock(return_value=subject_compat)
 
 
-def schema_ds_events(check):
-    """Return the parsed data-streams-message payloads with config_type 'schema' emitted by the check."""
+def ds_events_of_type(check, config_type):
+    """Return the parsed data-streams-message payloads with the given config_type emitted by the check."""
     events = []
     for call in check.event_platform_event.call_args_list:
         args = call[0]
         if len(args) > 1 and args[1] == 'data-streams-message':
             payload = json.loads(args[0])
-            if payload.get('config_type') == 'schema':
+            if payload.get('config_type') == config_type:
                 events.append(payload)
     return events
+
+
+def schema_ds_events(check):
+    return ds_events_of_type(check, 'schema')
 
 
 def _make_schema_registry_check(check, instance_overrides=None):
@@ -1918,15 +1922,7 @@ def test_malformed_cache_does_not_abort_collection(check, aggregator):
 
 
 def consumer_membership_events(check):
-    """Return parsed data-streams-message payloads with config_type 'consumer_membership'."""
-    events = []
-    for call in check.event_platform_event.call_args_list:
-        args = call[0]
-        if len(args) > 1 and args[1] == 'data-streams-message':
-            payload = json.loads(args[0])
-            if payload.get('config_type') == 'consumer_membership':
-                events.append(payload)
-    return events
+    return ds_events_of_type(check, 'consumer_membership')
 
 
 def test_consumer_membership_event_emitted(check):
@@ -1955,6 +1951,19 @@ def test_consumer_membership_event_emitted(check):
             'member_host': 'h2',
             'topic_partitions': [{'topic': 'test-topic', 'partition': 0}],
         },
+    ]
+
+
+def test_consumer_membership_event_member_without_assignment(check):
+    """A member with no assignment yields an empty topic_partitions list."""
+    members = [_make_member(client_id='c1', host='h1', assignment_tps=None)]
+    describe_result = _make_group_describe(members=members)
+    kafka_consumer_check = _collect_groups_with_cache(check, describe_result)
+
+    events = consumer_membership_events(kafka_consumer_check)
+    assert len(events) == 1
+    assert events[0]['members'] == [
+        {'member_id': 'm-c1', 'client_id': 'c1', 'member_host': 'h1', 'topic_partitions': []},
     ]
 
 

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1967,6 +1967,18 @@ def test_consumer_membership_event_member_without_assignment(check):
     ]
 
 
+def test_consumer_membership_members_sorted_by_member_id(check):
+    """members and member_ids are sorted by member_id regardless of broker order."""
+    members = [_make_member(client_id='c2', host='h2'), _make_member(client_id='c1', host='h1')]
+    describe_result = _make_group_describe(members=members)
+    kafka_consumer_check = _collect_groups_with_cache(check, describe_result)
+
+    events = consumer_membership_events(kafka_consumer_check)
+    assert len(events) == 1
+    assert events[0]['member_ids'] == ['m-c1', 'm-c2']
+    assert [m['member_id'] for m in events[0]['members']] == ['m-c1', 'm-c2']
+
+
 def test_heartbeat_connect_api_status_present_when_urls_configured(check):
     """connect_api_status appears in heartbeat payload when Connect URLs are configured."""
     instance = {

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1917,7 +1917,7 @@ def test_malformed_cache_does_not_abort_collection(check, aggregator):
     aggregator.assert_metric('kafka.consumer_group.membership_changes', count=0)
 
 
-def _consumer_membership_events(check):
+def consumer_membership_events(check):
     """Return parsed data-streams-message payloads with config_type 'consumer_membership'."""
     events = []
     for call in check.event_platform_event.call_args_list:
@@ -1935,7 +1935,7 @@ def test_consumer_membership_event_emitted(check):
     describe_result = _make_group_describe(members=members)
     kafka_consumer_check = _collect_groups_with_cache(check, describe_result)
 
-    events = _consumer_membership_events(kafka_consumer_check)
+    events = consumer_membership_events(kafka_consumer_check)
     assert len(events) == 1
     event = events[0]
     assert event['kafka_cluster_id'] == 'test-cluster-id'

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1941,10 +1941,20 @@ def test_consumer_membership_event_emitted(check):
     assert event['kafka_cluster_id'] == 'test-cluster-id'
     assert event['group_id'] == 'test-group'
     assert event['member_ids'] == ['m-c1', 'm-c2']
-    # Per-member detail includes client_id and member_host (captured for free from describe).
+    # Per-member detail includes client_id, member_host and the assigned topic-partitions.
     assert event['members'] == [
-        {'member_id': 'm-c1', 'client_id': 'c1', 'member_host': 'h1'},
-        {'member_id': 'm-c2', 'client_id': 'c2', 'member_host': 'h2'},
+        {
+            'member_id': 'm-c1',
+            'client_id': 'c1',
+            'member_host': 'h1',
+            'topic_partitions': [{'topic': 'test-topic', 'partition': 0}],
+        },
+        {
+            'member_id': 'm-c2',
+            'client_id': 'c2',
+            'member_host': 'h2',
+            'topic_partitions': [{'topic': 'test-topic', 'partition': 0}],
+        },
     ]
 
 

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1703,7 +1703,7 @@ def _stub_consumer_groups(admin, describe_by_group):
 
 
 def _collect_groups(check, describe_result, group_id='test-group'):
-    """Run _collect_consumer_group_metadata against a single mocked consumer group.
+    """Run collect_all_metadata against a single mocked consumer group.
 
     Reuses the shared seed_mock_kafka_client wiring and only swaps in the
     consumer-group futures, so the admin-client mock setup is not duplicated.
@@ -1715,9 +1715,7 @@ def _collect_groups(check, describe_result, group_id='test-group'):
     _stub_consumer_groups(mock_client.kafka_client, {group_id: describe_result})
     kafka_consumer_check.metadata_collector.client = mock_client
 
-    metadata = mock.MagicMock()
-    metadata.cluster_id = 'test-cluster-id'
-    kafka_consumer_check.metadata_collector._collect_consumer_group_metadata(metadata)
+    kafka_consumer_check.metadata_collector.collect_all_metadata({}, {}, {})
     return kafka_consumer_check
 
 
@@ -1731,9 +1729,7 @@ def _collect_groups_with_cache(check, describe_result, seed=None, group_id='test
     kafka_consumer_check.metadata_collector.client = mock_client
     _wire_cache(kafka_consumer_check, seed)
 
-    metadata = mock.MagicMock()
-    metadata.cluster_id = 'test-cluster-id'
-    kafka_consumer_check.metadata_collector._collect_consumer_group_metadata(metadata)
+    kafka_consumer_check.metadata_collector.collect_all_metadata({}, {}, {})
     return kafka_consumer_check
 
 

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1931,7 +1931,7 @@ def _consumer_membership_events(check):
 
 def test_consumer_membership_event_emitted(check):
     """A consumer_membership event is emitted per group with the cluster id, group id and members."""
-    members = [_make_member(client_id='c1'), _make_member(client_id='c2')]
+    members = [_make_member(client_id='c1', host='h1'), _make_member(client_id='c2', host='h2')]
     describe_result = _make_group_describe(members=members)
     kafka_consumer_check = _collect_groups_with_cache(check, describe_result)
 
@@ -1941,6 +1941,11 @@ def test_consumer_membership_event_emitted(check):
     assert event['kafka_cluster_id'] == 'test-cluster-id'
     assert event['group_id'] == 'test-group'
     assert event['member_ids'] == ['m-c1', 'm-c2']
+    # Per-member detail includes client_id and member_host (captured for free from describe).
+    assert event['members'] == [
+        {'member_id': 'm-c1', 'client_id': 'c1', 'member_host': 'h1'},
+        {'member_id': 'm-c2', 'client_id': 'c2', 'member_host': 'h2'},
+    ]
 
 
 def test_heartbeat_connect_api_status_present_when_urls_configured(check):

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1917,6 +1917,32 @@ def test_malformed_cache_does_not_abort_collection(check, aggregator):
     aggregator.assert_metric('kafka.consumer_group.membership_changes', count=0)
 
 
+def _consumer_membership_events(check):
+    """Return parsed data-streams-message payloads with config_type 'consumer_membership'."""
+    events = []
+    for call in check.event_platform_event.call_args_list:
+        args = call[0]
+        if len(args) > 1 and args[1] == 'data-streams-message':
+            payload = json.loads(args[0])
+            if payload.get('config_type') == 'consumer_membership':
+                events.append(payload)
+    return events
+
+
+def test_consumer_membership_event_emitted(check):
+    """A consumer_membership event is emitted per group with the cluster id, group id and members."""
+    members = [_make_member(client_id='c1'), _make_member(client_id='c2')]
+    describe_result = _make_group_describe(members=members)
+    kafka_consumer_check = _collect_groups_with_cache(check, describe_result)
+
+    events = _consumer_membership_events(kafka_consumer_check)
+    assert len(events) == 1
+    event = events[0]
+    assert event['kafka_cluster_id'] == 'test-cluster-id'
+    assert event['group_id'] == 'test-group'
+    assert event['member_ids'] == ['m-c1', 'm-c2']
+
+
 def test_heartbeat_connect_api_status_present_when_urls_configured(check):
     """connect_api_status appears in heartbeat payload when Connect URLs are configured."""
     instance = {


### PR DESCRIPTION
## What
The `kafka_consumer` integration now emits a `consumer_membership` `data-streams-message` per consumer group. Emitted from `_collect_consumer_group_metadata`, where the member list is already gathered.

The payload is a full per-group snapshot:
- `config_type`: `consumer_membership`
- `kafka_cluster_id` (and `original_kafka_cluster_id` when a cluster-id override is configured)
- `group_id`
- `collection_timestamp` (ms)
- `member_ids`: sorted list of member ids
- `members`: sorted list of per-member detail — `member_id`, `client_id`, `member_host`, and the assigned `topic_partitions` (`[]` when the member has no assignment)

## Why
DSM uses this to reconcile consumer-group membership: it is a full-snapshot reconciliation heartbeat emitted every interval (not deduped on membership change), so the downstream writer can drop departed members and seed tagless rows for members the tracer hasn't reported, while tracer-sourced infra tags win. Because the writer deletes members absent from a snapshot after a staleness window, the `members` list is always complete and never truncated.

## Part of a cross-repo change
Feeds the same `dsm-kafka-configs` pipeline as the dd-trace-java tracer: → dsm-kafka-configs-writer → orgstore `kafka_consumer_group_members` → dsm-api.

## Tests
`ddev test kafka_consumer` — `tests/test_cluster_metadata.py` all pass (55), including `test_consumer_membership_event_emitted` and `test_consumer_membership_event_member_without_assignment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
