### PR TITLE
Add Supported OS::AIX tag to the process check

### DIFF
--- a/process/manifest.json
+++ b/process/manifest.json
@@ -16,6 +16,7 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
+      "Supported OS::AIX",
       "Category::OS & System",
       "Offering::Integration"
     ],


### PR DESCRIPTION
### What does this PR do?

Adds `Supported OS::AIX` to the `process` check's `classifier_tags` in `manifest.json`, so the tile metadata accurately reflects AIX support.

### Motivation

The `process` check ships as part of the Datadog Agent AIX package but its integration tile doesn't list AIX as a supported OS, following the same pattern as #23484 which added this tag to other AIX-bundled integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged