### PR TITLE
Add an HTTP client factory seam and route wrapper construction through it

### DIFF
--- a/argocd/datadog_checks/argocd/resources.py
+++ b/argocd/datadog_checks/argocd/resources.py
@@ -16,8 +16,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse, urlunparse
 
-from datadog_checks.base.utils.http import RequestsWrapper
-
 try:
     import datadog_agent
 except ImportError:
@@ -318,12 +316,7 @@ class ArgocdResourceCollector:
                     auth_token=self._auth_token,
                     backoff_max_seconds=self._backoff_max,
                     read_timeout_seconds=self._stream_read_timeout,
-                    http=RequestsWrapper(
-                        self.check.instance,
-                        self.check.init_config,
-                        self.check.HTTP_CONFIG_REMAPPER,
-                        self.check.log,
-                    ),
+                    http=self.check.create_http_client(),
                 )
             if not self._listener.is_alive():
                 self._listener.start()

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -441,16 +441,21 @@ class AgentCheck(object):
 
         return self._http
 
-    def create_http_client(self) -> HTTPClient:
+    def create_http_client(self, instance: dict | None = None) -> HTTPClient:
         """Construct the HTTP client backing self.http.
 
-        Override this to build a bespoke wrapper or swap the backend. The default returns a
-        RequestsWrapper configured from this check's instance and init config.
+        Override this to build a bespoke wrapper or swap the backend. Pass ``instance`` to build a
+        client from a config other than this check's own instance, for example a per-endpoint config.
         """
         # See Performance Optimizations in this package's README.md.
-        from datadog_checks.base.utils.http import RequestsWrapper
+        from datadog_checks.base.utils.http import create_http_client
 
-        return RequestsWrapper(self.instance or {}, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log)
+        return create_http_client(
+            self.instance if instance is None else instance,
+            self.init_config,
+            self.HTTP_CONFIG_REMAPPER,
+            self.log,
+        )
 
     @property
     def logs_enabled(self):

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -442,11 +442,7 @@ class AgentCheck(object):
         return self._http
 
     def create_http_client(self, instance: dict | None = None) -> HTTPClient:
-        """Construct the HTTP client backing self.http.
-
-        Override this to build a bespoke wrapper or swap the backend. Pass ``instance`` to build a
-        client from a config other than this check's own instance, for example a per-endpoint config.
-        """
+        """Construct the HTTP client backing self.http, optionally from a given instance config."""
         # See Performance Optimizations in this package's README.md.
         from datadog_checks.base.utils.http import create_http_client
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -18,6 +18,7 @@ from datadog_checks.base.checks.libs.prometheus import text_fd_to_metric_familie
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.errors import CheckException
 from datadog_checks.base.utils.common import to_native_string
+from datadog_checks.base.utils.http import create_http_client
 from datadog_checks.base.utils.http_exceptions import HTTPRequestError, HTTPSSLError, HTTPStatusError
 
 
@@ -391,7 +392,9 @@ class OpenMetricsScraperMixin(object):
         if scraper_config['ssl_verify'] is False:
             scraper_config.setdefault('tls_ignore_warning', True)
 
-        http_handler = self._http_handlers[prometheus_url] = self.create_http_client(scraper_config)
+        http_handler = self._http_handlers[prometheus_url] = create_http_client(
+            scraper_config, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log
+        )
 
         headers = http_handler.options['headers']
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -18,7 +18,6 @@ from datadog_checks.base.checks.libs.prometheus import text_fd_to_metric_familie
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.errors import CheckException
 from datadog_checks.base.utils.common import to_native_string
-from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.base.utils.http_exceptions import HTTPRequestError, HTTPSSLError, HTTPStatusError
 
 
@@ -392,9 +391,7 @@ class OpenMetricsScraperMixin(object):
         if scraper_config['ssl_verify'] is False:
             scraper_config.setdefault('tls_ignore_warning', True)
 
-        http_handler = self._http_handlers[prometheus_url] = RequestsWrapper(
-            scraper_config, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log
-        )
+        http_handler = self._http_handlers[prometheus_url] = self.create_http_client(scraper_config)
 
         headers = http_handler.options['headers']
 

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -13,6 +13,7 @@ from google.protobuf.internal.decoder import _DecodeVarint32  # pylint: disable=
 from datadog_checks.base.checks import AgentCheck
 from datadog_checks.base.checks.libs.prometheus import text_fd_to_metric_families
 from datadog_checks.base.config import is_affirmative
+from datadog_checks.base.utils.http import create_http_client
 from datadog_checks.base.utils.http_exceptions import HTTPRequestError, HTTPSSLError, HTTPStatusError
 from datadog_checks.base.utils.prometheus import metrics_pb2
 
@@ -463,7 +464,9 @@ class PrometheusScraperMixin(object):
             http_config['ssl_ignore_warning'] = True
             http_config['ssl_verify'] = False
 
-        http_handler = self._http_handlers[endpoint] = self.create_http_client(http_config)
+        http_handler = self._http_handlers[endpoint] = create_http_client(
+            http_config, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log
+        )
 
         headers = http_handler.options['headers']
 

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -13,7 +13,6 @@ from google.protobuf.internal.decoder import _DecodeVarint32  # pylint: disable=
 from datadog_checks.base.checks import AgentCheck
 from datadog_checks.base.checks.libs.prometheus import text_fd_to_metric_families
 from datadog_checks.base.config import is_affirmative
-from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.base.utils.http_exceptions import HTTPRequestError, HTTPSSLError, HTTPStatusError
 from datadog_checks.base.utils.prometheus import metrics_pb2
 
@@ -464,9 +463,7 @@ class PrometheusScraperMixin(object):
             http_config['ssl_ignore_warning'] = True
             http_config['ssl_verify'] = False
 
-        http_handler = self._http_handlers[endpoint] = RequestsWrapper(
-            http_config, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log
-        )
+        http_handler = self._http_handlers[endpoint] = self.create_http_client(http_config)
 
         headers = http_handler.options['headers']
 

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -833,9 +833,9 @@ class RequestsWrapper(object):
 
 
 def create_http_client(
-    instance: dict, init_config: dict, remapper: dict | None = None, logger: logging.Logger | None = None
+    instance: dict | None, init_config: dict, remapper: dict | None = None, logger: logging.Logger | None = None
 ) -> HTTPClient:
-    """Build the agnostic HTTP client from explicit config. The single seam that names the backend."""
+    """Build the agnostic HTTP client from explicit config, confining the concrete backend to one place."""
     return RequestsWrapper(instance or {}, init_config, remapper, logger)
 
 

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -832,6 +832,13 @@ class RequestsWrapper(object):
         session.mount('https://', https_adapter)
 
 
+def create_http_client(
+    instance: dict, init_config: dict, remapper: dict | None = None, logger: logging.Logger | None = None
+) -> HTTPClient:
+    """Build the agnostic HTTP client from explicit config. The single seam that names the backend."""
+    return RequestsWrapper(instance or {}, init_config, remapper, logger)
+
+
 @contextmanager
 def handle_kerberos_keytab(keytab_file):
     # There are no keytab options in any wrapper libs. The env var will be

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
@@ -2739,8 +2739,11 @@ def test_get_http_handler_routes_through_create_http_client(mocked_openmetrics_c
     scraper_config = check.get_scraper_config(instance)
     sentinel = mock.MagicMock()
 
-    with mock.patch.object(check, 'create_http_client', return_value=sentinel):
+    with mock.patch(
+        'datadog_checks.base.checks.openmetrics.mixins.create_http_client', return_value=sentinel
+    ) as factory:
         assert check.get_http_handler(scraper_config) is sentinel
+        factory.assert_called_once_with(scraper_config, check.init_config, check.HTTP_CONFIG_REMAPPER, check.log)
 
 
 def test_simple_type_overrides(aggregator, mocked_prometheus_check, text_data):

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
@@ -2729,6 +2729,20 @@ def test_http_handler(mocked_openmetrics_check_factory):
     assert http_handler.options['headers']['accept'] == 'text/plain'
 
 
+def test_get_http_handler_routes_through_create_http_client(mocked_openmetrics_check_factory):
+    instance = {
+        'prometheus_url': 'https://www.example.com',
+        'metrics': [{'foo': 'bar'}],
+        'namespace': 'openmetrics',
+    }
+    check = mocked_openmetrics_check_factory(instance)
+    scraper_config = check.get_scraper_config(instance)
+    sentinel = mock.MagicMock()
+
+    with mock.patch.object(check, 'create_http_client', return_value=sentinel):
+        assert check.get_http_handler(scraper_config) is sentinel
+
+
 def test_simple_type_overrides(aggregator, mocked_prometheus_check, text_data):
     """
     Test that metric type is overridden correctly.

--- a/datadog_checks_base/tests/base/utils/http/test_http.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http.py
@@ -100,7 +100,7 @@ class TestAttribute:
         sentinel = object()
 
         class CustomCheck(AgentCheck):
-            def create_http_client(self):
+            def create_http_client(self, instance=None):
                 return sentinel
 
         check = CustomCheck('test', {}, [{}])
@@ -117,6 +117,15 @@ class TestAttribute:
         client = check.create_http_client({'timeout': 42})
 
         assert client.options['timeout'] == (42.0, 42.0)
+
+    def test_factory_empty_instance_override_is_honored(self):
+        from datadog_checks.base.utils.http import create_http_client
+
+        check = AgentCheck('test', {}, [{'timeout': 7}])
+
+        # {} is an explicit override, distinct from None, so self.instance's timeout must not leak in.
+        empty_default = create_http_client({}, {}).options['timeout']
+        assert check.create_http_client({}).options['timeout'] == empty_default
 
     def test_module_factory_builds_from_given_config(self):
         from datadog_checks.base.utils.http import create_http_client

--- a/datadog_checks_base/tests/base/utils/http/test_http.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http.py
@@ -106,6 +106,32 @@ class TestAttribute:
         check = CustomCheck('test', {}, [{}])
         assert check.http is sentinel
 
+    def test_factory_default_uses_instance_config(self):
+        check = AgentCheck('test', {}, [{'timeout': 7}])
+
+        assert check.create_http_client().options['timeout'] == (7.0, 7.0)
+
+    def test_factory_instance_override(self):
+        check = AgentCheck('test', {}, [{'timeout': 7}])
+
+        client = check.create_http_client({'timeout': 42})
+
+        assert client.options['timeout'] == (42.0, 42.0)
+
+    def test_module_factory_builds_from_given_config(self):
+        from datadog_checks.base.utils.http import create_http_client
+
+        client = create_http_client({'timeout': 24.5}, {})
+
+        assert client.options['timeout'] == (24.5, 24.5)
+
+    def test_module_factory_applies_remapper(self):
+        from datadog_checks.base.utils.http import create_http_client
+
+        client = create_http_client({'prometheus_timeout': 9}, {}, {'prometheus_timeout': {'name': 'timeout'}})
+
+        assert client.options['timeout'] == (9, 9)
+
 
 class TestTLSCiphers:
     @pytest.mark.parametrize(

--- a/hpe_aruba_edgeconnect/datadog_checks/hpe_aruba_edgeconnect/check.py
+++ b/hpe_aruba_edgeconnect/datadog_checks/hpe_aruba_edgeconnect/check.py
@@ -11,7 +11,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 from datadog_checks.base import AgentCheck
-from datadog_checks.base.utils.http import RequestsWrapper
 
 from .appliance_models import Appliance, Appliances
 from .client import ApplianceClient, OrchestratorClient
@@ -169,7 +168,7 @@ class HpeArubaEdgeconnectCheck(AgentCheck, ConfigMixin):
         cached = self._appliance_clients.get(app_ip)
         if cached is not None:
             return cached
-        http = RequestsWrapper(self.instance or {}, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log)
+        http = self.create_http_client()
         http.persist_connections = True
         client = ApplianceClient(http, app_ip, self.log)
         client.login(username, password)

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
@@ -8,7 +8,6 @@ from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.kube_leader import KubeLeaderElectionMixin
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.config import is_affirmative
-from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.base.utils.http_exceptions import HTTPError
 
 from .sli_metrics import SliMetricsScraperMixin
@@ -271,8 +270,6 @@ class KubeControllerManagerCheck(KubeLeaderElectionMixin, SliMetricsScraperMixin
             config['tls_ignore_warning'] = True
             config['tls_verify'] = False
 
-        http_handler = self._http_handlers[endpoint] = RequestsWrapper(
-            config, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log
-        )
+        http_handler = self._http_handlers[endpoint] = self.create_http_client(config)
 
         return http_handler

--- a/kube_controller_manager/tests/conftest.py
+++ b/kube_controller_manager/tests/conftest.py
@@ -23,6 +23,6 @@ def instance():
 
 @pytest.fixture
 def mock_healthcheck_wrapper():
-    # _healthcheck_http_handler builds its own RequestsWrapper outside self.http
-    with mock.patch('datadog_checks.kube_controller_manager.kube_controller_manager.RequestsWrapper'):
+    # _healthcheck_http_handler builds its own client via create_http_client, outside self.http
+    with mock.patch('datadog_checks.base.checks.base.AgentCheck.create_http_client'):
         yield

--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
-from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.base.utils.http_exceptions import HTTPError
 
 
@@ -165,8 +164,6 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
             config['tls_ignore_warning'] = True
             config['tls_verify'] = False
 
-        http_handler = self._http_handlers[endpoint] = RequestsWrapper(
-            config, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log
-        )
+        http_handler = self._http_handlers[endpoint] = self.create_http_client(config)
 
         return http_handler

--- a/kube_dns/tests/conftest.py
+++ b/kube_dns/tests/conftest.py
@@ -25,6 +25,6 @@ def instance():
 
 @pytest.fixture
 def mock_healthcheck_wrapper():
-    # _healthcheck_http_handler builds its own RequestsWrapper outside self.http
-    with mock.patch('datadog_checks.kube_dns.kube_dns.RequestsWrapper'):
+    # _healthcheck_http_handler builds its own client via create_http_client, outside self.http
+    with mock.patch('datadog_checks.base.checks.base.AgentCheck.create_http_client'):
         yield

--- a/kube_metrics_server/datadog_checks/kube_metrics_server/kube_metrics_server.py
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/kube_metrics_server.py
@@ -5,7 +5,6 @@
 import re
 
 from datadog_checks.base import AgentCheck, OpenMetricsBaseCheck
-from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.base.utils.http_exceptions import HTTPError
 
 KUBE_METRICS_SERVER_NAMESPACE = "kube_metrics_server"
@@ -155,8 +154,6 @@ class KubeMetricsServerCheck(OpenMetricsBaseCheck):
             config['tls_ignore_warning'] = True
             config['tls_verify'] = False
 
-        http_handler = self._http_handlers[endpoint] = RequestsWrapper(
-            config, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log
-        )
+        http_handler = self._http_handlers[endpoint] = self.create_http_client(config)
 
         return http_handler

--- a/kube_metrics_server/tests/conftest.py
+++ b/kube_metrics_server/tests/conftest.py
@@ -26,6 +26,6 @@ def instance():
 
 @pytest.fixture
 def mock_healthcheck_wrapper():
-    # _healthcheck_http_handler builds its own RequestsWrapper outside self.http
-    with mock.patch('datadog_checks.kube_metrics_server.kube_metrics_server.RequestsWrapper'):
+    # _healthcheck_http_handler builds its own client via create_http_client, outside self.http
+    with mock.patch('datadog_checks.base.checks.base.AgentCheck.create_http_client'):
         yield

--- a/kube_proxy/datadog_checks/kube_proxy/kube_proxy.py
+++ b/kube_proxy/datadog_checks/kube_proxy/kube_proxy.py
@@ -5,7 +5,6 @@ import re
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
-from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.base.utils.http_exceptions import HTTPError
 
 METRICS = {
@@ -102,8 +101,6 @@ class KubeProxyCheck(OpenMetricsBaseCheck):
             config['tls_ignore_warning'] = True
             config['tls_verify'] = False
 
-        http_handler = self._http_handlers[endpoint] = RequestsWrapper(
-            config, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log
-        )
+        http_handler = self._http_handlers[endpoint] = self.create_http_client(config)
 
         return http_handler

--- a/kube_proxy/tests/conftest.py
+++ b/kube_proxy/tests/conftest.py
@@ -24,6 +24,6 @@ def instance():
 
 @pytest.fixture
 def mock_healthcheck_wrapper():
-    # _healthcheck_http_handler builds its own RequestsWrapper outside self.http
-    with mock.patch('datadog_checks.kube_proxy.kube_proxy.RequestsWrapper'):
+    # _healthcheck_http_handler builds its own client via create_http_client, outside self.http
+    with mock.patch('datadog_checks.base.checks.base.AgentCheck.create_http_client'):
         yield

--- a/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
@@ -9,7 +9,6 @@ from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.kube_leader import KubeLeaderElectionMixin
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.config import is_affirmative
-from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.base.utils.http_exceptions import HTTPError
 
 from .sli_metrics import SliMetricsScraperMixin
@@ -256,8 +255,6 @@ class KubeSchedulerCheck(KubeLeaderElectionMixin, SliMetricsScraperMixin, OpenMe
             config['tls_ignore_warning'] = True
             config['tls_verify'] = False
 
-        http_handler = self._http_handlers[endpoint] = RequestsWrapper(
-            config, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log
-        )
+        http_handler = self._http_handlers[endpoint] = self.create_http_client(config)
 
         return http_handler

--- a/kube_scheduler/tests/conftest.py
+++ b/kube_scheduler/tests/conftest.py
@@ -24,6 +24,6 @@ def instance():
 
 @pytest.fixture
 def mock_healthcheck_wrapper():
-    # _healthcheck_http_handler builds its own RequestsWrapper outside self.http
-    with mock.patch('datadog_checks.kube_scheduler.kube_scheduler.RequestsWrapper'):
+    # _healthcheck_http_handler builds its own client via create_http_client, outside self.http
+    with mock.patch('datadog_checks.base.checks.base.AgentCheck.create_http_client'):
         yield


### PR DESCRIPTION
### What does this PR do?

Adds a `create_http_client` factory seam and routes every direct `RequestsWrapper` construction site through it: the OpenMetrics/Prometheus v1 mixins, argocd, hpe_aruba_edgeconnect, and the five `kube_*` checks. Integration code no longer names the HTTP backend directly. `vsphere` is out of scope (Layer 3).

A module-level `create_http_client(instance, init_config, remapper, logger)` lives in `base.utils.http`, and `AgentCheck.create_http_client` delegates to it with an optional instance override. Callers keep the agnostic `HTTPClient` protocol as the return type, so the concrete backend stays confined to the factory.

### Motivation

Batch B4 of the agnostic HTTP floor. Checks that built their own `RequestsWrapper` bypassed `self.http`, leaving several places the backend swap and tests must reach. Centralizing construction in one factory gives the httpx cutover a single line to flip and gives tests a single seam to stub.

### Verification

- New unit tests for the factory, written failing first: module function honors the passed instance, init_config, and remapper; the method applies an instance override; the no-arg default still builds from the check's instance.
- Full base HTTP suite: 311 passed. The 10 errors are Docker/network integration fixtures (kerberos KDC, SOCKS proxy) unavailable locally and run in CI.
- OpenMetrics, Prometheus, and kubelet_base suites: 391 passed (mixin reroute).
- All five `kube_*`, argocd (67 passed), and hpe_aruba_edgeconnect (51 passed) green, including the health `service_check` on both success and failure paths.
- Lint and format clean across every touched package.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
