### PR TITLE
Run KEDA E2E with the Kubernetes Agent backend

### DIFF
--- a/keda/tests/conftest.py
+++ b/keda/tests/conftest.py
@@ -3,12 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import copy
 import os
-from contextlib import ExitStack
 
 import pytest
 
 from datadog_checks.dev.kind import kind_run
-from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.subprocess import run_command
 
 from . import common
@@ -27,13 +25,18 @@ def setup_ked():
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    with kind_run(conditions=[setup_ked], sleep=30) as kubeconfig, ExitStack() as stack:
-        keda_host, keda_port = stack.enter_context(
-            port_forward(kubeconfig, 'keda', 8080, 'deployment', 'keda-operator-metrics-apiserver')
-        )
-        instances = [{'openmetrics_endpoint': f'http://{keda_host}:{keda_port}/metrics'}]
+    with kind_run(conditions=[setup_ked], sleep=30) as kubeconfig:
+        instances = [
+            {'openmetrics_endpoint': ('http://keda-operator-metrics-apiserver.keda.svc.cluster.local:8080/metrics')}
+        ]
 
-        yield {'instances': instances}
+        yield (
+            {'instances': instances},
+            {
+                'agent_type': 'kubernetes',
+                'kubernetes': {'kubeconfig': kubeconfig},
+            },
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?
Migrates the KEDA Kind E2E to the Kubernetes Agent backend introduced in #24639. The check now reaches KEDA through the in-cluster Service DNS endpoint, `http://keda-operator-metrics-apiserver.keda.svc.cluster.local:8080/metrics`, and returns the Kind kubeconfig in the Kubernetes backend metadata. This removes the external Docker Agent and persistent `kubectl port-forward` while preserving the existing setup, waits, instance shape, assertions, and timeouts.

Validation:
- `cd ddev && hatch run -- ddev --no-interactive test -fs keda` (passed)
- `cd ddev && hatch run -- ddev --no-interactive test --lint keda` (passed)
- `cd ddev && hatch run -- ddev --no-interactive test keda` (2 passed, 1 E2E skipped)
- `cd ddev && hatch run -- ddev env start --dev keda py3.13-2.16.0` (passed)
- `cd ddev && hatch run -- ddev env test --dev keda py3.13-2.16.0` (1 passed, 2 deselected)
- `cd ddev && hatch run -- ddev env stop keda py3.13-2.16.0` (passed)

### Motivation
Exercise KEDA from the same Kubernetes network as the Agent and validate the new backend from #24639 without maintaining a host-side port-forward process.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
