### PR TITLE
Confirm before cancelling Togo flows

### DIFF
--- a/ddev/src/ddev/cli/meta/ai/tui/screens/cancel_run_modal.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/cancel_run_modal.py
@@ -1,0 +1,42 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""CancelRunModal — confirms cancellation of an active flow."""
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal
+from textual.screen import ModalScreen
+from textual.widget import Widget
+from textual.widgets import Button, Static
+
+
+class CancelRunModal(ModalScreen[bool]):
+    """Confirm whether to cancel an active flow."""
+
+    BINDINGS = [Binding("escape", "keep_running", "Keep running")]
+
+    def compose(self) -> ComposeResult:
+        dialog = Widget(id="dialog", classes="cancel-run")
+        dialog.border_title = "Cancel flow"
+        with dialog:
+            yield Static(
+                "The active run will stop. Files already changed will not be reverted.\n"
+                "Completed phases may be available when you resume the flow."
+            )
+            with Horizontal(classes="modal-actions"):
+                yield Button("Keep running", id="btn-keep-running", variant="primary")
+                yield Button("Cancel flow", id="btn-cancel-flow", variant="error")
+
+    def on_mount(self) -> None:
+        self.query_one("#btn-keep-running", Button).focus()
+
+    def action_keep_running(self) -> None:
+        """Dismiss the confirmation and continue the flow."""
+        self.dismiss(False)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-keep-running":
+            self.dismiss(False)
+        elif event.button.id == "btn-cancel-flow":
+            self.dismiss(True)

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -108,7 +108,6 @@ class ExecutionScreen(TogoScreen):
         self._run_worker: Worker[None] | None = None
         self._phase_errors: dict[str, BaseException] = {}
         self._run_active = False
-        self._cancel_confirmation_open = False
         # Records every renderable produced by the run — used by tests and to
         # populate phase log screens opened after the fact.
         self._output_renders: list[PhaseLogEntry] = []
@@ -155,15 +154,9 @@ class ExecutionScreen(TogoScreen):
         if not self._run_active:
             self.app.pop_screen()
             return
-        if self._cancel_confirmation_open:
-            return
-
         from ddev.cli.meta.ai.tui.screens.cancel_run_modal import CancelRunModal
 
-        self._cancel_confirmation_open = True
-
         def on_dismiss(confirmed: bool) -> None:
-            self._cancel_confirmation_open = False
             if confirmed:
                 self.action_cancel_run()
                 self.app.pop_screen()

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -107,6 +107,8 @@ class ExecutionScreen(TogoScreen):
         self._orchestrator: OrchestratorLike | None = None
         self._run_worker: Worker[None] | None = None
         self._phase_errors: dict[str, BaseException] = {}
+        self._run_active = False
+        self._cancel_confirmation_open = False
         # Records every renderable produced by the run — used by tests and to
         # populate phase log screens opened after the fact.
         self._output_renders: list[PhaseLogEntry] = []
@@ -130,6 +132,7 @@ class ExecutionScreen(TogoScreen):
                     if task_phase == phase_id:
                         self._task_statuses[(task_phase, task_name)] = RunStatus.DONE
         self._update_display()
+        self._run_active = True
         self._run_worker = self._run_orchestrator()
 
     def on_unmount(self) -> None:
@@ -140,6 +143,7 @@ class ExecutionScreen(TogoScreen):
 
     def action_cancel_run(self) -> None:
         """Cancel the running orchestrator worker."""
+        self._run_active = False
         if self._run_worker is not None:
             self._run_worker.cancel()
 
@@ -148,7 +152,23 @@ class ExecutionScreen(TogoScreen):
             self.action_cancel_run()
 
     def action_back(self) -> None:
-        self.app.pop_screen()
+        if not self._run_active:
+            self.app.pop_screen()
+            return
+        if self._cancel_confirmation_open:
+            return
+
+        from ddev.cli.meta.ai.tui.screens.cancel_run_modal import CancelRunModal
+
+        self._cancel_confirmation_open = True
+
+        def on_dismiss(confirmed: bool) -> None:
+            self._cancel_confirmation_open = False
+            if confirmed:
+                self.action_cancel_run()
+                self.app.pop_screen()
+
+        self.app.push_screen(CancelRunModal(), on_dismiss)
 
     def on_key(self, event: events.Key) -> None:
         if event.key == "escape":
@@ -174,6 +194,7 @@ class ExecutionScreen(TogoScreen):
             if orchestrator is None or orchestrator.failed_phase is None:
                 self.post_message(ExecutionFailed(error))
         finally:
+            self._run_active = False
             try:
                 self.query_one(TogoHeader).running = False
             except Exception:

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
@@ -24,6 +24,7 @@ from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseSelected, PipelineG
 class FlowScreen(TogoScreen):
     """Show resolved flow details and controls for launching or resuming execution."""
 
+    AUTO_FOCUS = "#launch-btn"
     BINDINGS = [
         Binding("escape", "app.pop_screen", "Back"),
         Binding("l", "launch", "Launch"),

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/main.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/main.py
@@ -20,6 +20,7 @@ from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
 class MainScreen(TogoScreen):
     """Main dashboard screen listing all available flows."""
 
+    AUTO_FOCUS = "FlowCard"
     TITLE = "Flows"
 
     @property

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -488,6 +488,11 @@ MarkdownH3 {
     color: $status-failed;
 }
 
+.phase-node:focus {
+    border: round $accent;
+    background: $panel-lighten-1;
+}
+
 #phase-log-output {
     width: 1fr;
     height: 1fr;

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -73,6 +73,18 @@ Button.-primary:focus {
     color: $secondary;
 }
 
+Button.-error {
+    border: round $error;
+    color: $error;
+}
+
+Button.-error:hover,
+Button.-error:focus {
+    border: round $error;
+    background: $panel-lighten-1;
+    color: $error;
+}
+
 Button.-warning {
     border: round $warning;
 }
@@ -559,6 +571,10 @@ ModalScreen {
 
 #phase-error-message {
     height: auto;
+}
+
+#dialog.cancel-run {
+    min-height: 11;
 }
 
 #diagnostic-errors {

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/pipeline_graph.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/pipeline_graph.py
@@ -339,6 +339,13 @@ class PhaseNode(Static):
     def action_select(self) -> None:
         self.post_message(PhaseSelected(self.phase_id))
 
+    def update_status(self, status: RunStatus, label: str) -> None:
+        """Update the displayed status without replacing the focused widget."""
+        self.status = status
+        self.update(label)
+        self.remove_class(*(f"status-{old_status.value}" for old_status in RunStatus))
+        self.add_class(f"status-{status.value}")
+
     def on_click(self) -> None:
         if self.screen.get_selected_text():
             return
@@ -408,4 +415,7 @@ class PipelineGraph(Widget):
 
     def update_statuses(self, statuses: dict[str, RunStatus]) -> None:
         self._statuses = dict(statuses)
-        self.refresh(recompose=True, layout=True)
+        labels = _pad_labels({entry.phase: _phase_label(entry.phase, self._statuses) for entry in self.flow.flow})
+        for phase_node in self.query(PhaseNode):
+            status = self._statuses.get(phase_node.phase_id, RunStatus.PENDING)
+            phase_node.update_status(status, labels[phase_node.phase_id][0])

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/pipeline_graph.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/pipeline_graph.py
@@ -14,6 +14,7 @@ from textual.binding import Binding
 from textual.css.query import NoMatches
 from textual.geometry import Offset
 from textual.message import Message
+from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
 
@@ -330,21 +331,23 @@ class PhaseNode(Static):
 
     can_focus = True
     BINDINGS = [Binding("enter", "select", "Select phase")]
+    status: reactive[RunStatus] = reactive(RunStatus.PENDING, init=False)
 
-    def __init__(self, phase_id: str, status: RunStatus, label: str) -> None:
-        super().__init__(label, classes=f"phase-node status-{status.value}")
+    def __init__(self, phase_id: str, status: RunStatus, label_width: int) -> None:
+        super().__init__(classes=f"phase-node status-{status.value}")
         self.phase_id = phase_id
-        self.status = status
+        self.label_width = label_width
+        self.set_reactive(PhaseNode.status, status)
+
+    def render(self) -> str:
+        label, _ = _phase_label(self.phase_id, {self.phase_id: self.status})
+        return label.ljust(self.label_width)
+
+    def watch_status(self, old_status: RunStatus, new_status: RunStatus) -> None:
+        self.toggle_class(f"status-{old_status.value}", f"status-{new_status.value}")
 
     def action_select(self) -> None:
         self.post_message(PhaseSelected(self.phase_id))
-
-    def update_status(self, status: RunStatus, label: str) -> None:
-        """Update the displayed status without replacing the focused widget."""
-        self.status = status
-        self.update(label)
-        self.remove_class(*(f"status-{old_status.value}" for old_status in RunStatus))
-        self.add_class(f"status-{status.value}")
 
     def on_click(self) -> None:
         if self.screen.get_selected_text():
@@ -375,7 +378,7 @@ class PipelineGraph(Widget):
         yield connectors
 
         for node in self._layout.nodes:
-            phase_node = PhaseNode(node.phase_id, node.status, node.label)
+            phase_node = PhaseNode(node.phase_id, node.status, len(node.label))
             phase_node.styles.position = "absolute"
             phase_node.styles.layer = "nodes"
             yield phase_node
@@ -415,7 +418,5 @@ class PipelineGraph(Widget):
 
     def update_statuses(self, statuses: dict[str, RunStatus]) -> None:
         self._statuses = dict(statuses)
-        labels = _pad_labels({entry.phase: _phase_label(entry.phase, self._statuses) for entry in self.flow.flow})
         for phase_node in self.query(PhaseNode):
-            status = self._statuses.get(phase_node.phase_id, RunStatus.PENDING)
-            phase_node.update_status(status, labels[phase_node.phase_id][0])
+            phase_node.status = self._statuses.get(phase_node.phase_id, RunStatus.PENDING)

--- a/ddev/tests/cli/meta/ai/tui/test_cancel_run_modal.py
+++ b/ddev/tests/cli/meta/ai/tui/test_cancel_run_modal.py
@@ -1,0 +1,75 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for the active-flow cancellation confirmation modal."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+
+from .conftest import TogoModalTestApp
+
+
+class CancelRunModalTestApp(TogoModalTestApp):
+    """Minimal app that records a CancelRunModal dismissal."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.dismiss_result: Any = "NOT_SET"
+
+    def compose(self) -> ComposeResult:
+        yield from []
+
+    def on_mount(self) -> None:
+        from ddev.cli.meta.ai.tui.screens.cancel_run_modal import CancelRunModal
+
+        self.push_screen(CancelRunModal(), lambda result: setattr(self, "dismiss_result", result))
+
+
+async def test_cancel_run_modal_has_safe_default_and_warning() -> None:
+    """The modal focuses the safe action and explains cancellation is not reversible."""
+    from ddev.cli.meta.ai.tui.screens.cancel_run_modal import CancelRunModal
+
+    app = CancelRunModalTestApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, CancelRunModal)
+        assert issubclass(CancelRunModal, ModalScreen)
+        assert modal.focused is modal.query_one("#btn-keep-running", Button)
+        assert isinstance(modal.query_one("#btn-cancel-flow", Button), Button)
+        assert "will not be reverted" in modal.query_one(Static).render().plain
+
+
+async def test_cancel_run_modal_escape_keeps_running() -> None:
+    """Escape dismisses the modal with the non-cancelling result."""
+    app = CancelRunModalTestApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.dismiss_result is False
+
+
+async def test_cancel_run_modal_keep_running_button_dismisses_safely() -> None:
+    """The safe button dismisses the modal with the non-cancelling result."""
+    app = CancelRunModalTestApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.click("#btn-keep-running")
+        await pilot.pause()
+        assert app.dismiss_result is False
+
+
+async def test_cancel_run_modal_cancel_button_confirms() -> None:
+    """The destructive button dismisses the modal with True."""
+    app = CancelRunModalTestApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.click("#btn-cancel-flow")
+        await pilot.pause()
+        assert app.dismiss_result is True

--- a/ddev/tests/cli/meta/ai/tui/test_cancel_run_modal.py
+++ b/ddev/tests/cli/meta/ai/tui/test_cancel_run_modal.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 from typing import Any
 
 from textual.app import ComposeResult
-from textual.screen import ModalScreen
-from textual.widgets import Button, Static
 
 from .conftest import TogoModalTestApp
 
@@ -28,21 +26,6 @@ class CancelRunModalTestApp(TogoModalTestApp):
         from ddev.cli.meta.ai.tui.screens.cancel_run_modal import CancelRunModal
 
         self.push_screen(CancelRunModal(), lambda result: setattr(self, "dismiss_result", result))
-
-
-async def test_cancel_run_modal_has_safe_default_and_warning() -> None:
-    """The modal focuses the safe action and explains cancellation is not reversible."""
-    from ddev.cli.meta.ai.tui.screens.cancel_run_modal import CancelRunModal
-
-    app = CancelRunModalTestApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        modal = app.screen
-        assert isinstance(modal, CancelRunModal)
-        assert issubclass(CancelRunModal, ModalScreen)
-        assert modal.focused is modal.query_one("#btn-keep-running", Button)
-        assert isinstance(modal.query_one("#btn-cancel-flow", Button), Button)
-        assert "will not be reverted" in modal.query_one(Static).render().plain
 
 
 async def test_cancel_run_modal_escape_keeps_running() -> None:

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -1370,6 +1370,80 @@ async def test_unmount_cancels_worker():
         assert pilot.app.is_running
 
 
+async def test_back_requires_confirmation_before_cancelling_active_run():
+    """Back keeps an active run alive until the destructive action is confirmed."""
+    import asyncio
+
+    from ddev.cli.meta.ai.tui.screens.cancel_run_modal import CancelRunModal
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    cancelled = asyncio.Event()
+
+    class _InfiniteDemo:
+        failed_phase = None
+
+        async def run_async(self) -> None:
+            try:
+                await asyncio.sleep(999)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=lambda _callbacks: _InfiniteDemo())
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        screen.action_back()
+        await pilot.pause()
+        assert isinstance(app.screen, CancelRunModal)
+        assert app.screen_stack[-2] is screen
+        assert not cancelled.is_set()
+
+        screen_stack_size = len(app.screen_stack)
+        screen.action_back()
+        assert len(app.screen_stack) == screen_stack_size
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.screen is screen
+        assert not cancelled.is_set()
+
+        screen.action_back()
+        await pilot.pause()
+        await pilot.click("#btn-cancel-flow")
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+        assert cancelled.is_set()
+
+
+async def test_back_pops_immediately_after_run_finishes():
+    """Back does not prompt once the worker has finished."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.main import MainScreen
+
+    class _FinishedDemo:
+        failed_phase = None
+
+        async def run_async(self) -> None:
+            return
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=lambda _callbacks: _FinishedDemo())
+        await app.push_screen(screen)
+        await pilot.pause()
+        screen.action_back()
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+
+
 # ---------------------------------------------------------------------------
 # ExecutionScreen: failing orchestrator does not crash the app
 # ---------------------------------------------------------------------------

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -1408,10 +1408,6 @@ async def test_escape_requires_confirmation_before_cancelling_active_run():
         assert app.screen_stack[-2] is screen
         assert not cancelled.is_set()
 
-        screen_stack_size = len(app.screen_stack)
-        screen.action_back()
-        assert len(app.screen_stack) == screen_stack_size
-
         await pilot.press("escape")
         await pilot.pause()
         assert app.screen is screen

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -494,8 +494,8 @@ async def test_pipeline_graph_updates_phase_node_status_classes():
         assert "status-pending" not in node.classes
 
 
-async def test_pipeline_graph_phase_node_selection_posts_phase_id():
-    """Activating a phase node emits the selected phase id."""
+async def test_phase_node_enter_selects_focused_phase_after_status_update():
+    """Enter selects the focused phase after its status changes."""
     from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseNode, PipelineGraph
 
     graph = PipelineGraph(_make_dag_flow(), {"research": RunStatus.PENDING})
@@ -505,7 +505,10 @@ async def test_pipeline_graph_phase_node_selection_posts_phase_id():
         await pilot.pause()
         await app.push_screen(harness)
         await pilot.pause()
-        graph.query_one(PhaseNode).action_select()
+        graph.query_one(PhaseNode).focus()
+        graph.update_statuses({"research": RunStatus.DONE})
+        await pilot.pause()
+        await pilot.press("enter")
         await pilot.pause()
         assert harness.selected_phases == ["research"]
 
@@ -731,6 +734,31 @@ async def test_execution_phase_activation_opens_config_for_pending_phase():
         screen.on_phase_selected(PhaseSelected("phase_1"))
         await pilot.pause()
         assert isinstance(pilot.app.screen, PhaseConfigScreen)
+
+
+async def test_execution_enter_opens_focused_phase_after_status_update():
+    """A status update preserves keyboard activation of the focused phase."""
+    from ddev.cli.meta.ai.tui.messages import PhaseStarted
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseNode
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=_make_builder(phases=[]))
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        screen.query_one(PhaseNode).focus()
+        screen.post_message(PhaseStarted("phase_1"))
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, PhaseLogScreen)
+        assert app.screen.phase_id == "phase_1"
 
 
 @pytest.mark.parametrize("status", [RunStatus.RUNNING, RunStatus.DONE])
@@ -1397,15 +1425,10 @@ async def test_escape_requires_confirmation_before_cancelling_active_run():
         screen = ExecutionScreen(flow, orchestrator_builder=lambda _callbacks: _InfiniteDemo())
         await app.push_screen(screen)
         await pilot.pause()
-        assert screen._run_active
-        assert "escape" in app.active_bindings, [
-            (type(node).__name__, list(bindings.key_to_bindings)) for node, bindings in screen._binding_chain
-        ]
 
         await pilot.press("escape")
         await pilot.pause()
         assert isinstance(app.screen, CancelRunModal)
-        assert app.screen_stack[-2] is screen
         assert not cancelled.is_set()
 
         await pilot.press("escape")

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -1370,8 +1370,8 @@ async def test_unmount_cancels_worker():
         assert pilot.app.is_running
 
 
-async def test_back_requires_confirmation_before_cancelling_active_run():
-    """Back keeps an active run alive until the destructive action is confirmed."""
+async def test_escape_requires_confirmation_before_cancelling_active_run():
+    """Escape keeps an active run alive until the destructive action is confirmed."""
     import asyncio
 
     from ddev.cli.meta.ai.tui.screens.cancel_run_modal import CancelRunModal
@@ -1397,8 +1397,12 @@ async def test_back_requires_confirmation_before_cancelling_active_run():
         screen = ExecutionScreen(flow, orchestrator_builder=lambda _callbacks: _InfiniteDemo())
         await app.push_screen(screen)
         await pilot.pause()
+        assert screen._run_active
+        assert "escape" in app.active_bindings, [
+            (type(node).__name__, list(bindings.key_to_bindings)) for node, bindings in screen._binding_chain
+        ]
 
-        screen.action_back()
+        await pilot.press("escape")
         await pilot.pause()
         assert isinstance(app.screen, CancelRunModal)
         assert app.screen_stack[-2] is screen

--- a/ddev/tests/cli/meta/ai/tui/test_navigation.py
+++ b/ddev/tests/cli/meta/ai/tui/test_navigation.py
@@ -11,20 +11,37 @@ from __future__ import annotations
 
 
 async def test_enter_on_flow_card_pushes_flow_screen(make_flow, make_togo_app):
-    """Pressing Enter on a focused FlowCard pushes FlowScreen."""
+    """Pressing Enter when the app starts opens the first flow."""
     from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
     from ddev.cli.meta.ai.tui.screens.main import MainScreen
-    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
 
-    app = make_togo_app([make_flow("Alpha Flow", n_phases=3), make_flow("Beta Flow", n_phases=1)])
+    alpha_flow = make_flow("Alpha Flow", n_phases=3)
+    app = make_togo_app([make_flow("Beta Flow", n_phases=1), alpha_flow])
     async with app.run_test() as pilot:
         await pilot.pause()
         assert isinstance(pilot.app.screen, MainScreen)
-        card = pilot.app.screen.query(FlowCard).first()
-        card.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        flow_screen = pilot.app.screen
+        assert isinstance(flow_screen, FlowScreen)
+        assert flow_screen.flow is alpha_flow
+
+
+async def test_enter_on_opened_flow_pushes_launch_modal(make_flow, make_togo_app):
+    """Pressing Enter immediately after opening a flow opens its launch modal."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchModal
+
+    app = make_togo_app([make_flow("Alpha Flow", n_phases=3)])
+    async with app.run_test() as pilot:
+        await pilot.pause()
         await pilot.press("enter")
         await pilot.pause()
         assert isinstance(pilot.app.screen, FlowScreen)
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, LaunchModal)
 
 
 async def test_flow_screen_receives_correct_flow(make_flow, make_togo_app):


### PR DESCRIPTION
### What does this PR do?

- Adds a confirmation modal when Escape is used to leave a running Togo flow. The safe action, **Keep running**, is focused by default; Escape in the modal also keeps the flow running. **Cancel flow** explicitly stops the worker and returns to the flow screen.
- Warns that files already changed by the run are not reverted, while completed phases may be available when the flow is resumed.
- Keeps Escape available immediately after launching a flow. Pipeline status updates now update existing phase widgets rather than recreating them, so they retain their connection to the execution screen and its Escape/Ctrl+C bindings; selecting or clicking a phase is no longer required first.

<img width="916" height="478" alt="Confirmation modal shown before cancelling a running Togo flow" src="https://github.com/user-attachments/assets/ea219cab-b6fa-460c-8b52-8e0241433347" />

### Motivation

A stray Escape previously cancelled an active flow immediately, potentially leaving already-modified files behind. In addition, phase-widget recreation could detach the focused node from the execution screen, preventing Escape from being handled until a phase was clicked.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged