### PR TITLE
HiveMQ: design spec for OpenMetrics collection support

### DIFF
--- a/docs/superpowers/specs/2026-07-27-hivemq-openmetrics-design.md
+++ b/docs/superpowers/specs/2026-07-27-hivemq-openmetrics-design.md
@@ -1,0 +1,249 @@
+# HiveMQ: Add OpenMetrics collection as an alternative to JMX
+
+- Status: Draft
+- Related: [FRAGENT-3671](https://datadoghq.atlassian.net/browse/FRAGENT-3671)
+- Author: Ian Bucad (with Claude)
+- Date: 2026-07-27
+
+## Summary
+
+Add an OpenMetrics/Prometheus collection path to the HiveMQ integration, selectable
+per-instance via `is_jmx: false`, as an alternative to the existing JMXFetch-only
+collection. The two collection methods are mutually exclusive per instance, share no
+runtime code, and the existing JMX path's behavior and tests are unaffected.
+
+## Motivation
+
+JMX requires exposing a remote JMX port and, in containerized/Kubernetes environments,
+extra sidecar or attach machinery that OpenMetrics-style HTTP scraping avoids. HiveMQ
+ships a free, official extension
+([hivemq/hivemq-prometheus-extension](https://github.com/hivemq/hivemq-prometheus-extension))
+that exposes the same underlying metric registry over HTTP, making this a
+container/Kubernetes-friendliness improvement rather than a JMX deprecation — JMX
+remains the default and fully supported.
+
+## Background: why this is feasible
+
+HiveMQ's Prometheus extension hands the same Dropwizard `MetricRegistry` that backs
+JMX (`Services.metricRegistry()`) to `io.prometheus.client.dropwizard.DropwizardExports`
+with the default `MetricFilter.ALL` — no metric is excluded. This was confirmed by
+reading the extension's source directly:
+
+```java
+// PrometheusExtensionMain.java
+final var prometheusServer = new PrometheusServer(configuration, Services.metricRegistry());
+```
+```java
+// PrometheusServer.java
+.collector(new DropwizardExports(metricRegistry))
+```
+
+`DropwizardExports` (from `prometheus/client_java`, `simpleclient_dropwizard`) converts
+each Dropwizard metric type as follows — this is the exact, verified mapping, not an
+assumption:
+
+| Dropwizard type | JMX attribute(s) collected today | Prometheus/OpenMetrics wire type | Notes |
+|---|---|---|---|
+| `Gauge` | `Value` | `gauge` | 1:1, same value |
+| `Counter` | `Count` | `gauge` (not `counter`!) | Same numeric value, but wire type metadata says `gauge` |
+| `Histogram` | `50th/75th/95th/98th/99th/999thPercentile`, `Count`, `Max`, `Mean`, `Min`, `StdDev`, `SnapshotSize` (12 attrs) | `summary`: quantiles `{0.5,0.75,0.95,0.98,0.99,0.999}` + `_count` (7 of 12) | `Max`, `Mean`, `Min`, `StdDev`, `SnapshotSize` are **not exposed** — `DropwizardExports.fromHistogram` doesn't emit them |
+| `Meter`/`Timer` | not collected today | counter `_total` / summary | No regression; out of scope |
+
+Name mapping is deterministic: `Collector.sanitizeMetricName()` replaces every
+non-alphanumeric character (`.`, `-`) with `_`, e.g.
+`com.hivemq.cache.payload-persistence.hit-rate` → `com_hivemq_cache_payload_persistence_hit_rate`.
+
+### Documented gap
+
+The 9 histogram-backed metric groups currently collected via JMX lose their `.max`,
+`.mean`, `.min`, `.std_dev`, `.snapshot_size` sub-metrics under OpenMetrics (45 of the
+current ~246 `metadata.csv` rows). This is a permanent limitation of the Dropwizard →
+Prometheus exporter, not a config gap on our side:
+
+- `extension.managed_executor.scheduled.percent_of_period`
+- `messages.incoming.publish.bytes`
+- `messages.incoming.total.bytes`
+- `messages.outgoing.publish.bytes`
+- `messages.outgoing.total.bytes`
+- `messages.retained.mean`
+- `networking.connections.mean`
+- `payload_persistence.cleanup_executor.scheduled.percent_of_period`
+- `persistence_scheduled_executor.scheduled.percent_of_period`
+
+All ~64 gauges and ~46 counters carry over unchanged (only wire-level type metadata
+differs for counters, not availability). This gap must be stated explicitly in the
+`is_jmx` config description and README so it's a known tradeoff, not a silent
+regression when a user switches modes.
+
+## Prior art in this repo (and why it doesn't fully apply)
+
+- `amazon_msk` toggles between two `OpenMetricsBaseCheck(V2)` implementations via a
+  `use_openmetrics` boolean and a `__new__` override — both its paths are already
+  OpenMetrics (scraping a JMX Exporter's Prometheus endpoint), so this doesn't
+  demonstrate a real JMXFetch ↔ OpenMetrics switch.
+- `sonarqube` and `hazelcast` both combine a real `check.py` with a JMX
+  `data/metrics.yaml`, gated by an `is_jmx` instance/init_config flag. This *is* the
+  right mechanism (see below) — but their non-JMX path is hand-rolled REST/HTTP, not
+  OpenMetrics. Confirmed by reading both check.py files in full: no
+  `OpenMetricsBaseCheck` import in either package.
+- A repo-wide cross-reference of every integration importing
+  `OpenMetricsBaseCheck`/`OpenMetricsBaseCheckV2` (61 hits) against every integration
+  with `jmx_metrics:` in its `data/metrics.yaml` (15 hits) found **zero overlap**.
+  No integration in `integrations-core` currently combines JMXFetch with OpenMetrics
+  for the same data source, and there is no existing shared-metrics-definition or
+  codegen mechanism to reuse. This design establishes that pattern for the first time,
+  scoped locally to HiveMQ rather than as a new repo-wide convention.
+
+## Architecture
+
+### Toggle: `is_jmx`, corrected for HiveMQ's current spec
+
+The Agent's collector reads `is_jmx` natively (outside this repo, in Go) to decide
+whether to run JMXFetch against `data/metrics.yaml` (never invoking Python) or to load
+`check.py` instead. HiveMQ's current `assets/configuration/spec.yaml` already imports
+both `init_config/jmx` and `instances/jmx`, but as currently configured this doesn't
+provide a working per-instance switch:
+
+- `init_config/jmx`'s `is_jmx` is `required: true` — this forces every instance in the
+  file into JMX mode unconditionally today.
+- `instances/jmx`'s `is_jmx` is `hidden: true` and, per its own description, is
+  *"ignored if `is_jmx` is set to true at the init_config level"* — so today it's dead
+  configuration.
+
+The fix (matching `hazelcast`'s pattern):
+
+```yaml
+- template: init_config
+  options:
+  - template: init_config/jmx
+    overrides:
+      is_jmx.required: false
+      is_jmx.value.example: false
+- template: instances
+  options:
+  - template: instances/jmx
+    overrides:
+      port.value.example: 9010
+      is_jmx.hidden: false
+      is_jmx.value.default: true   # preserve current behavior for configs with no flag set
+      is_jmx.value.example: true
+  - template: instances/openmetrics
+    overrides:
+      openmetrics_endpoint.value.example: http://%%host%%:9399/metrics
+```
+
+`is_jmx.value.default: true` at the instance level is required, not cosmetic: existing
+customer configs never had to set `is_jmx` (it was forced), so on upgrade its absence
+must still resolve to "JMX, exactly as before."
+
+### `check.py`
+
+```python
+from datadog_checks.base import OpenMetricsBaseCheckV2
+from datadog_checks.hivemq.config_models import ConfigMixin
+from datadog_checks.hivemq.metrics import METRIC_MAP
+
+
+class HivemqCheck(OpenMetricsBaseCheckV2, ConfigMixin):
+    __NAMESPACE__ = 'hivemq'
+
+    def get_default_config(self):
+        return {'metrics': [METRIC_MAP]}
+```
+
+When `is_jmx: true`, the Agent never instantiates this class at all — the JMX path is
+unaffected by anything in this file.
+
+### `metrics.py`
+
+Following the established convention used by `envoy`/`boundary` (both
+`OpenMetricsBaseCheckV2` checks keep their metric map in a dedicated `metrics.py`,
+imported into `check.py` and injected via `get_default_config()`):
+
+```python
+METRIC_MAP = {
+    # Gauges: plain rename, wire type gauge -> gauge
+    'com_hivemq_system_system_cpu_load': 'system.system_cpu.load',
+    ...
+    # Counters: wire type is gauge (DropwizardExports quirk); force counter semantics
+    # to match JMX's monotonic_count
+    'com_hivemq_messages_incoming_publish_count': {
+        'name': 'messages.incoming.publish.count',
+        'type': 'counter',
+    },
+    ...
+}
+```
+
+The map is generated once from the same Dropwizard metric names already itemized in
+`data/metrics.yaml`'s `bean_regex` lists — it is a rename table, not a hand-guessed
+list, and is scoped locally to this integration (no repo-wide shared-metrics
+convention is introduced).
+
+Histogram/summary metrics need a custom transformer (registered via
+`OpenMetricsBaseCheckV2`'s transformer mechanism) to split each summary's
+quantile-tagged samples back into the discrete `hivemq.foo.50th_percentile`,
+`.75th_percentile`, ..., `.count` metric names already in `metadata.csv`, instead of
+accepting the native `hivemq.foo.quantile{quantile:0.5}` tag-based shape. This keeps
+existing monitors/dashboards built on the current metric names working under either
+collection method, for the subset of stats that both methods actually expose.
+
+### Collision safety
+
+A unit test loads `metadata.csv` and the generated `METRIC_MAP`, asserting:
+
+1. Every `METRIC_MAP` target name already exists in `metadata.csv` (no accidentally
+   invented names), and
+2. No target name is reused across two `METRIC_MAP` entries with different semantics
+   (e.g., a histogram's derived `.count` must never collide with an unrelated
+   counter's `.count`).
+
+This is mechanical validation, not review-only, addressing the requirement that no
+metric name overlap slip through between the two collection paths.
+
+### Config (`assets/configuration/spec.yaml`)
+
+Beyond the `is_jmx` fix above, add the standard `instances/openmetrics` template
+as-is. It already has the right defaults for a custom (non-generic) OpenMetrics check:
+
+- `metrics` is `hidden: true` — it's the generic-`openmetrics`-integration-only field;
+  ours is set programmatically via `get_default_config()`, not user-facing.
+- `extra_metrics` is visible by default and takes precedence over our built-in map on
+  conflict — the escape hatch for anything the built-in map misses or that HiveMQ adds
+  in a future version.
+- `exclude_metrics`, `rename_labels`, `exclude_labels`/`include_labels` are present and
+  visible too.
+
+No overrides are needed for these beyond `openmetrics_endpoint`'s example value.
+
+`config_models/*.py` are regenerated via `ddev -x validate config -s hivemq` and
+`ddev -x validate models -s hivemq` per this repo's `AGENTS.md` — they are never
+hand-edited.
+
+## Testing
+
+- Existing `tests/test_e2e.py` (pure JMX, `is_jmx: true` implicit) stays unchanged and
+  must keep passing — confirmed as a working baseline: `ddev env start --dev hivemq
+  py3.13-4.3` + `ddev env test --dev hivemq py3.13-4.3` passes against a real
+  `hivemq/hivemq4:4.3.2` container today.
+- `tests/docker/docker-compose.yaml` gets the `hivemq-prometheus-extension` installed
+  into the HiveMQ container (or a second compose profile), exposing `:9399/metrics`.
+- New e2e/integration fixtures cover `is_jmx: false`, asserting the check submits the
+  expected renamed metrics and that the documented gap metrics are absent (not
+  silently missing due to a bug).
+- The `METRIC_MAP` collision-safety unit test described above.
+
+## Out of scope
+
+- Meter/Timer metric collection (not collected via JMX today either).
+- Any change to the default (`is_jmx: true`) collection behavior or its metric names.
+- A repo-wide JMX↔OpenMetrics shared-metrics-definition convention — this design is
+  scoped to HiveMQ only, since no other integration needs it today.
+
+## Open questions for implementation
+
+- Exact custom-transformer implementation for the histogram quantile-splitting
+  behavior (mechanism confirmed available in `OpenMetricsBaseCheckV2`; exact code
+  shape to be worked out during planning).
+- Whether the HiveMQ Prometheus extension needs to be vendored into the e2e Docker
+  image or fetched at container-start time.

--- a/hivemq/assets/configuration/spec.yaml
+++ b/hivemq/assets/configuration/spec.yaml
@@ -6,11 +6,68 @@ files:
   - template: init_config
     options:
     - template: init_config/jmx
-  - template: instances
-    options:
-    - template: instances/jmx
       overrides:
-        port.value.example: 9010
+        is_jmx.required: false
+        is_jmx.value.example: false
+  - template: instances
+    multiple_instances_defined: true
+    options:
+    - name: jmx
+      description: JMX instance example
+      options:
+      - template: instances/jmx
+        overrides:
+          host.required: false
+          port.required: false
+          port.value.example: 9010
+          is_jmx.hidden: false
+          is_jmx.enabled: true
+          is_jmx.value.default: true
+          is_jmx.value.example: true
+          is_jmx.description: |
+            Whether or not this instance is a configuration for a JMX integration.
+            If `is_jmx` is set to true at the init_config level, this flag is ignored.
+
+            Note: Set to `false` and set `use_openmetrics: true` to collect via the
+            HiveMQ Prometheus extension instead. See the `openmetrics` instance
+            example below.
+    - name: openmetrics
+      description: |
+        OpenMetrics instance example. Requires the free HiveMQ Prometheus extension
+        (https://github.com/hivemq/hivemq-prometheus-extension) to be installed and
+        enabled on the HiveMQ broker.
+
+        Note: `Max`, `Mean`, `Min`, `StdDev`, and `SnapshotSize` sub-metrics of
+        histogram-based metrics (for example `hivemq.messages.incoming.publish.bytes.*`)
+        are not available through this collection method -- only the percentile and
+        count sub-metrics are. This is a limitation of the HiveMQ Prometheus
+        extension itself, which does not expose them.
+      options:
+      - name: is_jmx
+        description: |
+          Whether or not this instance is a configuration for a JMX integration.
+          Must be `false` for this OpenMetrics instance example.
+        hidden: true
+        enabled: true
+        value:
+          type: boolean
+          default: false
+          example: false
+      - name: use_openmetrics
+        description: |
+          Whether or not this instance collects HiveMQ metrics from the HiveMQ
+          Prometheus extension instead of JMX. Must be set to `true`, alongside
+          `is_jmx: false`, to use this instance type.
+        enabled: true
+        value:
+          type: boolean
+          default: true
+          example: true
+        fleet_configurable: true
+      - template: instances/openmetrics
+        overrides:
+          openmetrics_endpoint.required: false
+          openmetrics_endpoint.value.example: http://%%host%%:9399/metrics
   - template: logs
     example:
     - type: file

--- a/hivemq/changelog.d/24694.added
+++ b/hivemq/changelog.d/24694.added
@@ -1,0 +1,1 @@
+Add OpenMetrics collection support via ``use_openmetrics``/``is_jmx: false``, as an alternative to the default JMX collection.

--- a/hivemq/datadog_checks/hivemq/__init__.py
+++ b/hivemq/datadog_checks/hivemq/__init__.py
@@ -2,5 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .__about__ import __version__
+from .check import HivemqCheck
 
-__all__ = ['__version__']
+__all__ = ['__version__', 'HivemqCheck']

--- a/hivemq/datadog_checks/hivemq/check.py
+++ b/hivemq/datadog_checks/hivemq/check.py
@@ -1,0 +1,73 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.base import OpenMetricsBaseCheckV2
+
+from .config_models import ConfigMixin
+from .metrics import COUNTER_METRICS, HISTOGRAM_METRICS, METRIC_MAP, QUANTILE_SUFFIXES
+
+
+class HivemqCheck(OpenMetricsBaseCheckV2, ConfigMixin):
+    """
+    Collect HiveMQ metrics from the HiveMQ Prometheus extension
+    (https://github.com/hivemq/hivemq-prometheus-extension), as an alternative to
+    this integration's default JMX collection. The Agent only loads this check when
+    `use_openmetrics: true` is set on the instance; otherwise JMXFetch handles
+    collection directly and this class is never instantiated.
+    """
+
+    __NAMESPACE__ = 'hivemq'
+    DEFAULT_METRIC_LIMIT = 0
+
+    def get_default_config(self):
+        return {'metrics': [METRIC_MAP]}
+
+    def configure_scrapers(self):
+        super().configure_scrapers()
+
+        metric_transformer = self.scrapers[self.instance['openmetrics_endpoint']].metric_transformer
+        for wire_name in COUNTER_METRICS:
+            metric_transformer.add_custom_transformer(wire_name, self._transform_counter)
+        for wire_name in HISTOGRAM_METRICS:
+            metric_transformer.add_custom_transformer(wire_name, self._transform_histogram)
+
+    def _transform_counter(self, metric, sample_data, _runtime_data):
+        """
+        HiveMQ's Dropwizard Counters are exposed as Prometheus gauges (not counters --
+        see metrics.py), carrying the raw count. Submit them as a monotonic_count to
+        match JMX's `Count` attribute handling, using our own naming: the native
+        `counter` metric type always appends `.count`, which would double up with our
+        target names that already end in `.count`.
+        """
+        target_name = COUNTER_METRICS[metric.name]
+
+        for sample, tags, hostname in sample_data:
+            self.monotonic_count(target_name, sample.value, tags=tags, hostname=hostname)
+
+    def _transform_histogram(self, metric, sample_data, _runtime_data):
+        """
+        HiveMQ's histograms are exposed as Prometheus summaries (quantiles + a count
+        sample). Split them back into the discrete `<name>.<Nth>_percentile` gauges
+        and `<name>.count` monotonic_count already used by JMX collection (see
+        data/metrics.yaml), instead of the native tag-based summary shape, so
+        dashboards/monitors work the same way regardless of collection method.
+
+        Note: unlike JMX, this does not have Max/Mean/Min/StdDev/SnapshotSize --
+        DropwizardExports does not expose them (see metrics.py for details).
+        """
+        base_name = HISTOGRAM_METRICS[metric.name]
+
+        for sample, tags, hostname in sample_data:
+            if sample.name.endswith('_count'):
+                self.monotonic_count(f'{base_name}.count', sample.value, tags=tags, hostname=hostname)
+            elif sample.name == metric.name:
+                quantile_tag = next((tag for tag in tags if tag.startswith('quantile:')), None)
+                if quantile_tag is None:
+                    continue
+
+                suffix = QUANTILE_SUFFIXES.get(quantile_tag.split(':', 1)[1])
+                if suffix is None:
+                    continue
+
+                remaining_tags = [tag for tag in tags if tag != quantile_tag]
+                self.gauge(f'{base_name}.{suffix}', sample.value, tags=remaining_tags, hostname=hostname)

--- a/hivemq/datadog_checks/hivemq/config_models/defaults.py
+++ b/hivemq/datadog_checks/hivemq/config_models/defaults.py
@@ -12,7 +12,31 @@ def shared_collect_default_metrics():
     return False
 
 
+def shared_is_jmx():
+    return False
+
+
 def shared_new_gc_metrics():
+    return False
+
+
+def instance_allow_redirects():
+    return True
+
+
+def instance_auth_type():
+    return 'basic'
+
+
+def instance_cache_metric_wildcards():
+    return True
+
+
+def instance_cache_shared_labels():
+    return True
+
+
+def instance_collect_counters_with_distributions():
     return False
 
 
@@ -20,16 +44,76 @@ def instance_collect_default_jvm_metrics():
     return True
 
 
+def instance_collect_histogram_buckets():
+    return True
+
+
+def instance_disable_generic_tags():
+    return False
+
+
 def instance_empty_default_hostname():
     return False
 
 
+def instance_enable_health_service_check():
+    return True
+
+
+def instance_enable_legacy_tags_normalization():
+    return True
+
+
+def instance_histogram_buckets_as_distributions():
+    return False
+
+
+def instance_ignore_connection_errors():
+    return False
+
+
 def instance_is_jmx():
+    return True
+
+
+def instance_kerberos_auth():
+    return 'disabled'
+
+
+def instance_kerberos_delegate():
+    return False
+
+
+def instance_kerberos_force_initiate():
+    return False
+
+
+def instance_log_requests():
     return False
 
 
 def instance_min_collection_interval():
     return 15
+
+
+def instance_non_cumulative_histogram_buckets():
+    return False
+
+
+def instance_openmetrics_endpoint():
+    return 'http://%%host%%:9399/metrics'
+
+
+def instance_persist_connections():
+    return False
+
+
+def instance_port():
+    return 9010
+
+
+def instance_request_size():
+    return 16
 
 
 def instance_rmi_client_timeout():
@@ -41,4 +125,48 @@ def instance_rmi_connection_timeout():
 
 
 def instance_rmi_registry_ssl():
+    return False
+
+
+def instance_skip_proxy():
+    return False
+
+
+def instance_tag_by_endpoint():
+    return True
+
+
+def instance_telemetry():
+    return False
+
+
+def instance_timeout():
+    return 10
+
+
+def instance_tls_ignore_warning():
+    return False
+
+
+def instance_tls_use_host_header():
+    return False
+
+
+def instance_tls_verify():
+    return True
+
+
+def instance_use_latest_spec():
+    return False
+
+
+def instance_use_legacy_auth_encoding():
+    return True
+
+
+def instance_use_openmetrics():
+    return True
+
+
+def instance_use_process_start_time():
     return False

--- a/hivemq/datadog_checks/hivemq/config_models/instance.py
+++ b/hivemq/datadog_checks/hivemq/config_models/instance.py
@@ -9,9 +9,11 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from types import MappingProxyType
+from typing import Any, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Literal
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -19,7 +21,77 @@ from datadog_checks.base.utils.models import validation
 from . import defaults, validators
 
 
-SECURE_FIELD_NAMES = frozenset(['java_bin_path', 'key_store_path', 'tools_jar_path', 'trust_store_path'])
+SECURE_FIELD_NAMES = frozenset(
+    [
+        'auth_token',
+        'java_bin_path',
+        'kerberos_cache',
+        'kerberos_keytab',
+        'key_store_path',
+        'tls_ca_cert',
+        'tls_cert',
+        'tls_private_key',
+        'tools_jar_path',
+        'trust_store_path',
+    ]
+)
+
+
+class AuthToken(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    reader: Optional[MappingProxyType[str, Any]] = None
+    writer: Optional[MappingProxyType[str, Any]] = None
+
+
+class ExtraMetrics(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra='allow',
+        frozen=True,
+    )
+    name: Optional[str] = None
+    type: Optional[str] = None
+
+
+class MetricPatterns(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    exclude: Optional[tuple[str, ...]] = None
+    include: Optional[tuple[str, ...]] = None
+
+
+class Metrics(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra='allow',
+        frozen=True,
+    )
+    name: Optional[str] = None
+    type: Optional[str] = None
+
+
+class Proxy(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    http: Optional[str] = None
+    https: Optional[str] = None
+    no_proxy: Optional[tuple[str, ...]] = None
+
+
+class ShareLabels(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    labels: Optional[tuple[str, ...]] = None
+    match: Optional[tuple[str, ...]] = None
 
 
 class InstanceConfig(BaseModel):
@@ -28,29 +100,94 @@ class InstanceConfig(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    allow_redirects: Optional[bool] = None
+    auth_token: Optional[AuthToken] = None
+    auth_type: Optional[str] = None
+    aws_host: Optional[str] = None
+    aws_region: Optional[str] = None
+    aws_service: Optional[str] = None
+    cache_metric_wildcards: Optional[bool] = None
+    cache_shared_labels: Optional[bool] = None
+    collect_counters_with_distributions: Optional[bool] = None
     collect_default_jvm_metrics: Optional[bool] = None
+    collect_histogram_buckets: Optional[bool] = None
+    connect_timeout: Optional[float] = None
+    disable_generic_tags: Optional[bool] = None
     empty_default_hostname: Optional[bool] = None
-    host: str
+    enable_health_service_check: Optional[bool] = None
+    enable_legacy_tags_normalization: Optional[bool] = None
+    exclude_labels: Optional[tuple[str, ...]] = None
+    exclude_metrics: Optional[tuple[str, ...]] = None
+    exclude_metrics_by_labels: Optional[MappingProxyType[str, Union[bool, tuple[str, ...]]]] = None
+    extra_headers: Optional[MappingProxyType[str, Any]] = None
+    extra_metrics: Optional[tuple[Union[str, MappingProxyType[str, Union[str, ExtraMetrics]]], ...]] = None
+    headers: Optional[MappingProxyType[str, Any]] = None
+    histogram_buckets_as_distributions: Optional[bool] = None
+    host: Optional[str] = None
+    hostname_format: Optional[str] = None
+    hostname_label: Optional[str] = None
+    ignore_connection_errors: Optional[bool] = None
+    ignore_tags: Optional[tuple[str, ...]] = None
+    include_labels: Optional[tuple[str, ...]] = None
     is_jmx: Optional[bool] = None
     java_bin_path: Optional[str] = None
     java_options: Optional[str] = None
     jmx_url: Optional[str] = None
+    kerberos_auth: Optional[Literal['required', 'optional', 'disabled']] = None
+    kerberos_cache: Optional[str] = None
+    kerberos_delegate: Optional[bool] = None
+    kerberos_force_initiate: Optional[bool] = None
+    kerberos_hostname: Optional[str] = None
+    kerberos_keytab: Optional[str] = None
+    kerberos_principal: Optional[str] = None
     key_store_password: Optional[str] = None
     key_store_path: Optional[str] = None
+    log_requests: Optional[bool] = None
+    metric_patterns: Optional[MetricPatterns] = None
+    metrics: Optional[tuple[Union[str, MappingProxyType[str, Union[str, Metrics]]], ...]] = None
     min_collection_interval: Optional[float] = None
     name: Optional[str] = None
+    namespace: Optional[str] = Field(None, pattern='\\w*')
+    non_cumulative_histogram_buckets: Optional[bool] = None
+    ntlm_domain: Optional[str] = None
+    openmetrics_endpoint: Optional[str] = None
     password: Optional[str] = None
-    port: int
+    persist_connections: Optional[bool] = None
+    port: Optional[int] = None
     process_name_regex: Optional[str] = None
+    proxy: Optional[Proxy] = None
+    raw_line_filters: Optional[tuple[str, ...]] = None
+    raw_metric_prefix: Optional[str] = None
+    read_timeout: Optional[float] = None
+    rename_labels: Optional[MappingProxyType[str, Any]] = None
+    request_size: Optional[float] = None
     rmi_client_timeout: Optional[float] = None
     rmi_connection_timeout: Optional[float] = None
     rmi_registry_ssl: Optional[bool] = None
     service: Optional[str] = None
+    share_labels: Optional[MappingProxyType[str, Union[bool, ShareLabels]]] = None
+    skip_proxy: Optional[bool] = None
+    tag_by_endpoint: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None
+    telemetry: Optional[bool] = None
+    timeout: Optional[float] = None
+    tls_ca_cert: Optional[str] = None
+    tls_cert: Optional[str] = None
+    tls_ciphers: Optional[tuple[str, ...]] = None
+    tls_ignore_warning: Optional[bool] = None
+    tls_private_key: Optional[str] = None
+    tls_protocols_allowed: Optional[tuple[str, ...]] = None
+    tls_use_host_header: Optional[bool] = None
+    tls_verify: Optional[bool] = None
     tools_jar_path: Optional[str] = None
     trust_store_password: Optional[str] = None
     trust_store_path: Optional[str] = None
+    use_latest_spec: Optional[bool] = None
+    use_legacy_auth_encoding: Optional[bool] = None
+    use_openmetrics: Optional[bool] = None
+    use_process_start_time: Optional[bool] = None
     user: Optional[str] = None
+    username: Optional[str] = None
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):

--- a/hivemq/datadog_checks/hivemq/config_models/shared.py
+++ b/hivemq/datadog_checks/hivemq/config_models/shared.py
@@ -28,7 +28,7 @@ class SharedConfig(BaseModel):
     )
     collect_default_metrics: Optional[bool] = None
     conf: Optional[tuple[MappingProxyType[str, Any], ...]] = None
-    is_jmx: bool
+    is_jmx: Optional[bool] = None
     new_gc_metrics: Optional[bool] = None
     service: Optional[str] = None
     service_check_prefix: Optional[str] = None

--- a/hivemq/datadog_checks/hivemq/data/conf.yaml.example
+++ b/hivemq/datadog_checks/hivemq/data/conf.yaml.example
@@ -2,10 +2,10 @@
 #
 init_config:
 
-    ## @param is_jmx - boolean - required
+    ## @param is_jmx - boolean - optional - default: false
     ## Whether or not this file is a configuration for a JMX integration.
     #
-    is_jmx: true
+    # is_jmx: false
 
     ## @param collect_default_metrics - boolean - optional - default: false
     ## Whether or not the check should collect all default metrics.
@@ -53,15 +53,27 @@ init_config:
 #
 instances:
 
-    ## @param host - string - required
+    ## JMX instance example
+  -
+    ## @param host - string - optional
     ## JMX hostname to connect to.
     #
-  - host: <HOST>
+    # host: <HOST>
 
-    ## @param port - integer - required
+    ## @param port - integer - optional - default: 9010
     ## JMX port to connect to.
     #
-    port: 9010
+    # port: 9010
+
+    ## @param is_jmx - boolean - optional - default: true
+    ## Whether or not this instance is a configuration for a JMX integration.
+    ## If `is_jmx` is set to true at the init_config level, this flag is ignored.
+    ##
+    ## Note: Set to `false` and set `use_openmetrics: true` to collect via the
+    ## HiveMQ Prometheus extension instead. See the `openmetrics` instance
+    ## example below.
+    #
+    is_jmx: true
 
     ## @param user - string - optional
     ## User to use when connecting to JMX.
@@ -182,6 +194,609 @@ instances:
     ## This is useful for cluster-level checks.
     #
     # empty_default_hostname: false
+
+    ## @param use_openmetrics - boolean - optional - default: true
+    ## Whether or not this instance collects HiveMQ metrics from the HiveMQ
+    ## Prometheus extension instead of JMX. Must be set to `true`, alongside
+    ## `is_jmx: false`, to use this instance type.
+    #
+    use_openmetrics: true
+
+    ## @param openmetrics_endpoint - string - optional - default: http://%%host%%:9399/metrics
+    ## The URL exposing metrics in the OpenMetrics format.
+    #
+    # openmetrics_endpoint: http://%%host%%:9399/metrics
+
+    ## @param raw_metric_prefix - string - optional
+    ## A prefix that is removed from all exposed metric names, if present.
+    ## All configuration options will use the prefix-less name.
+    #
+    # raw_metric_prefix: <PREFIX>_
+
+    ## @param extra_metrics - (list of string or mapping) - optional
+    ## This list defines metrics to collect from the `openmetrics_endpoint`, in addition to
+    ## what the check collects by default. If the check already collects a metric, then
+    ## metric definitions here take precedence. Metrics may be defined in 3 ways:
+    ##
+    ## 1. If the item is a string, then it represents the exposed metric name, and
+    ##    the sent metric name will be identical. For example:
+    ##      ```
+    ##      extra_metrics:
+    ##      - <METRIC_1>
+    ##      - <METRIC_2>
+    ##      ```
+    ## 2. If the item is a mapping, then the keys represent the exposed metric names.
+    ##
+    ##      1. If a value is a string, then it represents the sent metric name. For example:
+    ##           ```
+    ##           extra_metrics:
+    ##           - <EXPOSED_METRIC_1>: <SENT_METRIC_1>
+    ##           - <EXPOSED_METRIC_2>: <SENT_METRIC_2>
+    ##           ```
+    ##      2. If a value is a mapping, then it must have a `name` and/or `type` key.
+    ##         The `name` represents the sent metric name, and the `type` represents how
+    ##         the metric should be handled, overriding any type information the endpoint
+    ##         may provide. For example:
+    ##           ```
+    ##           extra_metrics:
+    ##           - <EXPOSED_METRIC_1>:
+    ##               name: <SENT_METRIC_1>
+    ##               type: <METRIC_TYPE_1>
+    ##           - <EXPOSED_METRIC_2>:
+    ##               name: <SENT_METRIC_2>
+    ##               type: <METRIC_TYPE_2>
+    ##           ```
+    ##         The supported native types are `gauge`, `counter`, `histogram`, and `summary`.
+    ##
+    ## Note: To collect counter metrics with names ending in `_total`, specify the metric name without the `_total`
+    ## suffix. For example, to collect the counter metric `promhttp_metric_handler_requests_total`, specify
+    ## `promhttp_metric_handler_requests`. This submits to Datadog the metric name appended with `.count`.
+    ## For more information, see:
+    ## https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#suffixes
+    ##
+    ## Regular expressions may be used to match the exposed metric names, for example:
+    ##   ```
+    ##   extra_metrics:
+    ##   - ^network_(ingress|egress)_.+
+    ##   - .+:
+    ##       type: gauge
+    ##   ```
+    #
+    # extra_metrics:
+    #   - <METRIC_1>
+    #   - <EXPOSED_METRIC_2>: <SENT_METRIC_2>
+    #   - <EXPOSED_METRIC_3>:
+    #       name: <SENT_METRIC_3>
+    #       type: <METRIC_TYPE_3>
+
+    ## @param exclude_metrics - list of strings - optional
+    ## A list of metrics to exclude, with each entry being either
+    ## the exact metric name or a regular expression.
+    ##
+    ## In order to exclude all metrics but the ones matching a specific filter,
+    ## you can use a negative lookahead regex like:
+    ##   - ^(?!foo).*$
+    #
+    # exclude_metrics: []
+
+    ## @param exclude_metrics_by_labels - mapping - optional
+    ## A mapping of labels to exclude metrics with matching label name and their corresponding metric values. To match
+    ## all values of a label, set it to `true`.
+    ##
+    ## Note: Label filtering happens before `rename_labels`.
+    ##
+    ## For example, the following configuration instructs the check to exclude all metrics with
+    ## a label `worker` or a label `pid` with the value of either `23` or `42`.
+    ##
+    ##   exclude_metrics_by_labels:
+    ##     worker: true
+    ##     pid:
+    ##     - '23'
+    ##     - '42'
+    #
+    # exclude_metrics_by_labels: {}
+
+    ## @param exclude_labels - list of strings - optional
+    ## A list of labels to exclude, useful for high cardinality values like timestamps or UUIDs.
+    ## May be used in conjunction with `include_labels`.
+    ## Labels defined in `exclude_labels` will take precedence in case of overlap.
+    ##
+    ## Note: Label filtering happens before `rename_labels`.
+    #
+    # exclude_labels: []
+
+    ## @param include_labels - list of strings - optional
+    ## A list of labels to include. May be used in conjunction with `exclude_labels`.
+    ## Labels defined in `exclude_labels` will take precedence in case of overlap.
+    ##
+    ## Note: Label filtering happens before `rename_labels`.
+    #
+    # include_labels: []
+
+    ## @param rename_labels - mapping - optional
+    ## A mapping of label names to their new names.
+    #
+    # rename_labels:
+    #   <LABEL_NAME_1>: <NEW_LABEL_NAME_1>
+    #   <LABEL_NAME_2>: <NEW_LABEL_NAME_2>
+
+    ## @param enable_health_service_check - boolean - optional - default: true
+    ## Whether or not to send a service check named `<NAMESPACE>.openmetrics.health` which reports
+    ## the health of the `openmetrics_endpoint`.
+    #
+    # enable_health_service_check: true
+
+    ## @param ignore_connection_errors - boolean - optional - default: false
+    ## Whether or not to ignore connection errors when scraping `openmetrics_endpoint`.
+    #
+    # ignore_connection_errors: false
+
+    ## @param hostname_label - string - optional
+    ## Override the hostname for every metric submission with the value of one of its labels.
+    #
+    # hostname_label: <HOSTNAME_LABEL>
+
+    ## @param hostname_format - string - optional
+    ## When `hostname_label` is set, this instructs the check how to format the values. The string
+    ## `<HOSTNAME>` is replaced by the value of the label defined by `hostname_label`.
+    #
+    # hostname_format: <HOSTNAME>
+
+    ## @param collect_histogram_buckets - boolean - optional - default: true
+    ## Whether or not to send histogram buckets.
+    #
+    # collect_histogram_buckets: true
+
+    ## @param non_cumulative_histogram_buckets - boolean - optional - default: false
+    ## Whether or not histogram buckets are non-cumulative and to come with a `lower_bound` tag.
+    #
+    # non_cumulative_histogram_buckets: false
+
+    ## @param histogram_buckets_as_distributions - boolean - optional - default: false
+    ## Whether or not to send histogram buckets as Datadog distribution metrics. This implicitly
+    ## enables the `collect_histogram_buckets` and `non_cumulative_histogram_buckets` options.
+    ##
+    ## Learn more about distribution metrics:
+    ## https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#metric-types
+    #
+    # histogram_buckets_as_distributions: false
+
+    ## @param collect_counters_with_distributions - boolean - optional - default: false
+    ## Whether or not to also collect the observation counter metrics ending in `.sum` and `.count`
+    ## when sending histogram buckets as Datadog distribution metrics. This implicitly enables the
+    ## `histogram_buckets_as_distributions` option.
+    #
+    # collect_counters_with_distributions: false
+
+    ## @param use_process_start_time - boolean - optional - default: false
+    ## Whether to enable a heuristic for reporting counter values on the first scrape. When true,
+    ## the first time an endpoint is scraped, check `process_start_time_seconds` to decide whether zero
+    ## initial value can be assumed for counters. This requires keeping metrics in memory until the entire
+    ## response is received.
+    #
+    # use_process_start_time: false
+
+    ## @param share_labels - mapping - optional
+    ## This mapping allows for the sharing of labels across multiple metrics. The keys represent the
+    ## exposed metrics from which to share labels, and the values are mappings that configure the
+    ## sharing behavior. Each mapping must have at least one of the following keys:
+    ##
+    ##   - labels - This is a list of labels to share. All labels are shared if this is not set.
+    ##   - match - This is a list of labels to match on other metrics as a condition for sharing.
+    ##   - values - This is a list of allowed values as a condition for sharing.
+    ##
+    ## To unconditionally share all labels of a metric, set it to `true`.
+    ##
+    ## For example, the following configuration instructs the check to apply all labels from `metric_a`
+    ## to all other metrics, the `node` label from `metric_b` to only those metrics that have a `pod`
+    ## label value that matches the `pod` label value of `metric_b`, and all labels from `metric_c`
+    ## to all other metrics if their value is equal to `23` or `42`.
+    #
+    # share_labels:
+    #   metric_a: true
+    #   metric_b:
+    #     labels:
+    #     - node
+    #     match:
+    #     - pod
+    #   metric_c:
+    #     values:
+    #     - 23
+    #     - 42
+
+    ## @param cache_shared_labels - boolean - optional - default: true
+    ## When `share_labels` is set, it instructs the check to cache labels collected from the first payload
+    ## for improved performance.
+    ##
+    ## Set this to `false` to compute label sharing for every payload at the risk of potentially increased memory usage.
+    #
+    # cache_shared_labels: true
+
+    ## @param raw_line_filters - list of strings - optional
+    ## A list of regular expressions used to exclude lines read from the `openmetrics_endpoint`
+    ## from being parsed.
+    #
+    # raw_line_filters: []
+
+    ## @param cache_metric_wildcards - boolean - optional - default: true
+    ## Whether or not to cache data from metrics that are defined by regular expressions rather
+    ## than the full metric name.
+    #
+    # cache_metric_wildcards: true
+
+    ## @param telemetry - boolean - optional - default: false
+    ## Whether or not to submit metrics prefixed by `<NAMESPACE>.telemetry.` for debugging purposes.
+    #
+    # telemetry: false
+
+    ## @param ignore_tags - list of strings - optional
+    ## A list of regular expressions used to ignore tags added by Autodiscovery and entries in the `tags` option.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
+
+    ## @param proxy - mapping - optional
+    ## This overrides the `proxy` setting in `init_config`.
+    ##
+    ## Set HTTP or HTTPS proxies for this instance. Use the `no_proxy` list
+    ## to specify hosts that must bypass proxies.
+    ##
+    ## The SOCKS protocol is also supported, for example:
+    ##
+    ##   socks5://user:pass@host:port
+    ##
+    ## Using the scheme `socks5` causes the DNS resolution to happen on the
+    ## client, rather than on the proxy server. This is in line with `curl`,
+    ## which uses the scheme to decide whether to do the DNS resolution on
+    ## the client or proxy. If you want to resolve the domains on the proxy
+    ## server, use `socks5h` as the scheme.
+    #
+    # proxy:
+    #   http: http://<PROXY_SERVER_FOR_HTTP>:<PORT>
+    #   https: https://<PROXY_SERVER_FOR_HTTPS>:<PORT>
+    #   no_proxy:
+    #   - <HOSTNAME_1>
+    #   - <HOSTNAME_2>
+
+    ## @param skip_proxy - boolean - optional - default: false
+    ## This overrides the `skip_proxy` setting in `init_config`.
+    ##
+    ## If set to `true`, this makes the check bypass any proxy
+    ## settings enabled and attempt to reach services directly.
+    #
+    # skip_proxy: false
+
+    ## @param auth_type - string - optional - default: basic
+    ## The type of authentication to use. The available types (and related options) are:
+    ## ```
+    ##   - basic
+    ##     |__ username
+    ##     |__ password
+    ##     |__ use_legacy_auth_encoding
+    ##   - digest
+    ##     |__ username
+    ##     |__ password
+    ##   - ntlm
+    ##     |__ ntlm_domain
+    ##     |__ password
+    ##   - kerberos
+    ##     |__ kerberos_auth
+    ##     |__ kerberos_cache
+    ##     |__ kerberos_delegate
+    ##     |__ kerberos_force_initiate
+    ##     |__ kerberos_hostname
+    ##     |__ kerberos_keytab
+    ##     |__ kerberos_principal
+    ##   - aws
+    ##     |__ aws_region
+    ##     |__ aws_host
+    ##     |__ aws_service
+    ## ```
+    ## The `aws` auth type relies on boto3 to automatically gather AWS credentials, for example: from `.aws/credentials`.
+    ## Details: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials
+    #
+    # auth_type: basic
+
+    ## @param use_legacy_auth_encoding - boolean - optional - default: true
+    ## When `auth_type` is set to `basic`, this determines whether to encode as `latin1` rather than `utf-8`.
+    #
+    # use_legacy_auth_encoding: true
+
+    ## @param username - string - optional
+    ## The username to use if services are behind basic or digest auth.
+    #
+    # username: <USERNAME>
+
+    ## @param password - string - optional
+    ## The password to use if services are behind basic or NTLM auth.
+    #
+    # password: <PASSWORD>
+
+    ## @param ntlm_domain - string - optional
+    ## If your services use NTLM authentication, specify
+    ## the domain used in the check. For NTLM Auth, append
+    ## the username to domain, not as the `username` parameter.
+    #
+    # ntlm_domain: <NTLM_DOMAIN>\<USERNAME>
+
+    ## @param kerberos_auth - string - optional - default: disabled
+    ## If your services use Kerberos authentication, you can specify the Kerberos
+    ## strategy to use between:
+    ##
+    ##   - required
+    ##   - optional
+    ##   - disabled
+    ##
+    ## See https://github.com/requests/requests-kerberos#mutual-authentication
+    #
+    # kerberos_auth: disabled
+
+    ## @param kerberos_cache - string - optional
+    ## Sets the KRB5CCNAME environment variable.
+    ## It should point to a credential cache with a valid TGT.
+    #
+    # kerberos_cache: <KERBEROS_CACHE>
+
+    ## @param kerberos_delegate - boolean - optional - default: false
+    ## Set to `true` to enable Kerberos delegation of credentials to a server that requests delegation.
+    ##
+    ## See https://github.com/requests/requests-kerberos#delegation
+    #
+    # kerberos_delegate: false
+
+    ## @param kerberos_force_initiate - boolean - optional - default: false
+    ## Set to `true` to preemptively initiate the Kerberos GSS exchange and
+    ## present a Kerberos ticket on the initial request (and all subsequent).
+    ##
+    ## See https://github.com/requests/requests-kerberos#preemptive-authentication
+    #
+    # kerberos_force_initiate: false
+
+    ## @param kerberos_hostname - string - optional
+    ## Override the hostname used for the Kerberos GSS exchange if its DNS name doesn't
+    ## match its Kerberos hostname, for example: behind a content switch or load balancer.
+    ##
+    ## See https://github.com/requests/requests-kerberos#hostname-override
+    #
+    # kerberos_hostname: <KERBEROS_HOSTNAME>
+
+    ## @param kerberos_principal - string - optional
+    ## Set an explicit principal, to force Kerberos to look for a
+    ## matching credential cache for the named user.
+    ##
+    ## See https://github.com/requests/requests-kerberos#explicit-principal
+    #
+    # kerberos_principal: <KERBEROS_PRINCIPAL>
+
+    ## @param kerberos_keytab - string - optional
+    ## Set the path to your Kerberos key tab file.
+    #
+    # kerberos_keytab: <KEYTAB_FILE_PATH>
+
+    ## @param auth_token - mapping - optional
+    ## This allows for the use of authentication information from dynamic sources.
+    ## Both a reader and writer must be configured.
+    ##
+    ## The available readers are:
+    ##
+    ##   - type: file
+    ##     path (required): The absolute path for the file to read from.
+    ##     pattern: A regular expression pattern with a single capture group used to find the
+    ##              token rather than using the entire file, for example: Your secret is (.+)
+    ##   - type: oauth
+    ##     url (required): The token endpoint.
+    ##     client_id (required): The client identifier.
+    ##     client_secret (required): The client secret.
+    ##     basic_auth: Whether the provider expects credentials to be transmitted in
+    ##                 an HTTP Basic Auth header. The default is: false
+    ##     options: Mapping of additional options to pass to the provider, such as the audience
+    ##              or the scope. For example:
+    ##                 options:
+    ##                   audience: https://example.com
+    ##                   scope: read:example
+    ##
+    ## The available writers are:
+    ##
+    ##   - type: header
+    ##     name (required): The name of the field, for example: Authorization
+    ##     value: The template value, for example `Bearer <TOKEN>`. The default is: <TOKEN>
+    ##     placeholder: The substring in `value` to replace with the token, defaults to: <TOKEN>
+    #
+    # auth_token:
+    #   reader:
+    #     type: <READER_TYPE>
+    #     <OPTION_1>: <VALUE_1>
+    #     <OPTION_2>: <VALUE_2>
+    #   writer:
+    #     type: <WRITER_TYPE>
+    #     <OPTION_1>: <VALUE_1>
+    #     <OPTION_2>: <VALUE_2>
+
+    ## @param aws_region - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the region.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_region: <AWS_REGION>
+
+    ## @param aws_host - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
+    ##
+    ## Note: This setting is not necessary for official integrations.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_host: <AWS_HOST>
+
+    ## @param aws_service - string - optional
+    ## If your services require AWS Signature Version 4 signing, set the service code. For a list
+    ## of available service codes, see https://docs.aws.amazon.com/general/latest/gr/rande.html
+    ##
+    ## Note: This setting is not necessary for official integrations.
+    ##
+    ## See https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+    #
+    # aws_service: <AWS_SERVICE>
+
+    ## @param tls_verify - boolean - optional - default: true
+    ## Instructs the check to validate the TLS certificate of services.
+    #
+    # tls_verify: true
+
+    ## @param tls_use_host_header - boolean - optional - default: false
+    ## If a `Host` header is set, this enables its use for SNI (matching against the TLS certificate CN or SAN).
+    #
+    # tls_use_host_header: false
+
+    ## @param tls_ignore_warning - boolean - optional - default: false
+    ## If `tls_verify` is disabled, security warnings are logged by the check.
+    ## Disable those by setting `tls_ignore_warning` to true.
+    #
+    # tls_ignore_warning: false
+
+    ## @param tls_cert - string - optional
+    ## The path to a single file in PEM format containing a certificate as well as any
+    ## number of CA certificates needed to establish the certificate's authenticity for
+    ## use when connecting to services. It may also contain an unencrypted private key to use.
+    #
+    # tls_cert: <CERT_PATH>
+
+    ## @param tls_private_key - string - optional
+    ## The unencrypted private key to use for `tls_cert` when connecting to services. This is
+    ## required if `tls_cert` is set and it does not already contain a private key.
+    #
+    # tls_private_key: <PRIVATE_KEY_PATH>
+
+    ## @param tls_ca_cert - string - optional
+    ## The path to a file of concatenated CA certificates in PEM format or a directory
+    ## containing several CA certificates in PEM format. If a directory, the directory
+    ## must have been processed using the `openssl rehash` command. See:
+    ## https://www.openssl.org/docs/man3.2/man1/c_rehash.html
+    #
+    # tls_ca_cert: <CA_CERT_PATH>
+
+    ## @param tls_protocols_allowed - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocols_allowed:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
+    ## @param tls_ciphers - list of strings - optional
+    ## The list of ciphers suites to use when connecting to an endpoint. If not specified, 
+    ## `ALL` ciphers are used. For list of ciphers see: 
+    ## https://www.openssl.org/docs/man1.0.2/man1/ciphers.html
+    #
+    # tls_ciphers:
+    #   - TLS_AES_256_GCM_SHA384
+    #   - TLS_CHACHA20_POLY1305_SHA256
+    #   - TLS_AES_128_GCM_SHA256
+
+    ## @param headers - mapping - optional
+    ## The headers parameter allows you to send specific headers with every request.
+    ## You can use it for explicitly specifying the host header or adding headers for
+    ## authorization purposes.
+    ##
+    ## This overrides any default headers.
+    #
+    # headers:
+    #   Host: <ALTERNATIVE_HOSTNAME>
+    #   X-Auth-Token: <AUTH_TOKEN>
+
+    ## @param extra_headers - mapping - optional
+    ## Additional headers to send with every request.
+    #
+    # extra_headers:
+    #   Host: <ALTERNATIVE_HOSTNAME>
+    #   X-Auth-Token: <AUTH_TOKEN>
+
+    ## @param timeout - number - optional - default: 10
+    ## The timeout for accessing services.
+    ##
+    ## This overrides the `timeout` setting in `init_config`.
+    #
+    # timeout: 10
+
+    ## @param connect_timeout - number - optional
+    ## The connect timeout for accessing services. Defaults to `timeout`.
+    #
+    # connect_timeout: <CONNECT_TIMEOUT>
+
+    ## @param read_timeout - number - optional
+    ## The read timeout for accessing services. Defaults to `timeout`.
+    #
+    # read_timeout: <READ_TIMEOUT>
+
+    ## @param request_size - number - optional - default: 16
+    ## The number of kibibytes (KiB) to read from streaming HTTP responses at a time.
+    #
+    # request_size: 16
+
+    ## @param log_requests - boolean - optional - default: false
+    ## Whether or not to debug log the HTTP(S) requests made, including the method and URL.
+    #
+    # log_requests: false
+
+    ## @param persist_connections - boolean - optional - default: false
+    ## Whether or not to persist cookies and use connection pooling for improved performance.
+    #
+    # persist_connections: false
+
+    ## @param allow_redirects - boolean - optional - default: true
+    ## Whether or not to allow URL redirection.
+    #
+    # allow_redirects: true
+
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Overrides any `service` defined in the `init_config` section.
+    #
+    # service: <SERVICE>
+
+    ## @param min_collection_interval - number - optional - default: 15
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    # min_collection_interval: 15
+
+    ## @param empty_default_hostname - boolean - optional - default: false
+    ## This forces the check to send metrics with no hostname.
+    ##
+    ## This is useful for cluster-level checks.
+    #
+    # empty_default_hostname: false
+
+    ## @param metric_patterns - mapping - optional
+    ## A mapping of metrics to include or exclude, with each entry being a regular expression.
+    ##
+    ## Metrics defined in `exclude` will take precedence in case of overlap.
+    #
+    # metric_patterns:
+    #   include:
+    #   - <INCLUDE_REGEX>
+    #   exclude:
+    #   - <EXCLUDE_REGEX>
 
 ## Log Section
 ##

--- a/hivemq/datadog_checks/hivemq/metrics.py
+++ b/hivemq/datadog_checks/hivemq/metrics.py
@@ -1,0 +1,210 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""
+Mapping from the metric names exposed by the HiveMQ Prometheus extension
+(https://github.com/hivemq/hivemq-prometheus-extension) to the metric names
+already used by this integration's JMX collection (see data/metrics.yaml and
+metadata.csv), so dashboards and monitors keep working regardless of which
+collection method (`use_openmetrics`) is active.
+
+The extension exports the same underlying Dropwizard MetricRegistry that also
+backs JMX, via io.prometheus.client.dropwizard.DropwizardExports, which converts:
+  - Dropwizard Gauge   -> Prometheus gauge (1:1 value)
+  - Dropwizard Counter -> Prometheus gauge carrying the raw count. Submitted here
+    as a monotonic_count via a custom transformer (see HivemqCheck._transform_counter)
+    to match JMX's `Count` attribute handling -- the native `counter` metric type
+    always appends `.count` to the configured name, which would double up with names
+    that already end in `.count`.
+  - Dropwizard Histogram -> Prometheus summary: quantiles {0.5,0.75,0.95,0.98,0.99,
+    0.999} plus a count sample. NOTE: Max/Mean/Min/StdDev/SnapshotSize, which JMX
+    does expose for these metrics, have no OpenMetrics equivalent and are not
+    collected via `use_openmetrics`.
+"""
+
+GAUGE_METRICS = {
+    'com_hivemq_cache_payload_persistence_average_load_penalty': 'cache.payload_persistence.average_load_penalty',
+    'com_hivemq_cache_payload_persistence_eviction_count': 'cache.payload_persistence.eviction_count',
+    'com_hivemq_cache_payload_persistence_hit_count': 'cache.payload_persistence.hit_count',
+    'com_hivemq_cache_payload_persistence_hit_rate': 'cache.payload_persistence.hit_rate',
+    'com_hivemq_cache_payload_persistence_load_count': 'cache.payload_persistence.load_count',
+    'com_hivemq_cache_payload_persistence_load_exception_count': 'cache.payload_persistence.load_exception_count',
+    'com_hivemq_cache_payload_persistence_load_exception_rate': 'cache.payload_persistence.load_exception_rate',
+    'com_hivemq_cache_payload_persistence_load_success_count': 'cache.payload_persistence.load_success_count',
+    'com_hivemq_cache_payload_persistence_miss_count': 'cache.payload_persistence.miss_count',
+    'com_hivemq_cache_payload_persistence_miss_rate': 'cache.payload_persistence.miss_rate',
+    'com_hivemq_cache_payload_persistence_request_count': 'cache.payload_persistence.request_count',
+    'com_hivemq_cache_payload_persistence_total_load_time': 'cache.payload_persistence.total_load_time',
+    'com_hivemq_cache_shared_subscription_average_load_penalty': 'cache.shared_subscription.average_load_penalty',
+    'com_hivemq_cache_shared_subscription_eviction_count': 'cache.shared_subscription.eviction_count',
+    'com_hivemq_cache_shared_subscription_hit_count': 'cache.shared_subscription.hit_count',
+    'com_hivemq_cache_shared_subscription_hit_rate': 'cache.shared_subscription.hit_rate',
+    'com_hivemq_cache_shared_subscription_load_count': 'cache.shared_subscription.load_count',
+    'com_hivemq_cache_shared_subscription_load_exception_count': 'cache.shared_subscription.load_exception_count',
+    'com_hivemq_cache_shared_subscription_load_exception_rate': 'cache.shared_subscription.load_exception_rate',
+    'com_hivemq_cache_shared_subscription_load_success_count': 'cache.shared_subscription.load_success_count',
+    'com_hivemq_cache_shared_subscription_miss_count': 'cache.shared_subscription.miss_count',
+    'com_hivemq_cache_shared_subscription_miss_rate': 'cache.shared_subscription.miss_rate',
+    'com_hivemq_cache_shared_subscription_request_count': 'cache.shared_subscription.request_count',
+    'com_hivemq_cache_shared_subscription_total_load_time': 'cache.shared_subscription.total_load_time',
+    'com_hivemq_cpu_cores_licensed': 'cpu_cores.licensed',
+    'com_hivemq_cpu_cores_used': 'cpu_cores.used',
+    'com_hivemq_messages_pending_qos_0_count': 'messages.pending.qos_0.count',
+    'com_hivemq_messages_pending_total_count': 'messages.pending.total.count',
+    'com_hivemq_messages_queued_count': 'messages.queued.count',
+    'com_hivemq_messages_retained_current': 'messages.retained.current',
+    'com_hivemq_messages_retained_pending_total_count': 'messages.retained.pending.total.count',
+    'com_hivemq_messages_retained_queued_count': 'messages.retained.queued.count',
+    'com_hivemq_networking_bytes_read_current': 'networking.bytes.read.current',
+    'com_hivemq_networking_bytes_read_total': 'networking.bytes.read.total',
+    'com_hivemq_networking_bytes_write_current': 'networking.bytes.write.current',
+    'com_hivemq_networking_bytes_write_total': 'networking.bytes.write.total',
+    'com_hivemq_networking_connections_current': 'networking.connections.current',
+    'com_hivemq_overload_protection_clients_average_credits': 'overload_protection.clients.average_credits',
+    'com_hivemq_overload_protection_clients_backpressure_active': 'overload_protection.clients.backpressure_active',
+    'com_hivemq_overload_protection_clients_using_credits': 'overload_protection.clients.using_credits',
+    'com_hivemq_overload_protection_credits_per_tick': 'overload_protection.credits.per_tick',
+    'com_hivemq_overload_protection_level': 'overload_protection.level',
+    'com_hivemq_persistence_executor_client_session_tasks': 'persistence.executor.client_session.tasks',
+    'com_hivemq_persistence_executor_noempty_queues': 'persistence.executor.noempty_queues',
+    'com_hivemq_persistence_executor_outgoing_message_flow_tasks': 'persistence.executor.outgoing_message_flow.tasks',
+    'com_hivemq_persistence_executor_queued_messages_tasks': 'persistence.executor.queued_messages.tasks',
+    'com_hivemq_persistence_executor_request_event_bus_tasks': 'persistence.executor.request_event_bus.tasks',
+    'com_hivemq_persistence_executor_retained_messages_tasks': 'persistence.executor.retained_messages.tasks',
+    'com_hivemq_persistence_executor_running_threads': 'persistence.executor.running.threads',
+    'com_hivemq_persistence_executor_subscription_tasks': 'persistence.executor.subscription.tasks',
+    'com_hivemq_persistence_executor_total_tasks': 'persistence.executor.total.tasks',
+    'com_hivemq_persistence_payload_entries_count': 'persistence.payload_entries.count',
+    'com_hivemq_persistence_removable_entries_count': 'persistence.removable_entries.count',
+    'com_hivemq_qos_0_memory_exceeded_per_client': 'qos_0_memory.exceeded.per_client',
+    'com_hivemq_qos_0_memory_max': 'qos_0_memory.max',
+    'com_hivemq_qos_0_memory_used': 'qos_0_memory.used',
+    'com_hivemq_sessions_overall_current': 'sessions.overall.current',
+    'com_hivemq_system_max_file_descriptor': 'system.max_file_descriptor',
+    'com_hivemq_system_open_file_descriptor': 'system.open_file_descriptor',
+    'com_hivemq_system_os_file_descriptors_max': 'system.os.file_descriptors.max',
+    'com_hivemq_system_os_file_descriptors_open': 'system.os.file_descriptors.open',
+    'com_hivemq_system_os_global_memory_available': 'system.os.global.memory.available',
+    'com_hivemq_system_os_global_memory_swap_total': 'system.os.global.memory.swap.total',
+    'com_hivemq_system_os_global_memory_swap_used': 'system.os.global.memory.swap.used',
+    'com_hivemq_system_os_global_memory_total': 'system.os.global.memory.total',
+    'com_hivemq_system_os_global_uptime': 'system.os.global.uptime',
+    'com_hivemq_system_os_process_disk_bytes_read': 'system.os.process.disk.bytes_read',
+    'com_hivemq_system_os_process_disk_bytes_written': 'system.os.process.disk.bytes_written',
+    'com_hivemq_system_os_process_memory_resident_set_size': 'system.os.process.memory.resident_set_size',
+    'com_hivemq_system_os_process_memory_virtual': 'system.os.process.memory.virtual',
+    'com_hivemq_system_os_process_threads_count': 'system.os.process.threads.count',
+    'com_hivemq_system_os_process_time_spent_kernel': 'system.os.process.time_spent.kernel',
+    'com_hivemq_system_os_process_time_spent_user': 'system.os.process.time_spent.user',
+    'com_hivemq_system_physical_memory_free': 'system.physical_memory.free',
+    'com_hivemq_system_physical_memory_total': 'system.physical_memory.total',
+    'com_hivemq_system_process_cpu_load': 'system.process_cpu.load',
+    'com_hivemq_system_process_cpu_time': 'system.process_cpu.time',
+    'com_hivemq_system_swap_space_free': 'system.swap_space.free',
+    'com_hivemq_system_swap_space_total': 'system.swap_space.total',
+    'com_hivemq_system_system_cpu_load': 'system.system_cpu.load',
+    'com_hivemq_topic_alias_count_total': 'topic_alias.count.total',
+    'com_hivemq_topic_alias_memory_usage': 'topic_alias.memory.usage',
+}
+
+# Wire name -> target name for Dropwizard Counters. Handled via a custom
+# transformer (HivemqCheck._transform_counter), not the declarative `metrics`
+# config -- see the module docstring for why.
+COUNTER_METRICS = {
+    'com_hivemq_cluster_name_request_retry_count': 'cluster.name_request.retry.count',
+    'com_hivemq_extension_managed_executor_running': 'extension.managed_executor.running',
+    'com_hivemq_extension_managed_executor_scheduled_overrun': 'extension.managed_executor.scheduled.overrun',
+    'com_hivemq_extension_services_publish_service_publishes': 'extension.services.publish_service_publishes',
+    'com_hivemq_extension_services_publish_service_publishes_to_client': (
+        'extension.services.publish_service_publishes_to_client'
+    ),
+    'com_hivemq_extension_services_rate_limit_exceeded_count': 'extension.services.rate_limit_exceeded.count',
+    'com_hivemq_keep_alive_disconnect_count': 'keep_alive.disconnect.count',
+    'com_hivemq_messages_dropped_count': 'messages.dropped.count',
+    'com_hivemq_messages_dropped_internal_error_count': 'messages.dropped.internal_error.count',
+    'com_hivemq_messages_dropped_message_too_large_count': 'messages.dropped.message_too_large.count',
+    'com_hivemq_messages_dropped_mqtt_packet_too_large_count': 'messages.dropped.mqtt_packet_too_large.count',
+    'com_hivemq_messages_dropped_not_writable_count': 'messages.dropped.not_writable.count',
+    'com_hivemq_messages_dropped_publish_inbound_intercepted_count': (
+        'messages.dropped.publish_inbound_intercepted.count'
+    ),
+    'com_hivemq_messages_dropped_qos_0_memory_exceeded_count': 'messages.dropped.qos_0_memory_exceeded.count',
+    'com_hivemq_messages_dropped_queue_full_count': 'messages.dropped.queue_full.count',
+    'com_hivemq_messages_expired_messages': 'messages.expired_messages',
+    'com_hivemq_messages_incoming_auth_count': 'messages.incoming.auth.count',
+    'com_hivemq_messages_incoming_connect_count': 'messages.incoming.connect.count',
+    'com_hivemq_messages_incoming_connect_mqtt3_count': 'messages.incoming.connect.mqtt3.count',
+    'com_hivemq_messages_incoming_connect_mqtt5_count': 'messages.incoming.connect.mqtt5.count',
+    'com_hivemq_messages_incoming_disconnect_count': 'messages.incoming.disconnect.count',
+    'com_hivemq_messages_incoming_pingreq_count': 'messages.incoming.pingreq.count',
+    'com_hivemq_messages_incoming_puback_count': 'messages.incoming.puback.count',
+    'com_hivemq_messages_incoming_pubcomp_count': 'messages.incoming.pubcomp.count',
+    'com_hivemq_messages_incoming_publish_count': 'messages.incoming.publish.count',
+    'com_hivemq_messages_incoming_pubrec_count': 'messages.incoming.pubrec.count',
+    'com_hivemq_messages_incoming_pubrel_count': 'messages.incoming.pubrel.count',
+    'com_hivemq_messages_incoming_subscribe_count': 'messages.incoming.subscribe.count',
+    'com_hivemq_messages_incoming_total_count': 'messages.incoming.total.count',
+    'com_hivemq_messages_incoming_unsubscribe_count': 'messages.incoming.unsubscribe.count',
+    'com_hivemq_messages_outgoing_auth_count': 'messages.outgoing.auth.count',
+    'com_hivemq_messages_outgoing_connack_count': 'messages.outgoing.connack.count',
+    'com_hivemq_messages_outgoing_disconnect_count': 'messages.outgoing.disconnect.count',
+    'com_hivemq_messages_outgoing_pingresp_count': 'messages.outgoing.pingresp.count',
+    'com_hivemq_messages_outgoing_puback_count': 'messages.outgoing.puback.count',
+    'com_hivemq_messages_outgoing_pubcomp_count': 'messages.outgoing.pubcomp.count',
+    'com_hivemq_messages_outgoing_publish_count': 'messages.outgoing.publish.count',
+    'com_hivemq_messages_outgoing_pubrec_count': 'messages.outgoing.pubrec.count',
+    'com_hivemq_messages_outgoing_pubrel_count': 'messages.outgoing.pubrel.count',
+    'com_hivemq_messages_outgoing_suback_count': 'messages.outgoing.suback.count',
+    'com_hivemq_messages_outgoing_total_count': 'messages.outgoing.total.count',
+    'com_hivemq_messages_outgoing_unsuback_count': 'messages.outgoing.unsuback.count',
+    'com_hivemq_networking_connections_closed_graceful_count': 'networking.connections_closed.graceful.count',
+    'com_hivemq_networking_connections_closed_total_count': 'networking.connections_closed.total.count',
+    'com_hivemq_networking_connections_closed_ungraceful_count': 'networking.connections_closed.ungraceful.count',
+    'com_hivemq_payload_persistence_cleanup_executor_running': 'payload_persistence.cleanup_executor.running',
+    'com_hivemq_payload_persistence_cleanup_executor_scheduled_overrun': (
+        'payload_persistence.cleanup_executor.scheduled.overrun'
+    ),
+    'com_hivemq_persistence_executor_running': 'persistence_executor.running',
+    'com_hivemq_persistence_scheduled_executor_running': 'persistence_scheduled_executor.running',
+    'com_hivemq_persistence_scheduled_executor_scheduled_overrun': 'persistence_scheduled_executor.scheduled.overrun',
+    'com_hivemq_persistence_executor_queue_misses': 'persistence.executor.queue_misses',
+    'com_hivemq_publish_without_matching_subscribers': 'publish.without_matching_subscribers',
+    'com_hivemq_sessions_persistent_active': 'sessions.persistent.active',
+    'com_hivemq_single_writer_executor_running': 'single_writer_executor.running',
+    'com_hivemq_subscriptions_overall_current': 'subscriptions.overall.current',
+}
+
+# Wire name -> target name for Dropwizard Histograms. Each expands, via
+# HivemqCheck._transform_histogram, into `<name>.<Nth>_percentile` gauges and a
+# `<name>.count` monotonic_count, matching data/metrics.yaml exactly.
+HISTOGRAM_METRICS = {
+    'com_hivemq_extension_managed_executor_scheduled_percent_of_period': (
+        'extension.managed_executor.scheduled.percent_of_period'
+    ),
+    'com_hivemq_messages_incoming_publish_bytes': 'messages.incoming.publish.bytes',
+    'com_hivemq_messages_incoming_total_bytes': 'messages.incoming.total.bytes',
+    'com_hivemq_messages_outgoing_publish_bytes': 'messages.outgoing.publish.bytes',
+    'com_hivemq_messages_outgoing_total_bytes': 'messages.outgoing.total.bytes',
+    'com_hivemq_messages_retained_mean': 'messages.retained.mean',
+    'com_hivemq_networking_connections_mean': 'networking.connections.mean',
+    'com_hivemq_payload_persistence_cleanup_executor_scheduled_percent_of_period': (
+        'payload_persistence.cleanup_executor.scheduled.percent_of_period'
+    ),
+    'com_hivemq_persistence_scheduled_executor_scheduled_percent_of_period': (
+        'persistence_scheduled_executor.scheduled.percent_of_period'
+    ),
+}
+
+# Only gauges are declared through the standard `metrics` config; counters and
+# histograms are handled by custom transformers registered in HivemqCheck.
+METRIC_MAP = dict(GAUGE_METRICS)
+
+# Prometheus summary quantile label value -> JMX-style percentile suffix.
+QUANTILE_SUFFIXES = {
+    '0.5': '50th_percentile',
+    '0.75': '75th_percentile',
+    '0.95': '95th_percentile',
+    '0.98': '98th_percentile',
+    '0.99': '99th_percentile',
+    '0.999': '999th_percentile',
+}

--- a/hivemq/tests/common.py
+++ b/hivemq/tests/common.py
@@ -8,4 +8,13 @@ HOST = get_docker_hostname()
 
 JMX_PORT = 9010
 
-INSTANCE = {'host': HOST, 'port': JMX_PORT, 'max_returned_metrics': 99999}
+INSTANCE = {'host': HOST, 'port': JMX_PORT, 'max_returned_metrics': 99999, 'is_jmx': True}
+
+OPENMETRICS_PORT = 9399
+OPENMETRICS_ENDPOINT = f'http://{HOST}:{OPENMETRICS_PORT}/metrics'
+
+OPENMETRICS_INSTANCE = {
+    'is_jmx': False,
+    'use_openmetrics': True,
+    'openmetrics_endpoint': OPENMETRICS_ENDPOINT,
+}

--- a/hivemq/tests/fixtures/metrics.txt
+++ b/hivemq/tests/fixtures/metrics.txt
@@ -1,0 +1,15 @@
+# HELP com_hivemq_system_system_cpu_load Generated from Dropwizard metric import (metric=com.hivemq.system.system-cpu.load, type=com.codahale.metrics.Gauge)
+# TYPE com_hivemq_system_system_cpu_load gauge
+com_hivemq_system_system_cpu_load 0.42
+# HELP com_hivemq_messages_incoming_publish_count Generated from Dropwizard metric import (metric=com.hivemq.messages.incoming.publish.count, type=com.codahale.metrics.Counter)
+# TYPE com_hivemq_messages_incoming_publish_count gauge
+com_hivemq_messages_incoming_publish_count 1234
+# HELP com_hivemq_messages_incoming_publish_bytes Generated from Dropwizard metric import (metric=com.hivemq.messages.incoming.publish.bytes, type=com.codahale.metrics.Histogram)
+# TYPE com_hivemq_messages_incoming_publish_bytes summary
+com_hivemq_messages_incoming_publish_bytes{quantile="0.5",} 100.0
+com_hivemq_messages_incoming_publish_bytes{quantile="0.75",} 150.0
+com_hivemq_messages_incoming_publish_bytes{quantile="0.95",} 200.0
+com_hivemq_messages_incoming_publish_bytes{quantile="0.98",} 220.0
+com_hivemq_messages_incoming_publish_bytes{quantile="0.99",} 240.0
+com_hivemq_messages_incoming_publish_bytes{quantile="0.999",} 260.0
+com_hivemq_messages_incoming_publish_bytes_count 42

--- a/hivemq/tests/test_unit.py
+++ b/hivemq/tests/test_unit.py
@@ -1,0 +1,107 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import csv
+import os
+
+import pytest
+
+from datadog_checks.hivemq import HivemqCheck
+from datadog_checks.hivemq.metrics import COUNTER_METRICS, GAUGE_METRICS, HISTOGRAM_METRICS
+
+from . import common
+
+pytestmark = [pytest.mark.unit]
+
+HISTOGRAM_SUFFIXES = (
+    '50th_percentile',
+    '75th_percentile',
+    '95th_percentile',
+    '98th_percentile',
+    '99th_percentile',
+    '999th_percentile',
+    'count',
+)
+
+
+def _load_metadata_names():
+    metadata_path = os.path.join(os.path.dirname(common.HERE), 'metadata.csv')
+    with open(metadata_path) as f:
+        return {row['metric_name'] for row in csv.DictReader(f)}
+
+
+def test_metric_map_targets_exist_in_metadata():
+    """
+    Every name the OpenMetrics collection path can submit must already be a metric
+    this integration documents (via JMX collection today), so that switching
+    `use_openmetrics` never introduces a name that isn't in metadata.csv.
+    """
+    metadata_names = _load_metadata_names()
+    missing = set()
+
+    for target in GAUGE_METRICS.values():
+        missing.add(f'hivemq.{target}') if f'hivemq.{target}' not in metadata_names else None
+
+    for target in COUNTER_METRICS.values():
+        full = f'hivemq.{target}'
+        if full not in metadata_names:
+            missing.add(full)
+
+    for base in HISTOGRAM_METRICS.values():
+        for suffix in HISTOGRAM_SUFFIXES:
+            full = f'hivemq.{base}.{suffix}'
+            if full not in metadata_names:
+                missing.add(full)
+
+    assert not missing
+
+
+def test_metric_map_has_no_name_collisions():
+    """
+    No two entries across the gauge/counter/histogram maps may resolve to the same
+    submitted metric name -- e.g. a histogram's derived `.count` must never collide
+    with an unrelated counter's `.count`.
+    """
+    seen = {}
+    collisions = []
+
+    def register(name, source):
+        if name in seen and seen[name] != source:
+            collisions.append((name, seen[name], source))
+        else:
+            seen[name] = source
+
+    for wire, target in GAUGE_METRICS.items():
+        register(target, ('gauge', wire))
+
+    for wire, target in COUNTER_METRICS.items():
+        register(target, ('counter', wire))
+
+    for wire, base in HISTOGRAM_METRICS.items():
+        for suffix in HISTOGRAM_SUFFIXES:
+            register(f'{base}.{suffix}', ('histogram', wire))
+
+    assert not collisions
+
+
+def test_check_collects_gauge_counter_and_histogram(dd_run_check, aggregator, mock_http_response):
+    fixture_path = os.path.join(common.HERE, 'fixtures', 'metrics.txt')
+    mock_http_response(file_path=fixture_path)
+
+    check = HivemqCheck('hivemq', {}, [common.OPENMETRICS_INSTANCE])
+    dd_run_check(check)
+
+    aggregator.assert_metric('hivemq.system.system_cpu.load', value=0.42, metric_type=aggregator.GAUGE)
+    aggregator.assert_metric(
+        'hivemq.messages.incoming.publish.count', value=1234, metric_type=aggregator.MONOTONIC_COUNT
+    )
+
+    aggregator.assert_metric(
+        'hivemq.messages.incoming.publish.bytes.50th_percentile', value=100.0, metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_metric(
+        'hivemq.messages.incoming.publish.bytes.999th_percentile', value=260.0, metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_metric(
+        'hivemq.messages.incoming.publish.bytes.count', value=42, metric_type=aggregator.MONOTONIC_COUNT
+    )


### PR DESCRIPTION
### What does this PR do?
Adds OpenMetrics/Prometheus collection support to the HiveMQ integration, as an alternative to the existing JMX-only check. Selectable per-instance via `is_jmx: false` + `use_openmetrics: true`, scraping the free HiveMQ Prometheus extension (https://github.com/hivemq/hivemq-prometheus-extension) instead of JMXFetch. The two collection methods are mutually exclusive per instance and share no runtime code; the default (`is_jmx: true`) behavior and its existing e2e test are unchanged.

Includes:
- `check.py` / `metrics.py`: an `OpenMetricsBaseCheckV2`-based check with a metric map that renames the extension's exposed Prometheus names back to the existing `hivemq.*` metric names, so dashboards/monitors keep working regardless of collection method.
- Custom transformers for counters and histograms, to avoid metric-shape/naming mismatches with JMX (e.g. the native `counter` type always appends `.count`, which would double up with names that already end in `.count`; histograms are split back into discrete `.Nth_percentile`/`.count` metrics instead of the native tag-based summary shape).
- `assets/configuration/spec.yaml` changes: relaxed `is_jmx` at the `init_config` level (previously forced every instance into JMX mode unconditionally) and added an `openmetrics` instance example alongside the `jmx` one.
- Unit tests, including a collision-safety test asserting every OpenMetrics-path metric name already exists in `metadata.csv` with no name reused across gauge/counter/histogram groups.

See `docs/superpowers/specs/2026-07-27-hivemq-openmetrics-design.md` (added in an earlier commit on this branch) for the full design rationale, including the DropwizardExports feasibility research behind this and the documented gap: `Max`/`Mean`/`Min`/`StdDev`/`SnapshotSize` sub-metrics of histogram-based metrics have no OpenMetrics equivalent and are not collected via `use_openmetrics`.

### Motivation
[FRAGENT-3671](https://datadoghq.atlassian.net/browse/FRAGENT-3671) asks for Prometheus/OpenMetrics support as an alternative to JMX, primarily for container/Kubernetes-friendliness (avoiding remote JMX port exposure).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

[FRAGENT-3671]: https://datadoghq.atlassian.net/browse/FRAGENT-3671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ