### PR TITLE
Decouple vsphere REST client tests from the requests backend

### DIFF
--- a/vsphere/datadog_checks/vsphere/api_rest.py
+++ b/vsphere/datadog_checks/vsphere/api_rest.py
@@ -9,7 +9,6 @@ from pyVmomi import vim
 
 from datadog_checks.base.log import CheckLoggingAdapter  # noqa: F401
 from datadog_checks.base.utils.http import create_http_client
-from datadog_checks.base.utils.http_protocol import HTTPClient  # noqa: F401
 from datadog_checks.vsphere.config import VSphereConfig  # noqa: F401
 from datadog_checks.vsphere.constants import ALL_RESOURCES_WITH_METRICS
 from datadog_checks.vsphere.types import ResourceTags, TagAssociation  # noqa: F401
@@ -32,11 +31,11 @@ class VSphereRestAPI(object):
     Abstraction class over the vSphere REST api
     """
 
-    def __init__(self, config, log, deprecated_api=True, http_client=None):
-        # type: (VSphereConfig, CheckLoggingAdapter, bool, HTTPClient | None) -> None
+    def __init__(self, config, log, deprecated_api=True):
+        # type: (VSphereConfig, CheckLoggingAdapter, bool) -> None
         self.config = config
         self.log = log
-        self._client = VSphereRestClient(config, log, deprecated_api, http_client)
+        self._client = VSphereRestClient(config, log, deprecated_api)
         self.smart_connect()
 
     def smart_connect(self):
@@ -159,8 +158,8 @@ class VSphereRestClient(object):
         },
     }
 
-    def __init__(self, config, log, deprecated_api, http_client=None):
-        # type: (VSphereConfig, CheckLoggingAdapter, bool, HTTPClient | None) -> None
+    def __init__(self, config, log, deprecated_api):
+        # type: (VSphereConfig, CheckLoggingAdapter, bool) -> None
         self.log = log
         self.deprecated_api = deprecated_api
         self._api_base_url = "https://{}/api/".format(config.hostname)
@@ -168,11 +167,7 @@ class VSphereRestClient(object):
         if deprecated_api:
             self._api_base_url = "https://{}/rest/com/vmware/cis/".format(config.hostname)
             self.endpoints = self.API_ENDPOINTS['deprecated']
-        self._http = (
-            http_client
-            if http_client is not None
-            else create_http_client(config.rest_api_options, config.shared_rest_api_options)
-        )
+        self._http = create_http_client(config.rest_api_options, config.shared_rest_api_options)
 
     def connect_session(self):
         # type: () -> None

--- a/vsphere/datadog_checks/vsphere/api_rest.py
+++ b/vsphere/datadog_checks/vsphere/api_rest.py
@@ -31,11 +31,11 @@ class VSphereRestAPI(object):
     Abstraction class over the vSphere REST api
     """
 
-    def __init__(self, config, log, deprecated_api=True):
-        # type: (VSphereConfig, CheckLoggingAdapter, bool) -> None
+    def __init__(self, config, log, deprecated_api=True, http_client=None):
+        # type: (VSphereConfig, CheckLoggingAdapter, bool, Any) -> None
         self.config = config
         self.log = log
-        self._client = VSphereRestClient(config, log, deprecated_api)
+        self._client = VSphereRestClient(config, log, deprecated_api, http_client)
         self.smart_connect()
 
     def smart_connect(self):
@@ -158,8 +158,8 @@ class VSphereRestClient(object):
         },
     }
 
-    def __init__(self, config, log, deprecated_api):
-        # type: (VSphereConfig, CheckLoggingAdapter, bool) -> None
+    def __init__(self, config, log, deprecated_api, http_client=None):
+        # type: (VSphereConfig, CheckLoggingAdapter, bool, Any) -> None
         self.log = log
         self.deprecated_api = deprecated_api
         self._api_base_url = "https://{}/api/".format(config.hostname)
@@ -167,7 +167,7 @@ class VSphereRestClient(object):
         if deprecated_api:
             self._api_base_url = "https://{}/rest/com/vmware/cis/".format(config.hostname)
             self.endpoints = self.API_ENDPOINTS['deprecated']
-        self._http = RequestsWrapper(config.rest_api_options, config.shared_rest_api_options)
+        self._http = http_client or RequestsWrapper(config.rest_api_options, config.shared_rest_api_options)
 
     def connect_session(self):
         # type: () -> None
@@ -176,7 +176,7 @@ class VSphereRestClient(object):
         if not session_token:
             raise APIResponseError("Failed to retrieve session token")
 
-        self._http.options['headers']['vmware-api-session-id'] = session_token
+        self._http.set_header('vmware-api-session-id', session_token)
 
     def session_create(self):
         # type: () -> str

--- a/vsphere/datadog_checks/vsphere/api_rest.py
+++ b/vsphere/datadog_checks/vsphere/api_rest.py
@@ -8,7 +8,8 @@ from typing import Any, Dict, Iterator, List, Set  # noqa: F401
 from pyVmomi import vim
 
 from datadog_checks.base.log import CheckLoggingAdapter  # noqa: F401
-from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.http import create_http_client
+from datadog_checks.base.utils.http_protocol import HTTPClient  # noqa: F401
 from datadog_checks.vsphere.config import VSphereConfig  # noqa: F401
 from datadog_checks.vsphere.constants import ALL_RESOURCES_WITH_METRICS
 from datadog_checks.vsphere.types import ResourceTags, TagAssociation  # noqa: F401
@@ -32,7 +33,7 @@ class VSphereRestAPI(object):
     """
 
     def __init__(self, config, log, deprecated_api=True, http_client=None):
-        # type: (VSphereConfig, CheckLoggingAdapter, bool, Any) -> None
+        # type: (VSphereConfig, CheckLoggingAdapter, bool, HTTPClient | None) -> None
         self.config = config
         self.log = log
         self._client = VSphereRestClient(config, log, deprecated_api, http_client)
@@ -159,7 +160,7 @@ class VSphereRestClient(object):
     }
 
     def __init__(self, config, log, deprecated_api, http_client=None):
-        # type: (VSphereConfig, CheckLoggingAdapter, bool, Any) -> None
+        # type: (VSphereConfig, CheckLoggingAdapter, bool, HTTPClient | None) -> None
         self.log = log
         self.deprecated_api = deprecated_api
         self._api_base_url = "https://{}/api/".format(config.hostname)
@@ -167,7 +168,11 @@ class VSphereRestClient(object):
         if deprecated_api:
             self._api_base_url = "https://{}/rest/com/vmware/cis/".format(config.hostname)
             self.endpoints = self.API_ENDPOINTS['deprecated']
-        self._http = http_client or RequestsWrapper(config.rest_api_options, config.shared_rest_api_options)
+        self._http = (
+            http_client
+            if http_client is not None
+            else create_http_client(config.rest_api_options, config.shared_rest_api_options)
+        )
 
     def connect_session(self):
         # type: () -> None

--- a/vsphere/tests/common.py
+++ b/vsphere/tests/common.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import os
 import re
+from typing import Any, Callable
 from urllib.parse import urlparse
 
 import mock
@@ -1098,32 +1099,34 @@ REALTIME_TAG_ASSOCIATIONS = [
 ]
 
 
-class MockHttp:
-    def __init__(self, tag_associations=None):
-        self.exceptions = {}
-        self.headers = {}
-        self.tag_associations = HISTORICAL_TAG_ASSOCIATIONS if tag_associations is None else tag_associations
+def configure_vsphere_rest_mock_http(mock_http: Any, tag_associations: list[dict[str, Any]] | None = None) -> Any:
+    mock_http.exceptions = {}
+    mock_http.tag_associations = HISTORICAL_TAG_ASSOCIATIONS if tag_associations is None else tag_associations
 
-    def set_header(self, name, value):
-        self.headers[name] = value
+    if VSPHERE_VERSION.startswith('7.'):
+        mock_http.get.side_effect = make_mock_http_v7_get(mock_http)
+        mock_http.post.side_effect = make_mock_http_v7_post(mock_http)
+    else:
+        mock_http.get.side_effect = make_mock_http_v6_get(mock_http)
+        mock_http.post.side_effect = make_mock_http_v6_post(mock_http)
 
-    def get_header(self, name, default=None):
-        return self.headers.get(name, default)
-
-    def raise_if_configured(self, url):
-        parsed_url = urlparse(url)
-        path_and_args = parsed_url.path + "?" + parsed_url.query if parsed_url.query else parsed_url.path
-        path_parts = path_and_args.split('/')
-        subpath = os.path.join(*path_parts)
-        if subpath in self.exceptions:
-            raise self.exceptions[subpath]
+    return mock_http
 
 
-class MockHttpV6(MockHttp):
-    def get(self, url, *args, **kwargs):
+def raise_if_rest_exception_configured(mock_http: Any, url: str) -> None:
+    parsed_url = urlparse(url)
+    path_and_args = parsed_url.path + "?" + parsed_url.query if parsed_url.query else parsed_url.path
+    path_parts = path_and_args.split('/')
+    subpath = os.path.join(*path_parts)
+    if subpath in mock_http.exceptions:
+        raise mock_http.exceptions[subpath]
+
+
+def make_mock_http_v6_get(mock_http: Any) -> Callable[..., MockHTTPResponse]:
+    def get(url: str, **kwargs: Any) -> MockHTTPResponse:
         if '/api/' in url:
             return MockHTTPResponse(json_data={}, status_code=404)
-        self.raise_if_configured(url)
+        raise_if_rest_exception_configured(mock_http, url)
         if re.match(r'.*/category/id:.*$', url):
             parts = url.split('_')
             num = parts[len(parts) - 1]
@@ -1156,11 +1159,15 @@ class MockHttpV6(MockHttp):
             )
         raise Exception("Rest api mock request not matched: method={}, url={}".format('get', url))
 
-    def post(self, url, *args, **kwargs):
+    return get
+
+
+def make_mock_http_v6_post(mock_http: Any) -> Callable[..., MockHTTPResponse]:
+    def post(url: str, **kwargs: Any) -> MockHTTPResponse:
         if '/api/' in url:
             return MockHTTPResponse(json_data={}, status_code=404)
         assert kwargs['extra_headers']['Content-Type'] == 'application/json'
-        self.raise_if_configured(url)
+        raise_if_rest_exception_configured(mock_http, url)
         if re.match(r'.*/session$', url):
             return MockHTTPResponse(
                 json_data={"value": "dummy-token"},
@@ -1168,15 +1175,17 @@ class MockHttpV6(MockHttp):
             )
         elif re.match(r'.*/tagging/tag-association\?~action=list-attached-tags-on-objects$', url):
             return MockHTTPResponse(
-                json_data={"value": self.tag_associations},
+                json_data={"value": mock_http.tag_associations},
                 status_code=200,
             )
         raise Exception("Rest api mock request not matched: method={}, url={}".format('post', url))
 
+    return post
 
-class MockHttpV7(MockHttp):
-    def get(self, url, *args, **kwargs):
-        self.raise_if_configured(url)
+
+def make_mock_http_v7_get(mock_http: Any) -> Callable[..., MockHTTPResponse]:
+    def get(url: str, **kwargs: Any) -> MockHTTPResponse:
+        raise_if_rest_exception_configured(mock_http, url)
         if re.match(r'.*/category/.*$', url):
             parts = url.split('_')
             num = parts[len(parts) - 1]
@@ -1205,9 +1214,13 @@ class MockHttpV7(MockHttp):
             )
         raise Exception("Rest api mock request not matched: method={}, url={}".format('get', url))
 
-    def post(self, url, *args, **kwargs):
+    return get
+
+
+def make_mock_http_v7_post(mock_http: Any) -> Callable[..., MockHTTPResponse]:
+    def post(url: str, **kwargs: Any) -> MockHTTPResponse:
         assert kwargs['extra_headers']['Content-Type'] == 'application/json'
-        self.raise_if_configured(url)
+        raise_if_rest_exception_configured(mock_http, url)
         if re.match(r'.*/session$', url):
             return MockHTTPResponse(
                 json_data="dummy-token",
@@ -1215,7 +1228,9 @@ class MockHttpV7(MockHttp):
             )
         elif re.match(r'.*/tagging/tag-association\?action=list-attached-tags-on-objects$', url):
             return MockHTTPResponse(
-                json_data=self.tag_associations,
+                json_data=mock_http.tag_associations,
                 status_code=200,
             )
         raise Exception("Rest api mock request not matched: method={}, url={}".format('post', url))
+
+    return post

--- a/vsphere/tests/common.py
+++ b/vsphere/tests/common.py
@@ -1100,7 +1100,7 @@ REALTIME_TAG_ASSOCIATIONS = [
 ]
 
 
-class MockHttpV6:
+class MockHttp:
     def __init__(self, tag_associations=None):
         self.exceptions = {}
         self.headers = {}
@@ -1112,15 +1112,20 @@ class MockHttpV6:
     def get_header(self, name, default=None):
         return self.headers.get(name, default)
 
-    def get(self, url, *args, **kwargs):
-        if '/api/' in url:
-            return MockHTTPResponse(json_data={}, status_code=404)
+    def raise_if_configured(self, url):
         parsed_url = urlparse(url)
         path_and_args = parsed_url.path + "?" + parsed_url.query if parsed_url.query else parsed_url.path
         path_parts = path_and_args.split('/')
         subpath = os.path.join(*path_parts)
         if subpath in self.exceptions:
             raise self.exceptions[subpath]
+
+
+class MockHttpV6(MockHttp):
+    def get(self, url, *args, **kwargs):
+        if '/api/' in url:
+            return MockHTTPResponse(json_data={}, status_code=404)
+        self.raise_if_configured(url)
         if re.match(r'.*/category/id:.*$', url):
             parts = url.split('_')
             num = parts[len(parts) - 1]
@@ -1157,12 +1162,7 @@ class MockHttpV6:
         if '/api/' in url:
             return MockHTTPResponse(json_data={}, status_code=404)
         assert kwargs['extra_headers']['Content-Type'] == 'application/json'
-        parsed_url = urlparse(url)
-        path_and_args = parsed_url.path + "?" + parsed_url.query if parsed_url.query else parsed_url.path
-        path_parts = path_and_args.split('/')
-        subpath = os.path.join(*path_parts)
-        if subpath in self.exceptions:
-            raise self.exceptions[subpath]
+        self.raise_if_configured(url)
         if re.match(r'.*/session$', url):
             return MockHTTPResponse(
                 json_data={"value": "dummy-token"},
@@ -1176,25 +1176,9 @@ class MockHttpV6:
         raise Exception("Rest api mock request not matched: method={}, url={}".format('post', url))
 
 
-class MockHttpV7:
-    def __init__(self, tag_associations=None):
-        self.exceptions = []
-        self.headers = {}
-        self.tag_associations = HISTORICAL_TAG_ASSOCIATIONS if tag_associations is None else tag_associations
-
-    def set_header(self, name, value):
-        self.headers[name] = value
-
-    def get_header(self, name, default=None):
-        return self.headers.get(name, default)
-
+class MockHttpV7(MockHttp):
     def get(self, url, *args, **kwargs):
-        parsed_url = urlparse(url)
-        path_and_args = parsed_url.path + "?" + parsed_url.query if parsed_url.query else parsed_url.path
-        path_parts = path_and_args.split('/')
-        subpath = os.path.join(*path_parts)
-        if subpath in self.exceptions:
-            raise self.exceptions[subpath]
+        self.raise_if_configured(url)
         if re.match(r'.*/category/.*$', url):
             parts = url.split('_')
             num = parts[len(parts) - 1]
@@ -1225,12 +1209,7 @@ class MockHttpV7:
 
     def post(self, url, *args, **kwargs):
         assert kwargs['extra_headers']['Content-Type'] == 'application/json'
-        parsed_url = urlparse(url)
-        path_and_args = parsed_url.path + "?" + parsed_url.query if parsed_url.query else parsed_url.path
-        path_parts = path_and_args.split('/')
-        subpath = os.path.join(*path_parts)
-        if subpath in self.exceptions:
-            raise self.exceptions[subpath]
+        self.raise_if_configured(url)
         if re.match(r'.*/session$', url):
             return MockHTTPResponse(
                 json_data="dummy-token",

--- a/vsphere/tests/common.py
+++ b/vsphere/tests/common.py
@@ -1085,9 +1085,32 @@ VM_INVALID_GATEWAY_PROPERTIES_EX = mock.MagicMock(
 )
 
 
+# Tag associations returned by the REST mock. Object IDs must match the moIds of the
+# SOAP inventory the consuming test drives: the historical fixtures use vm1/host1/ds1,
+# the realtime fixtures use VM4-4-1/10.0.0.104-1/NFS-Share-1.
+HISTORICAL_TAG_ASSOCIATIONS = [
+    {"object_id": {"id": "vm1", "type": "VirtualMachine"}, "tag_ids": ["tag_id_1", "tag_id_2"]},
+    {"object_id": {"id": "host1", "type": "HostSystem"}, "tag_ids": ["tag_id_2"]},
+    {"object_id": {"id": "ds1", "type": "Datastore"}, "tag_ids": ["tag_id_2"]},
+]
+REALTIME_TAG_ASSOCIATIONS = [
+    {"object_id": {"id": "VM4-4-1", "type": "VirtualMachine"}, "tag_ids": ["tag_id_1", "tag_id_2"]},
+    {"object_id": {"id": "10.0.0.104-1", "type": "HostSystem"}, "tag_ids": ["tag_id_2"]},
+    {"object_id": {"id": "NFS-Share-1", "type": "Datastore"}, "tag_ids": ["tag_id_2"]},
+]
+
+
 class MockHttpV6:
-    def __init__(self):
+    def __init__(self, tag_associations=None):
         self.exceptions = {}
+        self.headers = {}
+        self.tag_associations = HISTORICAL_TAG_ASSOCIATIONS if tag_associations is None else tag_associations
+
+    def set_header(self, name, value):
+        self.headers[name] = value
+
+    def get_header(self, name, default=None):
+        return self.headers.get(name, default)
 
     def get(self, url, *args, **kwargs):
         if '/api/' in url:
@@ -1133,7 +1156,7 @@ class MockHttpV6:
     def post(self, url, *args, **kwargs):
         if '/api/' in url:
             return MockHTTPResponse(json_data={}, status_code=404)
-        assert kwargs['headers']['Content-Type'] == 'application/json'
+        assert kwargs['extra_headers']['Content-Type'] == 'application/json'
         parsed_url = urlparse(url)
         path_and_args = parsed_url.path + "?" + parsed_url.query if parsed_url.query else parsed_url.path
         path_parts = path_and_args.split('/')
@@ -1147,21 +1170,23 @@ class MockHttpV6:
             )
         elif re.match(r'.*/tagging/tag-association\?~action=list-attached-tags-on-objects$', url):
             return MockHTTPResponse(
-                json_data={
-                    "value": [
-                        {"object_id": {"id": "vm1", "type": "VirtualMachine"}, "tag_ids": ["tag_id_1", "tag_id_2"]},
-                        {"object_id": {"id": "host1", "type": "HostSystem"}, "tag_ids": ["tag_id_2"]},
-                        {"object_id": {"id": "ds1", "type": "Datastore"}, "tag_ids": ["tag_id_2"]},
-                    ]
-                },
+                json_data={"value": self.tag_associations},
                 status_code=200,
             )
         raise Exception("Rest api mock request not matched: method={}, url={}".format('post', url))
 
 
 class MockHttpV7:
-    def __init__(self):
+    def __init__(self, tag_associations=None):
         self.exceptions = []
+        self.headers = {}
+        self.tag_associations = HISTORICAL_TAG_ASSOCIATIONS if tag_associations is None else tag_associations
+
+    def set_header(self, name, value):
+        self.headers[name] = value
+
+    def get_header(self, name, default=None):
+        return self.headers.get(name, default)
 
     def get(self, url, *args, **kwargs):
         parsed_url = urlparse(url)
@@ -1199,7 +1224,7 @@ class MockHttpV7:
         raise Exception("Rest api mock request not matched: method={}, url={}".format('get', url))
 
     def post(self, url, *args, **kwargs):
-        assert kwargs['headers']['Content-Type'] == 'application/json'
+        assert kwargs['extra_headers']['Content-Type'] == 'application/json'
         parsed_url = urlparse(url)
         path_and_args = parsed_url.path + "?" + parsed_url.query if parsed_url.query else parsed_url.path
         path_parts = path_and_args.split('/')
@@ -1213,11 +1238,7 @@ class MockHttpV7:
             )
         elif re.match(r'.*/tagging/tag-association\?action=list-attached-tags-on-objects$', url):
             return MockHTTPResponse(
-                json_data=[
-                    {'tag_ids': ['tag_id_1', 'tag_id_2'], 'object_id': {'id': 'vm1', 'type': 'VirtualMachine'}},
-                    {'tag_ids': ['tag_id_2'], 'object_id': {'id': 'ds1', 'type': 'Datastore'}},
-                    {'tag_ids': ['tag_id_2'], 'object_id': {'id': 'host1', 'type': 'HostSystem'}},
-                ],
+                json_data=self.tag_associations,
                 status_code=200,
             )
         raise Exception("Rest api mock request not matched: method={}, url={}".format('post', url))

--- a/vsphere/tests/common.py
+++ b/vsphere/tests/common.py
@@ -1085,9 +1085,7 @@ VM_INVALID_GATEWAY_PROPERTIES_EX = mock.MagicMock(
 )
 
 
-# Tag associations returned by the REST mock. Object IDs must match the moIds of the
-# SOAP inventory the consuming test drives: the historical fixtures use vm1/host1/ds1,
-# the realtime fixtures use VM4-4-1/10.0.0.104-1/NFS-Share-1.
+# REST mock tag associations; object IDs must match the moIds of the SOAP inventory each consuming test drives.
 HISTORICAL_TAG_ASSOCIATIONS = [
     {"object_id": {"id": "vm1", "type": "VirtualMachine"}, "tag_ids": ["tag_id_1", "tag_id_2"]},
     {"object_id": {"id": "host1", "type": "HostSystem"}, "tag_ids": ["tag_id_2"]},

--- a/vsphere/tests/common.py
+++ b/vsphere/tests/common.py
@@ -1086,13 +1086,12 @@ VM_INVALID_GATEWAY_PROPERTIES_EX = mock.MagicMock(
 )
 
 
-# REST mock tag associations; object IDs must match the moIds of the SOAP inventory each consuming test drives.
-HISTORICAL_TAG_ASSOCIATIONS = [
+TAG_ASSOCIATIONS = [
     {"object_id": {"id": "vm1", "type": "VirtualMachine"}, "tag_ids": ["tag_id_1", "tag_id_2"]},
     {"object_id": {"id": "host1", "type": "HostSystem"}, "tag_ids": ["tag_id_2"]},
     {"object_id": {"id": "ds1", "type": "Datastore"}, "tag_ids": ["tag_id_2"]},
 ]
-REALTIME_TAG_ASSOCIATIONS = [
+TOPOLOGY_TAG_ASSOCIATIONS = [
     {"object_id": {"id": "VM4-4-1", "type": "VirtualMachine"}, "tag_ids": ["tag_id_1", "tag_id_2"]},
     {"object_id": {"id": "10.0.0.104-1", "type": "HostSystem"}, "tag_ids": ["tag_id_2"]},
     {"object_id": {"id": "NFS-Share-1", "type": "Datastore"}, "tag_ids": ["tag_id_2"]},
@@ -1101,7 +1100,7 @@ REALTIME_TAG_ASSOCIATIONS = [
 
 def configure_vsphere_rest_mock_http(mock_http: Any, tag_associations: list[dict[str, Any]] | None = None) -> Any:
     mock_http.exceptions = {}
-    mock_http.tag_associations = HISTORICAL_TAG_ASSOCIATIONS if tag_associations is None else tag_associations
+    mock_http.tag_associations = TAG_ASSOCIATIONS if tag_associations is None else tag_associations
 
     if VSPHERE_VERSION.startswith('7.'):
         mock_http.get.side_effect = make_mock_http_v7_get(mock_http)

--- a/vsphere/tests/conftest.py
+++ b/vsphere/tests/conftest.py
@@ -248,7 +248,7 @@ def service_instance(
 def _inject_rest_http_client(tag_associations):
     mock_cls = MockHttpV7 if VSPHERE_VERSION.startswith('7.') else MockHttpV6
     http = mock_cls(tag_associations=tag_associations)
-    return patch('datadog_checks.vsphere.api_rest.RequestsWrapper', return_value=http), http
+    return patch('datadog_checks.vsphere.api_rest.create_http_client', return_value=http), http
 
 
 @pytest.fixture

--- a/vsphere/tests/conftest.py
+++ b/vsphere/tests/conftest.py
@@ -28,8 +28,7 @@ from .common import (
     VM_INVALID_PROPERTIES_EX,
     VM_PROPERTIES_EX,
     VSPHERE_VERSION,
-    MockHttpV6,
-    MockHttpV7,
+    configure_vsphere_rest_mock_http,
 )
 from .mocked_api import MockedAPI
 
@@ -245,21 +244,17 @@ def service_instance(
         yield mock_si
 
 
-def inject_rest_http_client(tag_associations):
-    mock_cls = MockHttpV7 if VSPHERE_VERSION.startswith('7.') else MockHttpV6
-    http = mock_cls(tag_associations=tag_associations)
-    return patch('datadog_checks.vsphere.api_rest.create_http_client', return_value=http), http
+def inject_rest_http_client(mock_http, mocker, tag_associations):
+    http = configure_vsphere_rest_mock_http(mock_http, tag_associations=tag_associations)
+    mocker.patch('datadog_checks.vsphere.api_rest.create_http_client', return_value=http)
+    return http
 
 
 @pytest.fixture
-def mock_http_api():
-    ctx, http = inject_rest_http_client(tag_associations=None)
-    with ctx:
-        yield http
+def mock_http_api(mock_http, mocker):
+    return inject_rest_http_client(mock_http, mocker, tag_associations=None)
 
 
 @pytest.fixture
-def mock_rest_api():
-    ctx, http = inject_rest_http_client(tag_associations=REALTIME_TAG_ASSOCIATIONS)
-    with ctx:
-        yield http
+def mock_rest_api(mock_http, mocker):
+    return inject_rest_http_client(mock_http, mocker, tag_associations=REALTIME_TAG_ASSOCIATIONS)

--- a/vsphere/tests/conftest.py
+++ b/vsphere/tests/conftest.py
@@ -23,7 +23,7 @@ from .common import (
     PERF_METRIC_ID,
     PROPERTIES_EX,
     REALTIME_INSTANCE,
-    REALTIME_TAG_ASSOCIATIONS,
+    TOPOLOGY_TAG_ASSOCIATIONS,
     VM_INVALID_GATEWAY_PROPERTIES_EX,
     VM_INVALID_PROPERTIES_EX,
     VM_PROPERTIES_EX,
@@ -257,4 +257,4 @@ def mock_http_api(mock_http, mocker):
 
 @pytest.fixture
 def mock_rest_api(mock_http, mocker):
-    return inject_rest_http_client(mock_http, mocker, tag_associations=REALTIME_TAG_ASSOCIATIONS)
+    return inject_rest_http_client(mock_http, mocker, tag_associations=TOPOLOGY_TAG_ASSOCIATIONS)

--- a/vsphere/tests/conftest.py
+++ b/vsphere/tests/conftest.py
@@ -245,7 +245,7 @@ def service_instance(
         yield mock_si
 
 
-def _inject_rest_http_client(tag_associations):
+def inject_rest_http_client(tag_associations):
     mock_cls = MockHttpV7 if VSPHERE_VERSION.startswith('7.') else MockHttpV6
     http = mock_cls(tag_associations=tag_associations)
     return patch('datadog_checks.vsphere.api_rest.create_http_client', return_value=http), http
@@ -253,13 +253,13 @@ def _inject_rest_http_client(tag_associations):
 
 @pytest.fixture
 def mock_http_api():
-    ctx, http = _inject_rest_http_client(tag_associations=None)
+    ctx, http = inject_rest_http_client(tag_associations=None)
     with ctx:
         yield http
 
 
 @pytest.fixture
 def mock_rest_api():
-    ctx, http = _inject_rest_http_client(tag_associations=REALTIME_TAG_ASSOCIATIONS)
+    ctx, http = inject_rest_http_client(tag_associations=REALTIME_TAG_ASSOCIATIONS)
     with ctx:
         yield http

--- a/vsphere/tests/conftest.py
+++ b/vsphere/tests/conftest.py
@@ -23,6 +23,7 @@ from .common import (
     PERF_METRIC_ID,
     PROPERTIES_EX,
     REALTIME_INSTANCE,
+    REALTIME_TAG_ASSOCIATIONS,
     VM_INVALID_GATEWAY_PROPERTIES_EX,
     VM_INVALID_PROPERTIES_EX,
     VM_PROPERTIES_EX,
@@ -30,7 +31,7 @@ from .common import (
     MockHttpV6,
     MockHttpV7,
 )
-from .mocked_api import MockedAPI, mock_http_rest_api_v6, mock_http_rest_api_v7
+from .mocked_api import MockedAPI
 
 try:
     from contextlib import ExitStack
@@ -244,34 +245,21 @@ def service_instance(
         yield mock_si
 
 
+def _inject_rest_http_client(tag_associations):
+    mock_cls = MockHttpV7 if VSPHERE_VERSION.startswith('7.') else MockHttpV6
+    http = mock_cls(tag_associations=tag_associations)
+    return patch('datadog_checks.vsphere.api_rest.RequestsWrapper', return_value=http), http
+
+
 @pytest.fixture
-def mock_http_api(monkeypatch):
-    if VSPHERE_VERSION.startswith('7.'):
-        http = MockHttpV7()
-    else:
-        http = MockHttpV6()
-
-    def mock_get(*args, **kwargs):
-        return http.get(*args, **kwargs)
-
-    def mock_post(*args, **kwargs):
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.warning(args)
-
-        return http.post(*args, **kwargs)
-
-    monkeypatch.setattr('requests.Session.get', MagicMock(side_effect=mock_get))
-    monkeypatch.setattr('requests.Session.post', MagicMock(side_effect=mock_post))
-    yield http
+def mock_http_api():
+    ctx, http = _inject_rest_http_client(tag_associations=None)
+    with ctx:
+        yield http
 
 
 @pytest.fixture
 def mock_rest_api():
-    if VSPHERE_VERSION.startswith('7.'):
-        with patch('requests.Session.request', mock_http_rest_api_v7):
-            yield
-    else:
-        with patch('requests.Session.request', mock_http_rest_api_v6):
-            yield
+    ctx, http = _inject_rest_http_client(tag_associations=REALTIME_TAG_ASSOCIATIONS)
+    with ctx:
+        yield http

--- a/vsphere/tests/mocked_api.py
+++ b/vsphere/tests/mocked_api.py
@@ -4,11 +4,9 @@
 import datetime as dt
 import json
 import os
-import re
 
 from mock import MagicMock
 from pyVmomi import vim
-from requests import Response
 
 from datadog_checks.vsphere.api import VersionInfo
 from tests.common import HERE, VSPHERE_VERSION
@@ -181,117 +179,3 @@ class MockedAPI(object):
         ]
         self.vsan_metrics_data = [mock_health_data, mock_performance_data]
         return self.vsan_metrics_data
-
-
-class MockResponse(Response):
-    def __init__(self, json_data, status_code):
-        super(MockResponse, self).__init__()
-        self.json_data = json_data
-        self.status_code = status_code
-
-    def json(self):
-        return self.json_data
-
-
-def mock_http_rest_api_v6(self, method, url, **kwargs):
-    if '/api/' in url:
-        return MockResponse({}, 404)
-    if method.lower() == 'get':
-        if re.match(r'.*/category/id:.*$', url):
-            parts = url.split('_')
-            num = parts[len(parts) - 1]
-            return MockResponse(
-                {
-                    "value": {
-                        "name": "my_cat_name_{}".format(num),
-                        "description": "",
-                        "id": "cat_id_{}".format(num),
-                        "used_by": [],
-                        "cardinality": "SINGLE",
-                    }
-                },
-                200,
-            )
-        elif re.match(r'.*/tagging/tag/id:.*$', url):
-            parts = url.split('_')
-            num = parts[len(parts) - 1]
-            return MockResponse(
-                {
-                    "value": {
-                        "category_id": "cat_id_{}".format(num),
-                        "name": "my_tag_name_{}".format(num),
-                        "description": "",
-                        "id": "xxx",
-                        "used_by": [],
-                    }
-                },
-                200,
-            )
-    elif method.lower() == 'post':
-        assert kwargs['headers']['Content-Type'] == 'application/json'
-        if re.match(r'.*/session$', url):
-            return MockResponse(
-                {"value": "dummy-token"},
-                200,
-            )
-        elif re.match(r'.*/tagging/tag-association\?~action=list-attached-tags-on-objects$', url):
-            return MockResponse(
-                {
-                    "value": [
-                        {"object_id": {"id": "VM4-4-1", "type": "VirtualMachine"}, "tag_ids": ["tag_id_1", "tag_id_2"]},
-                        {"object_id": {"id": "10.0.0.104-1", "type": "HostSystem"}, "tag_ids": ["tag_id_2"]},
-                        {"object_id": {"id": "NFS-Share-1", "type": "Datastore"}, "tag_ids": ["tag_id_2"]},
-                    ]
-                },
-                200,
-            )
-    raise Exception("Rest api mock request not matched: method={}, url={}".format(method, url))
-
-
-def mock_http_rest_api_v7(self, method, url, **kwargs):
-    if method.lower() == 'get':
-        if re.match(r'.*/category/.*$', url):
-            parts = url.split('_')
-            num = parts[len(parts) - 1]
-            return MockResponse(
-                {
-                    'name': 'my_cat_name_{}'.format(num),
-                    'description': 'VM category description',
-                    'id': 'cat_id_{}'.format(num),
-                    'used_by': [],
-                    'cardinality': 'SINGLE',
-                },
-                200,
-            )
-
-        elif re.match(r'.*/tagging/tag/.*$', url):
-            parts = url.split('_')
-            num = parts[len(parts) - 1]
-            return MockResponse(
-                {
-                    'category_id': 'cat_id_{}'.format(num),
-                    'name': 'my_tag_name_{}'.format(num),
-                    'description': '',
-                    'id': 'tag_id_{}'.format(num),
-                    'used_by': [],
-                },
-                200,
-            )
-    elif method.lower() == 'post':
-        assert kwargs['headers']['Content-Type'] == 'application/json'
-        if re.match(r'.*/session$', url):
-            return MockResponse(
-                "dummy-token",
-                200,
-            )
-        elif re.match(r'.*/tagging/tag-association\?action=list-attached-tags-on-objects$', url):
-            return MockResponse(
-                [
-                    {'tag_ids': ['tag_id_1', 'tag_id_2'], 'object_id': {'id': 'VM4-4-1', 'type': 'VirtualMachine'}},
-                    {'tag_ids': ['tag_id_2'], 'object_id': {'id': 'NFS-Share-1', 'type': 'Datastore'}},
-                    {'tag_ids': ['tag_id_2'], 'object_id': {'id': '10.0.0.104-1', 'type': 'HostSystem'}},
-                ],
-                200,
-            )
-
-    raise Exception("Rest api mock request not matched: method={}, url={}".format(method, url))

--- a/vsphere/tests/test_api_rest.py
+++ b/vsphere/tests/test_api_rest.py
@@ -244,7 +244,7 @@ def test_create_session(realtime_instance):
     config = VSphereConfig(realtime_instance, {}, logger)
     mock_api = build_rest_api_client(config, logger)
 
-    assert mock_api._client._http.options['headers']['vmware-api-session-id'] == "dummy-token"
+    assert mock_api._client._http.get_header('vmware-api-session-id') == "dummy-token"
 
 
 @pytest.mark.usefixtures("mock_rest_api")

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -277,13 +277,17 @@ def test_tag_prefix(aggregator, dd_run_check, realtime_instance):
 
 
 @pytest.mark.usefixtures('mock_type', 'mock_threadpool', 'mock_api')
-def test_continue_if_tag_collection_fail(aggregator, dd_run_check, realtime_instance):
+def test_continue_if_tag_collection_fail(aggregator, dd_run_check, realtime_instance, mock_rest_api):
     realtime_instance.update({'collect_tags': True})
     check = VSphereCheck('vsphere', {}, [realtime_instance])
     check.log = MagicMock()
 
-    with mock.patch('requests.Session.post', side_effect=Exception, autospec=True):
-        dd_run_check(check)
+    # Fail session creation on both API versions so the check exhausts its v7->v6 fallback.
+    mock_rest_api.exceptions = {
+        'api/session': Exception(),
+        'rest/com/vmware/cis/session': Exception(),
+    }
+    dd_run_check(check)
 
     aggregator.assert_metric('vsphere.cpu.usage.avg', tags=['vcenter_server:FAKE'], hostname='10.0.0.104')
 

--- a/vsphere/tests/test_unit.py
+++ b/vsphere/tests/test_unit.py
@@ -2123,8 +2123,6 @@ def test_rest_api_tags_session_exception(aggregator, dd_run_check, historical_in
             'vsphere_type:datastore',
         ],
     )
-    # Session creation failed, so the tag must not have been collected.
-    aggregator.assert_metric_has_tag('vsphere.datastore.busResets.sum', 'my_cat_name_2:my_tag_name_2', count=0)
 
 
 def test_rest_api_tags_tag_association_exception(aggregator, dd_run_check, historical_instance, mock_http_api):
@@ -2147,8 +2145,6 @@ def test_rest_api_tags_tag_association_exception(aggregator, dd_run_check, histo
             'vsphere_type:datastore',
         ],
     )
-    # Tag-association listing failed, so the tag must not have been collected.
-    aggregator.assert_metric_has_tag('vsphere.datastore.busResets.sum', 'my_cat_name_2:my_tag_name_2', count=0)
 
 
 @pytest.mark.usefixtures('mock_http_api')

--- a/vsphere/tests/test_unit.py
+++ b/vsphere/tests/test_unit.py
@@ -2123,6 +2123,8 @@ def test_rest_api_tags_session_exception(aggregator, dd_run_check, historical_in
             'vsphere_type:datastore',
         ],
     )
+    # Session creation failed, so the tag must not have been collected.
+    aggregator.assert_metric_has_tag('vsphere.datastore.busResets.sum', 'my_cat_name_2:my_tag_name_2', count=0)
 
 
 def test_rest_api_tags_tag_association_exception(aggregator, dd_run_check, historical_instance, mock_http_api):
@@ -2145,6 +2147,8 @@ def test_rest_api_tags_tag_association_exception(aggregator, dd_run_check, histo
             'vsphere_type:datastore',
         ],
     )
+    # Tag-association listing failed, so the tag must not have been collected.
+    aggregator.assert_metric_has_tag('vsphere.datastore.busResets.sum', 'my_cat_name_2:my_tag_name_2', count=0)
 
 
 @pytest.mark.usefixtures('mock_http_api')


### PR DESCRIPTION
### What does this PR do?

Routes the vSphere REST tagging client through a backend-neutral seam instead of naming the requests backend directly in the tests. `VSphereRestClient` now builds its HTTP client via `create_http_client` and sets the session-id header through the `set_header` protocol method rather than mutating the wrapper's `options` dict.

The vSphere tests now patch `create_http_client` to return the shared `mock_http` fixture from `datadog_checks_dev`. The vSphere-specific REST behavior lives in version-specific `get`/`post` side effects, while the shared fixture provides the agnostic HTTP client surface, including `set_header`, `get_header`, and `MockHTTPResponse` responses.

This removes the local `MockHttp`, `MockHttpV6`, and `MockHttpV7` client classes while preserving the test controls for configured REST exceptions and tag associations.

### Motivation

vSphere was one of the last integrations still asserting against `requests.Session`/`requests.Response` in its tests. Driving the REST client through the backend-neutral HTTP protocol (`set_header`/`get_header`) removes the requests coupling from the test suite.

Production now builds the client through the shared `create_http_client` factory in `datadog_checks_base`, which confines the concrete backend (`RequestsWrapper`) to a single location, so a future backend cutover flips one default there instead of editing vSphere.

Behavior is preserved: no metric, service-check, or configuration change.

### Verification

- `ddev test --lint vsphere`
- `ddev --no-interactive test vsphere`
  - `py3.13-6.7`: `319 passed, 2 skipped`
  - `py3.13-7.0`: `319 passed, 2 skipped`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
