### PR TITLE
[Option 1] Add clickhouse_node tag to query metrics

### DIFF
--- a/clickhouse/changelog.d/24627.added
+++ b/clickhouse/changelog.d/24627.added
@@ -1,0 +1,1 @@
+Add a `clickhouse_node` tag to query metrics.

--- a/clickhouse/datadog_checks/clickhouse/statements.py
+++ b/clickhouse/datadog_checks/clickhouse/statements.py
@@ -21,6 +21,7 @@ from datadog_checks.base.utils.db.utils import default_json_event_encoding
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.clickhouse.query_log_job import ClickhouseQueryLogJob, agent_check_getter
+from datadog_checks.clickhouse.utils import CLUSTER_NODE_TAG
 
 # Query to fetch aggregated metrics from system.query_log using checkpoint-based collection.
 #
@@ -82,7 +83,7 @@ def _row_key(row):
     :param row: a normalized row from system.query_log
     :return: a tuple uniquely identifying this row
     """
-    return row['query_signature'], row.get('user', ''), row.get('databases', '')
+    return row['query_signature'], row.get('user', ''), row.get('databases', ''), row.get('server_node', '')
 
 
 class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
@@ -138,30 +139,39 @@ class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
             for event in self._rows_to_fqt_events(rows):
                 self._check.database_monitoring_query_sample(json.dumps(event, default=default_json_event_encoding))
 
-            # Prepare metrics payload wrapper
-            payload_wrapper = {
-                'host': self._check.reported_hostname,
-                'database_instance': self._check.database_identifier,
-                'timestamp': time.time() * 1000,
-                'min_collection_interval': self._collection_interval,
-                'tags': self._tags_no_db,
-                'ddagentversion': datadog_agent.get_version(),
-                'clickhouse_version': self._check.dbms_version,
-            }
+            # Submit one metrics payload per node so each carries its own
+            # clickhouse_node tag. Rows are collected per-(query, node); for
+            # single-node deployments this yields a single group.
+            for node, node_rows in self._group_rows_by_node(rows).items():
+                if node:
+                    node_tags = self._tags_no_db + ["{}:{}".format(CLUSTER_NODE_TAG, node)]
+                else:
+                    node_tags = self._tags_no_db
 
-            # Get query metrics payloads (may be split into multiple if too large)
-            payloads = self._get_query_metrics_payloads(payload_wrapper, rows)
+                payload_wrapper = {
+                    'host': self._check.reported_hostname,
+                    'database_instance': self._check.database_identifier,
+                    'timestamp': time.time() * 1000,
+                    'min_collection_interval': self._collection_interval,
+                    'tags': node_tags,
+                    'ddagentversion': datadog_agent.get_version(),
+                    'clickhouse_version': self._check.dbms_version,
+                }
 
-            for payload in payloads:
-                payload_data = json.loads(payload)
-                num_rows = len(payload_data.get('clickhouse_rows', []))
-                self._log.info(
-                    "Submitting query metrics payload: %d bytes, %d rows, database_instance=%s",
-                    len(payload),
-                    num_rows,
-                    payload_data.get('database_instance', 'MISSING'),
-                )
-                self._check.database_monitoring_query_metrics(payload)
+                # Get query metrics payloads (may be split into multiple if too large)
+                payloads = self._get_query_metrics_payloads(payload_wrapper, node_rows)
+
+                for payload in payloads:
+                    payload_data = json.loads(payload)
+                    num_rows = len(payload_data.get('clickhouse_rows', []))
+                    self._log.info(
+                        "Submitting query metrics payload: %d bytes, %d rows, node=%s, database_instance=%s",
+                        len(payload),
+                        num_rows,
+                        node or 'unknown',
+                        payload_data.get('database_instance', 'MISSING'),
+                    )
+                    self._check.database_monitoring_query_metrics(payload)
 
             if self._current_checkpoint_microseconds is not None:
                 self._log.info("Collection complete. Checkpoint saved: %d", self._current_checkpoint_microseconds)
@@ -205,6 +215,14 @@ class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
                 queue.append(current[mid:])
 
         return payloads
+
+    @staticmethod
+    def _group_rows_by_node(rows):
+        """Group per-(query, node) rows by their server_node value."""
+        groups = {}
+        for row in rows:
+            groups.setdefault(row.get('server_node', ''), []).append(row)
+        return groups
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _load_query_log_statements(self):
@@ -275,6 +293,7 @@ class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
 
                 result_row = {
                     'normalized_query_hash': str(normalized_query_hash),
+                    'server_node': str(server_node) if server_node else '',
                     'query': str(query_text) if query_text else '',
                     'user': str(query_user) if query_user else '',
                     'query_type': str(query_type) if query_type else '',
@@ -299,9 +318,8 @@ class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
 
             self._set_checkpoint_from_event_time(global_max_event_time)
 
-            if result_rows:
-                result_rows = self._merge_rows_across_nodes(result_rows)
-
+            # Rows are kept per-(query, node): the node dimension is preserved so
+            # each node's metrics can be tagged with clickhouse_node at submission.
             return result_rows
 
         except Exception as e:
@@ -313,59 +331,6 @@ class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
                 raw=True,
             )
             raise
-
-    @staticmethod
-    def _merge_rows_across_nodes(node_rows):
-        """
-        Merge per-(query, node) rows into per-query rows.
-
-        Summable metrics (count, total_time, …) are summed.
-        peak_memory_usage takes the max.
-        Non-metric fields are taken from the node with the highest execution count.
-        """
-        groups = {}
-        for row in node_rows:
-            key = row['normalized_query_hash']
-            if key not in groups:
-                groups[key] = []
-            groups[key].append(row)
-
-        result = []
-        for rows in groups.values():
-            if len(rows) == 1:
-                result.append(rows[0])
-                continue
-
-            base = max(rows, key=lambda r: r.get('count', 0))
-            merged = dict(base)
-
-            sum_fields = [
-                'count',
-                'total_time',
-                'read_rows',
-                'read_bytes',
-                'written_rows',
-                'written_bytes',
-                'result_rows',
-                'result_bytes',
-                'memory_usage',
-                'cpu_us',
-                'cpu_wait_us',
-            ]
-            for field in sum_fields:
-                merged[field] = sum(r.get(field, 0) for r in rows)
-
-            merged['peak_memory_usage'] = max(r.get('peak_memory_usage', 0) for r in rows)
-
-            total_count = merged['count']
-            if total_count > 0:
-                merged['mean_time'] = merged['total_time'] / total_count
-            else:
-                merged['mean_time'] = 0.0
-
-            result.append(merged)
-
-        return result
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _collect_metrics_rows(self):

--- a/clickhouse/tests/test_statement_metrics.py
+++ b/clickhouse/tests/test_statement_metrics.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from unittest import mock
+
 import pytest
 
 from datadog_checks.base.utils.db.sql import compute_sql_signature
@@ -238,6 +240,8 @@ def test_row_key():
     assert key1 != key3
     # Same inputs should produce same key
     assert key1 == _row_key(row1)
+    # Same query on different nodes should produce different keys
+    assert _row_key({**row1, 'server_node': 'node-1'}) != _row_key({**row1, 'server_node': 'node-2'})
 
 
 def test_rows_to_fqt_events(check_with_dbm):
@@ -512,127 +516,68 @@ def test_statements_query_format():
     assert "ProfileEvents['OSCPUWaitMicroseconds']" in STATEMENTS_QUERY
 
 
-def test_merge_rows_across_nodes_single_node():
-    """When a query only appears on one node, it should pass through unchanged."""
-    from datadog_checks.clickhouse.statements import ClickhouseStatementMetrics
-
+def test_group_rows_by_node():
+    """Rows are grouped by their server_node value."""
     rows = [
-        {
-            'normalized_query_hash': 'hash1',
-            'query': 'SELECT 1',
-            'count': 10,
-            'total_time': 100.0,
-            'mean_time': 10.0,
-            'read_rows': 100,
-            'read_bytes': 1000,
-            'written_rows': 0,
-            'written_bytes': 0,
-            'result_rows': 10,
-            'result_bytes': 500,
-            'memory_usage': 5000,
-            'peak_memory_usage': 8000,
-            'cpu_us': 80000,
-            'cpu_wait_us': 8000,
-        }
+        {'server_node': 'node-1', 'normalized_query_hash': 'hash1'},
+        {'server_node': 'node-2', 'normalized_query_hash': 'hash1'},
+        {'server_node': 'node-1', 'normalized_query_hash': 'hash2'},
     ]
 
-    result = ClickhouseStatementMetrics._merge_rows_across_nodes(rows)
-    assert len(result) == 1
-    assert result[0]['count'] == 10
-    assert result[0]['total_time'] == 100.0
-    assert result[0]['cpu_us'] == 80000
-    assert result[0]['cpu_wait_us'] == 8000
+    groups = ClickhouseStatementMetrics._group_rows_by_node(rows)
+    assert set(groups.keys()) == {'node-1', 'node-2'}
+    assert len(groups['node-1']) == 2
+    assert len(groups['node-2']) == 1
 
 
-def test_merge_rows_across_nodes_sums_counts():
-    """Summable metrics should be added across nodes."""
-    from datadog_checks.clickhouse.statements import ClickhouseStatementMetrics
+def test_group_rows_by_node_missing_node():
+    """Rows without a server_node fall into the empty-string group."""
+    rows = [{'normalized_query_hash': 'hash1'}, {'server_node': '', 'normalized_query_hash': 'hash2'}]
 
-    rows = [
-        {
-            'normalized_query_hash': 'hash1',
-            'query': 'SELECT 1',
-            'count': 100,
-            'total_time': 500.0,
-            'mean_time': 5.0,
-            'read_rows': 1000,
-            'read_bytes': 10000,
-            'written_rows': 0,
-            'written_bytes': 0,
-            'result_rows': 100,
-            'result_bytes': 5000,
-            'memory_usage': 50000,
-            'peak_memory_usage': 80000,
-            'cpu_us': 500000,
-            'cpu_wait_us': 50000,
-        },
-        {
-            'normalized_query_hash': 'hash1',
-            'query': 'SELECT 1',
-            'count': 50,
-            'total_time': 300.0,
-            'mean_time': 6.0,
-            'read_rows': 500,
-            'read_bytes': 5000,
-            'written_rows': 10,
-            'written_bytes': 100,
-            'result_rows': 50,
-            'result_bytes': 2500,
-            'memory_usage': 30000,
-            'peak_memory_usage': 90000,
-            'cpu_us': 300000,
-            'cpu_wait_us': 30000,
-        },
-    ]
-
-    result = ClickhouseStatementMetrics._merge_rows_across_nodes(rows)
-    assert len(result) == 1
-
-    merged = result[0]
-    assert merged['count'] == 150
-    assert merged['total_time'] == 800.0
-    assert merged['read_rows'] == 1500
-    assert merged['read_bytes'] == 15000
-    assert merged['written_rows'] == 10
-    assert merged['written_bytes'] == 100
-    assert merged['result_rows'] == 150
-    assert merged['result_bytes'] == 7500
-    assert merged['memory_usage'] == 80000
-    assert merged['peak_memory_usage'] == 90000
-    assert merged['cpu_us'] == 800000
-    assert merged['cpu_wait_us'] == 80000
-    assert merged['mean_time'] == 800.0 / 150
+    groups = ClickhouseStatementMetrics._group_rows_by_node(rows)
+    assert set(groups.keys()) == {''}
+    assert len(groups['']) == 2
 
 
-def test_merge_rows_across_nodes_different_queries():
-    """Rows with different query hashes should not be merged."""
-    from datadog_checks.clickhouse.statements import ClickhouseStatementMetrics
+def test_collect_and_submit_emits_one_payload_per_node(check_with_dbm):
+    """Each node gets its own query-metrics payload tagged with clickhouse_node."""
+    metrics = check_with_dbm.statement_metrics
+    metrics._tags_no_db = ['test:clickhouse']
 
-    base = {
-        'query': 'q',
-        'count': 10,
-        'total_time': 100.0,
-        'mean_time': 10.0,
-        'read_rows': 0,
-        'read_bytes': 0,
-        'written_rows': 0,
-        'written_bytes': 0,
-        'result_rows': 0,
-        'result_bytes': 0,
-        'memory_usage': 0,
-        'peak_memory_usage': 0,
-        'cpu_us': 80000,
-        'cpu_wait_us': 8000,
+    base_row = {
+        'query': 'SELECT 1',
+        'query_signature': 'sig1',
+        'normalized_query_hash': 'hash1',
+        'user': 'default',
+        'databases': 'db',
+        'dd_tables': [],
+        'dd_commands': [],
+        'dd_comments': [],
+        'count': 5,
     }
-
     rows = [
-        {**base, 'normalized_query_hash': 'hash1'},
-        {**base, 'normalized_query_hash': 'hash2'},
-        {**base, 'normalized_query_hash': 'hash3'},
+        {**base_row, 'server_node': 'node-1'},
+        {**base_row, 'server_node': 'node-2'},
     ]
 
-    result = ClickhouseStatementMetrics._merge_rows_across_nodes(rows)
-    assert len(result) == 3
+    submitted = []
+    with (
+        mock.patch.object(metrics, '_collect_metrics_rows', return_value=rows),
+        mock.patch.object(metrics._check, 'database_monitoring_query_metrics', side_effect=submitted.append),
+        mock.patch.object(metrics._check, 'database_monitoring_query_sample'),
+    ):
+        metrics._collect_and_submit()
+
+    payloads = [json.loads(p) for p in submitted]
+    node_tags = set()
+    for payload in payloads:
+        matches = [t for t in payload['tags'] if t.startswith('clickhouse_node:')]
+        assert len(matches) == 1
+        node_tags.add(matches[0])
+        # The base instance tags are preserved on every per-node payload
+        assert 'test:clickhouse' in payload['tags']
+
+    assert node_tags == {'clickhouse_node:node-1', 'clickhouse_node:node-2'}
 
 
 def test_metrics_row_with_empty_values(check_with_dbm):


### PR DESCRIPTION
### What does this PR do?
Adds a `clickhouse_node` tag to ClickHouse DBM **query metrics** so per-node data can be sliced in-app. Query metrics previously read `hostName() as server_node` only for per-node checkpointing, then collapsed the node dimension via `_merge_rows_across_nodes` before emitting.

This change:
- Preserves the per-(query, node) dimension by carrying `server_node` on each row and removing the cross-node merge.
- Groups rows by node and submits one query-metrics payload per node, appending `clickhouse_node:<node>` to that payload's tags (reusing `CLUSTER_NODE_TAG` from `utils.py`, the same key the standard non-DBM metrics already emit).
- Includes `server_node` in the FQT row-identity key so the same query on different nodes is tracked distinctly. FQT events themselves are unchanged (node is not a meaningful dimension for the query-text catalog).

This is "Plan 1" (agent-only delivery). A follow-up "Plan 2" will align with the DBM-standard row-field + backend-materialization pattern used by postgres/mysql/sqlserver.

### Motivation
The standard (non-DBM) ClickHouse metrics already tag per-node data with `clickhouse_node`, but the DBM checks do not expose that dimension. This brings the node-level tag to query metrics first, as the initial step of rolling it out across all DBM checks.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged