### PR TITLE
Add missing marklogic.forests.current_foreign_master_database metric to metadata

### DIFF
--- a/marklogic/changelog.d/24686.fixed
+++ b/marklogic/changelog.d/24686.fixed
@@ -1,0 +1,1 @@
+Add the missing `marklogic.forests.current_foreign_master_database` metric to `metadata.csv`.

--- a/marklogic/changelog.d/24686.fixed
+++ b/marklogic/changelog.d/24686.fixed
@@ -1,1 +1,0 @@
-Add the missing `marklogic.forests.current_foreign_master_database` metric to `metadata.csv`.

--- a/marklogic/metadata.csv
+++ b/marklogic/metadata.csv
@@ -69,6 +69,7 @@ marklogic.forests.compressed_tree_cache_hit_rate,gauge,,hit,second,"The average 
 marklogic.forests.compressed_tree_cache_miss_rate,gauge,,miss,second,"The average number of misses on the compressed cache.",0,marklogic,forest tree cache miss,
 marklogic.forests.compressed_tree_cache_ratio,gauge,,percent,,"The compressed cache ratio",0,marklogic,forest tree cache ratio,
 marklogic.forests.current_foreign_master_cluster,gauge,,unit,,"The cluster ID coupled with the local cluster.",0,marklogic,forest foreign master cluster,
+marklogic.forests.current_foreign_master_database,gauge,,unit,,"The database ID coupled with the local cluster.",0,marklogic,forest foreign master database,
 marklogic.forests.current_foreign_master_fsn,gauge,,unit,,"The ID of the last journal frame received from the foreign master",0,marklogic,forest foreign master fsn,
 marklogic.forests.current_master_fsn,gauge,,unit,,"The journal frame ID of the local master",0,marklogic,forest master fsn,
 marklogic.forests.database_replication_receive_load,gauge,,,,"Time threads spent receiving data for database replication, in proportion to the elapsed time.",0,marklogic,forest db replication recv load,


### PR DESCRIPTION
### What does this PR do?

Adds the missing `marklogic.forests.current_foreign_master_database` metric to `marklogic/metadata.csv`.

### Motivation

The MarkLogic check emits `marklogic.forests.current-foreign-master-database` (a forest status metric, declared as an optional metric in the test suite), but it was never listed in `metadata.csv`. Its two siblings (`current_foreign_master_cluster` and `current_foreign_master_fsn`) are present, so the omission looks accidental.

This caused the metadata assertion to fail in CI:

```
AssertionError: Metadata assertion errors using metadata.csv:
 - Expect `marklogic.forests.current_foreign_master_database` to be in metadata.csv.
```

See the failing marklogic job: https://github.com/DataDog/integrations-core/actions/runs/30017399457/job/89240919915?pr=24646

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
