### PR TITLE
fix(mysql): handle NULL event_timer_end in activity query

### DIFF
--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -305,7 +305,7 @@ class MySQLActivity(ManagedAuthConnectionMixin, DBMAsyncJob):
             if row["thread_id"] in seen:
                 # `performance_schema.events_statements_current` can contain previous statements
                 # for the same thread. We only want the most recent one.
-                if row["event_timer_end"] < seen[row["thread_id"]]["event_timer_start"]:
+                if row["event_timer_end"] is None or row["event_timer_end"] < seen[row["thread_id"]]["event_timer_start"]:
                     continue
                 else:
                     second_pass[row["thread_id"]] = {"event_timer_start": row["event_timer_start"]}
@@ -329,7 +329,7 @@ class MySQLActivity(ManagedAuthConnectionMixin, DBMAsyncJob):
         for row in rows:
             if (
                 row["thread_id"] in second_pass
-                and row["event_timer_end"] < second_pass[row["thread_id"]]["event_timer_start"]
+                and row.get("event_timer_end") is not None and row["event_timer_end"] < second_pass[row["thread_id"]]["event_timer_start"]
             ):
                 continue
             filtered_rows.append(row)


### PR DESCRIPTION
## What Does This PR Do?

Fixes a `TypeError` crash in the MySQL DBM activity job when `event_timer_end` is `NULL`.

## Motivation

In `performance_schema.events_statements_current`, `TIMER_END` is `NULL` while a statement is still executing. The `_normalize_rows` method compares `event_timer_end` against a previously seen `event_timer_start` without a NULL guard:

```python
if row["event_timer_end"] < seen[row["thread_id"]]["event_timer_start"]:
```

When `event_timer_end` is `None`, this raises:
```
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

This crashes the `query-activity` job loop on every collection cycle. Regular `mysql.*` metrics keep flowing, but query activity/samples stop being collected entirely.

## Solution

Add a `None` guard before the comparison. When `event_timer_end` is `NULL` (statement still running), the row is kept — it's the most recent activity for that thread and should not be discarded.

## Testing

Verified with simulated rows:
- Row with `event_timer_end=None` is correctly kept (active statement)
- Row with `event_timer_end < seen_start` is correctly skipped (older statement)
- Old code crashes with `TypeError`, fixed code handles it gracefully

Fixes #24697
