### PR TITLE
Decouple integration tests from the requests library

### DIFF
--- a/crio/tests/test_crio.py
+++ b/crio/tests/test_crio.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
-import mock
 import pytest
 
 from datadog_checks.base import AgentCheck
@@ -14,17 +13,11 @@ NAMESPACE = 'crio'
 
 
 @pytest.fixture()
-def mock_data():
-    f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    with mock.patch(
-        'requests.Session.get',
-        return_value=mock.MagicMock(
-            status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-        ),
-    ):
-        yield
+def mock_data(mock_http_response):
+    mock_http_response(
+        file_path=os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics.txt'),
+        headers={'Content-Type': 'text/plain'},
+    )
 
 
 def test_crio(aggregator, mock_data, instance):

--- a/dell_powerflex/tests/conftest.py
+++ b/dell_powerflex/tests/conftest.py
@@ -6,14 +6,14 @@ import os
 from pathlib import Path
 from urllib.parse import urlparse
 
-import mock
 import pytest
-import requests
 
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs, CheckEndpoints
 from datadog_checks.dev.docker import get_docker_hostname
 from datadog_checks.dev.fs import get_here
+from datadog_checks.dev.http import MockHTTPResponse
 from datadog_checks.dev.utils import find_free_port
 
 from .common import DEFAULT_GATEWAY_URL
@@ -100,31 +100,23 @@ def mock_http_call(mock_responses):
         data = mock_responses(url, file=file, **kwargs)
         if data is not None:
             return data
-        resp = requests.models.Response()
-        resp.status_code = 404
-        resp.reason = "Not Found"
-        resp.url = url
-        raise requests.exceptions.HTTPError(response=resp)
+        raise HTTPStatusError('404 Not Found', response=MockHTTPResponse(status_code=404))
 
     yield call
 
 
 @pytest.fixture
-def mock_auth(monkeypatch):
+def mock_auth(mock_http):
     def post(url, *args, **kwargs):
-        token_response = {'access_token': 'fake-token', 'expires_in': 300}
-        mock_json = mock.MagicMock(return_value=token_response)
-        return mock.MagicMock(json=mock_json, status_code=200)
+        return MockHTTPResponse(json_data={'access_token': 'fake-token', 'expires_in': 300}, status_code=200)
 
-    monkeypatch.setattr('requests.Session.post', mock.MagicMock(side_effect=post))
+    mock_http.post.side_effect = post
 
 
 @pytest.fixture
-def mock_http_get(monkeypatch, mock_http_call, mock_auth):
+def mock_http_get(mock_http, mock_http_call, mock_auth):
     def get(url, *args, **kwargs):
-        mock_json = mock.MagicMock(return_value=mock_http_call(url, **kwargs))
-        return mock.MagicMock(json=mock_json, status_code=200)
+        return MockHTTPResponse(json_data=mock_http_call(url, **kwargs), status_code=200)
 
-    mock_get = mock.MagicMock(side_effect=get)
-    monkeypatch.setattr('requests.Session.get', mock_get)
-    return mock_get
+    mock_http.get.side_effect = get
+    return mock_http

--- a/dell_powerflex/tests/test_unit.py
+++ b/dell_powerflex/tests/test_unit.py
@@ -3,12 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import logging
-from unittest.mock import MagicMock
 
 import pytest
-from requests.exceptions import ConnectionError, HTTPError
 
+from datadog_checks.base.utils.http_exceptions import HTTPConnectionError, HTTPStatusError
 from datadog_checks.dell_powerflex import DellPowerflexCheck
+from datadog_checks.dev.http import MockHTTPResponse
 from datadog_checks.dev.utils import get_metadata_metrics
 
 from .common import (
@@ -60,22 +60,17 @@ def assert_bwc_metrics(aggregator, bwc_metrics, tags, value=0):
         aggregator.assert_metric(f'{metric_prefix}.num_occured', value=value, tags=tags)
 
 
-def test_can_connect_down(dd_run_check, aggregator, instance, mocker):
-    mocker.patch('requests.Session.post', side_effect=ConnectionError('connection refused'))
+def test_can_connect_down(dd_run_check, aggregator, instance, mock_http):
+    mock_http.post.side_effect = HTTPConnectionError('connection refused')
     check = DellPowerflexCheck('dell_powerflex', {}, [instance])
     dd_run_check(check)
 
     aggregator.assert_metric('dell_powerflex.api.can_connect', value=0, tags=BASE_TAGS)
 
 
-def test_auth_response_missing_access_token(dd_run_check, aggregator, instance, mocker, caplog):
-    mocker.patch(
-        'requests.Session.post',
-        return_value=MagicMock(
-            raise_for_status=MagicMock(),
-            json=MagicMock(return_value={'error': 'unauthorized_client'}),
-            status_code=200,
-        ),
+def test_auth_response_missing_access_token(dd_run_check, aggregator, instance, mock_http, caplog):
+    mock_http.post.side_effect = lambda *a, **k: MockHTTPResponse(
+        json_data={'error': 'unauthorized_client'}, status_code=200
     )
     caplog.set_level(logging.WARNING)
     check = DellPowerflexCheck('dell_powerflex', {}, [instance])
@@ -85,8 +80,8 @@ def test_auth_response_missing_access_token(dd_run_check, aggregator, instance, 
     assert 'Auth response missing access_token' in caplog.text
 
 
-def test_version_failure(dd_run_check, aggregator, instance, mock_auth, mocker, caplog):
-    mocker.patch('requests.Session.get', side_effect=HTTPError(response=MagicMock(status_code=500)))
+def test_version_failure(dd_run_check, aggregator, instance, mock_auth, mock_http, caplog):
+    mock_http.get.side_effect = HTTPStatusError('500 Server Error', response=MockHTTPResponse(status_code=500))
 
     check = DellPowerflexCheck('dell_powerflex', {}, [instance])
     caplog.set_level(logging.WARNING)
@@ -96,27 +91,23 @@ def test_version_failure(dd_run_check, aggregator, instance, mock_auth, mocker, 
     assert 'Could not connect to PowerFlex Gateway' in caplog.text
 
 
-def test_can_connect_up(dd_run_check, aggregator, instance, mock_auth, mocker):
-    mocker.patch('requests.Session.get', return_value=MagicMock(raise_for_status=MagicMock()))
+def test_can_connect_up(dd_run_check, aggregator, instance, mock_auth, mock_http):
+    mock_http.get.side_effect = lambda *a, **k: MockHTTPResponse(json_data={}, status_code=200)
     check = DellPowerflexCheck('dell_powerflex', {}, [instance])
     dd_run_check(check)
 
     aggregator.assert_metric('dell_powerflex.api.can_connect', value=1, tags=BASE_TAGS)
 
 
-def test_unauthenticated_mode(dd_run_check, aggregator, mock_http_call, mocker):
+def test_unauthenticated_mode(dd_run_check, aggregator, mock_http_call, mock_http):
     instance = {'powerflex_gateway_url': DEFAULT_GATEWAY_URL}
-    mocker.patch(
-        'requests.Session.get',
-        side_effect=lambda url, *args, **kwargs: MagicMock(
-            json=MagicMock(return_value=mock_http_call(url)), status_code=200
-        ),
+    mock_http.get.side_effect = lambda url, *args, **kwargs: MockHTTPResponse(
+        json_data=mock_http_call(url), status_code=200
     )
-    mock_post = mocker.patch('requests.Session.post')
     check = DellPowerflexCheck('dell_powerflex', {}, [instance])
     dd_run_check(check)
 
-    mock_post.assert_not_called()
+    mock_http.post.assert_not_called()
     aggregator.assert_metric('dell_powerflex.api.can_connect', value=1)
     aggregator.assert_metric('dell_powerflex.capacity.in_use_in_kb', at_least=1)
     aggregator.assert_metric('dell_powerflex.system.count', at_least=1)

--- a/flink/tests/conftest.py
+++ b/flink/tests/conftest.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import copy
 import os
-from unittest import mock
 
 import pytest
 
@@ -47,16 +46,8 @@ def check(instance):
 
 
 @pytest.fixture()
-def mock_metrics():
-    f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    with mock.patch(
-        'requests.Session.get',
-        return_value=mock.MagicMock(
-            status_code=200,
-            iter_lines=lambda **kwargs: text_data.split("\n"),
-            headers={'Content-Type': "text/plain"},
-        ),
-    ):
-        yield
+def mock_metrics(mock_http_response):
+    mock_http_response(
+        file_path=os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics.txt'),
+        headers={'Content-Type': 'text/plain'},
+    )

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -446,7 +446,7 @@ def test_data_methods(aggregator, http_check):
         aggregator.reset()
 
 
-def test_unexisting_ca_cert_should_log_warning(aggregator, dd_run_check):
+def test_unexisting_ca_cert_should_log_warning(aggregator, dd_run_check, mock_http_response):
     instance = {
         'name': 'Test Web VM HTTPS SSL',
         'url': 'https://foo.bar.net/',
@@ -458,10 +458,8 @@ def test_unexisting_ca_cert_should_log_warning(aggregator, dd_run_check):
         'skip_proxy': 'false',
     }
 
-    with (
-        mock.patch('datadog_checks.base.utils.http.logging.Logger.warning') as mock_warning,
-        mock.patch('requests.Session.get'),
-    ):
+    mock_http_response()
+    with mock.patch('datadog_checks.base.utils.http.logging.Logger.warning') as mock_warning:
         check = HTTPCheck('http_check', {'ca_certs': 'foo'}, [instance])
         dd_run_check(check)
         mock_warning.assert_called()

--- a/nginx/tests/test_vts.py
+++ b/nginx/tests/test_vts.py
@@ -48,8 +48,8 @@ def test_vts(check, instance_vts, aggregator):
 
 
 @pytest.mark.unit
-def test_vts_unit(dd_run_check, aggregator, mocked_instance_vts, check, mocker):
-    mocker.patch("requests.Session.get", wraps=mock_http_responses)
+def test_vts_unit(dd_run_check, aggregator, mocked_instance_vts, check, mock_http):
+    mock_http.get.side_effect = mock_http_responses
     c = check(mocked_instance_vts)
     dd_run_check(c)
 

--- a/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
+++ b/nginx_ingress_controller/tests/test_nginx_ingress_controller.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
-import mock
 import pytest
 
 from datadog_checks.dev.utils import get_metadata_metrics
@@ -16,17 +15,11 @@ NAMESPACE = 'nginx_ingress'
 
 
 @pytest.fixture()
-def mock_data():
-    f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    with mock.patch(
-        'requests.Session.get',
-        return_value=mock.MagicMock(
-            status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-        ),
-    ):
-        yield
+def mock_data(mock_http_response):
+    mock_http_response(
+        file_path=os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics.txt'),
+        headers={'Content-Type': 'text/plain'},
+    )
 
 
 EXPECTED_METRICS = [

--- a/nvidia_nim/tests/test_unit.py
+++ b/nvidia_nim/tests/test_unit.py
@@ -2,8 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from unittest import mock
-
 import pytest
 
 from datadog_checks.base.constants import ServiceCheck
@@ -14,17 +12,14 @@ from datadog_checks.nvidia_nim import NvidiaNIMCheck
 from .common import METRICS_MOCK, get_fixture_path
 
 
-def test_check_nvidia_nim(dd_run_check, aggregator, datadog_agent, instance):
+def test_check_nvidia_nim(dd_run_check, aggregator, datadog_agent, instance, mock_http):
     check = NvidiaNIMCheck("nvidia_nim", {}, [instance])
     check.check_id = "test:123"
-    with mock.patch(
-        'requests.Session.get',
-        side_effect=[
-            MockHTTPResponse(file_path=get_fixture_path("nim_metrics.txt")),
-            MockHTTPResponse(file_path=get_fixture_path("nim_version.json")),
-        ],
-    ):
-        dd_run_check(check)
+    mock_http.get.side_effect = [
+        MockHTTPResponse(file_path=get_fixture_path("nim_metrics.txt")),
+        MockHTTPResponse(file_path=get_fixture_path("nim_version.json")),
+    ]
+    dd_run_check(check)
 
     for metric in METRICS_MOCK:
         aggregator.assert_metric(metric)

--- a/silk/tests/test_integration.py
+++ b/silk/tests/test_integration.py
@@ -1,16 +1,16 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import mock
 import pytest
 
 from datadog_checks.silk import SilkCheck
 
 from .common import BASE_TAGS, BLOCKSIZE_METRICS, METRICS, READ_WRITE_METRICS, SYSTEM_TAGS
 
-pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("dd_environment")]
+pytestmark = [pytest.mark.integration]
 
 
+@pytest.mark.usefixtures("dd_environment")
 @pytest.mark.parametrize(
     'enable_rw, enable_bs, expected_metrics',
     [
@@ -33,17 +33,17 @@ def test_check(dd_run_check, aggregator, instance, enable_rw, enable_bs, expecte
             aggregator.assert_metric_has_tag(metric, tag)
 
 
-def test_error_msg_response(dd_run_check, aggregator, instance):
+def test_error_msg_response(dd_run_check, aggregator, instance, mock_http_response):
     error_response = {"error_msg": "Statistics data is unavailable while system is OFFLINE"}
-    with mock.patch('datadog_checks.base.utils.http.requests.Response.json') as g:
-        g.return_value = error_response
-        check = SilkCheck('silk', {}, [instance])
-        dd_run_check(check)
-        aggregator.assert_service_check(
-            'silk.can_connect', SilkCheck.WARNING, message="Received error message: " + error_response["error_msg"]
-        )
+    mock_http_response(json_data=error_response)
+    check = SilkCheck('silk', {}, [instance])
+    dd_run_check(check)
+    aggregator.assert_service_check(
+        'silk.can_connect', SilkCheck.WARNING, message="Received error message: " + error_response["error_msg"]
+    )
 
 
+@pytest.mark.usefixtures("dd_environment")
 def test_submit_system_state(instance, datadog_agent):
     check = SilkCheck('silk', {}, [instance])
     check.check_id = 'test:123'


### PR DESCRIPTION
### What does this PR do?

Removes hardcoded `requests` library coupling from the test suites of seven integrations, so the tests keep working when the HTTP backend swaps from `requests` to `httpx`. Each test is moved onto a sanctioned, backend-agnostic seam:

- `mock_http` (patches the `AgentCheck.http` property) for checks that call `self.http` directly.
- `mock_http_response` / `mock_http_response_per_endpoint` (the single central `_DEFAULT_MOCK_METHOD` seam) for OpenMetrics and response-body cases.
- Agnostic exceptions from `datadog_checks.base.utils.http_exceptions` in place of `requests.exceptions.*`.

Integrations touched: crio, flink, nginx_ingress_controller, nginx (VTS), silk, http_check, nvidia_nim, dell_powerflex. This is a test-only change: no production code and no changelog entries.

### Motivation

Tests that hardcode `mock.patch('requests.Session.get'/'.post'/'.request')`, import from `requests.exceptions`, or patch `requests.Response.json` bypass the sanctioned fixtures and would break silently once the backend is no longer `requests`. Centralizing them on the agnostic fixtures/exceptions makes the eventual httpx cutover a single-seam change instead of a scattered one. Stacked on #24516.

Out of scope: kube_* (already migrated by the catch-narrowing branch), and vsphere / openstack_controller (blocked on their production HTTP migration).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged