### PR TITLE
Generalize Togo launch input widgets

### DIFF
--- a/ddev/src/ddev/cli/meta/ai/tui/screens/launch_modal.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/launch_modal.py
@@ -5,79 +5,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from pathlib import Path
-from typing import Literal
-
-from textual import events
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal
-from textual.content import Content
 from textual.screen import ModalScreen
-from textual.validation import Number
 from textual.widget import Widget
-from textual.widgets import Button, Input, Label, Static, Switch
-from textual_autocomplete import DropdownItem, PathAutoComplete, TargetState
+from textual.widgets import Button, Static
 
-from ddev.ai.config.models import FlowInput, InputType, ResolvedFlow
+from ddev.ai.config.models import ResolvedFlow
+from ddev.cli.meta.ai.tui.widgets.launch_flow_input import LaunchFlowInput
 
-type LaunchInputValue = str | bool
 type LaunchInputValues = dict[str, str]
-
-
-class TogoPathAutoComplete(PathAutoComplete):
-    """PathAutoComplete that expands a leading ``~`` and skips emoji prefixes.
-
-    The typed value is never rewritten to an existing entry: Enter always
-    submits the field's literal text (including paths that don't exist yet,
-    e.g. an output directory to be created), and only Tab accepts a
-    suggestion from the dropdown.
-    """
-
-    def __init__(self, target: Input | str) -> None:
-        super().__init__(
-            target,
-            folder_prefix=Content(""),
-            file_prefix=Content(""),
-        )
-
-    def get_candidates(self, target_state: TargetState) -> list[DropdownItem]:
-        current_input = target_state.text[: target_state.cursor_position]
-        if current_input.startswith("~"):
-            expanded = str(Path(current_input).expanduser())
-            if current_input.endswith("/") and not expanded.endswith("/"):
-                expanded += "/"
-            target_state = TargetState(text=expanded, cursor_position=len(expanded))
-        return super().get_candidates(target_state)
-
-    def _listen_to_messages(self, event: events.Event) -> None:
-        """Handle enter/escape ourselves instead of delegating to the base class.
-
-        The base implementation only runs its enter/escape handling when the dropdown
-        currently has at least one candidate (``option_list.option_count`` — it auto-hides
-        with zero matches), and even then it applies the highlighted completion on enter
-        regardless of ``prevent_default_enter``. Neither behavior is what we want for a
-        path field that must accept freely typed, possibly nonexistent paths: typing a new
-        output directory (no matching candidates) left enter/escape unhandled by the
-        dropdown entirely, so escape fell through to the modal's own ``escape`` binding and
-        dismissed the whole dialog, discarding whatever was typed. We handle both keys
-        directly based on whether the path field itself has focus (not on the dropdown's
-        visibility, which can't be relied on), so the typed text is never silently
-        overwritten or discarded.
-        """
-        if isinstance(event, events.Key) and self.target.has_focus:
-            if event.key == "enter":
-                if self.display:
-                    self.action_hide()
-                return
-            if event.key == "escape":
-                event.prevent_default()
-                event.stop()
-                if self.display:
-                    self.action_hide()
-                return
-        super()._listen_to_messages(event)
 
 
 class LaunchModal(ModalScreen):
@@ -88,6 +26,7 @@ class LaunchModal(ModalScreen):
     def __init__(self, flow: ResolvedFlow) -> None:
         super().__init__()
         self.flow = flow
+        self.launch_inputs = [LaunchFlowInput.get(flow_input) for flow_input in flow.inputs]
 
     # ------------------------------------------------------------------
     # Compose
@@ -99,34 +38,11 @@ class LaunchModal(ModalScreen):
         with dialog:
             yield Static("Provide inputs for this run, then start.", classes="desc")
             with Widget(id="launch-fields"):
-                yield from self._compose_inputs()
+                yield from self.launch_inputs
             yield Static("", id="launch-error")
             with Horizontal(classes="modal-actions"):
                 yield Button("Cancel", id="btn-cancel")
                 yield Button("Launch ▶", id="btn-launch", variant="primary")
-
-    def _compose_inputs(self) -> Iterator[Widget]:
-        for inp in self.flow.inputs:
-            yield Label(f"{inp.label.upper()} ({inp.input_type.value})", classes="eyebrow")
-            yield from self._widget_for(inp)
-
-    def _widget_for(self, inp: FlowInput) -> Iterator[Widget]:
-        widget_id = f"input-{inp.name}"
-        if inp.input_type == InputType.BOOLEAN:
-            default_enabled = inp.default if isinstance(inp.default, bool) else str(inp.default).lower() == "true"
-            yield Switch(value=default_enabled, id=widget_id)
-        elif inp.input_type == InputType.NUMBER:
-            default_text = str(inp.default) if inp.default is not None else ""
-            yield Input(value=default_text, placeholder=inp.placeholder or "", id=widget_id, validators=[Number()])
-        elif inp.input_type == InputType.PATH:
-            default_text = str(inp.default) if inp.default is not None else ""
-            path_input = Input(value=default_text, placeholder=inp.placeholder or "", id=widget_id)
-            yield path_input
-            yield TogoPathAutoComplete(target=f"#{widget_id}")
-        else:
-            # STRING (default)
-            default_text = str(inp.default) if inp.default is not None else ""
-            yield Input(value=default_text, placeholder=inp.placeholder or "", id=widget_id)
 
     # ------------------------------------------------------------------
     # Actions
@@ -150,50 +66,22 @@ class LaunchModal(ModalScreen):
     # ------------------------------------------------------------------
 
     def _try_launch(self) -> None:
-        values: dict[str, LaunchInputValue] = {}
-        for inp in self.flow.inputs:
-            widget_id = f"input-{inp.name}"
-            ok, value = self._read_value(inp, widget_id)
-            if not ok:
+        values: dict[str, object] = {}
+        for launch_input in self.launch_inputs:
+            try:
+                value = launch_input.get_value()
+            except ValueError as error:
+                self._show_error(str(error))
                 return
             if value is None:
                 continue
-            values[inp.name] = value
+            values[launch_input.flow_input.name] = value
         try:
             converted = self.flow.convert_inputs(values)
         except ValueError as error:
             self._show_error(str(error))
             return
         self.dismiss(converted)
-
-    def _read_value(
-        self, inp: FlowInput, widget_id: str
-    ) -> tuple[Literal[True], LaunchInputValue | None] | tuple[Literal[False], None]:
-        """Read and validate the value for one input.
-
-        Returns (success, value); on failure shows an inline error.
-        """
-        if inp.input_type == InputType.BOOLEAN:
-            sw = self.query_one(f"#{widget_id}", Switch)
-            return True, sw.value
-
-        widget = self.query_one(f"#{widget_id}", Input)
-        text = widget.value.strip()
-
-        if inp.required and not text:
-            self._show_error(f"{inp.label}: required field cannot be empty.")
-            return False, None
-        if not text:
-            return True, None
-
-        if inp.input_type == InputType.NUMBER:
-            try:
-                float(text)
-            except ValueError:
-                self._show_error(f"{inp.label}: must be a valid number.")
-                return False, None
-
-        return True, text
 
     def _show_error(self, message: str) -> None:
         try:

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -616,8 +616,18 @@ ModalScreen {
     overflow-y: auto;
 }
 
-#launch-fields > Label.eyebrow {
+.launch-flow-input {
+    height: auto;
+    border: round $border;
+    border-title-color: $secondary;
+    border-title-align: left;
+    background: $panel;
+    padding: 0 1;
     margin-top: 1;
+}
+
+.launch-value-editor {
+    height: auto;
 }
 
 .badge {

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/launch_flow_input.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/launch_flow_input.py
@@ -1,0 +1,245 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Composable launch input widgets."""
+
+from __future__ import annotations
+
+from abc import ABC, ABCMeta, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import assert_never
+
+from textual import events
+from textual.app import ComposeResult
+from textual.content import Content
+from textual.css.query import NoMatches
+from textual.geometry import Size
+from textual.validation import Number
+from textual.widget import Widget
+from textual.widgets import Input, Switch
+from textual_autocomplete import DropdownItem, PathAutoComplete, TargetState
+
+from ddev.ai.config.models import FlowInput, InputType
+
+
+@dataclass(frozen=True)
+class EditorSpec:
+    """Describe one value edited by a launch input control."""
+
+    widget_id: str
+    value_name: str
+    input_type: InputType
+    label: str
+    required: bool
+    default: object | None
+    placeholder: str | None
+
+
+def spec_for_input(flow_input: FlowInput) -> EditorSpec:
+    """Adapt a flow input to its UI editor specification."""
+    return EditorSpec(
+        widget_id=f"input-{flow_input.name}",
+        value_name=flow_input.name,
+        input_type=flow_input.input_type,
+        label=flow_input.label,
+        required=flow_input.required,
+        default=flow_input.default,
+        placeholder=flow_input.placeholder,
+    )
+
+
+class WidgetABCMeta(type(Widget), ABCMeta):  # type: ignore[misc]
+    """Combine Textual's widget metaclass with abstract interfaces."""
+
+
+class TogoPathAutoComplete(PathAutoComplete):
+    """PathAutoComplete that expands a leading ``~`` and skips emoji prefixes.
+
+    The typed value is never rewritten to an existing entry: Enter always
+    submits the field's literal text (including paths that don't exist yet,
+    e.g. an output directory to be created), and only Tab accepts a
+    suggestion from the dropdown.
+    """
+
+    def __init__(self, target: Input | str) -> None:
+        super().__init__(
+            target,
+            folder_prefix=Content(""),
+            file_prefix=Content(""),
+        )
+
+    def get_candidates(self, target_state: TargetState) -> list[DropdownItem]:
+        current_input = target_state.text[: target_state.cursor_position]
+        if current_input.startswith("~"):
+            expanded = str(Path(current_input).expanduser())
+            if current_input.endswith("/") and not expanded.endswith("/"):
+                expanded += "/"
+            target_state = TargetState(text=expanded, cursor_position=len(expanded))
+        return super().get_candidates(target_state)
+
+    def get_content_height(self, container: Size, viewport: Size, width: int) -> int:
+        try:
+            option_count = self.option_list.option_count
+        except NoMatches:
+            return super().get_content_height(container, viewport, width)
+        return min(option_count, 12)
+
+    def _listen_to_messages(self, event: events.Event) -> None:
+        """Handle enter/escape ourselves instead of delegating to the base class.
+
+        The base implementation only runs its enter/escape handling when the dropdown
+        currently has at least one candidate (``option_list.option_count`` — it auto-hides
+        with zero matches), and even then it applies the highlighted completion on enter
+        regardless of ``prevent_default_enter``. Neither behavior is what we want for a
+        path field that must accept freely typed, possibly nonexistent paths: typing a new
+        output directory (no matching candidates) left enter/escape unhandled by the
+        dropdown entirely, so escape fell through to the modal's own ``escape`` binding and
+        dismissed the whole dialog, discarding whatever was typed. We handle both keys
+        directly based on whether the path field itself has focus (not on the dropdown's
+        visibility, which can't be relied on), so the typed text is never silently
+        overwritten or discarded.
+        """
+        if isinstance(event, events.Key) and self.target.has_focus:
+            if event.key == "enter":
+                if self.display:
+                    self.action_hide()
+                return
+            if event.key == "escape":
+                event.prevent_default()
+                event.stop()
+                if self.display:
+                    self.action_hide()
+                return
+        super()._listen_to_messages(event)
+
+
+class LaunchValueEditor[T](Widget, ABC, metaclass=WidgetABCMeta):
+    """Edit one raw launch value."""
+
+    def __init__(self, spec: EditorSpec) -> None:
+        super().__init__(classes="launch-value-editor")
+        self.spec = spec
+
+    @abstractmethod
+    def get_value(self) -> T | None:
+        """Return the raw value represented by this editor."""
+
+
+class TextLaunchValueEditor(LaunchValueEditor[str], ABC):
+    """Base editor for text-like launch values."""
+
+    def _input(self) -> Input:
+        return self.query_one(f"#{self.spec.widget_id}", Input)
+
+    def _get_text(self) -> str | None:
+        return self._input().value.strip() or None
+
+    def _make_input(self, *, validators: list[Number] | None = None) -> Input:
+        default = str(self.spec.default) if self.spec.default is not None else ""
+        return Input(
+            value=default,
+            placeholder=self.spec.placeholder or "",
+            id=self.spec.widget_id,
+            validators=validators,
+        )
+
+
+class StringLaunchValueEditor(TextLaunchValueEditor):
+    """Edit a string launch value."""
+
+    def compose(self) -> ComposeResult:
+        yield self._make_input()
+
+    def get_value(self) -> str | None:
+        return self._get_text()
+
+
+class NumberLaunchValueEditor(TextLaunchValueEditor):
+    """Edit a numeric launch value."""
+
+    def compose(self) -> ComposeResult:
+        yield self._make_input(validators=[Number()])
+
+    def get_value(self) -> str | None:
+        value = self._get_text()
+        if value is None:
+            return None
+        try:
+            float(value)
+        except ValueError:
+            raise ValueError(f"{self.spec.label}: must be a valid number.") from None
+        return value
+
+
+class BooleanLaunchValueEditor(LaunchValueEditor[bool]):
+    """Edit a boolean launch value."""
+
+    def compose(self) -> ComposeResult:
+        default = self.spec.default
+        enabled = default if isinstance(default, bool) else str(default).lower() == "true"
+        yield Switch(value=enabled, id=self.spec.widget_id)
+
+    def get_value(self) -> bool:
+        return self.query_one(f"#{self.spec.widget_id}", Switch).value
+
+
+class PathLaunchValueEditor(TextLaunchValueEditor):
+    """Edit a path launch value with autocomplete."""
+
+    def compose(self) -> ComposeResult:
+        yield self._make_input()
+        yield TogoPathAutoComplete(target=f"#{self.spec.widget_id}")
+
+    def get_value(self) -> str | None:
+        return self._get_text()
+
+
+def get_value_editor(spec: EditorSpec) -> LaunchValueEditor[str] | LaunchValueEditor[bool]:
+    """Create the scalar editor declared by an editor specification."""
+    match spec.input_type:
+        case InputType.STRING:
+            return StringLaunchValueEditor(spec)
+        case InputType.NUMBER:
+            return NumberLaunchValueEditor(spec)
+        case InputType.BOOLEAN:
+            return BooleanLaunchValueEditor(spec)
+        case InputType.PATH:
+            return PathLaunchValueEditor(spec)
+        case unexpected:
+            assert_never(unexpected)
+
+
+class LaunchFlowInput[T](Widget, ABC, metaclass=WidgetABCMeta):
+    """Common framed interface for one declared launch input."""
+
+    def __init__(self, flow_input: FlowInput) -> None:
+        super().__init__(classes="launch-flow-input")
+        self.flow_input = flow_input
+        self.border_title = f"{flow_input.label.upper()} ({flow_input.input_type.value})"
+
+    @classmethod
+    def get(cls, flow_input: FlowInput) -> LaunchFlowInput[str] | LaunchFlowInput[bool]:
+        """Create the launch widget declared by a flow input."""
+        return SingleLaunchFlowInput(flow_input, get_value_editor(spec_for_input(flow_input)))
+
+    @abstractmethod
+    def get_value(self) -> T | None:
+        """Return the validated raw input value."""
+
+
+class SingleLaunchFlowInput[T](LaunchFlowInput[T]):
+    """Frame one scalar value editor."""
+
+    def __init__(self, flow_input: FlowInput, editor: LaunchValueEditor[T]) -> None:
+        super().__init__(flow_input)
+        self.editor = editor
+
+    def compose(self) -> ComposeResult:
+        yield self.editor
+
+    def get_value(self) -> T | None:
+        value = self.editor.get_value()
+        if value is None and self.flow_input.required:
+            raise ValueError(f"{self.flow_input.label}: required field cannot be empty.")
+        return value

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -1271,39 +1271,36 @@ async def test_header_shows_running_badge_during_run():
 
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
 
-    running_states: list[bool] = []
-    badge_states: list[str] = []
+    started = asyncio.Event()
+    release = asyncio.Event()
 
-    class _SlowDemo:
+    class _BlockedDemo:
         failed_phase = None
 
-        def __init__(self, cb: Any) -> None:
-            self._cb = cb
-
         async def run_async(self) -> None:
-            await asyncio.sleep(0.2)
+            started.set()
+            await release.wait()
 
     flow = _make_flow()
     app = _app(flow)
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = ExecutionScreen(flow, orchestrator_builder=lambda cb: _SlowDemo(cb))
+        screen = ExecutionScreen(flow, orchestrator_builder=lambda _callbacks: _BlockedDemo())
         await app.push_screen(screen)
-        await pilot.pause(0.05)
+        await asyncio.wait_for(started.wait(), timeout=5)
+        await pilot.pause()
+
         from ddev.cli.meta.ai.tui.widgets.header import TogoHeader
 
         header = screen.query_one(TogoHeader)
         badge = header.query_one("#header-right", Static)
-        running_states.append(header.running)
-        badge_states.append(str(badge.content))
-        await pilot.pause(0.3)
-        running_states.append(header.running)
-        badge_states.append(str(badge.content))
+        assert str(badge.content) in {"● running", "○ running"}
 
-    assert True in running_states
-    assert running_states[-1] is False
-    assert any(state in {"● running", "○ running"} for state in badge_states)
-    assert badge_states[-1] == ""
+        release.set()
+        await screen.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert str(badge.content) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/cli/meta/ai/tui/test_launch_modal.py
+++ b/ddev/tests/cli/meta/ai/tui/test_launch_modal.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from xml.etree import ElementTree
 
 import pytest
 from textual import events
@@ -33,24 +34,6 @@ async def test_launch_modal_occupies_at_least_half_viewport(make_launch_modal_ap
         assert dialog.region.height >= viewport[1] / 2
         assert actions.region.bottom == dialog.content_region.bottom
         assert launch_button.region.right == dialog.content_region.right
-
-
-async def test_input_labels_show_declared_types(make_launch_modal_app, all_flow_inputs) -> None:
-    app = make_launch_modal_app(all_flow_inputs)
-
-    async with app.run_test() as pilot:
-        await pilot.pause()
-
-        labels = [label.render().plain for label in app.screen.query("#launch-fields > Label.eyebrow")]
-
-        assert labels == [
-            "MY STRING (string)",
-            "MY NUMBER (number)",
-            "MY BOOL (boolean)",
-            "MY PATH (path)",
-            "PRODUCT REQUIREMENTS FILE (path)",
-            "MAX TIMEOUT (SECONDS) (number)",
-        ]
 
 
 @pytest.mark.parametrize(
@@ -371,7 +354,7 @@ async def test_path_autocomplete_expands_home_directory(make_launch_modal_app, l
         [FlowInput(name="p", label="P", input_type=InputType.PATH, default=None, required=False)]
     )
     async with app.run_test(size=large_terminal):
-        from ddev.cli.meta.ai.tui.screens.launch_modal import TogoPathAutoComplete
+        from ddev.cli.meta.ai.tui.widgets.launch_flow_input import TogoPathAutoComplete
 
         autocomplete = app.screen.query_one(TogoPathAutoComplete)
         home_candidates = autocomplete.get_candidates(
@@ -379,6 +362,32 @@ async def test_path_autocomplete_expands_home_directory(make_launch_modal_app, l
         )
         tilde_candidates = autocomplete.get_candidates(TargetState(text="~/", cursor_position=2))
         assert {c.main for c in tilde_candidates} == {c.main for c in home_candidates}
+
+
+async def test_path_autocomplete_renders_all_directory_suggestions(
+    make_launch_modal_app, large_terminal, tmp_path
+) -> None:
+    """Path suggestions remain visible when another launch input follows."""
+    candidate_names = [f"autocomplete-{letter}-unique" for letter in "abcdefgh"]
+    for candidate_name in candidate_names:
+        (tmp_path / candidate_name).mkdir()
+
+    app = make_launch_modal_app(
+        [
+            FlowInput(name="path", label="Path", input_type=InputType.PATH, default=str(tmp_path)),
+            FlowInput(name="following", label="Following", input_type=InputType.NUMBER),
+        ]
+    )
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        path_input = app.screen.query_one("#input-path", Input)
+        await pilot.click(path_input)
+        await pilot.press("end", "/")
+        await pilot.pause()
+
+        screenshot = ElementTree.fromstring(app.export_screenshot())
+        rendered_text = "".join(element.text or "" for element in screenshot.iter("{http://www.w3.org/2000/svg}text"))
+        assert candidate_names[-1] in rendered_text
 
 
 async def test_path_autocomplete_does_not_force_completion_on_enter(

--- a/ddev/tests/cli/meta/ai/tui/test_theme.py
+++ b/ddev/tests/cli/meta/ai/tui/test_theme.py
@@ -103,14 +103,6 @@ def test_flow_grid_scrolls_vertically():
     assert "overflow-y: auto;" in tcss
 
 
-def test_launch_fields_have_vertical_spacing():
-    """Launch modal fields must not render cramped against each other."""
-    from pathlib import Path
-
-    tcss = Path(TogoApp.CSS_PATH).read_text()
-    assert "#launch-fields > Label.eyebrow {\n    margin-top: 1;\n}" in tcss
-
-
 def test_input_focus_uses_muted_accent_not_bold_primary():
     """Focused inputs should use a subtle accent outline, not a bold filled primary border."""
     from pathlib import Path


### PR DESCRIPTION
### What does this PR do?
Refactor Togo's existing launch modal to render and read every declared flow input through a self-contained `LaunchFlowInput` widget. The modal now creates widgets with `LaunchFlowInput.get(...)`, mounts them in the existing inputs region, and collects values through their common `get_value()` interface.

The current string, number, boolean, and path inputs—including path autocomplete and validation—are moved into composable editors without changing launch behavior. This PR introduces no new input types; launching existing flows continues to produce the same runtime values through the new widget architecture.

### Motivation
This keeps the abstraction grounded in the working launch modal rather than adding unused widget classes. Object and repeatable inputs can build on the same factory and value interface in the following PRs without adding type-specific branching back to the modal.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged