### PR TITLE
Narrow HTTP exception catches in kube_* health checks

### DIFF
--- a/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
@@ -4,13 +4,12 @@
 
 import re
 
-import requests
-
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.kube_leader import KubeLeaderElectionMixin
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.http_exceptions import HTTPError
 
 from .sli_metrics import SliMetricsScraperMixin
 
@@ -253,7 +252,7 @@ class KubeControllerManagerCheck(KubeLeaderElectionMixin, SliMetricsScraperMixin
             response = http_handler.get(url)
             response.raise_for_status()
             self.service_check(service_check_name, AgentCheck.OK, tags=tags)
-        except requests.exceptions.RequestException as e:
+        except HTTPError as e:
             message = str(e)
             self.service_check(service_check_name, AgentCheck.CRITICAL, message=message, tags=tags)
 

--- a/kube_controller_manager/tests/test_kube_controller_manager.py
+++ b/kube_controller_manager/tests/test_kube_controller_manager.py
@@ -4,10 +4,10 @@
 
 import mock
 import pytest
-import requests
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.kube_leader import ElectionRecordAnnotation
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.dev.http import MockHTTPResponse
 from datadog_checks.kube_controller_manager import KubeControllerManagerCheck
 
@@ -128,7 +128,7 @@ def generic_check_metrics(aggregator, check_deprecated):
     'side_effect, expected_status, expected_message',
     [
         (None, AgentCheck.OK, None),
-        (requests.HTTPError('health check failed'), AgentCheck.CRITICAL, 'health check failed'),
+        (HTTPStatusError('health check failed'), AgentCheck.CRITICAL, 'health check failed'),
     ],
     ids=['ok', 'http_error'],
 )

--- a/kube_controller_manager/tests/test_kube_controller_manager.py
+++ b/kube_controller_manager/tests/test_kube_controller_manager.py
@@ -7,7 +7,7 @@ import pytest
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.kube_leader import ElectionRecordAnnotation
-from datadog_checks.base.utils.http_exceptions import HTTPStatusError
+from datadog_checks.base.utils.http_exceptions import HTTPConnectionError, HTTPStatusError
 from datadog_checks.dev.http import MockHTTPResponse
 from datadog_checks.kube_controller_manager import KubeControllerManagerCheck
 
@@ -129,8 +129,9 @@ def generic_check_metrics(aggregator, check_deprecated):
     [
         (None, AgentCheck.OK, None),
         (HTTPStatusError('health check failed'), AgentCheck.CRITICAL, 'health check failed'),
+        (HTTPConnectionError('connection refused'), AgentCheck.CRITICAL, 'connection refused'),
     ],
-    ids=['ok', 'http_error'],
+    ids=['ok', 'http_error', 'http_connection_error'],
 )
 def test_service_check(monkeypatch, mock_openmetrics_http, side_effect, expected_status, expected_message):
     instance = {'prometheus_url': 'http://localhost:10252/metrics'}

--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -5,11 +5,10 @@
 import re
 from copy import deepcopy
 
-import requests
-
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.http_exceptions import HTTPError
 
 
 class KubeDNSCheck(OpenMetricsBaseCheck):
@@ -147,7 +146,7 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
             response = http_handler.get(url)
             response.raise_for_status()
             self.service_check(service_check_name, AgentCheck.OK, tags=tags)
-        except requests.exceptions.RequestException as e:
+        except HTTPError as e:
             message = str(e)
             self.service_check(service_check_name, AgentCheck.CRITICAL, message=message, tags=tags)
 

--- a/kube_dns/tests/test_kube_dns.py
+++ b/kube_dns/tests/test_kube_dns.py
@@ -4,9 +4,9 @@
 
 import mock
 import pytest
-import requests
 
 from datadog_checks.base import AgentCheck
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.kube_dns import KubeDNSCheck
 
 from .common import make_mock_metrics
@@ -76,7 +76,7 @@ class TestKubeDNS:
         'side_effect, expected_status, extra_kwargs',
         [
             (None, AgentCheck.OK, {}),
-            (requests.HTTPError('health check failed'), AgentCheck.CRITICAL, {'message': 'health check failed'}),
+            (HTTPStatusError('health check failed'), AgentCheck.CRITICAL, {'message': 'health check failed'}),
         ],
         ids=['ok', 'http_error'],
     )

--- a/kube_dns/tests/test_kube_dns.py
+++ b/kube_dns/tests/test_kube_dns.py
@@ -6,7 +6,7 @@ import mock
 import pytest
 
 from datadog_checks.base import AgentCheck
-from datadog_checks.base.utils.http_exceptions import HTTPStatusError
+from datadog_checks.base.utils.http_exceptions import HTTPConnectionError, HTTPStatusError
 from datadog_checks.kube_dns import KubeDNSCheck
 
 from .common import make_mock_metrics
@@ -77,8 +77,9 @@ class TestKubeDNS:
         [
             (None, AgentCheck.OK, {}),
             (HTTPStatusError('health check failed'), AgentCheck.CRITICAL, {'message': 'health check failed'}),
+            (HTTPConnectionError('connection refused'), AgentCheck.CRITICAL, {'message': 'connection refused'}),
         ],
-        ids=['ok', 'http_error'],
+        ids=['ok', 'http_error', 'http_connection_error'],
     )
     def test_service_check(self, monkeypatch, side_effect, expected_status, extra_kwargs):
         instance_tags = [customtag]

--- a/kube_metrics_server/datadog_checks/kube_metrics_server/kube_metrics_server.py
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/kube_metrics_server.py
@@ -4,10 +4,9 @@
 
 import re
 
-import requests
-
 from datadog_checks.base import AgentCheck, OpenMetricsBaseCheck
 from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.http_exceptions import HTTPError
 
 KUBE_METRICS_SERVER_NAMESPACE = "kube_metrics_server"
 
@@ -137,7 +136,7 @@ class KubeMetricsServerCheck(OpenMetricsBaseCheck):
             response = http_handler.get(url)
             response.raise_for_status()
             self.service_check(service_check_name, AgentCheck.OK, tags=tags)
-        except requests.exceptions.RequestException as e:
+        except HTTPError as e:
             message = str(e)
             self.service_check(service_check_name, AgentCheck.CRITICAL, message=message, tags=tags)
 

--- a/kube_metrics_server/tests/test_kube_metrics_server.py
+++ b/kube_metrics_server/tests/test_kube_metrics_server.py
@@ -4,9 +4,9 @@
 
 import mock
 import pytest
-import requests
 
 from datadog_checks.base import AgentCheck
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.kube_metrics_server import KubeMetricsServerCheck
 
 from .common import make_mock_metrics
@@ -58,7 +58,7 @@ def test_check_metrics(aggregator, mock_metrics, mock_healthcheck_wrapper):
     'side_effect, expected_status, extra_kwargs',
     [
         (None, AgentCheck.OK, {}),
-        (requests.HTTPError('health check failed'), AgentCheck.CRITICAL, {'message': 'health check failed'}),
+        (HTTPStatusError('health check failed'), AgentCheck.CRITICAL, {'message': 'health check failed'}),
     ],
     ids=['ok', 'http_error'],
 )

--- a/kube_metrics_server/tests/test_kube_metrics_server.py
+++ b/kube_metrics_server/tests/test_kube_metrics_server.py
@@ -6,7 +6,7 @@ import mock
 import pytest
 
 from datadog_checks.base import AgentCheck
-from datadog_checks.base.utils.http_exceptions import HTTPStatusError
+from datadog_checks.base.utils.http_exceptions import HTTPConnectionError, HTTPStatusError
 from datadog_checks.kube_metrics_server import KubeMetricsServerCheck
 
 from .common import make_mock_metrics
@@ -59,8 +59,9 @@ def test_check_metrics(aggregator, mock_metrics, mock_healthcheck_wrapper):
     [
         (None, AgentCheck.OK, {}),
         (HTTPStatusError('health check failed'), AgentCheck.CRITICAL, {'message': 'health check failed'}),
+        (HTTPConnectionError('connection refused'), AgentCheck.CRITICAL, {'message': 'connection refused'}),
     ],
-    ids=['ok', 'http_error'],
+    ids=['ok', 'http_error', 'http_connection_error'],
 )
 def test_service_check(monkeypatch, side_effect, expected_status, extra_kwargs):
     instance_tags = []

--- a/kube_proxy/datadog_checks/kube_proxy/kube_proxy.py
+++ b/kube_proxy/datadog_checks/kube_proxy/kube_proxy.py
@@ -3,11 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
 
-import requests
-
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.http_exceptions import HTTPError
 
 METRICS = {
     'process_cpu_seconds_total': 'cpu.time',
@@ -84,7 +83,7 @@ class KubeProxyCheck(OpenMetricsBaseCheck):
             response = http_handler.get(url)
             response.raise_for_status()
             self.service_check(service_check_name, AgentCheck.OK, tags=tags)
-        except requests.exceptions.RequestException as e:
+        except HTTPError as e:
             message = str(e)
             self.service_check(service_check_name, AgentCheck.CRITICAL, message=message, tags=tags)
 

--- a/kube_proxy/tests/test_kube_proxy.py
+++ b/kube_proxy/tests/test_kube_proxy.py
@@ -4,9 +4,9 @@
 
 import mock
 import pytest
-import requests
 
 from datadog_checks.base import AgentCheck
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.kube_proxy import KubeProxyCheck
 
 from .common import make_mock_metrics
@@ -90,7 +90,7 @@ def test_service_check_custom_url():
     'side_effect, expected_status, extra_kwargs',
     [
         (None, AgentCheck.OK, {}),
-        (requests.HTTPError('health check failed'), AgentCheck.CRITICAL, {'message': 'health check failed'}),
+        (HTTPStatusError('health check failed'), AgentCheck.CRITICAL, {'message': 'health check failed'}),
     ],
     ids=['ok', 'http_error'],
 )

--- a/kube_proxy/tests/test_kube_proxy.py
+++ b/kube_proxy/tests/test_kube_proxy.py
@@ -6,7 +6,7 @@ import mock
 import pytest
 
 from datadog_checks.base import AgentCheck
-from datadog_checks.base.utils.http_exceptions import HTTPStatusError
+from datadog_checks.base.utils.http_exceptions import HTTPConnectionError, HTTPStatusError
 from datadog_checks.kube_proxy import KubeProxyCheck
 
 from .common import make_mock_metrics
@@ -91,8 +91,9 @@ def test_service_check_custom_url():
     [
         (None, AgentCheck.OK, {}),
         (HTTPStatusError('health check failed'), AgentCheck.CRITICAL, {'message': 'health check failed'}),
+        (HTTPConnectionError('connection refused'), AgentCheck.CRITICAL, {'message': 'connection refused'}),
     ],
-    ids=['ok', 'http_error'],
+    ids=['ok', 'http_error', 'http_connection_error'],
 )
 def test_service_check(monkeypatch, side_effect, expected_status, extra_kwargs):
     instance_tags = []

--- a/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
@@ -5,13 +5,12 @@ from __future__ import division
 
 import re
 
-import requests
-
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.kube_leader import KubeLeaderElectionMixin
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.http_exceptions import HTTPError
 
 from .sli_metrics import SliMetricsScraperMixin
 
@@ -238,7 +237,7 @@ class KubeSchedulerCheck(KubeLeaderElectionMixin, SliMetricsScraperMixin, OpenMe
             response = http_handler.get(url)
             response.raise_for_status()
             self.service_check(service_check_name, AgentCheck.OK, tags=tags)
-        except requests.exceptions.RequestException as e:
+        except HTTPError as e:
             message = str(e)
             self.service_check(service_check_name, AgentCheck.CRITICAL, message=message, tags=tags)
 

--- a/kube_scheduler/tests/test_kube_scheduler_1_14.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_14.py
@@ -4,10 +4,10 @@
 
 import mock
 import pytest
-import requests
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.kube_leader import ElectionRecordAnnotation
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.dev.http import MockHTTPResponse
 from datadog_checks.kube_scheduler import KubeSchedulerCheck
 
@@ -100,7 +100,7 @@ def test_check_metrics_1_14(aggregator, mock_metrics, mock_leader, mock_healthch
     'side_effect, expected_status, expected_message',
     [
         (None, AgentCheck.OK, None),
-        (requests.HTTPError('health check failed'), AgentCheck.CRITICAL, 'health check failed'),
+        (HTTPStatusError('health check failed'), AgentCheck.CRITICAL, 'health check failed'),
     ],
     ids=['ok', 'http_error'],
 )

--- a/kube_scheduler/tests/test_kube_scheduler_1_14.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_14.py
@@ -7,7 +7,7 @@ import pytest
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.kube_leader import ElectionRecordAnnotation
-from datadog_checks.base.utils.http_exceptions import HTTPStatusError
+from datadog_checks.base.utils.http_exceptions import HTTPConnectionError, HTTPStatusError
 from datadog_checks.dev.http import MockHTTPResponse
 from datadog_checks.kube_scheduler import KubeSchedulerCheck
 
@@ -101,8 +101,9 @@ def test_check_metrics_1_14(aggregator, mock_metrics, mock_leader, mock_healthch
     [
         (None, AgentCheck.OK, None),
         (HTTPStatusError('health check failed'), AgentCheck.CRITICAL, 'health check failed'),
+        (HTTPConnectionError('connection refused'), AgentCheck.CRITICAL, 'connection refused'),
     ],
-    ids=['ok', 'http_error'],
+    ids=['ok', 'http_error', 'http_connection_error'],
 )
 def test_service_check(monkeypatch, mock_openmetrics_http, side_effect, expected_status, expected_message):
     instance = {'prometheus_url': 'http://localhost:10251/metrics'}


### PR DESCRIPTION
### What does this PR do?

Narrows the `requests.exceptions.RequestException` catch in the five `kube_*` checks (`kube_dns`, `kube_proxy`, `kube_scheduler`, `kube_controller_manager`, `kube_metrics_server`) to the backend-agnostic `HTTPError` base (`datadog_checks.base.utils.http_exceptions`), and drops the now-unused `import requests`. The base is the root of the agnostic family, so this preserves the full breadth of the old catch.

### Motivation

The base branch makes `RequestsWrapper` raise only the agnostic `HTTPError` family, never raw `requests.exceptions.*`. On that base the remaining `requests.exceptions.RequestException` catches are dead code: the agnostic exception escapes uncaught, so the CRITICAL service check no longer fires on HTTP errors. Narrowing the catches restores that behavior and removes concrete-backend coupling from shipped integration code.

The `openstack_controller` legacy changes originally bundled here were split out into a separate PR so each integration can be reviewed independently.

### Verification

- Added a non-status `HTTPConnectionError` case to each check's `test_service_check` to pin the widened base catch; all `kube_*` service-check tests pass (17 passed).
- `ddev test -fs` reports all checks passed on all five integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged