### PR TITLE
Aggregate metrics per (destination, user, component_type, conn)

### DIFF
--- a/tibco_ems/changelog.d/24685.fixed
+++ b/tibco_ems/changelog.d/24685.fixed
@@ -1,0 +1,1 @@
+Aggregate metrics per (destination, user, component_type, conn)

--- a/tibco_ems/datadog_checks/tibco_ems/constants.py
+++ b/tibco_ems/datadog_checks/tibco_ems/constants.py
@@ -99,6 +99,7 @@ SHOW_METRIC_DATA = {
             'messages_rate_size',
         ],
         'tags': ['destination', 'user', 'component_type', 'conn'],
+        'aggregate': True,
     },
     'show stat producers': {
         'regex': re.compile(
@@ -119,6 +120,7 @@ SHOW_METRIC_DATA = {
             'messages_rate_size',
         ],
         'tags': ['destination', 'user', 'component_type', 'conn'],
+        'aggregate': True,
     },
     'show connections full': {
         'regex': re.compile(

--- a/tibco_ems/datadog_checks/tibco_ems/constants.py
+++ b/tibco_ems/datadog_checks/tibco_ems/constants.py
@@ -98,7 +98,7 @@ SHOW_METRIC_DATA = {
             'messages_rate',
             'messages_rate_size',
         ],
-        'tags': ['destination', 'user', 'component_type', 'conn', 'destination'],
+        'tags': ['destination', 'user', 'component_type', 'conn'],
     },
     'show stat producers': {
         'regex': re.compile(
@@ -118,7 +118,7 @@ SHOW_METRIC_DATA = {
             'messages_rate',
             'messages_rate_size',
         ],
-        'tags': ['destination', 'user', 'component_type', 'conn', 'destination'],
+        'tags': ['destination', 'user', 'component_type', 'conn'],
     },
     'show connections full': {
         'regex': re.compile(

--- a/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
+++ b/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
@@ -80,7 +80,7 @@ class TibcoEMSCheck(AgentCheck):
             if command == 'show server':
                 self._submit_metrics_factory(metric_prefix, metric_info, metric_keys, tag_keys)
             else:
-                if command in {'show stat consumers', 'show stat producers'}:
+                if SHOW_METRIC_DATA[command].get('aggregate'):
                     metric_info = self._aggregate_metric_entries(metric_info, metric_keys, tag_keys)
                 for metric_entry in metric_info:
                     self._submit_metrics_factory(metric_prefix, metric_entry, metric_keys, tag_keys)
@@ -217,9 +217,10 @@ class TibcoEMSCheck(AgentCheck):
     ) -> list[dict[str, Any]]:
         aggregated_entries = {}
         for metric_entry in metric_entries:
-            tag_values = tuple((key, metric_entry[key]) for key in tag_keys if metric_entry.get(key))
+            present_keys = [key for key in tag_keys if key in metric_entry]
+            tag_values = tuple((key, metric_entry[key]) for key in present_keys)
             aggregated_entry = aggregated_entries.setdefault(
-                tag_values, {key: metric_entry[key] for key in tag_keys if key in metric_entry}
+                tag_values, {key: metric_entry[key] for key in present_keys}
             )
             for metric_name in metric_names:
                 metric_value = metric_entry[metric_name]

--- a/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
+++ b/tibco_ems/datadog_checks/tibco_ems/tibco_ems.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
 import subprocess
-from typing import Any  # noqa: F401
+from typing import Any
 
 from datadog_checks.base import AgentCheck, is_affirmative
 
@@ -80,6 +80,8 @@ class TibcoEMSCheck(AgentCheck):
             if command == 'show server':
                 self._submit_metrics_factory(metric_prefix, metric_info, metric_keys, tag_keys)
             else:
+                if command in {'show stat consumers', 'show stat producers'}:
+                    metric_info = self._aggregate_metric_entries(metric_info, metric_keys, tag_keys)
                 for metric_entry in metric_info:
                     self._submit_metrics_factory(metric_prefix, metric_entry, metric_keys, tag_keys)
 
@@ -209,6 +211,23 @@ class TibcoEMSCheck(AgentCheck):
                         info[key] = self._parse_generic(value)
                 data.append(info)
         return data
+
+    def _aggregate_metric_entries(
+        self, metric_entries: list[dict[str, Any]], metric_names: list[str], tag_keys: list[str]
+    ) -> list[dict[str, Any]]:
+        aggregated_entries = {}
+        for metric_entry in metric_entries:
+            tag_values = tuple((key, metric_entry[key]) for key in tag_keys if metric_entry.get(key))
+            aggregated_entry = aggregated_entries.setdefault(
+                tag_values, {key: metric_entry[key] for key in tag_keys if key in metric_entry}
+            )
+            for metric_name in metric_names:
+                metric_value = metric_entry[metric_name]
+                if isinstance(metric_value, dict):
+                    metric_value = metric_value['value'] * TO_BYTES[metric_value['unit'].lower()]
+                aggregated_entry[metric_name] = aggregated_entry.get(metric_name, 0) + metric_value
+
+        return list(aggregated_entries.values())
 
     def _submit_metrics_factory(self, prefix, metric_data, metric_names, tag_keys):
         self.log.debug("Submitting %s metrics (%s tags) for %s", len(metric_names), len(tag_keys), prefix)

--- a/tibco_ems/tests/test_unit.py
+++ b/tibco_ems/tests/test_unit.py
@@ -104,6 +104,38 @@ def test_show_metrics(dd_run_check, aggregator, instance, output, expected_metri
 
 
 @pytest.mark.parametrize(
+    "command, metric_prefix",
+    [
+        pytest.param("show stat consumers", "consumer", id="consumers"),
+        pytest.param("show stat producers", "producer", id="producers"),
+    ],
+)
+def test_stat_metrics_are_aggregated_by_tags(dd_run_check, aggregator, instance, command, metric_prefix):
+    output = f"""Command: {command}
+                                      Total Count      Rate/Second
+User       Conn  T  Destination       Msgs   Size      Msgs   Size
+admin         2  Q  sample.queue         1    2.4 Kb      3    0.6 Kb
+admin         2  Q  sample.queue         4    0.5 Mb      5    0.4 Kb
+""".encode()
+    tags = [
+        'destination:sample.queue',
+        'user:admin',
+        'component_type:Q',
+        'conn:2',
+        'optional:tag1',
+    ]
+    check = TibcoEMSCheck('tibco_ems', {}, [instance])
+    check.run_tibco_command = MagicMock(return_value=output)
+
+    dd_run_check(check)
+
+    aggregator.assert_metric(f'tibco_ems.{metric_prefix}.total_messages', value=5, tags=tags, count=1)
+    aggregator.assert_metric(f'tibco_ems.{metric_prefix}.total_messages_size', value=502_400, tags=tags, count=1)
+    aggregator.assert_metric(f'tibco_ems.{metric_prefix}.messages_rate', value=8, tags=tags, count=1)
+    aggregator.assert_metric(f'tibco_ems.{metric_prefix}.messages_rate_size', value=1_000, tags=tags, count=1)
+
+
+@pytest.mark.parametrize(
     "expected_result, data, regex",
     [
         pytest.param(

--- a/tibco_ems/tests/test_unit.py
+++ b/tibco_ems/tests/test_unit.py
@@ -116,12 +116,29 @@ def test_stat_metrics_are_aggregated_by_tags(dd_run_check, aggregator, instance,
 User       Conn  T  Destination       Msgs   Size      Msgs   Size
 admin         2  Q  sample.queue         1    2.4 Kb      3    0.6 Kb
 admin         2  Q  sample.queue         4    0.5 Mb      5    0.4 Kb
+admin         2  Q  other.queue          6    1.0 Kb      7    2.0 Kb
+admin         0  Q  sample.queue         9    3.0 Kb     10    4.0 Kb
 """.encode()
     tags = [
         'destination:sample.queue',
         'user:admin',
         'component_type:Q',
         'conn:2',
+        'optional:tag1',
+    ]
+    other_tags = [
+        'destination:other.queue',
+        'user:admin',
+        'component_type:Q',
+        'conn:2',
+        'optional:tag1',
+    ]
+    # conn=0 parses falsy and is dropped at submission by _submit_metrics_factory's
+    # own truthy tag filter, same as it would be for a single, unaggregated row.
+    falsy_conn_tags = [
+        'destination:sample.queue',
+        'user:admin',
+        'component_type:Q',
         'optional:tag1',
     ]
     check = TibcoEMSCheck('tibco_ems', {}, [instance])
@@ -133,6 +150,15 @@ admin         2  Q  sample.queue         4    0.5 Mb      5    0.4 Kb
     aggregator.assert_metric(f'tibco_ems.{metric_prefix}.total_messages_size', value=502_400, tags=tags, count=1)
     aggregator.assert_metric(f'tibco_ems.{metric_prefix}.messages_rate', value=8, tags=tags, count=1)
     aggregator.assert_metric(f'tibco_ems.{metric_prefix}.messages_rate_size', value=1_000, tags=tags, count=1)
+
+    # A different destination must stay a separate series, not fold into the group above.
+    aggregator.assert_metric(f'tibco_ems.{metric_prefix}.total_messages', value=6, tags=other_tags, count=1)
+    aggregator.assert_metric(f'tibco_ems.{metric_prefix}.messages_rate', value=7, tags=other_tags, count=1)
+
+    # conn=0 is still its own aggregation group (grouping now keys on presence,
+    # not truthiness), even though the tag itself is dropped at submission.
+    aggregator.assert_metric(f'tibco_ems.{metric_prefix}.total_messages', value=9, tags=falsy_conn_tags, count=1)
+    aggregator.assert_metric(f'tibco_ems.{metric_prefix}.messages_rate', value=10, tags=falsy_conn_tags, count=1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?
Sums metrics per (destination, user, component_type, conn) before submitting them as gauges in the tibco_ems check.

### Motivation
tibco_ems submits distinct consumer or producer rows with the same metric identity when they share destination, user, type, and connection. The agent then keeps only the last gauge value for that context, so a portion of the metrics is dropped.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
