### PR TITLE
Decouple apache tests from the requests library

### DIFF
--- a/apache/tests/conftest.py
+++ b/apache/tests/conftest.py
@@ -5,14 +5,17 @@
 import os
 
 import pytest
-import requests
 
 from datadog_checks.apache import Apache
+from datadog_checks.base.utils.http import create_http_client
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
 from datadog_checks.dev.http import MockHTTPResponse
 
 from .common import AUTO_STATUS_URL, BASE_URL, CHECK_NAME, HERE, STATUS_CONFIG, STATUS_URL
+
+# Library-agnostic HTTP client shared by the e2e helpers and fixtures below.
+http_client = create_http_client({}, {})
 
 
 @pytest.fixture(scope="session")
@@ -33,7 +36,7 @@ def dd_environment():
 
 def generate_metrics():
     for _ in range(0, 100):
-        requests.get(BASE_URL)
+        http_client.get(BASE_URL)
 
 
 def check_status_page_ready():
@@ -41,7 +44,7 @@ def check_status_page_ready():
     Some status info we need for metrics do not appear immediately.
     This check help waiting for the full status page.
     """
-    resp = requests.get(AUTO_STATUS_URL)
+    resp = http_client.get(AUTO_STATUS_URL)
     data = resp.content.decode('utf-8')
     assert 'ReqPerSec: ' in data
     assert 'CPULoad: ' in data
@@ -50,7 +53,7 @@ def check_status_page_ready():
 @pytest.fixture
 def mock_hide_server_version(mock_http):
     def filter_server_version(url, *args, **kwargs):
-        r = requests.get(url, **kwargs)
+        r = http_client.get(url, **kwargs)
         content = '\n'.join(line for line in r.text.splitlines() if 'ServerVersion' not in line)
         return MockHTTPResponse(
             content=content,

--- a/nutanix/tests/scripts/record_fixtures.py
+++ b/nutanix/tests/scripts/record_fixtures.py
@@ -2,6 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+# NOTE: Exclude this file from the requests -> agnostic HTTP client migration.
+# It is a standalone developer helper run by hand to record fixtures. It is not
+# shipped with the Agent and is not exercised in CI, so it may keep using the
+# requests library directly.
+
 """Script to record fixtures from a live Nutanix Prism Central instance.
 
 This script connects to the AWS_INSTANCE defined in conftest.py and records


### PR DESCRIPTION
### What does this PR do?

Removes the remaining direct `requests` usage from the apache test code, routing it through the library-agnostic HTTP client (`create_http_client`) instead. Observable behavior is unchanged.

The e2e traffic-generation and readiness helpers, and the `mock_hide_server_version` fixture, now use the agnostic client.

### Motivation

Part of the ongoing migration off the `requests` library: the apache tests still imported and used `requests` directly, which stands in the way of swapping the underlying HTTP backend. This PR is scoped to apache only; the remaining `requests` imports in other integrations are addressed in separate PRs.

### Verification

- Lint and format pass via `ddev` for the integration.
- The full apache test suite passes, including the e2e path and the `mock_hide_server_version` fixture that exercises the agnostic client.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
