### PR TITLE
Add infrastructure_mode support to Nutanix

### DIFF
--- a/nutanix/assets/configuration/spec.yaml
+++ b/nutanix/assets/configuration/spec.yaml
@@ -254,6 +254,16 @@ files:
               - upper
               - lower
               - default
+          - name: infrastructure_mode
+            description: |
+              The infrastructure mode to use. Valid values are 'full' (default) and 'basic'.
+            fleet_configurable: true
+            value:
+              type: string
+              example: full
+              enum:
+              - full
+              - basic
           - template: instances/http
           - template: instances/default
             overrides:

--- a/nutanix/changelog.d/24667.added
+++ b/nutanix/changelog.d/24667.added
@@ -1,0 +1,1 @@
+Add support for `infrastructure_mode`.

--- a/nutanix/datadog_checks/nutanix/config_models/defaults.py
+++ b/nutanix/datadog_checks/nutanix/config_models/defaults.py
@@ -60,6 +60,10 @@ def instance_exclude_filtered_resources_from_cluster_capacity():
     return False
 
 
+def instance_infrastructure_mode():
+    return 'full'
+
+
 def instance_kerberos_auth():
     return 'disabled'
 

--- a/nutanix/datadog_checks/nutanix/config_models/instance.py
+++ b/nutanix/datadog_checks/nutanix/config_models/instance.py
@@ -92,6 +92,7 @@ class InstanceConfig(BaseModel):
     extra_headers: Optional[MappingProxyType[str, Any]] = None
     headers: Optional[MappingProxyType[str, Any]] = None
     hostname_transform: Optional[Literal['upper', 'lower', 'default']] = None
+    infrastructure_mode: Optional[Literal['full', 'basic']] = None
     kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
     kerberos_cache: Optional[str] = None
     kerberos_delegate: Optional[bool] = None

--- a/nutanix/datadog_checks/nutanix/data/conf.yaml.example
+++ b/nutanix/datadog_checks/nutanix/data/conf.yaml.example
@@ -204,6 +204,11 @@ instances:
     #
     # hostname_transform: <HOSTNAME_TRANSFORM>
 
+    ## @param infrastructure_mode - string - optional - default: full
+    ## The infrastructure mode to use. Valid values are 'full' (default) and 'basic'.
+    #
+    # infrastructure_mode: full
+
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
     ##

--- a/nutanix/datadog_checks/nutanix/infrastructure_monitor.py
+++ b/nutanix/datadog_checks/nutanix/infrastructure_monitor.py
@@ -247,7 +247,7 @@ class InfrastructureMonitor:
 
     def _report_vm_basic_metrics(self, vm: dict, vm_name: str, vm_tags: list[str]) -> None:
         """Report basic VM metrics (counts and status)."""
-        self.check.gauge("vm.count", 1, hostname=vm_name, tags=vm_tags)
+        self.check.gauge("vm.count", 1, hostname=vm_name, tags=vm_tags + self._infra_mode_tags())
 
         power_state = _normalize_tag_value(vm.get("powerState"))
         status_value = 0 if power_state == "on" else 1 if power_state == "paused" else 2
@@ -440,7 +440,7 @@ class InfrastructureMonitor:
             display_hostname = self._transform_hostname(host_name)
 
             host_tags = cluster_tags + self._extract_host_tags(host)
-            self.check.gauge("host.count", 1, hostname=display_hostname, tags=host_tags)
+            self.check.gauge("host.count", 1, hostname=display_hostname, tags=host_tags + self._infra_mode_tags())
             self._report_host_status_metrics(host, display_hostname, host_tags)
             self._set_external_tags_for_host(display_hostname, host_tags)
             self._report_host_capacity_metrics(host, display_hostname, host_tags)
@@ -590,6 +590,17 @@ class InfrastructureMonitor:
                 return
 
         self.external_tags.append((hostname, {self.check.__NAMESPACE__: tags}))
+
+    def _infra_mode_tags(self) -> list[str]:
+        """Return the ``infra_mode`` tag list for host-bearing count metrics.
+
+        In ``basic`` infrastructure mode this signals the backend that these hosts should
+        not be billed as full infrastructure hosts. Empty in the default ``full`` mode.
+        """
+        infra_mode = self.check.config.infrastructure_mode
+        if infra_mode and infra_mode != 'full':
+            return [f'infra_mode:{infra_mode}']
+        return []
 
     def _transform_hostname(self, hostname: str | None) -> str | None:
         """Apply hostname_transform config to a hostname."""

--- a/nutanix/tests/test_infrastructure_mode.py
+++ b/nutanix/tests/test_infrastructure_mode.py
@@ -1,0 +1,43 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+import pytest
+
+from datadog_checks.nutanix import NutanixCheck
+
+pytestmark = [pytest.mark.unit]
+
+# The only metrics that should ever carry the ``infra_mode`` tag.
+INFRA_MODE_METRICS = ("nutanix.host.count", "nutanix.vm.count")
+
+
+@pytest.mark.parametrize(
+    ("infrastructure_mode", "tag_expected"),
+    [
+        pytest.param("basic", True, id="basic mode adds infra_mode tag"),
+        pytest.param("full", False, id="full mode does not add infra_mode tag"),
+        pytest.param(None, False, id="unset mode does not add infra_mode tag"),
+    ],
+)
+def test_infra_mode_tag(dd_run_check, aggregator, mock_instance, mock_http_get, infrastructure_mode, tag_expected):
+    if infrastructure_mode is not None:
+        mock_instance["infrastructure_mode"] = infrastructure_mode
+    check = NutanixCheck("nutanix", {}, [mock_instance])
+    dd_run_check(check)
+
+    # In basic mode every count series carries infra_mode:basic; otherwise none do.
+    for metric_name in INFRA_MODE_METRICS:
+        aggregator.assert_metric(metric_name, at_least=1)
+        for metric in aggregator.metrics(metric_name):
+            has_tag = "infra_mode:basic" in metric.tags
+            assert has_tag is tag_expected
+            assert not any(tag.startswith("infra_mode:") and tag != "infra_mode:basic" for tag in metric.tags)
+
+    # No metric other than the two count metrics should ever carry an infra_mode tag.
+    for metric_name in aggregator.metric_names:
+        if metric_name in INFRA_MODE_METRICS:
+            continue
+        for metric in aggregator.metrics(metric_name):
+            assert not any(tag.startswith("infra_mode:") for tag in metric.tags)


### PR DESCRIPTION
### What does this PR do?

Adds an `infrastructure_mode` instance config option to the Nutanix integration (`full` (default) or `basic`, `fleet_configurable`), mirroring the existing Proxmox behavior.

In `basic` mode, an `infra_mode:basic` tag is added to the `host.count` and `vm.count` sentinel metrics. These are the count metrics emitted for every host-bearing entity (physical hosts and VMs), both of which are submitted with a `hostname`. The tag is a backend billing signal so these hosts are treated as basic rather than full infrastructure hosts. In `full` mode (or when unset) no tag is added. No other metric carries the tag.

### Motivation

Bring Nutanix to parity with Proxmox, which already supports `infrastructure_mode`, so users can opt hosts/VMs out of full infrastructure host billing.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)