### PR TITLE
Run Kuma E2E with the Kubernetes Agent backend

### DIFF
--- a/kuma/tests/conftest.py
+++ b/kuma/tests/conftest.py
@@ -2,82 +2,66 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
-import time
-from contextlib import ExitStack
 
 import pytest
-import requests
 
 from datadog_checks.dev.kind import kind_run
-from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.subprocess import run_command
+
+KUMA_NAMESPACE = 'kuma-system'
+KUMA_SERVICE = 'kuma-control-plane'
+KUMA_STARTUP_TIMEOUT = 600
+KUMA_METRICS_ENDPOINT = f'http://{KUMA_SERVICE}.{KUMA_NAMESPACE}.svc.cluster.local:5680/metrics'
 
 
 def setup_kuma():
-    kuma_version = os.environ.get("KUMA_VERSION", "2.10.6")
-    run_command(["kubectl", "create", "namespace", "kuma-system"])
-    run_command(["helm", "repo", "add", "kuma", "https://kumahq.github.io/charts"])
-    run_command(["helm", "repo", "update"])
+    kuma_version = os.environ.get('KUMA_VERSION', '2.10.6')
+    run_command(['kubectl', 'create', 'namespace', KUMA_NAMESPACE], check=True)
+    run_command(['helm', 'repo', 'add', 'kuma', 'https://kumahq.github.io/charts'], check=True)
+    run_command(['helm', 'repo', 'update'], check=True)
     run_command(
         [
-            "helm",
-            "upgrade",
-            "--install",
-            "kuma",
-            "kuma/kuma",
-            "--version",
+            'helm',
+            'upgrade',
+            '--install',
+            'kuma',
+            'kuma/kuma',
+            '--version',
             kuma_version,
-            "--create-namespace",
-            "-n",
-            "kuma-system",
-        ]
+            '--create-namespace',
+            '-n',
+            KUMA_NAMESPACE,
+        ],
+        check=True,
     )
     run_command(
-        ["kubectl", "rollout", "status", "deployment/kuma-control-plane", "-n", "kuma-system", "--timeout=180s"]
+        [
+            'kubectl',
+            'rollout',
+            'status',
+            f'deployment/{KUMA_SERVICE}',
+            '-n',
+            KUMA_NAMESPACE,
+            # The Kuma deployment's readiness probe checks its in-cluster /ready endpoint.
+            f'--timeout={KUMA_STARTUP_TIMEOUT}s',
+        ],
+        check=True,
     )
-
-
-def wait_for_kuma_readiness(api_url, api_port, max_wait=600):
-    """Wait for Kuma control plane to be ready by querying the /config endpoint."""
-    config_url = f'http://{api_url}:{api_port}/config'
-    start_time = time.monotonic()
-
-    while time.monotonic() - start_time < max_wait:
-        try:
-            response = requests.get(config_url, timeout=5)
-            if response.ok:
-                print(f"Kuma control plane is ready at {config_url} (took {time.monotonic() - start_time} seconds)")
-                return
-        except (requests.exceptions.RequestException, requests.exceptions.Timeout):
-            pass
-
-        print(f"Waiting for Kuma control plane to be ready at {config_url}...")
-        time.sleep(0.5)
-
-    raise TimeoutError(f"Kuma control plane did not become ready within {max_wait} seconds")
 
 
 @pytest.fixture(scope='session')
 def dd_environment(dd_save_state):
     with kind_run(conditions=[setup_kuma]) as kubeconfig:
-        with ExitStack() as stack:
-            kuma_metrics_url, kuma_metrics_port = stack.enter_context(
-                port_forward(kubeconfig, 'kuma-system', 5680, 'service', 'kuma-control-plane')
-            )
-            kuma_api_url, kuma_api_port = stack.enter_context(
-                port_forward(kubeconfig, 'kuma-system', 5681, 'service', 'kuma-control-plane')
-            )
+        instance = {'openmetrics_endpoint': KUMA_METRICS_ENDPOINT}
+        metadata = {
+            'agent_type': 'kubernetes',
+            'kubernetes': {
+                'kubeconfig': kubeconfig,
+            },
+        }
 
-            # Wait for Kuma control plane to be ready
-            wait_for_kuma_readiness(kuma_api_url, kuma_api_port)
-
-            metrics_endpoint = f'http://{kuma_metrics_url}:{kuma_metrics_port}/metrics'
-
-            env_instance = {'openmetrics_endpoint': metrics_endpoint}
-
-            dd_save_state("kuma_instance", env_instance)
-
-            yield env_instance
+        dd_save_state('kuma_instance', instance)
+        yield instance, metadata
 
 
 @pytest.fixture(scope='session')

--- a/kuma/tests/conftest.py
+++ b/kuma/tests/conftest.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+import shlex
 
 import pytest
 
@@ -12,6 +13,13 @@ KUMA_NAMESPACE = 'kuma-system'
 KUMA_SERVICE = 'kuma-control-plane'
 KUMA_STARTUP_TIMEOUT = 600
 KUMA_METRICS_ENDPOINT = f'http://{KUMA_SERVICE}.{KUMA_NAMESPACE}.svc.cluster.local:5680/metrics'
+KUMA_SOURCE_COMMAND = shlex.join(
+    [
+        '/opt/datadog-agent/embedded/bin/python3',
+        '-c',
+        "import datadog_checks.kuma; print('Resolved Kuma module source:', datadog_checks.kuma.__file__)",
+    ]
+)
 
 
 def setup_kuma():
@@ -58,6 +66,7 @@ def dd_environment(dd_save_state):
             'kubernetes': {
                 'kubeconfig': kubeconfig,
             },
+            'post_install_commands': [KUMA_SOURCE_COMMAND],
         }
 
         dd_save_state('kuma_instance', instance)


### PR DESCRIPTION
### What does this PR do?

Migrates Kuma's existing Kind E2E environment to the Kubernetes Agent backend.

The test fixture now:

- deploys Kuma to a Kind cluster with Helm and waits for the control-plane deployment to become ready;
- runs the Datadog Agent inside the Kind cluster;
- reaches Kuma through its in-cluster Service DNS endpoint (`http://kuma-control-plane.kuma-system.svc.cluster.local:5680/metrics`);
- removes the host-side `kubectl port-forward` processes and endpoint plumbing;
- fails environment setup immediately when Kubernetes or Helm commands fail.

The Kuma integration assertions are unchanged: the E2E still exercises the Helm-deployed Kuma control plane and verifies the expected Kuma metrics.

### Motivation

Run the existing Kuma E2E through the Kubernetes Agent path and verify in-cluster service discovery without host-local endpoint plumbing. This PR changes only the E2E fixture; it does not change the Kuma check or production behavior.

### Validation

- `ddev --no-interactive test -fs kuma`
- Kuma unit suite: 27 passed
- E2E test ran manually on laptop and workspace
- Kind E2E with the local base package: 2 passed
- Environment cleanup confirmed that the temporary Kind cluster is deleted

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, add the `backport/<branch-name>` label and a backport PR will be opened automatically after merge.
