### PR TITLE
[DBMON-6857] Fix query completions payload always reporting a null service

### DIFF
--- a/clickhouse/changelog.d/24632.fixed
+++ b/clickhouse/changelog.d/24632.fixed
@@ -1,0 +1,1 @@
+Fixes query completions payload always reporting a null service.

--- a/clickhouse/datadog_checks/clickhouse/query_completions.py
+++ b/clickhouse/datadog_checks/clickhouse/query_completions.py
@@ -336,7 +336,7 @@ class ClickhouseQueryCompletions(ClickhouseQueryLogJob):
             'ddtags': self._tags_no_db,
             'timestamp': time.time() * 1000,
             'clickhouse_version': self._check.dbms_version,
-            'service': getattr(self._check, 'service', None),
+            'service': getattr(self._check._config, 'service', None),
             'clickhouse_query_completions': query_completions,
         }
 

--- a/clickhouse/tests/test_query_completions.py
+++ b/clickhouse/tests/test_query_completions.py
@@ -214,6 +214,28 @@ def test_create_batched_payload_structure(check_with_dbm):
     assert payload['clickhouse_query_completions'][1]['query_details']['statement'] == 'INSERT INTO events VALUES (?)'
 
 
+@pytest.mark.parametrize('service', [None, 'test-clickhouse-service'])
+def test_create_batched_payload_service_field(check_with_dbm, service):
+    """The completions payload carries the configured service, or None when unset."""
+    check_with_dbm._config = check_with_dbm._config.model_copy(update={'service': service})
+
+    rows = [
+        {
+            'statement': 'SELECT * FROM users',
+            'query_signature': 'abc123',
+            'query_duration_ms': 100.0,
+            'databases': 'default',
+            'user': 'default',
+        },
+    ]
+
+    with mock.patch('datadog_checks.clickhouse.query_completions.datadog_agent') as mock_agent:
+        mock_agent.get_version.return_value = '7.64.0'
+        payload = check_with_dbm.query_completions._create_batched_payload(rows)
+
+    assert payload['service'] == service
+
+
 def test_rate_limiting(check_with_dbm):
     """Test that query sample rate limiting works correctly"""
     query_completions = check_with_dbm.query_completions


### PR DESCRIPTION
### What does this PR do?
Fixes the `service` field in the ClickHouse query completions DBM payload. It was read from `self._check` (which has no `service` attribute) instead of the instance config, so it always serialized as `null` regardless of the configured `service`. It now reads from `self._check._config.service`, matching the other ClickHouse DBM payload builders.

### Motivation
Discovered during review of the async insert flush log work: the new flush event
correctly read `service` from the config, which surfaced that the pre-existing
query completions payload used a different, broken accessor. The mismatch meant
query completion events never carried the user's configured service, degrading
service correlation in DBM.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged