### PR TITLE
Add object flow inputs

### DIFF
--- a/ddev/src/ddev/ai/config/models.py
+++ b/ddev/src/ddev/ai/config/models.py
@@ -41,58 +41,205 @@ class VariableDeclaration(BaseModel):
 
 
 class InputType(StrEnum):
-    STRING = "string"
-    NUMBER = "number"
-    BOOLEAN = "boolean"
-    PATH = "path"
+    STRING = auto()
+    NUMBER = auto()
+    BOOLEAN = auto()
+    PATH = auto()
+    OBJECT = auto()
 
 
-class FlowInput(BaseModel):
-    """Describe a typed value supplied when launching a flow."""
+type ScalarInputType = Literal[
+    InputType.STRING,
+    InputType.NUMBER,
+    InputType.BOOLEAN,
+    InputType.PATH,
+]
+type ScalarInputValue = str
+type ObjectInputValue = dict[str, str]
+type RuntimeInputValue = ScalarInputValue | ObjectInputValue
+type RuntimeVariables = dict[str, RuntimeInputValue]
+
+
+class FlowInputBase(BaseModel):
+    """Describe fields shared by flow inputs."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
     name: str = Field(pattern=VARIABLE_NAME_PATTERN)
     label: str
-    input_type: InputType = Field(alias="type")
     default: Any | None = None
     placeholder: str | None = None
     required: bool = True
     as_content: bool = False
 
+
+class FlowInputField(FlowInputBase):
+    """Describe one scalar field within an object input."""
+
+    input_type: ScalarInputType = Field(alias="type")
+
     @model_validator(mode="after")
-    def validate_input_options(self) -> FlowInput:
-        if self.as_content and self.input_type is not InputType.PATH:
-            raise ValueError("'as_content' may only be used with path inputs")
-        if self.placeholder is not None and self.input_type is InputType.BOOLEAN:
-            raise ValueError("'placeholder' may not be used with boolean inputs")
-        if self.default is not None:
-            match self.input_type:
-                case InputType.STRING | InputType.PATH:
-                    pass
-                case InputType.NUMBER:
-                    _validate_number(self.name, self.default, prefix="Default for number input")
-                case InputType.BOOLEAN:
-                    _convert_boolean(self.name, self.default, prefix="Default for boolean input")
-                case unexpected:
-                    assert_never(unexpected)
+    def validate_input_options(self) -> FlowInputField:
+        _validate_scalar_options(
+            self.input_type,
+            self.name,
+            default=self.default,
+            placeholder=self.placeholder,
+            as_content=self.as_content,
+        )
         return self
 
-    def convert_runtime_value(self, value: object) -> str:
+    def convert_runtime_value(self, value: object, *, error_path: str | None = None) -> str:
         """Convert one runtime value according to this input's declared type."""
-        match self.input_type:
-            case InputType.STRING:
-                return str(value)
-            case InputType.NUMBER:
-                _validate_number(self.name, value)
-                return str(value)
-            case InputType.BOOLEAN:
-                return _convert_boolean(self.name, value)
-            case InputType.PATH:
-                if self.as_content:
-                    return _read_path_content(self.name, value)
-                return str(value)
-            case unexpected:
-                assert_never(unexpected)
+        return _convert_scalar_runtime_value(
+            self.input_type, error_path or self.name, value, as_content=self.as_content
+        )
+
+
+class FlowInput(FlowInputBase):
+    """Describe a typed value supplied when launching a flow."""
+
+    input_type: InputType = Field(alias="type")
+    fields: list[FlowInputField] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_input_options(self) -> FlowInput:
+        if self.input_type is InputType.OBJECT:
+            _validate_object_options(
+                self.name,
+                self.fields,
+                default=self.default,
+                placeholder=self.placeholder,
+                as_content=self.as_content,
+            )
+        else:
+            if self.fields:
+                raise ValueError("'fields' may only be used with object inputs")
+            _validate_scalar_options(
+                self.input_type,
+                self.name,
+                default=self.default,
+                placeholder=self.placeholder,
+                as_content=self.as_content,
+            )
+        return self
+
+    def convert_runtime_value(self, value: object) -> RuntimeInputValue:
+        """Convert one runtime value according to this input's declared type."""
+        if self.input_type is not InputType.OBJECT:
+            return _convert_scalar_runtime_value(self.input_type, self.name, value, as_content=self.as_content)
+        return {
+            child.name: child.convert_runtime_value(child_value, error_path=qualified_name)
+            for child, child_value, qualified_name in _resolve_object_field_values(self.name, self.fields, value)
+        }
+
+
+def _validate_object_options(
+    error_path: str,
+    fields: list[FlowInputField],
+    *,
+    default: object | None,
+    placeholder: str | None,
+    as_content: bool,
+) -> None:
+    if not fields:
+        raise ValueError("Object inputs must declare at least one field")
+    field_names = [field.name for field in fields]
+    if len(field_names) != len(set(field_names)):
+        raise ValueError("Object field names must be unique")
+    if as_content:
+        raise ValueError("'as_content' may only be used with path inputs")
+    if placeholder is not None:
+        raise ValueError("'placeholder' may not be set on object inputs; set it on individual object fields instead")
+    if default is not None:
+        for child, child_value, qualified_name in _resolve_object_field_values(error_path, fields, default):
+            _validate_scalar_runtime_value(child.input_type, qualified_name, child_value)
+
+
+def _resolve_object_field_values(
+    error_path: str,
+    fields: list[FlowInputField],
+    value: object,
+) -> list[tuple[FlowInputField, object, str]]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"Input {error_path!r} must be an object")
+
+    field_names = {field.name for field in fields}
+    unknown_fields = sorted(set(value) - field_names)
+    if unknown_fields:
+        raise ValueError(f"Unknown fields for input {error_path!r}: {unknown_fields}")
+
+    values: list[tuple[FlowInputField, object, str]] = []
+    for child in fields:
+        child_value = value.get(child.name)
+        qualified_name = f"{error_path}.{child.name}"
+        if child_value is None:
+            if child.required:
+                raise ValueError(f"Required input {qualified_name!r} is missing")
+            if child.default is None:
+                continue
+            child_value = child.default
+        values.append((child, child_value, qualified_name))
+    return values
+
+
+def _validate_scalar_options(
+    input_type: ScalarInputType,
+    error_path: str,
+    *,
+    default: object | None,
+    placeholder: str | None,
+    as_content: bool,
+) -> None:
+    if as_content and input_type is not InputType.PATH:
+        raise ValueError("'as_content' may only be used with path inputs")
+    if placeholder is not None and input_type is InputType.BOOLEAN:
+        raise ValueError("'placeholder' may not be used with boolean inputs")
+    if default is None:
+        return
+    match input_type:
+        case InputType.STRING | InputType.PATH:
+            pass
+        case InputType.NUMBER:
+            _validate_number(error_path, default, prefix="Default for number input")
+        case InputType.BOOLEAN:
+            _convert_boolean(error_path, default, prefix="Default for boolean input")
+        case unexpected:
+            assert_never(unexpected)
+
+
+def _convert_scalar_runtime_value(
+    input_type: ScalarInputType,
+    error_path: str,
+    value: object,
+    *,
+    as_content: bool,
+) -> str:
+    match input_type:
+        case InputType.STRING:
+            return str(value)
+        case InputType.NUMBER:
+            _validate_number(error_path, value)
+            return str(value)
+        case InputType.BOOLEAN:
+            return _convert_boolean(error_path, value)
+        case InputType.PATH:
+            if as_content:
+                return _read_path_content(error_path, value)
+            return str(value)
+        case unexpected:
+            assert_never(unexpected)
+
+
+def _validate_scalar_runtime_value(input_type: ScalarInputType, error_path: str, value: object) -> None:
+    match input_type:
+        case InputType.STRING | InputType.PATH:
+            pass
+        case InputType.NUMBER:
+            _validate_number(error_path, value)
+        case InputType.BOOLEAN:
+            _convert_boolean(error_path, value)
+        case unexpected:
+            assert_never(unexpected)
 
 
 BUILT_IN_FLOW_INPUTS = (
@@ -259,9 +406,9 @@ class ResolvedFlow:
     description: str | None = None
     inputs: list[FlowInput] = field(default_factory=list)
 
-    def convert_inputs(self, values: Mapping[str, object]) -> dict[str, str]:
-        """Convert declared launch inputs to runtime variable strings."""
-        converted: dict[str, str] = {}
+    def convert_inputs(self, values: Mapping[str, object]) -> RuntimeVariables:
+        """Convert declared launch inputs to canonical runtime values."""
+        converted: RuntimeVariables = {}
         for flow_input in self.inputs:
             value = values.get(flow_input.name)
             if value is None:
@@ -275,38 +422,38 @@ class ResolvedFlow:
         return converted
 
 
-def _convert_boolean(name: str, value: object, *, prefix: str = "Input") -> str:
+def _convert_boolean(error_path: str, value: object, *, prefix: str = "Input") -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, str) and (lower := value.lower()) in {"true", "false"}:
         return lower
-    raise ValueError(f"{prefix} {name!r} must be a boolean")
+    raise ValueError(f"{prefix} {error_path!r} must be a boolean")
 
 
-def _validate_number(name: str, value: object, *, prefix: str = "Input") -> None:
+def _validate_number(error_path: str, value: object, *, prefix: str = "Input") -> None:
     if isinstance(value, bool):
-        raise ValueError(f"{prefix} {name!r} must be a number")
+        raise ValueError(f"{prefix} {error_path!r} must be a number")
     try:
         number = Decimal(str(value))
     except (InvalidOperation, ValueError):
-        raise ValueError(f"{prefix} {name!r} must be a number") from None
+        raise ValueError(f"{prefix} {error_path!r} must be a number") from None
     if not number.is_finite():
-        raise ValueError(f"{prefix} {name!r} must be a number")
+        raise ValueError(f"{prefix} {error_path!r} must be a number")
 
 
-def _read_path_content(name: str, value: object) -> str:
+def _read_path_content(error_path: str, value: object) -> str:
     """Read an existing regular UTF-8 file supplied as a path input."""
     if not isinstance(value, (str, PathLike)) or not str(value):
-        raise ValueError(f"Input {name!r} must be a valid path")
+        raise ValueError(f"Input {error_path!r} must be a valid path")
     path = Path(value)
     if not path.exists():
-        raise ValueError(f"Input {name!r} path does not exist: {path}")
+        raise ValueError(f"Input {error_path!r} path does not exist: {path}")
     if not path.is_file():
-        raise ValueError(f"Input {name!r} path is not a file: {path}")
+        raise ValueError(f"Input {error_path!r} path is not a file: {path}")
     try:
         return path.read_text(encoding="utf-8")
     except OSError as error:
-        raise ValueError(f"Input {name!r} path could not be read: {path}: {error}") from error
+        raise ValueError(f"Input {error_path!r} path could not be read: {path}: {error}") from error
 
 
 class ConfigStatus(StrEnum):

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -12,7 +12,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from ddev.ai.callbacks.callbacks import Callbacks
-from ddev.ai.config.models import PhaseConfig
+from ddev.ai.config.models import PhaseConfig, RuntimeVariables
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 class FlowContext:
     """Ambient, flow-scoped execution context shared by every phase."""
 
-    runtime_variables: dict[str, str]
+    runtime_variables: RuntimeVariables
     flow_variables: dict[str, str]
     callbacks: Callbacks = field(default_factory=Callbacks)
     logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))

--- a/ddev/src/ddev/ai/phases/template.py
+++ b/ddev/src/ddev/ai/phases/template.py
@@ -2,9 +2,14 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import json
 from collections.abc import Callable, Iterator, Mapping
 from string import Template
 from typing import Any
+
+
+class _FlowTemplate(Template):
+    braceidpattern = rf"{Template.idpattern}(?:\.{Template.idpattern})?"
 
 
 class _SafeMapping(Mapping[str, str]):
@@ -15,8 +20,21 @@ class _SafeMapping(Mapping[str, str]):
         self._resolver = resolver
 
     def __getitem__(self, key: str) -> str:
+        if "." in key:
+            object_name, field_name = key.split(".", 1)
+            if object_name not in self._context:
+                raise ValueError(f"Object variable {object_name!r} is missing")
+            value = self._context[object_name]
+            if not isinstance(value, Mapping):
+                raise ValueError(f"Variable {object_name!r} is not an object")
+            if field_name not in value:
+                raise ValueError(f"Object field {key!r} is missing")
+            return str(value[field_name])
         if key in self._context:
-            return str(self._context[key])
+            value = self._context[key]
+            if isinstance(value, Mapping):
+                return json.dumps(dict(value), separators=(",", ":"), ensure_ascii=False)
+            return str(value)
         if self._resolver is not None:
             return self._resolver(key)
         return f"<VARIABLE UNDEFINED: {key}>"
@@ -30,4 +48,4 @@ class _SafeMapping(Mapping[str, str]):
 
 def render_inline(prompt: str, context: dict[str, Any], resolver: Callable[[str], str] | None = None) -> str:
     """Render an inline prompt string with the given context."""
-    return Template(prompt).substitute(_SafeMapping(context, resolver))
+    return _FlowTemplate(prompt).substitute(_SafeMapping(context, resolver))

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from ddev.ai.agent.registry import AgentProviderRegistry
 from ddev.ai.callbacks.callbacks import Callbacks
-from ddev.ai.config.models import ResolvedFlow
+from ddev.ai.config.models import ResolvedFlow, RuntimeVariables
 from ddev.ai.phases.base import FlowContext
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.registry import PhaseRegistry
@@ -27,7 +27,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
         resolved_flow: ResolvedFlow,
         phase_registry: PhaseRegistry,
         checkpoint_path: Path,
-        runtime_variables: dict[str, str],
+        runtime_variables: RuntimeVariables,
         provider_registry: AgentProviderRegistry,
         file_access_policy: FileAccessPolicy,
         callbacks: Callbacks | None = None,

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -17,7 +17,7 @@ from textual.widgets import Static
 from textual.worker import Worker
 
 from ddev.ai.callbacks.callbacks import Callbacks
-from ddev.ai.config.models import ResolvedFlow
+from ddev.ai.config.models import ResolvedFlow, RuntimeVariables
 from ddev.ai.react.process import TOOL_RESULTS_SENTINEL
 from ddev.cli.meta.ai.rendering import (
     render_agent_error_line,
@@ -82,7 +82,7 @@ class ExecutionScreen(TogoScreen):
     def __init__(
         self,
         flow: ResolvedFlow,
-        runtime_variables: dict[str, str] | None = None,
+        runtime_variables: RuntimeVariables | None = None,
         resume: bool = False,
         runs_dir: Path | None = None,
         orchestrator_builder: OrchestratorBuilder | None = None,

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/launch_modal.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/launch_modal.py
@@ -12,10 +12,10 @@ from textual.screen import ModalScreen
 from textual.widget import Widget
 from textual.widgets import Button, Static
 
-from ddev.ai.config.models import ResolvedFlow
+from ddev.ai.config.models import ResolvedFlow, RuntimeVariables
 from ddev.cli.meta.ai.tui.widgets.launch_flow_input import LaunchFlowInput
 
-type LaunchInputValues = dict[str, str]
+type LaunchInputValues = RuntimeVariables
 
 
 class LaunchModal(ModalScreen):

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -630,6 +630,17 @@ ModalScreen {
     height: auto;
 }
 
+.object-field {
+    height: auto;
+    margin-bottom: 1;
+}
+
+.object-field-label {
+    height: auto;
+    color: $text-muted;
+    text-style: bold;
+}
+
 .badge {
     border: round $border;
     color: $foreground;

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/launch_flow_input.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/launch_flow_input.py
@@ -6,21 +6,23 @@
 from __future__ import annotations
 
 from abc import ABC, ABCMeta, abstractmethod
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import assert_never
 
 from textual import events
 from textual.app import ComposeResult
+from textual.containers import Vertical
 from textual.content import Content
 from textual.css.query import NoMatches
 from textual.geometry import Size
 from textual.validation import Number
 from textual.widget import Widget
-from textual.widgets import Input, Switch
+from textual.widgets import Input, Static, Switch
 from textual_autocomplete import DropdownItem, PathAutoComplete, TargetState
 
-from ddev.ai.config.models import FlowInput, InputType
+from ddev.ai.config.models import FlowInput, FlowInputField, InputType
 
 
 @dataclass(frozen=True)
@@ -46,6 +48,21 @@ def spec_for_input(flow_input: FlowInput) -> EditorSpec:
         required=flow_input.required,
         default=flow_input.default,
         placeholder=flow_input.placeholder,
+    )
+
+
+def spec_for_field(flow_input: FlowInput, field: FlowInputField) -> EditorSpec:
+    """Adapt an object field to its UI editor specification."""
+    object_default = flow_input.default if isinstance(flow_input.default, Mapping) else {}
+    parent_default = object_default.get(field.name)
+    return EditorSpec(
+        widget_id=f"input-{flow_input.name}-{field.name}",
+        value_name=field.name,
+        input_type=field.input_type,
+        label=field.label,
+        required=field.required,
+        default=field.default if parent_default is None else parent_default,
+        placeholder=field.placeholder,
     )
 
 
@@ -195,7 +212,7 @@ class PathLaunchValueEditor(TextLaunchValueEditor):
         return self._get_text()
 
 
-def get_value_editor(spec: EditorSpec) -> LaunchValueEditor[str] | LaunchValueEditor[bool]:
+def get_scalar_value_editor(spec: EditorSpec) -> LaunchValueEditor[str] | LaunchValueEditor[bool]:
     """Create the scalar editor declared by an editor specification."""
     match spec.input_type:
         case InputType.STRING:
@@ -210,6 +227,50 @@ def get_value_editor(spec: EditorSpec) -> LaunchValueEditor[str] | LaunchValueEd
             assert_never(unexpected)
 
 
+class ObjectValueEditor(LaunchValueEditor[dict[str, str | bool]]):
+    """Edit the scalar fields declared by an object input."""
+
+    def __init__(self, spec: EditorSpec, field_specs: tuple[EditorSpec, ...]) -> None:
+        super().__init__(spec)
+        self.field_specs = field_specs
+        self.editors = {field.value_name: get_scalar_value_editor(field) for field in field_specs}
+
+    def compose(self) -> ComposeResult:
+        for field in self.field_specs:
+            with Vertical(classes="object-field"):
+                yield Static(f"{field.label} ({field.input_type.value})", classes="object-field-label")
+                yield self.editors[field.value_name]
+
+    def get_value(self) -> dict[str, str | bool] | None:
+        field_values = {field.value_name: self.editors[field.value_name].get_value() for field in self.field_specs}
+        if (
+            not self.spec.required
+            and self.spec.default is None
+            and all(value is None for value in field_values.values())
+        ):
+            return None
+
+        values: dict[str, str | bool] = {}
+        for field in self.field_specs:
+            value = field_values[field.value_name]
+            if value is None:
+                if field.required:
+                    raise ValueError(f"{field.label}: required field cannot be empty.")
+                continue
+            values[field.value_name] = value
+        return values
+
+
+def get_value_editor(
+    flow_input: FlowInput,
+) -> LaunchValueEditor[str] | LaunchValueEditor[bool] | LaunchValueEditor[dict[str, str | bool]]:
+    """Create the editor declared by a flow input."""
+    spec = spec_for_input(flow_input)
+    if flow_input.input_type is InputType.OBJECT:
+        return ObjectValueEditor(spec, tuple(spec_for_field(flow_input, field) for field in flow_input.fields))
+    return get_scalar_value_editor(spec)
+
+
 class LaunchFlowInput[T](Widget, ABC, metaclass=WidgetABCMeta):
     """Common framed interface for one declared launch input."""
 
@@ -219,9 +280,12 @@ class LaunchFlowInput[T](Widget, ABC, metaclass=WidgetABCMeta):
         self.border_title = f"{flow_input.label.upper()} ({flow_input.input_type.value})"
 
     @classmethod
-    def get(cls, flow_input: FlowInput) -> LaunchFlowInput[str] | LaunchFlowInput[bool]:
+    def get(
+        cls,
+        flow_input: FlowInput,
+    ) -> LaunchFlowInput[str] | LaunchFlowInput[bool] | LaunchFlowInput[dict[str, str | bool]]:
         """Create the launch widget declared by a flow input."""
-        return SingleLaunchFlowInput(flow_input, get_value_editor(spec_for_input(flow_input)))
+        return SingleLaunchFlowInput(flow_input, get_value_editor(flow_input))
 
     @abstractmethod
     def get_value(self) -> T | None:

--- a/ddev/tests/ai/config/resolving/test_variables.py
+++ b/ddev/tests/ai/config/resolving/test_variables.py
@@ -103,6 +103,33 @@ def test_required_runtime_input_satisfies_required_variable_without_static_value
     assert diagnostics.resolved.variables == {}
 
 
+def test_object_fields_do_not_satisfy_separate_variable_declarations():
+    entries = [
+        phase_entry(
+            "p",
+            variables=[VariableDeclaration(name="endpoint"), VariableDeclaration(name="url")],
+        ),
+        flow_entry(
+            "demo",
+            [FlowEntry(phase="p")],
+            inputs=[
+                FlowInput.model_validate(
+                    {
+                        "name": "endpoint",
+                        "label": "Endpoint",
+                        "type": "object",
+                        "fields": [{"name": "url", "label": "URL", "type": "string"}],
+                    }
+                )
+            ],
+        ),
+    ]
+    diagnostics = FlowResolver(ResourceRegistry(entries), StubReg()).resolve("demo")
+
+    assert diagnostics.status == ConfigStatus.BROKEN
+    assert any(error.subject == "url" and "Required variable" in error.message for error in diagnostics.errors)
+
+
 def test_built_in_prd_input_satisfies_required_variable():
     entries = [
         phase_entry("p", variables=[VariableDeclaration(name="prd")]),

--- a/ddev/tests/ai/config/test_engine.py
+++ b/ddev/tests/ai/config/test_engine.py
@@ -189,6 +189,32 @@ def test_unparseable_yaml_recorded_as_file_error(tmp_path):
     assert any(p.name == "bad.yaml" for p in eng.file_errors)
 
 
+def test_object_placeholder_diagnostic_explains_field_placement(tmp_path):
+    path = tmp_path / "flow.yaml"
+    write(
+        path,
+        "- type: flow\n"
+        "  config:\n"
+        "    name: demo\n"
+        "    inputs:\n"
+        "      - name: endpoint\n"
+        "        label: Endpoint\n"
+        "        type: object\n"
+        "        placeholder: Configure endpoint\n"
+        "        fields:\n"
+        "          - name: url\n"
+        "            label: URL\n"
+        "            type: string\n"
+        "    flow: []\n",
+    )
+
+    engine = ConfigurationEngine(core_dir=tmp_path, user_dirs=[], phase_registry=StubReg())
+    diagnostic = engine.flows["demo"]
+
+    assert diagnostic.status is ConfigStatus.BROKEN
+    assert any("set it on individual object fields instead" in error.message for error in diagnostic.errors)
+
+
 def test_non_utf8_file_recorded_as_file_error(tmp_path):
     path = tmp_path / "bad.yaml"
     path.write_bytes(b"\xff")

--- a/ddev/tests/ai/config/test_models.py
+++ b/ddev/tests/ai/config/test_models.py
@@ -285,6 +285,101 @@ def test_flow_input_rejects_placeholder_for_boolean():
         models.FlowInput(name="enabled", label="Enabled", input_type="boolean", placeholder="Enabled")
 
 
+def object_input(**overrides: object) -> models.FlowInput:
+    data = {
+        "name": "endpoint",
+        "label": "Endpoint",
+        "type": "object",
+        "fields": [
+            {"name": "url", "label": "URL", "type": "string"},
+            {"name": "retries", "label": "Retries", "type": "number", "required": False, "default": 3},
+            {"name": "enabled", "label": "Enabled", "type": "boolean"},
+        ],
+    }
+    data.update(overrides)
+    return models.FlowInput.model_validate(data)
+
+
+def test_flow_input_rejects_empty_object_fields():
+    with pytest.raises(ValidationError, match="Object inputs must declare at least one field"):
+        object_input(fields=[])
+
+
+def test_flow_input_rejects_duplicate_object_field_names():
+    with pytest.raises(ValidationError, match="Object field names must be unique"):
+        object_input(
+            fields=[
+                {"name": "url", "label": "URL", "type": "string"},
+                {"name": "url", "label": "Other URL", "type": "path"},
+            ]
+        )
+
+
+def test_flow_input_rejects_fields_on_scalar_inputs():
+    with pytest.raises(ValidationError, match="'fields' may only be used with object inputs"):
+        models.FlowInput.model_validate(
+            {
+                "name": "subject",
+                "label": "Subject",
+                "type": "string",
+                "fields": [{"name": "value", "label": "Value", "type": "string"}],
+            }
+        )
+
+
+def test_flow_input_rejects_nested_object_fields():
+    with pytest.raises(ValidationError):
+        object_input(fields=[{"name": "nested", "label": "Nested", "type": "object", "fields": []}])
+
+
+def test_flow_input_rejects_invalid_object_field_options():
+    with pytest.raises(ValidationError, match="'placeholder' may not be used with boolean inputs"):
+        object_input(fields=[{"name": "enabled", "label": "Enabled", "type": "boolean", "placeholder": "yes"}])
+
+
+def test_object_path_default_reads_launch_time_content(tmp_path):
+    source = tmp_path / "endpoint.txt"
+    source.write_text("configuration-time content", encoding="utf-8")
+    flow_input = object_input(
+        required=False,
+        default={"source": source},
+        fields=[
+            {
+                "name": "source",
+                "label": "Source",
+                "type": "path",
+                "as_content": True,
+            }
+        ],
+    )
+
+    source.write_text("launch-time content", encoding="utf-8")
+    resolved = resolved_with_inputs(flow_input)
+
+    assert resolved.convert_inputs({}) == {"endpoint": {"source": "launch-time content"}}
+
+
+@pytest.mark.parametrize(
+    ("default", "message"),
+    [
+        ("https://example.test", "Input 'endpoint' must be an object"),
+        ({"url": "https://example.test"}, "Required input 'endpoint.enabled' is missing"),
+        (
+            {"url": "https://example.test", "enabled": True, "timeout": 10},
+            "Unknown fields for input 'endpoint'",
+        ),
+        (
+            {"url": "https://example.test", "retries": "many", "enabled": True},
+            "Input 'endpoint.retries' must be a number",
+        ),
+    ],
+    ids=["not-mapping", "missing-required-field", "unknown-field", "invalid-field"],
+)
+def test_flow_input_rejects_invalid_object_default_at_configuration_load(default, message):
+    with pytest.raises(ValidationError, match=message):
+        object_input(required=False, default=default)
+
+
 def resolved_with_inputs(*inputs: models.FlowInput) -> models.ResolvedFlow:
     return models.ResolvedFlow(
         name="demo",
@@ -332,6 +427,75 @@ def test_resolved_flow_rejects_invalid_boolean():
 
     with pytest.raises(ValueError, match="Input 'enabled' must be a boolean"):
         resolved.convert_inputs({"enabled": "sometimes"})
+
+
+def test_resolved_flow_converts_object_fields_to_strings():
+    resolved = resolved_with_inputs(object_input())
+
+    assert resolved.convert_inputs({"endpoint": {"url": "https://example.test", "retries": 2.5, "enabled": False}}) == {
+        "endpoint": {
+            "url": "https://example.test",
+            "retries": "2.5",
+            "enabled": "false",
+        }
+    }
+
+
+def test_resolved_flow_uses_optional_object_field_defaults():
+    resolved = resolved_with_inputs(object_input())
+
+    assert resolved.convert_inputs({"endpoint": {"url": "https://example.test", "enabled": True}}) == {
+        "endpoint": {
+            "url": "https://example.test",
+            "retries": "3",
+            "enabled": "true",
+        }
+    }
+
+
+def test_resolved_flow_uses_canonical_optional_object_default():
+    resolved = resolved_with_inputs(
+        object_input(
+            required=False,
+            default={"url": "https://example.test", "enabled": False},
+        )
+    )
+
+    assert resolved.convert_inputs({}) == {
+        "endpoint": {
+            "url": "https://example.test",
+            "retries": "3",
+            "enabled": "false",
+        }
+    }
+
+
+def test_resolved_flow_rejects_missing_required_object_field():
+    resolved = resolved_with_inputs(object_input())
+
+    with pytest.raises(ValueError, match="Required input 'endpoint.enabled' is missing"):
+        resolved.convert_inputs({"endpoint": {"url": "https://example.test"}})
+
+
+def test_resolved_flow_rejects_unknown_object_fields():
+    resolved = resolved_with_inputs(object_input())
+
+    with pytest.raises(ValueError, match="Unknown fields for input 'endpoint': \\['timeout'\\]"):
+        resolved.convert_inputs({"endpoint": {"url": "https://example.test", "enabled": True, "timeout": "10"}})
+
+
+def test_resolved_flow_rejects_non_mapping_object_value():
+    resolved = resolved_with_inputs(object_input())
+
+    with pytest.raises(ValueError, match="Input 'endpoint' must be an object"):
+        resolved.convert_inputs({"endpoint": "https://example.test"})
+
+
+def test_resolved_flow_reports_object_child_conversion_path():
+    resolved = resolved_with_inputs(object_input())
+
+    with pytest.raises(ValueError, match="Input 'endpoint.retries' must be a number"):
+        resolved.convert_inputs({"endpoint": {"url": "https://example.test", "retries": "many", "enabled": True}})
 
 
 def test_resolved_flow_requires_required_input_even_with_default():

--- a/ddev/tests/ai/phases/test_template.py
+++ b/ddev/tests/ai/phases/test_template.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import pytest
+
 from ddev.ai.phases.template import _SafeMapping, render_inline
 
 from .conftest import resolve_key
@@ -62,3 +64,57 @@ def test_render_inline_uses_resolver():
 def test_render_inline_escaped_dollar():
     result = render_inline("Price: $$5", {})
     assert result == "Price: $5"
+
+
+def test_render_inline_renders_objects_as_compact_json():
+    result = render_inline(
+        "Endpoint: ${endpoint}",
+        {"endpoint": {"url": "https://example.test", "enabled": "true"}},
+    )
+
+    assert result == 'Endpoint: {"url":"https://example.test","enabled":"true"}'
+
+
+def test_render_inline_preserves_unicode_and_escapes_object_json():
+    result = render_inline(
+        "Endpoint: ${endpoint}",
+        {"endpoint": {"label": 'café "primary"\nline'}},
+    )
+
+    assert result == 'Endpoint: {"label":"café \\"primary\\"\\nline"}'
+
+
+def test_render_inline_supports_one_level_braced_object_field_access():
+    result = render_inline(
+        "URL: ${endpoint.url}",
+        {"endpoint": {"url": "https://example.test"}},
+    )
+
+    assert result == "URL: https://example.test"
+
+
+@pytest.mark.parametrize(
+    ("prompt", "context", "message"),
+    [
+        ("${endpoint.url}", {}, "Object variable 'endpoint' is missing"),
+        ("${endpoint.url}", {"endpoint": "scalar"}, "Variable 'endpoint' is not an object"),
+        ("${endpoint.url}", {"endpoint": {}}, "Object field 'endpoint.url' is missing"),
+        (
+            "${endpoint.url.scheme}",
+            {"endpoint": {"url": "https://example.test"}},
+            "Invalid placeholder",
+        ),
+    ],
+)
+def test_render_inline_rejects_invalid_object_field_access(prompt, context, message):
+    with pytest.raises(ValueError, match=message):
+        render_inline(prompt, context)
+
+
+def test_render_inline_does_not_treat_unbraced_dots_as_object_access():
+    result = render_inline(
+        "$endpoint.url",
+        {"endpoint": {"url": "https://example.test"}},
+    )
+
+    assert result == '{"url":"https://example.test"}.url'

--- a/ddev/tests/cli/meta/ai/tui/test_launch_modal.py
+++ b/ddev/tests/cli/meta/ai/tui/test_launch_modal.py
@@ -15,6 +15,22 @@ from textual.widgets import Button, Input, Static, Switch
 
 from ddev.ai.config.models import FlowInput, InputType
 
+
+def object_flow_input(**overrides: object) -> FlowInput:
+    data = {
+        "name": "endpoint",
+        "label": "Endpoint",
+        "type": "object",
+        "fields": [
+            {"name": "url", "label": "URL", "type": "string"},
+            {"name": "retries", "label": "Retries", "type": "number", "required": False},
+            {"name": "enabled", "label": "Enabled", "type": "boolean"},
+        ],
+    }
+    data.update(overrides)
+    return FlowInput.model_validate(data)
+
+
 # ---------------------------------------------------------------------------
 # Widget rendering per InputType
 # ---------------------------------------------------------------------------
@@ -110,6 +126,89 @@ async def test_boolean_switch_prefilled(make_launch_modal_app, default, expected
         modal = app.screen
         sw = modal.query_one("#input-b", Switch)
         assert sw.value is expected
+
+
+async def test_object_input_prefills_and_submits_object_level_default(make_launch_modal_app, large_terminal) -> None:
+    flow_input = object_flow_input(
+        required=False,
+        default={"url": "https://default.test", "enabled": True},
+        fields=[
+            {"name": "url", "label": "URL", "type": "string", "default": "https://child.test"},
+            {"name": "retries", "label": "Retries", "type": "number", "required": False, "default": 3},
+            {"name": "enabled", "label": "Enabled", "type": "boolean"},
+        ],
+    )
+    app = make_launch_modal_app([flow_input])
+
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert app.dismiss_result == {
+            "endpoint": {
+                "url": "https://default.test",
+                "retries": "3",
+                "enabled": "true",
+            },
+            "prd": "Required product behavior.\n",
+        }
+
+
+async def test_object_null_parent_default_uses_child_default(make_launch_modal_app, large_terminal) -> None:
+    flow_input = object_flow_input(
+        required=False,
+        default={"enabled": None},
+        fields=[
+            {"name": "enabled", "label": "Enabled", "type": "boolean", "required": False, "default": True},
+        ],
+    )
+    app = make_launch_modal_app([flow_input])
+
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+
+        assert app.screen.query_one("#input-endpoint-enabled", Switch).value is True
+
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert app.dismiss_result == {
+            "endpoint": {"enabled": "true"},
+            "prd": "Required product behavior.\n",
+        }
+
+
+async def test_object_path_default_stays_raw_until_launch(make_launch_modal_app, large_terminal, tmp_path) -> None:
+    source = tmp_path / "endpoint.txt"
+    source.write_text("configuration-time content", encoding="utf-8")
+    flow_input = object_flow_input(
+        required=False,
+        default={"source": source},
+        fields=[
+            {
+                "name": "source",
+                "label": "Source",
+                "type": "path",
+                "as_content": True,
+            }
+        ],
+    )
+    app = make_launch_modal_app([flow_input])
+
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+
+        assert app.screen.query_one("#input-endpoint-source", Input).value == str(source)
+
+        source.write_text("launch-time content", encoding="utf-8")
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert app.dismiss_result == {
+            "endpoint": {"source": "launch-time content"},
+            "prd": "Required product behavior.\n",
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -244,6 +343,109 @@ async def test_valid_number_submission_dismisses(make_launch_modal_app, large_te
         assert app.dismiss_result is not None
         assert app.dismiss_result != "NOT_SET"
         assert app.dismiss_result == {"n": "99", "prd": "Required product behavior.\n"}
+
+
+async def test_object_submission_dismisses_with_canonical_nested_payload(make_launch_modal_app, large_terminal) -> None:
+    app = make_launch_modal_app([object_flow_input()])
+
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        app.screen.query_one("#input-endpoint-url", Input).value = "https://example.test"
+        app.screen.query_one("#input-endpoint-retries", Input).value = "2"
+        app.screen.query_one("#input-endpoint-enabled", Switch).value = False
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert app.dismiss_result == {
+            "endpoint": {
+                "url": "https://example.test",
+                "retries": "2",
+                "enabled": "false",
+            },
+            "prd": "Required product behavior.\n",
+        }
+
+
+async def test_missing_required_object_field_stays_inline(make_launch_modal_app, large_terminal) -> None:
+    app = make_launch_modal_app([object_flow_input()])
+
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert app.dismiss_result == "NOT_SET"
+        assert "URL: required field cannot be empty" in str(app.screen.query_one("#launch-error", Static).render())
+
+
+async def test_optional_object_with_every_child_empty_is_omitted(make_launch_modal_app, large_terminal) -> None:
+    """An empty object means no parent value only when the parent itself is optional."""
+    flow_input = object_flow_input(
+        required=False,
+        fields=[
+            {"name": "url", "label": "URL", "type": "string"},
+            {"name": "retries", "label": "Retries", "type": "number", "required": False},
+        ],
+    )
+    app = make_launch_modal_app([flow_input])
+
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert app.dismiss_result == {"prd": "Required product behavior.\n"}
+
+
+async def test_optional_object_with_any_child_value_validates_required_children(
+    make_launch_modal_app, large_terminal
+) -> None:
+    """Once an optional object has content, it is present and required child rules apply."""
+    flow_input = object_flow_input(
+        required=False,
+        fields=[
+            {"name": "url", "label": "URL", "type": "string"},
+            {"name": "retries", "label": "Retries", "type": "number", "required": False},
+        ],
+    )
+    app = make_launch_modal_app([flow_input])
+
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        app.screen.query_one("#input-endpoint-retries", Input).value = "2"
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert app.dismiss_result == "NOT_SET"
+        assert "URL: required field cannot be empty" in str(app.screen.query_one("#launch-error", Static).render())
+
+
+async def test_optional_object_with_boolean_field_is_present(make_launch_modal_app, large_terminal) -> None:
+    """Boolean switches always supply true or false, matching top-level boolean inputs."""
+    flow_input = object_flow_input(
+        required=False,
+        fields=[
+            {
+                "name": "enabled",
+                "label": "Enabled",
+                "type": "boolean",
+                "required": False,
+            }
+        ],
+    )
+    app = make_launch_modal_app([flow_input])
+
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        assert app.screen.query_one("#input-endpoint-enabled", Switch).value is False
+
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert app.dismiss_result == {
+            "endpoint": {"enabled": "false"},
+            "prd": "Required product behavior.\n",
+        }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?
Add object-valued flow inputs with typed child fields, grouped Togo editors, nested runtime values, compact JSON interpolation, and one-level dotted field interpolation.

### Motivation
Flows need to collect related values as one validated unit and pass that structure through execution without flattening it into unrelated variables.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged