### PR TITLE
Handle Proxmox HA/task API null responses gracefully

### DIFF
--- a/proxmox/README.md
+++ b/proxmox/README.md
@@ -16,7 +16,22 @@ Install the [Datadog Agent][2] and configure the Proxmox integration on one Prox
 
 ### Configuration
 
-1. Create an [API Token][10] in your Proxmox Management Interface. The [PVEAuditor][11] role can be associated with the token to provide access to the necessary API endpoints.
+1. Create a dedicated user and an [API Token][10] in your Proxmox Management Interface.
+   Assign the [PVEAuditor][11] role at the `/` path with propagation enabled. When token privilege separation is
+   enabled, assign the role to both the backing user and the token. Proxmox restricts a privilege-separated token
+   to the intersection of the user and token permissions.
+
+   Verify the effective permissions for both identities:
+
+   ```shell
+   pveum user permissions <USER>@<REALM>
+   pveum user token permissions <USER>@<REALM> <TOKEN_ID>
+   ```
+
+   The integration queries the QEMU Guest Agent for guest hostnames. That endpoint requires the `VM.Monitor`
+   privilege, which is not included in `PVEAuditor`. Without it, the integration safely uses the configured VM name
+   as the hostname. Only grant `VM.Monitor` through a custom role if guest hostnames are required and the broader
+   access is acceptable.
 2. Edit the `proxmox.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your proxmox performance data. See the [sample proxmox.d/conf.yaml][4] for all available configuration options. Ensure you have set the following parameters:
 
     ```

--- a/proxmox/changelog.d/24693.fixed
+++ b/proxmox/changelog.d/24693.fixed
@@ -1,0 +1,1 @@
+Handle null Proxmox API responses and isolate task collection failures by node.

--- a/proxmox/datadog_checks/proxmox/check.py
+++ b/proxmox/datadog_checks/proxmox/check.py
@@ -46,7 +46,8 @@ class ProxmoxCheck(AgentCheck, ConfigMixin):
     def __init__(self, name, init_config, instances):
         super(ProxmoxCheck, self).__init__(name, init_config, instances)
         self.all_resources = {}
-        self.last_event_collect_time = get_current_datetime()
+        self.initial_event_collect_time = get_current_datetime()
+        self.last_event_collect_times = {}
         self.resource_filters = self._parse_resource_filters(self.instance.get('resource_filters', []))
         self.check_initializations.append(self._parse_config)
 
@@ -409,15 +410,19 @@ class ProxmoxCheck(AgentCheck, ConfigMixin):
                 continue
 
             node_name = resource.get('hostname')
-            since = int(get_timestamp(self.last_event_collect_time))
+            last_collect_time = self.last_event_collect_times.get(node_name, self.initial_event_collect_time)
+            since = int(get_timestamp(last_collect_time))
             self.log.debug("Collecting events for node %s since %s", node_name, since)
 
-            now = get_current_datetime()
+            collection_time = get_current_datetime()
             params = {'since': since}
             url = f"{self.config.proxmox_server}/nodes/{node_name}/tasks"
-            response = self.http.get(url, params=params)
-            tasks = self._response_data(response, url, list, [])
-            self.last_event_collect_time = now
+            try:
+                response = self.http.get(url, params=params)
+                tasks = self._response_data(response, url, list, [])
+            except (HTTPError, InvalidURL, ConnectionError, Timeout, JSONDecodeError, CheckException) as e:
+                self.log.warning("Failed to collect tasks for node %s; endpoint: %s; %s", node_name, url, e)
+                continue
 
             for task in tasks:
                 task_type = task.get('type')
@@ -429,6 +434,8 @@ class ProxmoxCheck(AgentCheck, ConfigMixin):
                 if event is not None:
                     self.log.debug("Submitting event %s", event)
                     self.event(event)
+
+            self.last_event_collect_times[node_name] = collection_time
 
     def check(self, _):
         try:

--- a/proxmox/datadog_checks/proxmox/check.py
+++ b/proxmox/datadog_checks/proxmox/check.py
@@ -3,10 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import re
+from typing import Any, cast
 
 from requests.exceptions import ConnectionError, HTTPError, InvalidURL, JSONDecodeError, Timeout
 
 from datadog_checks.base import AgentCheck
+from datadog_checks.base.errors import CheckException
 from datadog_checks.base.utils.time import get_current_datetime, get_timestamp
 from datadog_checks.proxmox.config_models import ConfigMixin
 
@@ -25,6 +27,8 @@ from .constants import (
     VM_RESOURCE,
 )
 from .resource_filters import create_resource_filter, is_resource_collected_by_filters
+
+NULL_DEFAULT = object()
 
 
 def resource_type_for_event_type(event_type):
@@ -145,6 +149,51 @@ class ProxmoxCheck(AgentCheck, ConfigMixin):
                     metric_tags = list(tags) + [f'infra_mode:{infra_mode}']
                 metric_method(f'{metric_name_remapped}', metric_value, tags=metric_tags, hostname=hostname)
 
+    def _extract_data[T](
+        self,
+        response_json: object,
+        url: str,
+        expected_type: type[T],
+        null_default: T | object = NULL_DEFAULT,
+    ) -> T:
+        """Extract and validate data from a Proxmox API response."""
+        if not isinstance(response_json, dict):
+            raise CheckException(f"Proxmox API returned an invalid response for {url}: expected an object")
+
+        data = response_json.get('data')
+        if data is None:
+            if message := response_json.get('message'):
+                raise CheckException(f"Proxmox API returned an error for {url}: {message}")
+            if null_default is not NULL_DEFAULT:
+                return cast(T, null_default)
+            raise CheckException(f"Proxmox API returned null data for {url}")
+
+        if not isinstance(data, expected_type):
+            raise CheckException(
+                f"Proxmox API returned invalid data for {url}: expected {expected_type.__name__}, "
+                f"got {type(data).__name__}"
+            )
+
+        return data
+
+    def _response_data[T](
+        self,
+        response: Any,
+        url: str,
+        expected_type: type[T],
+        null_default: T | object = NULL_DEFAULT,
+    ) -> T:
+        """Raise API errors and return validated response data."""
+        try:
+            response_json = response.json()
+        except JSONDecodeError:
+            response.raise_for_status()
+            raise
+
+        data = self._extract_data(response_json, url, expected_type, null_default)
+        response.raise_for_status()
+        return data
+
     def _get_vm_hostname(self, vm_id, vm_name, node):
         try:
             url = f"{self.config.proxmox_server}/nodes/{node}/qemu/{vm_id}/agent/get-host-name"
@@ -211,9 +260,9 @@ class ProxmoxCheck(AgentCheck, ConfigMixin):
 
     def _collect_ha_metrics(self):
         self.log.debug("Collecting HA metrics")
-        ha_response = self.http.get(f"{self.config.proxmox_server}/cluster/ha/status/current")
-        ha_response_json = ha_response.json()
-        ha_statuses = ha_response_json.get('data', [])
+        url = f"{self.config.proxmox_server}/cluster/ha/status/current"
+        ha_response = self.http.get(url)
+        ha_statuses = self._response_data(ha_response, url, list, [])
         for ha_status in ha_statuses:
             if not ha_status.get('type') == 'quorum':
                 continue
@@ -228,15 +277,16 @@ class ProxmoxCheck(AgentCheck, ConfigMixin):
 
     def _collect_performance_metrics(self):
         self.log.debug("Collecting performance metrics")
-        metrics_response = self.http.get(f"{self.config.proxmox_server}/cluster/metrics/export")
-        if not metrics_response.ok:
+        url = f"{self.config.proxmox_server}/cluster/metrics/export"
+        metrics_response = self.http.get(url)
+        if metrics_response.status_code in {404, 501}:
             self.log.warning(
                 "Performance metrics endpoint not available (HTTP %s), skipping collection",
                 metrics_response.status_code,
             )
             return
-        metrics_response_json = metrics_response.json()
-        metrics = metrics_response_json.get('data', {}).get('data', [])
+        metrics_response_data = self._response_data(metrics_response, url, dict)
+        metrics = self._extract_data(metrics_response_data, f"{url} response data", list, [])
 
         for metric in metrics:
             resource_id = metric.get('id')
@@ -258,9 +308,9 @@ class ProxmoxCheck(AgentCheck, ConfigMixin):
 
     def _collect_resource_metrics(self):
         self.log.debug("Collecting resource metrics.")
-        resources_response = self.http.get(f"{self.config.proxmox_server}/cluster/resources")
-        resources_response_json = resources_response.json()
-        resources = resources_response_json.get("data", [])
+        url = f"{self.config.proxmox_server}/cluster/resources"
+        resources_response = self.http.get(url)
+        resources = self._response_data(resources_response, url, list)
 
         external_tags = []
         all_resources = {}
@@ -364,13 +414,12 @@ class ProxmoxCheck(AgentCheck, ConfigMixin):
 
             now = get_current_datetime()
             params = {'since': since}
-            response = self.http.get(f"{self.config.proxmox_server}/nodes/{node_name}/tasks", params=params)
-            response.raise_for_status()
-
-            response_json = response.json().get("data", [])
+            url = f"{self.config.proxmox_server}/nodes/{node_name}/tasks"
+            response = self.http.get(url, params=params)
+            tasks = self._response_data(response, url, list, [])
             self.last_event_collect_time = now
 
-            for task in response_json:
+            for task in tasks:
                 task_type = task.get('type')
 
                 if task_type not in self.config.collected_task_types:
@@ -383,15 +432,14 @@ class ProxmoxCheck(AgentCheck, ConfigMixin):
 
     def check(self, _):
         try:
-            response = self.http.get(f"{self.config.proxmox_server}/version")
-            response.raise_for_status()
-
-            response_json = response.json()
-            version = response_json.get("data", {}).get("version")
+            url = f"{self.config.proxmox_server}/version"
+            response = self.http.get(url)
+            version_data = self._response_data(response, url, dict)
+            version = version_data.get("version")
             self.set_metadata('version', version)
             self.gauge("api.up", 1, tags=self.base_tags + ['proxmox_status:up'])
 
-        except (HTTPError, InvalidURL, ConnectionError, Timeout, JSONDecodeError) as e:
+        except (HTTPError, InvalidURL, ConnectionError, Timeout, JSONDecodeError, CheckException) as e:
             self.log.error(
                 "Encountered an Exception when hitting the Proxmox API %s: %s", self.config.proxmox_server, e
             )

--- a/proxmox/tests/test_unit.py
+++ b/proxmox/tests/test_unit.py
@@ -577,6 +577,12 @@ def test_performance_metrics_null_data(dd_run_check, aggregator, instance):
 
 
 PERMISSION_DENIED_RESPONSE = {'data': None, 'message': 'Permission check failed (/ , Sys.Audit)'}
+TWO_NODE_RESOURCES = {
+    'data': [
+        {'id': 'node/node-1', 'node': 'node-1', 'status': 'online', 'type': 'node'},
+        {'id': 'node/node-2', 'node': 'node-2', 'status': 'online', 'type': 'node'},
+    ]
+}
 
 
 @pytest.mark.parametrize(
@@ -696,13 +702,90 @@ def test_tasks_null_data(dd_run_check, aggregator, instance):
     indirect=True,
 )
 @pytest.mark.usefixtures('mock_http_get')
-def test_tasks_api_error_response(dd_run_check, instance):
+def test_tasks_api_error_response(dd_run_check, instance, caplog):
     new_instance = copy.deepcopy(instance)
     new_instance['collect_tasks'] = True
     check = ProxmoxCheck('proxmox', {}, [new_instance])
 
-    with pytest.raises(Exception, match=r'Permission check failed \(/ , Sys.Audit\)'):
-        dd_run_check(check, extract_message=True)
+    dd_run_check(check)
+
+    assert "Failed to collect tasks for node ip-122-82-3-112" in caplog.text
+    assert "Permission check failed (/ , Sys.Audit)" in caplog.text
+
+
+@pytest.mark.parametrize(
+    'mock_http_get',
+    [
+        pytest.param(
+            {
+                'http_error': {
+                    '/api2/json/cluster/resources': MockResponse(status_code=200, json_data=TWO_NODE_RESOURCES),
+                    '/api2/json/nodes/node-1/tasks': MockResponse(status_code=200, json_data={'data': []}),
+                    '/api2/json/nodes/node-2/tasks': MockResponse(status_code=200, json_data={'data': []}),
+                }
+            },
+            id='two-nodes',
+        ),
+    ],
+    indirect=True,
+)
+def test_tasks_use_per_node_collection_windows(dd_run_check, instance, mock_http_get, monkeypatch):
+    collect_times = [
+        datetime.fromtimestamp(100, timezone.utc),
+        datetime.fromtimestamp(200, timezone.utc),
+        datetime.fromtimestamp(300, timezone.utc),
+    ]
+    monkeypatch.setattr('datadog_checks.proxmox.check.get_current_datetime', mock.MagicMock(side_effect=collect_times))
+    new_instance = copy.deepcopy(instance)
+    new_instance['collect_tasks'] = True
+    check = ProxmoxCheck('proxmox', {}, [new_instance])
+
+    dd_run_check(check)
+
+    task_calls = [call for call in mock_http_get.call_args_list if call.args[0].endswith('/tasks')]
+    assert [call.kwargs['params']['since'] for call in task_calls] == [100, 100]
+    assert check.last_event_collect_times == {'node-1': collect_times[1], 'node-2': collect_times[2]}
+
+
+@pytest.mark.parametrize(
+    'mock_http_get',
+    [
+        pytest.param(
+            {
+                'http_error': {
+                    '/api2/json/cluster/resources': MockResponse(status_code=200, json_data=TWO_NODE_RESOURCES),
+                    '/api2/json/nodes/node-1/tasks': MockResponse(
+                        status_code=500,
+                        json_data={'data': None, 'message': 'node unavailable'},
+                    ),
+                    '/api2/json/nodes/node-2/tasks': MockResponse(status_code=200, json_data={'data': []}),
+                }
+            },
+            id='first-node-unavailable',
+        ),
+    ],
+    indirect=True,
+)
+def test_task_error_does_not_block_other_nodes(dd_run_check, instance, mock_http_get, monkeypatch, caplog):
+    collect_times = [
+        datetime.fromtimestamp(100, timezone.utc),
+        datetime.fromtimestamp(200, timezone.utc),
+        datetime.fromtimestamp(300, timezone.utc),
+    ]
+    monkeypatch.setattr('datadog_checks.proxmox.check.get_current_datetime', mock.MagicMock(side_effect=collect_times))
+    new_instance = copy.deepcopy(instance)
+    new_instance['collect_tasks'] = True
+    check = ProxmoxCheck('proxmox', {}, [new_instance])
+
+    dd_run_check(check)
+
+    task_calls = [call for call in mock_http_get.call_args_list if call.args[0].endswith('/tasks')]
+    assert [call.args[0] for call in task_calls] == [
+        'http://localhost:8006/api2/json/nodes/node-1/tasks',
+        'http://localhost:8006/api2/json/nodes/node-2/tasks',
+    ]
+    assert check.last_event_collect_times == {'node-2': collect_times[2]}
+    assert "Failed to collect tasks for node node-1" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/proxmox/tests/test_unit.py
+++ b/proxmox/tests/test_unit.py
@@ -525,6 +525,187 @@ def test_ha_metrics(dd_run_check, aggregator, instance):
 
 
 @pytest.mark.parametrize(
+    'mock_http_get',
+    [
+        pytest.param(
+            {
+                'http_error': {
+                    '/api2/json/cluster/ha/status/current': MockResponse(
+                        status_code=200,
+                        json_data={'data': None},
+                    )
+                }
+            },
+            id='ha-disabled',
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures('mock_http_get')
+def test_ha_metrics_null_data(dd_run_check, aggregator, instance):
+    check = ProxmoxCheck('proxmox', {}, [instance])
+    dd_run_check(check)
+
+    aggregator.assert_metric('proxmox.ha.quorum', count=0)
+    aggregator.assert_metric('proxmox.ha.quorate', count=0)
+
+
+@pytest.mark.parametrize(
+    'mock_http_get',
+    [
+        pytest.param(
+            {
+                'http_error': {
+                    '/api2/json/cluster/metrics/export': MockResponse(
+                        status_code=200,
+                        json_data={'data': {'data': None}},
+                    )
+                }
+            },
+            id='no-exported-metrics',
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures('mock_http_get')
+def test_performance_metrics_null_data(dd_run_check, aggregator, instance):
+    check = ProxmoxCheck('proxmox', {}, [instance])
+    dd_run_check(check)
+
+    for metric in {'proxmox.cpu.current', 'proxmox.disk.total', 'proxmox.mem.total'}:
+        aggregator.assert_metric(metric, count=0)
+
+
+PERMISSION_DENIED_RESPONSE = {'data': None, 'message': 'Permission check failed (/ , Sys.Audit)'}
+
+
+@pytest.mark.parametrize(
+    'mock_http_get',
+    [
+        pytest.param(
+            {
+                'http_error': {
+                    '/api2/json/cluster/resources': MockResponse(
+                        status_code=200,
+                        json_data=PERMISSION_DENIED_RESPONSE,
+                    )
+                }
+            },
+            id='resources',
+        ),
+        pytest.param(
+            {
+                'http_error': {
+                    '/api2/json/cluster/metrics/export': MockResponse(
+                        status_code=403,
+                        json_data=PERMISSION_DENIED_RESPONSE,
+                    )
+                }
+            },
+            id='performance-metrics',
+        ),
+        pytest.param(
+            {
+                'http_error': {
+                    '/api2/json/cluster/ha/status/current': MockResponse(
+                        status_code=200,
+                        json_data=PERMISSION_DENIED_RESPONSE,
+                    )
+                }
+            },
+            id='ha',
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures('mock_http_get')
+def test_api_error_response(dd_run_check, instance):
+    check = ProxmoxCheck('proxmox', {}, [instance])
+
+    with pytest.raises(Exception, match=r'Permission check failed \(/ , Sys.Audit\)'):
+        dd_run_check(check, extract_message=True)
+
+
+@pytest.mark.parametrize(
+    'mock_http_get',
+    [
+        pytest.param(
+            {
+                'http_error': {
+                    '/api2/json/cluster/resources': MockResponse(
+                        status_code=200,
+                        json_data={'data': None},
+                    )
+                }
+            },
+            id='resources',
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures('mock_http_get')
+def test_required_null_data(dd_run_check, instance):
+    check = ProxmoxCheck('proxmox', {}, [instance])
+
+    with pytest.raises(Exception, match=r'Proxmox API returned null data for .*/cluster/resources'):
+        dd_run_check(check, extract_message=True)
+
+
+@pytest.mark.parametrize(
+    'mock_http_get',
+    [
+        pytest.param(
+            {
+                'http_error': {
+                    '/api2/json/nodes/ip-122-82-3-112/tasks': MockResponse(
+                        status_code=200,
+                        json_data={'data': None},
+                    )
+                }
+            },
+            id='no-tasks',
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures('mock_http_get')
+def test_tasks_null_data(dd_run_check, aggregator, instance):
+    new_instance = copy.deepcopy(instance)
+    new_instance['collect_tasks'] = True
+    check = ProxmoxCheck('proxmox', {}, [new_instance])
+
+    dd_run_check(check)
+    assert aggregator.events == []
+
+
+@pytest.mark.parametrize(
+    'mock_http_get',
+    [
+        pytest.param(
+            {
+                'http_error': {
+                    '/api2/json/nodes/ip-122-82-3-112/tasks': MockResponse(
+                        status_code=200,
+                        json_data=PERMISSION_DENIED_RESPONSE,
+                    )
+                }
+            },
+            id='tasks',
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures('mock_http_get')
+def test_tasks_api_error_response(dd_run_check, instance):
+    new_instance = copy.deepcopy(instance)
+    new_instance['collect_tasks'] = True
+    check = ProxmoxCheck('proxmox', {}, [new_instance])
+
+    with pytest.raises(Exception, match=r'Permission check failed \(/ , Sys.Audit\)'):
+        dd_run_check(check, extract_message=True)
+
+
+@pytest.mark.parametrize(
     ('collect_tasks, task_types, expected_events'),
     [
         pytest.param(


### PR DESCRIPTION
### What does this PR do?
Makes the Proxmox check resilient to Proxmox API endpoints returning `data: null` (instead of an empty list/object) and to task collection errors on individual nodes:

- `/cluster/ha/status/current`, `/cluster/metrics/export`, and `/cluster/resources` no longer crash the check when the `data` field is `null` rather than `[]`/`{}`.
- Task collection on one node failing no longer blocks task collection on other nodes.
- Clarifies the required Proxmox API token permissions in the README.

### Motivation
The check crashed with an unhandled exception when a Proxmox cluster returned `null` for `data` on these endpoints — notably `/cluster/ha/status/current` when HA is not configured on the cluster, since `dict.get('data', [])` only falls back to the default when the key is missing, not when its value is `None`. This meant the whole check run would error out instead of gracefully skipping the unavailable data.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged