### PR TITLE
Agnosticize test HTTP calls off requests

### DIFF
--- a/activemq/tests/conftest.py
+++ b/activemq/tests/conftest.py
@@ -2,11 +2,17 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import base64
+import http.cookiejar
+import json
 import os
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import WaitForPortListening
@@ -29,16 +35,35 @@ from .common import (
 )
 
 
+def basic_auth_header(auth: tuple[str, str]) -> str:
+    token = '{}:{}'.format(*auth).encode('utf-8')
+    return 'Basic {}'.format(base64.b64encode(token).decode('ascii'))
+
+
+def open_url_without_status_error(req: urllib.request.Request, opener: Any = None) -> Any:
+    try:
+        if opener is not None:
+            return opener.open(req)
+        return urllib.request.urlopen(req)
+    except urllib.error.HTTPError as e:
+        return e
+
+
 def populate_server():
     """Add some queues and topics to ensure more metrics are available."""
     time.sleep(3)
 
+    auth_header = basic_auth_header(TEST_AUTH)
+
     if IS_ARTEMIS:
-        s = requests.Session()
-        s.auth = TEST_AUTH
-        s.headers = {'accept': 'application/json', 'origin': BASE_URL}
-        data = s.get(ARTEMIS_URL + '/list')
-        channels = data.json()['value']['org.apache.activemq.artemis']
+        opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(http.cookiejar.CookieJar()))
+        headers = {'Accept': 'application/json', 'Origin': BASE_URL, 'Authorization': auth_header}
+        req = urllib.request.Request(ARTEMIS_URL + '/list', headers=headers)
+        response = open_url_without_status_error(req, opener=opener)
+        try:
+            channels = json.load(response)['value']['org.apache.activemq.artemis']
+        finally:
+            response.close()
         broker = [k for k in channels.keys() if k.startswith('broker') and ',' not in k][0]
         bean = 'org.apache.activemq.artemis:{}'.format(broker)
 
@@ -54,16 +79,29 @@ def populate_server():
                 "boolean,int,boolean,boolean)",
                 "arguments": ["activemq.notifications", "ANYCAST", queue, None, True, -1, False, True],
             }
-            s.post(ARTEMIS_URL + '/exec', json=body)
+            req = urllib.request.Request(
+                ARTEMIS_URL + '/exec',
+                data=json.dumps(body).encode('utf-8'),
+                headers={**headers, 'Content-Type': 'application/json'},
+                method='POST',
+            )
+            open_url_without_status_error(req, opener=opener).close()
 
     else:
+        headers = {
+            'Authorization': auth_header,
+            'Content-Type': 'application/x-www-form-urlencoded',
+        }
+        data = urllib.parse.urlencode(TEST_MESSAGE).encode('utf-8')
         for queue in TEST_QUEUES:
             url = '{}/{}?type=queue'.format(ACTIVEMQ_URL, queue)
-            requests.post(url, data=TEST_MESSAGE, auth=TEST_AUTH)
+            req = urllib.request.Request(url, data=data, headers=headers, method='POST')
+            open_url_without_status_error(req).close()
 
         for topic in TEST_TOPICS:
             url = '{}/{}?type=topic'.format(ACTIVEMQ_URL, topic)
-            requests.post(url, data=TEST_MESSAGE, auth=TEST_AUTH)
+            req = urllib.request.Request(url, data=data, headers=headers, method='POST')
+            open_url_without_status_error(req).close()
 
 
 @pytest.fixture(scope="session")

--- a/airflow/tests/test_check_metrics_up_to_date.py
+++ b/airflow/tests/test_check_metrics_up_to_date.py
@@ -3,9 +3,10 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import os
 import re
+import urllib.error
+import urllib.request
 
 import pytest
-import requests
 
 # Make sure this expected metrics list is up to date with:
 # - `dogstatsd_mapper_profiles` configuration from README.md
@@ -121,7 +122,7 @@ METRIC_PATTERN = re.compile(r'^``([^`]+)``\s+(.*)', re.MULTILINE)
 @pytest.mark.latest_metrics
 def test_check_metrics_up_to_date():  # pragma: no cover
     # Note: This test is marked with @pytest.mark.latest_metrics and is skipped in normal test runs.
-    # It makes external HTTP requests to GitHub, so it's intentionally run separately.
+    # It makes external HTTP calls to GitHub, so it's intentionally run separately.
     # Excluded from coverage as it's only run with --run-latest-metrics flag.
     airflow_version = os.getenv('AIRFLOW_VERSION', '2.11.0')
 
@@ -132,8 +133,14 @@ def test_check_metrics_up_to_date():  # pragma: no cover
         'docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst'
     )
 
-    resp = requests.get(url)
-    content = resp.content.decode('utf-8')
+    try:
+        resp = urllib.request.urlopen(url)
+    except urllib.error.HTTPError as e:
+        resp = e
+    try:
+        content = resp.read().decode('utf-8')
+    finally:
+        resp.close()
     matches = METRIC_PATTERN.findall(content)
 
     # Printed only on failure for convenience.

--- a/apache/tests/conftest.py
+++ b/apache/tests/conftest.py
@@ -3,9 +3,12 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import os
+import urllib.error
+import urllib.request
+from contextlib import closing
+from typing import Any
 
 import pytest
-import requests
 
 from datadog_checks.apache import Apache
 from datadog_checks.dev import docker_run
@@ -13,6 +16,20 @@ from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
 from datadog_checks.dev.http import MockHTTPResponse
 
 from .common import AUTO_STATUS_URL, BASE_URL, CHECK_NAME, HERE, STATUS_CONFIG, STATUS_URL
+
+
+def http_get(url: str, **kwargs: Any) -> Any:
+    req = urllib.request.Request(url, headers=kwargs.get('headers') or {})
+    timeout = kwargs.get('timeout')
+    if isinstance(timeout, tuple):
+        timeout = timeout[-1]
+
+    try:
+        if timeout is None:
+            return urllib.request.urlopen(req)
+        return urllib.request.urlopen(req, timeout=timeout)
+    except urllib.error.HTTPError as e:
+        return e
 
 
 @pytest.fixture(scope="session")
@@ -33,7 +50,7 @@ def dd_environment():
 
 def generate_metrics():
     for _ in range(0, 100):
-        requests.get(BASE_URL)
+        http_get(BASE_URL).close()
 
 
 def check_status_page_ready():
@@ -41,8 +58,11 @@ def check_status_page_ready():
     Some status info we need for metrics do not appear immediately.
     This check help waiting for the full status page.
     """
-    resp = requests.get(AUTO_STATUS_URL)
-    data = resp.content.decode('utf-8')
+    resp = http_get(AUTO_STATUS_URL)
+    try:
+        data = resp.read().decode('utf-8')
+    finally:
+        resp.close()
     assert 'ReqPerSec: ' in data
     assert 'CPULoad: ' in data
 
@@ -50,13 +70,16 @@ def check_status_page_ready():
 @pytest.fixture
 def mock_hide_server_version(mock_http):
     def filter_server_version(url, *args, **kwargs):
-        r = requests.get(url, **kwargs)
-        content = '\n'.join(line for line in r.text.splitlines() if 'ServerVersion' not in line)
+        with closing(http_get(url, **kwargs)) as r:
+            content = '\n'.join(line for line in r.read().decode('utf-8').splitlines() if 'ServerVersion' not in line)
+            status_code = r.getcode()
+            headers = dict(r.headers)
+            response_url = r.geturl()
         return MockHTTPResponse(
             content=content,
-            status_code=r.status_code,
-            headers=dict(r.headers),
-            url=r.url,
+            status_code=status_code,
+            headers=headers,
+            url=response_url,
         )
 
     mock_http.get.side_effect = filter_server_version

--- a/azure_iot_edge/tests/e2e_utils.py
+++ b/azure_iot_edge/tests/e2e_utils.py
@@ -1,9 +1,9 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import urllib.error
+import urllib.request
 from typing import Any  # noqa: F401
-
-import requests
 
 from datadog_checks.dev.docker import ComposeFileDown, ComposeFileUp
 from datadog_checks.dev.structures import LazyFunction
@@ -43,20 +43,26 @@ class IoTEdgeDown(LazyFunction):
 def edge_hub_endpoint_ready():
     # type: () -> bool
     try:
-        response = requests.get(common.E2E_EDGE_HUB_PROMETHEUS_URL)
-        response.raise_for_status()
-    except requests.HTTPError:
+        response = urllib.request.urlopen(common.E2E_EDGE_HUB_PROMETHEUS_URL)
+    except urllib.error.HTTPError as e:
+        e.close()
         return False
     else:
-        return response.status_code == 200
+        try:
+            return response.getcode() == 200
+        finally:
+            response.close()
 
 
 def edge_agent_endpoint_ready():
     # type: () -> bool
     try:
-        response = requests.get(common.E2E_EDGE_AGENT_PROMETHEUS_URL)
-        response.raise_for_status()
-    except requests.HTTPError:
+        response = urllib.request.urlopen(common.E2E_EDGE_AGENT_PROMETHEUS_URL)
+    except urllib.error.HTTPError as e:
+        e.close()
         return False
     else:
-        return response.status_code == 200
+        try:
+            return response.getcode() == 200
+        finally:
+            response.close()

--- a/azure_iot_edge/tests/test_e2e.py
+++ b/azure_iot_edge/tests/test_e2e.py
@@ -2,13 +2,15 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import copy
+import ssl
+import urllib.error
 from typing import Callable  # noqa: F401
 
 import pytest
-import requests
 
 from datadog_checks.azure_iot_edge import AzureIoTEdgeCheck
 from datadog_checks.base.stubs.aggregator import AggregatorStub  # noqa: F401
+from datadog_checks.base.utils.http_exceptions import HTTPSSLError
 
 from . import common
 
@@ -40,8 +42,10 @@ def test_bad_url_e2e(e2e_instance, dd_agent_check):
     bad_url_agent_instance = copy.deepcopy(e2e_instance)
     bad_url_agent_instance['edge_agent_prometheus_url'] = bad_url_hub_instance['edge_agent_prometheus_url'][:-2]
 
-    with pytest.raises(requests.exceptions.SSLError):
+    with pytest.raises((HTTPSSLError, urllib.error.URLError)) as exc_info:
         dd_agent_check(bad_url_hub_instance, rate=True)
+    if isinstance(exc_info.value, urllib.error.URLError):
+        assert isinstance(exc_info.value.reason, ssl.SSLError)
 
     aggregator = dd_agent_check(bad_url_agent_instance, rate=True)
     aggregator.assert_service_check('azure.iot_edge.edge_agent.prometheus.health', AzureIoTEdgeCheck.CRITICAL)

--- a/cisco_aci/tests/cisco_aci_query.py
+++ b/cisco_aci/tests/cisco_aci_query.py
@@ -3,11 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import json
-
-import requests
+import ssl
+import urllib.error
+import urllib.request
 
 # This is a python script that you can use to query a specific
-# tenant metric endpoint and includes the login and logout requests.
+# tenant metric endpoint and includes the login and logout calls.
 # You can change the parameters below for your configuration and tenant to query.
 
 # Edit this section. Below is a sample config using the public sandbox:
@@ -17,6 +18,34 @@ apic_password = '!v3G@!4@Y'
 tenant = 'infra'
 api_path = str.format('/api/mo/uni/tn-{}.json?rsp-subtree-include=stats,no-scoped', tenant)
 
+SSL_CONTEXT = ssl.create_default_context()
+SSL_CONTEXT.check_hostname = False
+SSL_CONTEXT.verify_mode = ssl.CERT_NONE
+
+
+def apic_request(url: str, method: str = 'GET', cookie: dict[str, str] | None = None, data: str | None = None) -> str:
+    headers = {}
+    if cookie:
+        headers['Cookie'] = '; '.join('{}={}'.format(name, value) for name, value in cookie.items())
+
+    if data is not None:
+        body = data.encode('utf-8')
+    elif method == 'POST':
+        body = b''
+    else:
+        body = None
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+
+    try:
+        response = urllib.request.urlopen(req, context=SSL_CONTEXT)
+    except urllib.error.HTTPError as e:
+        response = e
+
+    try:
+        return response.read().decode('utf-8')
+    finally:
+        response.close()
+
 
 def apic_login(apic, username, password):
     """APIC login and return session cookie"""
@@ -25,28 +54,28 @@ def apic_login(apic, username, password):
     json_credentials = json.dumps(credentials)
     base_url = 'https://' + apic + '/api/aaaLogin.json'
 
-    login_response = requests.post(base_url, data=json_credentials, verify=False)
+    login_response_text = apic_request(base_url, method='POST', data=json_credentials)
 
-    login_response_json = json.loads(login_response.text)
+    login_response_json = json.loads(login_response_text)
     token = login_response_json['imdata'][0]['aaaLogin']['attributes']['token']
     apic_cookie['APIC-Cookie'] = token
     return apic_cookie
 
 
 def apic_query(apic, path, cookie):
-    """APIC 'GET' query and return response"""
+    """APIC 'GET' query and return response body"""
     base_url = 'https://' + apic + path
 
-    get_response = requests.get(base_url, cookies=cookie, verify=False)
+    get_response = apic_request(base_url, cookie=cookie)
 
     return get_response
 
 
 def apic_logout(apic, cookie):
-    """APIC logout and return response"""
+    """APIC logout and return response body"""
     base_url = 'https://' + apic + '/api/aaaLogout.json'
 
-    post_response = requests.post(base_url, cookies=cookie, verify=False)
+    post_response = apic_request(base_url, method='POST', cookie=cookie)
 
     return post_response
 
@@ -55,6 +84,6 @@ apic_cookie = apic_login(apic=apic_url, username=apic_username, password=apic_pa
 response = apic_query(apic=apic_url, path=api_path, cookie=apic_cookie)
 logout_response = apic_logout(apic=apic_url, cookie=apic_cookie)
 
-response_json = json.loads(response.text)
+response_json = json.loads(response)
 
 print(json.dumps(response_json, indent=2, sort_keys=True))

--- a/clickhouse/scripts/generate_metrics.py
+++ b/clickhouse/scripts/generate_metrics.py
@@ -14,8 +14,7 @@ import re
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Iterable
-
-import requests
+from urllib.request import urlopen
 
 stats = collections.Counter()
 
@@ -150,6 +149,11 @@ def write_file(file, contents, encoding='utf-8'):
         f.write(contents)
 
 
+def fetch_url_text(url: str) -> str:
+    with urlopen(url, timeout=10) as response:
+        return response.read().decode('utf-8')
+
+
 def generate_queries_file(template: FileTemplate, config: dict):
     source_path = os.path.join(TEMPLATES_DIR, template.source_path)
     if not os.path.exists(source_path):
@@ -201,7 +205,7 @@ class ClickhouseMetric:
 
 
 def fetch_current_metrics(version: str) -> dict[str, ClickhouseMetric]:
-    raw_metrics = requests.get(SOURCE_URL_CURRENT_METRICS.format(branch=version), timeout=10).text
+    raw_metrics = fetch_url_text(SOURCE_URL_CURRENT_METRICS.format(branch=version))
 
     result = {}
     for match in METRIC_PATTERN.finditer(raw_metrics):
@@ -220,7 +224,7 @@ def fetch_profile_events(version: str) -> dict[str, ClickhouseMetric]:
 
         return VALUE_TYPE_COUNTER
 
-    raw_metrics = requests.get(SOURCE_URL_PROFILE_EVENTS.format(branch=version), timeout=10).text
+    raw_metrics = fetch_url_text(SOURCE_URL_PROFILE_EVENTS.format(branch=version))
 
     result = {}
     if version == '24.8':
@@ -255,13 +259,13 @@ def fetch_async_metrics(version: str) -> dict[str, ClickhouseMetric]:
 
     result = {}
     # common
-    raw_metrics = requests.get(SOURCE_URL_ASYNC_METRICS.format(branch=version), timeout=10).text
+    raw_metrics = fetch_url_text(SOURCE_URL_ASYNC_METRICS.format(branch=version))
     for match in ASYNC_METRICS_PATTERN.finditer(raw_metrics):
         name, description = match.groups()
         m = ClickhouseMetric(name=name, description=clean_description(description), prefix=PREFIX_ASYNC_METRICS)
         result[m.metric_name()] = m
     # server
-    raw_metrics = requests.get(SOURCE_URL_SERVER_ASYNC_METRICS.format(branch=version), timeout=10).text
+    raw_metrics = fetch_url_text(SOURCE_URL_SERVER_ASYNC_METRICS.format(branch=version))
     for match in ASYNC_METRICS_PATTERN.finditer(raw_metrics):
         name, description = match.groups()
         m = ClickhouseMetric(name=name, description=clean_description(description), prefix=PREFIX_ASYNC_METRICS)

--- a/clickhouse/tests/utils.py
+++ b/clickhouse/tests/utils.py
@@ -2,14 +2,14 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
-
-import requests
+from urllib.request import urlopen
 
 METRIC_PATTERN = re.compile(r'\s+M\((?P<metric>\w+),\s*"(?P<description>[^"]+)"\)\s*\\?')
 
 
 def parse_described_metrics(url):
-    text = requests.get(url, timeout=10).text
+    with urlopen(url, timeout=10) as response:
+        text = response.read().decode('utf-8')
     metrics = dict(match.groups() for match in METRIC_PATTERN.finditer(text))
 
     return {metric: description for metric, description in metrics.items() if description}

--- a/confluent_platform/tests/conftest.py
+++ b/confluent_platform/tests/conftest.py
@@ -3,9 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
 import os
+import urllib.error
+import urllib.request
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs, WaitFor
@@ -42,8 +43,19 @@ def create_connectors():
         },
     }
 
-    requests.post('http://localhost:8083/connectors', data=json.dumps(data_sink), headers=headers)
-    requests.post('http://localhost:8083/connectors', data=json.dumps(data), headers=headers)
+    for connector_data in (data_sink, data):
+        req = urllib.request.Request(
+            'http://localhost:8083/connectors',
+            data=json.dumps(connector_data).encode('utf-8'),
+            headers=headers,
+            method='POST',
+        )
+        try:
+            response = urllib.request.urlopen(req)
+        except urllib.error.HTTPError as e:
+            e.close()
+        else:
+            response.close()
 
 
 @pytest.fixture(scope="session")

--- a/consul/tests/conftest.py
+++ b/consul/tests/conftest.py
@@ -1,10 +1,11 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
 import os
+import urllib.request
 
 import pytest
-import requests
 
 from datadog_checks.dev import WaitFor, docker_run
 
@@ -20,11 +21,14 @@ def ping_cluster():
     """
     Wait for the slave to connect to the master
     """
-    response = requests.get('{}/v1/status/peers'.format(common.URL))
-    response.raise_for_status()
+    response = urllib.request.urlopen('{}/v1/status/peers'.format(common.URL))
+    try:
+        peers = json.load(response)
+    finally:
+        response.close()
 
     # Wait for all 3 agents to join the cluster
-    if len(response.json()) == 3:
+    if len(peers) == 3:
         return True
 
     return False

--- a/coredns/tests/conftest.py
+++ b/coredns/tests/conftest.py
@@ -3,9 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 import subprocess
+import urllib.error
+import urllib.request
 
 import pytest
-import requests
 
 from datadog_checks.dev import WaitFor, docker_run
 from datadog_checks.dev.utils import ON_WINDOWS
@@ -19,11 +20,20 @@ COREDNS_VERSION = [int(i) for i in os.environ['COREDNS_VERSION'].split(".")]
 
 
 def init_coredns():
-    res = requests.get(URL)
-    if not ON_WINDOWS:
-        # create some metrics by using dig
-        subprocess.check_call(DIG_ARGS)
-    res.raise_for_status()
+    status_error = None
+    try:
+        res = urllib.request.urlopen(URL)
+    except urllib.error.HTTPError as e:
+        res = e
+        status_error = e
+    try:
+        if not ON_WINDOWS:
+            # create some metrics by using dig
+            subprocess.check_call(DIG_ARGS)
+        if status_error is not None:
+            raise status_error
+    finally:
+        res.close()
 
 
 @pytest.fixture(scope="session")

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -1,18 +1,68 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import base64
+import http.client
 import json
 import os
+import urllib.error
+import urllib.request
 from copy import deepcopy
+from typing import Any
 
 import pytest
-import requests
 
 from datadog_checks.couch import CouchDb
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs, CheckEndpoints, WaitFor
 
 from . import common
+
+
+class HttpResponse:
+    def __init__(self, url: str, status_code: int, reason: str, content: bytes) -> None:
+        self.url = url
+        self.status_code = status_code
+        self.reason = reason or http.client.responses.get(status_code, '')
+        self.content = content
+
+    @property
+    def text(self) -> str:
+        return self.content.decode('utf-8')
+
+    def json(self) -> Any:
+        return json.loads(self.text)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise urllib.error.HTTPError(self.url, self.status_code, self.reason, http.client.HTTPMessage(), None)
+
+
+def http_request(
+    url: str,
+    method: str = 'GET',
+    *,
+    auth: tuple[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+    json_data: Any = None,
+) -> HttpResponse:
+    request_headers = dict(headers or {})
+    body = None
+    if json_data is not None:
+        body = json.dumps(json_data).encode('utf-8')
+        request_headers.setdefault('Content-Type', 'application/json')
+
+    if auth is not None:
+        username, password = auth
+        token = base64.b64encode('{}:{}'.format(username, password).encode('utf-8')).decode('ascii')
+        request_headers['Authorization'] = 'Basic {}'.format(token)
+
+    req = urllib.request.Request(url, data=body, headers=request_headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as response:
+            return HttpResponse(url, response.getcode(), response.reason, response.read())
+    except urllib.error.HTTPError as error:
+        return HttpResponse(url, error.code, error.reason, error.read())
 
 
 @pytest.fixture
@@ -91,10 +141,10 @@ def enable_cluster():
     auth = (common.USER, common.PASSWORD)
     headers = {'Accept': 'text/json'}
 
-    requests_data = []
+    cluster_setup_payloads = []
     for node in [common.NODE2, common.NODE3]:
         _, node_name = node['name'].split('@')
-        requests_data.append(
+        cluster_setup_payloads.append(
             {
                 "action": "enable_cluster",
                 "username": common.USER,
@@ -107,7 +157,7 @@ def enable_cluster():
                 "remote_current_password": common.PASSWORD,
             }
         )
-        requests_data.append(
+        cluster_setup_payloads.append(
             {
                 "action": "add_node",
                 "username": common.USER,
@@ -119,11 +169,13 @@ def enable_cluster():
         )
 
     resp_data = None
-    for data in requests_data:
-        resp = requests.post("{}/_cluster_setup".format(common.URL), json=data, auth=auth, headers=headers)
+    for data in cluster_setup_payloads:
+        resp = http_request(
+            "{}/_cluster_setup".format(common.URL), method='POST', json_data=data, auth=auth, headers=headers
+        )
         resp_data = resp.json()
 
-    resp = requests.get("{}/_membership".format(common.URL), auth=auth, headers=headers)
+    resp = http_request("{}/_membership".format(common.URL), auth=auth, headers=headers)
     membership = resp.json()
 
     expected_nb_nodes = 3
@@ -145,9 +197,9 @@ def generate_data(couch_version):
     headers = {'Accept': 'text/json'}
 
     # Generate a test database
-    requests.put("{}/kennel".format(common.URL), auth=auth, headers=headers)
+    http_request("{}/kennel".format(common.URL), method='PUT', auth=auth, headers=headers)
     for i in range(5):
-        requests.put("{}/db{}".format(common.URL, i), auth=auth, headers=headers)
+        http_request("{}/db{}".format(common.URL, i), method='PUT', auth=auth, headers=headers)
 
     # Populate the database
     data = {
@@ -157,7 +209,7 @@ def generate_data(couch_version):
             "by_data": {"map": "function(doc) { emit(doc.data, doc); }"},
         },
     }
-    requests.put("{}/kennel/_design/dummy".format(common.URL), json=data, auth=auth, headers=headers)
+    http_request("{}/kennel/_design/dummy".format(common.URL), method='PUT', json_data=data, auth=auth, headers=headers)
 
 
 def check_node_stats():
@@ -166,7 +218,7 @@ def check_node_stats():
     # Check all nodes have stats
     for node in common.ALL_NODES:
         url = "{}/_node/{}/_stats".format(common.URL, node['name'])
-        res = requests.get(url, auth=auth, headers=headers)
+        res = http_request(url, auth=auth, headers=headers)
         data = res.json()
         assert "global_changes" in data, "Invalid stats. Get stats url: {}".format(url)
 
@@ -188,11 +240,12 @@ def send_replication():
         body = replication_body.copy()
         body['_id'] = 'my_replication_id_{}'.format(i)
         body['target'] = body['target'] + str(i)
-        r = requests.post(
+        r = http_request(
             replicator_url,
+            method='POST',
             auth=(common.NODE1['user'], common.NODE1['password']),
             headers={'Content-Type': 'application/json'},
-            json=body,
+            json_data=body,
         )
         r.raise_for_status()
 
@@ -203,7 +256,7 @@ def get_replication():
     """
     task_url = "{}/_active_tasks".format(common.NODE1['server'])
 
-    r = requests.get(task_url, auth=(common.NODE1['user'], common.NODE1['password']))
+    r = http_request(task_url, auth=(common.NODE1['user'], common.NODE1['password']))
     r.raise_for_status()
     active_tasks = r.json()
     count = len(active_tasks)

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -1,17 +1,22 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import base64
 import csv
+import http.client
+import json
 import random
 import re
 import string
 import threading
 import time
+import urllib.error
+import urllib.request
 from collections import defaultdict
 from copy import deepcopy
+from typing import Any
 
 import pytest
-import requests
 
 from datadog_checks.couch import CouchDb
 from datadog_checks.dev.utils import get_metadata_metrics
@@ -21,6 +26,58 @@ from . import common
 pytestmark = pytest.mark.skipif(common.COUCH_MAJOR_VERSION == 1, reason='Test for version Couch v2+')
 
 INSTANCES = [common.NODE1, common.NODE2, common.NODE3]
+
+
+class HttpResponse:
+    def __init__(self, url: str, status_code: int, reason: str, content: bytes) -> None:
+        self.url = url
+        self.status_code = status_code
+        self.reason = reason or http.client.responses.get(status_code, '')
+        self.content = content
+
+    @property
+    def text(self) -> str:
+        return self.content.decode('utf-8')
+
+    def json(self) -> Any:
+        return json.loads(self.text)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise urllib.error.HTTPError(self.url, self.status_code, self.reason, http.client.HTTPMessage(), None)
+
+
+def http_request(
+    url: str,
+    method: str = 'GET',
+    *,
+    auth: tuple[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+    json_data: Any = None,
+    timeout: float | None = None,
+) -> HttpResponse:
+    request_headers = dict(headers or {})
+    body = None
+    if json_data is not None:
+        body = json.dumps(json_data).encode('utf-8')
+        request_headers.setdefault('Content-Type', 'application/json')
+
+    if auth is not None:
+        username, password = auth
+        token = base64.b64encode('{}:{}'.format(username, password).encode('utf-8')).decode('ascii')
+        request_headers['Authorization'] = 'Basic {}'.format(token)
+
+    req = urllib.request.Request(url, data=body, headers=request_headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            return HttpResponse(url, response.getcode(), response.reason, response.read())
+    except urllib.error.HTTPError as error:
+        return HttpResponse(url, error.code, error.reason, error.read())
+
+
+def is_timeout_error(error: BaseException) -> bool:
+    reason = getattr(error, 'reason', None)
+    return isinstance(error, TimeoutError) or isinstance(reason, TimeoutError)
 
 
 @pytest.fixture(scope="module")
@@ -360,35 +417,41 @@ def test_view_compaction_metrics(aggregator, gauges):
         def generate_views(self):
             url = '{}/kennel/_design/dummy/_view/all'.format(self._server)
             try:
-                r = requests.get(url, auth=self._auth, timeout=1)
+                r = http_request(url, auth=self._auth, timeout=1)
                 r.raise_for_status()
-            except requests.exceptions.Timeout:
-                pass
+            except (TimeoutError, urllib.error.URLError) as error:
+                if not is_timeout_error(error):
+                    raise
             url = '{}/kennel/_design/dummy/_view/by_data'.format(self._server)
             try:
-                r = requests.get(url, auth=self._auth, timeout=1)
+                r = http_request(url, auth=self._auth, timeout=1)
                 r.raise_for_status()
-            except requests.exceptions.Timeout:
-                pass
+            except (TimeoutError, urllib.error.URLError) as error:
+                if not is_timeout_error(error):
+                    raise
 
         def update_doc(self, doc):
             body = {'data': str(random.randint(0, 1000000000)), '_rev': doc['rev']}
 
             url = '{}/kennel/{}'.format(self._server, doc['id'])
-            r = requests.put(url, auth=self._auth, headers={'Content-Type': 'application/json'}, json=body)
+            r = http_request(
+                url, method='PUT', auth=self._auth, headers={'Content-Type': 'application/json'}, json_data=body
+            )
             r.raise_for_status()
             return r.json()
 
         def post_doc(self, doc_id):
             body = {"_id": doc_id, "data": str(time.time())}
             url = '{}/kennel'.format(self._server)
-            r = requests.post(url, auth=self._auth, headers={'Content-Type': 'application/json'}, json=body)
+            r = http_request(
+                url, method='POST', auth=self._auth, headers={'Content-Type': 'application/json'}, json_data=body
+            )
             r.raise_for_status()
             return r.json()
 
         def compact_views(self):
             url = '{}/kennel/_compact/dummy'.format(self._server)
-            r = requests.post(url, auth=self._auth, headers={'Content-Type': 'application/json'})
+            r = http_request(url, method='POST', auth=self._auth, headers={'Content-Type': 'application/json'})
             r.raise_for_status()
 
         def stop(self):

--- a/couchbase/tests/conftest.py
+++ b/couchbase/tests/conftest.py
@@ -2,18 +2,23 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import base64
+import http.client
+import json
 import os
 import subprocess
 import time
+import urllib.error
+import urllib.request
 from copy import deepcopy
+from typing import Any
 
 import pytest
-import requests
 
 from datadog_checks.couchbase import Couchbase
 from datadog_checks.dev import WaitFor, docker_run
 from datadog_checks.dev.docker import get_container_ip
-from datadog_checks.dev.http import MockHTTPResponse  # noqa: F401
+from datadog_checks.dev.http import MockHTTPResponse
 
 from .common import (
     BUCKET_NAME,
@@ -32,6 +37,51 @@ from .common import (
     URL,
     USER,
 )
+
+
+class HttpResponse:
+    def __init__(self, url: str, status_code: int, reason: str, content: bytes) -> None:
+        self.url = url
+        self.status_code = status_code
+        self.reason = reason or http.client.responses.get(status_code, '')
+        self.content = content
+
+    @property
+    def text(self) -> str:
+        return self.content.decode('utf-8')
+
+    def json(self) -> Any:
+        return json.loads(self.text)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise urllib.error.HTTPError(self.url, self.status_code, self.reason, http.client.HTTPMessage(), None)
+
+
+def http_request(
+    url: str,
+    method: str = 'GET',
+    *,
+    auth: tuple[str, str] | None = None,
+    json_data: Any = None,
+) -> HttpResponse:
+    request_headers = {}
+    body = None
+    if json_data is not None:
+        body = json.dumps(json_data).encode('utf-8')
+        request_headers['Content-Type'] = 'application/json'
+
+    if auth is not None:
+        username, password = auth
+        token = base64.b64encode('{}:{}'.format(username, password).encode('utf-8')).decode('ascii')
+        request_headers['Authorization'] = 'Basic {}'.format(token)
+
+    req = urllib.request.Request(url, data=body, headers=request_headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as response:
+            return HttpResponse(url, response.getcode(), response.reason, response.read())
+    except urllib.error.HTTPError as error:
+        return HttpResponse(url, error.code, error.reason, error.read())
 
 
 @pytest.fixture
@@ -180,8 +230,8 @@ def couchbase_init():
     ]
     subprocess.check_call(init_args)
 
-    r = requests.get('{}/pools/default'.format(URL), auth=(USER, PASSWORD))
-    return r.status_code == requests.codes.ok
+    r = http_request('{}/pools/default'.format(URL), auth=(USER, PASSWORD))
+    return r.status_code == http.client.OK
 
 
 def load_sample_bucket():
@@ -192,12 +242,13 @@ def load_sample_bucket():
     # Resources used:
     # https://docs.couchbase.com/server/current/manage/manage-settings/install-sample-buckets.html
 
-    r = requests.post(
+    r = http_request(
         '{}/sampleBuckets/install'.format(URL),
+        method='POST',
         auth=(USER, PASSWORD),
-        json=["gamesim-sample"],
+        json_data=["gamesim-sample"],
     )
-    if r.status_code == 400:
+    if r.status_code == http.client.BAD_REQUEST:
         if "Sample bucket gamesim-sample is already loaded" in r.text:
             return True
         return False
@@ -225,7 +276,7 @@ def load_sample_bucket():
 
     while True:
         # Loop until the task ID is gone, meaning the task is done.
-        r = requests.get(
+        r = http_request(
             '{}/pools/default/tasks'.format(URL),
             auth=(USER, PASSWORD),
         )
@@ -243,7 +294,7 @@ def load_sample_bucket():
 
 def gamesim_primary_index_ready():
     """Wait until every gamesim_primary keyspace reports initial_build_progress == 100."""
-    r = requests.get(
+    r = http_request(
         '{}/api/v1/stats'.format(INDEX_STATS_URL),
         auth=(USER, PASSWORD),
     )
@@ -283,10 +334,11 @@ def create_syncgw_database():
         payload["index"] = {"num_replicas": payload["num_index_replicas"]}
         del payload["num_index_replicas"]
 
-    r = requests.put(
+    r = http_request(
         '{}/sync_gateway/'.format(SG_URL),
+        method='PUT',
         auth=(USER, PASSWORD),
-        json=payload,
+        json_data=payload,
     )
     r.raise_for_status()
 
@@ -295,7 +347,7 @@ def node_stats():
     """
     Wait for couchbase to generate node stats
     """
-    r = requests.get('{}/pools/default'.format(URL), auth=(USER, PASSWORD))
+    r = http_request('{}/pools/default'.format(URL), auth=(USER, PASSWORD))
     r.raise_for_status()
     stats = r.json()
     return all(len(stats['interestingStats']) > 0 for stats in stats['nodes'])
@@ -305,7 +357,7 @@ def bucket_stats():
     """
     Wait for couchbase to generate bucket stats
     """
-    r = requests.get('{}/pools/default/buckets/{}/stats'.format(URL, BUCKET_NAME), auth=(USER, PASSWORD))
+    r = http_request('{}/pools/default/buckets/{}/stats'.format(URL, BUCKET_NAME), auth=(USER, PASSWORD))
     r.raise_for_status()
     stats = r.json()
     return stats['op']['lastTStamp'] != 0

--- a/elastic/tests/conftest.py
+++ b/elastic/tests/conftest.py
@@ -1,12 +1,18 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import base64
 import copy
+import http.client
+import json
 import os
+import ssl
+import urllib.error
+import urllib.request
+from typing import Any
 
 import mock
 import pytest
-import requests
 from packaging import version
 
 from datadog_checks.base.utils.common import exclude_undefined_keys
@@ -56,13 +62,64 @@ BENCHMARK_INSTANCE = {
 }
 
 
+class HttpResponse:
+    def __init__(self, url: str, status_code: int, reason: str, content: bytes) -> None:
+        self.url = url
+        self.status_code = status_code
+        self.reason = reason or http.client.responses.get(status_code, '')
+        self.content = content
+
+    @property
+    def text(self) -> str:
+        return self.content.decode('utf-8')
+
+    def json(self) -> Any:
+        return json.loads(self.text)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise urllib.error.HTTPError(self.url, self.status_code, self.reason, http.client.HTTPMessage(), None)
+
+
+def http_request(
+    url: str,
+    method: str = 'GET',
+    *,
+    auth: tuple[str, str] | None = None,
+    json_data: Any = None,
+    verify: bool = True,
+) -> HttpResponse:
+    request_headers = {}
+    body = None
+    if json_data is not None:
+        body = json.dumps(json_data).encode('utf-8')
+        request_headers['Content-Type'] = 'application/json'
+
+    if auth is not None:
+        username, password = auth
+        token = base64.b64encode('{}:{}'.format(username, password).encode('utf-8')).decode('ascii')
+        request_headers['Authorization'] = 'Basic {}'.format(token)
+
+    context = ssl._create_unverified_context() if not verify and url.startswith('https://') else None
+    open_kwargs: dict[str, Any] = {}
+    if context is not None:
+        open_kwargs['context'] = context
+
+    req = urllib.request.Request(url, data=body, headers=request_headers, method=method)
+    try:
+        with urllib.request.urlopen(req, **open_kwargs) as response:
+            return HttpResponse(url, response.getcode(), response.reason, response.read())
+    except urllib.error.HTTPError as error:
+        return HttpResponse(url, error.code, error.reason, error.read())
+
+
 def ping_elastic():
     """
     The PUT request we use to ping the server will create an index named `testindex`
     as soon as ES is available. This is just one possible ping strategy but it's needed
     as a fixture for tests that require that index to exist in order to pass.
     """
-    response = requests.put('{}/testindex'.format(URL), auth=(USER, PASSWORD), verify=False)
+    response = http_request('{}/testindex'.format(URL), method='PUT', auth=(USER, PASSWORD), verify=False)
     response.raise_for_status()
 
 
@@ -71,9 +128,10 @@ def create_slm():
         return
 
     create_backup_body = {"type": "fs", "settings": {"location": "data"}}
-    response = requests.put(
+    response = http_request(
         '{}/_snapshot/my_repository?pretty'.format(INSTANCE['url']),
-        json=create_backup_body,
+        method='PUT',
+        json_data=create_backup_body,
         auth=(INSTANCE['username'], INSTANCE['password']),
         verify=False,
     )
@@ -86,9 +144,10 @@ def create_slm():
         "config": {"indices": ["data-*", "important"], "ignore_unavailable": False, "include_global_state": False},
         "retention": {"expire_after": "30d", "min_count": 5, "max_count": 50},
     }
-    response = requests.put(
+    response = http_request(
         '{}/_slm/policy/daily-snapshots?pretty'.format(INSTANCE['url']),
-        json=create_slm_body,
+        method='PUT',
+        json_data=create_slm_body,
         auth=(INSTANCE['username'], INSTANCE['password']),
         verify=False,
     )
@@ -96,7 +155,7 @@ def create_slm():
 
 
 def index_starts_with_dot():
-    create_dot_testindex = requests.put('{}/.testindex'.format(URL), auth=(USER, PASSWORD), verify=False)
+    create_dot_testindex = http_request('{}/.testindex'.format(URL), method='PUT', auth=(USER, PASSWORD), verify=False)
     create_dot_testindex.raise_for_status()
 
 

--- a/elastic/tests/test_integration.py
+++ b/elastic/tests/test_integration.py
@@ -1,10 +1,15 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import http.client
+import json
 import logging
+import ssl
+import urllib.error
+import urllib.request
+from typing import Any
 
 import pytest
-import requests
 from packaging import version
 
 from datadog_checks.dev.utils import get_metadata_metrics
@@ -25,6 +30,54 @@ from .common import CLUSTER_TAG, ELASTIC_VERSION, IS_OPENSEARCH, JVM_RATES, PASS
 log = logging.getLogger('test_elastic')
 
 pytestmark = pytest.mark.integration
+
+
+class HttpResponse:
+    def __init__(self, url: str, status_code: int, reason: str, content: bytes) -> None:
+        self.url = url
+        self.status_code = status_code
+        self.reason = reason or http.client.responses.get(status_code, '')
+        self.content = content
+
+    @property
+    def text(self) -> str:
+        return self.content.decode('utf-8')
+
+    def json(self) -> Any:
+        return json.loads(self.text)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise urllib.error.HTTPError(self.url, self.status_code, self.reason, http.client.HTTPMessage(), None)
+
+
+def http_request(
+    url: str,
+    method: str = 'GET',
+    *,
+    data: str | bytes | None = None,
+    json_data: Any = None,
+    verify: bool = True,
+) -> HttpResponse:
+    request_headers = {}
+    body = None
+    if json_data is not None:
+        body = json.dumps(json_data).encode('utf-8')
+        request_headers['Content-Type'] = 'application/json'
+    elif data is not None:
+        body = data if isinstance(data, bytes) else data.encode('utf-8')
+
+    context = ssl._create_unverified_context() if not verify and url.startswith('https://') else None
+    open_kwargs: dict[str, Any] = {}
+    if context is not None:
+        open_kwargs['context'] = context
+
+    req = urllib.request.Request(url, data=body, headers=request_headers, method=method)
+    try:
+        with urllib.request.urlopen(req, **open_kwargs) as response:
+            return HttpResponse(url, response.getcode(), response.reason, response.read())
+    except urllib.error.HTTPError as error:
+        return HttpResponse(url, error.code, error.reason, error.read())
 
 
 def test_custom_queries_valid_metrics(dd_environment, dd_run_check, instance, aggregator):
@@ -134,14 +187,17 @@ def test_custom_queries_with_payload(dd_environment, dd_run_check, instance, agg
     version.parse(ELASTIC_VERSION) < version.parse('8.0.0'), reason='Test unavailable for Elasticsearch < 8.0.0'
 )
 def test_custom_queries_with_payload_multiterm(dd_environment, dd_run_check, instance, aggregator, cluster_tags):
-    response = requests.put(
+    response = http_request(
         "{}/multiterm_test".format(instance['url']),
-        json={"mappings": {"properties": {"field0": {"type": "keyword"}, "field1": {"type": "keyword"}}}},
+        method='PUT',
+        json_data={"mappings": {"properties": {"field0": {"type": "keyword"}, "field1": {"type": "keyword"}}}},
     )
     response.raise_for_status()
 
-    response = requests.post(
-        "{}/multiterm_test/_doc?refresh=wait_for".format(instance['url']), json={"field0": "foo", "field1": "bar"}
+    response = http_request(
+        "{}/multiterm_test/_doc?refresh=wait_for".format(instance['url']),
+        method='POST',
+        json_data={"field0": "foo", "field1": "bar"},
     )
     response.raise_for_status()
 
@@ -440,7 +496,7 @@ def test_health_event(dd_environment, aggregator):
     es_version = elastic_check._get_es_version()
 
     # Should be yellow at first
-    requests.put(URL + '/_settings', data='{"index": {"number_of_replicas": 100}', verify=False)
+    http_request(URL + '/_settings', method='PUT', data='{"index": {"number_of_replicas": 100}', verify=False)
 
     elastic_check.check(None)
 
@@ -468,7 +524,7 @@ def test_health_event_disabled(dd_environment, aggregator):
     elastic_check._get_es_version()
 
     # Should be yellow at first
-    requests.put(URL + '/_settings', data='{"index": {"number_of_replicas": 100}', verify=False)
+    http_request(URL + '/_settings', method='PUT', data='{"index": {"number_of_replicas": 100}', verify=False)
 
     elastic_check.check(None)
 

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -2,12 +2,13 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import copy
+import http.client
 import os
 import threading
 import time
+from urllib import error, request
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.envoy import Envoy
@@ -21,6 +22,14 @@ from .legacy.common import FLAVOR, INSTANCES
 # (or we ever set the interval explicitly in the test bootstrap config),
 # update this constant and the fixture timings follow.
 ENVOY_STATS_FLUSH_INTERVAL = 5
+
+
+def open_url(url: str) -> None:
+    try:
+        with request.urlopen(url):
+            pass
+    except error.HTTPError as exc:
+        exc.close()
 
 
 @pytest.fixture(scope='session')
@@ -50,7 +59,7 @@ def dd_environment():
 @pytest.fixture
 def exercise_envoy():
     # Drive continuous traffic through Envoy's listener for the entire
-    # lifetime of the test. A background thread keeps firing requests
+    # lifetime of the test. A background thread keeps firing traffic
     # until the fixture tears down, so every flush window — including
     # those that close while the agent's check is in flight — has
     # samples. Envoy's text /stats endpoint reports per-interval
@@ -63,9 +72,9 @@ def exercise_envoy():
     def fire_loop():
         while not stop.is_set():
             try:
-                requests.get('http://{}:8000/service/1'.format(HOST))
-                requests.get('http://{}:8000/service/2'.format(HOST))
-            except requests.RequestException:
+                open_url('http://{}:8000/service/1'.format(HOST))
+                open_url('http://{}:8000/service/2'.format(HOST))
+            except (error.URLError, http.client.HTTPException, TimeoutError):
                 pass
             stop.wait(ENVOY_STATS_FLUSH_INTERVAL / 10)
 

--- a/envoy/tests/docker/api_v2/service.py
+++ b/envoy/tests/docker/api_v2/service.py
@@ -1,7 +1,8 @@
 import os
 import socket
+from urllib import error
+from urllib import request as urlrequest
 
-import requests
 from flask import Flask, request
 
 app = Flask(__name__)
@@ -32,7 +33,12 @@ def trace(service_number):
         for header in TRACE_HEADERS_TO_PROPAGATE:
             if header in request.headers:
                 headers[header] = request.headers[header]
-        requests.get("http://localhost:9000/trace/2", headers=headers)
+        try:
+            req = urlrequest.Request("http://localhost:9000/trace/2", headers=headers)
+            with urlrequest.urlopen(req):
+                pass
+        except error.HTTPError as exc:
+            exc.close()
     return 'Hello from behind Envoy (service {})! hostname: {} resolved hostname: {}'.format(
         os.environ['SERVICE_NAME'], socket.gethostname(), socket.gethostbyname(socket.gethostname())
     )

--- a/envoy/tests/docker/api_v3/service.py
+++ b/envoy/tests/docker/api_v3/service.py
@@ -1,7 +1,8 @@
 import os
 import socket
+from urllib import error
+from urllib import request as urlrequest
 
-import requests
 from flask import Flask, request
 
 app = Flask(__name__)
@@ -32,7 +33,12 @@ def trace(service_number):
         for header in TRACE_HEADERS_TO_PROPAGATE:
             if header in request.headers:
                 headers[header] = request.headers[header]
-        requests.get("http://localhost:9000/trace/2", headers=headers)
+        try:
+            req = urlrequest.Request("http://localhost:9000/trace/2", headers=headers)
+            with urlrequest.urlopen(req):
+                pass
+        except error.HTTPError as exc:
+            exc.close()
     return 'Hello from behind Envoy (service {})! hostname: {} resolved hostname: {}'.format(
         os.environ['SERVICE_NAME'], socket.gethostname(), socket.gethostbyname(socket.gethostname())
     )

--- a/etcd/tests/utils.py
+++ b/etcd/tests/utils.py
@@ -1,11 +1,21 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import requests
+import json
+import urllib.error
+import urllib.request
 
 
 def is_leader(url):
-    response = requests.post('{}/v3/maintenance/status'.format(url), data='{}').json()
+    req = urllib.request.Request('{}/v3/maintenance/status'.format(url), data=b'{}', method='POST')
+    try:
+        resp = urllib.request.urlopen(req)
+    except urllib.error.HTTPError as e:
+        resp = e
+    try:
+        response = json.load(resp)
+    finally:
+        resp.close()
     leader = response.get('leader')
     member = response.get('header', {}).get('member_id')
 

--- a/gitlab/tests/conftest.py
+++ b/gitlab/tests/conftest.py
@@ -4,11 +4,12 @@
 import copy
 import json
 import os
+import urllib.error
+import urllib.request
 from contextlib import contextmanager
 from time import sleep
 
 import pytest
-import requests
 
 from datadog_checks.dev import EnvVars, TempDir, docker_run
 from datadog_checks.dev._env import get_state, save_state
@@ -84,7 +85,12 @@ def dd_environment():
     ):
         # run pre-test commands
         for _ in range(100):
-            requests.get(GITLAB_URL)
+            try:
+                response = urllib.request.urlopen(GITLAB_URL)
+            except urllib.error.HTTPError as e:
+                e.close()
+            else:
+                response.close()
         sleep(2)
 
         yield {
@@ -103,11 +109,11 @@ def dd_environment():
 
 @pytest.fixture()
 def mock_data(mock_openmetrics_http):
-    mock_openmetrics_http.get.side_effect = mocked_requests_get
+    mock_openmetrics_http.get.side_effect = mocked_http_get
     yield
 
 
-def mocked_requests_get(*args, **kwargs):
+def mocked_http_get(*args, **kwargs):
     url = args[0]
 
     if url.startswith("http://{}:{}/-/readiness".format(HOST, GITLAB_LOCAL_PORT)):

--- a/go_expvar/tests/conftest.py
+++ b/go_expvar/tests/conftest.py
@@ -5,10 +5,11 @@
 import json
 import logging
 import os
+import urllib.error
+import urllib.request
 
 import mock
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.go_expvar import GoExpvar
@@ -36,7 +37,12 @@ def dd_environment():
 
     with docker_run(os.path.join(common.HERE, 'compose', 'docker-compose.yaml'), endpoints=[common.URL]):
         for _ in range(9):
-            requests.get(common.URL + "?user=123456")
+            try:
+                response = urllib.request.urlopen(common.URL + "?user=123456")
+            except urllib.error.HTTPError as e:
+                e.close()
+            else:
+                response.close()
         yield common.INSTANCE
 
 

--- a/haproxy/tests/conftest.py
+++ b/haproxy/tests/conftest.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import base64
 import getpass
 import logging
 import os
@@ -8,10 +9,10 @@ import re
 import subprocess
 from contextlib import contextmanager
 from copy import deepcopy
+from urllib import request
 
 import mock
 import pytest
-import requests
 from packaging import version
 
 from datadog_checks.dev import TempDir, WaitFor, docker_run
@@ -41,6 +42,11 @@ from .legacy.common import (
 )
 
 log = logging.getLogger('test_haproxy')
+
+
+def basic_auth_header(username: str, password: str) -> str:
+    token = base64.b64encode(f'{username}:{password}'.encode('latin1')).decode('ascii')
+    return f'Basic {token}'
 
 
 @pytest.fixture(scope='session')
@@ -126,13 +132,14 @@ def prometheus_metricsv2(prometheus_metrics):
 
 
 def wait_for_haproxy():
-    res = requests.get(STATS_URL, auth=(USERNAME, PASSWORD))
-    res.raise_for_status()
+    req = request.Request(STATS_URL, headers={'Authorization': basic_auth_header(USERNAME, PASSWORD)})
+    with request.urlopen(req):
+        pass
 
 
 def wait_for_haproxy_open():
-    res_open = requests.get(STATS_URL_OPEN)
-    res_open.raise_for_status()
+    with request.urlopen(STATS_URL_OPEN):
+        pass
 
 
 @contextmanager

--- a/harbor/tests/conftest.py
+++ b/harbor/tests/conftest.py
@@ -1,10 +1,13 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import base64
+import json
 import os
+import ssl
+from urllib import error, request
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs, WaitFor
@@ -41,6 +44,11 @@ from .common import (
 )
 
 
+def basic_auth_header(username: str, password: str) -> str:
+    token = base64.b64encode(f'{username}:{password}'.encode('latin1')).decode('ascii')
+    return f'Basic {token}'
+
+
 @pytest.fixture(scope='session')
 def dd_environment(e2e_instance):
     compose_file = get_docker_compose_file()
@@ -58,17 +66,28 @@ def dd_environment(e2e_instance):
 
 
 def create_simple_user():
-    requests.post(
-        URL + USERS_PATH,
-        auth=("admin", "Harbor12345"),
-        json={
+    payload = json.dumps(
+        {
             "username": "NotAnAdmin",
             "email": "NotAnAdmin@goharbor.io",
             "password": "Str0ngPassw0rd",
             "realname": "Not An Admin",
+        }
+    ).encode()
+    req = request.Request(
+        URL + USERS_PATH,
+        data=payload,
+        headers={
+            "Authorization": basic_auth_header("admin", "Harbor12345"),
+            "Content-Type": "application/json",
         },
-        verify=False,
+        method='POST',
     )
+    try:
+        with request.urlopen(req, context=ssl._create_unverified_context()):
+            pass
+    except error.HTTPError as exc:
+        exc.close()
 
 
 @pytest.fixture(scope='session')

--- a/http_check/tests/conftest.py
+++ b/http_check/tests/conftest.py
@@ -2,10 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+import ssl
 import sys
+from urllib import request
 
 import pytest
-import requests
 from datadog_test_libs.utils.mock_dns import mock_local
 from mock import patch
 
@@ -37,8 +38,8 @@ def dd_environment(mock_local_http_dns):
 
 
 def call_endpoint(url):
-    response = requests.get(url, verify=False)
-    response.raise_for_status()
+    with request.urlopen(url, context=ssl._create_unverified_context()):
+        pass
     return True
 
 

--- a/kuma/tests/conftest.py
+++ b/kuma/tests/conftest.py
@@ -1,12 +1,13 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import http.client
 import os
 import time
 from contextlib import ExitStack
+from urllib import error, request
 
 import pytest
-import requests
 
 from datadog_checks.dev.kind import kind_run
 from datadog_checks.dev.kube_port_forward import port_forward
@@ -44,11 +45,11 @@ def wait_for_kuma_readiness(api_url, api_port, max_wait=600):
 
     while time.monotonic() - start_time < max_wait:
         try:
-            response = requests.get(config_url, timeout=5)
-            if response.ok:
-                print(f"Kuma control plane is ready at {config_url} (took {time.monotonic() - start_time} seconds)")
-                return
-        except (requests.exceptions.RequestException, requests.exceptions.Timeout):
+            with request.urlopen(config_url, timeout=5) as response:
+                if response.status < 400:
+                    print(f"Kuma control plane is ready at {config_url} (took {time.monotonic() - start_time} seconds)")
+                    return
+        except (error.URLError, http.client.HTTPException, TimeoutError):
             pass
 
         print(f"Waiting for Kuma control plane to be ready at {config_url}...")

--- a/kyototycoon/tests/conftest.py
+++ b/kyototycoon/tests/conftest.py
@@ -3,9 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import os
+from urllib import error, parse, request
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 
@@ -25,10 +25,21 @@ def dd_environment():
     ):
         # Generate a test database
         data = {'dddd': 'dddd'}
-        headers = {'X-Kt-Mode': 'set'}
+        payload = parse.urlencode(data).encode()
+        headers = {'X-Kt-Mode': 'set', 'Content-Type': 'application/x-www-form-urlencoded'}
 
         for _ in range(100):
-            requests.put(URL, data=data, headers=headers)
-            requests.get(URL)
+            try:
+                req = request.Request(URL, data=payload, headers=headers, method='PUT')
+                with request.urlopen(req):
+                    pass
+            except error.HTTPError as exc:
+                exc.close()
+
+            try:
+                with request.urlopen(URL):
+                    pass
+            except error.HTTPError as exc:
+                exc.close()
 
         yield DEFAULT_INSTANCE

--- a/mapreduce/tests/common.py
+++ b/mapreduce/tests/common.py
@@ -1,11 +1,12 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
 import random
 import time
 from contextlib import contextmanager
+from urllib import error, request
 
-import requests
 from datadog_test_libs.utils.mock_dns import mock_local
 
 from datadog_checks.dev import get_docker_hostname, get_here, run_command
@@ -69,8 +70,15 @@ def setup_mapreduce():
 
     # Called in WaitFor which catches initial exceptions when containers aren't ready
     for _ in range(15):
-        r = requests.get("{}/ws/v1/cluster/apps?states=RUNNING".format(INSTANCE_INTEGRATION['resourcemanager_uri']))
-        res = r.json()
+        url = "{}/ws/v1/cluster/apps?states=RUNNING".format(INSTANCE_INTEGRATION['resourcemanager_uri'])
+        try:
+            response = request.urlopen(url)
+        except error.HTTPError as exc:
+            response = exc
+        try:
+            res = json.loads(response.read().decode())
+        finally:
+            response.close()
         if res.get("apps", None) is not None and res.get("apps"):
             return True
 

--- a/marklogic/tests/conftest.py
+++ b/marklogic/tests/conftest.py
@@ -1,11 +1,14 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import http.client
 import os
+import urllib.error
+import urllib.parse
+import urllib.request
 from typing import Any, Dict, Generator  # noqa: F401
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs, WaitFor
@@ -21,6 +24,50 @@ from .common import (
     MARKLOGIC_VERSION,
     PASSWORD,
 )
+
+
+class HttpResponse:
+    def __init__(self, url: str, status_code: int, reason: str, content: bytes) -> None:
+        self.url = url
+        self.status_code = status_code
+        self.reason = reason or http.client.responses.get(status_code, '')
+        self.content = content
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise urllib.error.HTTPError(self.url, self.status_code, self.reason, http.client.HTTPMessage(), None)
+
+
+def http_request(
+    url: str,
+    method: str = 'GET',
+    *,
+    data: dict[str, str] | str | bytes | None = None,
+    headers: dict[str, str] | None = None,
+    digest_auth: tuple[str, str] | None = None,
+) -> HttpResponse:
+    request_headers = dict(headers or {})
+    body = None
+    if isinstance(data, dict):
+        body = urllib.parse.urlencode(data).encode('utf-8')
+    elif isinstance(data, str):
+        body = data.encode('utf-8')
+    elif data is not None:
+        body = data
+
+    req = urllib.request.Request(url, data=body, headers=request_headers, method=method)
+    opener = urllib.request.build_opener()
+    if digest_auth is not None:
+        username, password = digest_auth
+        password_manager = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+        password_manager.add_password(None, url, username, password)
+        opener = urllib.request.build_opener(urllib.request.HTTPDigestAuthHandler(password_manager))
+
+    try:
+        with opener.open(req) as response:
+            return HttpResponse(url, response.getcode(), response.reason, response.read())
+    except urllib.error.HTTPError as error:
+        return HttpResponse(url, error.code, error.reason, error.read())
 
 
 @pytest.fixture(scope="session")
@@ -53,8 +100,9 @@ def setup_admin_user():
     # type: () -> None
     # From https://docs.marklogic.com/10.0/guide/admin-api/cluster
     # Reset admin user password (useful for cluster setup)
-    requests.post(
+    http_request(
         'http://localhost:8001/admin/v1/instance-admin',
+        method='POST',
         data={
             "admin-username": ADMIN_USERNAME,
             "admin-password": ADMIN_PASSWORD,
@@ -64,7 +112,7 @@ def setup_admin_user():
         headers={"Content-type": "application/x-www-form-urlencoded"},
     )
 
-    r = requests.get('{}/manage/v2'.format(API_URL), auth=requests.auth.HTTPDigestAuth(ADMIN_USERNAME, ADMIN_PASSWORD))
+    r = http_request('{}/manage/v2'.format(API_URL), digest_auth=(ADMIN_USERNAME, ADMIN_PASSWORD))
 
     r.raise_for_status()
 
@@ -72,24 +120,26 @@ def setup_admin_user():
 def setup_datadog_users():
     # type: () -> None
     # Create datadog users with the admin account
-    r = requests.post(
+    r = http_request(
         '{}/manage/v2/users'.format(API_URL),
+        method='POST',
         headers={'Content-Type': 'application/json'},
         data='{{"user-name": "{}", "password": "{}", "roles": {{"role": "manage-user"}}}}'.format(
             MANAGE_USER_USERNAME, PASSWORD
         ),
-        auth=requests.auth.HTTPDigestAuth(ADMIN_USERNAME, ADMIN_PASSWORD),
+        digest_auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
     )
 
     r.raise_for_status()
 
-    r = requests.post(
+    r = http_request(
         '{}/manage/v2/users'.format(API_URL),
+        method='POST',
         headers={'Content-Type': 'application/json'},
         data='{{"user-name": "{}", "password": "{}", "roles": {{"role": "manage-admin"}}}}'.format(
             MANAGE_ADMIN_USERNAME, PASSWORD
         ),
-        auth=requests.auth.HTTPDigestAuth(ADMIN_USERNAME, ADMIN_PASSWORD),
+        digest_auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
     )
 
     r.raise_for_status()

--- a/n8n/tests/conftest.py
+++ b/n8n/tests/conftest.py
@@ -3,14 +3,15 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import copy
+import http.client
 import json
 import subprocess
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, Iterator
+from urllib import error, request
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run, get_e2e_discovery_metadata
 from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
@@ -23,6 +24,7 @@ WEBHOOK_OK_PATH = '/webhook/test'
 WEBHOOK_FAIL_PATH = '/webhook/fail'
 
 CONTAINER = 'n8n-test'
+HTTP_EXCEPTIONS = (error.URLError, http.client.HTTPException, TimeoutError)
 
 # Directories whose ``*.json`` workflow files are bind-mounted into the container.
 # In test mode only the two test fixtures are mounted at ``/workflows/``;
@@ -31,13 +33,25 @@ _TEST_WORKFLOW_DIR = Path(common.HERE) / 'docker'
 _LAB_WORKFLOW_DIR = Path(common.HERE) / 'lab' / 'workflows'
 
 
+def get_response(url: str, timeout: int) -> tuple[int, str]:
+    try:
+        response = request.urlopen(url, timeout=timeout)
+    except error.HTTPError as exc:
+        response = exc
+    try:
+        return response.getcode(), response.read().decode()
+    finally:
+        response.close()
+
+
 def _docker_exec(*cmd: str) -> str:
     return subprocess.check_output(['docker', 'exec', CONTAINER, *cmd], stderr=subprocess.STDOUT).decode()
 
 
 def _n8n_healthy() -> None:
     """WaitFor predicate: succeeds once /healthz returns 200, retries on connection errors or non-2xx."""
-    requests.get(f'http://{common.HOST}:{common.MAIN_PORT}/healthz', timeout=2).raise_for_status()
+    with request.urlopen(f'http://{common.HOST}:{common.MAIN_PORT}/healthz', timeout=2):
+        pass
 
 
 def _test_webhook_registered() -> None:
@@ -48,8 +62,8 @@ def _test_webhook_registered() -> None:
     to make ``_generate_workflow_traffic`` race the registration and observe a 404. Polling the
     webhook itself closes the race.
     """
-    response = requests.get(f'http://{common.HOST}:{common.MAIN_PORT}{WEBHOOK_OK_PATH}', timeout=5)
-    if response.status_code == 404:
+    status_code, _ = get_response(f'http://{common.HOST}:{common.MAIN_PORT}{WEBHOOK_OK_PATH}', timeout=5)
+    if status_code == 404:
         raise RuntimeError(f'Webhook {WEBHOOK_OK_PATH} not yet registered (status 404)')
 
 
@@ -107,18 +121,18 @@ def _generate_workflow_traffic(iterations: int = 5) -> None:
     last_exc: Exception | None = None
     for _ in range(iterations):
         try:
-            ok = requests.get(f'{base_url}{WEBHOOK_OK_PATH}', timeout=5)
-            last_status = ok.status_code
+            ok_status, _ = get_response(f'{base_url}{WEBHOOK_OK_PATH}', timeout=5)
+            last_status = ok_status
             # 4xx means the webhook responded but didn't execute the workflow (e.g. not yet
             # registered after restart); only 200 proves the workflow body ran end-to-end.
-            if ok.status_code == 200:
+            if ok_status == 200:
                 ok_responses += 1
-        except requests.RequestException as exc:
+        except HTTP_EXCEPTIONS as exc:
             last_exc = exc
         # Webhook fail is *expected* to error out — that's the point of triggering it.
         for path in (WEBHOOK_FAIL_PATH, *api_paths):
-            with suppress(requests.RequestException):
-                requests.get(f'{base_url}{path}', timeout=5)
+            with suppress(*HTTP_EXCEPTIONS):
+                get_response(f'{base_url}{path}', timeout=5)
     if ok_responses == 0:
         raise RuntimeError(
             f'Test webhook returned no 200 responses (last_status={last_status}, last_exc={last_exc!r}); '
@@ -134,7 +148,7 @@ def _workflow_started_non_zero() -> None:
     Parses the metric value as a float so that ``0.0`` / ``0e+0`` are recognised as zero and
     ``# HELP``/``# TYPE`` comment lines that happen to share the prefix are skipped.
     """
-    payload = requests.get(common.MAIN_INSTANCE['openmetrics_endpoint'], timeout=3).text
+    _, payload = get_response(common.MAIN_INSTANCE['openmetrics_endpoint'], timeout=3)
     matching: list[str] = []
     for line in payload.splitlines():
         if line.startswith('#') or not line.startswith('n8n_workflow_started_total'):

--- a/nutanix/tests/scripts/record_fixtures.py
+++ b/nutanix/tests/scripts/record_fixtures.py
@@ -21,16 +21,17 @@ Dependency resolution:
 """
 
 import argparse
+import base64
 import json
+import ssl
 import sys
 from datetime import datetime, timedelta, timezone
+from http.client import HTTPMessage, responses
 from pathlib import Path
-
-import requests
+from urllib import error, parse, request
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from conftest import AWS_INSTANCE  # noqa: E402
-from requests.auth import HTTPBasicAuth  # noqa: E402
 
 RESOURCES = (
     "clusters",
@@ -64,13 +65,25 @@ if not BASE_URL.startswith("http"):
     BASE_URL = f"https://{BASE_URL}"
 BASE_URL = f"{BASE_URL}:{PC_PORT}"
 
-# Create session with auth
-session = requests.Session()
-session.auth = HTTPBasicAuth(PC_USERNAME, PC_PASSWORD)
-session.verify = TLS_VERIFY
+BASIC_AUTH_HEADER = "Basic {}".format(base64.b64encode(f"{PC_USERNAME}:{PC_PASSWORD}".encode()).decode())
+TLS_CONTEXT = ssl.create_default_context() if TLS_VERIFY else ssl._create_unverified_context()
 
 
-def make_request(endpoint: str, params: dict | None = None) -> requests.Response:
+class APIResponse:
+    def __init__(self, body: bytes, status: int, url: str) -> None:
+        self.body = body
+        self.status = status
+        self.url = url
+
+    def json(self) -> dict:
+        return json.loads(self.body.decode("utf-8"))
+
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            raise error.HTTPError(self.url, self.status, responses.get(self.status, ""), HTTPMessage(), None)
+
+
+def make_request(endpoint: str, params: dict | None = None) -> APIResponse:
     """Make a request to the Nutanix API.
 
     Args:
@@ -81,12 +94,14 @@ def make_request(endpoint: str, params: dict | None = None) -> requests.Response
         Response object
     """
     url = f"{BASE_URL}/{endpoint}"
+    if params:
+        url = f"{url}?{parse.urlencode(params)}"
     print(f"  GET {endpoint}")
     if params:
         print(f"    params: {params}")
-    response = session.get(url, params=params)
-    response.raise_for_status()
-    return response
+    api_request = request.Request(url, headers={"Authorization": BASIC_AUTH_HEADER})
+    with request.urlopen(api_request, context=TLS_CONTEXT) as response:
+        return APIResponse(response.read(), response.status, response.geturl())
 
 
 def fetch_paginated_endpoint(endpoint: str, params: dict | None = None) -> list[dict]:
@@ -221,7 +236,7 @@ def record_hosts(clusters: list[dict], save: bool = True) -> list[tuple[str, str
                     host_id = host.get("extId")
                     if host_id:
                         cluster_host_pairs.append((cluster_id, host_id))
-        except requests.exceptions.HTTPError as e:
+        except error.HTTPError as e:
             print(f"  ⚠ Failed to fetch hosts for this cluster: {e}")
             print("  (This is expected for Prism Central deployment clusters)")
 
@@ -265,7 +280,7 @@ def record_cluster_stats(clusters: list[dict]) -> None:
             # Use shortened cluster ID for filename
             short_cluster_id = cluster_id.split("-")[0]
             save_fixture(f"cluster_stats_{short_cluster_id}.json", data)
-        except requests.exceptions.HTTPError as e:
+        except error.HTTPError as e:
             print(f"  ⚠ Failed to fetch cluster stats: {e}")
 
 
@@ -303,7 +318,7 @@ def record_host_stats(cluster_host_pairs: list[tuple[str, str]]) -> None:
             short_cluster_id = cluster_id.split("-")[0]
             short_host_id = host_id.split("-")[0]
             save_fixture(f"host_stats_{short_cluster_id}_{short_host_id}.json", data)
-        except requests.exceptions.HTTPError as e:
+        except error.HTTPError as e:
             print(f"  ⚠ Failed to fetch host stats: {e}")
 
 
@@ -338,7 +353,7 @@ def record_vm_stats() -> None:
     try:
         pages = fetch_paginated_endpoint("api/vmm/v4.0/ahv/stats/vms", params=params)
         save_fixture("vms_stats.json", pages)
-    except requests.exceptions.HTTPError as e:
+    except error.HTTPError as e:
         print(f"  ⚠ Failed to fetch VM stats: {e}")
 
 
@@ -348,7 +363,7 @@ def record_disks() -> None:
     try:
         pages = fetch_paginated_endpoint("api/clustermgmt/v4.0/config/disks")
         save_fixture("disks.json", pages)
-    except requests.exceptions.HTTPError as e:
+    except error.HTTPError as e:
         print(f"  ⚠ Failed to fetch disks: {e}")
 
 
@@ -369,7 +384,7 @@ def record_events() -> None:
     try:
         pages = fetch_paginated_endpoint("api/monitoring/v4.0/serviceability/events", params=params)
         save_fixture("events.json", pages)
-    except requests.exceptions.HTTPError as e:
+    except error.HTTPError as e:
         print(f"  ⚠ Failed to fetch events: {e}")
 
 
@@ -390,7 +405,7 @@ def record_audits() -> None:
     try:
         pages = fetch_paginated_endpoint("api/monitoring/v4.0/serviceability/audits", params=params)
         save_fixture("audits.json", pages)
-    except requests.exceptions.HTTPError as e:
+    except error.HTTPError as e:
         print(f"  ⚠ Failed to fetch audits: {e}")
 
 
@@ -406,7 +421,7 @@ def record_alerts() -> None:
     try:
         pages = fetch_paginated_endpoint("api/monitoring/v4.0/serviceability/alerts", params=params)
         save_fixture("alerts.json", pages)
-    except requests.exceptions.HTTPError as e:
+    except error.HTTPError as e:
         print(f"  ⚠ alerts fetch failed: {e}")
 
 
@@ -427,7 +442,7 @@ def record_tasks() -> None:
     try:
         pages = fetch_paginated_endpoint("api/prism/v4.0/config/tasks", params=params)
         save_fixture("tasks.json", pages)
-    except requests.exceptions.HTTPError as e:
+    except error.HTTPError as e:
         print(f"  ⚠ Failed to fetch tasks: {e}")
 
 
@@ -554,7 +569,7 @@ def main(argv: list[str] | None = None) -> None:
     # Test connectivity
     try:
         print("\nTesting connectivity...")
-        response = session.get(f"{BASE_URL}/console")
+        response = make_request("console")
         response.raise_for_status()
         print("✓ Connection successful")
     except Exception as e:

--- a/prefect/tests/conftest.py
+++ b/prefect/tests/conftest.py
@@ -3,11 +3,14 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
+import http.client
+import json
+import urllib.error
+import urllib.request
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 import pytest
-import requests
 
 from datadog_checks.dev.conditions import CheckDockerLogs, CheckEndpoints, WaitFor
 from datadog_checks.dev.docker import docker_run, get_docker_hostname, get_e2e_discovery_metadata
@@ -21,16 +24,57 @@ E2E_METADATA = {
 }
 
 
+class HttpResponse:
+    def __init__(self, url: str, status_code: int, reason: str, content: bytes) -> None:
+        self.url = url
+        self.status_code = status_code
+        self.reason = reason or http.client.responses.get(status_code, '')
+        self.content = content
+
+    @property
+    def text(self) -> str:
+        return self.content.decode('utf-8')
+
+    def json(self) -> Any:
+        return json.loads(self.text)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise urllib.error.HTTPError(self.url, self.status_code, self.reason, http.client.HTTPMessage(), None)
+
+
+def http_request(
+    url: str,
+    method: str = "GET",
+    *,
+    json_data: Any = None,
+    timeout: float | None = None,
+) -> HttpResponse:
+    headers = {}
+    body = None
+    if json_data is not None:
+        body = json.dumps(json_data).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            return HttpResponse(url, response.getcode(), response.reason, response.read())
+    except urllib.error.HTTPError as error:
+        return HttpResponse(url, error.code, error.reason, error.read())
+
+
 def _check_task_runs_available(prefect_url: str):
     """Verify that the Prefect API has task runs and task-run events queryable."""
-    resp = requests.post(f"{prefect_url}/task_runs/filter", json={}, timeout=1)
+    resp = http_request(f"{prefect_url}/task_runs/filter", method="POST", json_data={}, timeout=1)
     resp.raise_for_status()
     task_runs = resp.json()
     assert task_runs, "No task runs available in Prefect API yet"
 
-    resp = requests.post(
+    resp = http_request(
         f"{prefect_url}/events/filter",
-        json={"filter": {"event": {"prefix": ["prefect.task-run"]}}},
+        method="POST",
+        json_data={"filter": {"event": {"prefix": ["prefect.task-run"]}}},
         timeout=1,
     )
     resp.raise_for_status()

--- a/rabbitmq/tests/conftest.py
+++ b/rabbitmq/tests/conftest.py
@@ -2,16 +2,22 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import base64
 import os
 import subprocess
+from urllib import request
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run, temp_dir
 from datadog_checks.rabbitmq import RabbitMQ
 
 from .common import CHECK_NAME, CONFIG, HERE, HOST, OPENMETRICS_CONFIG, PORT, RABBITMQ_METRICS_PLUGIN
+
+
+def basic_auth_header(username: str, password: str) -> str:
+    token = base64.b64encode(f'{username}:{password}'.encode('latin1')).decode('ascii')
+    return f'Basic {token}'
 
 
 @pytest.fixture(scope="session")
@@ -38,12 +44,12 @@ def dd_environment():
 def setup_rabbitmq():
     with temp_dir() as tmpdir:
         url = 'http://{}:{}/cli/rabbitmqadmin'.format(HOST, PORT)
-        res = requests.get(url)
-        res.raise_for_status()
+        with request.urlopen(url) as res:
+            rabbitmq_admin = res.read().decode()
 
         rabbitmq_admin_script = os.path.join(tmpdir, 'rabbitmqadmin')
         with open(rabbitmq_admin_script, 'w+') as f:
-            f.write(res.text)
+            f.write(rabbitmq_admin)
 
         setup_vhosts(rabbitmq_admin_script)
         setup_more(rabbitmq_admin_script)
@@ -51,10 +57,14 @@ def setup_rabbitmq():
 
         # Set cluster name
         url = "http://{}:{}/api/cluster-name".format(HOST, PORT)
-        res = requests.put(
-            url, data='{"name": "rabbitmqtest"}', auth=("guest", "guest"), headers={"Content-Type": "application/json"}
+        req = request.Request(
+            url,
+            data=b'{"name": "rabbitmqtest"}',
+            headers={"Authorization": basic_auth_header("guest", "guest"), "Content-Type": "application/json"},
+            method='PUT',
         )
-        res.raise_for_status()
+        with request.urlopen(req):
+            pass
 
 
 def setup_vhosts(rabbitmq_admin_script):

--- a/ray/tests/conftest.py
+++ b/ray/tests/conftest.py
@@ -5,10 +5,10 @@ import copy
 import os
 import time
 from contextlib import contextmanager
+from urllib import request
 from urllib.parse import urljoin
 
 import pytest
-import requests
 
 from datadog_checks.dev import EnvVars, TempDir, docker_run, get_e2e_discovery_metadata
 from datadog_checks.dev._env import get_state, save_state
@@ -111,16 +111,16 @@ def mocked_worker_instance():
 
 def run_add():
     try:
-        response = requests.post(
+        req = request.Request(
             urljoin(SERVE_URL, "add"),
-            data='{"a": 1, "b": 2}',
+            data=b'{"a": 1, "b": 2}',
             headers={'Content-Type': 'application/json'},
+            method='POST',
         )
-        response.raise_for_status()
+        with request.urlopen(req) as response:
+            return response.status == 200
     except Exception:
         return False
-    else:
-        return response.status_code == 200
 
 
 def prepare_service():

--- a/ray/tests/docker/call_apis.py
+++ b/ray/tests/docker/call_apis.py
@@ -5,8 +5,16 @@ import logging
 import threading
 import time
 from random import randint, randrange
+from urllib import error, request
 
-import requests
+
+def open_url(url: str, data: str | None = None, headers: dict[str, str] | None = None) -> None:
+    req = request.Request(url, data=data.encode() if data is not None else None, headers=headers or {})
+    try:
+        with request.urlopen(req):
+            pass
+    except error.HTTPError as exc:
+        exc.close()
 
 
 def do_stuff(id, func, *args):
@@ -17,11 +25,11 @@ def do_stuff(id, func, *args):
 
 
 def run_hello():
-    requests.get("http://ray-head:8000/hello")
+    open_url("http://ray-head:8000/hello")
 
 
 def run_add():
-    requests.post(
+    open_url(
         "http://ray-head:8000/add",
         data=f'{{"a": {randint(1, 10)}, "b": {randint(1, 10)}}}',
         headers={'Content-Type': 'application/json'},
@@ -29,7 +37,7 @@ def run_add():
 
 
 def generate_500():
-    requests.post(
+    open_url(
         "http://ray-head:8000/add",
         data='{"a"}',
         headers={'Content-Type': 'application/json'},
@@ -37,12 +45,12 @@ def generate_500():
 
 
 def generate_404():
-    requests.get("http://ray-head:8000/not-found")
+    open_url("http://ray-head:8000/not-found")
     time.sleep(randrange(50))
 
 
 def call_openmetrics_endpoint(server):
-    requests.get(f"http://{server}:8080")
+    open_url(f"http://{server}:8080")
 
 
 if __name__ == "__main__":

--- a/riak/tests/conftest.py
+++ b/riak/tests/conftest.py
@@ -2,11 +2,13 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import http.client
 import os
 from copy import deepcopy
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
@@ -15,14 +17,31 @@ from datadog_checks.riak import Riak
 from . import common
 
 
+def response_ok(http_request: Request) -> bool:
+    try:
+        with urlopen(http_request) as response:
+            return response.status < http.client.BAD_REQUEST
+    except HTTPError as e:
+        e.close()
+        return e.code < http.client.BAD_REQUEST
+
+
 def populate():
-    post = requests.post(
-        "{}/riak/bucket/german".format(common.BASE_URL),
-        headers={"Content-Type": "text/plain"},
-        data='herzlich willkommen',
+    post = response_ok(
+        Request(
+            "{}/riak/bucket/german".format(common.BASE_URL),
+            data=b'herzlich willkommen',
+            headers={"Content-Type": "text/plain"},
+            method='POST',
+        )
     )
-    get = requests.get("{}/riak/bucket/german".format(common.BASE_URL))
-    return post.ok and get.ok
+    get = response_ok(
+        Request(
+            "{}/riak/bucket/german".format(common.BASE_URL),
+            method='GET',
+        )
+    )
+    return post and get
 
 
 @pytest.fixture(scope="session")

--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -6,9 +6,10 @@ import os
 import shutil
 import socket
 from copy import deepcopy
+from urllib.error import HTTPError
+from urllib.request import urlopen
 
 import pytest
-import requests
 import yaml
 
 from datadog_checks.base.agent import datadog_agent
@@ -46,6 +47,15 @@ E2E_METADATA = {
 EXPECTED_AUTODISCOVERY_CHECKS = 6
 
 
+def read_url(url: str) -> bytes:
+    try:
+        with urlopen(url) as response:
+            return response.read()
+    except HTTPError as e:
+        with e:
+            return e.read()
+
+
 @pytest.fixture(scope='session')
 def dd_environment():
     new_e2e_metadata = deepcopy(E2E_METADATA)
@@ -55,9 +65,8 @@ def dd_environment():
         if not os.path.exists(data_dir):
             shutil.copytree(os.path.join(COMPOSE_DIR, 'data'), data_dir)
             for data_file in FILES:
-                response = requests.get(data_file)
                 with open(os.path.join(data_dir, data_file.rsplit('/', 1)[1]), 'wb') as output:
-                    output.write(response.content)
+                    output.write(read_url(data_file))
 
         with docker_run(os.path.join(COMPOSE_DIR, 'docker-compose.yaml'), env_vars=env, log_patterns="Listening at"):
             if SNMP_LISTENER_ENV == 'true':

--- a/spark/tests/conftest.py
+++ b/spark/tests/conftest.py
@@ -1,16 +1,27 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
 import os
+from urllib.error import HTTPError
+from urllib.request import urlopen
 
 import pytest
-import requests
 from datadog_test_libs.utils.mock_dns import mock_local
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
 
 from .common import HERE, HOST, HOSTNAME_TO_PORT_MAPPING, INSTANCE_STANDALONE
+
+
+def read_url(url: str) -> bytes:
+    try:
+        with urlopen(url) as response:
+            return response.read()
+    except HTTPError as e:
+        with e:
+            return e.read()
 
 
 @pytest.fixture(scope='session')
@@ -36,8 +47,7 @@ def dd_environment():
 
 def check_metrics_available():
     endpoint = 'http://{}:4050/metrics/json'.format(HOST)
-    r = requests.get(endpoint)
-    return r.text.count("driver.spark.streaming") >= 6
+    return read_url(endpoint).decode('utf-8').count("driver.spark.streaming") >= 6
 
 
 def check_executors_registered():
@@ -49,11 +59,13 @@ def check_executors_registered():
     # of the two apps can own a non-driver executor at a time; either app having one is
     # enough for `test_integration_standalone` to observe executor metrics.
     for port in (4040, 4050):
-        apps = requests.get('http://{}:{}/api/v1/applications'.format(HOST, port)).json()
+        apps = json.loads(read_url('http://{}:{}/api/v1/applications'.format(HOST, port)).decode('utf-8'))
         if not apps:
             continue
         app_id = apps[0]['id']
-        executors = requests.get('http://{}:{}/api/v1/applications/{}/executors'.format(HOST, port, app_id)).json()
+        executors = json.loads(
+            read_url('http://{}:{}/api/v1/applications/{}/executors'.format(HOST, port, app_id)).decode('utf-8')
+        )
         if any(executor.get('id') != 'driver' for executor in executors):
             return True
     return False

--- a/temporal/scripts/update_temporal_integration.py
+++ b/temporal/scripts/update_temporal_integration.py
@@ -19,8 +19,7 @@ import pathlib
 import re
 import sys
 from urllib.parse import urljoin
-
-import requests
+from urllib.request import urlopen
 
 # We need access to METRIC_MAP and helper functions
 # ``scripts`` is **not** a package, so add its parent (repository root) to sys.path
@@ -50,7 +49,7 @@ def fetch_temporal_metrics(tag: str) -> str:
         str: The content of the metrics definitions file
 
     Raises:
-        requests.RequestException: If the request fails
+        urllib.error.URLError: If the request fails
         ValueError: If the tag format is invalid
     """
     if not tag.startswith('v'):
@@ -61,9 +60,8 @@ def fetch_temporal_metrics(tag: str) -> str:
     url = urljoin(f"{base_url}/{tag}/", metrics_path)
 
     print(f"Fetching metrics from {url}")
-    response = requests.get(url)
-    response.raise_for_status()
-    return response.text
+    with urlopen(url, timeout=10) as response:
+        return response.read().decode('utf-8')
 
 
 def extract_metric_defs(go_code: str) -> dict:

--- a/tomcat/tests/compose/client/client.py
+++ b/tomcat/tests/compose/client/client.py
@@ -5,8 +5,17 @@ import logging
 import threading
 import time
 from random import randrange
+from urllib.error import HTTPError
+from urllib.request import urlopen
 
-import requests
+
+def get_url(url: str) -> None:
+    try:
+        with urlopen(url) as response:
+            response.read()
+    except HTTPError as e:
+        with e:
+            e.read()
 
 
 def do_stuff(id, func, *args):
@@ -20,11 +29,11 @@ def do_stuff(id, func, *args):
 
 
 def call_hello_world():
-    requests.get("http://tomcat:8080/sample/hello.jsp")
+    get_url("http://tomcat:8080/sample/hello.jsp")
 
 
 def call_404():
-    requests.get("http://tomcat:8080/404")
+    get_url("http://tomcat:8080/404")
 
 
 if __name__ == "__main__":

--- a/torchserve/tests/tools/generate_traffic.py
+++ b/torchserve/tests/tools/generate_traffic.py
@@ -5,8 +5,22 @@ import logging
 import threading
 import time
 from random import randrange
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
-import requests
+
+def with_query_params(url: str, params: dict[str, object]) -> str:
+    return '{}?{}'.format(url, urlencode(params))
+
+
+def send_request(http_request: Request) -> None:
+    try:
+        with urlopen(http_request) as response:
+            response.read()
+    except HTTPError as e:
+        with e:
+            e.read()
 
 
 def do_stuff(id, func, *args):
@@ -17,41 +31,54 @@ def do_stuff(id, func, *args):
 
 
 def run_prediction(model):
-    requests.post(
-        f"http://localhost:8080/predictions/{model}",
-        data='{"input": 2.0}',
-        headers={'Content-Type': 'application/json'},
+    send_request(
+        Request(
+            f"http://localhost:8080/predictions/{model}",
+            data=b'{"input": 2.0}',
+            headers={'Content-Type': 'application/json'},
+            method='POST',
+        )
     )
 
 
 # Will generate 5xx errors
 def run_bad_prediction():
-    requests.post(
-        f"http://localhost:8080/predictions/{model}",
-        data='{input": 2.0}',
-        headers={'Content-Type': 'application/json'},
+    send_request(
+        Request(
+            f"http://localhost:8080/predictions/{model}",
+            data=b'{input": 2.0}',
+            headers={'Content-Type': 'application/json'},
+            method='POST',
+        )
     )
     time.sleep(randrange(50))
 
 
 def add_remove_model():
-    requests.post("http://localhost:8081/models", params={"url": "linear_regression_3_3.mar"})
+    send_request(
+        Request(
+            with_query_params("http://localhost:8081/models", {"url": "linear_regression_3_3.mar"}),
+            method='POST',
+        )
+    )
     time.sleep(150)
-    requests.delete("http://localhost:8081/models/linear_regression_3_3/1")
+    send_request(Request("http://localhost:8081/models/linear_regression_3_3/1", method='DELETE'))
     time.sleep(200)
 
 
 def change_default_version():
-    requests.put(f"http://localhost:8081/models/linear_regression_1_2/{randrange(1, 4)}/set-default")
+    send_request(
+        Request(f"http://localhost:8081/models/linear_regression_1_2/{randrange(1, 4)}/set-default", method='PUT')
+    )
     time.sleep(randrange(200))
 
 
 def call_openmetrics_endpoint():
-    requests.get("http://localhost:8082/metrics")
+    send_request(Request("http://localhost:8082/metrics", method='GET'))
 
 
 def run_bad_healthcheck():
-    requests.get("http://localhost:8080/pin")
+    send_request(Request("http://localhost:8080/pin", method='GET'))
 
 
 if __name__ == "__main__":

--- a/torchserve/tests/torchserve_api.py
+++ b/torchserve/tests/torchserve_api.py
@@ -1,7 +1,8 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import requests
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
 from .common import INFERENCE_API_URL, MANAGEMENT_API_URL
 
@@ -9,53 +10,69 @@ from .common import INFERENCE_API_URL, MANAGEMENT_API_URL
 # They are mainly used to set up the e2e environment
 
 
+def with_query_params(url: str, params: dict[str, object]) -> str:
+    return '{}?{}'.format(url, urlencode(params))
+
+
+def send_request(http_request: Request) -> int:
+    with urlopen(http_request) as response:
+        return response.status
+
+
 def run_prediction(model):
     try:
-        response = requests.post(
-            f"{INFERENCE_API_URL}/predictions/{model}",
-            data='{"input": 2.0}',
-            headers={'Content-Type': 'application/json'},
+        status = send_request(
+            Request(
+                f"{INFERENCE_API_URL}/predictions/{model}",
+                data=b'{"input": 2.0}',
+                headers={'Content-Type': 'application/json'},
+                method='POST',
+            )
         )
-        response.raise_for_status()
     except Exception:
         return False
     else:
-        return response.status_code == 200
+        return status == 200
 
 
 def set_model_default_version(model, version):
     try:
-        response = requests.put(
-            f"{MANAGEMENT_API_URL}/models/{model}/{version}/set-default",
+        status = send_request(
+            Request(
+                f"{MANAGEMENT_API_URL}/models/{model}/{version}/set-default",
+                method='PUT',
+            )
         )
-        response.raise_for_status()
     except Exception:
         return False
     else:
-        return response.status_code == 200
+        return status == 200
 
 
 def update_workers(model, min, max):
     try:
-        response = requests.put(
-            f"{MANAGEMENT_API_URL}/models/{model}",
-            params={
-                "min_worker": min,
-                "max_worker": max,
-            },
+        status = send_request(
+            Request(
+                with_query_params(
+                    f"{MANAGEMENT_API_URL}/models/{model}",
+                    {
+                        "min_worker": min,
+                        "max_worker": max,
+                    },
+                ),
+                method='PUT',
+            )
         )
-        response.raise_for_status()
     except Exception:
         return False
     else:
-        return response.status_code == 202
+        return status == 202
 
 
 def register_model(model):
     try:
-        response = requests.post(f"{MANAGEMENT_API_URL}/models", params={"url": model})
-        response.raise_for_status()
+        status = send_request(Request(with_query_params(f"{MANAGEMENT_API_URL}/models", {"url": model}), method='POST'))
     except Exception:
         return False
     else:
-        return response.status_code == 200
+        return status == 200

--- a/twemproxy/tests/conftest.py
+++ b/twemproxy/tests/conftest.py
@@ -1,8 +1,11 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs
@@ -11,11 +14,31 @@ from datadog_checks.twemproxy import Twemproxy
 from . import common
 
 
+def send_request(http_request: Request) -> None:
+    try:
+        with urlopen(http_request) as response:
+            response.read()
+    except HTTPError as e:
+        with e:
+            e.read()
+
+
+def put_etcd_value(key: str, value: str) -> None:
+    send_request(
+        Request(
+            'http://{}:2379/v2/keys/{}'.format(common.HOST, key),
+            data=urlencode({'value': value}).encode('utf-8'),
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            method='PUT',
+        )
+    )
+
+
 def setup_post_data():
-    requests.put('http://{}:2379/v2/keys/services/redis/01'.format(common.HOST), data={'value': 'redis1:6101'})
-    requests.put('http://{}:2379/v2/keys/services/redis/02'.format(common.HOST), data={'value': 'redis2:6102'})
-    requests.put('http://{}:2379/v2/keys/services/twemproxy/port'.format(common.HOST), data={'value': '6100'})
-    requests.put('http://{}:2379/v2/keys/services/twemproxy/host'.format(common.HOST), data={'value': 'localhost'})
+    put_etcd_value('services/redis/01', 'redis1:6101')
+    put_etcd_value('services/redis/02', 'redis2:6102')
+    put_etcd_value('services/twemproxy/port', '6100')
+    put_etcd_value('services/twemproxy/host', 'localhost')
 
 
 @pytest.fixture(scope="session")
@@ -49,6 +72,6 @@ def setup_request():
     """
     url = "http://{}:{}".format(common.HOST, common.PORT)
     try:
-        requests.get(url)
+        send_request(Request(url, method='GET'))
     except Exception:
         pass

--- a/vault/tests/conftest.py
+++ b/vault/tests/conftest.py
@@ -2,11 +2,13 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import getpass
+import json
 import os
 import time
+from urllib.error import HTTPError
+from urllib.request import urlopen
 
 import pytest
-import requests
 
 from datadog_checks.dev import LazyFunction, TempDir, docker_run, run_command
 from datadog_checks.dev.ci import running_on_ci
@@ -162,8 +164,18 @@ class WaitAndUnsealVault(WaitFor):
             run_command('docker exec vault-leader vault {}'.format(command), capture=True, check=True)
 
 
+def read_json(url: str, timeout: int) -> object:
+    try:
+        response = urlopen(url, timeout=timeout)
+    except HTTPError as e:
+        response = e
+
+    with response:
+        return json.loads(response.read().decode('utf-8'))
+
+
 def api_working(api_endpoint):
-    response = requests.get(api_endpoint, timeout=1).json()
+    response = read_json(api_endpoint, timeout=1)
     if response:
         return True
     return False

--- a/weaviate/tests/conftest.py
+++ b/weaviate/tests/conftest.py
@@ -5,9 +5,10 @@ import json
 import os
 import time
 from contextlib import ExitStack
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 import pytest
-import requests
 
 from datadog_checks.dev import get_here
 from datadog_checks.dev.kind import kind_run
@@ -19,6 +20,26 @@ from .common import BATCH_OBJECTS, USE_AUTH
 
 HERE = get_here()
 opj = os.path.join
+
+
+def post_json(url: str, headers: dict[str, str], payload: object) -> None:
+    try:
+        with urlopen(
+            Request(url, data=json.dumps(payload).encode('utf-8'), headers=headers, method='POST')
+        ) as response:
+            response.read()
+    except HTTPError as e:
+        with e:
+            e.read()
+
+
+def endpoint_ok(url: str, timeout: int) -> bool:
+    try:
+        with urlopen(url, timeout=timeout) as response:
+            return response.status < 400
+    except HTTPError as e:
+        e.close()
+        return False
 
 
 def setup_weaviate():
@@ -65,20 +86,19 @@ def make_weaviate_request(instance):
         headers.update(instance['headers'])
 
     if ready_check(weaviate_api_endpoint, 300):
-        requests.post(weaviate_batch_endpoint, headers=headers, data=json.dumps(BATCH_OBJECTS))
+        post_json(weaviate_batch_endpoint, headers, BATCH_OBJECTS)
 
 
 def ready_check(endpoint, timeout=300):
     # Sometimes the API endpoint isn't ready when the cluster is ready. This will try to ensure the
-    # API is ready for requests before we seed some dummy data.
+    # API is ready for HTTP calls before we seed some dummy data.
     stop_time = time.time() + timeout
     endpoint = f'{endpoint}{DEFAULT_LIVENESS_ENDPOINT}'
     while time.time() < stop_time:
         try:
-            response = requests.get(endpoint, timeout=5)
-            if response.ok:
+            if endpoint_ok(endpoint, timeout=5):
                 return True
-        except requests.RequestException as e:
+        except (URLError, TimeoutError) as e:
             print(f'Request failed: {e}')
 
         time.sleep(1)


### PR DESCRIPTION
### What does this PR do?
Replaces direct `requests` usage in the remaining selected test fixtures, test helpers, and maintenance scripts with backend-agnostic HTTP handling.

The changes use stdlib `urllib`/`http.client` for live test-environment calls and `MockHTTPResponse` where tests mock Agent HTTP responses.

### Motivation
This is stacked on the updated HTTP migration feature branch from #22676 after #24636 landed there, so the remaining test-side callers no longer depend on the `requests` library surface.

Validation run locally:

- `ddev test --lint`
- `python -m compileall` on the changed files
- strict grep for `requests` library imports/calls and `MockResponse`
- `git diff --check origin/mwdd146980/httpx-migration-base..HEAD`

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
