### PR TITLE
Route real-HTTP test fixtures through the agnostic dev seam

### DIFF
--- a/activemq/tests/conftest.py
+++ b/activemq/tests/conftest.py
@@ -6,10 +6,10 @@ import os
 import time
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import WaitForPortListening
+from datadog_checks.dev.http import dev_http_client, http_post
 from datadog_checks.dev.utils import load_jmx_config
 
 from .common import (
@@ -34,9 +34,7 @@ def populate_server():
     time.sleep(3)
 
     if IS_ARTEMIS:
-        s = requests.Session()
-        s.auth = TEST_AUTH
-        s.headers = {'accept': 'application/json', 'origin': BASE_URL}
+        s = dev_http_client(persist=True, auth=TEST_AUTH, headers={'accept': 'application/json', 'origin': BASE_URL})
         data = s.get(ARTEMIS_URL + '/list')
         channels = data.json()['value']['org.apache.activemq.artemis']
         broker = [k for k in channels.keys() if k.startswith('broker') and ',' not in k][0]
@@ -59,11 +57,11 @@ def populate_server():
     else:
         for queue in TEST_QUEUES:
             url = '{}/{}?type=queue'.format(ACTIVEMQ_URL, queue)
-            requests.post(url, data=TEST_MESSAGE, auth=TEST_AUTH)
+            http_post(url, data=TEST_MESSAGE, auth=TEST_AUTH)
 
         for topic in TEST_TOPICS:
             url = '{}/{}?type=topic'.format(ACTIVEMQ_URL, topic)
-            requests.post(url, data=TEST_MESSAGE, auth=TEST_AUTH)
+            http_post(url, data=TEST_MESSAGE, auth=TEST_AUTH)
 
 
 @pytest.fixture(scope="session")

--- a/airflow/tests/test_check_metrics_up_to_date.py
+++ b/airflow/tests/test_check_metrics_up_to_date.py
@@ -5,7 +5,8 @@ import os
 import re
 
 import pytest
-import requests
+
+from datadog_checks.dev.http import http_get
 
 # Make sure this expected metrics list is up to date with:
 # - `dogstatsd_mapper_profiles` configuration from README.md
@@ -132,7 +133,7 @@ def test_check_metrics_up_to_date():  # pragma: no cover
         'docs/apache-airflow/administration-and-deployment/logging-monitoring/metrics.rst'
     )
 
-    resp = requests.get(url)
+    resp = http_get(url)
     content = resp.content.decode('utf-8')
     matches = METRIC_PATTERN.findall(content)
 

--- a/apache/tests/conftest.py
+++ b/apache/tests/conftest.py
@@ -5,12 +5,11 @@
 import os
 
 import pytest
-import requests
 
 from datadog_checks.apache import Apache
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
-from datadog_checks.dev.http import MockHTTPResponse
+from datadog_checks.dev.http import MockHTTPResponse, dev_http_client, http_get
 
 from .common import AUTO_STATUS_URL, BASE_URL, CHECK_NAME, HERE, STATUS_CONFIG, STATUS_URL
 
@@ -32,8 +31,9 @@ def dd_environment():
 
 
 def generate_metrics():
+    client = dev_http_client(persist=True)
     for _ in range(0, 100):
-        requests.get(BASE_URL)
+        client.get(BASE_URL)
 
 
 def check_status_page_ready():
@@ -41,7 +41,7 @@ def check_status_page_ready():
     Some status info we need for metrics do not appear immediately.
     This check help waiting for the full status page.
     """
-    resp = requests.get(AUTO_STATUS_URL)
+    resp = http_get(AUTO_STATUS_URL)
     data = resp.content.decode('utf-8')
     assert 'ReqPerSec: ' in data
     assert 'CPULoad: ' in data
@@ -50,7 +50,7 @@ def check_status_page_ready():
 @pytest.fixture
 def mock_hide_server_version(mock_http):
     def filter_server_version(url, *args, **kwargs):
-        r = requests.get(url, **kwargs)
+        r = http_get(url, **kwargs)
         content = '\n'.join(line for line in r.text.splitlines() if 'ServerVersion' not in line)
         return MockHTTPResponse(
             content=content,

--- a/argocd/datadog_checks/argocd/resources.py
+++ b/argocd/datadog_checks/argocd/resources.py
@@ -400,9 +400,7 @@ class ArgocdResourceCollector:
 
     def _fetch(self, api_path: str) -> list[dict]:
         url = self._endpoint.rstrip("/") + api_path
-        # Pass a dedicated genresources token only when set, via extra_headers (merges with configured
-        # headers). Omit it otherwise: even empty extra_headers forces a per-request header override before
-        # inherited auth headers are applied, which would drop that auth.
+        # Add genresources auth via extra_headers only when set; an empty override would drop inherited auth.
         kwargs: dict = {}
         headers = auth_headers(self._auth_token)
         if headers:

--- a/argocd/datadog_checks/argocd/stream_listener.py
+++ b/argocd/datadog_checks/argocd/stream_listener.py
@@ -127,9 +127,7 @@ class ArgocdApplicationStreamListener:
             "stream": True,
             "timeout": (CONNECT_TIMEOUT_SECONDS, self._read_timeout),
         }
-        # Pass a dedicated genresources token only when set, via extra_headers (merges with configured
-        # headers). Omit it otherwise: even empty extra_headers forces a per-request header override before
-        # inherited auth headers are applied, which would drop that auth.
+        # Add genresources auth via extra_headers only when set; an empty override would drop inherited auth.
         headers = auth_headers(self._auth_token)
         if headers:
             kwargs["extra_headers"] = headers

--- a/argocd/tests/test_resources.py
+++ b/argocd/tests/test_resources.py
@@ -645,7 +645,7 @@ def test_fetch_adds_bearer_via_extra_headers_so_configured_auth_is_preserved(moc
 
     kwargs = mock_http.get.call_args.kwargs
     assert kwargs.get("extra_headers") == {"Authorization": "Bearer tok"}  # merged into configured headers
-    assert "headers" not in kwargs  # never pass `headers`; it would shadow the HTTP client's configured auth
+    assert "headers" not in kwargs  # never pass headers; it would shadow the HTTP client's configured auth
 
 
 def test_fetch_inherits_http_client_auth_when_no_genresources_token(mock_http):

--- a/azure_iot_edge/tests/e2e_utils.py
+++ b/azure_iot_edge/tests/e2e_utils.py
@@ -3,9 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from typing import Any  # noqa: F401
 
-import requests
-
 from datadog_checks.dev.docker import ComposeFileDown, ComposeFileUp
+from datadog_checks.dev.http import HTTPStatusError, http_get
 from datadog_checks.dev.structures import LazyFunction
 from datadog_checks.dev.subprocess import run_command
 
@@ -43,9 +42,9 @@ class IoTEdgeDown(LazyFunction):
 def edge_hub_endpoint_ready():
     # type: () -> bool
     try:
-        response = requests.get(common.E2E_EDGE_HUB_PROMETHEUS_URL)
+        response = http_get(common.E2E_EDGE_HUB_PROMETHEUS_URL)
         response.raise_for_status()
-    except requests.HTTPError:
+    except HTTPStatusError:
         return False
     else:
         return response.status_code == 200
@@ -54,9 +53,9 @@ def edge_hub_endpoint_ready():
 def edge_agent_endpoint_ready():
     # type: () -> bool
     try:
-        response = requests.get(common.E2E_EDGE_AGENT_PROMETHEUS_URL)
+        response = http_get(common.E2E_EDGE_AGENT_PROMETHEUS_URL)
         response.raise_for_status()
-    except requests.HTTPError:
+    except HTTPStatusError:
         return False
     else:
         return response.status_code == 200

--- a/azure_iot_edge/tests/test_e2e.py
+++ b/azure_iot_edge/tests/test_e2e.py
@@ -5,10 +5,10 @@ import copy
 from typing import Callable  # noqa: F401
 
 import pytest
-import requests
 
 from datadog_checks.azure_iot_edge import AzureIoTEdgeCheck
 from datadog_checks.base.stubs.aggregator import AggregatorStub  # noqa: F401
+from datadog_checks.dev.http import HTTPSSLError
 
 from . import common
 
@@ -40,7 +40,7 @@ def test_bad_url_e2e(e2e_instance, dd_agent_check):
     bad_url_agent_instance = copy.deepcopy(e2e_instance)
     bad_url_agent_instance['edge_agent_prometheus_url'] = bad_url_hub_instance['edge_agent_prometheus_url'][:-2]
 
-    with pytest.raises(requests.exceptions.SSLError):
+    with pytest.raises(HTTPSSLError):
         dd_agent_check(bad_url_hub_instance, rate=True)
 
     aggregator = dd_agent_check(bad_url_agent_instance, rate=True)

--- a/cisco_aci/tests/cisco_aci_query.py
+++ b/cisco_aci/tests/cisco_aci_query.py
@@ -4,7 +4,7 @@
 
 import json
 
-import requests
+from datadog_checks.dev.http import http_get, http_post
 
 # This is a python script that you can use to query a specific
 # tenant metric endpoint and includes the login and logout requests.
@@ -25,7 +25,7 @@ def apic_login(apic, username, password):
     json_credentials = json.dumps(credentials)
     base_url = 'https://' + apic + '/api/aaaLogin.json'
 
-    login_response = requests.post(base_url, data=json_credentials, verify=False)
+    login_response = http_post(base_url, data=json_credentials, verify=False)
 
     login_response_json = json.loads(login_response.text)
     token = login_response_json['imdata'][0]['aaaLogin']['attributes']['token']
@@ -37,7 +37,7 @@ def apic_query(apic, path, cookie):
     """APIC 'GET' query and return response"""
     base_url = 'https://' + apic + path
 
-    get_response = requests.get(base_url, cookies=cookie, verify=False)
+    get_response = http_get(base_url, cookies=cookie, verify=False)
 
     return get_response
 
@@ -46,7 +46,7 @@ def apic_logout(apic, cookie):
     """APIC logout and return response"""
     base_url = 'https://' + apic + '/api/aaaLogout.json'
 
-    post_response = requests.post(base_url, cookies=cookie, verify=False)
+    post_response = http_post(base_url, cookies=cookie, verify=False)
 
     return post_response
 

--- a/clickhouse/tests/utils.py
+++ b/clickhouse/tests/utils.py
@@ -3,13 +3,13 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
 
-import requests
+from datadog_checks.dev.http import http_get
 
 METRIC_PATTERN = re.compile(r'\s+M\((?P<metric>\w+),\s*"(?P<description>[^"]+)"\)\s*\\?')
 
 
 def parse_described_metrics(url):
-    text = requests.get(url, timeout=10).text
+    text = http_get(url, timeout=10).text
     metrics = dict(match.groups() for match in METRIC_PATTERN.finditer(text))
 
     return {metric: description for metric, description in metrics.items() if description}

--- a/confluent_platform/tests/conftest.py
+++ b/confluent_platform/tests/conftest.py
@@ -5,10 +5,10 @@ import json
 import os
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs, WaitFor
+from datadog_checks.dev.http import http_post
 
 from .common import CHECK_CONFIG, HERE
 
@@ -42,8 +42,8 @@ def create_connectors():
         },
     }
 
-    requests.post('http://localhost:8083/connectors', data=json.dumps(data_sink), headers=headers)
-    requests.post('http://localhost:8083/connectors', data=json.dumps(data), headers=headers)
+    http_post('http://localhost:8083/connectors', data=json.dumps(data_sink), headers=headers)
+    http_post('http://localhost:8083/connectors', data=json.dumps(data), headers=headers)
 
 
 @pytest.fixture(scope="session")

--- a/consul/tests/conftest.py
+++ b/consul/tests/conftest.py
@@ -4,9 +4,9 @@
 import os
 
 import pytest
-import requests
 
 from datadog_checks.dev import WaitFor, docker_run
+from datadog_checks.dev.http import http_get
 
 from . import common
 
@@ -20,7 +20,7 @@ def ping_cluster():
     """
     Wait for the slave to connect to the master
     """
-    response = requests.get('{}/v1/status/peers'.format(common.URL))
+    response = http_get('{}/v1/status/peers'.format(common.URL))
     response.raise_for_status()
 
     # Wait for all 3 agents to join the cluster

--- a/coredns/tests/conftest.py
+++ b/coredns/tests/conftest.py
@@ -5,9 +5,9 @@ import os
 import subprocess
 
 import pytest
-import requests
 
 from datadog_checks.dev import WaitFor, docker_run
+from datadog_checks.dev.http import http_get
 from datadog_checks.dev.utils import ON_WINDOWS
 
 from .common import ATHOST, CONFIG_FILE, HERE, URL
@@ -19,7 +19,7 @@ COREDNS_VERSION = [int(i) for i in os.environ['COREDNS_VERSION'].split(".")]
 
 
 def init_coredns():
-    res = requests.get(URL)
+    res = http_get(URL)
     if not ON_WINDOWS:
         # create some metrics by using dig
         subprocess.check_call(DIG_ARGS)

--- a/couch/tests/conftest.py
+++ b/couch/tests/conftest.py
@@ -6,11 +6,11 @@ import os
 from copy import deepcopy
 
 import pytest
-import requests
 
 from datadog_checks.couch import CouchDb
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs, CheckEndpoints, WaitFor
+from datadog_checks.dev.http import http_get, http_post, http_put
 
 from . import common
 
@@ -120,10 +120,10 @@ def enable_cluster():
 
     resp_data = None
     for data in requests_data:
-        resp = requests.post("{}/_cluster_setup".format(common.URL), json=data, auth=auth, headers=headers)
+        resp = http_post("{}/_cluster_setup".format(common.URL), json=data, auth=auth, headers=headers)
         resp_data = resp.json()
 
-    resp = requests.get("{}/_membership".format(common.URL), auth=auth, headers=headers)
+    resp = http_get("{}/_membership".format(common.URL), auth=auth, headers=headers)
     membership = resp.json()
 
     expected_nb_nodes = 3
@@ -145,9 +145,9 @@ def generate_data(couch_version):
     headers = {'Accept': 'text/json'}
 
     # Generate a test database
-    requests.put("{}/kennel".format(common.URL), auth=auth, headers=headers)
+    http_put("{}/kennel".format(common.URL), auth=auth, headers=headers)
     for i in range(5):
-        requests.put("{}/db{}".format(common.URL, i), auth=auth, headers=headers)
+        http_put("{}/db{}".format(common.URL, i), auth=auth, headers=headers)
 
     # Populate the database
     data = {
@@ -157,7 +157,7 @@ def generate_data(couch_version):
             "by_data": {"map": "function(doc) { emit(doc.data, doc); }"},
         },
     }
-    requests.put("{}/kennel/_design/dummy".format(common.URL), json=data, auth=auth, headers=headers)
+    http_put("{}/kennel/_design/dummy".format(common.URL), json=data, auth=auth, headers=headers)
 
 
 def check_node_stats():
@@ -166,7 +166,7 @@ def check_node_stats():
     # Check all nodes have stats
     for node in common.ALL_NODES:
         url = "{}/_node/{}/_stats".format(common.URL, node['name'])
-        res = requests.get(url, auth=auth, headers=headers)
+        res = http_get(url, auth=auth, headers=headers)
         data = res.json()
         assert "global_changes" in data, "Invalid stats. Get stats url: {}".format(url)
 
@@ -188,7 +188,7 @@ def send_replication():
         body = replication_body.copy()
         body['_id'] = 'my_replication_id_{}'.format(i)
         body['target'] = body['target'] + str(i)
-        r = requests.post(
+        r = http_post(
             replicator_url,
             auth=(common.NODE1['user'], common.NODE1['password']),
             headers={'Content-Type': 'application/json'},
@@ -203,7 +203,7 @@ def get_replication():
     """
     task_url = "{}/_active_tasks".format(common.NODE1['server'])
 
-    r = requests.get(task_url, auth=(common.NODE1['user'], common.NODE1['password']))
+    r = http_get(task_url, auth=(common.NODE1['user'], common.NODE1['password']))
     r.raise_for_status()
     active_tasks = r.json()
     count = len(active_tasks)

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -11,9 +11,9 @@ from collections import defaultdict
 from copy import deepcopy
 
 import pytest
-import requests
 
 from datadog_checks.couch import CouchDb
+from datadog_checks.dev.http import HTTPTimeoutError, http_get, http_post, http_put
 from datadog_checks.dev.utils import get_metadata_metrics
 
 from . import common
@@ -360,35 +360,35 @@ def test_view_compaction_metrics(aggregator, gauges):
         def generate_views(self):
             url = '{}/kennel/_design/dummy/_view/all'.format(self._server)
             try:
-                r = requests.get(url, auth=self._auth, timeout=1)
+                r = http_get(url, auth=self._auth, timeout=1)
                 r.raise_for_status()
-            except requests.exceptions.Timeout:
+            except HTTPTimeoutError:
                 pass
             url = '{}/kennel/_design/dummy/_view/by_data'.format(self._server)
             try:
-                r = requests.get(url, auth=self._auth, timeout=1)
+                r = http_get(url, auth=self._auth, timeout=1)
                 r.raise_for_status()
-            except requests.exceptions.Timeout:
+            except HTTPTimeoutError:
                 pass
 
         def update_doc(self, doc):
             body = {'data': str(random.randint(0, 1000000000)), '_rev': doc['rev']}
 
             url = '{}/kennel/{}'.format(self._server, doc['id'])
-            r = requests.put(url, auth=self._auth, headers={'Content-Type': 'application/json'}, json=body)
+            r = http_put(url, auth=self._auth, headers={'Content-Type': 'application/json'}, json=body)
             r.raise_for_status()
             return r.json()
 
         def post_doc(self, doc_id):
             body = {"_id": doc_id, "data": str(time.time())}
             url = '{}/kennel'.format(self._server)
-            r = requests.post(url, auth=self._auth, headers={'Content-Type': 'application/json'}, json=body)
+            r = http_post(url, auth=self._auth, headers={'Content-Type': 'application/json'}, json=body)
             r.raise_for_status()
             return r.json()
 
         def compact_views(self):
             url = '{}/kennel/_compact/dummy'.format(self._server)
-            r = requests.post(url, auth=self._auth, headers={'Content-Type': 'application/json'})
+            r = http_post(url, auth=self._auth, headers={'Content-Type': 'application/json'})
             r.raise_for_status()
 
         def stop(self):

--- a/couchbase/tests/conftest.py
+++ b/couchbase/tests/conftest.py
@@ -8,12 +8,11 @@ import time
 from copy import deepcopy
 
 import pytest
-import requests
 
 from datadog_checks.couchbase import Couchbase
 from datadog_checks.dev import WaitFor, docker_run
 from datadog_checks.dev.docker import get_container_ip
-from datadog_checks.dev.http import MockHTTPResponse  # noqa: F401
+from datadog_checks.dev.http import MockHTTPResponse, http_get, http_post, http_put  # noqa: F401
 
 from .common import (
     BUCKET_NAME,
@@ -180,8 +179,8 @@ def couchbase_init():
     ]
     subprocess.check_call(init_args)
 
-    r = requests.get('{}/pools/default'.format(URL), auth=(USER, PASSWORD))
-    return r.status_code == requests.codes.ok
+    r = http_get('{}/pools/default'.format(URL), auth=(USER, PASSWORD))
+    return r.status_code == 200
 
 
 def load_sample_bucket():
@@ -192,7 +191,7 @@ def load_sample_bucket():
     # Resources used:
     # https://docs.couchbase.com/server/current/manage/manage-settings/install-sample-buckets.html
 
-    r = requests.post(
+    r = http_post(
         '{}/sampleBuckets/install'.format(URL),
         auth=(USER, PASSWORD),
         json=["gamesim-sample"],
@@ -225,7 +224,7 @@ def load_sample_bucket():
 
     while True:
         # Loop until the task ID is gone, meaning the task is done.
-        r = requests.get(
+        r = http_get(
             '{}/pools/default/tasks'.format(URL),
             auth=(USER, PASSWORD),
         )
@@ -243,7 +242,7 @@ def load_sample_bucket():
 
 def gamesim_primary_index_ready():
     """Wait until every gamesim_primary keyspace reports initial_build_progress == 100."""
-    r = requests.get(
+    r = http_get(
         '{}/api/v1/stats'.format(INDEX_STATS_URL),
         auth=(USER, PASSWORD),
     )
@@ -283,7 +282,7 @@ def create_syncgw_database():
         payload["index"] = {"num_replicas": payload["num_index_replicas"]}
         del payload["num_index_replicas"]
 
-    r = requests.put(
+    r = http_put(
         '{}/sync_gateway/'.format(SG_URL),
         auth=(USER, PASSWORD),
         json=payload,
@@ -295,7 +294,7 @@ def node_stats():
     """
     Wait for couchbase to generate node stats
     """
-    r = requests.get('{}/pools/default'.format(URL), auth=(USER, PASSWORD))
+    r = http_get('{}/pools/default'.format(URL), auth=(USER, PASSWORD))
     r.raise_for_status()
     stats = r.json()
     return all(len(stats['interestingStats']) > 0 for stats in stats['nodes'])
@@ -305,7 +304,7 @@ def bucket_stats():
     """
     Wait for couchbase to generate bucket stats
     """
-    r = requests.get('{}/pools/default/buckets/{}/stats'.format(URL, BUCKET_NAME), auth=(USER, PASSWORD))
+    r = http_get('{}/pools/default/buckets/{}/stats'.format(URL, BUCKET_NAME), auth=(USER, PASSWORD))
     r.raise_for_status()
     stats = r.json()
     return stats['op']['lastTStamp'] != 0

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -817,14 +817,7 @@ class OpenMetricsScraperMixin(object):
             )
 
     def poll(self, scraper_config, headers=None):
-        """
-        Returns a valid response, otherwise raise HTTPStatusError if the status code of the
-        response isn't valid - see `response.raise_for_status()`
-
-        The caller needs to close the response.
-
-        Custom headers can be added to the default headers.
-        """
+        """Return a valid response, raising HTTPStatusError for bad status codes; caller closes it."""
         endpoint = scraper_config.get('prometheus_url')
 
         # Should we send a service check for when we make a request

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/base_scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/base_scraper.py
@@ -406,11 +406,8 @@ class OpenMetricsScraper:
                 for line in connection.iter_lines(decode_unicode=True):
                     yield line
         except (HTTPConnectionError, HTTPTimeoutError) as e:
-            # HTTPTimeoutError is included because requests' ConnectTimeout (previously caught by the raw
-            # ConnectionError) now translates to HTTPTimeoutError, a sibling of HTTPConnectionError. The
-            # agnostic hierarchy does not distinguish connect from read timeouts, so a mid-stream ReadTimeout
-            # is now swallowed here too under ignore_connection_errors. That is intentional: an unresponsive
-            # endpoint is exactly what the flag is meant to tolerate.
+            # ConnectTimeout now maps to HTTPTimeoutError; ignore_connection_errors should tolerate
+            # any unresponsive endpoint, including mid-stream timeouts.
             if self.ignore_connection_errors:
                 self.log.warning("OpenMetrics endpoint %s is not accessible", self.endpoint)
             else:

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -539,17 +539,9 @@ class PrometheusScraperMixin(object):
             self.log.debug("Unable to handle metric: %s - error: %s", message.name, err)
 
     def poll(self, endpoint, pFormat=PrometheusFormat.PROTOBUF, headers=None, instance=None):
-        """
-        Polls the metrics from the prometheus metrics endpoint provided.
-        Defaults to the protobuf format, but can use the formats specified by
-        the PrometheusFormat class.
-        Custom headers can be added to the default headers.
+        """Poll the Prometheus endpoint and return a valid response.
 
-        Returns a valid response, raise HTTPStatusError if the status code of the response
-        isn't valid - see response.raise_for_status()
-
-        The caller needs to close the response
-
+        Headers can extend defaults; caller must close the response.
         :param endpoint: string url endpoint
         :param pFormat: the preferred format defined in PrometheusFormat
         :param headers: extra headers

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -217,13 +217,9 @@ class _SSLContextAdapter(requests.adapters.HTTPAdapter):
 
 
 def _translate_requests_exception(exc: BaseException, *, response: ResponseWrapper | None = None) -> HTTPError:
-    """Translate a requests exception into the library-agnostic equivalent.
+    """Translate a requests exception into a backend-neutral HTTPError.
 
-    Order is significant. Several requests types subclass others, so the most
-    specific must be tested first.
-
-    ``response`` is supplied only by the ``raise_for_status`` seam, which passes the
-    agnostic wrapper. Every other seam leaves it ``None`` so no raw backend response leaks.
+    Order matters because requests exception classes overlap; response is only provided by raise_for_status.
     """
     message = str(exc) or exc.__class__.__name__
     request = getattr(exc, 'request', None)
@@ -291,8 +287,7 @@ class ResponseWrapper(ObjectProxy):
             )
 
     def __iter__(self):
-        # requests.Response.__iter__ delegates to the raw iter_content, so route direct iteration
-        # through the translating override instead of the wrapt-forwarded raw one.
+        # Route direct iteration through iter_content so mid-stream errors are translated.
         return self.iter_content(128)
 
     @property
@@ -316,8 +311,7 @@ class ResponseWrapper(ObjectProxy):
         raw = getattr(self.__wrapped__, 'raw', None)
         connection = getattr(raw, 'connection', None)
         sock = getattr(connection, 'sock', None)
-        # sock is None once the connection is released, and a bare (non-TLS) socket has no getpeercert,
-        # so a plain http:// request lands here. Either way there is no peer certificate to report.
+        # A released connection or plain HTTP socket has no peer certificate to report.
         getpeercert = getattr(sock, 'getpeercert', None)
         if getpeercert is None:
             return None
@@ -532,9 +526,7 @@ class RequestsWrapper(object):
         self.persist_connections = self.tls_use_host_header or is_affirmative(config['persist_connections'])
         self._session = session
 
-        # Whether to trust environment configuration (proxies, auth, CA bundles).
-        # Mirrors requests.Session.trust_env, which defaults to True. Adopt an injected session's
-        # value so the reported state matches it.
+        # Trust environment config, mirroring requests.Session.trust_env and injected sessions.
         self._trust_env = getattr(session, 'trust_env', True) if session is not None else True
 
         # Whether or not to log request information like method and url
@@ -569,19 +561,13 @@ class RequestsWrapper(object):
             self._session.trust_env = value
 
     def close(self) -> None:
-        """Close any open connections. Idempotent; the client stays usable and lazily rebuilds a default
-        session on the next request. An injected session is not restored after being closed."""
+        """Close open connections; next request rebuilds a default session, not an injected one."""
         if self._session is not None:
             self._session.close()
             self._session = None
 
     def get_cookie(self, name: str, default: str | None = None) -> str | None:
-        """Look up a cookie by name on the persistent session, returning its value, or default if absent or ambiguous.
-
-        Only cookies retained on the persistent session are visible. Requests made without persistence
-        (the default unless persist_connections is set or persist=True is passed) use a throwaway session
-        whose cookies are discarded, so a cookie set by such a request is not found here.
-        """
+        """Return a persisted cookie value, or default if absent, ambiguous, or discarded after a throwaway request."""
         try:
             return self.session.cookies.get(name, default)
         except requests_cookies.CookieConflictError:

--- a/datadog_checks_base/datadog_checks/base/utils/http_protocol.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http_protocol.py
@@ -7,10 +7,8 @@ from collections.abc import Iterator, Mapping
 from datetime import timedelta
 from typing import Any, Protocol
 
-# Provisional backend-neutral HTTP surface (stabilizes once the httpx backend lands). RequestsWrapper
-# implements it on requests today; a future HTTPX2Wrapper implements the same surface on httpx. Do not
-# change existing methods, attributes, or their semantics without coordinating both backends.
-# Capabilities expose behavior, never a backend object (no requests or httpx type is returned).
+# Provisional backend-neutral HTTP surface; requests and future httpx backends must preserve this API.
+# Capabilities expose behavior, never backend objects.
 
 
 class HTTPResponse(Protocol):
@@ -72,7 +70,7 @@ class HTTPClient(Protocol):
     def put(self, url: str, **options: Any) -> HTTPResponse: ...
     def patch(self, url: str, **options: Any) -> HTTPResponse: ...
     def delete(self, url: str, **options: Any) -> HTTPResponse: ...
-    # The HTTP OPTIONS verb. Suffixed because ``options`` above is the request-defaults dict.
+    # The HTTP OPTIONS verb, suffixed because options above is the request-defaults dict.
     def options_method(self, url: str, **options: Any) -> HTTPResponse: ...
     def get_header(self, name: str, default: str | None = None) -> str | None: ...
     def set_header(self, name: str, value: str) -> None: ...
@@ -80,13 +78,10 @@ class HTTPClient(Protocol):
     # Suppress all HTTP-level auth (config-derived and environment/.netrc) for later requests, leaving trust_env intact.
     def disable_auth(self) -> None: ...
 
-    # Close any open connections. Idempotent (safe to call repeatedly or before any connection was
-    # opened); the client stays usable and reconnects on the next request.
+    # Close open connections; the client stays usable and reconnects on the next request.
     def close(self) -> None: ...
 
-    # Look up a persisted cookie by name, returning its value as a plain string, or default when the
-    # cookie is absent or its name is ambiguous (the same name set for multiple domains or paths). A
-    # backend must return default in the ambiguous case rather than raising.
+    # Return a persisted cookie value, or default when absent or ambiguous across domains/paths.
     def get_cookie(self, name: str, default: str | None = None) -> str | None: ...
 
     # Whether url should bypass any configured proxy under the client's no_proxy rules, False if none match.

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_stream_connection_lines.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_stream_connection_lines.py
@@ -9,8 +9,7 @@ import pytest
 from datadog_checks.base.checks.openmetrics.v2.scraper.base_scraper import OpenMetricsScraper
 from datadog_checks.base.utils.http_exceptions import HTTPConnectionError, HTTPTimeoutError
 
-# A raw requests ConnectTimeout translates to HTTPTimeoutError, a sibling of HTTPConnectionError, so both
-# must be swallowed under ignore_connection_errors to preserve the pre-migration ConnectionError coverage.
+# Both connection errors must be swallowed to preserve pre-migration ConnectTimeout coverage.
 AGNOSTIC_CONNECTION_ERRORS = [HTTPConnectionError, HTTPTimeoutError]
 
 

--- a/datadog_checks_base/tests/base/utils/http/test_capabilities.py
+++ b/datadog_checks_base/tests/base/utils/http/test_capabilities.py
@@ -42,8 +42,7 @@ class TestClose:
         assert http._session is None
 
     def test_request_succeeds_after_close(self):
-        # The documented contract is that the client stays usable after close(): a subsequent request
-        # transparently rebuilds the session and goes through.
+        # After close(), a subsequent request should rebuild the session and succeed.
         http = RequestsWrapper({}, {})
         http.persist_connections = True
         with mock.patch('requests.Session.get') as get:
@@ -127,8 +126,7 @@ class TestCookies:
 
     def test_get_cookie_conflict_returns_default(self):
         http = RequestsWrapper({}, {})
-        # Same cookie name on multiple domains makes RequestsCookieJar.get raise
-        # CookieConflictError. get_cookie must still honor its value-or-default contract.
+        # Cookie name conflicts raise in RequestsCookieJar.get; get_cookie must return the default.
         http.session.cookies.set('dup', 'a', domain='a.example.com')
         http.session.cookies.set('dup', 'b', domain='b.example.com')
         assert http.get_cookie('dup', 'fallback') == 'fallback'

--- a/datadog_checks_base/tests/base/utils/http/test_dev_http_client.py
+++ b/datadog_checks_base/tests/base/utils/http/test_dev_http_client.py
@@ -1,0 +1,163 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for the real (non-mock) HTTP client seam in ``datadog_checks.dev.http``.
+
+These live in the base test suite because base's environment installs both ``datadog_checks_base``
+(which provides ``create_http_client`` and the agnostic exceptions) and ``datadog_checks_dev`` (which
+defines the seam), mirroring the existing ``MockHTTPResponse`` tests in ``test_http_testing.py``.
+"""
+
+import json
+import socket
+import threading
+from contextlib import closing
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from datadog_checks.base.utils import http_exceptions
+from datadog_checks.dev.http import HTTPStatusError, dev_http_client, http_get, http_post
+
+
+class _EchoHandler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        # Keep the test output pristine.
+        pass
+
+    def _reply(self, body=b''):
+        status = int(self.path.rsplit('/', 1)[1]) if self.path.startswith('/status/') else 200
+        payload = json.dumps(
+            {
+                'method': self.command,
+                'path': self.path,
+                'headers': {key.lower(): value for key, value in self.headers.items()},
+                'body': body.decode('utf-8'),
+            }
+        ).encode('utf-8')
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self):
+        self._reply()
+
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        self._reply(self.rfile.read(length))
+
+
+@pytest.fixture
+def http_server():
+    server = HTTPServer(('127.0.0.1', 0), _EchoHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield 'http://{}:{}'.format(host, port)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def _unused_port():
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(('127.0.0.1', 0))
+        return sock.getsockname()[1]
+
+
+def test_http_get_reaches_real_server(http_server):
+    response = http_get('{}/hello'.format(http_server))
+
+    assert response.status_code == 200
+    echoed = response.json()
+    assert echoed['method'] == 'GET'
+    assert echoed['path'] == '/hello'
+
+
+def test_http_get_forwards_query_params(http_server):
+    response = http_get(http_server, params={'foo': 'bar'})
+
+    assert 'foo=bar' in response.json()['path']
+
+
+def test_http_get_forwards_headers(http_server):
+    response = http_get(http_server, headers={'X-Test': 'value'})
+
+    assert response.json()['headers']['x-test'] == 'value'
+
+
+def test_http_post_sends_json_body(http_server):
+    response = http_post('{}/submit'.format(http_server), json={'key': 'value'})
+
+    echoed = response.json()
+    assert echoed['method'] == 'POST'
+    assert json.loads(echoed['body']) == {'key': 'value'}
+    assert echoed['headers']['content-type'] == 'application/json'
+
+
+def test_raise_for_status_raises_agnostic_error(http_server):
+    response = http_get('{}/status/404'.format(http_server))
+
+    assert response.status_code == 404
+    with pytest.raises(http_exceptions.HTTPStatusError):
+        response.raise_for_status()
+
+
+def test_connection_failure_raises_agnostic_error():
+    url = 'http://127.0.0.1:{}/'.format(_unused_port())
+
+    with pytest.raises(http_exceptions.HTTPError):
+        http_get(url)
+
+
+def test_dev_http_client_persist_flag():
+    assert dev_http_client(persist=True).persist_connections is True
+    assert dev_http_client().persist_connections is False
+
+
+def test_dev_http_client_applies_default_options(http_server):
+    client = dev_http_client(headers={'X-Default': 'yes'})
+
+    response = client.get(http_server)
+
+    assert response.json()['headers']['x-default'] == 'yes'
+
+
+def test_dev_http_client_reuses_connection_when_persistent(http_server):
+    client = dev_http_client(persist=True)
+
+    first = client.get('{}/one'.format(http_server))
+    second = client.get('{}/two'.format(http_server))
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+
+def test_exception_reexports_are_the_base_types():
+    from datadog_checks.dev import http as dev_http
+
+    for name in (
+        'HTTPError',
+        'HTTPRequestError',
+        'HTTPStatusError',
+        'HTTPTimeoutError',
+        'HTTPConnectionError',
+        'HTTPInvalidURLError',
+        'HTTPSSLError',
+    ):
+        assert getattr(dev_http, name) is getattr(http_exceptions, name)
+
+    # The imported symbol resolves to the same agnostic type callers would catch.
+    assert HTTPStatusError is http_exceptions.HTTPStatusError
+
+
+def test_unknown_module_attribute_raises():
+    from datadog_checks.dev import http as dev_http
+
+    missing_attribute = 'NotARealSymbol'
+    with pytest.raises(AttributeError):
+        getattr(dev_http, missing_attribute)

--- a/datadog_checks_base/tests/base/utils/http/test_dev_http_client.py
+++ b/datadog_checks_base/tests/base/utils/http/test_dev_http_client.py
@@ -1,12 +1,7 @@
 # (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-"""Tests for the real (non-mock) HTTP client seam in ``datadog_checks.dev.http``.
-
-These live in the base test suite because base's environment installs both ``datadog_checks_base``
-(which provides ``create_http_client`` and the agnostic exceptions) and ``datadog_checks_dev`` (which
-defines the seam), mirroring the existing ``MockHTTPResponse`` tests in ``test_http_testing.py``.
-"""
+"""Tests for the real HTTP client seam across datadog_checks_base and datadog_checks_dev."""
 
 import json
 import socket
@@ -45,8 +40,7 @@ class _EchoHandler(BaseHTTPRequestHandler):
                 'path': self.path,
                 'headers': {key.lower(): value for key, value in self.headers.items()},
                 'body': body.decode('utf-8'),
-                # Source port of the client connection. Equal across two calls only when the
-                # underlying TCP connection is reused (keep-alive), so it makes reuse observable.
+                # Source port makes keep-alive connection reuse observable.
                 'client_port': self.client_address[1],
             }
         ).encode('utf-8')
@@ -91,8 +85,7 @@ class _EchoHandler(BaseHTTPRequestHandler):
 
 @pytest.fixture
 def http_server():
-    # ThreadingHTTPServer handles each connection on its own daemon thread, so a held-open
-    # keep-alive connection cannot starve accept() on the single serve_forever thread.
+    # Use per-connection daemon threads so keep-alive sockets do not block serve_forever.
     server = ThreadingHTTPServer(('127.0.0.1', 0), _EchoHandler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -107,12 +100,9 @@ def http_server():
 
 @pytest.fixture
 def refused_url():
-    # Bind an ephemeral port to learn a free one, then release it so connects are refused
-    # (RST) deterministically. Holding the socket bound-but-not-listening would eliminate the
-    # port-reassignment TOCTOU, but on macOS that makes the kernel drop the SYN so the connect
-    # times out (HTTPTimeoutError) instead of being refused. Releasing the port is the robust
-    # choice: it refuses instantly and cross-platform, at the cost of a negligible reuse window
-    # on a loopback ephemeral port within a single test.
+    # Release a probed ephemeral port so connects are refused quickly and cross-platform.
+    # Holding it bound avoids reuse races but makes macOS drop SYNs and time out instead.
+    # The loopback reuse window is negligible within this test.
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
         sock.bind(('127.0.0.1', 0))
         port = sock.getsockname()[1]

--- a/datadog_checks_base/tests/base/utils/http/test_dev_http_client.py
+++ b/datadog_checks_base/tests/base/utils/http/test_dev_http_client.py
@@ -12,15 +12,27 @@ import json
 import socket
 import threading
 from contextlib import closing
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
 from datadog_checks.base.utils import http_exceptions
-from datadog_checks.dev.http import HTTPStatusError, dev_http_client, http_get, http_post
+from datadog_checks.dev.http import (
+    HTTPStatusError,
+    dev_http_client,
+    http_delete,
+    http_get,
+    http_head,
+    http_patch,
+    http_post,
+    http_put,
+)
 
 
 class _EchoHandler(BaseHTTPRequestHandler):
+    # HTTP/1.1 enables keep-alive so a persistent client reuses one TCP connection across calls.
+    protocol_version = 'HTTP/1.1'
+
     def log_message(self, *args):
         # Keep the test output pristine.
         pass
@@ -33,6 +45,9 @@ class _EchoHandler(BaseHTTPRequestHandler):
                 'path': self.path,
                 'headers': {key.lower(): value for key, value in self.headers.items()},
                 'body': body.decode('utf-8'),
+                # Source port of the client connection. Equal across two calls only when the
+                # underlying TCP connection is reused (keep-alive), so it makes reuse observable.
+                'client_port': self.client_address[1],
             }
         ).encode('utf-8')
         self.send_response(status)
@@ -41,17 +56,44 @@ class _EchoHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(payload)
 
+    def _read_body(self):
+        length = int(self.headers.get('Content-Length', 0))
+        return self.rfile.read(length)
+
     def do_GET(self):
+        if self.path == '/redirect':
+            self.send_response(302)
+            self.send_header('Location', '/final')
+            self.send_header('Content-Length', '0')
+            self.end_headers()
+            return
         self._reply()
 
     def do_POST(self):
-        length = int(self.headers.get('Content-Length', 0))
-        self._reply(self.rfile.read(length))
+        self._reply(self._read_body())
+
+    def do_PUT(self):
+        self._reply(self._read_body())
+
+    def do_PATCH(self):
+        self._reply(self._read_body())
+
+    def do_DELETE(self):
+        self._reply(self._read_body())
+
+    def do_HEAD(self):
+        # HEAD must echo the method via a header and send no body.
+        self.send_response(200)
+        self.send_header('X-Echo-Method', 'HEAD')
+        self.send_header('Content-Length', '0')
+        self.end_headers()
 
 
 @pytest.fixture
 def http_server():
-    server = HTTPServer(('127.0.0.1', 0), _EchoHandler)
+    # ThreadingHTTPServer handles each connection on its own daemon thread, so a held-open
+    # keep-alive connection cannot starve accept() on the single serve_forever thread.
+    server = ThreadingHTTPServer(('127.0.0.1', 0), _EchoHandler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     host, port = server.server_address
@@ -63,10 +105,18 @@ def http_server():
         thread.join()
 
 
-def _unused_port():
+@pytest.fixture
+def refused_url():
+    # Bind an ephemeral port to learn a free one, then release it so connects are refused
+    # (RST) deterministically. Holding the socket bound-but-not-listening would eliminate the
+    # port-reassignment TOCTOU, but on macOS that makes the kernel drop the SYN so the connect
+    # times out (HTTPTimeoutError) instead of being refused. Releasing the port is the robust
+    # choice: it refuses instantly and cross-platform, at the cost of a negligible reuse window
+    # on a loopback ephemeral port within a single test.
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
         sock.bind(('127.0.0.1', 0))
-        return sock.getsockname()[1]
+        port = sock.getsockname()[1]
+    yield 'http://127.0.0.1:{}/'.format(port)
 
 
 def test_http_get_reaches_real_server(http_server):
@@ -90,6 +140,12 @@ def test_http_get_forwards_headers(http_server):
     assert response.json()['headers']['x-test'] == 'value'
 
 
+def test_http_get_forwards_cookies(http_server):
+    response = http_get(http_server, cookies={'session': 'abc'})
+
+    assert 'session=abc' in response.json()['headers']['cookie']
+
+
 def test_http_post_sends_json_body(http_server):
     response = http_post('{}/submit'.format(http_server), json={'key': 'value'})
 
@@ -97,6 +153,45 @@ def test_http_post_sends_json_body(http_server):
     assert echoed['method'] == 'POST'
     assert json.loads(echoed['body']) == {'key': 'value'}
     assert echoed['headers']['content-type'] == 'application/json'
+
+
+def test_http_post_sends_form_body(http_server):
+    response = http_post('{}/submit'.format(http_server), data={'key': 'value'})
+
+    echoed = response.json()
+    assert 'key=value' in echoed['body']
+    assert echoed['headers']['content-type'] == 'application/x-www-form-urlencoded'
+
+
+def test_http_put_sends_body(http_server):
+    response = http_put('{}/resource'.format(http_server), data='payload')
+
+    echoed = response.json()
+    assert echoed['method'] == 'PUT'
+    assert echoed['body'] == 'payload'
+
+
+def test_http_patch_sends_body(http_server):
+    response = http_patch('{}/resource'.format(http_server), data='delta')
+
+    echoed = response.json()
+    assert echoed['method'] == 'PATCH'
+    assert echoed['body'] == 'delta'
+
+
+def test_http_delete_reaches_real_server(http_server):
+    response = http_delete('{}/resource'.format(http_server))
+
+    echoed = response.json()
+    assert echoed['method'] == 'DELETE'
+    assert echoed['path'] == '/resource'
+
+
+def test_http_head_reaches_real_server(http_server):
+    response = http_head(http_server)
+
+    assert response.status_code == 200
+    assert response.headers['X-Echo-Method'] == 'HEAD'
 
 
 def test_raise_for_status_raises_agnostic_error(http_server):
@@ -107,11 +202,25 @@ def test_raise_for_status_raises_agnostic_error(http_server):
         response.raise_for_status()
 
 
-def test_connection_failure_raises_agnostic_error():
-    url = 'http://127.0.0.1:{}/'.format(_unused_port())
+def test_http_get_follows_redirect(http_server):
+    response = http_get('{}/redirect'.format(http_server))
 
-    with pytest.raises(http_exceptions.HTTPError):
-        http_get(url)
+    assert response.status_code == 200
+    assert response.json()['path'] == '/final'
+
+
+def test_http_get_server_error_status(http_server):
+    response = http_get('{}/status/500'.format(http_server))
+
+    assert response.status_code == 500
+    with pytest.raises(http_exceptions.HTTPStatusError):
+        response.raise_for_status()
+
+
+def test_connection_failure_raises_agnostic_error(refused_url):
+    # A refused connection maps requests.ConnectionError -> the specific HTTPConnectionError.
+    with pytest.raises(http_exceptions.HTTPConnectionError):
+        http_get(refused_url)
 
 
 def test_dev_http_client_persist_flag():
@@ -127,14 +236,27 @@ def test_dev_http_client_applies_default_options(http_server):
     assert response.json()['headers']['x-default'] == 'yes'
 
 
+def test_dev_http_client_per_call_overrides_client_level(http_server):
+    client = dev_http_client(headers={'X-Test': 'client'})
+
+    response = client.get(http_server, headers={'X-Test': 'percall'})
+
+    assert response.json()['headers']['x-test'] == 'percall'
+
+
+def test_dev_http_client_verify_propagation():
+    assert dev_http_client(verify=False).options['verify'] is False
+    assert dev_http_client().options['verify']
+
+
 def test_dev_http_client_reuses_connection_when_persistent(http_server):
     client = dev_http_client(persist=True)
 
     first = client.get('{}/one'.format(http_server))
     second = client.get('{}/two'.format(http_server))
 
-    assert first.status_code == 200
-    assert second.status_code == 200
+    # A reused keep-alive connection keeps the same client source port across both calls.
+    assert first.json()['client_port'] == second.json()['client_port']
 
 
 def test_exception_reexports_are_the_base_types():

--- a/datadog_checks_base/tests/base/utils/http/test_exceptions.py
+++ b/datadog_checks_base/tests/base/utils/http/test_exceptions.py
@@ -157,8 +157,7 @@ def test_json_parse_error_converges_to_stdlib():
     assert exc_info.value.pos == 0
 
 
-# Group E: the auth-token seam. The poll runs before the main request (see handle_auth_token), so a
-# transport failure while fetching the token must surface as an agnostic type, not a raw requests one.
+# Group E: auth-token transport failures must surface as agnostic errors, not raw requests ones.
 def test_auth_token_fetch_error_maps_to_agnostic():
     http = RequestsWrapper({}, {})
     http.auth_token_handler = mock.MagicMock()
@@ -181,8 +180,7 @@ class IterableFailingResponse:
         return self.iter_content(128)
 
 
-# Group F: direct iteration. requests.Response.__iter__ delegates to iter_content, so `for chunk in
-# response` must translate mid-stream errors the same as an explicit iter_content() call.
+# Group F: direct for chunk in response iteration must translate mid-stream errors like iter_content.
 def test_direct_iteration_maps_mid_stream_exceptions():
     response = IterableFailingResponse(requests.exceptions.ConnectionError('dropped'))
     http = RequestsWrapper({}, {})

--- a/datadog_checks_base/tests/base/utils/http/test_http.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http.py
@@ -314,15 +314,7 @@ class TestSession:
             assert getattr(http.session, key) == value
 
     def test_timeout(self):
-        """
-        Respect the request timeout.
-
-        Here we test two things:
-        - We pass the timemout option correctly to the requests library.
-        - The timeout surfaces as the agnostic HTTPTimeoutError.
-
-        We trust requests to respect the timeout so we mock its response.
-        """
+        """Respect the request timeout and translate request timeout errors to HTTPTimeoutError."""
 
         mock_session = mock.create_autospec(requests.Session)
         mock_session.get.side_effect = requests.exceptions.Timeout()

--- a/datadog_checks_dev/datadog_checks/dev/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/http.py
@@ -9,10 +9,13 @@ from functools import lru_cache
 from http.client import responses as http_responses
 from io import BytesIO
 from textwrap import dedent
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 from requests import Response
+
+if TYPE_CHECKING:
+    from datadog_checks.base.utils.http_protocol import HTTPClient, HTTPResponse
 
 
 class MockResponse(Response):
@@ -293,3 +296,78 @@ class MockHTTPResponse:
 
     def __iter__(self) -> Iterator[bytes | str]:
         return iter(self.__wrapped__)
+
+
+# Agnostic HTTP exceptions re-exported from datadog_checks_base so test setup code has a single import
+# site (``from datadog_checks.dev.http import HTTPTimeoutError``). Resolved lazily to avoid forcing a
+# base import when this module is loaded only for its mock helpers.
+_AGNOSTIC_EXCEPTIONS = frozenset(
+    {
+        'HTTPError',
+        'HTTPRequestError',
+        'HTTPStatusError',
+        'HTTPTimeoutError',
+        'HTTPConnectionError',
+        'HTTPInvalidURLError',
+        'HTTPSSLError',
+    }
+)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _AGNOSTIC_EXCEPTIONS:
+        from datadog_checks.base.utils import http_exceptions
+
+        return getattr(http_exceptions, name)
+    raise AttributeError('module {!r} has no attribute {!r}'.format(__name__, name))
+
+
+def dev_http_client(persist: bool = False, **options: Any) -> 'HTTPClient':
+    """Build a real (non-mock) agnostic HTTP client for test fixtures, ``dd_environment`` conditions,
+    and dev scripts.
+
+    Routes through the same ``create_http_client`` factory the Agent uses, so real test traffic runs on
+    the production HTTP backend and follows it across the ``requests`` -> ``httpx`` cutover. Use this
+    instead of calling ``requests`` directly in test setup code.
+
+    :param persist: Reuse a single connection across calls, replacing a ``requests.Session``.
+    :param options: Client-level request defaults (for example ``headers``, ``auth``, ``verify``,
+        ``timeout``). Per-call keyword arguments on the verb methods override these.
+    """
+    from datadog_checks.base.utils.http import create_http_client
+
+    client = create_http_client({}, {})
+    client.persist_connections = persist
+    if options:
+        client.options.update(options)
+    return client
+
+
+def http_get(url: str, **options: Any) -> 'HTTPResponse':
+    """One-shot agnostic GET mirroring ``requests.get`` ergonomics. See :func:`dev_http_client`."""
+    return dev_http_client().get(url, **options)
+
+
+def http_post(url: str, **options: Any) -> 'HTTPResponse':
+    """One-shot agnostic POST mirroring ``requests.post`` ergonomics. See :func:`dev_http_client`."""
+    return dev_http_client().post(url, **options)
+
+
+def http_head(url: str, **options: Any) -> 'HTTPResponse':
+    """One-shot agnostic HEAD. See :func:`dev_http_client`."""
+    return dev_http_client().head(url, **options)
+
+
+def http_put(url: str, **options: Any) -> 'HTTPResponse':
+    """One-shot agnostic PUT. See :func:`dev_http_client`."""
+    return dev_http_client().put(url, **options)
+
+
+def http_patch(url: str, **options: Any) -> 'HTTPResponse':
+    """One-shot agnostic PATCH. See :func:`dev_http_client`."""
+    return dev_http_client().patch(url, **options)
+
+
+def http_delete(url: str, **options: Any) -> 'HTTPResponse':
+    """One-shot agnostic DELETE. See :func:`dev_http_client`."""
+    return dev_http_client().delete(url, **options)

--- a/datadog_checks_dev/datadog_checks/dev/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/http.py
@@ -15,8 +15,7 @@ from unittest.mock import MagicMock
 from requests import Response
 
 if TYPE_CHECKING:
-    # Re-exported at runtime via the module-level __getattr__ below; imported here only so static
-    # analyzers can resolve ``from datadog_checks.dev.http import HTTPStatusError`` and friends.
+    # Imported for static analyzers; runtime access goes through module-level __getattr__.
     from datadog_checks.base.utils.http_exceptions import (  # noqa: F401
         HTTPConnectionError,
         HTTPError,
@@ -133,8 +132,7 @@ class MockHTTPResponseImpl:
             headers = dict(headers) if headers is not None else {}
             headers.setdefault('Content-Type', 'application/json')
         elif file_path is not None:
-            # Open in binary mode to handle both text and binary files correctly
-            # This prevents encoding errors and platform-specific newline translation
+            # Open binary files unchanged across encodings and platform newlines.
             with open(file_path, 'rb') as f:
                 content = f.read()
 
@@ -167,8 +165,7 @@ class MockHTTPResponseImpl:
 
     @property
     def ok(self) -> bool:
-        # Transitional: mirrors requests.Response.ok for current production code.
-        # httpx uses is_success/is_client_error/is_server_error instead.
+        # Mirrors requests.Response.ok until production code adopts httpx success helpers.
         return self.status_code < 400
 
     @property
@@ -237,10 +234,8 @@ class MockHTTPResponseImpl:
 
         self._stream.seek(0)
         lines = self._stream.read().split(delimiter)
-        # bytes.split() produces a trailing empty element when content ends with the
-        # delimiter (e.g. b'a\nb\n'.split(b'\n') == [b'a', b'b', b'']). requests uses
-        # splitlines() for the default case which does not have this behavior, so we
-        # strip the trailing empty element to match.
+        # bytes.split leaves a trailing empty element when content ends with the delimiter.
+        # Strip it to match requests' default splitlines behavior.
         if lines and not lines[-1]:
             lines.pop()
         for line in lines:
@@ -248,9 +243,7 @@ class MockHTTPResponseImpl:
             yield line.decode('utf-8') if decode_unicode else line
 
     def close(self) -> None:
-        # No-op: requests.Response.close() releases the network connection, but
-        # content is already buffered in memory. Matching that behaviour here
-        # so the same instance can be returned by a mock multiple times.
+        # No-op because buffered mock responses can be reused after close.
         pass
 
     def __enter__(self) -> 'MockHTTPResponseImpl':
@@ -309,9 +302,7 @@ class MockHTTPResponse:
         return iter(self.__wrapped__)
 
 
-# Agnostic HTTP exceptions re-exported from datadog_checks_base so test setup code has a single import
-# site (``from datadog_checks.dev.http import HTTPTimeoutError``). Resolved lazily to avoid forcing a
-# base import when this module is loaded only for its mock helpers.
+# Re-export agnostic HTTP exceptions lazily so test setup has one import site without forcing base imports.
 AGNOSTIC_EXCEPTIONS = frozenset(
     {
         'HTTPError',
@@ -337,21 +328,13 @@ def __getattr__(name: str) -> Any:
 
 
 def dev_http_client(persist: bool = False, **options: Any) -> 'HTTPClient':
-    """Build a real (non-mock) agnostic HTTP client for test fixtures, ``dd_environment`` conditions,
-    and dev scripts.
+    """Build a real agnostic HTTP client for test fixtures and dev scripts.
 
-    Routes through the same ``create_http_client`` factory the Agent uses, so real test traffic runs on
-    the production HTTP backend and follows it across the ``requests`` -> ``httpx`` cutover. Use this
-    instead of calling ``requests`` directly in test setup code.
+    Traffic uses create_http_client, matching the Agent backend across the requests to httpx cutover.
+    Prefer this to direct requests calls in test setup code.
 
-    Options passed here become client-level defaults that are forwarded to every request, so they must
-    be valid request options (for example ``headers``, ``auth``, ``verify``, ``timeout``). An
-    unrecognized key, or one that is only valid per call, raises on the first request rather than at
-    construction.
-
-    :param persist: Reuse a single connection across calls, replacing a ``requests.Session``.
-    :param options: Client-level request defaults (for example ``headers``, ``auth``, ``verify``,
-        ``timeout``). Per-call keyword arguments on the verb methods override these.
+    :param persist: Reuse one connection across calls, replacing requests.Session.
+    :param options: Client-level request defaults; per-call verb options override these.
     """
     try:
         from datadog_checks.base.utils.http import create_http_client
@@ -366,34 +349,30 @@ def dev_http_client(persist: bool = False, **options: Any) -> 'HTTPClient':
 
 
 def http_get(url: str, **options: Any) -> 'HTTPResponse':
-    """One-shot agnostic GET mirroring ``requests.get`` ergonomics. See :func:`dev_http_client`.
-
-    Each one-shot helper builds a fresh client per call, so connections are not reused across calls.
-    For cross-call connection reuse, use ``dev_http_client(persist=True)`` and call its verb methods.
-    """
+    """One-shot agnostic GET. Use dev_http_client(persist=True) for cross-call connection reuse."""
     return dev_http_client().get(url, **options)
 
 
 def http_post(url: str, **options: Any) -> 'HTTPResponse':
-    """One-shot agnostic POST mirroring ``requests.post`` ergonomics. See :func:`dev_http_client`."""
+    """One-shot agnostic POST. See dev_http_client."""
     return dev_http_client().post(url, **options)
 
 
 def http_head(url: str, **options: Any) -> 'HTTPResponse':
-    """One-shot agnostic HEAD. See :func:`dev_http_client`."""
+    """One-shot agnostic HEAD. See dev_http_client."""
     return dev_http_client().head(url, **options)
 
 
 def http_put(url: str, **options: Any) -> 'HTTPResponse':
-    """One-shot agnostic PUT. See :func:`dev_http_client`."""
+    """One-shot agnostic PUT. See dev_http_client."""
     return dev_http_client().put(url, **options)
 
 
 def http_patch(url: str, **options: Any) -> 'HTTPResponse':
-    """One-shot agnostic PATCH. See :func:`dev_http_client`."""
+    """One-shot agnostic PATCH. See dev_http_client."""
     return dev_http_client().patch(url, **options)
 
 
 def http_delete(url: str, **options: Any) -> 'HTTPResponse':
-    """One-shot agnostic DELETE. See :func:`dev_http_client`."""
+    """One-shot agnostic DELETE. See dev_http_client."""
     return dev_http_client().delete(url, **options)

--- a/datadog_checks_dev/datadog_checks/dev/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/http.py
@@ -15,6 +15,17 @@ from unittest.mock import MagicMock
 from requests import Response
 
 if TYPE_CHECKING:
+    # Re-exported at runtime via the module-level __getattr__ below; imported here only so static
+    # analyzers can resolve ``from datadog_checks.dev.http import HTTPStatusError`` and friends.
+    from datadog_checks.base.utils.http_exceptions import (  # noqa: F401
+        HTTPConnectionError,
+        HTTPError,
+        HTTPInvalidURLError,
+        HTTPRequestError,
+        HTTPSSLError,
+        HTTPStatusError,
+        HTTPTimeoutError,
+    )
     from datadog_checks.base.utils.http_protocol import HTTPClient, HTTPResponse
 
 
@@ -301,7 +312,7 @@ class MockHTTPResponse:
 # Agnostic HTTP exceptions re-exported from datadog_checks_base so test setup code has a single import
 # site (``from datadog_checks.dev.http import HTTPTimeoutError``). Resolved lazily to avoid forcing a
 # base import when this module is loaded only for its mock helpers.
-_AGNOSTIC_EXCEPTIONS = frozenset(
+AGNOSTIC_EXCEPTIONS = frozenset(
     {
         'HTTPError',
         'HTTPRequestError',
@@ -315,11 +326,14 @@ _AGNOSTIC_EXCEPTIONS = frozenset(
 
 
 def __getattr__(name: str) -> Any:
-    if name in _AGNOSTIC_EXCEPTIONS:
-        from datadog_checks.base.utils import http_exceptions
+    if name in AGNOSTIC_EXCEPTIONS:
+        try:
+            from datadog_checks.base.utils import http_exceptions
+        except ImportError:
+            raise ImportError('datadog-checks-base is not installed!')
 
         return getattr(http_exceptions, name)
-    raise AttributeError('module {!r} has no attribute {!r}'.format(__name__, name))
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
 
 
 def dev_http_client(persist: bool = False, **options: Any) -> 'HTTPClient':
@@ -330,11 +344,19 @@ def dev_http_client(persist: bool = False, **options: Any) -> 'HTTPClient':
     the production HTTP backend and follows it across the ``requests`` -> ``httpx`` cutover. Use this
     instead of calling ``requests`` directly in test setup code.
 
+    Options passed here become client-level defaults that are forwarded to every request, so they must
+    be valid request options (for example ``headers``, ``auth``, ``verify``, ``timeout``). An
+    unrecognized key, or one that is only valid per call, raises on the first request rather than at
+    construction.
+
     :param persist: Reuse a single connection across calls, replacing a ``requests.Session``.
     :param options: Client-level request defaults (for example ``headers``, ``auth``, ``verify``,
         ``timeout``). Per-call keyword arguments on the verb methods override these.
     """
-    from datadog_checks.base.utils.http import create_http_client
+    try:
+        from datadog_checks.base.utils.http import create_http_client
+    except ImportError:
+        raise ImportError('datadog-checks-base is not installed!')
 
     client = create_http_client({}, {})
     client.persist_connections = persist
@@ -344,7 +366,11 @@ def dev_http_client(persist: bool = False, **options: Any) -> 'HTTPClient':
 
 
 def http_get(url: str, **options: Any) -> 'HTTPResponse':
-    """One-shot agnostic GET mirroring ``requests.get`` ergonomics. See :func:`dev_http_client`."""
+    """One-shot agnostic GET mirroring ``requests.get`` ergonomics. See :func:`dev_http_client`.
+
+    Each one-shot helper builds a fresh client per call, so connections are not reused across calls.
+    For cross-call connection reuse, use ``dev_http_client(persist=True)`` and call its verb methods.
+    """
     return dev_http_client().get(url, **options)
 
 

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -332,8 +332,7 @@ def mock_http(mocker):
     from datadog_checks.base.utils.http_protocol import HTTPClient
 
     client = create_autospec(HTTPClient)
-    # Protocol annotations are not picked up by create_autospec, so set data attributes explicitly;
-    # otherwise reading them off the mock raises AttributeError. Defaults mirror RequestsWrapper.
+    # create_autospec skips Protocol data attributes, so set RequestsWrapper-like defaults explicitly.
     client.options = {
         'auth': None,
         'cert': None,
@@ -369,12 +368,7 @@ def mock_http(mocker):
 
 @pytest.fixture
 def mock_openmetrics_http(mock_http, mocker):
-    """OpenMetrics HTTP mock with dual interception:
-
-    - v1 checks (OpenMetricsBaseCheck): patches OpenMetricsScraperMixin.get_http_handler to return mock_http.
-    - v2 checks (OpenMetricsBaseCheckV2): inherited via mock_http's AgentCheck.http PropertyMock; the
-      get_http_handler patch is unused on this path because v2 calls self.http.get(...) directly.
-    """
+    """OpenMetrics HTTP mock for v1 handler patching and v2 AgentCheck.http access."""
     mocker.patch(
         'datadog_checks.base.checks.openmetrics.mixins.OpenMetricsScraperMixin.get_http_handler',
         return_value=mock_http,

--- a/elastic/tests/conftest.py
+++ b/elastic/tests/conftest.py
@@ -6,12 +6,11 @@ import os
 
 import mock
 import pytest
-import requests
 from packaging import version
 
 from datadog_checks.base.utils.common import exclude_undefined_keys
 from datadog_checks.dev import WaitFor, docker_run
-from datadog_checks.dev.http import MockHTTPResponse
+from datadog_checks.dev.http import MockHTTPResponse, http_put
 from datadog_checks.elastic import ESCheck
 
 from .common import (
@@ -62,7 +61,7 @@ def ping_elastic():
     as soon as ES is available. This is just one possible ping strategy but it's needed
     as a fixture for tests that require that index to exist in order to pass.
     """
-    response = requests.put('{}/testindex'.format(URL), auth=(USER, PASSWORD), verify=False)
+    response = http_put('{}/testindex'.format(URL), auth=(USER, PASSWORD), verify=False)
     response.raise_for_status()
 
 
@@ -71,7 +70,7 @@ def create_slm():
         return
 
     create_backup_body = {"type": "fs", "settings": {"location": "data"}}
-    response = requests.put(
+    response = http_put(
         '{}/_snapshot/my_repository?pretty'.format(INSTANCE['url']),
         json=create_backup_body,
         auth=(INSTANCE['username'], INSTANCE['password']),
@@ -86,7 +85,7 @@ def create_slm():
         "config": {"indices": ["data-*", "important"], "ignore_unavailable": False, "include_global_state": False},
         "retention": {"expire_after": "30d", "min_count": 5, "max_count": 50},
     }
-    response = requests.put(
+    response = http_put(
         '{}/_slm/policy/daily-snapshots?pretty'.format(INSTANCE['url']),
         json=create_slm_body,
         auth=(INSTANCE['username'], INSTANCE['password']),
@@ -96,7 +95,7 @@ def create_slm():
 
 
 def index_starts_with_dot():
-    create_dot_testindex = requests.put('{}/.testindex'.format(URL), auth=(USER, PASSWORD), verify=False)
+    create_dot_testindex = http_put('{}/.testindex'.format(URL), auth=(USER, PASSWORD), verify=False)
     create_dot_testindex.raise_for_status()
 
 

--- a/elastic/tests/test_integration.py
+++ b/elastic/tests/test_integration.py
@@ -4,9 +4,9 @@
 import logging
 
 import pytest
-import requests
 from packaging import version
 
+from datadog_checks.dev.http import http_post, http_put
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.elastic import ESCheck
 from datadog_checks.elastic.metrics import (
@@ -134,13 +134,13 @@ def test_custom_queries_with_payload(dd_environment, dd_run_check, instance, agg
     version.parse(ELASTIC_VERSION) < version.parse('8.0.0'), reason='Test unavailable for Elasticsearch < 8.0.0'
 )
 def test_custom_queries_with_payload_multiterm(dd_environment, dd_run_check, instance, aggregator, cluster_tags):
-    response = requests.put(
+    response = http_put(
         "{}/multiterm_test".format(instance['url']),
         json={"mappings": {"properties": {"field0": {"type": "keyword"}, "field1": {"type": "keyword"}}}},
     )
     response.raise_for_status()
 
-    response = requests.post(
+    response = http_post(
         "{}/multiterm_test/_doc?refresh=wait_for".format(instance['url']), json={"field0": "foo", "field1": "bar"}
     )
     response.raise_for_status()
@@ -440,7 +440,7 @@ def test_health_event(dd_environment, aggregator):
     es_version = elastic_check._get_es_version()
 
     # Should be yellow at first
-    requests.put(URL + '/_settings', data='{"index": {"number_of_replicas": 100}', verify=False)
+    http_put(URL + '/_settings', data='{"index": {"number_of_replicas": 100}', verify=False)
 
     elastic_check.check(None)
 
@@ -468,7 +468,7 @@ def test_health_event_disabled(dd_environment, aggregator):
     elastic_check._get_es_version()
 
     # Should be yellow at first
-    requests.put(URL + '/_settings', data='{"index": {"number_of_replicas": 100}', verify=False)
+    http_put(URL + '/_settings', data='{"index": {"number_of_replicas": 100}', verify=False)
 
     elastic_check.check(None)
 

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -7,9 +7,9 @@ import threading
 import time
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
+from datadog_checks.dev.http import HTTPError, http_get
 from datadog_checks.envoy import Envoy
 
 from .common import DEFAULT_INSTANCE, DOCKER_DIR, FIXTURE_DIR, HOST, URL
@@ -63,9 +63,9 @@ def exercise_envoy():
     def fire_loop():
         while not stop.is_set():
             try:
-                requests.get('http://{}:8000/service/1'.format(HOST))
-                requests.get('http://{}:8000/service/2'.format(HOST))
-            except requests.RequestException:
+                http_get('http://{}:8000/service/1'.format(HOST))
+                http_get('http://{}:8000/service/2'.format(HOST))
+            except HTTPError:
                 pass
             stop.wait(ENVOY_STATS_FLUSH_INTERVAL / 10)
 

--- a/etcd/tests/utils.py
+++ b/etcd/tests/utils.py
@@ -1,11 +1,11 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import requests
+from datadog_checks.dev.http import http_post
 
 
 def is_leader(url):
-    response = requests.post('{}/v3/maintenance/status'.format(url), data='{}').json()
+    response = http_post('{}/v3/maintenance/status'.format(url), data='{}').json()
     leader = response.get('leader')
     member = response.get('header', {}).get('member_id')
 

--- a/gitlab/tests/conftest.py
+++ b/gitlab/tests/conftest.py
@@ -8,12 +8,11 @@ from contextlib import contextmanager
 from time import sleep
 
 import pytest
-import requests
 
 from datadog_checks.dev import EnvVars, TempDir, docker_run
 from datadog_checks.dev._env import get_state, save_state
 from datadog_checks.dev.conditions import CheckEndpoints
-from datadog_checks.dev.http import MockHTTPResponse
+from datadog_checks.dev.http import MockHTTPResponse, http_get
 from datadog_checks.gitlab import GitlabCheck
 
 from .common import (
@@ -84,7 +83,7 @@ def dd_environment():
     ):
         # run pre-test commands
         for _ in range(100):
-            requests.get(GITLAB_URL)
+            http_get(GITLAB_URL)
         sleep(2)
 
         yield {

--- a/go_expvar/tests/conftest.py
+++ b/go_expvar/tests/conftest.py
@@ -8,9 +8,9 @@ import os
 
 import mock
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
+from datadog_checks.dev.http import dev_http_client
 from datadog_checks.go_expvar import GoExpvar
 
 from . import common
@@ -35,8 +35,9 @@ def dd_environment():
     """
 
     with docker_run(os.path.join(common.HERE, 'compose', 'docker-compose.yaml'), endpoints=[common.URL]):
+        client = dev_http_client(persist=True)
         for _ in range(9):
-            requests.get(common.URL + "?user=123456")
+            client.get(common.URL + "?user=123456")
         yield common.INSTANCE
 
 

--- a/haproxy/tests/conftest.py
+++ b/haproxy/tests/conftest.py
@@ -11,11 +11,10 @@ from copy import deepcopy
 
 import mock
 import pytest
-import requests
 from packaging import version
 
 from datadog_checks.dev import TempDir, WaitFor, docker_run
-from datadog_checks.dev.http import MockHTTPResponse
+from datadog_checks.dev.http import MockHTTPResponse, http_get
 from datadog_checks.haproxy import HAProxyCheck
 from datadog_checks.haproxy.metrics import METRIC_MAP
 
@@ -126,12 +125,12 @@ def prometheus_metricsv2(prometheus_metrics):
 
 
 def wait_for_haproxy():
-    res = requests.get(STATS_URL, auth=(USERNAME, PASSWORD))
+    res = http_get(STATS_URL, auth=(USERNAME, PASSWORD))
     res.raise_for_status()
 
 
 def wait_for_haproxy_open():
-    res_open = requests.get(STATS_URL_OPEN)
+    res_open = http_get(STATS_URL_OPEN)
     res_open.raise_for_status()
 
 

--- a/harbor/tests/conftest.py
+++ b/harbor/tests/conftest.py
@@ -4,11 +4,10 @@
 import os
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs, WaitFor
-from datadog_checks.dev.http import MockHTTPResponse
+from datadog_checks.dev.http import MockHTTPResponse, http_post
 from datadog_checks.harbor import HarborCheck
 from datadog_checks.harbor.api import HarborAPI
 from datadog_checks.harbor.common import (
@@ -58,7 +57,7 @@ def dd_environment(e2e_instance):
 
 
 def create_simple_user():
-    requests.post(
+    http_post(
         URL + USERS_PATH,
         auth=("admin", "Harbor12345"),
         json={

--- a/http_check/tests/conftest.py
+++ b/http_check/tests/conftest.py
@@ -5,12 +5,12 @@ import os
 import sys
 
 import pytest
-import requests
 from datadog_test_libs.utils.mock_dns import mock_local
 from mock import patch
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import WaitFor
+from datadog_checks.dev.http import http_get
 from datadog_checks.dev.utils import ON_WINDOWS
 from datadog_checks.http_check import HTTPCheck
 
@@ -37,7 +37,7 @@ def dd_environment(mock_local_http_dns):
 
 
 def call_endpoint(url):
-    response = requests.get(url, verify=False)
+    response = http_get(url, verify=False)
     response.raise_for_status()
     return True
 

--- a/http_check/tests/test_unit.py
+++ b/http_check/tests/test_unit.py
@@ -89,7 +89,5 @@ def test_use_cert_from_response_reads_peer_cert(aggregator, dd_run_check):
     with mock.patch.object(type(check.http), 'get', return_value=MockHTTPResponse(status_code=200)):
         dd_run_check(check)
 
-    # The mock's `get_peer_cert` return value isn't a parsable certificate, so cert inspection
-    # reports UNKNOWN rather than raising. The point here is that no AttributeError is raised
-    # from accessing `.raw`, which the protocol-enforcing mock no longer exposes.
+    # Mock cert inspection should report UNKNOWN without touching the removed raw attribute.
     aggregator.assert_service_check(HTTPCheck.SC_SSL_CERT, status=HTTPCheck.UNKNOWN, count=1)

--- a/http_check/tests/test_unit_config.py
+++ b/http_check/tests/test_unit_config.py
@@ -59,10 +59,7 @@ def test_from_instance():
 
 
 def test_from_instance_header_override_is_case_insensitive():
-    """
-    A user-supplied header should override the matching default header regardless of case,
-    instead of being sent alongside it as a duplicate.
-    """
+    """User headers override matching default headers case-insensitively instead of duplicating them."""
     config = from_instance({'url': 'https://example.com', 'name': 'UpService', 'headers': {'user-agent': 'Custom-UA'}})
 
     headers = config.headers

--- a/kube_controller_manager/tests/test_kube_controller_manager.py
+++ b/kube_controller_manager/tests/test_kube_controller_manager.py
@@ -135,8 +135,7 @@ def generic_check_metrics(aggregator, check_deprecated):
 )
 def test_service_check(monkeypatch, mock_openmetrics_http, side_effect, expected_status, expected_message):
     instance = {'prometheus_url': 'http://localhost:10252/metrics'}
-    # mock_openmetrics_http satisfies detect_sli_endpoint during __init__
-    # the service-check path under test is driven by the seeded _http_handlers below
+    # mock_openmetrics_http handles detect_sli_endpoint; seeded _http_handlers drive this service-check path.
     mock_openmetrics_http.get.return_value = MockHTTPResponse(status_code=200)
 
     check = KubeControllerManagerCheck(CHECK_NAME, {}, [instance])

--- a/kube_scheduler/tests/test_kube_scheduler_1_14.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_14.py
@@ -107,8 +107,7 @@ def test_check_metrics_1_14(aggregator, mock_metrics, mock_leader, mock_healthch
 )
 def test_service_check(monkeypatch, mock_openmetrics_http, side_effect, expected_status, expected_message):
     instance = {'prometheus_url': 'http://localhost:10251/metrics'}
-    # mock_openmetrics_http satisfies detect_sli_endpoint during __init__
-    # the service-check path under test is driven by the seeded _http_handlers below
+    # mock_openmetrics_http handles detect_sli_endpoint; seeded _http_handlers drive this service-check path.
     mock_openmetrics_http.get.return_value = MockHTTPResponse(status_code=200)
 
     check = KubeSchedulerCheck(CHECK_NAME, {}, [instance])

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -1073,8 +1073,7 @@ def test_report_node_metrics_kubernetes1_18(monkeypatch, aggregator):
 
 
 def test_report_node_metrics_kubernetes1_18_httpstatuserror(monkeypatch, aggregator):
-    # In production, the check HTTP client returns a response whose raise_for_status()
-    # raises the agnostic HTTPStatusError.
+    # Production HTTP clients raise agnostic HTTPStatusError from response.raise_for_status().
     check = KubeletCheck('kubelet', {}, [{}])
     check.kubelet_credentials = KubeletCredentials({'verify_tls': 'false'})
     check.node_spec_url = "http://localhost:10255/spec"

--- a/kuma/tests/conftest.py
+++ b/kuma/tests/conftest.py
@@ -6,8 +6,8 @@ import time
 from contextlib import ExitStack
 
 import pytest
-import requests
 
+from datadog_checks.dev.http import HTTPError, HTTPTimeoutError, http_get
 from datadog_checks.dev.kind import kind_run
 from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.subprocess import run_command
@@ -44,11 +44,11 @@ def wait_for_kuma_readiness(api_url, api_port, max_wait=600):
 
     while time.monotonic() - start_time < max_wait:
         try:
-            response = requests.get(config_url, timeout=5)
+            response = http_get(config_url, timeout=5)
             if response.ok:
                 print(f"Kuma control plane is ready at {config_url} (took {time.monotonic() - start_time} seconds)")
                 return
-        except (requests.exceptions.RequestException, requests.exceptions.Timeout):
+        except (HTTPError, HTTPTimeoutError):
             pass
 
         print(f"Waiting for Kuma control plane to be ready at {config_url}...")

--- a/kyototycoon/tests/conftest.py
+++ b/kyototycoon/tests/conftest.py
@@ -5,9 +5,9 @@
 import os
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
+from datadog_checks.dev.http import http_get, http_put
 
 from .common import DEFAULT_INSTANCE, HERE, URL
 
@@ -28,7 +28,7 @@ def dd_environment():
         headers = {'X-Kt-Mode': 'set'}
 
         for _ in range(100):
-            requests.put(URL, data=data, headers=headers)
-            requests.get(URL)
+            http_put(URL, data=data, headers=headers)
+            http_get(URL)
 
         yield DEFAULT_INSTANCE

--- a/mapreduce/tests/common.py
+++ b/mapreduce/tests/common.py
@@ -5,10 +5,10 @@ import random
 import time
 from contextlib import contextmanager
 
-import requests
 from datadog_test_libs.utils.mock_dns import mock_local
 
 from datadog_checks.dev import get_docker_hostname, get_here, run_command
+from datadog_checks.dev.http import http_get
 from datadog_checks.mapreduce import MapReduceCheck
 
 HERE = get_here()
@@ -69,7 +69,7 @@ def setup_mapreduce():
 
     # Called in WaitFor which catches initial exceptions when containers aren't ready
     for _ in range(15):
-        r = requests.get("{}/ws/v1/cluster/apps?states=RUNNING".format(INSTANCE_INTEGRATION['resourcemanager_uri']))
+        r = http_get("{}/ws/v1/cluster/apps?states=RUNNING".format(INSTANCE_INTEGRATION['resourcemanager_uri']))
         res = r.json()
         if res.get("apps", None) is not None and res.get("apps"):
             return True

--- a/marklogic/tests/conftest.py
+++ b/marklogic/tests/conftest.py
@@ -9,6 +9,7 @@ import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs, WaitFor
+from datadog_checks.dev.http import http_post
 
 from .common import (
     ADMIN_PASSWORD,
@@ -53,7 +54,7 @@ def setup_admin_user():
     # type: () -> None
     # From https://docs.marklogic.com/10.0/guide/admin-api/cluster
     # Reset admin user password (useful for cluster setup)
-    requests.post(
+    http_post(
         'http://localhost:8001/admin/v1/instance-admin',
         data={
             "admin-username": ADMIN_USERNAME,

--- a/n8n/tests/conftest.py
+++ b/n8n/tests/conftest.py
@@ -10,10 +10,10 @@ from pathlib import Path
 from typing import Any, Iterator
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run, get_e2e_discovery_metadata
 from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
+from datadog_checks.dev.http import HTTPError, http_get
 
 from . import common
 
@@ -37,7 +37,7 @@ def _docker_exec(*cmd: str) -> str:
 
 def _n8n_healthy() -> None:
     """WaitFor predicate: succeeds once /healthz returns 200, retries on connection errors or non-2xx."""
-    requests.get(f'http://{common.HOST}:{common.MAIN_PORT}/healthz', timeout=2).raise_for_status()
+    http_get(f'http://{common.HOST}:{common.MAIN_PORT}/healthz', timeout=2).raise_for_status()
 
 
 def _test_webhook_registered() -> None:
@@ -48,7 +48,7 @@ def _test_webhook_registered() -> None:
     to make ``_generate_workflow_traffic`` race the registration and observe a 404. Polling the
     webhook itself closes the race.
     """
-    response = requests.get(f'http://{common.HOST}:{common.MAIN_PORT}{WEBHOOK_OK_PATH}', timeout=5)
+    response = http_get(f'http://{common.HOST}:{common.MAIN_PORT}{WEBHOOK_OK_PATH}', timeout=5)
     if response.status_code == 404:
         raise RuntimeError(f'Webhook {WEBHOOK_OK_PATH} not yet registered (status 404)')
 
@@ -107,18 +107,18 @@ def _generate_workflow_traffic(iterations: int = 5) -> None:
     last_exc: Exception | None = None
     for _ in range(iterations):
         try:
-            ok = requests.get(f'{base_url}{WEBHOOK_OK_PATH}', timeout=5)
+            ok = http_get(f'{base_url}{WEBHOOK_OK_PATH}', timeout=5)
             last_status = ok.status_code
             # 4xx means the webhook responded but didn't execute the workflow (e.g. not yet
             # registered after restart); only 200 proves the workflow body ran end-to-end.
             if ok.status_code == 200:
                 ok_responses += 1
-        except requests.RequestException as exc:
+        except HTTPError as exc:
             last_exc = exc
         # Webhook fail is *expected* to error out — that's the point of triggering it.
         for path in (WEBHOOK_FAIL_PATH, *api_paths):
-            with suppress(requests.RequestException):
-                requests.get(f'{base_url}{path}', timeout=5)
+            with suppress(HTTPError):
+                http_get(f'{base_url}{path}', timeout=5)
     if ok_responses == 0:
         raise RuntimeError(
             f'Test webhook returned no 200 responses (last_status={last_status}, last_exc={last_exc!r}); '
@@ -134,7 +134,7 @@ def _workflow_started_non_zero() -> None:
     Parses the metric value as a float so that ``0.0`` / ``0e+0`` are recognised as zero and
     ``# HELP``/``# TYPE`` comment lines that happen to share the prefix are skipped.
     """
-    payload = requests.get(common.MAIN_INSTANCE['openmetrics_endpoint'], timeout=3).text
+    payload = http_get(common.MAIN_INSTANCE['openmetrics_endpoint'], timeout=3).text
     matching: list[str] = []
     for line in payload.splitlines():
         if line.startswith('#') or not line.startswith('n8n_workflow_started_total'):

--- a/openstack/tests/test_openstack.py
+++ b/openstack/tests/test_openstack.py
@@ -108,7 +108,7 @@ def test_from_config():
 
 
 def test_keystone_auth_ssl_verify_default():
-    """The HTTP client verifies TLS by default and honors an explicit ``ssl_verify: false`` opt-out."""
+    """The HTTP client verifies TLS by default and honors explicit ssl_verify: false."""
     base_init_config = {'keystone_server_url': 'http://10.0.2.15:5000'}
 
     default_check = OpenStackCheck('openstack', base_init_config, instances=[{'name': 'test'}])

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
@@ -65,8 +65,7 @@ class ApiSdk(Api):
         return self._catalog.has_component(component_types)
 
     def _build_keystone_session(self, auth):
-        # keystoneauth builds its own transport; mirror the TLS config and headers from our HTTP
-        # client via the backend-neutral protocol surface instead of handing it the requests session.
+        # Mirror TLS config and headers through the backend-neutral protocol surface for keystoneauth.
         return session.Session(
             auth=auth,
             verify=self.http.options['verify'],

--- a/openstack_controller/tests/test_unit_component.py
+++ b/openstack_controller/tests/test_unit_component.py
@@ -29,16 +29,14 @@ def component():
     return DummyComponent(mock.MagicMock())
 
 
-# Exceptions the decorator must treat as expected HTTP failures: swallowed, logged at DEBUG,
-# and (when the method reports a service check) surfaced as a CRITICAL service check.
+# Expected HTTP failures are swallowed, logged at DEBUG, and surfaced as CRITICAL service checks.
 CAUGHT_HTTP_EXCEPTIONS = [
     pytest.param(openstack.exceptions.HttpException(), id='sdk HttpException'),
     pytest.param(HTTPRequestError('boom'), id='agnostic HTTPRequestError'),
     pytest.param(HTTPStatusError('boom'), id='agnostic HTTPStatusError'),
 ]
 
-# Exceptions the decorator must let fall through to the generic handler: logged at ERROR,
-# with no service check reported. A non-HTTP SDKException is the case the catch narrowing hinges on.
+# Generic handler fallthroughs are logged at ERROR with no service check.
 FELL_THROUGH_EXCEPTIONS = [
     pytest.param(openstack.exceptions.SDKException(), id='non-http SDKException'),
     pytest.param(ValueError('boom'), id='unrelated exception'),

--- a/prefect/tests/conftest.py
+++ b/prefect/tests/conftest.py
@@ -7,10 +7,10 @@ from pathlib import Path
 from typing import Callable
 
 import pytest
-import requests
 
 from datadog_checks.dev.conditions import CheckDockerLogs, CheckEndpoints, WaitFor
 from datadog_checks.dev.docker import docker_run, get_docker_hostname, get_e2e_discovery_metadata
+from datadog_checks.dev.http import http_post
 from datadog_checks.dev.utils import find_free_port
 from datadog_checks.prefect import PrefectCheck
 
@@ -23,12 +23,12 @@ E2E_METADATA = {
 
 def _check_task_runs_available(prefect_url: str):
     """Verify that the Prefect API has task runs and task-run events queryable."""
-    resp = requests.post(f"{prefect_url}/task_runs/filter", json={}, timeout=1)
+    resp = http_post(f"{prefect_url}/task_runs/filter", json={}, timeout=1)
     resp.raise_for_status()
     task_runs = resp.json()
     assert task_runs, "No task runs available in Prefect API yet"
 
-    resp = requests.post(
+    resp = http_post(
         f"{prefect_url}/events/filter",
         json={"filter": {"event": {"prefix": ["prefect.task-run"]}}},
         timeout=1,

--- a/rabbitmq/tests/conftest.py
+++ b/rabbitmq/tests/conftest.py
@@ -6,9 +6,9 @@ import os
 import subprocess
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run, temp_dir
+from datadog_checks.dev.http import http_get, http_put
 from datadog_checks.rabbitmq import RabbitMQ
 
 from .common import CHECK_NAME, CONFIG, HERE, HOST, OPENMETRICS_CONFIG, PORT, RABBITMQ_METRICS_PLUGIN
@@ -38,7 +38,7 @@ def dd_environment():
 def setup_rabbitmq():
     with temp_dir() as tmpdir:
         url = 'http://{}:{}/cli/rabbitmqadmin'.format(HOST, PORT)
-        res = requests.get(url)
+        res = http_get(url)
         res.raise_for_status()
 
         rabbitmq_admin_script = os.path.join(tmpdir, 'rabbitmqadmin')
@@ -51,7 +51,7 @@ def setup_rabbitmq():
 
         # Set cluster name
         url = "http://{}:{}/api/cluster-name".format(HOST, PORT)
-        res = requests.put(
+        res = http_put(
             url, data='{"name": "rabbitmqtest"}', auth=("guest", "guest"), headers={"Content-Type": "application/json"}
         )
         res.raise_for_status()

--- a/ray/tests/conftest.py
+++ b/ray/tests/conftest.py
@@ -8,11 +8,11 @@ from contextlib import contextmanager
 from urllib.parse import urljoin
 
 import pytest
-import requests
 
 from datadog_checks.dev import EnvVars, TempDir, docker_run, get_e2e_discovery_metadata
 from datadog_checks.dev._env import get_state, save_state
 from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
+from datadog_checks.dev.http import http_post
 from datadog_checks.ray import RayCheck
 
 from .common import (
@@ -111,7 +111,7 @@ def mocked_worker_instance():
 
 def run_add():
     try:
-        response = requests.post(
+        response = http_post(
             urljoin(SERVE_URL, "add"),
             data='{"a": 1, "b": 2}',
             headers={'Content-Type': 'application/json'},

--- a/riak/tests/conftest.py
+++ b/riak/tests/conftest.py
@@ -6,22 +6,22 @@ import os
 from copy import deepcopy
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
+from datadog_checks.dev.http import http_get, http_post
 from datadog_checks.riak import Riak
 
 from . import common
 
 
 def populate():
-    post = requests.post(
+    post = http_post(
         "{}/riak/bucket/german".format(common.BASE_URL),
         headers={"Content-Type": "text/plain"},
         data='herzlich willkommen',
     )
-    get = requests.get("{}/riak/bucket/german".format(common.BASE_URL))
+    get = http_get("{}/riak/bucket/german".format(common.BASE_URL))
     return post.ok and get.ok
 
 

--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -8,12 +8,12 @@ import socket
 from copy import deepcopy
 
 import pytest
-import requests
 import yaml
 
 from datadog_checks.base.agent import datadog_agent
 from datadog_checks.dev import TempDir, WaitFor, docker_run, run_command
 from datadog_checks.dev.docker import get_container_ip
+from datadog_checks.dev.http import http_get
 
 from .common import (
     ACTIVE_ENV_NAME,
@@ -55,7 +55,7 @@ def dd_environment():
         if not os.path.exists(data_dir):
             shutil.copytree(os.path.join(COMPOSE_DIR, 'data'), data_dir)
             for data_file in FILES:
-                response = requests.get(data_file)
+                response = http_get(data_file)
                 with open(os.path.join(data_dir, data_file.rsplit('/', 1)[1]), 'wb') as output:
                     output.write(response.content)
 

--- a/spark/tests/conftest.py
+++ b/spark/tests/conftest.py
@@ -4,11 +4,11 @@
 import os
 
 import pytest
-import requests
 from datadog_test_libs.utils.mock_dns import mock_local
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
+from datadog_checks.dev.http import http_get
 
 from .common import HERE, HOST, HOSTNAME_TO_PORT_MAPPING, INSTANCE_STANDALONE
 
@@ -36,7 +36,7 @@ def dd_environment():
 
 def check_metrics_available():
     endpoint = 'http://{}:4050/metrics/json'.format(HOST)
-    r = requests.get(endpoint)
+    r = http_get(endpoint)
     return r.text.count("driver.spark.streaming") >= 6
 
 
@@ -49,11 +49,11 @@ def check_executors_registered():
     # of the two apps can own a non-driver executor at a time; either app having one is
     # enough for `test_integration_standalone` to observe executor metrics.
     for port in (4040, 4050):
-        apps = requests.get('http://{}:{}/api/v1/applications'.format(HOST, port)).json()
+        apps = http_get('http://{}:{}/api/v1/applications'.format(HOST, port)).json()
         if not apps:
             continue
         app_id = apps[0]['id']
-        executors = requests.get('http://{}:{}/api/v1/applications/{}/executors'.format(HOST, port, app_id)).json()
+        executors = http_get('http://{}:{}/api/v1/applications/{}/executors'.format(HOST, port, app_id)).json()
         if any(executor.get('id') != 'driver' for executor in executors):
             return True
     return False

--- a/squid/tests/test_unit.py
+++ b/squid/tests/test_unit.py
@@ -67,8 +67,7 @@ def test_get_counters(check, mock_http):
         mock_http.get.return_value = MockHTTPResponse(content="client_http.requests=42\n\n")
         check.parse_counter = mock.MagicMock(return_value=('foo', 'bar'))
         check.get_counters('host', 'port', [])
-        # we assert `parse_counter` was called only once despite the raw text
-        # containing multiple `\n` chars
+        # Assert parse_counter is called once despite multiple newline chars in the raw text.
         check.parse_counter.assert_called_once()
 
 

--- a/torchserve/tests/torchserve_api.py
+++ b/torchserve/tests/torchserve_api.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import requests
+from datadog_checks.dev.http import http_post, http_put
 
 from .common import INFERENCE_API_URL, MANAGEMENT_API_URL
 
@@ -11,7 +11,7 @@ from .common import INFERENCE_API_URL, MANAGEMENT_API_URL
 
 def run_prediction(model):
     try:
-        response = requests.post(
+        response = http_post(
             f"{INFERENCE_API_URL}/predictions/{model}",
             data='{"input": 2.0}',
             headers={'Content-Type': 'application/json'},
@@ -25,7 +25,7 @@ def run_prediction(model):
 
 def set_model_default_version(model, version):
     try:
-        response = requests.put(
+        response = http_put(
             f"{MANAGEMENT_API_URL}/models/{model}/{version}/set-default",
         )
         response.raise_for_status()
@@ -37,7 +37,7 @@ def set_model_default_version(model, version):
 
 def update_workers(model, min, max):
     try:
-        response = requests.put(
+        response = http_put(
             f"{MANAGEMENT_API_URL}/models/{model}",
             params={
                 "min_worker": min,
@@ -53,7 +53,7 @@ def update_workers(model, min, max):
 
 def register_model(model):
     try:
-        response = requests.post(f"{MANAGEMENT_API_URL}/models", params={"url": model})
+        response = http_post(f"{MANAGEMENT_API_URL}/models", params={"url": model})
         response.raise_for_status()
     except Exception:
         return False

--- a/twemproxy/tests/conftest.py
+++ b/twemproxy/tests/conftest.py
@@ -2,20 +2,20 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs
+from datadog_checks.dev.http import http_get, http_put
 from datadog_checks.twemproxy import Twemproxy
 
 from . import common
 
 
 def setup_post_data():
-    requests.put('http://{}:2379/v2/keys/services/redis/01'.format(common.HOST), data={'value': 'redis1:6101'})
-    requests.put('http://{}:2379/v2/keys/services/redis/02'.format(common.HOST), data={'value': 'redis2:6102'})
-    requests.put('http://{}:2379/v2/keys/services/twemproxy/port'.format(common.HOST), data={'value': '6100'})
-    requests.put('http://{}:2379/v2/keys/services/twemproxy/host'.format(common.HOST), data={'value': 'localhost'})
+    http_put('http://{}:2379/v2/keys/services/redis/01'.format(common.HOST), data={'value': 'redis1:6101'})
+    http_put('http://{}:2379/v2/keys/services/redis/02'.format(common.HOST), data={'value': 'redis2:6102'})
+    http_put('http://{}:2379/v2/keys/services/twemproxy/port'.format(common.HOST), data={'value': '6100'})
+    http_put('http://{}:2379/v2/keys/services/twemproxy/host'.format(common.HOST), data={'value': 'localhost'})
 
 
 @pytest.fixture(scope="session")
@@ -49,6 +49,6 @@ def setup_request():
     """
     url = "http://{}:{}".format(common.HOST, common.PORT)
     try:
-        requests.get(url)
+        http_get(url)
     except Exception:
         pass

--- a/vault/tests/conftest.py
+++ b/vault/tests/conftest.py
@@ -6,12 +6,12 @@ import os
 import time
 
 import pytest
-import requests
 
 from datadog_checks.dev import LazyFunction, TempDir, docker_run, run_command
 from datadog_checks.dev.ci import running_on_ci
 from datadog_checks.dev.conditions import WaitFor
 from datadog_checks.dev.fs import create_file
+from datadog_checks.dev.http import http_get
 from datadog_checks.dev.utils import ON_WINDOWS
 from datadog_checks.vault import Vault
 
@@ -163,7 +163,7 @@ class WaitAndUnsealVault(WaitFor):
 
 
 def api_working(api_endpoint):
-    response = requests.get(api_endpoint, timeout=1).json()
+    response = http_get(api_endpoint, timeout=1).json()
     if response:
         return True
     return False

--- a/voltdb/datadog_checks/voltdb/client.py
+++ b/voltdb/datadog_checks/voltdb/client.py
@@ -33,8 +33,7 @@ class Client(object):
                 parameters = json.dumps(parameters)
             params['Parameters'] = parameters
 
-        # VoltDB expects credentials as query params.
-        # See: https://docs.voltdb.com/UsingVoltDB/ProgLangJson.php
+        # VoltDB expects credentials as query params: https://docs.voltdb.com/UsingVoltDB/ProgLangJson.php
         params['User'] = self._username
         params[self._password_field] = self._password
 

--- a/voltdb/tests/test_unit.py
+++ b/voltdb/tests/test_unit.py
@@ -84,7 +84,6 @@ CREDENTIAL_CASES = [
 
 def test_check_disables_http_auth():
     # type: () -> None
-    # VoltDB authenticates via query params, so the check disables HTTP-level auth (config-derived and .netrc).
     instance = {'url': 'http://localhost:8080', 'username': 'doggo', 'password': 'doggopass'}
     fake = mock.MagicMock()
 
@@ -96,7 +95,6 @@ def test_check_disables_http_auth():
 
 def test_raise_for_status_includes_response_details():
     # type: () -> None
-    # HTTP errors are enriched with VoltDB's statusstring detail from the response body.
     instance = {'url': 'http://localhost:8080', 'username': 'admin', 'password': 'secret'}
     check = VoltDBCheck('voltdb', {}, [instance])
     response = MockHTTPResponse(status_code=400, json_data={'statusstring': 'Bad procedure'})
@@ -160,7 +158,6 @@ def test_request_encodes_parameters(parameters, expected_value):
 @pytest.mark.parametrize('password_hashed, password_field, absent_field', CREDENTIAL_CASES)
 def test_check_wires_credentials_into_query_params(password_hashed, password_field, absent_field):
     # type: (bool, str, str) -> None
-    # Only the through-the-check path proves config.password_hashed selects the right field, with no per-call auth.
     instance = {
         'url': 'http://localhost:8080',
         'username': 'admin',

--- a/voltdb/tests/utils.py
+++ b/voltdb/tests/utils.py
@@ -55,7 +55,6 @@ class EnsureExpectedMetricsShowUp(LazyFunction):
 
     def __init__(self, instance):
         # type: (Instance) -> None
-        # Reuse the check's backend-neutral HTTP client factory. Admin creds are needed to seed data and snapshots.
         admin_instance = dict(instance, username='admin', password='admin')
         self._client = VoltDBCheck('voltdb', {}, [admin_instance])._client
 

--- a/weaviate/tests/conftest.py
+++ b/weaviate/tests/conftest.py
@@ -7,9 +7,9 @@ import time
 from contextlib import ExitStack
 
 import pytest
-import requests
 
 from datadog_checks.dev import get_here
+from datadog_checks.dev.http import HTTPError, http_get, http_post
 from datadog_checks.dev.kind import kind_run
 from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.subprocess import run_command
@@ -65,7 +65,7 @@ def make_weaviate_request(instance):
         headers.update(instance['headers'])
 
     if ready_check(weaviate_api_endpoint, 300):
-        requests.post(weaviate_batch_endpoint, headers=headers, data=json.dumps(BATCH_OBJECTS))
+        http_post(weaviate_batch_endpoint, headers=headers, data=json.dumps(BATCH_OBJECTS))
 
 
 def ready_check(endpoint, timeout=300):
@@ -75,10 +75,10 @@ def ready_check(endpoint, timeout=300):
     endpoint = f'{endpoint}{DEFAULT_LIVENESS_ENDPOINT}'
     while time.time() < stop_time:
         try:
-            response = requests.get(endpoint, timeout=5)
+            response = http_get(endpoint, timeout=5)
             if response.ok:
                 return True
-        except requests.RequestException as e:
+        except HTTPError as e:
             print(f'Request failed: {e}')
 
         time.sleep(1)


### PR DESCRIPTION
### What does this PR do?

Routes the intentional real-HTTP calls in test-harness code (readiness checks in `dd_environment`, fixture setup, e2e helpers) across 34 integrations from `requests` to the library-agnostic dev seam in `datadog_checks.dev.http` (`dev_http_client` / `http_get` plus the agnostic HTTP exceptions), and adds that seam and its unit tests. Loops reuse a single `dev_http_client(persist=True)`. The `except requests.*` handlers are remapped to the agnostic exception types. Response usage is unchanged, since the real client returns a requests-compatible response.

Open items needing a decision (marklogic digest, the cisco_aci utility), the skipped container-side and script files, and the validation status are tracked in Confluence: [Harness HTTP fixture agnosticization (PR #24682)](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/7013105770/Harness+HTTP+fixture+agnosticization+PR+24682+open+items+skips+validation).

Intentionally left on `requests`:
- marklogic: 3 `HTTPDigestAuth` calls (digest is a known open parity item).
- Container-side code (`tests/docker/`, `tests/compose/`) and standalone `scripts/`, which do not run in the ddev test environment where `datadog_checks.dev` is importable.

Production check code is already backend-agnostic. This PR touches test code plus the new dev seam only. No changelog entry here by design.

### Motivation

Part of moving the entire repo to agnostic HTTP. Test setup that hits real endpoints was still bound to `requests`. Routing it through the same `create_http_client` factory the Agent uses keeps the test harness on the production HTTP backend, so it follows the library across the cutover.

### Verification

`ddev test -fs` is clean across the changed set, and pytest collection succeeds for the swapped integrations. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
