### PR TITLE
[AI-7050] Add ExecutionStatus to Togo TUI header

### DIFF
--- a/ddev/src/ddev/cli/meta/ai/tui/app.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/app.py
@@ -15,6 +15,7 @@ from textual.app import App
 from textual.binding import Binding
 from textual.message import Message
 from textual.message_pump import MessagePump
+from textual.reactive import reactive
 
 from ddev.ai.agent.registry import AgentProviderRegistry
 from ddev.ai.phases.registry import PhaseRegistry
@@ -36,6 +37,7 @@ from ddev.cli.meta.ai.tui.messages import (
     PhaseStarted,
     RunErrored,
 )
+from ddev.cli.meta.ai.tui.status import ExecutionStatus
 from ddev.cli.meta.ai.tui.theme import togo_markdown_theme, togo_theme
 
 if TYPE_CHECKING:
@@ -58,6 +60,7 @@ class TogoApp(App):
     Registers and activates the ``togo`` theme on mount.  Exposes:
 
     - ``engine``: the configuration engine whose validated flow results are displayed.
+    - ``execution_status``: the app-wide reactive lifecycle of the active flow.
     - ``bridge_target``: the MessagePump that bridge callbacks post to.
       Defaults to the app itself; later phases can swap in a screen.
     - ``run_flow(orchestrator)``: async worker that awaits
@@ -68,6 +71,8 @@ class TogoApp(App):
 
     CSS_PATH = str(Path(__file__).parent / "togo.tcss")
     ENABLE_COMMAND_PALETTE = False
+
+    execution_status: reactive[ExecutionStatus] = reactive(ExecutionStatus.IDLE)
 
     BINDINGS = [
         Binding("ctrl+q", "quit", "Quit"),

--- a/ddev/src/ddev/cli/meta/ai/tui/messages.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/messages.py
@@ -41,6 +41,10 @@ class PhaseErrored(Message):
         self.error = error
 
 
+class ExecutionSucceeded(Message):
+    """Fired when orchestration exits successfully."""
+
+
 class RunErrored(Message):
     """Fired when orchestration stops because a phase failed."""
 

--- a/ddev/src/ddev/cli/meta/ai/tui/messages.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/messages.py
@@ -41,10 +41,6 @@ class PhaseErrored(Message):
         self.error = error
 
 
-class ExecutionSucceeded(Message):
-    """Fired when orchestration exits successfully."""
-
-
 class RunErrored(Message):
     """Fired when orchestration stops because a phase failed."""
 

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -50,7 +50,6 @@ from ddev.cli.meta.ai.tui.messages import (
     BeforeGoalCheck,
     ContextCleared,
     ExecutionFailed,
-    ExecutionSucceeded,
     PhaseErrored,
     PhaseFinished,
     PhaseStarted,
@@ -188,7 +187,7 @@ class ExecutionScreen(TogoScreen):
                 orchestrator = self._build_real_orchestrator(callbacks)
             self._orchestrator = orchestrator
             await orchestrator.run_async()
-            self.post_message(ExecutionSucceeded())
+            self.togo_app.execution_status = ExecutionStatus.COMPLETED
         except asyncio.CancelledError:
             if self.togo_app.bridge_target is self:
                 self.togo_app.execution_status = ExecutionStatus.IDLE
@@ -348,9 +347,6 @@ class ExecutionScreen(TogoScreen):
             status is RunStatus.DONE for status in self._phase_statuses.values()
         ):
             self.togo_app.execution_status = ExecutionStatus.FINISHING
-
-    def on_execution_succeeded(self, msg: ExecutionSucceeded) -> None:
-        self.togo_app.execution_status = ExecutionStatus.COMPLETED
 
     def on_phase_errored(self, msg: PhaseErrored) -> None:
         self._phase_errors[msg.phase_id] = msg.error

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import shutil
 from collections.abc import Callable, Iterator
 from pathlib import Path
@@ -12,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from textual import events, work
 from textual.binding import Binding
+from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Static
 from textual.worker import Worker
@@ -48,6 +50,7 @@ from ddev.cli.meta.ai.tui.messages import (
     BeforeGoalCheck,
     ContextCleared,
     ExecutionFailed,
+    ExecutionSucceeded,
     PhaseErrored,
     PhaseFinished,
     PhaseStarted,
@@ -58,8 +61,7 @@ from ddev.cli.meta.ai.tui.screens.base import TogoScreen
 from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
 from ddev.cli.meta.ai.tui.screens.phase_error_modal import PhaseErrorModal
 from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogEntry, PhaseLogScreen
-from ddev.cli.meta.ai.tui.status import RunStatus
-from ddev.cli.meta.ai.tui.widgets.header import TogoHeader
+from ddev.cli.meta.ai.tui.status import ExecutionStatus, RunStatus
 from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseSelected, PipelineGraph
 
 if TYPE_CHECKING:
@@ -107,7 +109,6 @@ class ExecutionScreen(TogoScreen):
         self._orchestrator: OrchestratorLike | None = None
         self._run_worker: Worker[None] | None = None
         self._phase_errors: dict[str, BaseException] = {}
-        self._run_active = False
         # Records every renderable produced by the run — used by tests and to
         # populate phase log screens opened after the fact.
         self._output_renders: list[PhaseLogEntry] = []
@@ -131,27 +132,32 @@ class ExecutionScreen(TogoScreen):
                     if task_phase == phase_id:
                         self._task_statuses[(task_phase, task_name)] = RunStatus.DONE
         self._update_display()
-        self._run_active = True
+        self.togo_app.execution_status = ExecutionStatus.RUNNING
+        self._transition_to_finishing_if_phases_done()
         self._run_worker = self._run_orchestrator()
 
     def on_unmount(self) -> None:
-        if self._run_worker is not None:
-            self._run_worker.cancel()
+        self._cancel_run_worker()
         if self.togo_app.bridge_target is self:
+            self.togo_app.execution_status = ExecutionStatus.IDLE
             self.togo_app.bridge_target = self.togo_app
 
     def action_cancel_run(self) -> None:
         """Cancel the running orchestrator worker."""
-        self._run_active = False
+        self._cancel_run_worker()
+
+    def _cancel_run_worker(self) -> None:
         if self._run_worker is not None:
             self._run_worker.cancel()
+        if self.togo_app.bridge_target is self and self.togo_app.execution_status.is_active:
+            self.togo_app.execution_status = ExecutionStatus.IDLE
 
     def action_copy_or_cancel_run(self) -> None:
         if not self.copy_selection():
             self.action_cancel_run()
 
     def action_back(self) -> None:
-        if not self._run_active:
+        if not self.togo_app.execution_status.is_active:
             self.app.pop_screen()
             return
         from ddev.cli.meta.ai.tui.screens.cancel_run_modal import CancelRunModal
@@ -181,17 +187,15 @@ class ExecutionScreen(TogoScreen):
             else:
                 orchestrator = self._build_real_orchestrator(callbacks)
             self._orchestrator = orchestrator
-            self.query_one(TogoHeader).running = True
             await orchestrator.run_async()
+            self.post_message(ExecutionSucceeded())
+        except asyncio.CancelledError:
+            if self.togo_app.bridge_target is self:
+                self.togo_app.execution_status = ExecutionStatus.IDLE
+            raise
         except Exception as error:
             if orchestrator is None or orchestrator.failed_phase is None:
                 self.post_message(ExecutionFailed(error))
-        finally:
-            self._run_active = False
-            try:
-                self.query_one(TogoHeader).running = False
-            except Exception:
-                pass
 
     def _build_real_orchestrator(self, callbacks: Callbacks) -> PhaseOrchestrator:
         """Construct the real PhaseOrchestrator for production use."""
@@ -226,7 +230,7 @@ class ExecutionScreen(TogoScreen):
     def _update_display(self) -> None:
         try:
             self.query_one("#pipeline", PipelineGraph).update_statuses(self._phase_statuses)
-        except Exception:
+        except NoMatches:
             pass
 
     def _compact_error_detail(self, error: BaseException, phase_id: str | None = None) -> str:
@@ -241,10 +245,10 @@ class ExecutionScreen(TogoScreen):
     def _show_error_banner(self, message: str) -> None:
         try:
             widget = self.query_one("#execution-error", Static)
-            widget.update(message)
-            widget.display = True
-        except Exception:
-            pass
+        except NoMatches:
+            return
+        widget.update(message)
+        widget.display = True
 
     def _show_run_error(self, error: BaseException, phase_id: str | None = None) -> None:
         detail = self._compact_error_detail(error, phase_id)
@@ -337,6 +341,16 @@ class ExecutionScreen(TogoScreen):
             if p == msg.phase_id and status in (RunStatus.RUNNING, RunStatus.PENDING):
                 self._task_statuses[(p, t)] = RunStatus.DONE
         self._update_display()
+        self._transition_to_finishing_if_phases_done()
+
+    def _transition_to_finishing_if_phases_done(self) -> None:
+        if self.togo_app.execution_status is ExecutionStatus.RUNNING and all(
+            status is RunStatus.DONE for status in self._phase_statuses.values()
+        ):
+            self.togo_app.execution_status = ExecutionStatus.FINISHING
+
+    def on_execution_succeeded(self, msg: ExecutionSucceeded) -> None:
+        self.togo_app.execution_status = ExecutionStatus.COMPLETED
 
     def on_phase_errored(self, msg: PhaseErrored) -> None:
         self._phase_errors[msg.phase_id] = msg.error
@@ -348,12 +362,14 @@ class ExecutionScreen(TogoScreen):
         self._update_display()
 
     def on_run_errored(self, msg: RunErrored) -> None:
+        self.togo_app.execution_status = ExecutionStatus.FAILED
         if self._phase_errors:
             self._show_phase_error_summary()
         else:
             self._show_error_banner("Run failed.")
 
     def on_execution_failed(self, msg: ExecutionFailed) -> None:
+        self.togo_app.execution_status = ExecutionStatus.FAILED
         self._show_run_error(msg.error)
 
     def on_phase_selected(self, msg: PhaseSelected) -> None:

--- a/ddev/src/ddev/cli/meta/ai/tui/status.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/status.py
@@ -8,6 +8,21 @@ from __future__ import annotations
 from enum import StrEnum
 
 
+class ExecutionStatus(StrEnum):
+    """Whole-flow execution lifecycle states."""
+
+    IDLE = "idle"
+    RUNNING = "running"
+    FINISHING = "finishing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+    @property
+    def is_active(self) -> bool:
+        """Return whether the orchestrator is still active."""
+        return self in (ExecutionStatus.RUNNING, ExecutionStatus.FINISHING)
+
+
 class RunStatus(StrEnum):
     """Finite phase/task execution states shown in the TUI."""
 

--- a/ddev/src/ddev/cli/meta/ai/tui/status.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/status.py
@@ -5,17 +5,17 @@
 
 from __future__ import annotations
 
-from enum import StrEnum
+from enum import StrEnum, auto
 
 
 class ExecutionStatus(StrEnum):
     """Whole-flow execution lifecycle states."""
 
-    IDLE = "idle"
-    RUNNING = "running"
-    FINISHING = "finishing"
-    COMPLETED = "completed"
-    FAILED = "failed"
+    IDLE = auto()
+    RUNNING = auto()
+    FINISHING = auto()
+    COMPLETED = auto()
+    FAILED = auto()
 
     @property
     def is_active(self) -> bool:
@@ -26,10 +26,10 @@ class ExecutionStatus(StrEnum):
 class RunStatus(StrEnum):
     """Finite phase/task execution states shown in the TUI."""
 
-    PENDING = "pending"
-    RUNNING = "running"
-    DONE = "done"
-    FAILED = "failed"
+    PENDING = auto()
+    RUNNING = auto()
+    DONE = auto()
+    FAILED = auto()
 
     @property
     def has_started(self) -> bool:

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -124,6 +124,10 @@ TogoHeader {
     text-style: bold;
 }
 
+#header-right.status-idle {
+    display: none;
+}
+
 #header-right.status-running {
     color: $status-running;
 }

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -121,8 +121,23 @@ TogoHeader {
 
 #header-right {
     width: auto;
-    color: $status-running;
     text-style: bold;
+}
+
+#header-right.status-running {
+    color: $status-running;
+}
+
+#header-right.status-finishing {
+    color: $warning;
+}
+
+#header-right.status-completed {
+    color: $status-done;
+}
+
+#header-right.status-failed {
+    color: $status-failed;
 }
 
 #header-badge {

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/header.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/header.py
@@ -27,48 +27,57 @@ TOGO_HUSKY = """█▀▄     ▄▀█
 █▀▄▄▄█▄▄▄▀█
   ▀▀███▀▀"""
 
-EXECUTION_STATUS_CLASSES = (
-    "status-running",
-    "status-finishing",
-    "status-completed",
-    "status-failed",
-)
+EXECUTION_STATUS_TEXT = {
+    ExecutionStatus.IDLE: "",
+    ExecutionStatus.RUNNING: "● running",
+    ExecutionStatus.FINISHING: "◌ finishing",
+    ExecutionStatus.COMPLETED: "✓ completed",
+    ExecutionStatus.FAILED: "✕ failed",
+}
 
 
 class ExecutionStatusBadge(Static):
     """Render the current app-wide execution status."""
 
-    _pulse_on: reactive[bool] = reactive(True)
+    execution_status: reactive[ExecutionStatus] = reactive(ExecutionStatus.IDLE)
 
     def on_mount(self) -> None:
-        self.watch(self.app, "execution_status", self._watch_execution_status)
-        self.set_interval(0.6, self._tick_pulse)
+        self.watch(cast("TogoApp", self.app), "execution_status", self._sync_execution_status)
 
-    def render(self) -> str:
-        status = cast("TogoApp", self.app).execution_status
-        if status is ExecutionStatus.IDLE:
-            return ""
-        if status is ExecutionStatus.RUNNING:
-            marker = "●" if self._pulse_on else "○"
-            return f"{marker} running"
-        return {
-            ExecutionStatus.FINISHING: "◌ finishing",
-            ExecutionStatus.COMPLETED: "✓ completed",
-            ExecutionStatus.FAILED: "✕ failed",
-        }[status]
+    def watch_execution_status(self, old_status: ExecutionStatus, new_status: ExecutionStatus) -> None:
+        self.remove_class(f"status-{old_status.value}")
+        self.add_class(f"status-{new_status.value}")
+        self.update(EXECUTION_STATUS_TEXT[new_status])
 
-    def watch__pulse_on(self) -> None:
-        self.refresh()
+        if new_status is ExecutionStatus.RUNNING:
+            self._pulse_down()
+        else:
+            self.styles.animate("text_opacity", 1.0, duration=0.2)
 
-    def _watch_execution_status(self, status: ExecutionStatus) -> None:
-        self.remove_class(*EXECUTION_STATUS_CLASSES)
-        if status is not ExecutionStatus.IDLE:
-            self.add_class(f"status-{status.value}")
-        self.refresh(layout=True)
+    def _sync_execution_status(self, status: ExecutionStatus) -> None:
+        self.execution_status = status
 
-    def _tick_pulse(self) -> None:
-        if cast("TogoApp", self.app).execution_status is ExecutionStatus.RUNNING:
-            self._pulse_on = not self._pulse_on
+    def _pulse_down(self) -> None:
+        if self.execution_status is not ExecutionStatus.RUNNING or self.app.animation_level != "full":
+            return
+        self.styles.animate(
+            "text_opacity",
+            0.35,
+            duration=0.8,
+            easing="in_out_sine",
+            on_complete=self._pulse_up,
+        )
+
+    def _pulse_up(self) -> None:
+        if self.execution_status is not ExecutionStatus.RUNNING or self.app.animation_level != "full":
+            return
+        self.styles.animate(
+            "text_opacity",
+            1.0,
+            duration=0.8,
+            easing="in_out_sine",
+            on_complete=self._pulse_down,
+        )
 
 
 class TogoHeader(Widget):
@@ -88,7 +97,7 @@ class TogoHeader(Widget):
             yield Static(product, id="header-product")
             yield Static("", id="header-flow-summary")
             yield Static("", id="header-repo")
-        yield ExecutionStatusBadge(id="header-right")
+        yield ExecutionStatusBadge(id="header-right", classes="status-idle")
 
     def on_mount(self) -> None:
         self._update_context()

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/header.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/header.py
@@ -39,14 +39,13 @@ EXECUTION_STATUS_TEXT = {
 class ExecutionStatusBadge(Static):
     """Render the current app-wide execution status."""
 
-    execution_status: reactive[ExecutionStatus] = reactive(ExecutionStatus.IDLE)
+    execution_status: reactive[ExecutionStatus] = reactive(ExecutionStatus.IDLE, init=False)
 
     def on_mount(self) -> None:
         self.watch(cast("TogoApp", self.app), "execution_status", self._sync_execution_status)
 
     def watch_execution_status(self, old_status: ExecutionStatus, new_status: ExecutionStatus) -> None:
-        self.remove_class(f"status-{old_status.value}")
-        self.add_class(f"status-{new_status.value}")
+        self.toggle_class(f"status-{old_status.value}", f"status-{new_status.value}")
         self.update(EXECUTION_STATUS_TEXT[new_status])
 
         if new_status is ExecutionStatus.RUNNING:

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/header.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/header.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-"""TogoHeader widget — wordmark, screen title, optional running badge, clock."""
+"""TogoHeader widget — wordmark, flow context, and execution badge."""
 
 from __future__ import annotations
 
@@ -16,6 +16,7 @@ from textual.widgets import Static
 
 from ddev.ai.config.models import ConfigStatus
 from ddev.cli.meta.ai.palette import ERROR, PRIMARY
+from ddev.cli.meta.ai.tui.status import ExecutionStatus
 
 if TYPE_CHECKING:
     from ddev.cli.meta.ai.tui.app import TogoApp
@@ -26,19 +27,58 @@ TOGO_HUSKY = """█▀▄     ▄▀█
 █▀▄▄▄█▄▄▄▀█
   ▀▀███▀▀"""
 
+EXECUTION_STATUS_CLASSES = (
+    "status-running",
+    "status-finishing",
+    "status-completed",
+    "status-failed",
+)
+
+
+class ExecutionStatusBadge(Static):
+    """Render the current app-wide execution status."""
+
+    _pulse_on: reactive[bool] = reactive(True)
+
+    def on_mount(self) -> None:
+        self.watch(self.app, "execution_status", self._watch_execution_status)
+        self.set_interval(0.6, self._tick_pulse)
+
+    def render(self) -> str:
+        status = cast("TogoApp", self.app).execution_status
+        if status is ExecutionStatus.IDLE:
+            return ""
+        if status is ExecutionStatus.RUNNING:
+            marker = "●" if self._pulse_on else "○"
+            return f"{marker} running"
+        return {
+            ExecutionStatus.FINISHING: "◌ finishing",
+            ExecutionStatus.COMPLETED: "✓ completed",
+            ExecutionStatus.FAILED: "✕ failed",
+        }[status]
+
+    def watch__pulse_on(self) -> None:
+        self.refresh()
+
+    def _watch_execution_status(self, status: ExecutionStatus) -> None:
+        self.remove_class(*EXECUTION_STATUS_CLASSES)
+        if status is not ExecutionStatus.IDLE:
+            self.add_class(f"status-{status.value}")
+        self.refresh(layout=True)
+
+    def _tick_pulse(self) -> None:
+        if cast("TogoApp", self.app).execution_status is ExecutionStatus.RUNNING:
+            self._pulse_on = not self._pulse_on
+
 
 class TogoHeader(Widget):
     """App header with the Togo mascot, flow summary, repository, and run state."""
 
     DEFAULT_CSS = ""
 
-    running: reactive[bool] = reactive(False)
-    _pulse_on: reactive[bool] = reactive(True)
-
-    def __init__(self, title: str = "", running: bool = False) -> None:
+    def __init__(self, title: str = "") -> None:
         super().__init__()
         self._title = title
-        self.running = running
 
     def compose(self) -> ComposeResult:
         yield Static(TOGO_HUSKY, id="header-mascot")
@@ -48,22 +88,10 @@ class TogoHeader(Widget):
             yield Static(product, id="header-product")
             yield Static("", id="header-flow-summary")
             yield Static("", id="header-repo")
-        yield Static("", id="header-right")
+        yield ExecutionStatusBadge(id="header-right")
 
     def on_mount(self) -> None:
-        self.set_interval(0.6, self._tick_pulse)
         self._update_context()
-        self._update_running_badge()
-
-    def watch_running(self, running: bool) -> None:
-        self._update_running_badge()
-
-    def watch__pulse_on(self, pulse_on: bool) -> None:
-        self._update_running_badge()
-
-    def _tick_pulse(self) -> None:
-        if self.running:
-            self._pulse_on = not self._pulse_on
 
     def _update_context(self) -> None:
         app = cast("TogoApp", self.app)
@@ -74,14 +102,3 @@ class TogoHeader(Widget):
             summary.append(f" / {broken_count} flows need attention", style=ERROR)
         self.query_one("#header-flow-summary", Static).update(summary)
         self.query_one("#header-repo", Static).update(str(app.ddev_app.repo.path))
-
-    def _update_running_badge(self) -> None:
-        try:
-            right = self.query_one("#header-right", Static)
-        except Exception:
-            return
-        if not self.running:
-            right.update("")
-            return
-        marker = "●" if self._pulse_on else "○"
-        right.update(f"{marker} running")

--- a/ddev/tests/cli/meta/ai/tui/conftest.py
+++ b/ddev/tests/cli/meta/ai/tui/conftest.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from html import unescape
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -31,6 +32,11 @@ from ddev.cli.meta.ai.tui.theme import togo_theme
 
 LARGE_TERMINAL = (120, 50)
 STATUS_VARIABLE_KEYS = ("status-running", "status-pending", "status-done", "status-failed")
+
+
+def export_screenshot_text(app: App[Any]) -> str:
+    """Return Textual's exported screenshot with HTML spaces normalized."""
+    return unescape(app.export_screenshot()).replace("\N{NO-BREAK SPACE}", " ")
 
 
 def make_test_ddev_app(api_key: str | None = None, repo_path: Path | None = None) -> SimpleNamespace:

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -1259,48 +1259,129 @@ async def test_output_contains_agent_start_header():
 
 
 # ---------------------------------------------------------------------------
-# ExecutionScreen: header running badge
+# ExecutionScreen: execution lifecycle
 # ---------------------------------------------------------------------------
 
 
-async def test_header_shows_running_badge_during_run():
-    """Header running badge is shown while the orchestrator runs."""
+async def test_execution_finishes_phases_before_reporting_success() -> None:
+    """All-green phases show finishing until the orchestrator returns cleanly."""
     import asyncio
 
-    from textual.widgets import Static
-
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.widgets.header import ExecutionStatusBadge
 
-    started = asyncio.Event()
     release = asyncio.Event()
 
-    class _BlockedDemo:
+    class ControlledOrchestrator:
         failed_phase = None
 
+        def __init__(self, callbacks: Any) -> None:
+            self.callbacks = callbacks
+
         async def run_async(self) -> None:
-            started.set()
+            for phase_id, _ in DEMO_PHASES:
+                await self.callbacks.fire_phase_finish(phase_id)
             await release.wait()
 
     flow = _make_flow()
     app = _app(flow)
     async with app.run_test() as pilot:
         await pilot.pause()
-        screen = ExecutionScreen(flow, orchestrator_builder=lambda _callbacks: _BlockedDemo())
+        screen = ExecutionScreen(flow, orchestrator_builder=ControlledOrchestrator)
         await app.push_screen(screen)
-        await asyncio.wait_for(started.wait(), timeout=5)
         await pilot.pause()
 
-        from ddev.cli.meta.ai.tui.widgets.header import TogoHeader
-
-        header = screen.query_one(TogoHeader)
-        badge = header.query_one("#header-right", Static)
-        assert str(badge.content) in {"● running", "○ running"}
+        badge = screen.query_one(ExecutionStatusBadge)
+        assert str(badge.render()) == "◌ finishing"
 
         release.set()
-        await screen.workers.wait_for_complete()
         await pilot.pause()
 
-        assert str(badge.content) == ""
+        assert str(badge.render()) == "✓ completed"
+
+
+async def test_execution_failure_during_finalization_never_reports_success() -> None:
+    """A failure after all phases finish replaces finishing with a failed result."""
+    import asyncio
+
+    from textual.widgets import Static
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.widgets.header import ExecutionStatusBadge
+
+    release = asyncio.Event()
+
+    class FailingFinalizer:
+        failed_phase = None
+
+        def __init__(self, callbacks: Any) -> None:
+            self.callbacks = callbacks
+
+        async def run_async(self) -> None:
+            for phase_id, _ in DEMO_PHASES:
+                await self.callbacks.fire_phase_finish(phase_id)
+            await release.wait()
+            raise RuntimeError("finalization failed")
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=FailingFinalizer)
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        badge = screen.query_one(ExecutionStatusBadge)
+        assert str(badge.render()) == "◌ finishing"
+
+        release.set()
+        await pilot.pause()
+
+        error = screen.query_one("#execution-error", Static)
+        assert str(badge.render()) == "✕ failed"
+        assert "finalization failed" in str(error.render())
+
+
+async def test_phase_log_header_keeps_running_status() -> None:
+    """Opening a phase log keeps the active flow status visible."""
+    import asyncio
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen
+    from ddev.cli.meta.ai.tui.widgets.header import ExecutionStatusBadge
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseNode
+
+    release = asyncio.Event()
+
+    class RunningPhase:
+        failed_phase = None
+
+        def __init__(self, callbacks: Any) -> None:
+            self.callbacks = callbacks
+
+        async def run_async(self) -> None:
+            await self.callbacks.fire_phase_start("phase_1")
+            await release.wait()
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=RunningPhase)
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        screen.query_one(PhaseNode).focus()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, PhaseLogScreen)
+        badge = app.screen.query_one(ExecutionStatusBadge)
+        assert str(badge.render()) in {"● running", "○ running"}
+
+        release.set()
+        await pilot.pause()
+        assert str(badge.render()) == "✓ completed"
 
 
 # ---------------------------------------------------------------------------
@@ -1309,11 +1390,14 @@ async def test_header_shows_running_badge_during_run():
 
 
 async def test_cancel_stops_worker_without_crash():
-    """Pressing ctrl+c cancels the worker without crashing the app."""
+    """Ctrl+C cancels the run without reporting successful completion."""
     import asyncio
 
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
     from ddev.cli.meta.ai.tui.screens.main import MainScreen
+    from ddev.cli.meta.ai.tui.widgets.header import ExecutionStatusBadge
+
+    cancelled = asyncio.Event()
 
     class _InfiniteDemo:
         failed_phase = None
@@ -1322,7 +1406,11 @@ async def test_cancel_stops_worker_without_crash():
             self._cb = cb
 
         async def run_async(self) -> None:
-            await asyncio.sleep(999)
+            try:
+                await asyncio.sleep(999)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
 
     flow = _make_flow()
     app = _app(flow)
@@ -1333,8 +1421,11 @@ async def test_cancel_stops_worker_without_crash():
         await app.push_screen(screen)
         await pilot.pause(0.05)
         await pilot.press("ctrl+c")
-        await pilot.pause(0.1)
+        await pilot.pause()
+
         assert pilot.app.is_running
+        assert cancelled.is_set()
+        assert str(screen.query_one(ExecutionStatusBadge).render()) == ""
 
 
 async def test_execution_ctrl_c_copies_selection_before_cancelling(monkeypatch):
@@ -1435,7 +1526,7 @@ async def test_escape_requires_confirmation_before_cancelling_active_run():
         assert app.screen is screen
         assert not cancelled.is_set()
 
-        screen.action_back()
+        await pilot.press("escape")
         await pilot.pause()
         await pilot.click("#btn-cancel-flow")
         await pilot.pause()
@@ -1447,6 +1538,7 @@ async def test_back_pops_immediately_after_run_finishes():
     """Back does not prompt once the worker has finished."""
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
     from ddev.cli.meta.ai.tui.screens.main import MainScreen
+    from ddev.cli.meta.ai.tui.widgets.header import ExecutionStatusBadge
 
     class _FinishedDemo:
         failed_phase = None
@@ -1461,9 +1553,11 @@ async def test_back_pops_immediately_after_run_finishes():
         screen = ExecutionScreen(flow, orchestrator_builder=lambda _callbacks: _FinishedDemo())
         await app.push_screen(screen)
         await pilot.pause()
-        screen.action_back()
+        await pilot.press("escape")
         await pilot.pause()
+
         assert isinstance(app.screen, MainScreen)
+        assert str(app.screen.query_one(ExecutionStatusBadge).render()) == ""
 
 
 # ---------------------------------------------------------------------------
@@ -1475,6 +1569,7 @@ async def test_failing_orchestrator_no_app_crash():
     """A raising orchestrator surfaces failure in UI without crashing the app."""
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
     from ddev.cli.meta.ai.tui.screens.main import MainScreen
+    from ddev.cli.meta.ai.tui.widgets.header import ExecutionStatusBadge
 
     flow = _make_flow()
     app = _app(flow)
@@ -1486,8 +1581,7 @@ async def test_failing_orchestrator_no_app_crash():
         await pilot.pause(0.5)
         assert pilot.app.is_running
         assert isinstance(pilot.app.screen, ExecutionScreen)
-
-    assert screen._phase_statuses["phase_1"] is RunStatus.FAILED
+        assert str(screen.query_one(ExecutionStatusBadge).render()) == "✕ failed"
 
 
 async def test_orchestrator_build_failure_is_visible_and_screen_stays_stable() -> None:
@@ -1495,6 +1589,7 @@ async def test_orchestrator_build_failure_is_visible_and_screen_stays_stable() -
     from textual.widgets import Static
 
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.widgets.header import ExecutionStatusBadge
 
     def fail_to_build(_callbacks: Any) -> Any:
         raise RuntimeError("constructor exploded")
@@ -1510,6 +1605,7 @@ async def test_orchestrator_build_failure_is_visible_and_screen_stays_stable() -
         error = screen.query_one("#execution-error", Static)
         assert error.display
         assert "constructor exploded" in str(error.render())
+        assert str(screen.query_one(ExecutionStatusBadge).render()) == "✕ failed"
         assert app.screen is screen
         assert app.is_running
 
@@ -1721,6 +1817,57 @@ final_review:
 
         assert screen._phase_statuses["research"] is RunStatus.DONE
         assert screen._phase_statuses["final_review"] is RunStatus.PENDING
+
+
+async def test_resume_transitions_to_finishing_after_remaining_phase(tmp_path: Path) -> None:
+    """A resumed done phase participates in the all-green finishing check."""
+    import asyncio
+
+    from ddev.cli.meta.ai.tui.runs import flow_slug
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    run_dir = tmp_path / flow_slug(flow)
+    run_dir.mkdir()
+    (run_dir / "checkpoints.yaml").write_text(
+        """phase_1:
+  status: success
+  started_at: '2024-01-01T00:00:00'
+  finished_at: '2024-01-01T00:01:00'
+  tokens: {total_input: 1, total_output: 1}
+  memory_path: phase_1_memory.md
+"""
+    )
+    release = asyncio.Event()
+
+    class ResumeOrchestrator:
+        failed_phase = None
+
+        def __init__(self, callbacks: Any) -> None:
+            self.callbacks = callbacks
+
+        async def run_async(self) -> None:
+            await self.callbacks.fire_phase_finish("phase_2")
+            await release.wait()
+
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(
+            flow,
+            resume=True,
+            runs_dir=tmp_path,
+            orchestrator_builder=ResumeOrchestrator,
+        )
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        from ddev.cli.meta.ai.tui.widgets.header import ExecutionStatusBadge
+
+        assert str(screen.query_one(ExecutionStatusBadge).render()) == "◌ finishing"
+        release.set()
+        await pilot.pause()
+        assert str(screen.query_one(ExecutionStatusBadge).render()) == "✓ completed"
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -21,7 +21,7 @@ from ddev.ai.phases.registry import PhaseRegistry
 from ddev.cli.meta.ai.tui.app import TogoApp
 from ddev.cli.meta.ai.tui.status import RunStatus
 
-from .conftest import StaticConfigurationEngine
+from .conftest import StaticConfigurationEngine, export_screenshot_text
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1348,7 +1348,6 @@ async def test_phase_log_header_keeps_running_status() -> None:
 
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
     from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen
-    from ddev.cli.meta.ai.tui.widgets.header import ExecutionStatusBadge
     from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseNode
 
     release = asyncio.Event()
@@ -1365,6 +1364,7 @@ async def test_phase_log_header_keeps_running_status() -> None:
 
     flow = _make_flow()
     app = _app(flow)
+    app.animation_level = "none"
     async with app.run_test() as pilot:
         await pilot.pause()
         screen = ExecutionScreen(flow, orchestrator_builder=RunningPhase)
@@ -1376,12 +1376,11 @@ async def test_phase_log_header_keeps_running_status() -> None:
         await pilot.pause()
 
         assert isinstance(app.screen, PhaseLogScreen)
-        badge = app.screen.query_one(ExecutionStatusBadge)
-        assert str(badge.render()) in {"● running", "○ running"}
+        assert "● running" in export_screenshot_text(app)
 
         release.set()
         await pilot.pause()
-        assert str(badge.render()) == "✓ completed"
+        assert "✓ completed" in export_screenshot_text(app)
 
 
 # ---------------------------------------------------------------------------
@@ -1510,6 +1509,7 @@ async def test_escape_requires_confirmation_before_cancelling_active_run():
 
     flow = _make_flow()
     app = _app(flow)
+    app.animation_level = "none"
     async with app.run_test() as pilot:
         await pilot.pause()
         screen = ExecutionScreen(flow, orchestrator_builder=lambda _callbacks: _InfiniteDemo())

--- a/ddev/tests/cli/meta/ai/tui/test_shell.py
+++ b/ddev/tests/cli/meta/ai/tui/test_shell.py
@@ -19,7 +19,7 @@ from ddev.cli.meta.ai.tui.screens.base import TogoScreen
 from ddev.cli.meta.ai.tui.status import ExecutionStatus
 from ddev.cli.meta.ai.tui.widgets.header import ExecutionStatusBadge, TogoHeader
 
-from .conftest import StaticConfigurationEngine
+from .conftest import StaticConfigurationEngine, export_screenshot_text
 
 
 def _app_kwargs(ddev_app):
@@ -111,13 +111,13 @@ async def test_togo_header_displays_husky_mascot(ddev_app):
     """The application header visibly identifies Togo and its repository."""
     async with _DummyApp(**_app_kwargs(ddev_app)).run_test(size=(120, 40)) as pilot:
         await pilot.pause()
-        screenshot = pilot.app.export_screenshot()
+        screenshot = export_screenshot_text(pilot.app)
 
         assert "█▀▄" in screenshot
         assert "▀▀███▀▀" in screenshot
         assert "Togo" in screenshot
-        assert "Agent&#160;Integrations" in screenshot
-        assert "0&#160;Flows&#160;Discovered" in screenshot
+        assert "Agent Integrations" in screenshot
+        assert "0 Flows Discovered" in screenshot
         assert str(ddev_app.repo.path) in screenshot
 
 
@@ -137,24 +137,41 @@ async def test_togo_header_calls_attention_to_broken_flows(ddev_app):
     async with _DummyApp(**kwargs).run_test(size=(120, 40)) as pilot:
         await pilot.pause()
 
-        assert "1&#160;flows&#160;need&#160;attention" in pilot.app.export_screenshot()
+        assert "1 flows need attention" in export_screenshot_text(pilot.app)
 
 
-async def test_togo_header_running_badge_pulses(ddev_app):
-    """The running badge is visible and alternates its marker."""
+async def test_togo_header_running_badge_pulses_and_restores_full_opacity(ddev_app: Any) -> None:
+    """The running status breathes smoothly and the completed status is fully visible."""
     async with _DummyApp(**_app_kwargs(ddev_app)).run_test() as pilot:
         await pilot.pause()
         badge = pilot.app.screen.query_one(ExecutionStatusBadge)
+        pilot.app.animation_level = "full"
+
+        pilot.app.execution_status = ExecutionStatus.RUNNING
+        await pilot.pause(0.4)
+
+        assert "● running" in export_screenshot_text(pilot.app)
+        assert badge.styles.text_opacity < 1.0
+
+        pilot.app.execution_status = ExecutionStatus.COMPLETED
+        await pilot.pause(0.3)
+
+        assert "✓ completed" in export_screenshot_text(pilot.app)
+        assert badge.styles.text_opacity == 1.0
+
+
+async def test_togo_header_running_badge_respects_disabled_animations(ddev_app: Any) -> None:
+    """The running status remains readable when the user disables animations."""
+    async with _DummyApp(**_app_kwargs(ddev_app)).run_test() as pilot:
+        await pilot.pause()
+        badge = pilot.app.screen.query_one(ExecutionStatusBadge)
+        pilot.app.animation_level = "none"
 
         pilot.app.execution_status = ExecutionStatus.RUNNING
         await pilot.pause(0.1)
-        first = str(badge.render())
-        await pilot.pause(0.7)
-        second = str(badge.render())
 
-    assert first in {"● running", "○ running"}
-    assert second in {"● running", "○ running"}
-    assert first != second
+        assert "● running" in export_screenshot_text(pilot.app)
+        assert badge.styles.text_opacity == 1.0
 
 
 async def test_togo_header_idle_badge_is_empty(ddev_app: Any) -> None:
@@ -163,7 +180,7 @@ async def test_togo_header_idle_badge_is_empty(ddev_app: Any) -> None:
         await pilot.pause()
         badge = pilot.app.screen.query_one(ExecutionStatusBadge)
 
-        assert str(badge.render()) == ""
+        assert not badge.display
 
 
 @pytest.mark.parametrize(
@@ -183,7 +200,8 @@ async def test_togo_header_stable_execution_badges(ddev_app: Any, status: Execut
         pilot.app.execution_status = status
         await pilot.pause()
 
-        assert str(badge.render()) == label
+        assert badge.display
+        assert label in export_screenshot_text(pilot.app)
 
 
 async def test_new_screen_header_shows_current_execution_status(ddev_app: Any) -> None:
@@ -194,5 +212,4 @@ async def test_new_screen_header_shows_current_execution_status(ddev_app: Any) -
         await pilot.app.push_screen(_DummyScreen())
         await pilot.pause()
 
-        badge = pilot.app.screen.query_one(ExecutionStatusBadge)
-        assert str(badge.render()) == "◌ finishing"
+        assert "◌ finishing" in export_screenshot_text(pilot.app)

--- a/ddev/tests/cli/meta/ai/tui/test_shell.py
+++ b/ddev/tests/cli/meta/ai/tui/test_shell.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from textual.widgets import Footer
 
@@ -14,7 +16,8 @@ from ddev.ai.config.models import ConfigStatus, FlowResult
 from ddev.ai.phases.registry import PhaseRegistry
 from ddev.cli.meta.ai.tui.app import TogoApp
 from ddev.cli.meta.ai.tui.screens.base import TogoScreen
-from ddev.cli.meta.ai.tui.widgets.header import TogoHeader
+from ddev.cli.meta.ai.tui.status import ExecutionStatus
+from ddev.cli.meta.ai.tui.widgets.header import ExecutionStatusBadge, TogoHeader
 
 from .conftest import StaticConfigurationEngine
 
@@ -139,19 +142,57 @@ async def test_togo_header_calls_attention_to_broken_flows(ddev_app):
 
 async def test_togo_header_running_badge_pulses(ddev_app):
     """The running badge is visible and alternates its marker."""
-    from textual.widgets import Static
-
     async with _DummyApp(**_app_kwargs(ddev_app)).run_test() as pilot:
         await pilot.pause()
-        header = pilot.app.screen.query_one(TogoHeader)
-        badge = header.query_one("#header-right", Static)
+        badge = pilot.app.screen.query_one(ExecutionStatusBadge)
 
-        header.running = True
+        pilot.app.execution_status = ExecutionStatus.RUNNING
         await pilot.pause(0.1)
-        first = str(badge.content)
+        first = str(badge.render())
         await pilot.pause(0.7)
-        second = str(badge.content)
+        second = str(badge.render())
 
     assert first in {"● running", "○ running"}
     assert second in {"● running", "○ running"}
     assert first != second
+
+
+async def test_togo_header_idle_badge_is_empty(ddev_app: Any) -> None:
+    """Non-execution headers do not show a lifecycle badge."""
+    async with _DummyApp(**_app_kwargs(ddev_app)).run_test() as pilot:
+        await pilot.pause()
+        badge = pilot.app.screen.query_one(ExecutionStatusBadge)
+
+        assert str(badge.render()) == ""
+
+
+@pytest.mark.parametrize(
+    ("status", "label"),
+    [
+        (ExecutionStatus.FINISHING, "◌ finishing"),
+        (ExecutionStatus.COMPLETED, "✓ completed"),
+        (ExecutionStatus.FAILED, "✕ failed"),
+    ],
+)
+async def test_togo_header_stable_execution_badges(ddev_app: Any, status: ExecutionStatus, label: str) -> None:
+    """Terminal and finishing states have stable visible labels."""
+    async with _DummyApp(**_app_kwargs(ddev_app)).run_test() as pilot:
+        await pilot.pause()
+        badge = pilot.app.screen.query_one(ExecutionStatusBadge)
+
+        pilot.app.execution_status = status
+        await pilot.pause()
+
+        assert str(badge.render()) == label
+
+
+async def test_new_screen_header_shows_current_execution_status(ddev_app: Any) -> None:
+    """Screens opened during a run retain the app-wide execution status."""
+    async with _DummyApp(**_app_kwargs(ddev_app)).run_test() as pilot:
+        await pilot.pause()
+        pilot.app.execution_status = ExecutionStatus.FINISHING
+        await pilot.app.push_screen(_DummyScreen())
+        await pilot.pause()
+
+        badge = pilot.app.screen.query_one(ExecutionStatusBadge)
+        assert str(badge.render()) == "◌ finishing"


### PR DESCRIPTION
### What does this PR do?

This PR adds a persistent execution status to the Togo header so the current flow lifecycle remains visible while navigating between execution-related screens.

The implementation introduces `ExecutionStatus` with five states:

- `IDLE`: no flow is active.
- `RUNNING`: the orchestrator is executing phases.
- `FINISHING`: every phase has completed, but the orchestrator is still performing finalization work.
- `COMPLETED`: the orchestrator returned successfully.
- `FAILED`: execution or finalization failed.

`TogoApp.execution_status` is a Textual `reactive[ExecutionStatus]` and is the single source of truth for the active flow lifecycle. Keeping this state on `TogoApp`, instead of individual screens or headers, allows every header in the screen stack to display the same status. For example, opening a phase log while a flow is running does not lose the execution context.

The new `ExecutionStatusBadge` observes `TogoApp.execution_status` directly and renders the matching marker, label, and color.

The previous `_run_active` flag and screen-local `TogoHeader.running` state are removed. Active-run behavior, including whether Escape should open the cancellation confirmation, is now derived from `ExecutionStatus.is_active`. This avoids maintaining separate booleans that could disagree with the status shown to the user.

#### Header execution status screenshots

<img width="120" height="47" alt="image" src="https://github.com/user-attachments/assets/58efd794-800b-495e-8586-64541bf71cf2" />

<img width="105" height="39" alt="image" src="https://github.com/user-attachments/assets/9119636e-aa72-4a93-b784-0b797cfe6219" />

<img width="91" height="38" alt="image" src="https://github.com/user-attachments/assets/cced2f0b-7113-44dd-9489-798ce4e86ef7" />



### Motivation

Previously, Togo only displayed a temporary running indicator. Once the worker stopped, that indicator disappeared without communicating whether the flow completed successfully, failed, or was still finalizing. Completed phase nodes alone were not sufficient because all phases can finish before orchestrator-level finalization returns, and users could navigate to another screen whose header had no knowledge of the active run.

An app-wide reactive execution status makes the flow outcome explicit and consistent across the TUI while keeping the feedback compact in the shared header.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7050]: https://datadoghq.atlassian.net/browse/AI-7050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ