### PR TITLE
zk: Fix TLS E2E tests

### DIFF
--- a/zk/tests/conftest.py
+++ b/zk/tests/conftest.py
@@ -97,6 +97,8 @@ def get_conn_failure_config():
 @pytest.fixture
 def get_multiple_expected_modes_config():
     config = deepcopy(VALID_CONFIG)
+    if get_tls():
+        config = deepcopy(VALID_TLS_CONFIG_FOR_TEST)
     config.update({'expected_mode': ['standalone', 'leader']})
     return config
 

--- a/zk/tests/conftest.py
+++ b/zk/tests/conftest.py
@@ -153,7 +153,9 @@ def dd_environment(get_instance):
 
     if is_tls:
         condition = [
-            CheckDockerLogs(compose_file, patterns=['Starting server', 'Started AdminServer', 'bound to port'])
+            CheckDockerLogs(
+                compose_file, patterns=['Starting server', 'Started AdminServer', 'bound to port'], matches='all'
+            )
         ]
     else:
         condition = [condition_non_tls]

--- a/zk/tests/conftest.py
+++ b/zk/tests/conftest.py
@@ -110,7 +110,7 @@ def get_version():
 
 
 def get_tls():
-    return os.environ.get("SSL") == 'True'
+    return os.environ.get("SSL", "").lower() == 'true'
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
### What does this PR do?

Fixes ZooKeeper test TLS detection so that Hatch matrix environments with `SSL=true` actually enable the TLS fixture and TLS instance configuration.

Also updates the multiple expected modes fixture to use the TLS test config when the TLS matrix row is active, similar to the other fixtures, since it fails once TLS detection works.

Finally, the TLS environment startup condition now waits for all expected ZooKeeper startup log markers before yielding to tests.

### Motivation
`zk/hatch.toml` maps the `ssl` matrix values to lowercase `true` and `false`, but `get_tls()` only checked for `SSL == 'True'`. That made the nominal `ssl=true` rows use the non-TLS compose file and non-TLS check configuration.

Once those rows actually run with TLS, the existing multiple expected modes fixture also needs TLS credentials, and the TLS compose readiness check needs to wait for all configured log markers rather than passing after the first marker.

These are test-only fixes with no Agent-shipped code changes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
