### PR TITLE
[AI-7051] Add Phase descriptions in the Togo TUI

### DIFF
--- a/ddev/src/ddev/ai/config/models.py
+++ b/ddev/src/ddev/ai/config/models.py
@@ -197,6 +197,7 @@ class AgentConfig(BaseModel):
 class PhaseConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
     name: str = Field(pattern=NAME_PATTERN)
+    description: str | None = None
     class_: str = Field(default="AgenticPhase", alias="class")
     agent: str | None = None
     tasks: list[TaskConfig] = Field(default_factory=list)

--- a/ddev/src/ddev/ai/flows/openmetrics/phases.yaml
+++ b/ddev/src/ddev/ai/flows/openmetrics/phases.yaml
@@ -1,6 +1,8 @@
 - type: phase
   config:
     name: inspect_endpoint
+    description: >-
+      Fetch and validate every OpenMetrics endpoint, then save metric catalogs and exposition snapshots for downstream phases.
     class: InspectEndpointPhase
     variables:
       - name: inspect_input
@@ -8,6 +10,8 @@
 - type: phase
   config:
     name: rename_metrics
+    description: >-
+      Scaffold the integration, map every discovered metric to a Datadog name, and generate the combined metric metadata.
     class: AgenticPhase
     agent: metrics_renamer
     variables:
@@ -29,6 +33,8 @@
 - type: phase
   config:
     name: build_integration
+    description: >-
+      Copy the test environment and captured fixtures, then implement the OpenMetrics check and its configuration specification.
     class: AgenticPhase
     agent: integration_coder
     variables:
@@ -50,6 +56,8 @@
 - type: phase
   config:
     name: write_tests
+    description: >-
+      Build and run the unit, integration, and end-to-end test suite for the completed integration.
     class: AgenticPhase
     agent: integration_tester
     variables:
@@ -67,6 +75,8 @@
 - type: phase
   config:
     name: write_readme
+    description: >-
+      Turn the scaffolded README into accurate customer-facing documentation for the completed integration.
     class: AgenticPhase
     agent: readme_writer
     variables:

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/cancel_run_modal.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/cancel_run_modal.py
@@ -14,6 +14,7 @@ from textual.widgets import Button, Static
 class CancelRunModal(ModalScreen[bool]):
     """Confirm whether to cancel an active flow."""
 
+    AUTO_FOCUS = "#btn-keep-running"
     BINDINGS = [Binding("escape", "keep_running", "Keep running")]
 
     def compose(self) -> ComposeResult:
@@ -27,9 +28,6 @@ class CancelRunModal(ModalScreen[bool]):
             with Horizontal(classes="modal-actions"):
                 yield Button("Keep running", id="btn-keep-running", variant="primary")
                 yield Button("Cancel flow", id="btn-cancel-flow", variant="error")
-
-    def on_mount(self) -> None:
-        self.query_one("#btn-keep-running", Button).focus()
 
     def action_keep_running(self) -> None:
         """Dismiss the confirmation and continue the flow."""

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/phase_config.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/phase_config.py
@@ -39,6 +39,9 @@ class PhaseConfigScreen(TogoScreen):
                 with Vertical(id="phase-heading"):
                     yield Static(f"Phase {phase_index:02d}", id="phase-index", classes="eyebrow")
                     yield Static(self.phase_id, id="phase-title")
+                    if phase.description:
+                        with VerticalScroll(id="phase-description"):
+                            yield Markdown(phase.description, classes="desc")
                 with Vertical(id="phase-dependencies-summary"):
                     yield Static("DEPENDENCIES", classes="eyebrow")
                     yield Static(
@@ -77,10 +80,7 @@ class PhaseConfigScreen(TogoScreen):
 
     def _compose_agent(self, agent_name: str, config: AgentConfig) -> Iterator[Widget]:
         yield Static(agent_name, id="phase-agent-name")
-        with Horizontal(id="phase-agent-meta"):
-            yield Static(f"provider · {config.provider}", id="phase-agent-provider", classes="badge")
-            if config.model:
-                yield Static(f"model · {config.model}", id="phase-agent-model", classes="badge")
+        yield Static(f"model · {config.model} ({config.provider})", id="phase-agent-model", classes="badge")
         yield Static("TOOLS", classes="eyebrow")
         if config.tools:
             yield Static(" · ".join(config.tools), id="phase-agent-tools", classes="tools-box")

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/phase_config.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/phase_config.py
@@ -41,7 +41,7 @@ class PhaseConfigScreen(TogoScreen):
                     yield Static(self.phase_id, id="phase-title")
                     if phase.description:
                         with VerticalScroll(id="phase-description"):
-                            yield Markdown(phase.description, classes="desc")
+                            yield Static(phase.description, classes="desc", markup=False)
                 with Vertical(id="phase-dependencies-summary"):
                     yield Static("DEPENDENCIES", classes="eyebrow")
                     yield Static(

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/phase_error_modal.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/phase_error_modal.py
@@ -18,6 +18,7 @@ from ddev.cli.meta.ai.palette import ERROR
 class PhaseErrorModal(ModalScreen[None]):
     """Show the complete error for a failed phase over the execution view."""
 
+    AUTO_FOCUS = "#btn-close"
     BINDINGS = [Binding("escape", "dismiss_modal", "Close")]
 
     def __init__(self, phase_id: str, error: BaseException) -> None:

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -300,6 +300,17 @@ Collapsible {
     margin-top: 1;
 }
 
+#phase-description {
+    height: auto;
+    max-height: 4;
+    margin-top: 1;
+    overflow-y: auto;
+}
+
+#phase-description > Markdown {
+    height: auto;
+}
+
 #phase-config-grid {
     layout: horizontal;
     height: 1fr;
@@ -384,10 +395,9 @@ MarkdownH3 {
     margin-bottom: 1;
 }
 
-#phase-agent-meta {
-    layout: horizontal;
-    height: auto;
-    margin: 0 0 1 0;
+#phase-agent-model {
+    width: 1fr;
+    margin-bottom: 1;
 }
 
 #phase-agent-tools {

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -163,6 +163,25 @@ FlowCard {
     min-width: 36;
 }
 
+.flow-card-name {
+    height: 1;
+    text-style: bold;
+    text-overflow: ellipsis;
+    text-wrap: nowrap;
+}
+
+.flow-card-description {
+    height: auto;
+    max-height: 2;
+    color: $text-muted;
+    overflow: hidden hidden;
+}
+
+.flow-card-footer {
+    dock: bottom;
+    height: auto;
+}
+
 FlowCard:hover {
     border: solid $primary;
 }
@@ -302,13 +321,9 @@ Collapsible {
 
 #phase-description {
     height: auto;
-    max-height: 4;
+    max-height: 2;
     margin-top: 1;
     overflow-y: auto;
-}
-
-#phase-description > Markdown {
-    height: auto;
 }
 
 #phase-config-grid {

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/flow_card.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/flow_card.py
@@ -14,6 +14,8 @@ from ddev.ai.config.models import ConfigStatus, FlowResult
 from ddev.cli.meta.ai.palette import ERROR, SUCCESS
 from ddev.cli.meta.ai.tui.widgets.pipeline_graph import COLOR_RUNNING
 
+FLOW_DESCRIPTION_MAX_LINES = 2
+
 
 class FlowCard(Static):
     """Focusable card for one validated or broken flow result."""
@@ -51,7 +53,7 @@ class FlowCard(Static):
         content = Text(name, style="bold", no_wrap=True, overflow="ellipsis")
         if desc:
             content.append("\n")
-            content.append(desc, style="dim")
+            content.append_text(self._render_description(desc))
         content.append("\n\n")
         if self.result.status is ConfigStatus.BROKEN:
             count = len(self.result.errors)
@@ -67,6 +69,19 @@ class FlowCard(Static):
             if self.resumable:
                 content.append("\n↻ resumable run available", style=COLOR_RUNNING)
         return content
+
+    def _render_description(self, description: str) -> Text:
+        width = self.content_size.width
+        if width <= 0:
+            return Text(description, style="dim")
+
+        lines = Text(description, style="dim").wrap(self.app.console, width)
+        visible_lines = lines[:FLOW_DESCRIPTION_MAX_LINES]
+        if len(lines) > FLOW_DESCRIPTION_MAX_LINES:
+            last_line = visible_lines[-1]
+            last_line.truncate(max(width - 1, 0))
+            last_line.append("…", style="dim")
+        return Text("\n").join(visible_lines)
 
     def action_select(self) -> None:
         self.post_message(self.Selected(self.result))

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/flow_card.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/flow_card.py
@@ -6,18 +6,18 @@
 from __future__ import annotations
 
 from rich.text import Text
+from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.message import Message
+from textual.widget import Widget
 from textual.widgets import Static
 
 from ddev.ai.config.models import ConfigStatus, FlowResult
 from ddev.cli.meta.ai.palette import ERROR, SUCCESS
 from ddev.cli.meta.ai.tui.widgets.pipeline_graph import COLOR_RUNNING
 
-FLOW_DESCRIPTION_MAX_LINES = 2
 
-
-class FlowCard(Static):
+class FlowCard(Widget):
     """Focusable card for one validated or broken flow result."""
 
     can_focus = True
@@ -44,17 +44,19 @@ class FlowCard(Static):
         """Number of phases in the flow."""
         return len(self.flow.flow) if self.flow is not None else 0
 
-    def render(self) -> Text:
+    def compose(self) -> ComposeResult:
         name = self.result.name or "(unnamed)"
         desc = self.flow.description if self.flow is not None and self.flow.description else ""
         if self.result.status is ConfigStatus.BROKEN:
             desc = self.result.errors[0].message if self.result.errors else "Invalid flow configuration"
-        n = self.phase_count
-        content = Text(name, style="bold", no_wrap=True, overflow="ellipsis")
+
+        yield Static(name, classes="flow-card-name", markup=False)
         if desc:
-            content.append("\n")
-            content.append_text(self._render_description(desc))
-        content.append("\n\n")
+            yield Static(desc, classes="flow-card-description", markup=False)
+        yield Static(self._render_footer(), classes="flow-card-footer")
+
+    def _render_footer(self) -> Text:
+        content = Text()
         if self.result.status is ConfigStatus.BROKEN:
             count = len(self.result.errors)
             content.append(
@@ -63,25 +65,13 @@ class FlowCard(Static):
             )
             content.append("\nEnter to inspect diagnostics", style="dim")
         else:
+            n = self.phase_count
             phase_word = "phase" if n == 1 else "phases"
             content.append("●", style=SUCCESS)
             content.append(f" {n} {phase_word}")
             if self.resumable:
                 content.append("\n↻ resumable run available", style=COLOR_RUNNING)
         return content
-
-    def _render_description(self, description: str) -> Text:
-        width = self.content_size.width
-        if width <= 0:
-            return Text(description, style="dim")
-
-        lines = Text(description, style="dim").wrap(self.app.console, width)
-        visible_lines = lines[:FLOW_DESCRIPTION_MAX_LINES]
-        if len(lines) > FLOW_DESCRIPTION_MAX_LINES:
-            last_line = visible_lines[-1]
-            last_line.truncate(max(width - 1, 0))
-            last_line.append("…", style="dim")
-        return Text("\n").join(visible_lines)
 
     def action_select(self) -> None:
         self.post_message(self.Selected(self.result))

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/flow_card.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/flow_card.py
@@ -17,6 +17,29 @@ from ddev.cli.meta.ai.palette import ERROR, SUCCESS
 from ddev.cli.meta.ai.tui.widgets.pipeline_graph import COLOR_RUNNING
 
 
+class FlowCardDescription(Static):
+    """Flow description that marks clipped text with an ellipsis."""
+
+    def __init__(self, description: str) -> None:
+        super().__init__(description, classes="flow-card-description", markup=False)
+        self.description = description
+
+    def render(self) -> Text:
+        width, height = self.content_size
+        if width <= 0 or height <= 0:
+            return Text(self.description)
+
+        lines = Text(self.description).wrap(self.app.console, width)
+        if len(lines) <= height:
+            return Text("\n").join(lines)
+
+        visible_lines = lines[:height]
+        last_line = visible_lines[-1]
+        last_line.truncate(max(width - 3, 0))
+        last_line.append("...")
+        return Text("\n").join(visible_lines)
+
+
 class FlowCard(Widget):
     """Focusable card for one validated or broken flow result."""
 
@@ -52,7 +75,7 @@ class FlowCard(Widget):
 
         yield Static(name, classes="flow-card-name", markup=False)
         if desc:
-            yield Static(desc, classes="flow-card-description", markup=False)
+            yield FlowCardDescription(desc)
         yield Static(self._render_footer(), classes="flow-card-footer")
 
     def _render_footer(self) -> Text:

--- a/ddev/tests/ai/config/test_engine.py
+++ b/ddev/tests/ai/config/test_engine.py
@@ -33,7 +33,7 @@ def real_phase_registry():
 
 
 PHASE_AND_FLOW = (
-    "- type: phase\n  config:\n    name: p\n    agent: ag\n"
+    "- type: phase\n  config:\n    name: p\n    description: Prepare the integration\n    agent: ag\n"
     "    tasks:\n      - name: t\n        prompt_ref: intro\n        goal_ref: g\n"
     "    checkpoint:\n      memory_prompt_ref: mem\n"
     "- type: flow\n  config:\n    name: demo\n    description: Generate an integration\n"
@@ -85,6 +85,7 @@ def test_get_flow_resolves_all_refs_and_variables(tmp_path):
     assert rf.phases["p"].checkpoint.memory_prompt_ref is None
     assert rf.variables == {"x": "hi"}
     assert rf.agents["ag"].system_prompt == "sys"
+    assert rf.phases["p"].description == "Prepare the integration"
     assert rf.description == "Generate an integration"
     assert "topic" in [flow_input.name for flow_input in rf.inputs]
 

--- a/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
@@ -359,6 +359,28 @@ async def test_phase_config_screen_renders_phase_info_and_agent_details() -> Non
         assert "_No system prompt configured._" in screen.query_one("#phase-agent-prompt").source
 
 
+async def test_phase_config_long_description_scrolls_without_displacing_config() -> None:
+    """Long phase descriptions use a bounded scroll region above the configuration cards."""
+    from textual.containers import VerticalScroll
+
+    from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+
+    flow = _make_flow()
+    phase = flow.phases[flow.flow[0].phase]
+    phase.description = "\n\n".join(["Explain this phase clearly."] * 20)
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(PhaseConfigScreen(flow, phase.name))
+        await pilot.pause()
+
+        description = pilot.app.screen.query_one("#phase-description", VerticalScroll)
+        config_grid = pilot.app.screen.query_one("#phase-config-grid")
+        assert description.region.height <= 4
+        assert description.max_scroll_y > 0
+        assert config_grid.region.height > description.region.height
+
+
 async def test_phase_config_screen_renders_resolved_task_prompt() -> None:
     """PhaseConfigScreen renders the prompt already inlined by the engine."""
     from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
@@ -520,13 +542,15 @@ async def test_phase_config_agent_panel_renders_tools_and_prompt() -> None:
         variables={},
     )
     app = _app()
-    async with app.run_test() as pilot:
+    async with app.run_test(size=(120, 50)) as pilot:
         await pilot.pause()
         await pilot.app.push_screen(PhaseConfigScreen(flow, "analyse"))
         await pilot.pause()
 
         assert "analyst" in str(pilot.app.screen.query_one("#phase-agent-name").render())
-        assert "claude-3-sonnet" in str(pilot.app.screen.query_one("#phase-agent-model").render())
+        model = pilot.app.screen.query_one("#phase-agent-model")
+        assert "model claude-3-sonnet (anthropic)" in str(model.render())
+        assert model.region.right <= pilot.app.screen.query_one("#phase-agent-card").content_region.right
         rendered_tools = str(pilot.app.screen.query_one("#phase-agent-tools").render())
         assert rendered_tools == "read_file · create_file · ddev_test"
         assert "inline analyst" in pilot.app.screen.query_one("#phase-agent-prompt").source

--- a/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
@@ -355,7 +355,7 @@ async def test_phase_config_screen_renders_phase_info_and_agent_details() -> Non
         task_prompt = screen.query(".task-prompt").first()
         assert "do something" in task_prompt.source
         assert "agent_a" in str(screen.query_one("#phase-agent-name").render())
-        assert "provider · anthropic" in str(screen.query_one("#phase-agent-provider").render())
+        assert "anthropic" in str(screen.query_one("#phase-agent-model").render())
         assert "_No system prompt configured._" in screen.query_one("#phase-agent-prompt").source
 
 
@@ -549,7 +549,8 @@ async def test_phase_config_agent_panel_renders_tools_and_prompt() -> None:
 
         assert "analyst" in str(pilot.app.screen.query_one("#phase-agent-name").render())
         model = pilot.app.screen.query_one("#phase-agent-model")
-        assert "model claude-3-sonnet (anthropic)" in str(model.render())
+        assert "claude-3-sonnet" in str(model.render())
+        assert "anthropic" in str(model.render())
         assert model.region.right <= pilot.app.screen.query_one("#phase-agent-card").content_region.right
         rendered_tools = str(pilot.app.screen.query_one("#phase-agent-tools").render())
         assert rendered_tools == "read_file · create_file · ddev_test"

--- a/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
@@ -359,26 +359,38 @@ async def test_phase_config_screen_renders_phase_info_and_agent_details() -> Non
         assert "_No system prompt configured._" in screen.query_one("#phase-agent-prompt").source
 
 
-async def test_phase_config_long_description_scrolls_without_displacing_config() -> None:
-    """Long phase descriptions use a bounded scroll region above the configuration cards."""
+async def test_phase_config_description_does_not_reduce_config_at_small_terminal() -> None:
+    """A phase description fits the existing summary height and remains scrollable."""
     from textual.containers import VerticalScroll
+    from textual.widgets import Static
 
     from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
 
     flow = _make_flow()
     phase = flow.phases[flow.flow[0].phase]
-    phase.description = "\n\n".join(["Explain this phase clearly."] * 20)
     app = _app()
-    async with app.run_test(size=(120, 50)) as pilot:
+    async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
+        await pilot.app.push_screen(PhaseConfigScreen(flow, phase.name))
+        await pilot.pause()
+        baseline_grid_height = pilot.app.screen.query_one("#phase-config-grid").region.height
+        await pilot.press("escape")
+        await pilot.pause()
+
+        phase.description = "\n\n".join(["Explain **this phase** clearly."] * 20)
         await pilot.app.push_screen(PhaseConfigScreen(flow, phase.name))
         await pilot.pause()
 
         description = pilot.app.screen.query_one("#phase-description", VerticalScroll)
+        description_text = description.query_one(Static)
         config_grid = pilot.app.screen.query_one("#phase-config-grid")
-        assert description.region.height <= 4
+        task_title = pilot.app.screen.query_one("CollapsibleTitle")
+        footer = pilot.app.screen.query_one("Footer")
+        assert description_text.content == phase.description
+        assert description.region.height == 2
         assert description.max_scroll_y > 0
-        assert config_grid.region.height > description.region.height
+        assert config_grid.region.height == baseline_grid_height
+        assert task_title.region.bottom <= footer.region.y
 
 
 async def test_phase_config_screen_renders_resolved_task_prompt() -> None:

--- a/ddev/tests/cli/meta/ai/tui/test_main_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_main_screen.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 from ddev.ai.config.errors import ErrorKind, FlowError
@@ -236,6 +237,22 @@ async def test_flow_card_uses_available_width_before_truncating(make_flow, make_
         assert card.render().plain.splitlines()[0] == name
 
 
+async def test_flow_card_limits_description_without_hiding_phase_count(make_flow, make_togo_app) -> None:
+    flow = replace(
+        make_flow("Long Description", n_phases=2),
+        description=" ".join(["A detailed flow description that should wrap across the card."] * 10),
+    )
+    app = make_togo_app([flow])
+
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        rendered_lines = app.screen.query_one("FlowCard").render().plain.splitlines()
+
+        assert len(rendered_lines) == 5
+        assert rendered_lines[2].endswith("…")
+        assert rendered_lines[-1] == "● 2 phases"
+
+
 async def test_flow_card_click_does_not_navigate_when_text_is_selected(monkeypatch, make_togo_app):
     """Releasing a drag selection over a card does not activate the card."""
     from ddev.cli.meta.ai.tui.screens.main import MainScreen
@@ -302,7 +319,10 @@ async def test_resume_discovery_uses_repository_root_when_cwd_differs(tmp_path, 
     other_cwd = tmp_path / "elsewhere"
     repo_path.mkdir()
     other_cwd.mkdir()
-    flow = make_flow("Repo Flow", n_phases=2)
+    flow = replace(
+        make_flow("Repo Flow", n_phases=2),
+        description=" ".join(["A resumable flow with a deliberately long description."] * 10),
+    )
     run_dir = repo_path / ".ddev" / "ai-runs" / flow_slug(flow)
     run_dir.mkdir(parents=True)
     (run_dir / "checkpoints.yaml").write_text(
@@ -324,6 +344,10 @@ async def test_resume_discovery_uses_repository_root_when_cwd_differs(tmp_path, 
         await pilot.pause()
         card = app.screen.query_one(FlowCard)
         assert card.resumable
+        rendered_lines = card.render().plain.splitlines()
+        assert len(rendered_lines) == 6
+        assert rendered_lines[-2] == "● 2 phases"
+        assert rendered_lines[-1] == "↻ resumable run available"
         card.action_select()
         await pilot.pause()
         assert isinstance(app.screen, FlowScreen)

--- a/ddev/tests/cli/meta/ai/tui/test_main_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_main_screen.py
@@ -242,7 +242,9 @@ async def test_flow_card_uses_available_width_before_truncating(make_flow, make_
 
         assert card.content_region.width > len(name)
         assert rendered_name == name
-        assert card.query_one(".flow-card-description").region.height == 1
+        description = card.query_one(".flow-card-description")
+        assert description.region.height == 1
+        assert str(description.render()) == flow.description
 
 
 async def test_flow_card_limits_description_without_hiding_phase_count(make_flow, make_togo_app) -> None:
@@ -257,10 +259,13 @@ async def test_flow_card_limits_description_without_hiding_phase_count(make_flow
         card = app.screen.query_one("FlowCard")
         description = card.query_one(".flow-card-description")
         footer = card.query_one(".flow-card-footer")
+        rendered_description = str(description.render())
 
         assert description.content == flow.description
         assert description.region.height == 2
         assert len(flow.description) > description.content_region.width * description.region.height
+        assert len(rendered_description.splitlines()) == 2
+        assert rendered_description.endswith("...")
         assert str(footer.render()) == "● 2 phases"
         assert footer.region.bottom <= card.content_region.bottom
 

--- a/ddev/tests/cli/meta/ai/tui/test_main_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_main_screen.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from dataclasses import replace
 from pathlib import Path
 
+from rich.text import Text
+
 from ddev.ai.config.errors import ErrorKind, FlowError
 from ddev.ai.config.models import ConfigStatus, FlowResult
 
@@ -212,16 +214,20 @@ async def test_flow_card_carries_flow_config(make_flow):
     assert card.flow is flow
 
 
-async def test_valid_flow_marker_uses_success_palette(make_flow):
+async def test_valid_flow_marker_uses_success_palette(make_flow, make_togo_app):
     """The valid marker uses the established success color."""
     from ddev.cli.meta.ai.palette import SUCCESS
-    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
 
     flow = make_flow("Valid", n_phases=1)
-    card = FlowCard(result=FlowResult(flow.name, ConfigStatus.OK, resolved=flow), index=0)
-    rendered = card.render()
-    marker_index = rendered.plain.index("●")
-    assert any(span.start <= marker_index < span.end and span.style == SUCCESS for span in rendered.spans)
+    app = make_togo_app([flow])
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        rendered = app.screen.query_one(".flow-card-footer").content
+
+        assert isinstance(rendered, Text)
+        marker_index = rendered.plain.index("●")
+        assert any(span.start <= marker_index < span.end and span.style == SUCCESS for span in rendered.spans)
 
 
 async def test_flow_card_uses_available_width_before_truncating(make_flow, make_togo_app):
@@ -232,9 +238,11 @@ async def test_flow_card_uses_available_width_before_truncating(make_flow, make_
     async with app.run_test(size=(240, 50)) as pilot:
         await pilot.pause()
         card = app.screen.query_one("FlowCard")
+        rendered_name = card.query_one(".flow-card-name").content
 
         assert card.content_region.width > len(name)
-        assert card.render().plain.splitlines()[0] == name
+        assert rendered_name == name
+        assert card.query_one(".flow-card-description").region.height == 1
 
 
 async def test_flow_card_limits_description_without_hiding_phase_count(make_flow, make_togo_app) -> None:
@@ -246,11 +254,35 @@ async def test_flow_card_limits_description_without_hiding_phase_count(make_flow
 
     async with app.run_test(size=(120, 50)) as pilot:
         await pilot.pause()
-        rendered_lines = app.screen.query_one("FlowCard").render().plain.splitlines()
+        card = app.screen.query_one("FlowCard")
+        description = card.query_one(".flow-card-description")
+        footer = card.query_one(".flow-card-footer")
 
-        assert len(rendered_lines) == 5
-        assert rendered_lines[2].endswith("…")
-        assert rendered_lines[-1] == "● 2 phases"
+        assert description.content == flow.description
+        assert description.region.height == 2
+        assert len(flow.description) > description.content_region.width * description.region.height
+        assert str(footer.render()) == "● 2 phases"
+        assert footer.region.bottom <= card.content_region.bottom
+
+
+async def test_flow_card_keeps_resumable_footer_with_long_description(make_flow, make_togo_app) -> None:
+    flow = replace(
+        make_flow("Long Resumable Description", n_phases=2),
+        description=" ".join(["A resumable flow with a deliberately long description."] * 10),
+    )
+    app = make_togo_app([flow])
+
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        card = app.screen.query_one("FlowCard")
+        card.resumable = True
+        await card.recompose()
+        await pilot.pause()
+
+        footer = card.query_one(".flow-card-footer")
+        assert str(footer.render()).splitlines() == ["● 2 phases", "↻ resumable run available"]
+        assert footer.region.height == 2
+        assert footer.region.bottom <= card.content_region.bottom
 
 
 async def test_flow_card_click_does_not_navigate_when_text_is_selected(monkeypatch, make_togo_app):
@@ -319,10 +351,7 @@ async def test_resume_discovery_uses_repository_root_when_cwd_differs(tmp_path, 
     other_cwd = tmp_path / "elsewhere"
     repo_path.mkdir()
     other_cwd.mkdir()
-    flow = replace(
-        make_flow("Repo Flow", n_phases=2),
-        description=" ".join(["A resumable flow with a deliberately long description."] * 10),
-    )
+    flow = make_flow("Repo Flow", n_phases=2)
     run_dir = repo_path / ".ddev" / "ai-runs" / flow_slug(flow)
     run_dir.mkdir(parents=True)
     (run_dir / "checkpoints.yaml").write_text(
@@ -344,10 +373,6 @@ async def test_resume_discovery_uses_repository_root_when_cwd_differs(tmp_path, 
         await pilot.pause()
         card = app.screen.query_one(FlowCard)
         assert card.resumable
-        rendered_lines = card.render().plain.splitlines()
-        assert len(rendered_lines) == 6
-        assert rendered_lines[-2] == "● 2 phases"
-        assert rendered_lines[-1] == "↻ resumable run available"
         card.action_select()
         await pilot.pause()
         assert isinstance(app.screen, FlowScreen)


### PR DESCRIPTION
### What does this PR do?

- Adds an optional description to phase configuration and displays it in the phase configuration header. Short descriptions use only the space they need, while longer descriptions are capped at four lines and remain available in a scrollable region so they do not displace task and agent details.
- Adds concise descriptions to every phase in the built-in OpenMetrics flow, including the deterministic endpoint-inspection phase.
- Limits flow-card descriptions to two rendered lines with an ellipsis, preserving the phase count and resumable-run indicator even when a flow has a long description.
- Shows the agent model and provider together in a single badge, for example `model · sonnet (anthropic)`.
- Uses Textual's `AUTO_FOCUS` for the safe **Keep running** action in the cancellation modal and the **Close** action in the phase-error modal.

<img width="807" height="172" alt="image" src="https://github.com/user-attachments/assets/48ad9681-df20-49c1-acdd-a72daf4708d0" />
<img width="844" height="163" alt="image" src="https://github.com/user-attachments/assets/33ec3a2e-b15f-45e6-85fc-b535a7c07cfa" />


### Motivation

Deterministic phases such as `inspect_endpoint` do not configure an agent or tasks. Selecting one of these phases therefore showed empty task and agent panels without explaining the phase's purpose. Optional phase descriptions provide that context at a glance while keeping tasks—the primary information for agentic phases—prominent.

Flow descriptions could also grow enough to push important flow-card metadata out of view. Bounding the preview keeps cards predictable and ensures phase and resume information is always visible, while the complete description remains available in the flow overview.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
