### PR TITLE
Add multi flow inputs

### DIFF
--- a/ddev/src/ddev/ai/config/models.py
+++ b/ddev/src/ddev/ai/config/models.py
@@ -10,7 +10,7 @@ from decimal import Decimal, InvalidOperation
 from enum import StrEnum, auto
 from os import PathLike
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Mapping, assert_never
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Mapping, assert_never, cast
 
 from pydantic import AfterValidator, BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
@@ -56,7 +56,7 @@ type ScalarInputType = Literal[
 ]
 type ScalarInputValue = str
 type ObjectInputValue = dict[str, str]
-type RuntimeInputValue = ScalarInputValue | ObjectInputValue
+type RuntimeInputValue = ScalarInputValue | ObjectInputValue | list[ScalarInputValue] | list[ObjectInputValue]
 type RuntimeVariables = dict[str, RuntimeInputValue]
 
 
@@ -100,36 +100,84 @@ class FlowInput(FlowInputBase):
 
     input_type: InputType = Field(alias="type")
     fields: list[FlowInputField] = Field(default_factory=list)
+    multi: bool = False
 
     @model_validator(mode="after")
     def validate_input_options(self) -> FlowInput:
+        defaults: list[object] = []
+        if self.default is not None:
+            if self.multi:
+                if not isinstance(self.default, list):
+                    raise ValueError(f"Default for multi input {self.name!r} must be a list")
+                if not self.default:
+                    raise ValueError(f"Default for multi input {self.name!r} must contain at least one item")
+                defaults.extend(self.default)
+            else:
+                defaults.append(self.default)
+
         if self.input_type is InputType.OBJECT:
             _validate_object_options(
                 self.name,
                 self.fields,
-                default=self.default,
+                defaults=defaults,
                 placeholder=self.placeholder,
                 as_content=self.as_content,
+                multi=self.multi,
             )
         else:
             if self.fields:
                 raise ValueError("'fields' may only be used with object inputs")
-            _validate_scalar_options(
-                self.input_type,
-                self.name,
-                default=self.default,
-                placeholder=self.placeholder,
-                as_content=self.as_content,
-            )
+            if defaults:
+                for index, default in enumerate(defaults):
+                    name = f"{self.name}[{index}]" if self.multi else self.name
+                    _validate_scalar_options(
+                        self.input_type,
+                        name,
+                        default=default,
+                        placeholder=self.placeholder,
+                        as_content=self.as_content,
+                    )
+            else:
+                _validate_scalar_options(
+                    self.input_type,
+                    self.name,
+                    default=None,
+                    placeholder=self.placeholder,
+                    as_content=self.as_content,
+                )
         return self
 
     def convert_runtime_value(self, value: object) -> RuntimeInputValue:
+        """Convert runtime values according to this input's type and cardinality."""
+        if self.multi:
+            if not isinstance(value, list):
+                raise ValueError(f"Input {self.name!r} must be a list")
+            if not value and self.required:
+                raise ValueError(f"Required input {self.name!r} must contain at least one item")
+            if self.input_type is InputType.OBJECT:
+                return [
+                    cast(ObjectInputValue, self.convert_single_runtime_value(item, error_path=f"{self.name}[{index}]"))
+                    for index, item in enumerate(value)
+                ]
+            return [
+                cast(ScalarInputValue, self.convert_single_runtime_value(item, error_path=f"{self.name}[{index}]"))
+                for index, item in enumerate(value)
+            ]
+        return self.convert_single_runtime_value(value)
+
+    def convert_single_runtime_value(
+        self,
+        value: object,
+        *,
+        error_path: str | None = None,
+    ) -> ScalarInputValue | ObjectInputValue:
         """Convert one runtime value according to this input's declared type."""
+        input_error_path = error_path or self.name
         if self.input_type is not InputType.OBJECT:
-            return _convert_scalar_runtime_value(self.input_type, self.name, value, as_content=self.as_content)
+            return _convert_scalar_runtime_value(self.input_type, input_error_path, value, as_content=self.as_content)
         return {
             child.name: child.convert_runtime_value(child_value, error_path=qualified_name)
-            for child, child_value, qualified_name in _resolve_object_field_values(self.name, self.fields, value)
+            for child, child_value, qualified_name in _resolve_object_field_values(input_error_path, self.fields, value)
         }
 
 
@@ -137,9 +185,10 @@ def _validate_object_options(
     error_path: str,
     fields: list[FlowInputField],
     *,
-    default: object | None,
+    defaults: list[object],
     placeholder: str | None,
     as_content: bool,
+    multi: bool,
 ) -> None:
     if not fields:
         raise ValueError("Object inputs must declare at least one field")
@@ -150,8 +199,9 @@ def _validate_object_options(
         raise ValueError("'as_content' may only be used with path inputs")
     if placeholder is not None:
         raise ValueError("'placeholder' may not be set on object inputs; set it on individual object fields instead")
-    if default is not None:
-        for child, child_value, qualified_name in _resolve_object_field_values(error_path, fields, default):
+    for index, default in enumerate(defaults):
+        object_error_path = f"{error_path}[{index}]" if multi else error_path
+        for child, child_value, qualified_name in _resolve_object_field_values(object_error_path, fields, default):
             _validate_scalar_runtime_value(child.input_type, qualified_name, child_value)
 
 
@@ -418,6 +468,10 @@ class ResolvedFlow:
                     continue
                 value = flow_input.default
 
+            if flow_input.multi and isinstance(value, list) and not value and not flow_input.required:
+                if flow_input.default is None:
+                    continue
+                value = flow_input.default
             converted[flow_input.name] = flow_input.convert_runtime_value(value)
         return converted
 

--- a/ddev/src/ddev/ai/flows/openmetrics/flow.yaml
+++ b/ddev/src/ddev/ai/flows/openmetrics/flow.yaml
@@ -4,11 +4,20 @@ config:
   description: >-
     Generate an OpenMetrics integration.
   inputs:
-    - name: inspect_input
-      label: Endpoints JSON
-      type: string
-      placeholder: '{"endpoints":[{"name":"api","url":"http://localhost:9090/metrics"}]}'
+    - name: endpoints
+      label: Endpoints
+      type: object
+      multi: true
       required: true
+      fields:
+        - name: name
+          label: Name
+          type: string
+          required: true
+        - name: url
+          label: URL
+          type: string
+          required: true
     - name: integration
       label: Integration name
       type: string

--- a/ddev/src/ddev/ai/flows/openmetrics/phases.yaml
+++ b/ddev/src/ddev/ai/flows/openmetrics/phases.yaml
@@ -3,7 +3,7 @@
     name: inspect_endpoint
     class: InspectEndpointPhase
     variables:
-      - name: inspect_input
+      - name: endpoints
 
 - type: phase
   config:

--- a/ddev/src/ddev/ai/phases/openmetrics/inspect_endpoint.py
+++ b/ddev/src/ddev/ai/phases/openmetrics/inspect_endpoint.py
@@ -303,7 +303,7 @@ async def _inspect_one(
 class InspectEndpointPhase(Phase):
     """Deterministic Phase 0 for the OpenMetrics pipeline.
 
-    Fetches every named endpoint in ``inspect_input`` concurrently and, per endpoint:
+    Fetches every named endpoint in ``endpoints`` concurrently and, per endpoint:
 
     1. Confirms the endpoint is reachable (HTTP 200).
     2. Confirms the body is valid Prometheus or OpenMetrics exposition.
@@ -329,13 +329,13 @@ class InspectEndpointPhase(Phase):
             raise ConfigError(f"Phase {phase_id!r} (InspectEndpointPhase) must not declare 'checkpoint'")
 
     async def execute(self, context: dict[str, Any]) -> PhaseOutcome:
-        raw = context.get("inspect_input")
-        if not raw:
-            raise ConfigError("'inspect_input' runtime variable is required")
+        raw = context.get("endpoints")
+        if raw is None:
+            raise ConfigError("'endpoints' runtime variable is required")
         try:
-            endpoints = InspectInput.model_validate_json(raw).endpoints
+            endpoints = InspectInput.model_validate({"endpoints": raw}).endpoints
         except ValidationError as e:
-            raise ConfigError(f"invalid 'inspect_input': {e}") from e
+            raise ConfigError(f"invalid 'endpoints': {e}") from e
 
         memory_dir = self._checkpoint_manager.memory_dir
         memory_dir.mkdir(parents=True, exist_ok=True)

--- a/ddev/src/ddev/ai/phases/template.py
+++ b/ddev/src/ddev/ai/phases/template.py
@@ -25,6 +25,8 @@ class _SafeMapping(Mapping[str, str]):
             if object_name not in self._context:
                 raise ValueError(f"Object variable {object_name!r} is missing")
             value = self._context[object_name]
+            if isinstance(value, list):
+                raise ValueError(f"List variable {object_name!r} cannot be rendered")
             if not isinstance(value, Mapping):
                 raise ValueError(f"Variable {object_name!r} is not an object")
             if field_name not in value:
@@ -32,6 +34,8 @@ class _SafeMapping(Mapping[str, str]):
             return str(value[field_name])
         if key in self._context:
             value = self._context[key]
+            if isinstance(value, list):
+                raise ValueError(f"List variable {key!r} cannot be rendered")
             if isinstance(value, Mapping):
                 return json.dumps(dict(value), separators=(",", ":"), ensure_ascii=False)
             return str(value)

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -649,6 +649,47 @@ ModalScreen {
     height: auto;
 }
 
+.multi-items {
+    height: auto;
+}
+
+.multi-entry {
+    height: auto;
+    margin-bottom: 1;
+}
+
+.multi-entry.object-entry {
+    border: round $border;
+    background: $surface;
+    padding: 0 1;
+}
+
+.multi-entry-header,
+.multi-scalar-row {
+    height: auto;
+    layout: horizontal;
+    align-vertical: middle;
+}
+
+.multi-entry-title,
+.multi-scalar-row > .launch-value-editor {
+    width: 1fr;
+}
+
+.multi-entry-title {
+    color: $text-muted;
+    text-style: bold;
+}
+
+.remove-multi-item,
+.add-multi-item {
+    min-width: 10;
+}
+
+.add-multi-item {
+    margin-bottom: 1;
+}
+
 .object-field {
     height: auto;
     margin-bottom: 1;

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/launch_flow_input.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/launch_flow_input.py
@@ -13,13 +13,13 @@ from typing import assert_never
 
 from textual import events
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.content import Content
 from textual.css.query import NoMatches
 from textual.geometry import Size
 from textual.validation import Number
 from textual.widget import Widget
-from textual.widgets import Input, Static, Switch
+from textual.widgets import Button, Input, Static, Switch
 from textual_autocomplete import DropdownItem, PathAutoComplete, TargetState
 
 from ddev.ai.config.models import FlowInput, FlowInputField, InputType
@@ -53,16 +53,35 @@ def spec_for_input(flow_input: FlowInput) -> EditorSpec:
 
 def spec_for_field(flow_input: FlowInput, field: FlowInputField) -> EditorSpec:
     """Adapt an object field to its UI editor specification."""
-    object_default = flow_input.default if isinstance(flow_input.default, Mapping) else {}
+    return _spec_for_object_field(spec_for_input(flow_input), field)
+
+
+def _spec_for_object_field(object_spec: EditorSpec, field: FlowInputField) -> EditorSpec:
+    object_default = object_spec.default if isinstance(object_spec.default, Mapping) else {}
     parent_default = object_default.get(field.name)
     return EditorSpec(
-        widget_id=f"input-{flow_input.name}-{field.name}",
+        widget_id=f"{object_spec.widget_id}-{field.name}",
         value_name=field.name,
         input_type=field.input_type,
         label=field.label,
         required=field.required,
         default=field.default if parent_default is None else parent_default,
         placeholder=field.placeholder,
+    )
+
+
+def spec_for_item(flow_input: FlowInput, index: int) -> EditorSpec:
+    """Adapt one multi input item to its UI editor specification."""
+    defaults = flow_input.default if isinstance(flow_input.default, list) else []
+    default = defaults[index] if index < len(defaults) else None
+    return EditorSpec(
+        widget_id=f"input-{flow_input.name}-item-{index}",
+        value_name=flow_input.name,
+        input_type=flow_input.input_type,
+        label=flow_input.label,
+        required=flow_input.required,
+        default=default,
+        placeholder=flow_input.placeholder,
     )
 
 
@@ -283,8 +302,17 @@ class LaunchFlowInput[T](Widget, ABC, metaclass=WidgetABCMeta):
     def get(
         cls,
         flow_input: FlowInput,
-    ) -> LaunchFlowInput[str] | LaunchFlowInput[bool] | LaunchFlowInput[dict[str, str | bool]]:
+    ) -> (
+        LaunchFlowInput[str]
+        | LaunchFlowInput[bool]
+        | LaunchFlowInput[dict[str, str | bool]]
+        | LaunchFlowInput[list[str]]
+        | LaunchFlowInput[list[bool]]
+        | LaunchFlowInput[list[dict[str, str | bool]]]
+    ):
         """Create the launch widget declared by a flow input."""
+        if flow_input.multi:
+            return MultiLaunchFlowInput(flow_input)
         return SingleLaunchFlowInput(flow_input, get_value_editor(flow_input))
 
     @abstractmethod
@@ -307,3 +335,114 @@ class SingleLaunchFlowInput[T](LaunchFlowInput[T]):
         if value is None and self.flow_input.required:
             raise ValueError(f"{self.flow_input.label}: required field cannot be empty.")
         return value
+
+
+type LaunchEditor = LaunchValueEditor[str] | LaunchValueEditor[bool] | LaunchValueEditor[dict[str, str | bool]]
+
+
+class MultiValueEntry(Widget):
+    """Display one removable value in a repeated launch input."""
+
+    def __init__(self, editor: LaunchEditor, *, object_entry: bool, item_label: str, ordinal: int) -> None:
+        classes = "multi-entry object-entry" if object_entry else "multi-entry scalar-entry"
+        super().__init__(classes=classes)
+        self.editor = editor
+        self.object_entry = object_entry
+        self.item_label = item_label
+        self.ordinal = ordinal
+
+    def compose(self) -> ComposeResult:
+        if self.object_entry:
+            with Horizontal(classes="multi-entry-header"):
+                yield Static(f"{self.item_label} {self.ordinal}", classes="multi-entry-title")
+                yield Button("Remove", classes="remove-multi-item", variant="warning")
+            yield self.editor
+        else:
+            with Horizontal(classes="multi-scalar-row"):
+                yield self.editor
+                yield Button("Remove", classes="remove-multi-item", variant="warning")
+
+    def set_ordinal(self, ordinal: int) -> None:
+        self.ordinal = ordinal
+        if self.object_entry and self.is_mounted:
+            self.query_one(".multi-entry-title", Static).update(f"{self.item_label} {ordinal}")
+
+
+class MultiLaunchFlowInput(LaunchFlowInput[list[object]]):
+    """Collect an ordered list using repeated single-value editors."""
+
+    def __init__(self, flow_input: FlowInput) -> None:
+        super().__init__(flow_input)
+        self.border_title = f"{flow_input.label.upper()} (multi · {flow_input.input_type.value})"
+        self.next_entry_id = 0
+        defaults = flow_input.default if isinstance(flow_input.default, list) else []
+        self.entries: list[MultiValueEntry] = []
+        initial_entry_count = len(defaults) if defaults else int(flow_input.required)
+        for _ in range(initial_entry_count):
+            self.entries.append(self._create_entry())
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="multi-items"):
+            yield from self.entries
+        yield Button(f"+ Add {self._item_label()}", classes="add-multi-item")
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.has_class("add-multi-item"):
+            entry = self._create_entry()
+            self.entries.append(entry)
+            await self.query_one(".multi-items", Vertical).mount(entry)
+            self._renumber_entries()
+            controls = entry.query("Input, Switch")
+            if controls:
+                controls.first().focus()
+            event.stop()
+        elif event.button.has_class("remove-multi-item"):
+            entry = next(
+                ancestor for ancestor in event.button.ancestors_with_self if isinstance(ancestor, MultiValueEntry)
+            )
+            self.entries.remove(entry)
+            await entry.remove()
+            self._renumber_entries()
+            event.stop()
+
+    def get_value(self) -> list[object]:
+        values: list[object] = []
+        for index, entry in enumerate(self.entries, start=1):
+            value = entry.editor.get_value()
+            if value is None:
+                raise ValueError(f"{self.flow_input.label} item {index}: cannot be empty.")
+            values.append(value)
+        if not values and self.flow_input.required:
+            raise ValueError(f"{self.flow_input.label}: must contain at least one item.")
+        return values
+
+    def _create_entry(self) -> MultiValueEntry:
+        entry_id = self.next_entry_id
+        self.next_entry_id += 1
+        item_spec = spec_for_item(self.flow_input, entry_id)
+        if self.flow_input.input_type is InputType.OBJECT:
+            field_specs = tuple(_spec_for_object_field(item_spec, field) for field in self.flow_input.fields)
+            editor: LaunchEditor = ObjectValueEditor(item_spec, field_specs)
+        else:
+            editor = get_scalar_value_editor(item_spec)
+        return MultiValueEntry(
+            editor,
+            object_entry=self.flow_input.input_type is InputType.OBJECT,
+            item_label=self._item_label(),
+            ordinal=len(self.entries) + 1,
+        )
+
+    def _renumber_entries(self) -> None:
+        for ordinal, entry in enumerate(self.entries, start=1):
+            entry.set_ordinal(ordinal)
+
+    def _item_label(self) -> str:
+        label = self.flow_input.label
+        lowercase_label = label.lower()
+        if lowercase_label.endswith(("ss", "us", "is", "series")):
+            return label
+        if lowercase_label.endswith("ies"):
+            return f"{label[:-3]}y"
+        if lowercase_label.endswith("s"):
+            return label[:-1]
+        return label

--- a/ddev/tests/ai/config/test_models.py
+++ b/ddev/tests/ai/config/test_models.py
@@ -285,6 +285,26 @@ def test_flow_input_rejects_placeholder_for_boolean():
         models.FlowInput(name="enabled", label="Enabled", input_type="boolean", placeholder="Enabled")
 
 
+def test_flow_config_rejects_empty_optional_multi_default():
+    with pytest.raises(ValidationError, match="Default for multi input 'tags' must contain at least one item"):
+        FlowConfig.model_validate(
+            {
+                "name": "demo",
+                "inputs": [
+                    {
+                        "name": "tags",
+                        "label": "Tags",
+                        "type": "string",
+                        "multi": True,
+                        "required": False,
+                        "default": [],
+                    }
+                ],
+                "flow": [],
+            }
+        )
+
+
 def object_input(**overrides: object) -> models.FlowInput:
     data = {
         "name": "endpoint",
@@ -439,6 +459,87 @@ def test_resolved_flow_converts_object_fields_to_strings():
             "enabled": "false",
         }
     }
+
+
+def test_resolved_flow_converts_multi_values_in_declared_order():
+    resolved = resolved_with_inputs(
+        models.FlowInput(name="ports", label="Ports", input_type="number", multi=True),
+        object_input(name="endpoints", label="Endpoints", multi=True),
+    )
+
+    assert resolved.convert_inputs(
+        {
+            "ports": [9090, "8080"],
+            "endpoints": [
+                {"url": "https://first.test", "retries": 1, "enabled": True},
+                {"url": "https://second.test", "retries": 2, "enabled": False},
+            ],
+        }
+    ) == {
+        "ports": ["9090", "8080"],
+        "endpoints": [
+            {"url": "https://first.test", "retries": "1", "enabled": "true"},
+            {"url": "https://second.test", "retries": "2", "enabled": "false"},
+        ],
+    }
+
+
+def test_resolved_flow_reports_multi_item_conversion_path():
+    resolved = resolved_with_inputs(
+        object_input(name="endpoints", label="Endpoints", multi=True),
+    )
+
+    with pytest.raises(ValueError, match=r"Input 'endpoints\[1\]\.retries' must be a number"):
+        resolved.convert_inputs(
+            {
+                "endpoints": [
+                    {"url": "https://first.test", "enabled": True},
+                    {"url": "https://second.test", "retries": "many", "enabled": False},
+                ]
+            }
+        )
+
+
+def test_resolved_flow_rejects_empty_required_multi_input():
+    resolved = resolved_with_inputs(
+        models.FlowInput(name="tags", label="Tags", input_type="string", multi=True),
+    )
+
+    with pytest.raises(ValueError, match="Required input 'tags' must contain at least one item"):
+        resolved.convert_inputs({"tags": []})
+
+
+def test_resolved_flow_omits_empty_optional_multi_input():
+    resolved = resolved_with_inputs(
+        models.FlowInput(name="tags", label="Tags", input_type="string", multi=True, required=False),
+    )
+
+    assert resolved.convert_inputs({"tags": []}) == {}
+
+
+@pytest.mark.parametrize("value", ["", False, {}], ids=["empty-string", "false", "empty-object"])
+def test_resolved_flow_rejects_falsy_non_list_optional_multi_values(value):
+    resolved = resolved_with_inputs(
+        models.FlowInput(name="tags", label="Tags", input_type="string", multi=True, required=False),
+    )
+
+    with pytest.raises(ValueError, match="Input 'tags' must be a list"):
+        resolved.convert_inputs({"tags": value})
+
+
+def test_resolved_flow_converts_optional_multi_default_when_launched():
+    resolved = resolved_with_inputs(
+        models.FlowInput(
+            name="enabled",
+            label="Enabled states",
+            input_type="boolean",
+            multi=True,
+            required=False,
+            default=[True, "false"],
+        ),
+    )
+
+    assert resolved.convert_inputs({}) == {"enabled": ["true", "false"]}
 
 
 def test_resolved_flow_uses_optional_object_field_defaults():

--- a/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
+++ b/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
@@ -112,9 +112,8 @@ def message_queue():
     return asyncio.Queue()
 
 
-def _inspect_input_var(*pairs: tuple[str, str]) -> dict[str, str]:
-    payload = {"endpoints": [{"name": n, "url": u} for n, u in pairs]}
-    return {"inspect_input": json.dumps(payload)}
+def _endpoint_variables(*pairs: tuple[str, str]) -> dict[str, list[dict[str, str]]]:
+    return {"endpoints": [{"name": name, "url": url} for name, url in pairs]}
 
 
 def _make_phase(
@@ -122,12 +121,12 @@ def _make_phase(
     message_queue,
     *,
     phase_id: str = PHASE_ID,
-    runtime_variables: dict[str, str] | None = None,
+    runtime_variables: dict[str, object] | None = None,
 ) -> tuple[InspectEndpointPhase, CheckpointManager]:
     checkpoint_mgr = CheckpointManager(flow_dir / "checkpoints.yaml")
     context = FlowContext(
         runtime_variables=(
-            runtime_variables if runtime_variables is not None else _inspect_input_var((ENDPOINT_NAME, ENDPOINT_URL))
+            runtime_variables if runtime_variables is not None else _endpoint_variables((ENDPOINT_NAME, ENDPOINT_URL))
         ),
         flow_variables={},
     )
@@ -339,14 +338,14 @@ async def test_failure_request_error(flow_dir, message_queue, monkeypatch):
     await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="request failed")
 
 
-async def test_failure_missing_inspect_input(flow_dir, message_queue):
+async def test_failure_missing_endpoints(flow_dir, message_queue):
     phase, checkpoint_mgr = _make_phase(flow_dir, message_queue, runtime_variables={})
 
     trigger = PhaseTrigger(id="start", phase_id=None)
-    with pytest.raises(ConfigError, match="inspect_input"):
+    with pytest.raises(ConfigError, match="endpoints"):
         await phase.process_message(trigger)
 
-    wrapped = MessageProcessingError(phase._phase_id, trigger, ConfigError("inspect_input required"))
+    wrapped = MessageProcessingError(phase._phase_id, trigger, ConfigError("endpoints required"))
     await phase.on_error(wrapped)
 
     checkpoint = checkpoint_mgr.read()[PHASE_ID]
@@ -792,7 +791,7 @@ def two_endpoint_run(flow_dir, message_queue, monkeypatch):
     phase, checkpoint_mgr = _make_phase(
         flow_dir,
         message_queue,
-        runtime_variables=_inspect_input_var(("agent", url_a), ("operator", url_b)),
+        runtime_variables=_endpoint_variables(("agent", url_a), ("operator", url_b)),
     )
     return phase, checkpoint_mgr, url_a, url_b
 
@@ -897,7 +896,7 @@ async def test_all_or_nothing_one_endpoint_fails_aborts_phase(flow_dir, message_
     phase, checkpoint_mgr = _make_phase(
         flow_dir,
         message_queue,
-        runtime_variables=_inspect_input_var(("agent", url_a), ("operator", url_b)),
+        runtime_variables=_endpoint_variables(("agent", url_a), ("operator", url_b)),
     )
 
     raised = await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="[operator]")
@@ -932,7 +931,7 @@ async def test_all_or_nothing_cleans_up_partial_write_of_failing_endpoint(flow_d
     phase, checkpoint_mgr = _make_phase(
         flow_dir,
         message_queue,
-        runtime_variables=_inspect_input_var(("agent", url_a), ("operator", url_b)),
+        runtime_variables=_endpoint_variables(("agent", url_a), ("operator", url_b)),
     )
 
     await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="endpoint(s) failed to inspect")
@@ -957,7 +956,7 @@ async def test_multiple_failures_are_all_reported(flow_dir, message_queue, monke
     phase, checkpoint_mgr = _make_phase(
         flow_dir,
         message_queue,
-        runtime_variables=_inspect_input_var(("agent", url_a), ("operator", url_b)),
+        runtime_variables=_endpoint_variables(("agent", url_a), ("operator", url_b)),
     )
 
     raised = await _assert_phase_fails(phase, checkpoint_mgr, message_queue, error_contains="2 endpoint(s) failed")
@@ -971,18 +970,18 @@ async def test_multiple_failures_are_all_reported(flow_dir, message_queue, monke
 @pytest.mark.parametrize(
     ("runtime_variables", "match"),
     [
-        pytest.param({}, "inspect_input", id="missing"),
-        pytest.param({"inspect_input": "not json"}, "invalid 'inspect_input'", id="malformed_json"),
-        pytest.param({"inspect_input": '{"endpoints": []}'}, "inspect_input", id="empty_endpoints"),
+        pytest.param({}, "endpoints", id="missing"),
+        pytest.param({"endpoints": "not a list"}, "invalid 'endpoints'", id="not_a_list"),
+        pytest.param({"endpoints": []}, "endpoints", id="empty_endpoints"),
         pytest.param(
-            _inspect_input_var(("App Controller", "http://h:1/m"), ("app-controller", "http://h:2/m")),
+            _endpoint_variables(("App Controller", "http://h:1/m"), ("app-controller", "http://h:2/m")),
             "duplicate endpoint names",
             id="duplicate_names",
         ),
-        pytest.param(_inspect_input_var(("main", "example.com/metrics")), "inspect_input", id="url_without_scheme"),
+        pytest.param(_endpoint_variables(("main", "example.com/metrics")), "endpoints", id="url_without_scheme"),
     ],
 )
-async def test_invalid_inspect_input_raises_config_error(flow_dir, message_queue, runtime_variables, match):
+async def test_invalid_endpoints_raise_config_error(flow_dir, message_queue, runtime_variables, match):
     phase, _checkpoint_mgr = _make_phase(flow_dir, message_queue, runtime_variables=runtime_variables)
     with pytest.raises(ConfigError, match=match):
         await phase.process_message(PhaseTrigger(id="start", phase_id=None))
@@ -992,7 +991,7 @@ async def test_endpoint_name_normalized_to_snake_case(flow_dir, message_queue, m
     url = "http://host:9962/metrics"
     _install_mock_transport(monkeypatch, _ok_handler(200, PROMETHEUS_BODY, "text/plain"))
     phase, checkpoint_mgr = _make_phase(
-        flow_dir, message_queue, runtime_variables=_inspect_input_var(("App Controller", url))
+        flow_dir, message_queue, runtime_variables=_endpoint_variables(("App Controller", url))
     )
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))

--- a/ddev/tests/ai/phases/test_template.py
+++ b/ddev/tests/ai/phases/test_template.py
@@ -93,6 +93,12 @@ def test_render_inline_supports_one_level_braced_object_field_access():
     assert result == "URL: https://example.test"
 
 
+@pytest.mark.parametrize("prompt", ["Tags: ${tags}", "Name: ${endpoints.name}"])
+def test_render_inline_rejects_multi_value_interpolation(prompt):
+    with pytest.raises(ValueError, match="List variable .* cannot be rendered"):
+        render_inline(prompt, {"tags": ["api", "worker"], "endpoints": [{"name": "api"}]})
+
+
 @pytest.mark.parametrize(
     ("prompt", "context", "message"),
     [

--- a/ddev/tests/cli/meta/ai/tui/test_launch_modal.py
+++ b/ddev/tests/cli/meta/ai/tui/test_launch_modal.py
@@ -11,6 +11,7 @@ from xml.etree import ElementTree
 import pytest
 from textual import events
 from textual.containers import Horizontal
+from textual.screen import Screen
 from textual.widgets import Button, Input, Static, Switch
 
 from ddev.ai.config.models import FlowInput, InputType
@@ -29,6 +30,12 @@ def object_flow_input(**overrides: object) -> FlowInput:
     }
     data.update(overrides)
     return FlowInput.model_validate(data)
+
+
+def button_labeled(screen: Screen, label: str) -> Button:
+    button = next((button for button in screen.query(Button) if str(button.label) == label), None)
+    assert button is not None, f"Button labeled {label!r} was not visible"
+    return button
 
 
 # ---------------------------------------------------------------------------
@@ -364,6 +371,200 @@ async def test_object_submission_dismisses_with_canonical_nested_payload(make_la
             },
             "prd": "Required product behavior.\n",
         }
+
+
+async def test_multi_scalar_entries_can_be_added_removed_and_submitted_in_order(
+    make_launch_modal_app,
+) -> None:
+    flow_input = FlowInput(name="tags", label="Tags", input_type=InputType.STRING, multi=True, required=False)
+    app = make_launch_modal_app([flow_input])
+
+    async with app.run_test(size=(160, 100)) as pilot:
+        await pilot.pause()
+        add_button = button_labeled(app.screen, "+ Add Tag")
+        add_button.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.focused, Input)
+        await pilot.press(*"first")
+        await pilot.press("tab")
+        assert isinstance(app.focused, Button)
+        assert str(app.focused.label) == "Remove"
+        await pilot.press("tab")
+        assert app.focused is add_button
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.focused, Input)
+        await pilot.press(*"second")
+
+        first_remove = button_labeled(app.screen, "Remove")
+        first_remove.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        button_labeled(app.screen, "Launch ▶").focus()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert app.dismiss_result == {"tags": ["second"], "prd": "Required product behavior.\n"}
+
+
+async def test_singular_collection_label_adds_and_submits_value(make_launch_modal_app) -> None:
+    flow_input = FlowInput(
+        name="series",
+        label="Series",
+        input_type=InputType.STRING,
+        multi=True,
+        required=False,
+    )
+    app = make_launch_modal_app([flow_input])
+
+    async with app.run_test(size=(160, 100)) as pilot:
+        await pilot.pause()
+        add_button = button_labeled(app.screen, "+ Add Series")
+        add_button.focus()
+        await pilot.press("enter")
+        await pilot.press(*"requests")
+        button_labeled(app.screen, "Launch ▶").focus()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert app.dismiss_result == {"series": ["requests"], "prd": "Required product behavior.\n"}
+
+
+async def test_required_multi_object_starts_with_a_usable_entry(make_launch_modal_app) -> None:
+    flow_input = object_flow_input(
+        name="endpoints",
+        label="Endpoints",
+        multi=True,
+        fields=[
+            {"name": "name", "label": "Name", "type": "string"},
+            {"name": "url", "label": "URL", "type": "string"},
+        ],
+    )
+    app = make_launch_modal_app([flow_input])
+
+    async with app.run_test(size=(160, 100)) as pilot:
+        await pilot.pause()
+        button_labeled(app.screen, "Remove").focus()
+        await pilot.press("tab")
+        await pilot.press(*"primary")
+        await pilot.press("tab")
+        await pilot.press(*"https://primary.test")
+        button_labeled(app.screen, "Launch ▶").focus()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert app.dismiss_result == {
+            "endpoints": [{"name": "primary", "url": "https://primary.test"}],
+            "prd": "Required product behavior.\n",
+        }
+
+
+async def test_multi_object_entries_can_be_added_removed_and_submitted_in_order(
+    make_launch_modal_app,
+) -> None:
+    flow_input = object_flow_input(
+        name="endpoints",
+        label="Endpoints",
+        multi=True,
+        required=False,
+        fields=[
+            {"name": "name", "label": "Name", "type": "string"},
+            {"name": "url", "label": "URL", "type": "string"},
+        ],
+    )
+    app = make_launch_modal_app([flow_input])
+
+    async with app.run_test(size=(160, 100)) as pilot:
+        await pilot.pause()
+        add_button = button_labeled(app.screen, "+ Add Endpoint")
+        add_button.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.focused, Input)
+        await pilot.press(*"first")
+        await pilot.press("tab")
+        assert isinstance(app.focused, Input)
+        await pilot.press(*"https://first.test")
+
+        add_button.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.focused, Input)
+        await pilot.press(*"second")
+        await pilot.press("tab")
+        assert isinstance(app.focused, Input)
+        await pilot.press(*"https://second.test")
+
+        first_remove = button_labeled(app.screen, "Remove")
+        first_remove.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        button_labeled(app.screen, "Launch ▶").focus()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert app.dismiss_result == {
+            "endpoints": [{"name": "second", "url": "https://second.test"}],
+            "prd": "Required product behavior.\n",
+        }
+
+
+async def test_multi_defaults_launch_as_ordered_runtime_values(make_launch_modal_app, large_terminal) -> None:
+    flow_input = FlowInput(
+        name="ports",
+        label="Ports",
+        input_type=InputType.NUMBER,
+        multi=True,
+        required=False,
+        default=[9090, 8080],
+    )
+    app = make_launch_modal_app([flow_input])
+
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert app.dismiss_result == {"ports": ["9090", "8080"], "prd": "Required product behavior.\n"}
+
+
+async def test_multi_defaults_are_restored_after_all_entries_are_removed(make_launch_modal_app, large_terminal) -> None:
+    flow_input = FlowInput(
+        name="ports",
+        label="Ports",
+        input_type=InputType.NUMBER,
+        multi=True,
+        required=False,
+        default=[9090, 8080],
+    )
+    app = make_launch_modal_app([flow_input])
+
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        for _ in range(2):
+            button_labeled(app.screen, "Remove").focus()
+            await pilot.press("enter")
+            await pilot.pause()
+        button_labeled(app.screen, "Launch ▶").focus()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert app.dismiss_result == {"ports": ["9090", "8080"], "prd": "Required product behavior.\n"}
+
+
+async def test_required_multi_input_blocks_launch_while_initial_entry_is_empty(
+    make_launch_modal_app, large_terminal
+) -> None:
+    app = make_launch_modal_app([FlowInput(name="tags", label="Tags", input_type=InputType.STRING, multi=True)])
+
+    async with app.run_test(size=large_terminal) as pilot:
+        await pilot.pause()
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert app.dismiss_result == "NOT_SET"
+        assert "cannot be empty" in str(app.screen.query_one("#launch-error", Static).render())
 
 
 async def test_missing_required_object_field_stays_inline(make_launch_modal_app, large_terminal) -> None:


### PR DESCRIPTION
### What does this PR do?
Add repeatable scalar and object flow inputs to Togo with ordered add/remove interactions and strict runtime validation. Migrate the OpenMetrics flow to collect and validate endpoint objects directly as an ordered list.

### Motivation
OpenMetrics generation needs to inspect multiple named endpoints in one launch while preserving typed values through the orchestrator.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged