### PR TITLE
Use Docker labels for discovery container lookup

### DIFF
--- a/datadog_checks_dev/changelog.d/24638.fixed
+++ b/datadog_checks_dev/changelog.d/24638.fixed
@@ -1,0 +1,1 @@
+Use Docker Compose labels to find containers during discovery stability tests without reparsing Compose files.

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -114,13 +114,23 @@ def assert_all_discovery_candidates_stable(
 def _get_compose_container_id(
     compose_file: str | os.PathLike[str] | None, compose_service: str, *, project_name: str | None = None
 ) -> str:
-    compose_file = compose_file or _get_default_compose_file()
     project_name = project_name or _get_default_compose_project_name()
 
-    command = ['docker', 'compose']
     if project_name:
-        command.extend(['-p', project_name])
-    command.extend(['-f', os.fspath(compose_file), 'ps', '-q', compose_service])
+        command = [
+            'docker',
+            'ps',
+            '--quiet',
+            '--filter',
+            f'label=com.docker.compose.project={project_name}',
+            '--filter',
+            f'label=com.docker.compose.service={compose_service}',
+            '--filter',
+            'label=com.docker.compose.oneoff=False',
+        ]
+    else:
+        compose_file = compose_file or _get_default_compose_file()
+        command = ['docker', 'compose', '-f', os.fspath(compose_file), 'ps', '-q', compose_service]
 
     container_id = run_command(command, capture='out', check=True).stdout.strip()
     if not container_id:

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -115,22 +115,24 @@ def _get_compose_container_id(
     compose_file: str | os.PathLike[str] | None, compose_service: str, *, project_name: str | None = None
 ) -> str:
     project_name = project_name or _get_default_compose_project_name()
+    if not project_name:
+        raise AssertionError(
+            'Could not determine the Compose project name. '
+            'Pass project_name explicitly or use docker_run with a Compose file.'
+        )
 
-    if project_name:
-        command = [
-            'docker',
-            'ps',
-            '--quiet',
-            '--filter',
-            f'label=com.docker.compose.project={project_name}',
-            '--filter',
-            f'label=com.docker.compose.service={compose_service}',
-            '--filter',
-            'label=com.docker.compose.oneoff=False',
-        ]
-    else:
-        compose_file = compose_file or _get_default_compose_file()
-        command = ['docker', 'compose', '-f', os.fspath(compose_file), 'ps', '-q', compose_service]
+    command = [
+        'docker',
+        'ps',
+        '--quiet',
+        '--filter',
+        f'label=com.docker.compose.project={project_name}',
+        '--filter',
+        f'label=com.docker.compose.service={compose_service}',
+        '--filter',
+        # Exclude temporary containers created by `docker compose run` for the same project and service.
+        'label=com.docker.compose.oneoff=False',
+    ]
 
     container_id = run_command(command, capture='out', check=True).stdout.strip()
     if not container_id:
@@ -145,20 +147,6 @@ def _get_default_compose_service() -> str:
         return docker_metadata['service_name']
 
     return os.path.basename(find_check_root(depth=2))
-
-
-def _get_default_compose_file() -> str:
-    docker_metadata = get_state('docker_compose_metadata', {})
-    if docker_metadata.get('compose_file'):
-        return docker_metadata['compose_file']
-
-    compose_file = os.path.join(find_check_root(depth=3), 'tests', 'docker', 'docker-compose.yml')
-    if os.path.exists(compose_file):
-        return compose_file
-
-    raise AssertionError(
-        'Could not determine the compose file. Pass compose_file explicitly or use docker_run with a compose file.'
-    )
 
 
 def _get_default_compose_project_name() -> str | None:

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -14,6 +14,7 @@ from datadog_checks.dev._env import get_state, serialize_data
 from datadog_checks.dev.ci import running_on_ci
 from datadog_checks.dev.docker import (
     ComposeFileUp,
+    _get_compose_container_id,
     assert_all_discovery_candidates_stable,
     compose_file_active,
     docker_run,
@@ -196,7 +197,7 @@ def test_assert_all_discovery_candidates_stable_generates_and_runs_candidates():
     )
 
     def fake_run_command(command, **kwargs):
-        if command[:2] == ['docker', 'compose']:
+        if command[:2] == ['docker', 'ps']:
             return _docker_result(stdout='container-id\n')
         if command[:2] == ['docker', 'inspect']:
             return _docker_result(stdout=json.dumps([inspect_data]))
@@ -237,7 +238,7 @@ def test_assert_all_discovery_candidates_stable_uses_docker_run_metadata():
 
     def fake_run_command(command, **kwargs):
         commands.append(command)
-        if command[:2] == ['docker', 'compose']:
+        if command[:2] == ['docker', 'ps']:
             return _docker_result(stdout='container-id\n')
         if command[:2] == ['docker', 'inspect']:
             return _docker_result(stdout=json.dumps([_container_inspect(ports=('8080/tcp',))]))
@@ -251,8 +252,33 @@ def test_assert_all_discovery_candidates_stable_uses_docker_run_metadata():
         with mock.patch('datadog_checks.dev.docker.run_command', side_effect=fake_run_command):
             assert_all_discovery_candidates_stable(mock.Mock(), DiscoveryCheck)
 
-    assert commands[0] == ['docker', 'compose', '-p', 'project', '-f', '/tmp/docker-compose.yml', 'ps', '-q', 'service']
+    assert commands[0] == [
+        'docker',
+        'ps',
+        '--quiet',
+        '--filter',
+        'label=com.docker.compose.project=project',
+        '--filter',
+        'label=com.docker.compose.service=service',
+        '--filter',
+        'label=com.docker.compose.oneoff=False',
+    ]
     assert DiscoveryCheck.service.id == 'service'
+
+
+def test_get_compose_container_id_falls_back_to_compose_file_without_project_metadata():
+    with mock.patch('datadog_checks.dev.docker.get_state', return_value={}):
+        with mock.patch(
+            'datadog_checks.dev.docker.run_command', return_value=_docker_result(stdout='container-id\n')
+        ) as run:
+            container_id = _get_compose_container_id('/tmp/docker-compose.yml', 'service')
+
+    assert container_id == 'container-id'
+    run.assert_called_once_with(
+        ['docker', 'compose', '-f', '/tmp/docker-compose.yml', 'ps', '-q', 'service'],
+        capture='out',
+        check=True,
+    )
 
 
 def test_docker_run_saves_compose_metadata(monkeypatch):
@@ -353,7 +379,7 @@ def test_assert_all_discovery_candidates_stable_reports_incremental_logs(caplog)
     )
 
     def fake_run_command(command, **kwargs):
-        if command[:2] == ['docker', 'compose']:
+        if command[:2] == ['docker', 'ps']:
             return _docker_result(stdout='container-id\n')
         if command[:2] == ['docker', 'inspect']:
             return _docker_result(stdout=json.dumps([_container_inspect()]))
@@ -368,6 +394,7 @@ def test_assert_all_discovery_candidates_stable_reports_incremental_logs(caplog)
                 DiscoveryCheck,
                 '/tmp/docker-compose.yml',
                 'service',
+                project_name='project',
             )
 
     assert [record.message for record in caplog.records if record.message.startswith('New log line:')] == [
@@ -390,7 +417,7 @@ def test_assert_all_discovery_candidates_stable_detects_restarts():
     )
 
     def fake_run_command(command, **kwargs):
-        if command[:2] == ['docker', 'compose']:
+        if command[:2] == ['docker', 'ps']:
             return _docker_result(stdout='container-id\n')
         if command[:2] == ['docker', 'inspect']:
             return _docker_result(stdout=json.dumps([next(inspect_results)]))
@@ -405,6 +432,7 @@ def test_assert_all_discovery_candidates_stable_detects_restarts():
                 DiscoveryCheck,
                 '/tmp/docker-compose.yml',
                 'service',
+                project_name='project',
             )
 
 
@@ -422,7 +450,7 @@ def test_assert_all_discovery_candidates_stable_detects_new_crash_logs():
     )
 
     def fake_run_command(command, **kwargs):
-        if command[:2] == ['docker', 'compose']:
+        if command[:2] == ['docker', 'ps']:
             return _docker_result(stdout='container-id\n')
         if command[:2] == ['docker', 'inspect']:
             return _docker_result(stdout=json.dumps([_container_inspect()]))
@@ -437,6 +465,7 @@ def test_assert_all_discovery_candidates_stable_detects_new_crash_logs():
                 DiscoveryCheck,
                 '/tmp/docker-compose.yml',
                 'service',
+                project_name='project',
             )
 
 
@@ -455,7 +484,7 @@ def test_assert_all_discovery_candidates_stable_ignores_old_stderr_when_new_stdo
     )
 
     def fake_run_command(command, **kwargs):
-        if command[:2] == ['docker', 'compose']:
+        if command[:2] == ['docker', 'ps']:
             return _docker_result(stdout='container-id\n')
         if command[:2] == ['docker', 'inspect']:
             return _docker_result(stdout=json.dumps([_container_inspect()]))
@@ -469,4 +498,5 @@ def test_assert_all_discovery_candidates_stable_ignores_old_stderr_when_new_stdo
             DiscoveryCheck,
             '/tmp/docker-compose.yml',
             'service',
+            project_name='project',
         )

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -252,17 +252,8 @@ def test_assert_all_discovery_candidates_stable_uses_docker_run_metadata():
         with mock.patch('datadog_checks.dev.docker.run_command', side_effect=fake_run_command):
             assert_all_discovery_candidates_stable(mock.Mock(), DiscoveryCheck)
 
-    assert commands[0] == [
-        'docker',
-        'ps',
-        '--quiet',
-        '--filter',
-        'label=com.docker.compose.project=project',
-        '--filter',
-        'label=com.docker.compose.service=service',
-        '--filter',
-        'label=com.docker.compose.oneoff=False',
-    ]
+    assert 'label=com.docker.compose.project=project' in commands[0]
+    assert 'label=com.docker.compose.service=service' in commands[0]
     assert DiscoveryCheck.service.id == 'service'
 
 

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -252,6 +252,7 @@ def test_assert_all_discovery_candidates_stable_uses_docker_run_metadata():
         with mock.patch('datadog_checks.dev.docker.run_command', side_effect=fake_run_command):
             assert_all_discovery_candidates_stable(mock.Mock(), DiscoveryCheck)
 
+    assert commands[0][:2] == ['docker', 'ps']
     assert 'label=com.docker.compose.project=project' in commands[0]
     assert 'label=com.docker.compose.service=service' in commands[0]
     assert DiscoveryCheck.service.id == 'service'

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -266,19 +266,13 @@ def test_assert_all_discovery_candidates_stable_uses_docker_run_metadata():
     assert DiscoveryCheck.service.id == 'service'
 
 
-def test_get_compose_container_id_falls_back_to_compose_file_without_project_metadata():
+def test_get_compose_container_id_requires_project_metadata():
     with mock.patch('datadog_checks.dev.docker.get_state', return_value={}):
-        with mock.patch(
-            'datadog_checks.dev.docker.run_command', return_value=_docker_result(stdout='container-id\n')
-        ) as run:
-            container_id = _get_compose_container_id('/tmp/docker-compose.yml', 'service')
+        with mock.patch('datadog_checks.dev.docker.run_command') as run:
+            with pytest.raises(AssertionError, match='Could not determine the Compose project name'):
+                _get_compose_container_id('/tmp/docker-compose.yml', 'service')
 
-    assert container_id == 'container-id'
-    run.assert_called_once_with(
-        ['docker', 'compose', '-f', '/tmp/docker-compose.yml', 'ps', '-q', 'service'],
-        capture='out',
-        check=True,
-    )
+    run.assert_not_called()
 
 
 def test_docker_run_saves_compose_metadata(monkeypatch):


### PR DESCRIPTION
### What does this PR do?

Changes `assert_all_discovery_candidates_stable` to find the target container through Docker's Compose project and service labels. This replaces the previous `docker compose ps` lookup with `docker ps` and requires the Compose project metadata saved by `docker_run`.

### Motivation

Docker Compose starts a group of containers from a YAML file. After a service has started, our discovery stability test needs to find its container so it can inspect its health and logs.

Previously, the test used `docker compose ps` to find the container. Even though the container was already running, that command reread the Compose file and tried to resolve all of its environment variables. Some of those variables may only be available when the environment starts, so the later lookup could fail even when the container was healthy.

For example, a Compose file might contain:

```yaml
services:
  database:
    image: ${DATABASE_IMAGE:?DATABASE_IMAGE is required}
```

The environment can be started successfully with:

```shell
DATABASE_IMAGE=postgres:17 docker compose up -d
```

If `DATABASE_IMAGE` is no longer set when the stability test runs, `docker compose ps -q database` fails while rereading the file, despite the database container still running.

Docker Compose already labels every running container with its project and service names. The new lookup asks Docker directly for the container carrying those labels:

```shell
docker ps \
  --filter label=com.docker.compose.project=my-project \
  --filter label=com.docker.compose.service=database
```

This finds the existing container without reopening the Compose file or depending on the original startup environment. It also excludes temporary containers created by `docker compose run`.

**Validation**

- The discovery-candidate E2E test passed in PR CI for all 15 current callers.
- Four in-flight discovery PRs (GitLab #24324, Fluentd #24479, Gearmand #24487, and Boundary #24494) use a temporary workaround. To verify that this PR can replace the workaround, I applied only each integration's changes on top of this branch, leaving out the workaround. 
- Ran a one-time Docker contract test with two projects containing the same service plus a `docker compose run` one-off container. After removing a required Compose interpolation variable, `docker compose ps` failed while label lookup selected exactly the normal container from each project and excluded the one-off container.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

