### PR TITLE
Remove residual requests/RequestsWrapper coupling

### DIFF
--- a/argocd/assets/configuration/spec.yaml
+++ b/argocd/assets/configuration/spec.yaml
@@ -95,7 +95,7 @@ files:
         When set, the collector adds ``Authorization: Bearer <token>`` to
         each REST request. Leave unset to inherit the request authentication
         configured on the instance (for example, the structured ``auth_token``
-        config object handled by the HTTP wrapper).
+        config object handled by the HTTP client).
       secret: true
       value:
         display_default: null

--- a/argocd/datadog_checks/argocd/resources.py
+++ b/argocd/datadog_checks/argocd/resources.py
@@ -401,8 +401,8 @@ class ArgocdResourceCollector:
     def _fetch(self, api_path: str) -> list[dict]:
         url = self._endpoint.rstrip("/") + api_path
         # Pass a dedicated genresources token only when set, via extra_headers (merges with configured
-        # headers). Omit it otherwise: even an empty extra_headers makes RequestsWrapper snapshot the default
-        # headers before its auth_token handler writes the inherited token, which would drop that auth.
+        # headers). Omit it otherwise: even empty extra_headers forces a per-request header override before
+        # inherited auth headers are applied, which would drop that auth.
         kwargs: dict = {}
         headers = auth_headers(self._auth_token)
         if headers:

--- a/argocd/datadog_checks/argocd/stream_listener.py
+++ b/argocd/datadog_checks/argocd/stream_listener.py
@@ -17,9 +17,7 @@ from .resources_constants import (
 )
 
 if TYPE_CHECKING:
-    from requests import Response
-
-    from datadog_checks.base.utils.http import RequestsWrapper
+    from datadog_checks.base.utils.http_protocol import HTTPClient, HTTPResponse
 
     from .check import ArgocdCheck
     from .resources import ArgocdResourceCollector
@@ -53,7 +51,7 @@ class ArgocdApplicationStreamListener:
         auth_token: str | None,
         backoff_max_seconds: int,
         read_timeout_seconds: int,
-        http: "RequestsWrapper",
+        http: "HTTPClient",
     ) -> None:
         self.check = check
         self._collector = collector
@@ -65,7 +63,7 @@ class ArgocdApplicationStreamListener:
         self._stop = threading.Event()
         self._connected = threading.Event()
         self._thread: threading.Thread | None = None
-        self._response: Response | None = None
+        self._response: HTTPResponse | None = None
 
     def start(self) -> None:
         if self.is_alive():

--- a/argocd/datadog_checks/argocd/stream_listener.py
+++ b/argocd/datadog_checks/argocd/stream_listener.py
@@ -128,8 +128,8 @@ class ArgocdApplicationStreamListener:
             "timeout": (CONNECT_TIMEOUT_SECONDS, self._read_timeout),
         }
         # Pass a dedicated genresources token only when set, via extra_headers (merges with configured
-        # headers). Omit it otherwise: even an empty extra_headers makes RequestsWrapper snapshot the default
-        # headers before its auth_token handler writes the inherited token, which would drop that auth.
+        # headers). Omit it otherwise: even empty extra_headers forces a per-request header override before
+        # inherited auth headers are applied, which would drop that auth.
         headers = auth_headers(self._auth_token)
         if headers:
             kwargs["extra_headers"] = headers

--- a/argocd/tests/test_resources.py
+++ b/argocd/tests/test_resources.py
@@ -645,17 +645,17 @@ def test_fetch_adds_bearer_via_extra_headers_so_configured_auth_is_preserved():
         check._resource_collector._fetch("/api/v1/applications")
 
     kwargs = get.call_args.kwargs
-    assert kwargs.get("extra_headers") == {"Authorization": "Bearer tok"}  # merged into the wrapper's headers
-    assert "headers" not in kwargs  # never pass `headers`; it would shadow the wrapper's configured auth
+    assert kwargs.get("extra_headers") == {"Authorization": "Bearer tok"}  # merged into configured headers
+    assert "headers" not in kwargs  # never pass `headers`; it would shadow the HTTP client's configured auth
 
 
-def test_fetch_inherits_wrapper_auth_when_no_genresources_token():
+def test_fetch_inherits_http_client_auth_when_no_genresources_token():
     check = build_check(genresources_auth_token=None)  # rely on the instance's HTTP auth (headers / auth_token)
     with patch.object(RequestsWrapper, "get", return_value=MockResponse(json_data={"items": []})) as get:
         check._resource_collector._fetch("/api/v1/applications")
 
     kwargs = get.call_args.kwargs
-    assert "headers" not in kwargs  # must not clobber the wrapper's configured headers
+    assert "headers" not in kwargs  # must not clobber the HTTP client's configured headers
     assert (
         "extra_headers" not in kwargs
     )  # omit entirely -- even empty extra_headers would drop the inherited auth_token

--- a/argocd/tests/test_resources_stream.py
+++ b/argocd/tests/test_resources_stream.py
@@ -189,7 +189,7 @@ def test_ensure_listener_gives_the_listener_its_own_http_session():
 
     http = listener_cls.call_args.kwargs["http"]
     assert http is not None
-    assert http is not check.http  # a dedicated RequestsWrapper, not the check's shared session
+    assert http is not check.http  # a dedicated HTTP client, not the check's shared client
 
 
 def test_ensure_listener_passes_the_configured_read_timeout():
@@ -343,7 +343,7 @@ def test_stream_once_reports_data_received_even_when_the_connection_then_errors(
     assert got_data is True  # data arrived before the drop; _stream_once caught the error and reported it
 
 
-def test_stream_once_inherits_wrapper_auth_when_no_token():
+def test_stream_once_inherits_http_client_auth_when_no_token():
     check = build_check(genresources_stream_applications_enabled=True, genresources_auth_token=None)
     collector = check._resource_collector
 
@@ -372,7 +372,7 @@ def test_stream_once_inherits_wrapper_auth_when_no_token():
     listener._stream_once()
 
     kwargs = http.get.call_args.kwargs
-    assert "headers" not in kwargs  # must not clobber the wrapper's configured auth
+    assert "headers" not in kwargs  # must not clobber the HTTP client's configured auth
     assert (
         "extra_headers" not in kwargs
     )  # omit entirely -- even empty extra_headers would drop the inherited auth_token

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import yaml
-from requests.exceptions import RequestException
 
 from datadog_checks.base.checks import AgentCheck
 from datadog_checks.base.errors import ConfigurationError
@@ -93,8 +92,7 @@ class OpenMetricsBaseCheckV2(AgentCheck):
             with self.adopt_namespace(scraper.namespace):
                 try:
                     scraper.scrape()
-                # Pairs requests-native + library-agnostic exceptions; simplify to HTTPError after migration.
-                except (ConnectionError, RequestException, HTTPRequestError, HTTPStatusError) as e:
+                except (ConnectionError, HTTPRequestError, HTTPStatusError) as e:
                     self.log.error("There was an error scraping endpoint %s: %s", endpoint, str(e))
                     raise type(e)("There was an error scraping endpoint {}: {}".format(endpoint, e)) from None
 

--- a/dell_powerflex/datadog_checks/dell_powerflex/api.py
+++ b/dell_powerflex/datadog_checks/dell_powerflex/api.py
@@ -1,11 +1,15 @@
 # (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
 from time import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from datadog_checks.base.log import CheckLoggingAdapter
-from datadog_checks.base.utils.http import RequestsWrapper
+
+if TYPE_CHECKING:
+    from datadog_checks.base.utils.http_protocol import HTTPClient
 
 TOKEN_PATH = '/auth/realms/powerflex/protocol/openid-connect/token'
 
@@ -13,7 +17,7 @@ TOKEN_PATH = '/auth/realms/powerflex/protocol/openid-connect/token'
 class PowerFlexAPI:
     def __init__(
         self,
-        http: RequestsWrapper,
+        http: HTTPClient,
         gateway_url: str,
         logger: CheckLoggingAdapter,
         username: str | None = None,

--- a/fly_io/datadog_checks/fly_io/errors.py
+++ b/fly_io/datadog_checks/fly_io/errors.py
@@ -14,7 +14,7 @@ def handle_error(f):
             return result
         except (HTTPRequestError, HTTPStatusError) as e:
             check.log.debug(
-                "Encountered a RequestException in '%s' [%s]: %s",
+                "Encountered an HTTP error in '%s' [%s]: %s",
                 f.__name__,
                 type(e),
                 e,

--- a/fly_io/tests/test_unit.py
+++ b/fly_io/tests/test_unit.py
@@ -171,7 +171,7 @@ def test_http_error_exception(dd_run_check, instance, aggregator, caplog):
     dd_run_check(check)
 
     assert (
-        "Encountered a RequestException in '_collect_volumes_for_app'"
+        "Encountered an HTTP error in '_collect_volumes_for_app'"
         " [<class 'datadog_checks.base.utils.http_exceptions.HTTPStatusError'>]: "
         "404 Client Error" in caplog.text
     )
@@ -223,7 +223,7 @@ def test_external_host_tags(instance, datadog_agent, dd_run_check):
         pytest.param(
             {'http_error': {'/v1/apps/example-app-2': MockHTTPResponse(status_code=404)}},
             [
-                "RequestException in '_get_app_status'"
+                "Encountered an HTTP error in '_get_app_status'"
                 " [<class 'datadog_checks.base.utils.http_exceptions.HTTPStatusError'>]:"
                 " 404 Client Error"
             ],
@@ -237,10 +237,10 @@ def test_external_host_tags(instance, datadog_agent, dd_run_check):
                 }
             },
             [
-                "RequestException in '_get_app_status'"
+                "Encountered an HTTP error in '_get_app_status'"
                 " [<class 'datadog_checks.base.utils.http_exceptions.HTTPStatusError'>]:"
                 " 404 Client Error",
-                "RequestException in '_get_app_status'"
+                "Encountered an HTTP error in '_get_app_status'"
                 " [<class 'datadog_checks.base.utils.http_exceptions.HTTPStatusError'>]:"
                 " 500 Server Error",
             ],

--- a/hpe_aruba_edgeconnect/datadog_checks/hpe_aruba_edgeconnect/client.py
+++ b/hpe_aruba_edgeconnect/datadog_checks/hpe_aruba_edgeconnect/client.py
@@ -5,18 +5,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from requests import Response
-
-from datadog_checks.base.utils.http import RequestsWrapper
-
 if TYPE_CHECKING:
     from datadog_checks.base.log import CheckLoggingAdapter
+    from datadog_checks.base.utils.http_protocol import HTTPClient, HTTPResponse
 
 
 class _BaseClient:
     """Shared HTTP client with transparent 401 re-login."""
 
-    def __init__(self, http: RequestsWrapper, base_url: str) -> None:
+    def __init__(self, http: HTTPClient, base_url: str) -> None:
         self._http = http
         self._base_url = base_url
         self._creds: tuple[str, str] | None = None
@@ -28,7 +25,7 @@ class _BaseClient:
     def _do_login(self, username: str, password: str) -> None:
         raise NotImplementedError
 
-    def _request(self, method: str, path: str, *, raise_on_error: bool = True, **kwargs: Any) -> Response:
+    def _request(self, method: str, path: str, *, raise_on_error: bool = True, **kwargs: Any) -> HTTPResponse:
         """Issue an HTTP request, transparently re-logging in once on 401 (expired session)."""
         url = f'{self._base_url}{path}'
         send = getattr(self._http, method)
@@ -44,7 +41,7 @@ class _BaseClient:
 class OrchestratorClient(_BaseClient):
     """HTTP client for the HPE Aruba EdgeConnect orchestrator API."""
 
-    def __init__(self, http: RequestsWrapper, orch_ip: str) -> None:
+    def __init__(self, http: HTTPClient, orch_ip: str) -> None:
         super().__init__(http, f'https://{orch_ip}')
 
     def _do_login(self, username: str, password: str) -> None:
@@ -84,7 +81,7 @@ class OrchestratorClient(_BaseClient):
 class ApplianceClient(_BaseClient):
     """HTTP client for an individual EdgeConnect appliance."""
 
-    def __init__(self, http: RequestsWrapper, app_ip: str, logger: CheckLoggingAdapter) -> None:
+    def __init__(self, http: HTTPClient, app_ip: str, logger: CheckLoggingAdapter) -> None:
         super().__init__(http, f'https://{app_ip}')
         self._app_ip = app_ip
         self._log = logger

--- a/http_check/datadog_checks/http_check/config.py
+++ b/http_check/datadog_checks/http_check/config.py
@@ -29,12 +29,36 @@ class CaseInsensitiveDict(dict):
             raise KeyError(key)
         return super().__getitem__(existing_key)
 
+    def __delitem__(self, key):
+        existing_key = self.matching_key(key)
+        if existing_key is None:
+            raise KeyError(key)
+        super().__delitem__(existing_key)
+
     def __contains__(self, key):
         return self.matching_key(key) is not None
 
     def get(self, key, default=None):
         existing_key = self.matching_key(key)
         return super().get(existing_key, default) if existing_key is not None else default
+
+    def pop(self, key, *args):
+        existing_key = self.matching_key(key)
+        if existing_key is None:
+            if args:
+                return args[0]
+            raise KeyError(key)
+        return super().pop(existing_key)
+
+    def setdefault(self, key, default=None):
+        existing_key = self.matching_key(key)
+        if existing_key is not None:
+            return super().__getitem__(existing_key)
+        self[key] = default
+        return default
+
+    def copy(self):
+        return CaseInsensitiveDict(self)
 
     def update(self, data=(), **kwargs):
         for key, value in dict(data, **kwargs).items():
@@ -53,12 +77,6 @@ class CaseInsensitiveDict(dict):
                 key.lower(): value for key, value in other.items()
             }
         return NotImplemented
-
-    def __ne__(self, other):
-        result = self.__eq__(other)
-        if result is NotImplemented:
-            return result
-        return not result
 
 
 Config = namedtuple(

--- a/http_check/datadog_checks/http_check/config.py
+++ b/http_check/datadog_checks/http_check/config.py
@@ -3,12 +3,62 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from collections import namedtuple
 
-from requests.structures import CaseInsensitiveDict
-
 from datadog_checks.base import ConfigurationError, ensure_unicode, is_affirmative
 from datadog_checks.base.utils.headers import headers as agent_headers
 
 DEFAULT_EXPECTED_CODE = r'(1|2|3)\d\d'
+
+
+class CaseInsensitiveDict(dict):
+    """Dict that merges header names case-insensitively, keeping the most recently set casing."""
+
+    def __init__(self, data=None):
+        super().__init__()
+        if data:
+            self.update(data)
+
+    def __setitem__(self, key, value):
+        existing_key = self.matching_key(key)
+        if existing_key is not None and existing_key != key:
+            super().__delitem__(existing_key)
+        super().__setitem__(key, value)
+
+    def __getitem__(self, key):
+        existing_key = self.matching_key(key)
+        if existing_key is None:
+            raise KeyError(key)
+        return super().__getitem__(existing_key)
+
+    def __contains__(self, key):
+        return self.matching_key(key) is not None
+
+    def get(self, key, default=None):
+        existing_key = self.matching_key(key)
+        return super().get(existing_key, default) if existing_key is not None else default
+
+    def update(self, data=(), **kwargs):
+        for key, value in dict(data, **kwargs).items():
+            self[key] = value
+
+    def matching_key(self, key):
+        lowered = key.lower()
+        for existing in self:
+            if existing.lower() == lowered:
+                return existing
+        return None
+
+    def __eq__(self, other):
+        if isinstance(other, dict):
+            return {key.lower(): value for key, value in self.items()} == {
+                key.lower(): value for key, value in other.items()
+            }
+        return NotImplemented
+
+    def __ne__(self, other):
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return result
+        return not result
 
 
 Config = namedtuple(

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -12,11 +12,11 @@ from urllib.parse import urlparse
 
 import socks
 from cryptography import x509
-from datadog_checks.base.utils.http_protocol import HTTPResponse  # noqa: F401
 
 from datadog_checks.base import AgentCheck, ensure_unicode, is_affirmative
 from datadog_checks.base.utils.http import should_bypass_proxy
 from datadog_checks.base.utils.http_exceptions import HTTPConnectionError, HTTPTimeoutError
+from datadog_checks.base.utils.http_protocol import HTTPResponse  # noqa: F401
 
 from .config import DEFAULT_EXPECTED_CODE, from_instance
 from .utils import get_ca_certs_path, parse_proxy_url

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 
 import socks
 from cryptography import x509
-from requests import Response  # noqa: F401
+from datadog_checks.base.utils.http_protocol import HTTPResponse  # noqa: F401
 
 from datadog_checks.base import AgentCheck, ensure_unicode, is_affirmative
 from datadog_checks.base.utils.http import should_bypass_proxy
@@ -110,7 +110,7 @@ class HTTPCheck(AgentCheck):
         tags_list.append("instance:{}".format(instance_name))
         service_checks = []
         service_checks_tags = self._get_service_checks_tags(instance)
-        r = None  # type: Response
+        r = None  # type: HTTPResponse
         peer_cert = None  # type: bytes | None
         try:
             parsed_uri = urlparse(addr)

--- a/http_check/tests/test_unit_config.py
+++ b/http_check/tests/test_unit_config.py
@@ -5,7 +5,7 @@ import pytest
 
 from datadog_checks.base import ConfigurationError
 from datadog_checks.base.utils.headers import headers as agent_headers
-from datadog_checks.http_check.config import DEFAULT_EXPECTED_CODE, from_instance
+from datadog_checks.http_check.config import DEFAULT_EXPECTED_CODE, CaseInsensitiveDict, from_instance
 
 
 def test_from_instance():
@@ -68,6 +68,71 @@ def test_from_instance_header_override_is_case_insensitive():
     headers = config.headers
     assert headers.get('User-Agent') == 'Custom-UA'
     assert len(headers) == len(agent_headers({}))
+
+
+def test_case_insensitive_dict_setdefault_matches_existing_key_regardless_of_case():
+    headers = CaseInsensitiveDict({'User-Agent': 'Original'})
+
+    result = headers.setdefault('user-agent', 'Fallback')
+
+    assert result == 'Original'
+    assert len(headers) == 1
+
+
+def test_case_insensitive_dict_setdefault_inserts_when_key_absent():
+    headers = CaseInsensitiveDict()
+
+    result = headers.setdefault('user-agent', 'Fallback')
+
+    assert result == 'Fallback'
+    assert headers['User-Agent'] == 'Fallback'
+
+
+def test_case_insensitive_dict_delitem_matches_existing_key_regardless_of_case():
+    headers = CaseInsensitiveDict({'User-Agent': 'Original'})
+
+    del headers['USER-AGENT']
+
+    assert 'user-agent' not in headers
+    assert len(headers) == 0
+
+
+def test_case_insensitive_dict_delitem_raises_key_error_when_absent():
+    headers = CaseInsensitiveDict()
+
+    with pytest.raises(KeyError):
+        del headers['user-agent']
+
+
+def test_case_insensitive_dict_pop_matches_existing_key_regardless_of_case():
+    headers = CaseInsensitiveDict({'User-Agent': 'Original'})
+
+    value = headers.pop('user-agent')
+
+    assert value == 'Original'
+    assert len(headers) == 0
+
+
+def test_case_insensitive_dict_pop_returns_default_when_absent():
+    headers = CaseInsensitiveDict()
+
+    assert headers.pop('user-agent', 'Fallback') == 'Fallback'
+
+
+def test_case_insensitive_dict_pop_raises_key_error_when_absent_without_default():
+    headers = CaseInsensitiveDict()
+
+    with pytest.raises(KeyError):
+        headers.pop('user-agent')
+
+
+def test_case_insensitive_dict_copy_preserves_case_insensitivity():
+    headers = CaseInsensitiveDict({'User-Agent': 'Original'})
+
+    copied = headers.copy()
+
+    assert isinstance(copied, CaseInsensitiveDict)
+    assert copied.get('user-agent') == 'Original'
 
 
 def test_instance_ca_cert():

--- a/http_check/tests/test_unit_config.py
+++ b/http_check/tests/test_unit_config.py
@@ -58,6 +58,18 @@ def test_from_instance():
     assert expected_headers == headers.get('User-Agent'), headers
 
 
+def test_from_instance_header_override_is_case_insensitive():
+    """
+    A user-supplied header should override the matching default header regardless of case,
+    instead of being sent alongside it as a duplicate.
+    """
+    config = from_instance({'url': 'https://example.com', 'name': 'UpService', 'headers': {'user-agent': 'Custom-UA'}})
+
+    headers = config.headers
+    assert headers.get('User-Agent') == 'Custom-UA'
+    assert len(headers) == len(agent_headers({}))
+
+
 def test_instance_ca_cert():
     """
     `instance_ca_cert` should default to the trusted ca_cert of the system

--- a/marklogic/datadog_checks/marklogic/api.py
+++ b/marklogic/datadog_checks/marklogic/api.py
@@ -3,14 +3,14 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from typing import Any, Dict  # noqa: F401
 
-from datadog_checks.base.utils.http import RequestsWrapper  # noqa: F401
+from datadog_checks.base.utils.http_protocol import HTTPClient  # noqa: F401
 
 from .constants import BASE_ENDPOINT
 
 
 class MarkLogicApi(object):
     def __init__(self, http, api_url):
-        # type: (RequestsWrapper, str) -> None
+        # type: (HTTPClient, str) -> None
         self._http = http
 
         # Remove a possible trailing '/', added by BASE_ENDPOINT

--- a/prefect/datadog_checks/prefect/check.py
+++ b/prefect/datadog_checks/prefect/check.py
@@ -24,7 +24,7 @@ from .metrics import METRICS_SPEC
 
 if TYPE_CHECKING:
     from datadog_checks.base.log import CheckLoggingAdapter
-    from datadog_checks.base.utils.http import RequestsWrapper
+    from datadog_checks.base.utils.http_protocol import HTTPClient
 
 
 class PrefectCheck(AgentCheck, ConfigMixin):
@@ -669,7 +669,7 @@ class PrefectCheck(AgentCheck, ConfigMixin):
 class PrefectClient:
     """HTTP client wrapping GET/POST requests and pagination for the Prefect API."""
 
-    def __init__(self, url: str, http: RequestsWrapper, log: CheckLoggingAdapter):
+    def __init__(self, url: str, http: HTTPClient, log: CheckLoggingAdapter):
         self.http_exceptions = (
             HTTPStatusError,
             HTTPInvalidURLError,


### PR DESCRIPTION
### What does this PR do?
Removes the last direct imports of `requests`/`RequestsWrapper` from production code across 6 integrations and one shared OpenMetrics v2 base path, replacing them with backend-agnostic HTTP protocols/exceptions from `datadog_checks.base`.

- **http_check** (behavioral): drops `requests.structures.CaseInsensitiveDict` in favor of a small integration-local `CaseInsensitiveDict`, preserving the existing case-insensitive header-merge behavior with no new dependency. Also repoints a `requests.Response` type comment.
- **argocd, dell_powerflex, hpe_aruba_edgeconnect, marklogic, prefect** (mechanical): repoint `RequestsWrapper`/`requests.Response` type-only references to `HTTPClient`/`HTTPResponse`. No runtime behavior change, the object handed to these constructors today is still a `RequestsWrapper` instance, only the declared type changes.
- **datadog_checks_base OpenMetrics v2**: drops the remaining `requests.exceptions.RequestException` import/catch from `OpenMetricsBaseCheckV2`. Scraper HTTP failures are already surfaced through the agnostic `HTTPRequestError`/`HTTPStatusError` path, so the base check no longer needs to name a requests-native exception.

### Motivation
Continues agnosticizing integrations and shared OpenMetrics infrastructure onto the backend-neutral HTTP protocol ahead of the httpx migration cutover, so these paths no longer depend on `requests` types directly.

### Verification
- Added characterization coverage for http_check's case-insensitive header override behavior.
- Added unit coverage for `CaseInsensitiveDict.pop`, `setdefault`, `__delitem__`, and `copy()`.
- `ddev --no-interactive test --lint` passed for argocd, dell_powerflex, hpe_aruba_edgeconnect, http_check, marklogic, prefect, and datadog_checks_base.
- `ddev --no-interactive test` passed for argocd, dell_powerflex, hpe_aruba_edgeconnect, and prefect.
- `ddev --no-interactive test http_check -- tests/test_unit.py tests/test_unit_config.py tests/test_unit_utils.py` passed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
