### PR TITLE
Agnosticize the azure_iot_edge bad-url HTTP exception test

### DIFF
--- a/azure_iot_edge/tests/test_check.py
+++ b/azure_iot_edge/tests/test_check.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import copy
-from typing import Callable  # noqa: F401
+from typing import Any, Callable  # noqa: F401
 
 import pytest
 
@@ -10,7 +10,7 @@ from datadog_checks.azure_iot_edge import AzureIoTEdgeCheck
 from datadog_checks.azure_iot_edge.types import Instance  # noqa: F401
 from datadog_checks.base.stubs.aggregator import AggregatorStub  # noqa: F401
 from datadog_checks.base.stubs.datadog_agent import DatadogAgentStub  # noqa: F401
-from datadog_checks.base.utils.http_exceptions import HTTPConnectionError
+from datadog_checks.base.utils.http_exceptions import HTTPConnectionError, HTTPSSLError
 from datadog_checks.dev.utils import get_metadata_metrics
 
 from . import common
@@ -108,3 +108,19 @@ def test_prometheus_endpoint_down(aggregator, mock_instance, option, url, servic
         check.check(instance)
 
     aggregator.assert_service_check(service_check, AzureIoTEdgeCheck.CRITICAL)
+
+
+def test_prometheus_endpoint_ssl_error(aggregator, mock_instance, mock_openmetrics_http):
+    # type: (AggregatorStub, Instance, Any) -> None
+    """
+    When scraping a Prometheus endpoint fails with an SSL error, it surfaces as
+    HTTPSSLError and no health service check is emitted.
+    """
+    mock_openmetrics_http.get.side_effect = HTTPSSLError('SSL validation failed')
+    check = AzureIoTEdgeCheck('azure_iot_edge', {}, [mock_instance])
+
+    # check() scrapes edge_hub first and raises there, never reaching edge_agent.
+    with pytest.raises(HTTPSSLError):
+        check.check(mock_instance)
+
+    aggregator.assert_service_check('azure.iot_edge.edge_hub.prometheus.health', count=0)

--- a/azure_iot_edge/tests/test_e2e.py
+++ b/azure_iot_edge/tests/test_e2e.py
@@ -5,7 +5,6 @@ import copy
 from typing import Callable  # noqa: F401
 
 import pytest
-import requests
 
 from datadog_checks.azure_iot_edge import AzureIoTEdgeCheck
 from datadog_checks.base.stubs.aggregator import AggregatorStub  # noqa: F401
@@ -29,20 +28,17 @@ def test_e2e(dd_agent_check):
 
 
 @pytest.mark.e2e
-def test_bad_url_e2e(e2e_instance, dd_agent_check):
+def test_bad_url_e2e(aggregator, e2e_instance, dd_agent_check):
     """
-    When giving a wrong url to `edge_hub_prometheus_url`, the redirection might cause SSL exception
-    Example: http://localhost:9601/metri -> https://localhost/metri
+    When an endpoint is unreachable, the run fails, that endpoint reports CRITICAL,
+    and the reachable endpoint reports OK.
     """
-    bad_url_hub_instance = copy.deepcopy(e2e_instance)
-    bad_url_hub_instance['edge_hub_prometheus_url'] = bad_url_hub_instance['edge_hub_prometheus_url'][:-2]
+    bad_instance = copy.deepcopy(e2e_instance)
+    # Nothing listens on this port, so scraping edge_agent fails with a connection error.
+    bad_instance['edge_agent_prometheus_url'] = 'http://localhost:9699/metrics'
 
-    bad_url_agent_instance = copy.deepcopy(e2e_instance)
-    bad_url_agent_instance['edge_agent_prometheus_url'] = bad_url_hub_instance['edge_agent_prometheus_url'][:-2]
+    with pytest.raises(Exception):
+        dd_agent_check(bad_instance, rate=True)
 
-    with pytest.raises(requests.exceptions.SSLError):
-        dd_agent_check(bad_url_hub_instance, rate=True)
-
-    aggregator = dd_agent_check(bad_url_agent_instance, rate=True)
-    aggregator.assert_service_check('azure.iot_edge.edge_agent.prometheus.health', AzureIoTEdgeCheck.CRITICAL)
     aggregator.assert_service_check('azure.iot_edge.edge_hub.prometheus.health', AzureIoTEdgeCheck.OK)
+    aggregator.assert_service_check('azure.iot_edge.edge_agent.prometheus.health', AzureIoTEdgeCheck.CRITICAL)


### PR DESCRIPTION
### What does this PR do?

Makes the azure_iot_edge bad-url tests library-agnostic, removing the last `requests` reference from the integration's test files:

- Rewrites the e2e `test_bad_url_e2e` to assert observable behavior (health service-check status) instead of a `requests.exceptions.SSLError`.
- Adds an in-process `test_prometheus_endpoint_ssl_error` in `test_check.py` that asserts the library-agnostic `HTTPSSLError` at the OpenMetrics HTTP client seam.

### Motivation

Part of the httpx migration floor work: removing `requests`-specific coupling from integration tests.

The old e2e test was broken in two ways:

- Its assertion could never match. In e2e mode, `dd_agent_check` runs the check in a subprocess, and a check error surfaces either as a generic `Exception` (from `replay_check_run` re-raising the collector's `LastError`) or as a `ValueError` (when no collector output is parsed at all), never as the original exception type. So `pytest.raises(requests.exceptions.SSLError)` cannot match. This has been the fixture's behavior since before the test was added, so the assertion never worked.
- It induced the failure by truncating the URL, which the test's own docstring hedged "might cause SSL." That trigger is indeterminate: a 404, an SSL redirect, or a connection error each drive a different `poll` branch, so its `CRITICAL` assertion could not be reliably true.

Rather than delete the e2e coverage, the rewrite induces a deterministic connection failure (a dead port) and asserts the observable outcome: the unreachable endpoint reports CRITICAL, the reachable one OK, and the run fails. The concrete exception type stays unassertable at the e2e layer, so the SSL contract is covered precisely in-process instead. The new unit test injects `HTTPSSLError` at the HTTP client seam via the `mock_openmetrics_http` fixture and asserts the check re-raises it while emitting no health service check, matching the legacy `poll` contract, where SSL errors re-raise without a service check (unlike connection errors, which report CRITICAL first).

### Verification

```
ddev test azure_iot_edge -- -k "not e2e"   # 10 passed
ddev test -s azure_iot_edge                # format + lint clean
```

The in-process unit test runs fully with no Azure credential dependency. The rewritten e2e test is gated behind the `IOT_EDGE_CONNSTR` Azure secret and could not be run locally; its assertions are reasoned from the `poll` source, not confirmed against a live run.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
