### PR TITLE
Expose status_code on HTTPStatusError

### DIFF
--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -723,7 +723,7 @@ class ConsulCheck(OpenMetricsBaseCheck):
                 str(e),
             )
         except HTTPStatusError as e:
-            if e.response.status_code == 404:
+            if e.status_code == 404:
                 self.log.warning(
                     "This Consul version (< 1.1.0) does not support the prometheus endpoint. "
                     "Update Consul or set back `use_prometheus_endpoint` to false to remove this warning. %s",

--- a/consul/tests/test_integration.py
+++ b/consul/tests/test_integration.py
@@ -87,7 +87,7 @@ def test_acl_forbidden(instance_bad_token, dd_environment):
     try:
         consul_check.check(None)
     except HTTPStatusError as e:
-        if e.response.status_code == 403:
+        if e.status_code == 403:
             got_error_403 = True
 
     assert got_error_403

--- a/couch/datadog_checks/couch/couch.py
+++ b/couch/datadog_checks/couch/couch.py
@@ -176,7 +176,7 @@ class CouchDB1:
                     db_stats = self.agent_check.get(url, tags)
                 except HTTPStatusError as e:
                     couchdb['databases'][dbName] = None
-                    if (e.response.status_code == 403) or (e.response.status_code == 401):
+                    if (e.status_code == 403) or (e.status_code == 401):
                         self.db_exclude[server].append(dbName)
 
                         self.agent_check.warning(

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -246,7 +246,10 @@ def _translate_requests_exception(exc: BaseException, *, response: ResponseWrapp
     if isinstance(exc, requests_exceptions.ContentDecodingError):
         return HTTPRequestError(message, request=request)
     if isinstance(exc, requests_exceptions.HTTPError):
-        return HTTPStatusError(message, request=request, response=response)
+        status_code = getattr(response, 'status_code', None)
+        if status_code is None:
+            status_code = getattr(getattr(exc, 'response', None), 'status_code', None)
+        return HTTPStatusError(message, request=request, response=response, status_code=status_code)
     if isinstance(exc, requests_exceptions.RequestException):
         return HTTPRequestError(message, request=request)
     return HTTPError(message)

--- a/datadog_checks_base/datadog_checks/base/utils/http_exceptions.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http_exceptions.py
@@ -26,7 +26,9 @@ class HTTPRequestError(HTTPError):
 
 
 class HTTPStatusError(HTTPError):
-    pass
+    def __init__(self, message: str, response: Any = None, request: Any = None, status_code: int | None = None):
+        super().__init__(message, response=response, request=request)
+        self.status_code = status_code
 
 
 class HTTPTimeoutError(HTTPRequestError):

--- a/datadog_checks_base/tests/base/utils/http/test_exceptions.py
+++ b/datadog_checks_base/tests/base/utils/http/test_exceptions.py
@@ -47,6 +47,7 @@ def test_ssl_error_maps_to_http_ssl_error():
 
 def test_raise_for_status_maps_to_status_error():
     response = mock.MagicMock()
+    response.status_code = 404
     response.raise_for_status.side_effect = requests.exceptions.HTTPError('404 Client Error')
     http = RequestsWrapper({}, {})
     with mock.patch('requests.Session.get', return_value=response):
@@ -55,6 +56,8 @@ def test_raise_for_status_maps_to_status_error():
             wrapped.raise_for_status()
     # .response carries the agnostic wrapper, never the raw backend response
     assert exc_info.value.response is wrapped
+    # status_code is exposed on the exception, translated from the backend
+    assert exc_info.value.status_code == 404
 
 
 # Group A: the translator as a pure function, over the full mapping table.
@@ -87,6 +90,22 @@ def test_translate_does_not_leak_raw_response():
     result = _translate_requests_exception(err)
     assert isinstance(result, HTTPStatusError)
     assert result.response is None
+
+
+def test_translate_exposes_status_code_from_backend_response():
+    # status_code is a clean scalar, translated from the backend response, not a raw-response leak.
+    err = requests.exceptions.HTTPError('404 Client Error')
+    err.response = mock.MagicMock(status_code=404)
+    result = _translate_requests_exception(err)
+    assert isinstance(result, HTTPStatusError)
+    assert result.status_code == 404
+
+
+def test_translate_status_code_defaults_to_none_without_response():
+    err = requests.exceptions.HTTPError('500 Server Error')
+    result = _translate_requests_exception(err)
+    assert isinstance(result, HTTPStatusError)
+    assert result.status_code is None
 
 
 # Group B: the streaming seam. The failure surfaces only when the generator is consumed.

--- a/datadog_checks_dev/datadog_checks/dev/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/http.py
@@ -196,7 +196,7 @@ class MockHTTPResponseImpl:
             message = (
                 f'{self.status_code} Client Error' if self.status_code < 500 else f'{self.status_code} Server Error'
             )
-            raise HTTPStatusError(message, response=self)
+            raise HTTPStatusError(message, response=self, status_code=self.status_code)
 
     def get_peer_cert(self, binary_form: bool = False) -> bytes | dict | None:
         return self.raw.connection.sock.getpeercert(binary_form=binary_form)

--- a/harbor/datadog_checks/harbor/harbor.py
+++ b/harbor/datadog_checks/harbor/harbor.py
@@ -30,7 +30,7 @@ class HarborCheck(AgentCheck):
             registries = api.registries()
             self.log.debug("Found %d registries", len(registries))
         except HTTPStatusError as e:
-            if e.response is not None and e.response.status_code in (401, 403):
+            if e.status_code in (401, 403):
                 # Forbidden, user is not admin
                 self.log.info(
                     "Provided user in harbor integration config is not an admin user. Ignoring registries health checks"
@@ -62,7 +62,7 @@ class HarborCheck(AgentCheck):
         try:
             volume_info = api.volume_info()
         except HTTPStatusError as e:
-            if e.response is not None and e.response.status_code in (401, 403):
+            if e.status_code in (401, 403):
                 # Forbidden, user is not admin
                 self.log.warning(
                     "Provided user in harbor integration config is not an admin user. Ignoring volume metrics"

--- a/nutanix/datadog_checks/nutanix/activity_monitor.py
+++ b/nutanix/datadog_checks/nutanix/activity_monitor.py
@@ -136,7 +136,7 @@ class ActivityMonitor:
                 "[%s] Failed to collect %ss: HTTP %s",
                 self._pc_label,
                 activity_kind,
-                e.response.status_code if e.response else "error",
+                e.status_code if e.status_code is not None else "error",
             )
             return 0
         except Exception:
@@ -352,7 +352,7 @@ class ActivityMonitor:
         try:
             alert = self.check._get_request_data(f"api/monitoring/v4.0/serviceability/alerts/{alert_ext_id}")
         except HTTPStatusError as e:
-            if e.response is not None and e.response.status_code == 404:
+            if e.status_code == 404:
                 self.check.log.debug("[%s] Alert %s not found (404).", self._pc_label, alert_ext_id)
                 return None
             self.check.log.warning("[%s] Transient HTTP error fetching alert %s: %s", self._pc_label, alert_ext_id, e)

--- a/nutanix/tests/conftest.py
+++ b/nutanix/tests/conftest.py
@@ -283,7 +283,7 @@ def mock_http_get(mocker, mock_http):
             else:
                 mock_resp.status_code = 404
                 mock_resp.raise_for_status = mocker.Mock(
-                    side_effect=HTTPStatusError('404 Client Error', response=mock_resp)
+                    side_effect=HTTPStatusError('404 Client Error', response=mock_resp, status_code=404)
                 )
             return mock_resp
 
@@ -316,7 +316,9 @@ def mock_http_get(mocker, mock_http):
 
         print(f"[MOCK ERROR] No matching endpoint for URL: {url}")
         mock_resp.status_code = 404
-        mock_resp.raise_for_status = mocker.Mock(side_effect=HTTPStatusError('404 Client Error', response=mock_resp))
+        mock_resp.raise_for_status = mocker.Mock(
+            side_effect=HTTPStatusError('404 Client Error', response=mock_resp, status_code=404)
+        )
         return mock_resp
 
     mock_http.get.side_effect = mock_response

--- a/nutanix/tests/test_alerts.py
+++ b/nutanix/tests/test_alerts.py
@@ -1327,7 +1327,11 @@ def test_get_alert_returns_none_on_404(dd_run_check, mock_instance, mock_http_ge
 
     response = mocker.Mock()
     response.status_code = 404
-    mocker.patch.object(check, '_get_request_data', side_effect=HTTPStatusError("mocked HTTP error", response=response))
+    mocker.patch.object(
+        check,
+        '_get_request_data',
+        side_effect=HTTPStatusError("mocked HTTP error", response=response, status_code=response.status_code),
+    )
 
     assert check.activity_monitor._get_alert("missing-ext-id") is None
 
@@ -1340,7 +1344,11 @@ def test_get_alert_propagates_on_transient_http_error(dd_run_check, mock_instanc
 
     response = mocker.Mock()
     response.status_code = status_code
-    mocker.patch.object(check, '_get_request_data', side_effect=HTTPStatusError("mocked HTTP error", response=response))
+    mocker.patch.object(
+        check,
+        '_get_request_data',
+        side_effect=HTTPStatusError("mocked HTTP error", response=response, status_code=response.status_code),
+    )
 
     with pytest.raises(HTTPStatusError):
         check.activity_monitor._get_alert("any-ext-id")
@@ -1367,7 +1375,9 @@ def test_transient_alert_get_failure_preserves_tracking(
     response = mocker.Mock()
     response.status_code = 503
     mocker.patch.object(
-        check.activity_monitor, '_get_alert', side_effect=HTTPStatusError("mocked HTTP error", response=response)
+        check.activity_monitor,
+        '_get_alert',
+        side_effect=HTTPStatusError("mocked HTTP error", response=response, status_code=response.status_code),
     )
 
     dd_run_check(check)

--- a/openstack/datadog_checks/openstack/openstack.py
+++ b/openstack/datadog_checks/openstack/openstack.py
@@ -932,7 +932,7 @@ class OpenStackCheck(AgentCheck):
             self.log.debug("Server %s is powered off and cannot be monitored", server_id)
             del self.server_details_by_id[server_id]
         except HTTPStatusError as e:
-            if e.response.status_code == 404:
+            if e.status_code == 404:
                 self.log.debug("Server %s is not in an ACTIVE state and cannot be monitored, %s", server_id, e)
                 del self.server_details_by_id[server_id]
             else:
@@ -1232,7 +1232,7 @@ class OpenStackCheck(AgentCheck):
             else:
                 self.warning("Configuration Incomplete! Check your openstack.yaml file")
         except HTTPStatusError as e:
-            if e.response.status_code >= 500:
+            if e.status_code is not None and e.status_code >= 500:
                 # exponential backoff
                 self.do_backoff(instance)
                 self.warning("There were some problems reaching the nova API - applying exponential backoff")


### PR DESCRIPTION
### What does this PR do?

Adds a `status_code` attribute to the agnostic `HTTPStatusError` exception, populated during requests-to-agnostic exception translation, and rewrites the call sites to read `e.status_code` instead of `e.response.status_code`.

### Motivation

`e.response` on the agnostic exception is the raw/wrapped backend response, so reading `e.response.status_code` reaches into a backend-specific object rather than a defined agnostic contract. Raised by Noueman in review of #24620. Exposing `status_code` on the exception itself, translated from the backend, keeps status checks backend-neutral and lets `status_code` be sourced separately from requests and (later) httpx.

`status_code` lives on `HTTPStatusError` only, not base `HTTPError`: an audit of every exception `status_code` access found each one is already narrowed to a status error before the read, and connection/timeout/SSL errors have no status to report.

Scope: base type + translator, the shared `MockHTTPResponse` test double, and the consul/couch/harbor/nutanix/openstack call sites. `openstack_controller` is intentionally excluded and handled in #24620. The `datadog_checks_dev` GitHub tooling is excluded because it uses `requests` directly and never goes through the agnostic translation.

### Verification

- Base HTTP exception suite passes, including new tests asserting `status_code` is populated from the backend response and defaults to `None` when absent.
- nutanix, harbor (unit), couch (unit), openstack, and datadog_checks_base suites pass.
- Lint and format clean across all touched packages.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged