### PR TITLE
Remove unused MD5 hashing from vSphere

### DIFF
--- a/vsphere/changelog.d/24611.fixed
+++ b/vsphere/changelog.d/24611.fixed
@@ -1,0 +1,1 @@
+Remove unused MD5 hashing from vSphere alarm events for FIPS compatibility.

--- a/vsphere/datadog_checks/vsphere/event.py
+++ b/vsphere/datadog_checks/vsphere/event.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import re
 from datetime import datetime
-from hashlib import md5
 
 from pyVmomi import vim
 
@@ -147,13 +146,6 @@ class VSphereEvent(object):
 
         TO_ALERT_TYPE = {'green': 'success', 'yellow': 'warning', 'red': 'error', 'gray': 'info'}
 
-        def get_agg_key(alarm_event):
-            return 'h:{0}|dc:{1}|a:{2}'.format(
-                md5(alarm_event.entity.name.encode('utf-8')).hexdigest()[:10],
-                md5(alarm_event.datacenter.name.encode('utf-8')).hexdigest()[:10],
-                md5(alarm_event.alarm.name.encode('utf-8')).hexdigest()[:10],
-            )
-
         host_name = self.hostname
         entity_name = self.raw_event.entity.name
 
@@ -182,7 +174,6 @@ class VSphereEvent(object):
             status=trans_after,
         )
         self.payload['alert_type'] = TO_ALERT_TYPE[trans_after]
-        self.payload['event_object'] = get_agg_key(self.raw_event)
         self.payload['msg_text'] = (
             "vCenter monitor status changed on this alarm, it was {before} and it's now {after}.".format(
                 before=trans_before, after=trans_after

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -98,6 +98,7 @@ def test_events_collection_one_event(aggregator, realtime_instance, dd_run_check
     )
     assert len(aggregator.events) == 1
     assert aggregator.events[0]['msg_title'] == "[Triggered] alarm1 on VM vm1 is now red"
+    assert 'event_object' not in aggregator.events[0]
     assert check.latest_event_query == time1 + dt.timedelta(seconds=1)
 
 


### PR DESCRIPTION
### What does this PR do?
Remove unused MD5 hashing from vSphere alarm events. The hash was assigned to the unsupported `event_object` field, which the Agent runtime discards before serialization. This also adds a regression assertion that the unused field is absent.

### Motivation
Calling `hashlib.md5` can fail in FIPS mode and interrupt vSphere alarm event processing even though the resulting value is never sent to the backend.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
