### PR TITLE
Add investigation as a valid unit name

### DIFF
--- a/ddev/changelog.d/24696.added
+++ b/ddev/changelog.d/24696.added
@@ -1,0 +1,1 @@
+Add ``investigation`` as a valid metric unit name.

--- a/ddev/src/ddev/cli/validate/metadata_utils.py
+++ b/ddev/src/ddev/cli/validate/metadata_utils.py
@@ -408,6 +408,7 @@ VALID_UNIT_NAMES = {
     'milliwatt-hour',
     'watt-hour',
     'kilowatt-hour',
+    'investigation',
 }
 
 ALLOWED_PREFIXES = ('system.', 'jvm.', 'http.', 'datadog.', 'sftp.', 'process.', 'runtime.', 'otelcol_')


### PR DESCRIPTION
### What does this PR do?

Adds `investigation` to the set of `VALID_UNIT_NAMES` recognized by ddev's metadata validator (`ddev/src/ddev/cli/validate/metadata_utils.py`), so integrations can declare metrics with this unit without failing `ddev validate metadata`.

### Motivation

A new metric unit type, `investigation`, is needed for metrics related to Bits investigations, but it isn't currently part of the validator's allow-list, causing `ddev validate metadata` to reject metadata that uses it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged