### PR TITLE
Decouple openstack_controller from the requests library

### DIFF
--- a/openstack_controller/datadog_checks/openstack_controller/components/component.py
+++ b/openstack_controller/datadog_checks/openstack_controller/components/component.py
@@ -6,7 +6,7 @@ import inspect
 from enum import Enum, unique
 from functools import wraps
 
-import requests
+from openstack.exceptions import SDKException
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.http_exceptions import HTTPRequestError, HTTPStatusError
@@ -77,7 +77,7 @@ class Component:
                         tags = argument_value('tags', func, *args, **kwargs)
                         self.check.service_check(self.SERVICE_CHECK, AgentCheck.OK, tags=tags)
                     return result if result is not None else True
-                except (requests.exceptions.RequestException, HTTPRequestError, HTTPStatusError) as e:
+                except (SDKException, HTTPRequestError, HTTPStatusError) as e:
                     self.check.log.debug(
                         "Encountered a RequestException in '%s:%s' [%s]: %s",
                         self.__class__.__name__,

--- a/openstack_controller/datadog_checks/openstack_controller/components/component.py
+++ b/openstack_controller/datadog_checks/openstack_controller/components/component.py
@@ -6,7 +6,7 @@ import inspect
 from enum import Enum, unique
 from functools import wraps
 
-from openstack.exceptions import SDKException
+from openstack.exceptions import HttpException
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.http_exceptions import HTTPRequestError, HTTPStatusError
@@ -77,9 +77,9 @@ class Component:
                         tags = argument_value('tags', func, *args, **kwargs)
                         self.check.service_check(self.SERVICE_CHECK, AgentCheck.OK, tags=tags)
                     return result if result is not None else True
-                except (SDKException, HTTPRequestError, HTTPStatusError) as e:
+                except (HttpException, HTTPRequestError, HTTPStatusError) as e:
                     self.check.log.debug(
-                        "Encountered a RequestException in '%s:%s' [%s]: %s",
+                        "Encountered an HTTP error in '%s:%s' [%s]: %s",
                         self.__class__.__name__,
                         func.__name__,
                         type(e),

--- a/openstack_controller/datadog_checks/openstack_controller/legacy/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/legacy/api.py
@@ -6,10 +6,9 @@ import copy
 from os import environ
 from urllib.parse import urljoin
 
-import requests
 from openstack import connection
 
-from datadog_checks.base.utils.http_exceptions import HTTPStatusError, HTTPTimeoutError
+from datadog_checks.base.utils.http_exceptions import HTTPConnectionError, HTTPStatusError, HTTPTimeoutError
 
 from .exceptions import (
     AuthenticationNeeded,
@@ -502,12 +501,7 @@ class Authenticator(object):
             logger.debug("url: %s || response: %s", auth_url, resp.json())
             return resp
 
-        except (
-            requests.exceptions.HTTPError,
-            requests.exceptions.Timeout,
-            requests.exceptions.ConnectionError,
-            HTTPTimeoutError,
-        ):
+        except (HTTPStatusError, HTTPTimeoutError, HTTPConnectionError):
             safe_identity = copy.deepcopy(identity)
             safe_identity['password']['user']['password'] = '********'
             msg = "Failed Keystone auth with identity:{identity} scope:{scope} @{url}".format(
@@ -527,12 +521,7 @@ class Authenticator(object):
             logger.debug("url: %s || response: %s", auth_url, jresp)
             projects = jresp.get('projects')
             return projects
-        except (
-            requests.exceptions.HTTPError,
-            requests.exceptions.Timeout,
-            requests.exceptions.ConnectionError,
-            HTTPTimeoutError,
-        ) as e:
+        except (HTTPStatusError, HTTPTimeoutError, HTTPConnectionError) as e:
             msg = "unable to retrieve project list from Keystone auth with identity: @{url}: {ex}".format(
                 url=auth_url, ex=e
             )

--- a/openstack_controller/datadog_checks/openstack_controller/legacy/openstack_controller_legacy.py
+++ b/openstack_controller/datadog_checks/openstack_controller/legacy/openstack_controller_legacy.py
@@ -412,7 +412,7 @@ class OpenStackControllerLegacyCheck(AgentCheck):
             self.log.debug("Server %s is powered off and cannot be monitored: %s", server_id, e)
             return
         except HTTPStatusError as e:
-            if e.response.status_code == 404:
+            if getattr(e.response, 'status_code', None) == 404:
                 self.log.debug("Server %s is not in an ACTIVE state and cannot be monitored, %s", server_id, e)
             else:
                 self.warning(
@@ -765,7 +765,8 @@ class OpenStackControllerLegacyCheck(AgentCheck):
             # Delete the scope, we'll populate a new one on the next run for this instance
             self.delete_api_cache()
         except (HTTPStatusError, HTTPTimeoutError, HTTPConnectionError) as e:
-            if isinstance(e, HTTPStatusError) and e.response.status_code < 500:
+            status_code = getattr(e.response, 'status_code', None) if isinstance(e, HTTPStatusError) else None
+            if status_code is not None and status_code < 500:
                 self.warning("Error reaching Nova API: %s", e)
             else:
                 # exponential backoff

--- a/openstack_controller/datadog_checks/openstack_controller/legacy/openstack_controller_legacy.py
+++ b/openstack_controller/datadog_checks/openstack_controller/legacy/openstack_controller_legacy.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 
 from openstack.config.loader import OpenStackConfig
+from openstack.exceptions import HttpException
 
 from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.common import pattern_filter
@@ -91,6 +92,14 @@ DIAGNOSTICABLE_STATES = ['ACTIVE']
 REMOVED_STATES = ['DELETED', 'SHUTOFF']
 
 SERVER_FIELDS_REQ = ['server_id', 'state', 'server_name', 'hypervisor_hostname', 'tenant_id']
+
+
+def get_http_status_code(exc: object) -> int | None:
+    response = getattr(exc, 'response', None)
+    status_code = getattr(response, 'status_code', None)
+    if status_code is not None:
+        return status_code
+    return getattr(exc, 'status_code', None)
 
 
 class OpenStackControllerLegacyCheck(AgentCheck):
@@ -411,8 +420,8 @@ class OpenStackControllerLegacyCheck(AgentCheck):
         except InstancePowerOffFailure as e:  # 409 response code came back for nova
             self.log.debug("Server %s is powered off and cannot be monitored: %s", server_id, e)
             return
-        except HTTPStatusError as e:
-            if getattr(e.response, 'status_code', None) == 404:
+        except (HttpException, HTTPStatusError) as e:
+            if get_http_status_code(e) == 404:
                 self.log.debug("Server %s is not in an ACTIVE state and cannot be monitored, %s", server_id, e)
             else:
                 self.warning(
@@ -569,6 +578,7 @@ class OpenStackControllerLegacyCheck(AgentCheck):
             self.get_nova_endpoint()
             self.service_check(self.COMPUTE_API_SC, AgentCheck.OK, tags=service_check_tags)
         except (
+            HttpException,
             HTTPStatusError,
             HTTPTimeoutError,
             HTTPConnectionError,
@@ -582,6 +592,7 @@ class OpenStackControllerLegacyCheck(AgentCheck):
             self.get_neutron_endpoint()
             self.service_check(self.NETWORK_API_SC, AgentCheck.OK, tags=service_check_tags)
         except (
+            HttpException,
             HTTPStatusError,
             HTTPTimeoutError,
             HTTPConnectionError,
@@ -764,8 +775,8 @@ class OpenStackControllerLegacyCheck(AgentCheck):
         except AuthenticationNeeded:
             # Delete the scope, we'll populate a new one on the next run for this instance
             self.delete_api_cache()
-        except (HTTPStatusError, HTTPTimeoutError, HTTPConnectionError) as e:
-            status_code = getattr(e.response, 'status_code', None) if isinstance(e, HTTPStatusError) else None
+        except (HttpException, HTTPStatusError, HTTPTimeoutError, HTTPConnectionError) as e:
+            status_code = get_http_status_code(e) if isinstance(e, (HttpException, HTTPStatusError)) else None
             if status_code is not None and status_code < 500:
                 self.warning("Error reaching Nova API: %s", e)
             else:

--- a/openstack_controller/datadog_checks/openstack_controller/legacy/openstack_controller_legacy.py
+++ b/openstack_controller/datadog_checks/openstack_controller/legacy/openstack_controller_legacy.py
@@ -8,12 +8,11 @@ import re
 from collections import defaultdict
 from datetime import datetime, timezone
 
-import requests
 from openstack.config.loader import OpenStackConfig
 
 from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.common import pattern_filter
-from datadog_checks.base.utils.http_exceptions import HTTPTimeoutError
+from datadog_checks.base.utils.http_exceptions import HTTPConnectionError, HTTPStatusError, HTTPTimeoutError
 
 from .api import ApiFactory
 from .exceptions import (
@@ -412,7 +411,7 @@ class OpenStackControllerLegacyCheck(AgentCheck):
         except InstancePowerOffFailure as e:  # 409 response code came back for nova
             self.log.debug("Server %s is powered off and cannot be monitored: %s", server_id, e)
             return
-        except requests.exceptions.HTTPError as e:
+        except HTTPStatusError as e:
             if e.response.status_code == 404:
                 self.log.debug("Server %s is not in an ACTIVE state and cannot be monitored, %s", server_id, e)
             else:
@@ -570,9 +569,9 @@ class OpenStackControllerLegacyCheck(AgentCheck):
             self.get_nova_endpoint()
             self.service_check(self.COMPUTE_API_SC, AgentCheck.OK, tags=service_check_tags)
         except (
-            requests.exceptions.HTTPError,
-            requests.exceptions.Timeout,
-            requests.exceptions.ConnectionError,
+            HTTPStatusError,
+            HTTPTimeoutError,
+            HTTPConnectionError,
             AuthenticationNeeded,
             InstancePowerOffFailure,
         ):
@@ -583,9 +582,9 @@ class OpenStackControllerLegacyCheck(AgentCheck):
             self.get_neutron_endpoint()
             self.service_check(self.NETWORK_API_SC, AgentCheck.OK, tags=service_check_tags)
         except (
-            requests.exceptions.HTTPError,
-            requests.exceptions.Timeout,
-            requests.exceptions.ConnectionError,
+            HTTPStatusError,
+            HTTPTimeoutError,
+            HTTPConnectionError,
             AuthenticationNeeded,
             InstancePowerOffFailure,
         ):
@@ -765,13 +764,8 @@ class OpenStackControllerLegacyCheck(AgentCheck):
         except AuthenticationNeeded:
             # Delete the scope, we'll populate a new one on the next run for this instance
             self.delete_api_cache()
-        except (
-            requests.exceptions.HTTPError,
-            requests.exceptions.Timeout,
-            requests.exceptions.ConnectionError,
-            HTTPTimeoutError,
-        ) as e:
-            if isinstance(e, requests.exceptions.HTTPError) and e.response.status_code < 500:
+        except (HTTPStatusError, HTTPTimeoutError, HTTPConnectionError) as e:
+            if isinstance(e, HTTPStatusError) and e.response.status_code < 500:
                 self.warning("Error reaching Nova API: %s", e)
             else:
                 # exponential backoff

--- a/openstack_controller/tests/conftest.py
+++ b/openstack_controller/tests/conftest.py
@@ -9,11 +9,13 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import mock
+import openstack.exceptions
 import pytest
-import requests
 import yaml
 
 import tests.configs as configs
+from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs
 from datadog_checks.dev.fs import get_here
@@ -173,11 +175,7 @@ def mock_http_call(mock_responses):
         response = mock_responses(method, url, file=file, headers=headers, params=params)
         if response is not None:
             return response
-        http_response = requests.models.Response()
-        http_response.status_code = 404
-        http_response.reason = "Not Found"
-        http_response.url = url
-        raise requests.exceptions.HTTPError(response=http_response)
+        raise HTTPStatusError("404 Not Found", response=MockHTTPResponse(status_code=404, url=url))
 
     yield call
 
@@ -233,7 +231,7 @@ def connection_authorize(request, mock_responses):
 
     def authorize():
         if http_error is not None:
-            raise requests.exceptions.HTTPError(response=http_error)
+            raise openstack.exceptions.HttpException(response=http_error)
 
     return mock.MagicMock(side_effect=authorize)
 
@@ -245,7 +243,7 @@ def connection_identity(request, mock_responses):
 
     def regions():
         if http_error and 'regions' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['regions'])
+            raise openstack.exceptions.HttpException(response=http_error['regions'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -257,7 +255,7 @@ def connection_identity(request, mock_responses):
 
     def domains():
         if http_error and 'domains' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['domains'])
+            raise openstack.exceptions.HttpException(response=http_error['domains'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -269,7 +267,7 @@ def connection_identity(request, mock_responses):
 
     def projects():
         if http_error and 'projects' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['projects'])
+            raise openstack.exceptions.HttpException(response=http_error['projects'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -281,7 +279,7 @@ def connection_identity(request, mock_responses):
 
     def users():
         if http_error and 'users' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['users'])
+            raise openstack.exceptions.HttpException(response=http_error['users'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -293,7 +291,7 @@ def connection_identity(request, mock_responses):
 
     def groups():
         if http_error and 'groups' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['groups'])
+            raise openstack.exceptions.HttpException(response=http_error['groups'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -305,7 +303,7 @@ def connection_identity(request, mock_responses):
 
     def group_users(group_id):
         if http_error and 'group_users' in http_error and group_id in http_error['group_users']:
-            raise requests.exceptions.HTTPError(response=http_error['group_users'][group_id])
+            raise openstack.exceptions.HttpException(response=http_error['group_users'][group_id])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -317,7 +315,7 @@ def connection_identity(request, mock_responses):
 
     def services():
         if http_error and 'services' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['services'])
+            raise openstack.exceptions.HttpException(response=http_error['services'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -329,7 +327,7 @@ def connection_identity(request, mock_responses):
 
     def registered_limits():
         if http_error and 'registered_limits' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['registered_limits'])
+            raise openstack.exceptions.HttpException(response=http_error['registered_limits'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -341,7 +339,7 @@ def connection_identity(request, mock_responses):
 
     def limits():
         if http_error and 'limits' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['limits'])
+            raise openstack.exceptions.HttpException(response=http_error['limits'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -371,7 +369,7 @@ def connection_block_storage(request, mock_responses):
 
     def volumes(project_id, limit=None):
         if http_error and 'volumes' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['volumes'])
+            raise openstack.exceptions.HttpException(response=http_error['volumes'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -383,7 +381,7 @@ def connection_block_storage(request, mock_responses):
 
     def transfers(project_id, details):
         if http_error and 'transfers' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['transfers'])
+            raise openstack.exceptions.HttpException(response=http_error['transfers'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -395,7 +393,7 @@ def connection_block_storage(request, mock_responses):
 
     def snapshots(project_id, limit=None):
         if http_error and 'snapshots' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['snapshots'])
+            raise openstack.exceptions.HttpException(response=http_error['snapshots'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -407,7 +405,7 @@ def connection_block_storage(request, mock_responses):
 
     def pools(project_id, details):
         if http_error and 'pools' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['pools'])
+            raise openstack.exceptions.HttpException(response=http_error['pools'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -419,7 +417,7 @@ def connection_block_storage(request, mock_responses):
 
     def clusters(project_id, details):
         if http_error and 'clusters' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['clusters'])
+            raise openstack.exceptions.HttpException(response=http_error['clusters'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -445,7 +443,7 @@ def connection_compute(request, mock_responses):
 
     def get_limits(tenant_id):
         if http_error and 'limits' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['limits'])
+            raise openstack.exceptions.HttpException(response=http_error['limits'])
         return mock.MagicMock(
             to_dict=mock.MagicMock(
                 return_value=mock_responses('GET', f'/compute/v2.1/limits?tenant_id={tenant_id}')['limits'],
@@ -454,7 +452,7 @@ def connection_compute(request, mock_responses):
 
     def services():
         if http_error and 'services' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['services'])
+            raise openstack.exceptions.HttpException(response=http_error['services'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -466,7 +464,7 @@ def connection_compute(request, mock_responses):
 
     def aggregates():
         if http_error and 'aggregates' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['aggregates'])
+            raise openstack.exceptions.HttpException(response=http_error['aggregates'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -478,7 +476,7 @@ def connection_compute(request, mock_responses):
 
     def flavors(details):
         if http_error and 'flavors' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['flavors'])
+            raise openstack.exceptions.HttpException(response=http_error['flavors'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -490,7 +488,7 @@ def connection_compute(request, mock_responses):
 
     def hypervisors(details):
         if http_error and 'hypervisors' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['hypervisors'])
+            raise openstack.exceptions.HttpException(response=http_error['hypervisors'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -502,7 +500,7 @@ def connection_compute(request, mock_responses):
 
     def get_hypervisor_uptime(hypervisor_id):
         if http_error and 'hypervisor_uptime' in http_error and hypervisor_id in http_error['hypervisor_uptime']:
-            raise requests.exceptions.HTTPError(response=http_error['hypervisor_uptime'][hypervisor_id])
+            raise openstack.exceptions.HttpException(response=http_error['hypervisor_uptime'][hypervisor_id])
         return mock.MagicMock(
             to_dict=mock.MagicMock(
                 return_value=mock_responses('GET', f'/compute/v2.1/os-hypervisors/{hypervisor_id}/uptime')[
@@ -513,7 +511,7 @@ def connection_compute(request, mock_responses):
 
     def get_quota_set(project_id):
         if http_error and 'quota_sets' in http_error and project_id in http_error['quota_sets']:
-            raise requests.exceptions.HTTPError(response=http_error['quota_sets'][project_id])
+            raise openstack.exceptions.HttpException(response=http_error['quota_sets'][project_id])
         return mock.MagicMock(
             to_dict=mock.MagicMock(
                 return_value=mock_responses('GET', f'/compute/v2.1/os-quota-sets/{project_id}')['quota_set']
@@ -522,7 +520,7 @@ def connection_compute(request, mock_responses):
 
     def servers(project_id, details=True, all_tenants=False, limit=None):
         if http_error and 'servers' in http_error and project_id in http_error['servers']:
-            raise requests.exceptions.HTTPError(response=http_error['servers'][project_id])
+            raise openstack.exceptions.HttpException(response=http_error['servers'][project_id])
         return (
             [
                 mock.MagicMock(
@@ -551,14 +549,14 @@ def connection_compute(request, mock_responses):
 
     def get_flavor(flavor_id):
         if http_error and 'flavors' in http_error and flavor_id in http_error['flavors']:
-            raise requests.exceptions.HTTPError(response=http_error['flavors'][flavor_id])
+            raise openstack.exceptions.HttpException(response=http_error['flavors'][flavor_id])
         return mock.MagicMock(
             to_dict=mock.MagicMock(return_value=mock_responses('GET', f'/compute/v2.1/flavors/{flavor_id}')['flavor'])
         )
 
     def get_server_diagnostics(server_id):
         if http_error and 'server_diagnostics' in http_error and server_id in http_error['server_diagnostics']:
-            raise requests.exceptions.HTTPError(response=http_error['server_diagnostics'][server_id])
+            raise openstack.exceptions.HttpException(response=http_error['server_diagnostics'][server_id])
         return mock.MagicMock(
             to_dict=mock.MagicMock(
                 return_value=mock_responses('GET', f'/compute/v2.1/servers/{server_id}/diagnostics'),
@@ -586,7 +584,7 @@ def connection_network(request, mock_responses):
 
     def agents():
         if http_error and 'agents' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['agents'])
+            raise openstack.exceptions.HttpException(response=http_error['agents'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -598,7 +596,7 @@ def connection_network(request, mock_responses):
 
     def networks(project_id, limit=None):
         if http_error and 'networks' in http_error and project_id in http_error['networks']:
-            raise requests.exceptions.HTTPError(response=http_error['networks'])
+            raise openstack.exceptions.HttpException(response=http_error['networks'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -610,7 +608,7 @@ def connection_network(request, mock_responses):
 
     def get_quota(project_id, details):
         if http_error and 'quotas' in http_error and project_id in http_error['quotas']:
-            raise requests.exceptions.HTTPError(response=http_error['quotas'][project_id])
+            raise openstack.exceptions.HttpException(response=http_error['quotas'][project_id])
         return mock.MagicMock(
             to_dict=mock.MagicMock(
                 return_value=mock_responses('GET', f'/networking/v2.0/quotas/{project_id}')['quota'],
@@ -631,7 +629,7 @@ def connection_baremetal(request, mock_responses):
 
     def nodes(details, limit=None):
         if http_error and 'nodes' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['nodes'])
+            raise openstack.exceptions.HttpException(response=http_error['nodes'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -643,7 +641,7 @@ def connection_baremetal(request, mock_responses):
 
     def portgroups(node_id, limit=None):
         if http_error and 'portgroups' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['portgroups'])
+            raise openstack.exceptions.HttpException(response=http_error['portgroups'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -655,7 +653,7 @@ def connection_baremetal(request, mock_responses):
 
     def ports(limit=None):
         if http_error and 'ports' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['ports'])
+            raise openstack.exceptions.HttpException(response=http_error['ports'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -667,7 +665,7 @@ def connection_baremetal(request, mock_responses):
 
     def conductors(limit=None):
         if http_error and 'conductors' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['conductors'])
+            raise openstack.exceptions.HttpException(response=http_error['conductors'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -679,7 +677,7 @@ def connection_baremetal(request, mock_responses):
 
     def volume_connectors(limit=None):
         if http_error and 'connectors' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['connectors'])
+            raise openstack.exceptions.HttpException(response=http_error['connectors'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -691,7 +689,7 @@ def connection_baremetal(request, mock_responses):
 
     def volume_targets(limit=None):
         if http_error and 'targets' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['targets'])
+            raise openstack.exceptions.HttpException(response=http_error['targets'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -703,7 +701,7 @@ def connection_baremetal(request, mock_responses):
 
     def drivers():
         if http_error and 'drivers' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['drivers'])
+            raise openstack.exceptions.HttpException(response=http_error['drivers'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -715,7 +713,7 @@ def connection_baremetal(request, mock_responses):
 
     def allocations(limit=None):
         if http_error and 'allocations' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['allocations'])
+            raise openstack.exceptions.HttpException(response=http_error['allocations'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -744,7 +742,7 @@ def connection_image(request, mock_responses):
 
     def images(limit=None):
         if http_error and 'images' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['images'])
+            raise openstack.exceptions.HttpException(response=http_error['images'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -756,7 +754,7 @@ def connection_image(request, mock_responses):
 
     def members(image_id):
         if http_error and 'members' in http_error:
-            raise requests.exceptions.HTTPError(response=http_error['members'])
+            raise openstack.exceptions.HttpException(response=http_error['members'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -779,7 +777,7 @@ def connection_load_balancer(request, mock_responses):
 
     def load_balancers(project_id, limit=None):
         if http_error and 'load_balancers' in http_error and project_id in http_error['load_balancers']:
-            raise requests.exceptions.HTTPError(response=http_error['load_balancers'][project_id])
+            raise openstack.exceptions.HttpException(response=http_error['load_balancers'][project_id])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -797,7 +795,7 @@ def connection_load_balancer(request, mock_responses):
             and 'load_balancer_statistics' in http_error
             and loadbalancer_id in http_error['load_balancer_statistics']
         ):
-            raise requests.exceptions.HTTPError(response=http_error['load_balancer_statistics'][loadbalancer_id])
+            raise openstack.exceptions.HttpException(response=http_error['load_balancer_statistics'][loadbalancer_id])
         return mock.MagicMock(
             to_dict=mock.MagicMock(
                 return_value=mock_responses(
@@ -808,7 +806,7 @@ def connection_load_balancer(request, mock_responses):
 
     def listeners(project_id, limit=None):
         if http_error and 'listeners' in http_error and project_id in http_error['listeners']:
-            raise requests.exceptions.HTTPError(response=http_error['listeners'][project_id])
+            raise openstack.exceptions.HttpException(response=http_error['listeners'][project_id])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -822,7 +820,7 @@ def connection_load_balancer(request, mock_responses):
 
     def get_listener_statistics(listener_id):
         if http_error and 'listener_statistics' in http_error and listener_id in http_error['listener_statistics']:
-            raise requests.exceptions.HTTPError(response=http_error['listener_statistics'][listener_id])
+            raise openstack.exceptions.HttpException(response=http_error['listener_statistics'][listener_id])
         return mock.MagicMock(
             to_dict=mock.MagicMock(
                 return_value=mock_responses('GET', f'/load-balancer/v2/lbaas/listeners/{listener_id}/stats').get(
@@ -833,7 +831,7 @@ def connection_load_balancer(request, mock_responses):
 
     def pools(project_id, limit=None):
         if http_error and 'pools' in http_error and project_id in http_error['pools']:
-            raise requests.exceptions.HTTPError(response=http_error['pools'][project_id])
+            raise openstack.exceptions.HttpException(response=http_error['pools'][project_id])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -845,7 +843,7 @@ def connection_load_balancer(request, mock_responses):
 
     def members(pool_id, project_id):
         if http_error and 'pool_members' in http_error and pool_id in http_error['pool_members']:
-            raise requests.exceptions.HTTPError(response=http_error['pool_members'][pool_id])
+            raise openstack.exceptions.HttpException(response=http_error['pool_members'][pool_id])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -859,7 +857,7 @@ def connection_load_balancer(request, mock_responses):
 
     def health_monitors(project_id):
         if http_error and 'health_monitors' in http_error and project_id in http_error['health_monitors']:
-            raise requests.exceptions.HTTPError(response=http_error['health_monitors'][project_id])
+            raise openstack.exceptions.HttpException(response=http_error['health_monitors'][project_id])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -873,7 +871,7 @@ def connection_load_balancer(request, mock_responses):
 
     def quotas(project_id):
         if http_error and 'quotas' in http_error and project_id in http_error['quotas']:
-            raise requests.exceptions.HTTPError(response=http_error['quotas'][project_id])
+            raise openstack.exceptions.HttpException(response=http_error['quotas'][project_id])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -885,7 +883,7 @@ def connection_load_balancer(request, mock_responses):
 
     def amphorae(project_id, limit=None):
         if http_error and 'amphorae' in http_error and project_id in http_error['amphorae']:
-            raise requests.exceptions.HTTPError(response=http_error['amphorae'][project_id])
+            raise openstack.exceptions.HttpException(response=http_error['amphorae'][project_id])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -917,7 +915,7 @@ def connection_heat(request, mock_responses):
 
     def stacks(project_id, limit=None):
         if http_error and 'stacks' in http_error and project_id in http_error['stacks']:
-            raise requests.exceptions.HTTPError(response=http_error['stacks'])
+            raise openstack.exceptions.HttpException(response=http_error['stacks'])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -937,7 +935,7 @@ def connection_swift(request, mock_responses):
 
     def containers(account_id, limit=None):
         if http_error and 'containers' in http_error and account_id in http_error['containers']:
-            raise requests.exceptions.HTTPError(response=http_error['containers'][account_id])
+            raise openstack.exceptions.HttpException(response=http_error['containers'][account_id])
         return [
             mock.MagicMock(
                 to_dict=mock.MagicMock(
@@ -995,22 +993,24 @@ def mock_http_get(request, monkeypatch, mock_http_call):
     data = param.pop('mock_data', {})
     elapsed_total_seconds = param.pop('elapsed_total_seconds', {})
 
-    def get(url, *args, **kwargs):
-        method = 'GET'
-        url = get_url_path(url)
-        if http_error and url in http_error:
-            return http_error[url]
-        if data and url in data:
-            return MockHTTPResponse(json_data=data[url], status_code=200)
-        headers = kwargs.get('headers')
-        params = kwargs.get('params')
-        mock_elapsed = mock.MagicMock(total_seconds=mock.MagicMock(return_value=elapsed_total_seconds.get(url, 0.0)))
-        mock_json = mock.MagicMock(return_value=mock_http_call(method, url, headers=headers, params=params))
-        mock_status_code = mock.MagicMock(return_value=200)
-        return mock.MagicMock(elapsed=mock_elapsed, json=mock_json, status_code=mock_status_code)
+    mock_get = mock.MagicMock()
 
-    mock_get = mock.MagicMock(side_effect=get)
-    monkeypatch.setattr('requests.Session.get', mock_get)
+    def get(wrapper, url, **options):
+        mock_get(url, **options)
+        path = get_url_path(url)
+        if http_error and path in http_error:
+            return http_error[path]
+        if data and path in data:
+            return MockHTTPResponse(json_data=data[path], status_code=200)
+        headers = {**wrapper.options.get('headers', {}), **(options.get('headers') or {})}
+        params = options.get('params')
+        return MockHTTPResponse(
+            json_data=mock_http_call('GET', path, headers=headers, params=params),
+            status_code=200,
+            elapsed_seconds=elapsed_total_seconds.get(path, 0.0),
+        )
+
+    monkeypatch.setattr(RequestsWrapper, 'get', get)
     return mock_get
 
 
@@ -1020,28 +1020,30 @@ def mock_http_post(request, monkeypatch, mock_http_call):
     replace = param.get('replace')
     http_error = param.get('http_error')
 
-    def post(url, *args, **kwargs):
+    mock_post = mock.MagicMock()
+
+    def post(wrapper, url, **options):
+        mock_post(url, **options)
         method = 'POST'
-        url = get_url_path(url)
-        if http_error and url in http_error:
-            return http_error[url]
+        path = get_url_path(url)
+        if http_error and path in http_error:
+            return http_error[path]
         headers = None
-        if url == '/identity/v3/auth/tokens':
-            data = kwargs['json']
+        if path == '/identity/v3/auth/tokens':
+            data = options['json']
             file = data.get('auth', {}).get('scope', 'unscoped')
             if isinstance(file, dict):
                 if 'system' in file:
                     file = 'system'
                 else:
                     file = file.get('project', {}).get('id')
-            json_data = mock_http_call(method, url, file, headers=kwargs.get('headers'))
+            json_data = mock_http_call(method, path, file, headers=wrapper.options.get('headers'))
             headers = {'X-Subject-Token': f'token_{file}'}
         else:
-            json_data = mock_http_call(method, url)
-        if replace and url in replace:
-            json_data = replace[url](json_data)
+            json_data = mock_http_call(method, path)
+        if replace and path in replace:
+            json_data = replace[path](json_data)
         return MockHTTPResponse(json_data=json_data, status_code=200, headers=headers)
 
-    mock_post = mock.MagicMock(side_effect=post)
-    monkeypatch.setattr('requests.Session.post', mock_post)
+    monkeypatch.setattr(RequestsWrapper, 'post', post)
     return mock_post

--- a/openstack_controller/tests/conftest.py
+++ b/openstack_controller/tests/conftest.py
@@ -14,7 +14,6 @@ import pytest
 import yaml
 
 import tests.configs as configs
-from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs
@@ -987,22 +986,19 @@ def get_url_path(url):
 
 
 @pytest.fixture
-def mock_http_get(request, monkeypatch, mock_http_call):
+def mock_http_get(request, mock_http_call, mock_http):
     param = request.param if hasattr(request, 'param') and request.param is not None else {}
     http_error = param.pop('http_error', {})
     data = param.pop('mock_data', {})
     elapsed_total_seconds = param.pop('elapsed_total_seconds', {})
 
-    mock_get = mock.MagicMock()
-
-    def get(wrapper, url, **options):
-        mock_get(url, **options)
+    def get(url, **options):
         path = get_url_path(url)
         if http_error and path in http_error:
             return http_error[path]
         if data and path in data:
             return MockHTTPResponse(json_data=data[path], status_code=200)
-        headers = {**wrapper.options.get('headers', {}), **(options.get('headers') or {})}
+        headers = {**mock_http.options.get('headers', {}), **(options.get('headers') or {})}
         params = options.get('params')
         return MockHTTPResponse(
             json_data=mock_http_call('GET', path, headers=headers, params=params),
@@ -1010,20 +1006,17 @@ def mock_http_get(request, monkeypatch, mock_http_call):
             elapsed_seconds=elapsed_total_seconds.get(path, 0.0),
         )
 
-    monkeypatch.setattr(RequestsWrapper, 'get', get)
-    return mock_get
+    mock_http.get.side_effect = get
+    return mock_http.get
 
 
 @pytest.fixture
-def mock_http_post(request, monkeypatch, mock_http_call):
+def mock_http_post(request, mock_http_call, mock_http):
     param = request.param if hasattr(request, 'param') and request.param is not None else {}
     replace = param.get('replace')
     http_error = param.get('http_error')
 
-    mock_post = mock.MagicMock()
-
-    def post(wrapper, url, **options):
-        mock_post(url, **options)
+    def post(url, **options):
         method = 'POST'
         path = get_url_path(url)
         if http_error and path in http_error:
@@ -1037,7 +1030,7 @@ def mock_http_post(request, monkeypatch, mock_http_call):
                     file = 'system'
                 else:
                     file = file.get('project', {}).get('id')
-            json_data = mock_http_call(method, path, file, headers=wrapper.options.get('headers'))
+            json_data = mock_http_call(method, path, file, headers=mock_http.options.get('headers'))
             headers = {'X-Subject-Token': f'token_{file}'}
         else:
             json_data = mock_http_call(method, path)
@@ -1045,5 +1038,5 @@ def mock_http_post(request, monkeypatch, mock_http_call):
             json_data = replace[path](json_data)
         return MockHTTPResponse(json_data=json_data, status_code=200, headers=headers)
 
-    monkeypatch.setattr(RequestsWrapper, 'post', post)
-    return mock_post
+    mock_http.post.side_effect = post
+    return mock_http.post

--- a/openstack_controller/tests/legacy/conftest.py
+++ b/openstack_controller/tests/legacy/conftest.py
@@ -6,7 +6,6 @@ import os
 
 import pytest
 
-from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs
 from datadog_checks.dev.fs import get_here
@@ -60,9 +59,3 @@ def instance():
 @pytest.fixture
 def check(instance):
     return OpenStackControllerLegacyCheck(CHECK_NAME, {}, [instance])
-
-
-@pytest.fixture
-def requests_wrapper():
-    instance = {'timeout': 10, 'ssl_verify': False}
-    yield RequestsWrapper(instance, {})

--- a/openstack_controller/tests/legacy/test_openstack.py
+++ b/openstack_controller/tests/legacy/test_openstack.py
@@ -12,7 +12,7 @@ import pytest
 from mock import ANY
 
 from datadog_checks.base import AgentCheck
-from datadog_checks.base.utils.http_exceptions import HTTPStatusError
+from datadog_checks.base.utils.http_exceptions import HTTPConnectionError, HTTPStatusError
 from datadog_checks.openstack_controller.legacy.api import AbstractApi, Authenticator, SimpleApi
 from datadog_checks.openstack_controller.legacy.exceptions import IncompleteConfig, KeystoneUnreachable
 from datadog_checks.openstack_controller.legacy.openstack_controller_legacy import OpenStackControllerLegacyCheck
@@ -365,6 +365,77 @@ def test_collect_server_metrics_pre_2_48(server_diagnostics, os_aggregates, aggr
     )
 
     aggregator.assert_all_metrics_covered()
+
+
+@mock.patch(
+    'datadog_checks.openstack_controller.legacy.openstack_controller_legacy.OpenStackControllerLegacyCheck.get_os_aggregates',
+    return_value=OS_AGGREGATES_RESPONSE,
+)
+def test_collect_server_diagnostic_metrics_404_is_debug_logged(os_aggregates, aggregator, caplog):
+    check = OpenStackControllerLegacyCheck(
+        "test", {'ssl_verify': False, 'paginated_server_limit': 1}, [common.KEYSTONE_INSTANCE]
+    )
+    error = HTTPStatusError('not found', response=mock.Mock(status_code=404))
+    with mock.patch.object(check, 'get_server_diagnostics', side_effect=error):
+        with mock.patch.object(check, 'warning') as warning:
+            with caplog.at_level(logging.DEBUG):
+                check.collect_server_diagnostic_metrics({'server_id': 'srv-1', 'server_name': 'srv-1'})
+
+    assert any("is not in an ACTIVE state" in message for _, _, message in caplog.record_tuples)
+    warning.assert_not_called()
+    aggregator.assert_metric('openstack.nova.server.vda_read_req', count=0)
+
+
+@mock.patch(
+    'datadog_checks.openstack_controller.legacy.openstack_controller_legacy.OpenStackControllerLegacyCheck.get_os_aggregates',
+    return_value=OS_AGGREGATES_RESPONSE,
+)
+@pytest.mark.parametrize(
+    'response',
+    [
+        mock.Mock(status_code=500),
+        None,
+    ],
+    ids=['status_500', 'missing_response'],
+)
+def test_collect_server_diagnostic_metrics_non_404_warns(os_aggregates, response, aggregator):
+    check = OpenStackControllerLegacyCheck(
+        "test", {'ssl_verify': False, 'paginated_server_limit': 1}, [common.KEYSTONE_INSTANCE]
+    )
+    error = HTTPStatusError('boom', response=response)
+    with mock.patch.object(check, 'get_server_diagnostics', side_effect=error):
+        with mock.patch.object(check, 'warning') as warning:
+            check.collect_server_diagnostic_metrics({'server_id': 'srv-1', 'server_name': 'srv-1'})
+
+    warning.assert_called_once()
+    aggregator.assert_metric('openstack.nova.server.vda_read_req', count=0)
+
+
+@mock.patch(
+    'datadog_checks.openstack_controller.legacy.api.ApiFactory.create', return_value=mock.MagicMock(AbstractApi)
+)
+@pytest.mark.parametrize(
+    'error, expect_backoff',
+    [
+        (HTTPStatusError('client error', response=mock.Mock(status_code=400)), False),
+        (HTTPStatusError('server error', response=mock.Mock(status_code=500)), True),
+        (HTTPStatusError('no response'), True),
+        (HTTPConnectionError('connection refused'), True),
+    ],
+    ids=['status_lt_500_warns', 'status_ge_500_backs_off', 'missing_response_backs_off', 'connection_error_backs_off'],
+)
+def test_check_nova_api_error_backoff(mock_api, error, expect_backoff):
+    check = OpenStackControllerLegacyCheck("test", {'ssl_verify': False}, [common.KEYSTONE_INSTANCE])
+    with mock.patch.object(check, 'init_api', side_effect=error):
+        with mock.patch.object(check, 'do_backoff') as do_backoff:
+            with mock.patch.object(check, 'warning') as warning:
+                check.check(common.KEYSTONE_INSTANCE)
+
+    if expect_backoff:
+        do_backoff.assert_called_once()
+    else:
+        do_backoff.assert_not_called()
+        warning.assert_called()
 
 
 def test_get_keystone_url_from_openstack_config():

--- a/openstack_controller/tests/legacy/test_openstack.py
+++ b/openstack_controller/tests/legacy/test_openstack.py
@@ -10,9 +10,9 @@ from copy import deepcopy
 import mock
 import pytest
 from mock import ANY
-from requests.exceptions import HTTPError
 
 from datadog_checks.base import AgentCheck
+from datadog_checks.base.utils.http_exceptions import HTTPStatusError
 from datadog_checks.openstack_controller.legacy.api import AbstractApi, Authenticator, SimpleApi
 from datadog_checks.openstack_controller.legacy.exceptions import IncompleteConfig, KeystoneUnreachable
 from datadog_checks.openstack_controller.legacy.openstack_controller_legacy import OpenStackControllerLegacyCheck
@@ -39,7 +39,7 @@ def test_parse_uptime_string(aggregator):
 
 
 def test_api_error_log_no_password(check, instance, caplog, mock_http):
-    mock_http.post.side_effect = HTTPError(mock.Mock(status=404), 'not found')
+    mock_http.post.side_effect = HTTPStatusError('not found')
     with caplog.at_level(logging.DEBUG):
         with pytest.raises(KeystoneUnreachable):
             check._api = SimpleApi(check.log, instance.get("keystone_server_url"), check.http)

--- a/openstack_controller/tests/legacy/test_openstack.py
+++ b/openstack_controller/tests/legacy/test_openstack.py
@@ -8,6 +8,7 @@ import os
 from copy import deepcopy
 
 import mock
+import openstack.exceptions
 import pytest
 from mock import ANY
 
@@ -26,6 +27,13 @@ pytestmark = [
         reason='Legacy test',
     ),
 ]
+
+
+def sdk_http_exception(status_code: int | None = None) -> openstack.exceptions.HttpException:
+    if status_code is None:
+        return openstack.exceptions.HttpException()
+
+    return openstack.exceptions.HttpException(response=mock.Mock(status_code=status_code, headers={}, request=None))
 
 
 def test_parse_uptime_string(aggregator):
@@ -139,6 +147,18 @@ def test_check_with_config_file(mock_api, aggregator):
     aggregator.assert_service_check('openstack.nova.api.up', AgentCheck.OK)
     aggregator.assert_service_check('openstack.neutron.api.up', AgentCheck.OK)
     mock_api.assert_called_with(ANY, common.CONFIG_FILE_INSTANCE, ANY)
+
+
+def test_send_api_service_checks_handles_sdk_http_exception(aggregator):
+    check = OpenStackControllerLegacyCheck("test", {'ssl_verify': False}, [common.CONFIG_FILE_INSTANCE])
+
+    with mock.patch.object(check, 'get_nova_endpoint', side_effect=sdk_http_exception(500)):
+        with mock.patch.object(check, 'get_neutron_endpoint', side_effect=sdk_http_exception(500)):
+            check._send_api_service_checks('http://10.0.2.15:5000', ['tag'])
+
+    tags = ['keystone_server: http://10.0.2.15:5000', 'tag']
+    aggregator.assert_service_check('openstack.nova.api.up', AgentCheck.CRITICAL, tags=tags)
+    aggregator.assert_service_check('openstack.neutron.api.up', AgentCheck.CRITICAL, tags=tags)
 
 
 def get_server_details_response(params):
@@ -371,11 +391,17 @@ def test_collect_server_metrics_pre_2_48(server_diagnostics, os_aggregates, aggr
     'datadog_checks.openstack_controller.legacy.openstack_controller_legacy.OpenStackControllerLegacyCheck.get_os_aggregates',
     return_value=OS_AGGREGATES_RESPONSE,
 )
-def test_collect_server_diagnostic_metrics_404_is_debug_logged(os_aggregates, aggregator, caplog):
+@pytest.mark.parametrize(
+    'error',
+    [
+        pytest.param(HTTPStatusError('not found', response=mock.Mock(status_code=404)), id='agnostic_status_error'),
+        pytest.param(sdk_http_exception(404), id='sdk_http_exception'),
+    ],
+)
+def test_collect_server_diagnostic_metrics_404_is_debug_logged(os_aggregates, error, aggregator, caplog):
     check = OpenStackControllerLegacyCheck(
         "test", {'ssl_verify': False, 'paginated_server_limit': 1}, [common.KEYSTONE_INSTANCE]
     )
-    error = HTTPStatusError('not found', response=mock.Mock(status_code=404))
     with mock.patch.object(check, 'get_server_diagnostics', side_effect=error):
         with mock.patch.object(check, 'warning') as warning:
             with caplog.at_level(logging.DEBUG):
@@ -391,18 +417,18 @@ def test_collect_server_diagnostic_metrics_404_is_debug_logged(os_aggregates, ag
     return_value=OS_AGGREGATES_RESPONSE,
 )
 @pytest.mark.parametrize(
-    'response',
+    'error',
     [
-        mock.Mock(status_code=500),
-        None,
+        pytest.param(HTTPStatusError('boom', response=mock.Mock(status_code=500)), id='agnostic_status_500'),
+        pytest.param(HTTPStatusError('boom'), id='agnostic_missing_response'),
+        pytest.param(sdk_http_exception(500), id='sdk_status_500'),
+        pytest.param(sdk_http_exception(), id='sdk_missing_response'),
     ],
-    ids=['status_500', 'missing_response'],
 )
-def test_collect_server_diagnostic_metrics_non_404_warns(os_aggregates, response, aggregator):
+def test_collect_server_diagnostic_metrics_non_404_warns(os_aggregates, error, aggregator):
     check = OpenStackControllerLegacyCheck(
         "test", {'ssl_verify': False, 'paginated_server_limit': 1}, [common.KEYSTONE_INSTANCE]
     )
-    error = HTTPStatusError('boom', response=response)
     with mock.patch.object(check, 'get_server_diagnostics', side_effect=error):
         with mock.patch.object(check, 'warning') as warning:
             check.collect_server_diagnostic_metrics({'server_id': 'srv-1', 'server_name': 'srv-1'})
@@ -421,8 +447,19 @@ def test_collect_server_diagnostic_metrics_non_404_warns(os_aggregates, response
         (HTTPStatusError('server error', response=mock.Mock(status_code=500)), True),
         (HTTPStatusError('no response'), True),
         (HTTPConnectionError('connection refused'), True),
+        (sdk_http_exception(400), False),
+        (sdk_http_exception(500), True),
+        (sdk_http_exception(), True),
     ],
-    ids=['status_lt_500_warns', 'status_ge_500_backs_off', 'missing_response_backs_off', 'connection_error_backs_off'],
+    ids=[
+        'status_lt_500_warns',
+        'status_ge_500_backs_off',
+        'missing_response_backs_off',
+        'connection_error_backs_off',
+        'sdk_status_lt_500_warns',
+        'sdk_status_ge_500_backs_off',
+        'sdk_missing_response_backs_off',
+    ],
 )
 def test_check_nova_api_error_backoff(mock_api, error, expect_backoff):
     check = OpenStackControllerLegacyCheck("test", {'ssl_verify': False}, [common.KEYSTONE_INSTANCE])

--- a/openstack_controller/tests/legacy/test_simple_api.py
+++ b/openstack_controller/tests/legacy/test_simple_api.py
@@ -8,7 +8,6 @@ import os
 
 import mock
 import pytest
-import requests
 import simplejson as json
 
 from datadog_checks.base.utils.http_exceptions import HTTPStatusError
@@ -771,8 +770,8 @@ def test__make_request_failure(requests_wrapper):
         api = ApiFactory.create(log, instance, requests_wrapper)
 
     response_mock = mock.MagicMock()
-    with mock.patch("requests.Session.get", return_value=response_mock):
-        response_mock.raise_for_status.side_effect = requests.exceptions.HTTPError
+    with mock.patch.object(type(requests_wrapper), "get", return_value=response_mock):
+        response_mock.raise_for_status.side_effect = HTTPStatusError("mocked HTTP error")
         response_mock.status_code = 401
         with pytest.raises(AuthenticationNeeded):
             api._make_request("", {})

--- a/openstack_controller/tests/legacy/test_simple_api.py
+++ b/openstack_controller/tests/legacy/test_simple_api.py
@@ -177,7 +177,7 @@ PROJECTS_RESPONSE = [
 PROJECT_RESPONSE = [{"domain_id": "1111", "id": "3333", "name": "name 1"}]
 
 
-def test_from_config(requests_wrapper):
+def test_from_config(mock_http):
     mock_http_response = copy.deepcopy(common.EXAMPLE_AUTH_RESPONSE)
     mock_response = MockHTTPResponse(response_dict=mock_http_response, headers={'X-Subject-Token': 'fake_token'})
 
@@ -188,7 +188,7 @@ def test_from_config(requests_wrapper):
             'datadog_checks.openstack_controller.legacy.api.Authenticator._get_auth_projects',
             return_value=PROJECTS_RESPONSE,
         ):
-            cred = Authenticator.from_config(log, 'http://10.0.2.15:5000', GOOD_USERS[0]['user'], requests_wrapper)
+            cred = Authenticator.from_config(log, 'http://10.0.2.15:5000', GOOD_USERS[0]['user'], mock_http)
             assert isinstance(cred, Credential)
             assert cred.auth_token == "fake_token"
             assert cred.name == "name 2"
@@ -198,7 +198,7 @@ def test_from_config(requests_wrapper):
             assert cred.neutron_endpoint == "http://10.0.2.15:9292"
 
 
-def test_from_config_with_admin(requests_wrapper):
+def test_from_config_with_admin(mock_http):
     mock_http_response = copy.deepcopy(common.EXAMPLE_AUTH_RESPONSE)
     del mock_http_response['token']['roles']
     mock_http_response['token']['roles'] = [
@@ -214,7 +214,7 @@ def test_from_config_with_admin(requests_wrapper):
             'datadog_checks.openstack_controller.legacy.api.Authenticator._get_auth_projects',
             return_value=PROJECTS_RESPONSE,
         ):
-            cred = Authenticator.from_config(log, 'http://10.0.2.15:5000', GOOD_USERS[0]['user'], requests_wrapper)
+            cred = Authenticator.from_config(log, 'http://10.0.2.15:5000', GOOD_USERS[0]['user'], mock_http)
             assert isinstance(cred, Credential)
             assert cred.auth_token == "fake_token"
             assert cred.name == "name 1"
@@ -224,7 +224,7 @@ def test_from_config_with_admin(requests_wrapper):
             assert cred.neutron_endpoint == "http://10.0.2.15:9292"
 
 
-def test_from_config_with_missing_name(requests_wrapper):
+def test_from_config_with_missing_name(mock_http):
     mock_http_response = copy.deepcopy(common.EXAMPLE_AUTH_RESPONSE)
     mock_response = MockHTTPResponse(response_dict=mock_http_response, headers={'X-Subject-Token': 'fake_token'})
 
@@ -238,11 +238,11 @@ def test_from_config_with_missing_name(requests_wrapper):
             'datadog_checks.openstack_controller.legacy.api.Authenticator._get_auth_projects',
             return_value=project_response_without_name,
         ):
-            cred = Authenticator.from_config(log, 'http://10.0.2.15:5000', GOOD_USERS[0]['user'], requests_wrapper)
+            cred = Authenticator.from_config(log, 'http://10.0.2.15:5000', GOOD_USERS[0]['user'], mock_http)
             assert cred is None
 
 
-def test_from_config_with_missing_id(requests_wrapper):
+def test_from_config_with_missing_id(mock_http):
     mock_http_response = copy.deepcopy(common.EXAMPLE_AUTH_RESPONSE)
     mock_response = MockHTTPResponse(response_dict=mock_http_response, headers={'X-Subject-Token': 'fake_token'})
 
@@ -256,7 +256,7 @@ def test_from_config_with_missing_id(requests_wrapper):
             'datadog_checks.openstack_controller.legacy.api.Authenticator._get_auth_projects',
             return_value=project_response_without_name,
         ):
-            cred = Authenticator.from_config(log, 'http://10.0.2.15:5000', GOOD_USERS[0]['user'], requests_wrapper)
+            cred = Authenticator.from_config(log, 'http://10.0.2.15:5000', GOOD_USERS[0]['user'], mock_http)
             assert cred is None
 
 
@@ -288,13 +288,13 @@ def get_os_hypervisor_uptime_post_v2_53_response(url, params=None, timeout=None)
     )
 
 
-def test_get_os_hypervisor_uptime(aggregator, requests_wrapper):
+def test_get_os_hypervisor_uptime(aggregator, mock_http):
     hypervisor_mock = mock.MagicMock(id=1)
     with mock.patch(
         'datadog_checks.openstack_controller.legacy.api.SimpleApi._make_request',
         side_effect=get_os_hypervisor_uptime_pre_v2_52_response,
     ):
-        api = SimpleApi(None, None, requests_wrapper)
+        api = SimpleApi(None, None, mock_http)
         assert (
             api.get_os_hypervisor_uptime(hypervisor_mock)
             == " 08:32:11 up 93 days, 18:25, 12 users,  load average: 0.20, 0.12, 0.14"
@@ -304,7 +304,7 @@ def test_get_os_hypervisor_uptime(aggregator, requests_wrapper):
         'datadog_checks.openstack_controller.legacy.api.SimpleApi._make_request',
         side_effect=get_os_hypervisor_uptime_post_v2_53_response,
     ):
-        api = SimpleApi(None, None, requests_wrapper)
+        api = SimpleApi(None, None, mock_http)
         assert (
             api.get_os_hypervisor_uptime(hypervisor_mock)
             == " 08:32:11 up 93 days, 18:25, 12 users,  load average: 0.20, 0.12, 0.14"
@@ -336,11 +336,11 @@ def get_os_aggregates_response(url, params=None, timeout=None):
     )
 
 
-def test_get_os_aggregates(aggregator, requests_wrapper):
+def test_get_os_aggregates(aggregator, mock_http):
     with mock.patch(
         'datadog_checks.openstack_controller.legacy.api.SimpleApi._make_request', side_effect=get_os_aggregates_response
     ):
-        api = SimpleApi(None, None, requests_wrapper)
+        api = SimpleApi(None, None, mock_http)
 
         aggregates = api.get_os_aggregates()
 
@@ -457,19 +457,19 @@ def get_os_hypervisors_detail_post_v2_53_response(url, params=None, timeout=None
     )
 
 
-def test_get_os_hypervisors_detail(aggregator, requests_wrapper):
+def test_get_os_hypervisors_detail(aggregator, mock_http):
     with mock.patch(
         'datadog_checks.openstack_controller.legacy.api.SimpleApi._make_request',
         side_effect=get_os_hypervisors_detail_post_v2_33_response,
     ):
-        api = SimpleApi(None, None, requests_wrapper)
+        api = SimpleApi(None, None, mock_http)
         assert api.get_os_hypervisors_detail() == common.EXAMPLE_GET_OS_HYPERVISORS_RETURN_VALUE
 
     with mock.patch(
         'datadog_checks.openstack_controller.legacy.api.SimpleApi._make_request',
         side_effect=get_os_hypervisors_detail_post_v2_53_response,
     ):
-        api = SimpleApi(None, None, requests_wrapper)
+        api = SimpleApi(None, None, mock_http)
         assert api.get_os_hypervisors_detail() == [
             {
                 "cpu_info": {
@@ -601,12 +601,12 @@ def get_servers_detail_post_v2_63_response(url, params=None, timeout=None):
     )
 
 
-def test_get_servers_detail(aggregator, requests_wrapper):
+def test_get_servers_detail(aggregator, mock_http):
     with mock.patch(
         'datadog_checks.openstack_controller.legacy.api.SimpleApi._make_request',
         side_effect=get_servers_detail_post_v2_63_response,
     ):
-        api = SimpleApi(None, None, requests_wrapper)
+        api = SimpleApi(None, None, mock_http)
         assert api.get_servers_detail(None) == [
             {
                 "OS-DCF:diskConfig": "AUTO",
@@ -692,14 +692,14 @@ def test_get_servers_detail(aggregator, requests_wrapper):
         ]
 
 
-def test__get_paginated_list(requests_wrapper):
+def test__get_paginated_list(mock_http):
     log = mock.MagicMock()
 
     instance = copy.deepcopy(common.MOCK_CONFIG["instances"][0])
     instance["paginated_limit"] = 4
 
     with mock.patch("datadog_checks.openstack_controller.legacy.api.SimpleApi.connect"):
-        api = ApiFactory.create(log, instance, requests_wrapper)
+        api = ApiFactory.create(log, instance, mock_http)
     with mock.patch(
         "datadog_checks.openstack_controller.legacy.api.SimpleApi._make_request",
         side_effect=[
@@ -760,33 +760,33 @@ def test__get_paginated_list(requests_wrapper):
             api._get_paginated_list("url", "obj", {})
 
 
-def test__make_request_failure(requests_wrapper):
+def test__make_request_failure(mock_http):
     log = mock.MagicMock()
 
     instance = copy.deepcopy(common.MOCK_CONFIG["instances"][0])
     instance["paginated_limit"] = 4
 
     with mock.patch("datadog_checks.openstack_controller.legacy.api.SimpleApi.connect"):
-        api = ApiFactory.create(log, instance, requests_wrapper)
+        api = ApiFactory.create(log, instance, mock_http)
 
     response_mock = mock.MagicMock()
-    with mock.patch.object(type(requests_wrapper), "get", return_value=response_mock):
-        response_mock.raise_for_status.side_effect = HTTPStatusError("mocked HTTP error")
-        response_mock.status_code = 401
-        with pytest.raises(AuthenticationNeeded):
-            api._make_request("", {})
+    mock_http.get.return_value = response_mock
+    response_mock.raise_for_status.side_effect = HTTPStatusError("mocked HTTP error")
+    response_mock.status_code = 401
+    with pytest.raises(AuthenticationNeeded):
+        api._make_request("", {})
 
-        response_mock.status_code = 409
-        with pytest.raises(InstancePowerOffFailure):
-            api._make_request("", {})
+    response_mock.status_code = 409
+    with pytest.raises(InstancePowerOffFailure):
+        api._make_request("", {})
 
-        response_mock.status_code = 500
-        with pytest.raises(HTTPStatusError):
-            api._make_request("", {})
+    response_mock.status_code = 500
+    with pytest.raises(HTTPStatusError):
+        api._make_request("", {})
 
-        response_mock.raise_for_status.side_effect = Exception
-        with pytest.raises(Exception):
-            api._make_request("", {})
+    response_mock.raise_for_status.side_effect = Exception
+    with pytest.raises(Exception):
+        api._make_request("", {})
 
 
 def get_server_diagnostics_post_v2_48_response(url, params=None, timeout=None):
@@ -862,12 +862,12 @@ def get_server_diagnostics_post_v2_1_response(url, params=None, timeout=None):
     )
 
 
-def test_get_server_diagnostics(aggregator, requests_wrapper):
+def test_get_server_diagnostics(aggregator, mock_http):
     with mock.patch(
         'datadog_checks.openstack_controller.legacy.api.SimpleApi._make_request',
         side_effect=get_server_diagnostics_post_v2_48_response,
     ):
-        api = SimpleApi(None, None, requests_wrapper)
+        api = SimpleApi(None, None, mock_http)
         assert api.get_server_diagnostics(None) == {
             "config_drive": True,
             "cpu_details": [{"id": 0, "time": 17300000000, "utilisation": 15}],
@@ -910,7 +910,7 @@ def test_get_server_diagnostics(aggregator, requests_wrapper):
         'datadog_checks.openstack_controller.legacy.api.SimpleApi._make_request',
         side_effect=get_server_diagnostics_post_v2_1_response,
     ):
-        api = SimpleApi(None, None, requests_wrapper)
+        api = SimpleApi(None, None, mock_http)
         assert api.get_server_diagnostics(None) == {
             "cpu0_time": 17300000000,
             "memory": 524288,
@@ -1015,10 +1015,10 @@ def get_network_quotas_response():
     )
 
 
-def test_get_project_limits(aggregator, requests_wrapper):
+def test_get_project_limits(aggregator, mock_http):
     with mock.patch(
         'datadog_checks.openstack_controller.legacy.api.SimpleApi._make_request',
         side_effect=[get_project_limits_response(), get_network_quotas_response()],
     ):
-        api = SimpleApi(None, None, requests_wrapper)
+        api = SimpleApi(None, None, mock_http)
         assert api.get_project_limits(None) == common.EXAMPLE_GET_PROJECT_LIMITS_RETURN_VALUE

--- a/openstack_controller/tests/legacy/test_simple_api.py
+++ b/openstack_controller/tests/legacy/test_simple_api.py
@@ -771,7 +771,7 @@ def test__make_request_failure(requests_wrapper):
         api = ApiFactory.create(log, instance, requests_wrapper)
 
     response_mock = mock.MagicMock()
-    with mock.patch("datadog_checks.openstack_controller.legacy.api.requests.Session.get", return_value=response_mock):
+    with mock.patch("requests.Session.get", return_value=response_mock):
         response_mock.raise_for_status.side_effect = requests.exceptions.HTTPError
         response_mock.status_code = 401
         with pytest.raises(AuthenticationNeeded):

--- a/openstack_controller/tests/test_unit_component.py
+++ b/openstack_controller/tests/test_unit_component.py
@@ -1,0 +1,68 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
+import openstack.exceptions
+import pytest
+
+from datadog_checks.base import AgentCheck
+from datadog_checks.base.utils.http_exceptions import HTTPRequestError, HTTPStatusError
+from datadog_checks.openstack_controller.components.component import Component
+
+
+class DummyComponent(Component):
+    ID = Component.Id.COMPUTE
+    TYPES = Component.Types.COMPUTE
+    SERVICE_CHECK = 'openstack.test.service_check'
+
+    @Component.http_error(report_service_check=True)
+    def report_with_service_check(self, exc, tags=None):
+        raise exc
+
+    @Component.http_error()
+    def report_metric(self, exc):
+        raise exc
+
+
+@pytest.fixture
+def component():
+    return DummyComponent(mock.MagicMock())
+
+
+# Exceptions the decorator must treat as expected HTTP failures: swallowed, logged at DEBUG,
+# and (when the method reports a service check) surfaced as a CRITICAL service check.
+CAUGHT_HTTP_EXCEPTIONS = [
+    pytest.param(openstack.exceptions.HttpException(), id='sdk HttpException'),
+    pytest.param(HTTPRequestError('boom'), id='agnostic HTTPRequestError'),
+    pytest.param(HTTPStatusError('boom'), id='agnostic HTTPStatusError'),
+]
+
+# Exceptions the decorator must let fall through to the generic handler: logged at ERROR,
+# with no service check reported. A non-HTTP SDKException is the case the catch narrowing hinges on.
+FELL_THROUGH_EXCEPTIONS = [
+    pytest.param(openstack.exceptions.SDKException(), id='non-http SDKException'),
+    pytest.param(ValueError('boom'), id='unrelated exception'),
+]
+
+
+@pytest.mark.parametrize('exc', CAUGHT_HTTP_EXCEPTIONS)
+def test_http_error_reports_critical_for_http_exceptions(component, exc):
+    assert component.report_with_service_check(exc, tags=['tag']) is None
+    component.check.service_check.assert_called_once_with(
+        DummyComponent.SERVICE_CHECK, AgentCheck.CRITICAL, tags=['tag']
+    )
+    component.check.log.error.assert_not_called()
+
+
+@pytest.mark.parametrize('exc', CAUGHT_HTTP_EXCEPTIONS)
+def test_http_error_swallows_http_exceptions_without_service_check(component, exc):
+    assert component.report_metric(exc) is None
+    component.check.service_check.assert_not_called()
+    component.check.log.error.assert_not_called()
+
+
+@pytest.mark.parametrize('exc', FELL_THROUGH_EXCEPTIONS)
+def test_http_error_lets_non_http_exceptions_fall_through(component, exc):
+    assert component.report_with_service_check(exc, tags=['tag']) is None
+    component.check.service_check.assert_not_called()
+    component.check.log.error.assert_called_once()


### PR DESCRIPTION
### What does this PR do?

Removes all direct use of the `requests` library from the openstack_controller integration, in both production code and tests, routing HTTP error handling and test mocking through the agnostic HTTP layer instead.

- Production: the component error boundary catches openstacksdk's `HttpException` alongside the agnostic `HTTPRequestError`/`HTTPStatusError`, and the legacy check and API catch agnostic `HTTPStatusError`/`HTTPTimeoutError`/`HTTPConnectionError` in place of `requests.exceptions.*`. Access to `response.status_code` is now guarded, since an agnostic exception may carry no response.
- Tests: SDK connection fixtures raise `openstack.exceptions.HttpException`, HTTP mocks return `MockHTTPResponse` through the `mock_http` protocol seam rather than patching `requests.Session`, and the  `RequestsWrapper` fixture is removed. Adds decorator-contract tests plus legacy 404-diagnostic and Nova backoff coverage.

### Motivation

Part of the httpx migration. The integration must not depend on `requests` directly so the underlying HTTP backend can be swapped without touching integration code. This clears the last direct `requests` imports and mocks from openstack_controller.

### Verification

`ddev test openstack_controller` passes (536 passed, 54 skipped). Format and lint are clean via `ddev test -fs openstack_controller`. An audit of the integration (production, legacy, and tests) confirms no remaining direct `requests` imports, no `RequestsWrapper` usage, and no direct `requests.*` mocks.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
