### PR TITLE
[wip] SQL Server Database Name Tag Alias Update

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/database_metrics/ao_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/ao_metrics.py
@@ -122,7 +122,7 @@ class SqlserverAoMetrics(SqlserverDatabaseMetricsBase):
                 "type": "tag",
             },
             # ADC - sys.availability_databases_cluster
-            "ADC.database_name": {"name": "database_name", "type": "tag"},
+            "ADC.database_name": {"name": "db", "type": "tag"},
             # DRS - sys.dm_hadr_database_replica_states
             "DRS.replica_id": {"name": "replica_id", "type": "tag"},
             "DRS.database_id": {"name": "database_id", "type": "tag"},

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/db_fragmentation_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/db_fragmentation_metrics.py
@@ -27,7 +27,7 @@ DB_FRAGMENTATION_QUERY = {
         WHERE DDIPS.fragment_count is not null
     """,
     "columns": [
-        {"name": "database_name", "type": "tag"},
+        {"name": "db", "type": "tag"},
         {"name": "object_name", "type": "tag"},
         {"name": "schema", "type": "tag"},
         {"name": "index_id", "type": "tag"},

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -220,7 +220,7 @@ def test_sqlserver_ao_metrics(
             )
             expected_tags = [
                 f'replica_role:{replica_role}',
-                f'database_name:{database_name}',
+                f'db:{database_name}',
                 f'availability_group:{availability_group}',
                 f'availability_group_name:{availability_group_name}',
                 f'replica_server_name:{replica_server_name}',
@@ -1286,7 +1286,6 @@ def test_sqlserver_db_fragmentation_metrics(
                 metrics = zip(db_fragmentation_metrics.metric_names()[0], metric_values)
                 expected_tags = [
                     f'db:{database_name}',
-                    f'database_name:{database_name}',
                     f'object_name:{object_name}',
                     f'schema:{schema}',
                     f'index_id:{index_id}',

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -572,7 +572,7 @@ def test_index_fragmentation_metrics(aggregator, dd_run_check, instance_docker, 
     seen_databases = set()
     for m in aggregator.metrics("sqlserver.database.avg_fragmentation_in_percent"):
         tags_by_key = dict([t.split(':', 1) for t in m.tags])
-        seen_databases.add(tags_by_key['database_name'])
+        seen_databases.add(tags_by_key['db'])
         assert tags_by_key['object_name'].lower() != 'none'
 
     assert 'master' in seen_databases


### PR DESCRIPTION
### What does this PR do?
This change updates the alias used when searching for a specific database within dbm. Currently, SQL Server is trying to use or forwards user searches to `database_name` when the correct tag is `db` resulting in a blank result page. 

### Motivation
Address a discrepancy for SQL server database search-by-name that differs from other DBMS' currently supported. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
