### PR TITLE
Run Kyverno E2E with the Kubernetes Agent backend

### DIFF
--- a/kyverno/tests/conftest.py
+++ b/kyverno/tests/conftest.py
@@ -2,13 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
-from contextlib import ExitStack
 
 import pytest
 
 from datadog_checks.dev import get_here
 from datadog_checks.dev.kind import kind_run
-from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.subprocess import run_command
 
 HERE = get_here()
@@ -34,24 +32,30 @@ def setup_kyverno():
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    with kind_run(conditions=[setup_kyverno], sleep=30) as kubeconfig, ExitStack() as stack:
-        kyverno_host1, kyverno_port1 = stack.enter_context(
-            port_forward(kubeconfig, 'kyverno', 8000, 'deployment', 'kyverno-admission-controller'),
-        )
-        kyverno_host2, kyverno_port2 = stack.enter_context(
-            port_forward(kubeconfig, 'kyverno', 8000, 'deployment', 'kyverno-background-controller'),
-        )
-        kyverno_host3, kyverno_port3 = stack.enter_context(
-            port_forward(kubeconfig, 'kyverno', 8000, 'deployment', 'kyverno-cleanup-controller'),
-        )
-        kyverno_host4, kyverno_port4 = stack.enter_context(
-            port_forward(kubeconfig, 'kyverno', 8000, 'deployment', 'kyverno-reports-controller'),
-        )
+    with kind_run(conditions=[setup_kyverno], sleep=30) as kubeconfig:
         instances = [
-            {'openmetrics_endpoint': f'http://{kyverno_host1}:{kyverno_port1}/metrics'},
-            {'openmetrics_endpoint': f'http://{kyverno_host2}:{kyverno_port2}/metrics'},
-            {'openmetrics_endpoint': f'http://{kyverno_host3}:{kyverno_port3}/metrics'},
-            {'openmetrics_endpoint': f'http://{kyverno_host4}:{kyverno_port4}/metrics'},
+            {'openmetrics_endpoint': 'http://kyverno-svc-metrics.kyverno.svc.cluster.local:8000/metrics'},
+            {
+                'openmetrics_endpoint': (
+                    'http://kyverno-background-controller-metrics.kyverno.svc.cluster.local:8000/metrics'
+                )
+            },
+            {
+                'openmetrics_endpoint': (
+                    'http://kyverno-cleanup-controller-metrics.kyverno.svc.cluster.local:8000/metrics'
+                )
+            },
+            {
+                'openmetrics_endpoint': (
+                    'http://kyverno-reports-controller-metrics.kyverno.svc.cluster.local:8000/metrics'
+                )
+            },
         ]
+        metadata = {
+            'agent_type': 'kubernetes',
+            'kubernetes': {
+                'kubeconfig': kubeconfig,
+            },
+        }
 
-        yield {'instances': instances}
+        yield {'instances': instances}, metadata

--- a/kyverno/tests/test_e2e.py
+++ b/kyverno/tests/test_e2e.py
@@ -1,9 +1,11 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.utils import assert_service_checks
 
 
 def test_kyverno_e2e(dd_agent_check):
     aggregator = dd_agent_check(rate=True)
+    aggregator.assert_service_check('kyverno.openmetrics.health', ServiceCheck.OK, count=8)
     assert_service_checks(aggregator)


### PR DESCRIPTION
### What does this PR do?

Runs the Kyverno Kind E2E Agent inside the test cluster through the Kubernetes Agent backend. The check now reaches the four Kyverno metrics services over in-cluster DNS instead of maintaining host port-forwards.

Validation:

- `cd ddev && hatch run -- ddev --no-interactive test -fs kyverno` — passed.
- `cd ddev && hatch run -- ddev --no-interactive test --lint kyverno` — passed.
- `cd ddev && hatch run -- ddev --no-interactive test kyverno` — 6 passed, 1 E2E test skipped by the unit-test run.
- `cd ddev && hatch run -- ddev env start --dev kyverno py3.13` — started the dedicated Kind cluster and Kubernetes Agent.
- `cd ddev && hatch run -- ddev env test --dev kyverno py3.13` — 1 E2E test passed.
- `cd ddev && hatch run -- ddev env stop kyverno py3.13` — deleted the dedicated Kind cluster.

### Motivation

Builds on #24639 to exercise the Kubernetes Agent backend against Kyverno while preserving the existing E2E coverage and startup behavior.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
