### PR TITLE
Show phase error details in the Togo UI

### DIFF
--- a/ddev/src/ddev/ai/callbacks/callbacks.py
+++ b/ddev/src/ddev/ai/callbacks/callbacks.py
@@ -95,9 +95,9 @@ class OnPhaseErrorCallback(Protocol):
 
 
 class OnRunErrorCallback(Protocol):
-    """Called when the orchestrator terminates a run with an error."""
+    """Called when the orchestrator stops a run because a phase failed."""
 
-    async def __call__(self, error: BaseException, phase_id: str | None) -> None: ...
+    async def __call__(self) -> None: ...
 
 
 class OnBeforeGoalCheckCallback(Protocol):
@@ -245,8 +245,8 @@ class CallbackSet:
         self._on_run_error.append(func)
         return func
 
-    async def fire_run_error(self, error: BaseException, phase_id: str | None) -> None:
-        await self._fire(self._on_run_error, error, phase_id)
+    async def fire_run_error(self) -> None:
+        await self._fire(self._on_run_error)
 
     def on_before_goal_check(self, func: OnBeforeGoalCheckCallback) -> OnBeforeGoalCheckCallback:
         self._on_before_goal_check.append(func)
@@ -323,9 +323,9 @@ class Callbacks:
         for s in self._sets:
             await s.fire_phase_error(phase_id, error)
 
-    async def fire_run_error(self, error: BaseException, phase_id: str | None) -> None:
+    async def fire_run_error(self) -> None:
         for s in self._sets:
-            await s.fire_run_error(error, phase_id)
+            await s.fire_run_error()
 
     async def fire_before_goal_check(self, phase_id: str, task_name: str, attempt: int) -> None:
         for s in self._sets:

--- a/ddev/src/ddev/ai/callbacks/callbacks.py
+++ b/ddev/src/ddev/ai/callbacks/callbacks.py
@@ -88,6 +88,18 @@ class OnPhaseFinishCallback(Protocol):
     async def __call__(self, phase_id: str) -> None: ...
 
 
+class OnPhaseErrorCallback(Protocol):
+    """Called once when a phase terminates with an error."""
+
+    async def __call__(self, phase_id: str, error: BaseException) -> None: ...
+
+
+class OnRunErrorCallback(Protocol):
+    """Called when the orchestrator terminates a run with an error."""
+
+    async def __call__(self, error: BaseException, phase_id: str | None) -> None: ...
+
+
 class OnBeforeGoalCheckCallback(Protocol):
     """Called immediately before each reviewer agent run for a task with a goal."""
 
@@ -133,6 +145,8 @@ class CallbackSet:
         self._on_agent_error: list[OnAgentErrorCallback] = []
         self._on_phase_start: list[OnPhaseStartCallback] = []
         self._on_phase_finish: list[OnPhaseFinishCallback] = []
+        self._on_phase_error: list[OnPhaseErrorCallback] = []
+        self._on_run_error: list[OnRunErrorCallback] = []
         self._on_before_goal_check: list[OnBeforeGoalCheckCallback] = []
         self._on_after_goal_check: list[OnAfterGoalCheckCallback] = []
 
@@ -220,6 +234,20 @@ class CallbackSet:
     async def fire_phase_finish(self, phase_id: str) -> None:
         await self._fire(self._on_phase_finish, phase_id)
 
+    def on_phase_error(self, func: OnPhaseErrorCallback) -> OnPhaseErrorCallback:
+        self._on_phase_error.append(func)
+        return func
+
+    async def fire_phase_error(self, phase_id: str, error: BaseException) -> None:
+        await self._fire(self._on_phase_error, phase_id, error)
+
+    def on_run_error(self, func: OnRunErrorCallback) -> OnRunErrorCallback:
+        self._on_run_error.append(func)
+        return func
+
+    async def fire_run_error(self, error: BaseException, phase_id: str | None) -> None:
+        await self._fire(self._on_run_error, error, phase_id)
+
     def on_before_goal_check(self, func: OnBeforeGoalCheckCallback) -> OnBeforeGoalCheckCallback:
         self._on_before_goal_check.append(func)
         return func
@@ -290,6 +318,14 @@ class Callbacks:
     async def fire_phase_finish(self, phase_id: str) -> None:
         for s in self._sets:
             await s.fire_phase_finish(phase_id)
+
+    async def fire_phase_error(self, phase_id: str, error: BaseException) -> None:
+        for s in self._sets:
+            await s.fire_phase_error(phase_id, error)
+
+    async def fire_run_error(self, error: BaseException, phase_id: str | None) -> None:
+        for s in self._sets:
+            await s.fire_run_error(error, phase_id)
 
     async def fire_before_goal_check(self, phase_id: str, task_name: str, attempt: int) -> None:
         for s in self._sets:

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
 from ddev.ai.agent.scope import AgentRole, AgentScope
@@ -12,7 +11,6 @@ from ddev.ai.config.errors import ConfigError
 from ddev.ai.config.models import AgentConfig, PhaseConfig, TaskConfig
 from ddev.ai.phases.base import FlowContext, Phase, PhaseOutcome
 from ddev.ai.phases.goal import GOAL_TASK_SUFFIX, GoalValidationError, run_goal_loop
-from ddev.ai.phases.messages import PhaseFailedMessage
 from ddev.ai.phases.template import render_inline
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.runtime.checkpoints import (
@@ -22,7 +20,6 @@ from ddev.ai.runtime.checkpoints import (
     FailedCheckpoint,
     GoalValidationRecord,
 )
-from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
 
 if TYPE_CHECKING:
     from ddev.ai.phases.goal import GoalLoopOutcome
@@ -311,28 +308,12 @@ class AgenticPhase(Phase):
             goal_validations=self._goal_attempt_log or None,
         )
 
-    async def on_error(self, error: MessageProcessingError | ProcessorHookError) -> None:
-        try:
-            self._checkpoint_manager.write_phase_checkpoint(
-                self._phase_id,
-                FailedCheckpoint(
-                    started_at=self._started_at.isoformat() if self._started_at else None,
-                    finished_at=datetime.now(UTC).isoformat(),
-                    error=str(error.original_exception),
-                    tokens=CheckpointTokenInfo(
-                        total_input=self._total_input_tokens,
-                        total_output=self._total_output_tokens,
-                    ),
-                    goal_validations=self._goal_attempt_log or None,
-                ),
-            )
-        except Exception:
-            self._logger.exception("Failed to write failure checkpoint for phase %s", self._phase_id)
-        finally:
-            self.submit_message(
-                PhaseFailedMessage(
-                    id=f"{self._phase_id}_failed",
-                    phase_id=self._phase_id,
-                    error=str(error.original_exception),
-                )
-            )
+    def build_failed_checkpoint(self, error: BaseException) -> FailedCheckpoint:
+        """Include partial token and goal progress in a failed checkpoint."""
+        checkpoint = super().build_failed_checkpoint(error)
+        checkpoint.tokens = CheckpointTokenInfo(
+            total_input=self._total_input_tokens,
+            total_output=self._total_output_tokens,
+        )
+        checkpoint.goal_validations = self._goal_attempt_log or None
+        return checkpoint

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -166,25 +166,31 @@ class Phase(AsyncProcessor[PhaseTrigger]):
             )
         )
 
+    def build_failed_checkpoint(self, error: BaseException) -> FailedCheckpoint:
+        """Build the checkpoint persisted when this phase fails."""
+        return FailedCheckpoint(
+            started_at=self._started_at.isoformat() if self._started_at else None,
+            finished_at=datetime.now(UTC).isoformat(),
+            error=str(error),
+            tokens=CheckpointTokenInfo(total_input=0, total_output=0),
+        )
+
     async def on_error(self, error: MessageProcessingError | ProcessorHookError) -> None:
-        """Write failed checkpoint and emit PhaseFailedMessage."""
+        """Persist and publish a phase failure."""
+        original_error = error.original_exception
         try:
             self._checkpoint_manager.write_phase_checkpoint(
                 self._phase_id,
-                FailedCheckpoint(
-                    started_at=self._started_at.isoformat() if self._started_at else None,
-                    finished_at=datetime.now(UTC).isoformat(),
-                    error=str(error.original_exception),
-                    tokens=CheckpointTokenInfo(total_input=0, total_output=0),
-                ),
+                self.build_failed_checkpoint(original_error),
             )
         except Exception:
             self._logger.exception("Failed to write failure checkpoint for phase %s", self._phase_id)
         finally:
+            await self._callbacks.fire_phase_error(self._phase_id, original_error)
             self.submit_message(
                 PhaseFailedMessage(
                     id=f"{self._phase_id}_failed",
                     phase_id=self._phase_id,
-                    error=str(error.original_exception),
+                    error=str(original_error),
                 )
             )

--- a/ddev/src/ddev/ai/phases/openmetrics/inspect_endpoint.py
+++ b/ddev/src/ddev/ai/phases/openmetrics/inspect_endpoint.py
@@ -331,11 +331,11 @@ class InspectEndpointPhase(Phase):
     async def execute(self, context: dict[str, Any]) -> PhaseOutcome:
         raw = context.get("inspect_input")
         if not raw:
-            raise ConfigError(f"Phase {self._phase_id!r}: 'inspect_input' runtime variable is required")
+            raise ConfigError("'inspect_input' runtime variable is required")
         try:
             endpoints = InspectInput.model_validate_json(raw).endpoints
         except ValidationError as e:
-            raise ConfigError(f"Phase {self._phase_id!r}: invalid 'inspect_input': {e}") from e
+            raise ConfigError(f"invalid 'inspect_input': {e}") from e
 
         memory_dir = self._checkpoint_manager.memory_dir
         memory_dir.mkdir(parents=True, exist_ok=True)

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -15,7 +15,7 @@ from ddev.ai.runtime.agent_log import AgentLogger
 from ddev.ai.runtime.checkpoints import CheckpointManager, resolve_resume_state
 from ddev.ai.runtime.resources import RunResources
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
-from ddev.event_bus.exceptions import FatalProcessingError
+from ddev.event_bus.exceptions import FatalProcessingError, OrchestratorHookError
 from ddev.event_bus.orchestrator import BaseMessage, EventBusOrchestrator
 
 
@@ -125,7 +125,14 @@ class PhaseOrchestrator(EventBusOrchestrator):
         if isinstance(message, PhaseFailedMessage):
             self._failed_phase = message.phase_id
             self._failed_error = message.error
-            raise FatalProcessingError(f"Phase '{message.phase_id}' failed: {message.error}")
+            error = FatalProcessingError(f"Phase '{message.phase_id}' failed: {message.error}")
+            await self._callbacks.fire_run_error(error, message.phase_id)
+            raise error
+
+    async def on_error(self, error: OrchestratorHookError) -> None:
+        """Publish unexpected orchestrator failures and stop the run."""
+        await self._callbacks.fire_run_error(error.original_exception, None)
+        raise FatalProcessingError(str(error)) from error.original_exception
 
     async def on_finalize(self, exception: Exception | None) -> None:
         if self._agent_logger is not None:

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -126,12 +126,11 @@ class PhaseOrchestrator(EventBusOrchestrator):
             self._failed_phase = message.phase_id
             self._failed_error = message.error
             error = FatalProcessingError(f"Phase '{message.phase_id}' failed: {message.error}")
-            await self._callbacks.fire_run_error(error, message.phase_id)
+            await self._callbacks.fire_run_error()
             raise error
 
     async def on_error(self, error: OrchestratorHookError) -> None:
-        """Publish unexpected orchestrator failures and stop the run."""
-        await self._callbacks.fire_run_error(error.original_exception, None)
+        """Stop the run after an unexpected orchestrator failure."""
         raise FatalProcessingError(str(error)) from error.original_exception
 
     async def on_finalize(self, exception: Exception | None) -> None:

--- a/ddev/src/ddev/cli/meta/ai/rendering.py
+++ b/ddev/src/ddev/cli/meta/ai/rendering.py
@@ -294,3 +294,8 @@ def render_agent_finish_line(scope: AgentScope, result: ReActResult) -> Text:
 def render_agent_error_line(scope: AgentScope, error: BaseException) -> Text:
     """Build the ``✗ <owner_id> — ErrorType: message`` error line."""
     return Text(f"✗ {scope.owner_id} — {describe_agent_error(error)}", style=ERROR)
+
+
+def render_phase_error_line(phase_id: str, error: BaseException) -> Text:
+    """Build the full error recorded when a phase terminates."""
+    return Text(f"✗ {phase_id} failed — {type(error).__name__}: {error}", style=ERROR)

--- a/ddev/src/ddev/cli/meta/ai/tui/app.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/app.py
@@ -31,8 +31,10 @@ from ddev.cli.meta.ai.tui.messages import (
     BeforeCompact,
     BeforeGoalCheck,
     ContextCleared,
+    PhaseErrored,
     PhaseFinished,
     PhaseStarted,
+    RunErrored,
 )
 from ddev.cli.meta.ai.tui.theme import togo_markdown_theme, togo_theme
 
@@ -146,6 +148,12 @@ class TogoApp(App):
         self._record(msg)
 
     async def on_phase_finished(self, msg: PhaseFinished) -> None:
+        self._record(msg)
+
+    async def on_phase_errored(self, msg: PhaseErrored) -> None:
+        self._record(msg)
+
+    async def on_run_errored(self, msg: RunErrored) -> None:
         self._record(msg)
 
     async def on_agent_started(self, msg: AgentStarted) -> None:

--- a/ddev/src/ddev/cli/meta/ai/tui/bridge.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/bridge.py
@@ -30,8 +30,10 @@ from ddev.cli.meta.ai.tui.messages import (
     BeforeCompact,
     BeforeGoalCheck,
     ContextCleared,
+    PhaseErrored,
     PhaseFinished,
     PhaseStarted,
+    RunErrored,
 )
 
 
@@ -66,6 +68,14 @@ def build_app_callback_set(app: BridgeApp) -> CallbackSet:
     @cb.on_phase_finish
     async def _(phase_id: str) -> None:
         _target().post_message(PhaseFinished(phase_id))
+
+    @cb.on_phase_error
+    async def _(phase_id: str, error: BaseException) -> None:
+        _target().post_message(PhaseErrored(phase_id, error))
+
+    @cb.on_run_error
+    async def _(error: BaseException, phase_id: str | None) -> None:
+        _target().post_message(RunErrored(error, phase_id))
 
     @cb.on_before_agent_send
     async def _(scope: AgentScope, prompt: str, iteration: int) -> None:

--- a/ddev/src/ddev/cli/meta/ai/tui/bridge.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/bridge.py
@@ -74,8 +74,8 @@ def build_app_callback_set(app: BridgeApp) -> CallbackSet:
         _target().post_message(PhaseErrored(phase_id, error))
 
     @cb.on_run_error
-    async def _(error: BaseException, phase_id: str | None) -> None:
-        _target().post_message(RunErrored(error, phase_id))
+    async def _() -> None:
+        _target().post_message(RunErrored())
 
     @cb.on_before_agent_send
     async def _(scope: AgentScope, prompt: str, iteration: int) -> None:

--- a/ddev/src/ddev/cli/meta/ai/tui/messages.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/messages.py
@@ -42,21 +42,15 @@ class PhaseErrored(Message):
 
 
 class RunErrored(Message):
-    """Fired when orchestration terminates a run with an exception."""
-
-    def __init__(self, error: BaseException, phase_id: str | None) -> None:
-        super().__init__()
-        self.error = error
-        self.phase_id = phase_id
+    """Fired when orchestration stops because a phase failed."""
 
 
 class ExecutionFailed(Message):
-    """Fired when orchestration exits with an exception."""
+    """Fired when execution exits through an unexpected exception."""
 
-    def __init__(self, error: BaseException, phase_id: str | None) -> None:
+    def __init__(self, error: BaseException) -> None:
         super().__init__()
         self.error = error
-        self.phase_id = phase_id
 
 
 class AgentStarted(Message):

--- a/ddev/src/ddev/cli/meta/ai/tui/messages.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/messages.py
@@ -32,6 +32,24 @@ class PhaseFinished(Message):
         self.phase_id = phase_id
 
 
+class PhaseErrored(Message):
+    """Fired when a phase terminates with an exception."""
+
+    def __init__(self, phase_id: str, error: BaseException) -> None:
+        super().__init__()
+        self.phase_id = phase_id
+        self.error = error
+
+
+class RunErrored(Message):
+    """Fired when orchestration terminates a run with an exception."""
+
+    def __init__(self, error: BaseException, phase_id: str | None) -> None:
+        super().__init__()
+        self.error = error
+        self.phase_id = phase_id
+
+
 class ExecutionFailed(Message):
     """Fired when orchestration exits with an exception."""
 

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -106,7 +106,6 @@ class ExecutionScreen(TogoScreen):
         self._active_thinking: dict[str, dict[str, str]] = {entry.phase: {} for entry in flow.flow}
         self._orchestrator: OrchestratorLike | None = None
         self._run_worker: Worker[None] | None = None
-        self._run_error_reported = False
         self._phase_errors: dict[str, BaseException] = {}
         # Records every renderable produced by the run — used by tests and to
         # populate phase log screens opened after the fact.
@@ -172,8 +171,8 @@ class ExecutionScreen(TogoScreen):
             self.query_one(TogoHeader).running = True
             await orchestrator.run_async()
         except Exception as error:
-            failed_phase = orchestrator.failed_phase if orchestrator is not None else None
-            self.post_message(ExecutionFailed(error, failed_phase))
+            if orchestrator is None or orchestrator.failed_phase is None:
+                self.post_message(ExecutionFailed(error))
         finally:
             try:
                 self.query_one(TogoHeader).running = False
@@ -331,27 +330,17 @@ class ExecutionScreen(TogoScreen):
         self._write_output(render_phase_error_line(msg.phase_id, msg.error), phase_id=msg.phase_id)
         if msg.phase_id in self._phase_statuses:
             self._mark_phase_failed(msg.phase_id)
-        if self._run_error_reported:
-            self._show_phase_error_summary()
+        self._show_phase_error_summary()
         self._update_display()
 
     def on_run_errored(self, msg: RunErrored) -> None:
-        self._run_error_reported = True
         if self._phase_errors:
             self._show_phase_error_summary()
         else:
-            self._show_run_error(msg.error, msg.phase_id)
+            self._show_error_banner("Run failed.")
 
     def on_execution_failed(self, msg: ExecutionFailed) -> None:
-        if not self._run_error_reported:
-            self._run_error_reported = True
-            if self._phase_errors:
-                self._show_phase_error_summary()
-            else:
-                self._show_run_error(msg.error, msg.phase_id)
-        if msg.phase_id in self._phase_statuses:
-            self._mark_phase_failed(msg.phase_id)
-            self._update_display()
+        self._show_run_error(msg.error)
 
     def on_phase_selected(self, msg: PhaseSelected) -> None:
         status = self._phase_statuses.get(msg.phase_id, RunStatus.PENDING)

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -26,6 +26,7 @@ from ddev.cli.meta.ai.rendering import (
     render_agent_tools_line,
     render_compact_notice,
     render_context_cleared_notice,
+    render_phase_error_line,
     render_prompt_panel,
     render_response_header,
     render_response_text,
@@ -47,12 +48,15 @@ from ddev.cli.meta.ai.tui.messages import (
     BeforeGoalCheck,
     ContextCleared,
     ExecutionFailed,
+    PhaseErrored,
     PhaseFinished,
     PhaseStarted,
+    RunErrored,
 )
 from ddev.cli.meta.ai.tui.runs import ai_runs_dir, flow_slug, resume_completed_phases
 from ddev.cli.meta.ai.tui.screens.base import TogoScreen
 from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+from ddev.cli.meta.ai.tui.screens.phase_error_modal import PhaseErrorModal
 from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogEntry, PhaseLogScreen
 from ddev.cli.meta.ai.tui.status import RunStatus
 from ddev.cli.meta.ai.tui.widgets.header import TogoHeader
@@ -63,6 +67,8 @@ if TYPE_CHECKING:
 
 
 type OrchestratorBuilder = Callable[[Callbacks], OrchestratorLike]
+
+BANNER_ERROR_MAX_CHARS = 200
 
 
 class ExecutionScreen(TogoScreen):
@@ -100,6 +106,8 @@ class ExecutionScreen(TogoScreen):
         self._active_thinking: dict[str, dict[str, str]] = {entry.phase: {} for entry in flow.flow}
         self._orchestrator: OrchestratorLike | None = None
         self._run_worker: Worker[None] | None = None
+        self._run_error_reported = False
+        self._phase_errors: dict[str, BaseException] = {}
         # Records every renderable produced by the run — used by tests and to
         # populate phase log screens opened after the fact.
         self._output_renders: list[PhaseLogEntry] = []
@@ -208,14 +216,47 @@ class ExecutionScreen(TogoScreen):
         except Exception:
             pass
 
-    def _show_execution_error(self, error: BaseException) -> None:
-        message = f"Execution failed: {type(error).__name__}: {error}"
+    def _compact_error_detail(self, error: BaseException, phase_id: str | None = None) -> str:
+        detail = next((line.strip() for line in str(error).splitlines() if line.strip()), type(error).__name__)
+        if phase_id is not None:
+            detail = detail.removeprefix(f"Phase '{phase_id}' failed: ")
+            detail = detail.removeprefix(f"Phase '{phase_id}': ")
+        if len(detail) > BANNER_ERROR_MAX_CHARS:
+            detail = f"{detail[: BANNER_ERROR_MAX_CHARS - 1].rstrip()}…"
+        return detail
+
+    def _show_error_banner(self, message: str) -> None:
         try:
             widget = self.query_one("#execution-error", Static)
             widget.update(message)
             widget.display = True
         except Exception:
             pass
+
+    def _show_run_error(self, error: BaseException, phase_id: str | None = None) -> None:
+        detail = self._compact_error_detail(error, phase_id)
+        title = f"Run failed in {phase_id}" if phase_id is not None else "Run failed"
+        hint = f"Select {phase_id} to view the full error." if phase_id is not None else ""
+        message = f"{title}: {detail}"
+        if hint:
+            message = f"{message}\n{hint}"
+        self._show_error_banner(message)
+
+    def _show_phase_error_summary(self) -> None:
+        ordered_errors = [
+            (phase_id, self._phase_errors[phase_id])
+            for phase_id in self._phase_statuses
+            if phase_id in self._phase_errors
+        ]
+        if len(ordered_errors) == 1:
+            phase_id, error = ordered_errors[0]
+            self._show_run_error(error, phase_id)
+            return
+
+        lines = [f"Run failed — {len(ordered_errors)} phases failed"]
+        lines.extend(f"{phase_id}: {self._compact_error_detail(error, phase_id)}" for phase_id, error in ordered_errors)
+        lines.append("Select a failed phase to view its full error.")
+        self._show_error_banner("\n".join(lines))
 
     def _mark_phase_failed(self, phase_id: str) -> None:
         self._phase_statuses[phase_id] = RunStatus.FAILED
@@ -267,6 +308,10 @@ class ExecutionScreen(TogoScreen):
             if key.startswith(prefix):
                 self._stop_thinking(phase_id, key)
 
+    def _stop_phase_thinking(self, phase_id: str) -> None:
+        for key in list(self._active_thinking.setdefault(phase_id, {})):
+            self._stop_thinking(phase_id, key)
+
     # ── Bridge message handlers ──────────────────────────────────────────
 
     def on_phase_started(self, msg: PhaseStarted) -> None:
@@ -280,15 +325,39 @@ class ExecutionScreen(TogoScreen):
                 self._task_statuses[(p, t)] = RunStatus.DONE
         self._update_display()
 
+    def on_phase_errored(self, msg: PhaseErrored) -> None:
+        self._phase_errors[msg.phase_id] = msg.error
+        self._stop_phase_thinking(msg.phase_id)
+        self._write_output(render_phase_error_line(msg.phase_id, msg.error), phase_id=msg.phase_id)
+        if msg.phase_id in self._phase_statuses:
+            self._mark_phase_failed(msg.phase_id)
+        if self._run_error_reported:
+            self._show_phase_error_summary()
+        self._update_display()
+
+    def on_run_errored(self, msg: RunErrored) -> None:
+        self._run_error_reported = True
+        if self._phase_errors:
+            self._show_phase_error_summary()
+        else:
+            self._show_run_error(msg.error, msg.phase_id)
+
     def on_execution_failed(self, msg: ExecutionFailed) -> None:
-        self._show_execution_error(msg.error)
+        if not self._run_error_reported:
+            self._run_error_reported = True
+            if self._phase_errors:
+                self._show_phase_error_summary()
+            else:
+                self._show_run_error(msg.error, msg.phase_id)
         if msg.phase_id in self._phase_statuses:
             self._mark_phase_failed(msg.phase_id)
             self._update_display()
 
     def on_phase_selected(self, msg: PhaseSelected) -> None:
         status = self._phase_statuses.get(msg.phase_id, RunStatus.PENDING)
-        if status.has_started:
+        if status is RunStatus.FAILED and (error := self._phase_errors.get(msg.phase_id)) is not None:
+            self.app.push_screen(PhaseErrorModal(msg.phase_id, error))
+        elif status.has_started:
             self.app.push_screen(PhaseLogScreen(self.flow, msg.phase_id, self._phase_logs[msg.phase_id], source=self))
         else:
             self.app.push_screen(PhaseConfigScreen(self.flow, msg.phase_id))
@@ -339,6 +408,7 @@ class ExecutionScreen(TogoScreen):
         self._stop_agent_thinking(phase_id, msg.scope.owner_id, msg.scope.role.value)
         self._write_output(render_agent_error_line(msg.scope, msg.error), phase_id=phase_id)
         if phase_id is not None:
+            self._phase_errors.setdefault(phase_id, msg.error)
             self._mark_phase_failed(phase_id)
         self._update_display()
 

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -408,7 +408,6 @@ class ExecutionScreen(TogoScreen):
         self._stop_agent_thinking(phase_id, msg.scope.owner_id, msg.scope.role.value)
         self._write_output(render_agent_error_line(msg.scope, msg.error), phase_id=phase_id)
         if phase_id is not None:
-            self._phase_errors.setdefault(phase_id, msg.error)
             self._mark_phase_failed(phase_id)
         self._update_display()
 

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/phase_error_modal.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/phase_error_modal.py
@@ -1,0 +1,45 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from __future__ import annotations
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widget import Widget
+from textual.widgets import Button, Static
+
+from ddev.cli.meta.ai.palette import ERROR
+
+
+class PhaseErrorModal(ModalScreen[None]):
+    """Show the complete error for a failed phase over the execution view."""
+
+    BINDINGS = [Binding("escape", "dismiss_modal", "Close")]
+
+    def __init__(self, phase_id: str, error: BaseException) -> None:
+        super().__init__()
+        self.phase_id = phase_id
+        self.error = error
+
+    def compose(self) -> ComposeResult:
+        dialog = Widget(id="dialog", classes="phase-error")
+        dialog.border_title = f"Phase failed · {self.phase_id}"
+        with dialog:
+            yield Static("The complete phase error is shown below.", classes="desc")
+            with VerticalScroll(id="phase-error-details"):
+                message = Text(f"{type(self.error).__name__}: ", style=f"bold {ERROR}")
+                message.append(str(self.error))
+                yield Static(message, id="phase-error-message")
+            with Horizontal(classes="modal-actions"):
+                yield Button("Close", id="btn-close", variant="primary")
+
+    def action_dismiss_modal(self) -> None:
+        self.dismiss(None)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-close":
+            self.dismiss(None)

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -542,6 +542,25 @@ ModalScreen {
     width: 96;
 }
 
+#dialog.phase-error {
+    width: 96;
+    min-height: 12;
+    max-height: 70%;
+}
+
+#phase-error-details {
+    height: auto;
+    max-height: 24;
+    margin-top: 1;
+    border: round $error;
+    background: $panel;
+    padding: 1 2;
+}
+
+#phase-error-message {
+    height: auto;
+}
+
 #diagnostic-errors {
     height: 1fr;
     margin-top: 1;

--- a/ddev/tests/ai/callbacks/test_callbacks.py
+++ b/ddev/tests/ai/callbacks/test_callbacks.py
@@ -457,16 +457,15 @@ async def test_phase_error_registered_and_fired() -> None:
 
 async def test_run_error_registered_and_fired() -> None:
     cb = CallbackSet()
-    received: list[tuple[BaseException, str | None]] = []
-    error = RuntimeError("boom")
+    received: list[bool] = []
 
     @cb.on_run_error
-    async def handler(error: BaseException, phase_id: str | None) -> None:
-        received.append((error, phase_id))
+    async def handler() -> None:
+        received.append(True)
 
-    await cb.fire_run_error(error, "inspect")
+    await cb.fire_run_error()
 
-    assert received == [(error, "inspect")]
+    assert received == [True]
 
 
 async def test_error_callback_exceptions_are_swallowed() -> None:
@@ -482,18 +481,18 @@ async def test_error_callback_exceptions_are_swallowed() -> None:
         fired.append(f"phase:{phase_id}")
 
     @cb.on_run_error
-    async def bad_run(error: BaseException, phase_id: str | None) -> None:
+    async def bad_run() -> None:
         raise RuntimeError("callback failed")
 
     @cb.on_run_error
-    async def good_run(error: BaseException, phase_id: str | None) -> None:
-        fired.append(f"run:{phase_id}")
+    async def good_run() -> None:
+        fired.append("run")
 
     error = RuntimeError("boom")
     await cb.fire_phase_error("inspect", error)
-    await cb.fire_run_error(error, "inspect")
+    await cb.fire_run_error()
 
-    assert fired == ["phase:inspect", "run:inspect"]
+    assert fired == ["phase:inspect", "run"]
 
 
 # ---------------------------------------------------------------------------
@@ -646,7 +645,7 @@ async def test_callbacks_empty_is_noop(
     await callbacks.fire_phase_start("p")
     await callbacks.fire_phase_finish("p")
     await callbacks.fire_phase_error("p", RuntimeError("boom"))
-    await callbacks.fire_run_error(RuntimeError("boom"), "p")
+    await callbacks.fire_run_error()
     await callbacks.fire_before_goal_check("p", "t", 1)
     await callbacks.fire_after_goal_check("p", "t", 1, True, "")
 

--- a/ddev/tests/ai/callbacks/test_callbacks.py
+++ b/ddev/tests/ai/callbacks/test_callbacks.py
@@ -437,6 +437,66 @@ async def test_phase_finish_exception_is_swallowed() -> None:
 
 
 # ---------------------------------------------------------------------------
+# on_phase_error and on_run_error
+# ---------------------------------------------------------------------------
+
+
+async def test_phase_error_registered_and_fired() -> None:
+    cb = CallbackSet()
+    received: list[tuple[str, BaseException]] = []
+    error = RuntimeError("boom")
+
+    @cb.on_phase_error
+    async def handler(phase_id: str, error: BaseException) -> None:
+        received.append((phase_id, error))
+
+    await cb.fire_phase_error("inspect", error)
+
+    assert received == [("inspect", error)]
+
+
+async def test_run_error_registered_and_fired() -> None:
+    cb = CallbackSet()
+    received: list[tuple[BaseException, str | None]] = []
+    error = RuntimeError("boom")
+
+    @cb.on_run_error
+    async def handler(error: BaseException, phase_id: str | None) -> None:
+        received.append((error, phase_id))
+
+    await cb.fire_run_error(error, "inspect")
+
+    assert received == [(error, "inspect")]
+
+
+async def test_error_callback_exceptions_are_swallowed() -> None:
+    cb = CallbackSet()
+    fired: list[str] = []
+
+    @cb.on_phase_error
+    async def bad_phase(phase_id: str, error: BaseException) -> None:
+        raise RuntimeError("callback failed")
+
+    @cb.on_phase_error
+    async def good_phase(phase_id: str, error: BaseException) -> None:
+        fired.append(f"phase:{phase_id}")
+
+    @cb.on_run_error
+    async def bad_run(error: BaseException, phase_id: str | None) -> None:
+        raise RuntimeError("callback failed")
+
+    @cb.on_run_error
+    async def good_run(error: BaseException, phase_id: str | None) -> None:
+        fired.append(f"run:{phase_id}")
+
+    error = RuntimeError("boom")
+    await cb.fire_phase_error("inspect", error)
+    await cb.fire_run_error(error, "inspect")
+
+    assert fired == ["phase:inspect", "run:inspect"]
+
+
+# ---------------------------------------------------------------------------
 # on_before_agent_send
 # ---------------------------------------------------------------------------
 
@@ -585,6 +645,8 @@ async def test_callbacks_empty_is_noop(
     await callbacks.fire_before_agent_send(scope, "p", 1)
     await callbacks.fire_phase_start("p")
     await callbacks.fire_phase_finish("p")
+    await callbacks.fire_phase_error("p", RuntimeError("boom"))
+    await callbacks.fire_run_error(RuntimeError("boom"), "p")
     await callbacks.fire_before_goal_check("p", "t", 1)
     await callbacks.fire_after_goal_check("p", "t", 1, True, "")
 

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -4,6 +4,7 @@
 
 from datetime import UTC, datetime
 
+from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
 from ddev.ai.config.models import PhaseConfig
 from ddev.ai.phases.base import FlowContext, Phase, PhaseOutcome
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
@@ -141,6 +142,28 @@ async def test_on_error_writes_failed_checkpoint_after_start(flow_dir, flow_cont
     checkpoint = mgr.read()["p1"]
     assert isinstance(checkpoint, FailedCheckpoint)
     assert checkpoint.started_at is not None
+
+
+async def test_on_error_fires_phase_error_callback(flow_dir, message_queue):
+    callback_set = CallbackSet()
+    received: list[tuple[str, BaseException]] = []
+
+    @callback_set.on_phase_error
+    async def handler(phase_id: str, error: BaseException) -> None:
+        received.append((phase_id, error))
+
+    context = FlowContext(
+        runtime_variables={},
+        flow_variables={},
+        callbacks=Callbacks([callback_set]),
+    )
+    phase, _ = _make_stub_phase(flow_dir, context, message_queue)
+    original_error = RuntimeError("boom")
+    wrapped = MessageProcessingError("p1", PhaseTrigger(id="start", phase_id=None), original_error)
+
+    await phase.on_error(wrapped)
+
+    assert received == [("p1", original_error)]
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -126,11 +126,11 @@ async def test_on_message_received_ignores_other_messages(core_dir, make_orchest
 
 async def test_on_message_received_fires_run_error_callback(core_dir, make_orchestrator):
     callback_set = CallbackSet()
-    received: list[tuple[BaseException, str | None]] = []
+    received: list[bool] = []
 
     @callback_set.on_run_error
-    async def handler(error: BaseException, phase_id: str | None) -> None:
-        received.append((error, phase_id))
+    async def handler() -> None:
+        received.append(True)
 
     orchestrator, _, _ = make_orchestrator(core_dir, callbacks=Callbacks([callback_set]))
     msg = PhaseFailedMessage(id="f1", phase_id="p1", error="something broke")
@@ -138,18 +138,16 @@ async def test_on_message_received_fires_run_error_callback(core_dir, make_orche
     with pytest.raises(FatalProcessingError):
         await orchestrator.on_message_received(msg)
 
-    assert len(received) == 1
-    assert isinstance(received[0][0], FatalProcessingError)
-    assert received[0][1] == "p1"
+    assert received == [True]
 
 
-async def test_on_error_fires_unscoped_run_error_callback(core_dir, make_orchestrator):
+async def test_on_error_does_not_fire_phase_failure_callback(core_dir, make_orchestrator):
     callback_set = CallbackSet()
-    received: list[tuple[BaseException, str | None]] = []
+    received: list[bool] = []
 
     @callback_set.on_run_error
-    async def handler(error: BaseException, phase_id: str | None) -> None:
-        received.append((error, phase_id))
+    async def handler() -> None:
+        received.append(True)
 
     orchestrator, _, _ = make_orchestrator(core_dir, callbacks=Callbacks([callback_set]))
     original_error = RuntimeError("scheduler broke")
@@ -158,7 +156,7 @@ async def test_on_error_fires_unscoped_run_error_callback(core_dir, make_orchest
     with pytest.raises(FatalProcessingError):
         await orchestrator.on_error(wrapped)
 
-    assert received == [(original_error, None)]
+    assert received == []
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -11,6 +11,7 @@ import pytest
 
 from ddev.ai.agent.anthropic_provider import DEFAULT_MODEL
 from ddev.ai.agent.registry import AgentProviderRegistry
+from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
 from ddev.ai.config.engine import ConfigurationEngine
 from ddev.ai.config.errors import ConfigError
 from ddev.ai.constants import CORE_PHASES_DIR, CORE_PHASES_PACKAGE
@@ -20,7 +21,7 @@ from ddev.ai.phases.registry import PhaseRegistry
 from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointStatus
 from ddev.ai.runtime.orchestrator import PhaseOrchestrator
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
-from ddev.event_bus.exceptions import FatalProcessingError
+from ddev.event_bus.exceptions import FatalProcessingError, HookName, OrchestratorHookError
 
 from .helpers import make_checkpoint
 
@@ -121,6 +122,43 @@ async def test_on_message_received_ignores_other_messages(core_dir, make_orchest
     orchestrator, _, _ = make_orchestrator(core_dir)
     await orchestrator.on_message_received(PhaseTrigger(id="start", phase_id=None))
     await orchestrator.on_message_received(PhaseTrigger(id="f1", phase_id="p1"))
+
+
+async def test_on_message_received_fires_run_error_callback(core_dir, make_orchestrator):
+    callback_set = CallbackSet()
+    received: list[tuple[BaseException, str | None]] = []
+
+    @callback_set.on_run_error
+    async def handler(error: BaseException, phase_id: str | None) -> None:
+        received.append((error, phase_id))
+
+    orchestrator, _, _ = make_orchestrator(core_dir, callbacks=Callbacks([callback_set]))
+    msg = PhaseFailedMessage(id="f1", phase_id="p1", error="something broke")
+
+    with pytest.raises(FatalProcessingError):
+        await orchestrator.on_message_received(msg)
+
+    assert len(received) == 1
+    assert isinstance(received[0][0], FatalProcessingError)
+    assert received[0][1] == "p1"
+
+
+async def test_on_error_fires_unscoped_run_error_callback(core_dir, make_orchestrator):
+    callback_set = CallbackSet()
+    received: list[tuple[BaseException, str | None]] = []
+
+    @callback_set.on_run_error
+    async def handler(error: BaseException, phase_id: str | None) -> None:
+        received.append((error, phase_id))
+
+    orchestrator, _, _ = make_orchestrator(core_dir, callbacks=Callbacks([callback_set]))
+    original_error = RuntimeError("scheduler broke")
+    wrapped = OrchestratorHookError(HookName.ON_INITIALIZE, original_error)
+
+    with pytest.raises(FatalProcessingError):
+        await orchestrator.on_error(wrapped)
+
+    assert received == [(original_error, None)]
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/cli/meta/ai/tui/test_bridge.py
+++ b/ddev/tests/cli/meta/ai/tui/test_bridge.py
@@ -77,7 +77,7 @@ class StubOrchestrator:
         await self.cb_set.fire_phase_start("phase1")
         await self.cb_set.fire_phase_finish("phase1")
         await self.cb_set.fire_phase_error("phase1", ValueError("phase boom"))
-        await self.cb_set.fire_run_error(RuntimeError("run boom"), "phase1")
+        await self.cb_set.fire_run_error()
         await self.cb_set.fire_agent_start(SCOPE, "sys_prompt", ["bash", "python"])
         await self.cb_set.fire_agent_response(SCOPE, _make_response(), 1)
         await self.cb_set.fire_tool_call(SCOPE, tool_call, result, 1)
@@ -152,11 +152,9 @@ async def test_phase_errored_payload(received_from_stub):
     assert str(msgs[0].error) == "phase boom"
 
 
-async def test_run_errored_payload(received_from_stub):
+async def test_run_errored_signal(received_from_stub):
     msgs = [m for m in received_from_stub if isinstance(m, RunErrored)]
     assert len(msgs) == 1
-    assert msgs[0].phase_id == "phase1"
-    assert str(msgs[0].error) == "run boom"
 
 
 async def test_agent_started_payload(received_from_stub):

--- a/ddev/tests/cli/meta/ai/tui/test_bridge.py
+++ b/ddev/tests/cli/meta/ai/tui/test_bridge.py
@@ -26,8 +26,10 @@ from ddev.cli.meta.ai.tui.messages import (
     BeforeCompact,
     BeforeGoalCheck,
     ContextCleared,
+    PhaseErrored,
     PhaseFinished,
     PhaseStarted,
+    RunErrored,
 )
 
 # ---------------------------------------------------------------------------
@@ -74,6 +76,8 @@ class StubOrchestrator:
 
         await self.cb_set.fire_phase_start("phase1")
         await self.cb_set.fire_phase_finish("phase1")
+        await self.cb_set.fire_phase_error("phase1", ValueError("phase boom"))
+        await self.cb_set.fire_run_error(RuntimeError("run boom"), "phase1")
         await self.cb_set.fire_agent_start(SCOPE, "sys_prompt", ["bash", "python"])
         await self.cb_set.fire_agent_response(SCOPE, _make_response(), 1)
         await self.cb_set.fire_tool_call(SCOPE, tool_call, result, 1)
@@ -139,6 +143,20 @@ async def test_phase_finished_payload(received_from_stub):
     msgs = [m for m in received_from_stub if isinstance(m, PhaseFinished)]
     assert len(msgs) == 1
     assert msgs[0].phase_id == "phase1"
+
+
+async def test_phase_errored_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, PhaseErrored)]
+    assert len(msgs) == 1
+    assert msgs[0].phase_id == "phase1"
+    assert str(msgs[0].error) == "phase boom"
+
+
+async def test_run_errored_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, RunErrored)]
+    assert len(msgs) == 1
+    assert msgs[0].phase_id == "phase1"
+    assert str(msgs[0].error) == "run boom"
 
 
 async def test_agent_started_payload(received_from_stub):
@@ -215,7 +233,7 @@ async def test_after_goal_check_payload(received_from_stub):
     assert msgs[0].reason == "looks good"
 
 
-async def test_all_12_messages_delivered(make_togo_app):
+async def test_all_14_messages_delivered(make_togo_app):
     """Every bridge event type delivers exactly one message to the sink."""
     app = make_togo_app([])
     async with app.run_test() as pilot:
@@ -224,7 +242,7 @@ async def test_all_12_messages_delivered(make_togo_app):
         app.run_flow(stub)
         await pilot.pause(0.3)
 
-    assert len(app.received) == 12
+    assert len(app.received) == 14
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -191,6 +191,8 @@ class _FakeOrchestrator:
             error = RuntimeError(f"Simulated failure in phase {phase_id!r}")
             await self._callbacks.fire_agent_error(scope, error)
             self.failed_phase = phase_id
+            await self._callbacks.fire_phase_error(phase_id, error)
+            await self._callbacks.fire_run_error()
             raise error
 
         # Goal validation for each task
@@ -1416,8 +1418,10 @@ async def test_orchestrator_build_failure_is_visible_and_screen_stays_stable() -
         assert app.is_running
 
 
-async def test_orchestrator_exception_only_marks_reported_failed_phase() -> None:
-    """A concurrent sibling stays running when the orchestrator identifies the failed phase."""
+async def test_phase_error_callback_only_marks_reported_failed_phase() -> None:
+    """A phase callback fails its phase without attributing the error to a concurrent sibling."""
+    from textual.widgets import Static
+
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
 
     class ConcurrentFailure:
@@ -1429,7 +1433,10 @@ async def test_orchestrator_exception_only_marks_reported_failed_phase() -> None
         async def run_async(self) -> None:
             await self.callbacks.fire_phase_start("phase_1")
             await self.callbacks.fire_phase_start("phase_2")
-            raise RuntimeError("phase 1 crashed")
+            error = RuntimeError("phase 1 crashed")
+            await self.callbacks.fire_phase_error("phase_1", error)
+            await self.callbacks.fire_run_error()
+            raise error
 
     flow = _make_flow()
     app = _app(flow)
@@ -1443,6 +1450,7 @@ async def test_orchestrator_exception_only_marks_reported_failed_phase() -> None
         assert screen._task_statuses[("phase_1", "task_one")] is RunStatus.FAILED
         assert screen._phase_statuses["phase_2"] is RunStatus.RUNNING
         assert screen._task_statuses[("phase_2", "task_two")] is RunStatus.PENDING
+        assert "Run failed in phase_1: phase 1 crashed" in str(screen.query_one("#execution-error", Static).render())
 
 
 async def test_orchestrator_exception_without_failed_phase_is_not_attributed() -> None:
@@ -1480,7 +1488,7 @@ async def test_orchestrator_exception_without_failed_phase_is_not_attributed() -
 async def test_run_error_banner_is_compact_and_points_to_phase_log() -> None:
     from textual.widgets import Static
 
-    from ddev.cli.meta.ai.tui.messages import RunErrored
+    from ddev.cli.meta.ai.tui.messages import PhaseErrored, RunErrored
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
 
     flow = _make_flow()
@@ -1491,12 +1499,13 @@ async def test_run_error_banner_is_compact_and_points_to_phase_log() -> None:
         await app.push_screen(screen)
         await pilot.pause()
 
-        screen.on_run_errored(
-            RunErrored(
-                RuntimeError("Phase 'phase_1' failed: invalid input\nfull validation detail\nhttps://errors.example"),
+        screen.on_phase_errored(
+            PhaseErrored(
                 "phase_1",
+                RuntimeError("invalid input\nfull validation detail\nhttps://errors.example"),
             )
         )
+        screen.on_run_errored(RunErrored())
 
         banner = str(screen.query_one("#execution-error", Static).render())
         assert "Run failed in phase_1: invalid input" in banner
@@ -1521,7 +1530,7 @@ async def test_run_error_banner_aggregates_parallel_phase_errors() -> None:
 
         screen.on_phase_errored(PhaseErrored("phase_1", RuntimeError("alpha failed\nalpha details")))
         screen.on_phase_errored(PhaseErrored("phase_2", RuntimeError("beta failed\nbeta details")))
-        screen.on_run_errored(RunErrored(RuntimeError("alpha failed"), "phase_1"))
+        screen.on_run_errored(RunErrored())
 
         banner = str(screen.query_one("#execution-error", Static).render())
         assert "Run failed — 2 phases failed" in banner
@@ -1546,7 +1555,7 @@ async def test_late_parallel_phase_error_updates_existing_banner() -> None:
         await pilot.pause()
 
         screen.on_phase_errored(PhaseErrored("phase_1", RuntimeError("alpha failed")))
-        screen.on_run_errored(RunErrored(RuntimeError("alpha failed"), "phase_1"))
+        screen.on_run_errored(RunErrored())
         screen.on_phase_errored(PhaseErrored("phase_2", RuntimeError("beta failed")))
 
         banner = str(screen.query_one("#execution-error", Static).render())

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -620,6 +620,22 @@ def test_interleaved_phase_error_only_mutates_scoped_phase() -> None:
     assert not any("phase A failed" in str(entry) for entry in screen._phase_logs["phase_2"])
 
 
+def test_phase_error_is_written_in_full_to_failed_phase_log() -> None:
+    from ddev.cli.meta.ai.tui.messages import PhaseErrored
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    screen = ExecutionScreen(_make_flow())
+    error = RuntimeError("first line\nfull validation detail\nhttps://errors.example.test/noise")
+
+    screen.on_phase_errored(PhaseErrored("phase_1", error))
+
+    assert screen._phase_statuses["phase_1"] is RunStatus.FAILED
+    rendered = str(screen._phase_logs["phase_1"][-1])
+    assert "first line" in rendered
+    assert "full validation detail" in rendered
+    assert "https://errors.example.test/noise" in rendered
+
+
 def test_scoped_goal_event_only_mutates_identified_phase() -> None:
     """A goal verdict for phase A cannot update the same-named task in phase B."""
     from ddev.cli.meta.ai.tui.messages import AfterGoalCheck, BeforeGoalCheck, PhaseStarted
@@ -715,7 +731,7 @@ async def test_execution_phase_activation_opens_config_for_pending_phase():
         assert isinstance(pilot.app.screen, PhaseConfigScreen)
 
 
-@pytest.mark.parametrize("status", [RunStatus.RUNNING, RunStatus.DONE, RunStatus.FAILED])
+@pytest.mark.parametrize("status", [RunStatus.RUNNING, RunStatus.DONE])
 async def test_execution_phase_activation_opens_log_for_started_phase(status: RunStatus):
     """Started phase activation opens a full-screen phase log."""
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
@@ -736,6 +752,60 @@ async def test_execution_phase_activation_opens_log_for_started_phase(status: Ru
         await pilot.pause()
         assert isinstance(pilot.app.screen, PhaseLogScreen)
         assert pilot.app.screen.phase_id == "phase_1"
+
+
+async def test_execution_failed_phase_activation_opens_error_modal() -> None:
+    from textual.widgets import Static
+
+    from ddev.cli.meta.ai.tui.messages import PhaseErrored
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+    from ddev.cli.meta.ai.tui.screens.phase_error_modal import PhaseErrorModal
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseSelected
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, MainScreen)
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder(phases=[]))
+        await app.push_screen(screen)
+        await pilot.pause()
+        error = RuntimeError("first line\nfull validation detail")
+        screen.on_phase_errored(PhaseErrored("phase_1", error))
+
+        screen.on_phase_selected(PhaseSelected("phase_1"))
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, PhaseErrorModal)
+        assert pilot.app.screen.phase_id == "phase_1"
+        rendered = str(pilot.app.screen.query_one("#phase-error-message", Static).render())
+        assert "RuntimeError: first line" in rendered
+        assert "full validation detail" in rendered
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert pilot.app.screen is screen
+
+
+async def test_execution_failed_phase_without_error_falls_back_to_log() -> None:
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseSelected
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder(phases=[]))
+        await app.push_screen(screen)
+        await pilot.pause()
+        screen._phase_statuses["phase_1"] = RunStatus.FAILED
+
+        screen.on_phase_selected(PhaseSelected("phase_1"))
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, PhaseLogScreen)
 
 
 async def test_phase_log_screen_ctrl_c_pushes_config_screen():
@@ -1397,6 +1467,84 @@ async def test_orchestrator_exception_without_failed_phase_is_not_attributed() -
         assert screen._task_statuses[("phase_1", "task_one")] is RunStatus.PENDING
         assert screen._task_statuses[("phase_2", "task_two")] is RunStatus.PENDING
         assert "scheduler crashed" in str(screen.query_one("#execution-error", Static).render())
+
+
+async def test_run_error_banner_is_compact_and_points_to_phase_log() -> None:
+    from textual.widgets import Static
+
+    from ddev.cli.meta.ai.tui.messages import RunErrored
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder(phases=[]))
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        screen.on_run_errored(
+            RunErrored(
+                RuntimeError("Phase 'phase_1' failed: invalid input\nfull validation detail\nhttps://errors.example"),
+                "phase_1",
+            )
+        )
+
+        banner = str(screen.query_one("#execution-error", Static).render())
+        assert "Run failed in phase_1: invalid input" in banner
+        assert "Select phase_1 to view the full error." in banner
+        assert "full validation detail" not in banner
+        assert "https://errors.example" not in banner
+
+
+async def test_run_error_banner_aggregates_parallel_phase_errors() -> None:
+    from textual.widgets import Static
+
+    from ddev.cli.meta.ai.tui.messages import PhaseErrored, RunErrored
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder(phases=[]))
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        screen.on_phase_errored(PhaseErrored("phase_1", RuntimeError("alpha failed\nalpha details")))
+        screen.on_phase_errored(PhaseErrored("phase_2", RuntimeError("beta failed\nbeta details")))
+        screen.on_run_errored(RunErrored(RuntimeError("alpha failed"), "phase_1"))
+
+        banner = str(screen.query_one("#execution-error", Static).render())
+        assert "Run failed — 2 phases failed" in banner
+        assert "phase_1: alpha failed" in banner
+        assert "phase_2: beta failed" in banner
+        assert "alpha details" not in banner
+        assert "beta details" not in banner
+
+
+async def test_late_parallel_phase_error_updates_existing_banner() -> None:
+    from textual.widgets import Static
+
+    from ddev.cli.meta.ai.tui.messages import PhaseErrored, RunErrored
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder(phases=[]))
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        screen.on_phase_errored(PhaseErrored("phase_1", RuntimeError("alpha failed")))
+        screen.on_run_errored(RunErrored(RuntimeError("alpha failed"), "phase_1"))
+        screen.on_phase_errored(PhaseErrored("phase_2", RuntimeError("beta failed")))
+
+        banner = str(screen.query_one("#execution-error", Static).render())
+        assert "Run failed — 2 phases failed" in banner
+        assert "phase_1: alpha failed" in banner
+        assert "phase_2: beta failed" in banner
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -788,7 +788,11 @@ async def test_execution_failed_phase_activation_opens_error_modal() -> None:
         assert pilot.app.screen is screen
 
 
-async def test_execution_failed_phase_without_error_falls_back_to_log() -> None:
+async def test_execution_cancelled_phase_falls_back_to_log() -> None:
+    import asyncio
+
+    from ddev.ai.agent.scope import AgentRole, AgentScope
+    from ddev.cli.meta.ai.tui.messages import AgentErrored
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
     from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen
     from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseSelected
@@ -800,7 +804,11 @@ async def test_execution_failed_phase_without_error_falls_back_to_log() -> None:
         screen = ExecutionScreen(flow, orchestrator_builder=_make_builder(phases=[]))
         await app.push_screen(screen)
         await pilot.pause()
-        screen._phase_statuses["phase_1"] = RunStatus.FAILED
+        scope = AgentScope(owner_id="phase_1", role=AgentRole.PHASE, phase_id="phase_1")
+        screen.on_agent_errored(AgentErrored(scope, asyncio.CancelledError()))
+
+        assert screen._phase_statuses["phase_1"] is RunStatus.FAILED
+        assert "phase_1" not in screen._phase_errors
 
         screen.on_phase_selected(PhaseSelected("phase_1"))
         await pilot.pause()


### PR DESCRIPTION
### What does this PR do?

Surface phase failures in the Togo TUI so users can understand why a flow stopped without inspecting checkpoint files.

This PR:

- adds phase- and run-error callbacks to propagate failures from the orchestrator to the UI;
- centralizes failed-checkpoint construction across deterministic and agentic phases;
- displays a compact flow-level banner that includes all failures from parallel phases; and
- opens a focused modal with the complete error when a failed phase is selected, while keeping the flow visible behind it.

#### Screenshots

Flow-level phase error banner:

<img width="1286" height="937" alt="image" src="https://github.com/user-attachments/assets/98063b50-34c8-4c7c-9f98-84b8e194345d" />

Phase error modal:

<img width="1273" height="936" alt="image" src="https://github.com/user-attachments/assets/ea7d0982-e291-4911-932b-03558b58cf27" />

### Motivation

Phase failures were recorded in checkpoints and rendered as failed tiles, but their error messages were not visible in the TUI. Users could see that a phase failed without knowing why, and parallel failures were especially difficult to diagnose. Exposing the existing errors through callbacks gives the UI consistent failure data while keeping orchestration and presentation concerns separate.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
