### PR TITLE
Use agnostic SSL error in Azure IoT Edge E2E test

### DIFF
--- a/azure_iot_edge/tests/test_e2e.py
+++ b/azure_iot_edge/tests/test_e2e.py
@@ -5,10 +5,10 @@ import copy
 from typing import Callable  # noqa: F401
 
 import pytest
-import requests
 
 from datadog_checks.azure_iot_edge import AzureIoTEdgeCheck
 from datadog_checks.base.stubs.aggregator import AggregatorStub  # noqa: F401
+from datadog_checks.base.utils.http_exceptions import HTTPSSLError
 
 from . import common
 
@@ -40,7 +40,7 @@ def test_bad_url_e2e(e2e_instance, dd_agent_check):
     bad_url_agent_instance = copy.deepcopy(e2e_instance)
     bad_url_agent_instance['edge_agent_prometheus_url'] = bad_url_hub_instance['edge_agent_prometheus_url'][:-2]
 
-    with pytest.raises(requests.exceptions.SSLError):
+    with pytest.raises(HTTPSSLError):
         dd_agent_check(bad_url_hub_instance, rate=True)
 
     aggregator = dd_agent_check(bad_url_agent_instance, rate=True)


### PR DESCRIPTION
### What does this PR do?
Replaces the Azure IoT Edge bad-url E2E test's `requests.exceptions.SSLError` expectation with the backend-agnostic `HTTPSSLError`.

This is a narrow CI probe stacked on #22676 to verify whether the live Azure IoT Edge E2E path surfaces the agnostic Agent HTTP exception without a stdlib fallback.

### Motivation
The HTTP backend migration needs integration tests to depend on `datadog_checks.base.utils.http_exceptions` rather than `requests` exception classes. CI should be sufficient to tell us whether this E2E case can rely on `HTTPSSLError` only.

Local validation:

- `python -m py_compile azure_iot_edge/tests/test_e2e.py`
- `ddev test --lint azure_iot_edge`
- `ddev --no-interactive test azure_iot_edge` (E2E tests skipped locally)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
