### PR TITLE
Fix flaky test_wal_receiver_metrics

### DIFF
--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -33,6 +33,21 @@ from .utils import _get_superconn, _wait_for_value, requires_over_10
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
 
 
+def _wait_for_wal_replay(pg_replica_instance: dict[str, object], target_lsn: str, attempts: int = 10) -> None:
+    conn = _get_superconn(pg_replica_instance)
+    try:
+        for _ in range(attempts):
+            with conn.cursor() as cur:
+                cur.execute("SELECT pg_wal_lsn_diff(pg_last_wal_replay_lsn(), %s::pg_lsn) >= 0", (target_lsn,))
+                if cur.fetchone()[0]:
+                    return
+            time.sleep(0.1)
+    finally:
+        conn.close()
+
+    pytest.fail(f'Replica did not replay WAL up to {target_lsn}')
+
+
 @requires_over_10
 def test_common_replica_metrics(aggregator, integration_check, metrics_cache_replica, pg_replica_instance):
     check = integration_check(pg_replica_instance)
@@ -90,38 +105,42 @@ def test_wal_receiver_metrics(aggregator, integration_check, pg_instance, pg_rep
     check = integration_check(pg_replica_instance)
     check._connect()
     check.initialize_is_aurora()
+    wal_change_started = time.monotonic()
     with _get_superconn(pg_instance) as conn:
         with conn.cursor() as cur:
             # Ask for a new txid to force a WAL change
             cur.execute('select txid_current();')
-            cur.fetchall()
-    # Wait for 200ms for WAL sender to send message
-    time.sleep(0.2)
+            cur.execute('select pg_current_wal_lsn();')
+            target_lsn = cur.fetchone()[0]
+    _wait_for_wal_replay(pg_replica_instance, target_lsn)
 
     check.check(pg_replica_instance)
     expected_tags = _get_expected_replication_tags(check, pg_replica_instance, status='streaming')
     aggregator.assert_metric('postgresql.wal_receiver.last_msg_send_age', count=1, tags=expected_tags)
     aggregator.assert_metric('postgresql.wal_receiver.last_msg_receipt_age', count=1, tags=expected_tags)
     aggregator.assert_metric('postgresql.wal_receiver.latest_end_age', count=1, tags=expected_tags)
-    # All ages should have been updated within the last second
+    higher_bound = time.monotonic() - wal_change_started
     assert_metric_at_least(
         aggregator,
         'postgresql.wal_receiver.last_msg_send_age',
-        higher_bound=1,
+        lower_bound=0,
+        higher_bound=higher_bound,
         tags=expected_tags,
         count=1,
     )
     assert_metric_at_least(
         aggregator,
         'postgresql.wal_receiver.last_msg_receipt_age',
-        higher_bound=1,
+        lower_bound=0,
+        higher_bound=higher_bound,
         tags=expected_tags,
         count=1,
     )
     assert_metric_at_least(
         aggregator,
         'postgresql.wal_receiver.latest_end_age',
-        higher_bound=1,
+        lower_bound=0,
+        higher_bound=higher_bound,
         tags=expected_tags,
         count=1,
     )

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -28,24 +28,9 @@ from .common import (
     check_wait_event_metrics,
     check_wal_receiver_metrics,
 )
-from .utils import _get_superconn, _wait_for_value, requires_over_10
+from .utils import _force_wal_change, _get_superconn, _wait_for_value, _wait_for_wal_replay, requires_over_10
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
-
-
-def _wait_for_wal_replay(pg_replica_instance: dict[str, object], target_lsn: str, attempts: int = 10) -> None:
-    conn = _get_superconn(pg_replica_instance)
-    try:
-        for _ in range(attempts):
-            with conn.cursor() as cur:
-                cur.execute("SELECT pg_wal_lsn_diff(pg_last_wal_replay_lsn(), %s::pg_lsn) >= 0", (target_lsn,))
-                if cur.fetchone()[0]:
-                    return
-            time.sleep(0.1)
-    finally:
-        conn.close()
-
-    pytest.fail(f'Replica did not replay WAL up to {target_lsn}')
 
 
 @requires_over_10
@@ -105,14 +90,10 @@ def test_wal_receiver_metrics(aggregator, integration_check, pg_instance, pg_rep
     check = integration_check(pg_replica_instance)
     check._connect()
     check.initialize_is_aurora()
+    # The receiver ages are only bounded by something the test controls once the replica has
+    # received WAL generated here, so force a WAL record and wait for the replica to replay it.
     wal_change_started = time.monotonic()
-    with _get_superconn(pg_instance) as conn:
-        with conn.cursor() as cur:
-            # Ask for a new txid to force a WAL change
-            cur.execute('select txid_current();')
-            cur.execute('select pg_current_wal_lsn();')
-            target_lsn = cur.fetchone()[0]
-    _wait_for_wal_replay(pg_replica_instance, target_lsn)
+    _wait_for_wal_replay(pg_replica_instance, _force_wal_change(pg_instance))
 
     check.check(pg_replica_instance)
     expected_tags = _get_expected_replication_tags(check, pg_replica_instance, status='streaming')

--- a/postgres/tests/utils.py
+++ b/postgres/tests/utils.py
@@ -110,6 +110,52 @@ def _wait_for_value(db_instance, lower_threshold, query, attempts=10, applicatio
     conn.close()
 
 
+# WAL positions are exchanged as a numeric byte offset rather than a pg_lsn or its text form.
+# psycopg has no pg_lsn loader, and on SQL_ASCII databases it also hands back bytes for text,
+# so either representation round-trips as bytes and the server then refuses to cast it back.
+WAL_OFFSET_EXPR = "pg_wal_lsn_diff({}, '0/0'::pg_lsn)"
+
+
+def _force_wal_change(db_instance, application_name='test'):
+    """
+    Write a WAL record on the primary and return the WAL byte offset that follows it.
+
+    A logical message is emitted rather than calling txid_current(): the latter only assigns a
+    transaction id, and a transaction that changes nothing commits without writing a WAL record,
+    so it produces no traffic for a WAL receiver to report on.
+    """
+    with _get_superconn(db_instance, application_name) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT pg_logical_emit_message(true, 'datadog', 'wal_receiver_metrics')")
+            cur.fetchall()
+            # Read the position after the emitting transaction has committed, so that the offset
+            # covers its commit record too.
+            cur.execute(f'SELECT {WAL_OFFSET_EXPR.format("pg_current_wal_lsn()")}')
+            return cur.fetchone()[0]
+
+
+def _wait_for_wal_replay(db_instance, target_offset, timeout=30.0, application_name='test'):
+    """
+    Block until the replica has replayed WAL up to target_offset, failing the test if it has not
+    done so within timeout seconds.
+    """
+    query = f'SELECT {WAL_OFFSET_EXPR.format("pg_last_wal_replay_lsn()")} >= %s'
+    conn = _get_superconn(db_instance, application_name)
+    deadline = time.monotonic() + timeout
+    try:
+        while time.monotonic() < deadline:
+            with conn.cursor() as cur:
+                cur.execute(query, (target_offset,))
+                # pg_last_wal_replay_lsn() is NULL until the replica has started replaying
+                if cur.fetchone()[0]:
+                    return
+            time.sleep(0.1)
+    finally:
+        conn.close()
+
+    pytest.fail(f'Replica did not replay WAL up to offset {target_offset} within {timeout}s')
+
+
 def run_query_thread(pg_instance, query, application_name='test', init_statements=None):
     def run_query():
         conn = _get_superconn(pg_instance, application_name)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a5ad6070-864e-4f03-98f4-0b3398f5463c","source":"chat","resourceId":"3d4986a0-4acd-4ea8-a371-1c0bed9ef9fb","workflowId":"0550e8f1-9e3d-47a2-8e90-925cb960af31","codeChangeId":"0550e8f1-9e3d-47a2-8e90-925cb960af31","sourceType":"test-optimization"} -->
### What does this PR do?

Makes `test_wal_receiver_metrics` synchronize on WAL the test itself generates, so the WAL receiver age assertions are bounded by the test's own elapsed time instead of a hard-coded one second.

Three things were needed:

- Emit a logical message on the primary to force a WAL record. The previous `txid_current()` call did not write WAL, so it never produced any WAL receiver traffic.
- Wait for the replica to replay past that record before collecting metrics, with a 30s deadline.
- Exchange WAL positions as a numeric byte offset (`pg_wal_lsn_diff(lsn, '0/0')`) rather than as `pg_lsn` or its text form.

The wait helpers live in `tests/utils.py` alongside `_wait_for_value`.

### Motivation

`test_wal_receiver_metrics` could fail when `postgresql.wal_receiver.last_msg_send_age` exceeded the hard-coded `<= 1` second assertion, for example with a value of `1.16968`.

The root cause is that nothing in the test influenced the metric it asserted on. `txid_current()` assigns a transaction id, but a transaction that changes nothing commits without writing a WAL record, so the primary's WAL position did not move. Measured on PG 16:

```
lsn_pre_txid  0/9009918
txid          868
lsn_post_txid 0/9009918   <- unchanged
```

With no WAL generated, the receiver ages were governed entirely by unrelated background replication traffic, which arrives sporadically. Values of 1.8s and 3.6s were observed while the test's own window was 0.09s, which is exactly the flake. Emitting a real WAL record and waiting for the replica to replay it makes the ages a function of something the test controls.

Two encoding notes on why positions travel as a numeric offset: psycopg has no `pg_lsn` loader, so a `pg_lsn` comes back as `bytes` and is re-adapted as `bytea` (`CannotCoerce: cannot cast type bytea to pg_lsn`); and casting to `::text` does not help either, because on the `-C` (SQL_ASCII) environments psycopg also returns `bytes` for `text`, which is why this integration ships `SQLASCIITextLoader`.

### Testing

Run against the compose replication environment:

- `ddev --no-interactive test postgres:py3.13-16.0-C -- -k test_wal_receiver_metrics tests/test_pg_replication.py` — passes, 3 consecutive runs
- `ddev --no-interactive test postgres:py3.13-10.0-C -- -k test_wal_receiver_metrics tests/test_pg_replication.py` — passes (oldest supported version)
- `ddev --no-interactive test postgres:py3.13-17.0-UTF8 -- -k test_wal_receiver_metrics tests/test_pg_replication.py` — passes (UTF8 encoding)
- `ddev --no-interactive test postgres:py3.13-16.0-C -- tests/test_pg_replication.py` — 6 passed, 1 skipped, no regressions in neighbouring tests
- `ddev test --lint postgres`

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/3d4986a0-4acd-4ea8-a371-1c0bed9ef9fb)

Comment @datadog to request changes
