### PR TITLE
[AI-7065] Refresh flow resume state in the Togo TUI without restarting the command

### DIFF
--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -4,14 +4,13 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 import yaml
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError
-
-from ddev.ai.config.errors import ConfigError
 
 if TYPE_CHECKING:
     from ddev.ai.config.models import ResolvedFlow
@@ -66,6 +65,24 @@ PhaseCheckpoint = Annotated[SuccessCheckpoint | FailedCheckpoint, Field(discrimi
 CheckpointAdapter: TypeAdapter[PhaseCheckpoint] = TypeAdapter(PhaseCheckpoint)
 
 
+@dataclass(frozen=True)
+class ResumeState:
+    """What a prior run left behind for a flow, and what resuming it would do.
+
+    ``completed`` is the dependency-closed set of phases that succeeded and whose every transitive
+    dependency also succeeded; a resume skips exactly these. ``frontier`` is the phases a resume
+    would start with. The default, empty state means there is no prior run to resume.
+    """
+
+    completed: frozenset[str] = frozenset()
+    frontier: frozenset[str] = frozenset()
+
+    @property
+    def is_resumable(self) -> bool:
+        """Whether resuming would actually run anything."""
+        return bool(self.frontier)
+
+
 class CheckpointManager:
     """Manages checkpoints.yaml and per-phase memory files for the full pipeline."""
 
@@ -91,6 +108,11 @@ class CheckpointManager:
         except (OSError, yaml.YAMLError) as e:
             raise CheckpointReadError(f"Failed to load checkpoints from {self._path}: {e}") from e
 
+        if not isinstance(raw, dict):
+            raise CheckpointReadError(
+                f"Checkpoints in {self._path} must be a mapping of phase ids, got {type(raw).__name__}."
+            )
+
         result: dict[str, PhaseCheckpoint] = {}
         for phase_id, data in raw.items():
             try:
@@ -107,9 +129,30 @@ class CheckpointManager:
         self._ensure_dir()
         self._path.write_text(yaml.dump(all_checkpoints, default_flow_style=False, sort_keys=False), encoding="utf-8")
 
-    def successful_phases(self) -> set[str]:
-        """Phase ids whose last recorded checkpoint reached 'success'."""
-        return {pid for pid, data in self.read().items() if data.status == CheckpointStatus.SUCCESS}
+    def resume_state(self, resolved_flow: ResolvedFlow) -> ResumeState:
+        """Return what a resume of *resolved_flow* would skip and where it would start.
+
+        Reads the checkpoint file once. An empty state is returned when nothing was ever recorded.
+
+        The single-pass closure relies on ``resolved_flow.flow`` being topologically sorted.
+
+        Raises:
+            CheckpointReadError: If the checkpoint file exists but cannot be read or parsed.
+        """
+        checkpoints = self.read()
+        if not checkpoints:
+            return ResumeState()
+
+        succeeded = {pid for pid, data in checkpoints.items() if data.status is CheckpointStatus.SUCCESS}
+        completed: set[str] = set()
+        frontier: set[str] = set()
+        for entry in resolved_flow.flow:
+            deps_done = all(dep in completed for dep in entry.dependencies)
+            if entry.phase in succeeded and deps_done:
+                completed.add(entry.phase)
+            elif deps_done:
+                frontier.add(entry.phase)
+        return ResumeState(completed=frozenset(completed), frontier=frozenset(frontier))
 
     def build_memory_prompt(self, user_additions: str | None) -> str:
         """Build the memory prompt to send to the agent at the end of a phase."""
@@ -140,31 +183,3 @@ class CheckpointManager:
         if key.endswith("_memory"):
             return self.memory_content(key.removesuffix("_memory"))
         return f"<VARIABLE UNDEFINED: {key}>"
-
-
-def resolve_resume_state(
-    resolved_flow: ResolvedFlow, checkpoint_manager: CheckpointManager
-) -> tuple[set[str], set[str]]:
-    """Compute (completed, frontier) for resuming a flow from its checkpoints.
-
-    ``completed`` is the dependency-closed set of phases that succeeded and whose every
-    transitive dependency also succeeded. ``frontier`` is the phases that will run first
-    on resume (not completed, but all their dependencies are).
-
-    The single-pass closure relies on ``resolved_flow.flow`` being topologically sorted.
-    """
-    try:
-        succeeded = checkpoint_manager.successful_phases()
-    except CheckpointReadError as e:
-        raise ConfigError(
-            f"Cannot resume: checkpoints file is unreadable ({e}). Delete it and restart from scratch."
-        ) from e
-    completed: set[str] = set()
-    frontier: set[str] = set()
-    for entry in resolved_flow.flow:
-        deps_done = all(dep in completed for dep in entry.dependencies)
-        if entry.phase in succeeded and deps_done:
-            completed.add(entry.phase)
-        elif deps_done:
-            frontier.add(entry.phase)
-    return completed, frontier

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -72,10 +72,15 @@ class ResumeState:
     ``completed`` is the dependency-closed set of phases that succeeded and whose every transitive
     dependency also succeeded; a resume skips exactly these. ``frontier`` is the phases a resume
     would start with. The default, empty state means there is no prior run to resume.
+
+    ``error`` distinguishes "nothing was recorded" from "the recording could not be read". Callers
+    that turn a :class:`CheckpointReadError` into a state rather than propagating it set it so the
+    reason survives; it is never set by :meth:`CheckpointManager.resume_state`, which raises instead.
     """
 
     completed: frozenset[str] = frozenset()
     frontier: frozenset[str] = frozenset()
+    error: str | None = None
 
     @property
     def is_resumable(self) -> bool:

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -7,12 +7,13 @@ from pathlib import Path
 
 from ddev.ai.agent.registry import AgentProviderRegistry
 from ddev.ai.callbacks.callbacks import Callbacks
+from ddev.ai.config.errors import ConfigError
 from ddev.ai.config.models import ResolvedFlow, RuntimeVariables
 from ddev.ai.phases.base import FlowContext
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.registry import PhaseRegistry
 from ddev.ai.runtime.agent_log import AgentLogger
-from ddev.ai.runtime.checkpoints import CheckpointManager, resolve_resume_state
+from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointReadError, ResumeState
 from ddev.ai.runtime.resources import RunResources
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.event_bus.exceptions import FatalProcessingError, OrchestratorHookError
@@ -70,14 +71,38 @@ class PhaseOrchestrator(EventBusOrchestrator):
     def failed_phase(self) -> str | None:
         return self._failed_phase
 
+    def _read_resume_state(self, checkpoint_manager: CheckpointManager) -> ResumeState:
+        """Read the resume plan, or an empty one when this run is not resuming.
+
+        Raises:
+            ConfigError: If this run asked to resume but there is nothing left to resume.
+        """
+        if not self._resume:
+            return ResumeState()
+
+        try:
+            state = checkpoint_manager.resume_state(self._resolved_flow)
+        except CheckpointReadError as e:
+            raise ConfigError(
+                f"Cannot resume: checkpoints file is unreadable ({e}). Delete it and restart from scratch."
+            ) from e
+
+        if not state.is_resumable:
+            reason = (
+                "every scheduled phase already completed successfully"
+                if state.completed
+                else "no incomplete run was recorded"
+            )
+            raise ConfigError(f"Cannot resume flow {self._resolved_flow.name!r}: {reason}. Launch it instead.")
+        return state
+
     async def on_initialize(self) -> None:
         """Construct phases from the resolved flow and submit the start PhaseTrigger."""
         checkpoint_manager = CheckpointManager(self._checkpoint_path)
         dependency_map: dict[str, list[str]] = {entry.phase: entry.dependencies for entry in self._resolved_flow.flow}
 
-        completed, frontier = (
-            resolve_resume_state(self._resolved_flow, checkpoint_manager) if self._resume else (set(), set())
-        )
+        resume_state = self._read_resume_state(checkpoint_manager)
+        completed, frontier = resume_state.completed, resume_state.frontier
         if self._resume:
             self._logger.info(
                 "Resuming: %d phase(s) completed, re-running frontier %r", len(completed), sorted(frontier)
@@ -97,7 +122,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
             flow_variables=self._resolved_flow.variables,
             callbacks=run_callbacks,
             logger=self._logger,
-            resume_frontier=frozenset(frontier),
+            resume_frontier=frontier,
         )
 
         for entry in self._resolved_flow.flow:

--- a/ddev/src/ddev/cli/meta/ai/tui/errors.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/errors.py
@@ -1,0 +1,26 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Shaping error text for single-line TUI surfaces such as banners and toasts."""
+
+from __future__ import annotations
+
+BANNER_ERROR_MAX_CHARS = 200
+
+
+def compact_error_detail(error: str, max_chars: int = BANNER_ERROR_MAX_CHARS) -> str:
+    """Reduce multi-line error text to one truncated line.
+
+    Exception text is frequently multi-line: a YAML parse error carries the offending source and a
+    caret, and a pydantic validation error one block per field. Banners and toasts have room for a
+    single line, and anything appended after the raw text lands after the last line rather than
+    after the message.
+
+    Args:
+        error: The error text to compact.
+        max_chars: Maximum length of the returned line, including the ellipsis.
+    """
+    detail = next((line.strip() for line in error.splitlines() if line.strip()), error.strip())
+    if len(detail) > max_chars:
+        detail = f"{detail[: max_chars - 1].rstrip()}…"
+    return detail

--- a/ddev/src/ddev/cli/meta/ai/tui/runs.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/runs.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-"""Run-directory helpers: detect whether a resumable run exists for a flow."""
+"""Run-directory helpers: locate a flow's run directory and read its resume state."""
 
 from __future__ import annotations
 
@@ -9,9 +9,8 @@ import hashlib
 import re
 from pathlib import Path
 
-from ddev.ai.config.errors import ConfigError
 from ddev.ai.config.models import ResolvedFlow
-from ddev.ai.runtime.checkpoints import CheckpointManager, resolve_resume_state
+from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointReadError, ResumeState
 
 
 def flow_slug(flow: ResolvedFlow) -> str:
@@ -27,42 +26,17 @@ def ai_runs_dir(repo_root: str | Path) -> Path:
     return Path(repo_root) / ".ddev" / "ai-runs"
 
 
-def has_resumable_run(flow: ResolvedFlow, runs_dir: Path) -> bool:
-    """Return True if an incomplete run exists for *flow*.
+def flow_resume_state(flow: ResolvedFlow, runs_dir: Path) -> ResumeState:
+    """Return the resume state recorded for *flow* below *runs_dir*.
 
-    A run is resumable when ``checkpoints.yaml`` exists inside the flow's run
-    directory, is non-empty, and ``resolve_resume_state`` (the same logic the
-    orchestrator uses to resume) finds at least one scheduled phase that
-    hasn't reached a dependency-closed success.
+    Unreadable checkpoints return an empty state: a corrupt file reads as nothing to resume.
 
     Args:
-        flow: The flow to check.
+        flow: The flow whose run directory to inspect.
         runs_dir: Base directory that contains per-flow run sub-directories.
     """
-    checkpoints_path = runs_dir / flow_slug(flow) / "checkpoints.yaml"
-    if not checkpoints_path.exists():
-        return False
-
-    manager = CheckpointManager(checkpoints_path)
-    try:
-        checkpoints = manager.read()
-    except Exception:
-        return False
-
-    if not checkpoints:
-        return False
-
-    try:
-        completed, _frontier = resolve_resume_state(flow, manager)
-    except ConfigError:
-        return False
-
-    scheduled = {entry.phase for entry in flow.flow}
-    return completed != scheduled
-
-
-def resume_completed_phases(flow: ResolvedFlow, runs_dir: Path) -> set[str]:
-    """Return dependency-closed completed phases from the flow checkpoint."""
     manager = CheckpointManager(runs_dir / flow_slug(flow) / "checkpoints.yaml")
-    completed, _frontier = resolve_resume_state(flow, manager)
-    return completed
+    try:
+        return manager.resume_state(flow)
+    except CheckpointReadError:
+        return ResumeState()

--- a/ddev/src/ddev/cli/meta/ai/tui/runs.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/runs.py
@@ -29,7 +29,9 @@ def ai_runs_dir(repo_root: str | Path) -> Path:
 def flow_resume_state(flow: ResolvedFlow, runs_dir: Path) -> ResumeState:
     """Return the resume state recorded for *flow* below *runs_dir*.
 
-    Unreadable checkpoints return an empty state: a corrupt file reads as nothing to resume.
+    Unreadable checkpoints are reported through ``ResumeState.error`` rather than raised, so one
+    corrupt file cannot crash a grid of flows. The reason is kept so callers can tell a corrupt
+    file apart from a clean slate and surface the remedy.
 
     Args:
         flow: The flow whose run directory to inspect.
@@ -38,5 +40,5 @@ def flow_resume_state(flow: ResolvedFlow, runs_dir: Path) -> ResumeState:
     manager = CheckpointManager(runs_dir / flow_slug(flow) / "checkpoints.yaml")
     try:
         return manager.resume_state(flow)
-    except CheckpointReadError:
-        return ResumeState()
+    except CheckpointReadError as e:
+        return ResumeState(error=str(e))

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -38,6 +38,7 @@ from ddev.cli.meta.ai.rendering import (
     render_web_search_line,
 )
 from ddev.cli.meta.ai.tui.app import OrchestratorLike
+from ddev.cli.meta.ai.tui.errors import compact_error_detail
 from ddev.cli.meta.ai.tui.messages import (
     AfterGoalCheck,
     AgentBeforeSend,
@@ -68,8 +69,6 @@ if TYPE_CHECKING:
 
 
 type OrchestratorBuilder = Callable[[Callbacks], OrchestratorLike]
-
-BANNER_ERROR_MAX_CHARS = 200
 
 
 class ExecutionScreen(TogoScreen):
@@ -233,13 +232,11 @@ class ExecutionScreen(TogoScreen):
             pass
 
     def _compact_error_detail(self, error: BaseException, phase_id: str | None = None) -> str:
-        detail = next((line.strip() for line in str(error).splitlines() if line.strip()), type(error).__name__)
+        detail = str(error) or type(error).__name__
         if phase_id is not None:
             detail = detail.removeprefix(f"Phase '{phase_id}' failed: ")
             detail = detail.removeprefix(f"Phase '{phase_id}': ")
-        if len(detail) > BANNER_ERROR_MAX_CHARS:
-            detail = f"{detail[: BANNER_ERROR_MAX_CHARS - 1].rstrip()}…"
-        return detail
+        return compact_error_detail(detail)
 
     def _show_error_banner(self, message: str) -> None:
         try:

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -55,7 +55,7 @@ from ddev.cli.meta.ai.tui.messages import (
     PhaseStarted,
     RunErrored,
 )
-from ddev.cli.meta.ai.tui.runs import ai_runs_dir, flow_slug, resume_completed_phases
+from ddev.cli.meta.ai.tui.runs import ai_runs_dir, flow_resume_state, flow_slug
 from ddev.cli.meta.ai.tui.screens.base import TogoScreen
 from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
 from ddev.cli.meta.ai.tui.screens.phase_error_modal import PhaseErrorModal
@@ -125,7 +125,7 @@ class ExecutionScreen(TogoScreen):
         self.togo_app.bridge_target = self
         if self.resume:
             runs_dir = self._runs_dir or ai_runs_dir(self.togo_app.ddev_app.repo.path)
-            for phase_id in resume_completed_phases(self.flow, runs_dir):
+            for phase_id in flow_resume_state(self.flow, runs_dir).completed:
                 self._phase_statuses[phase_id] = RunStatus.DONE
                 for task_phase, task_name in self._task_statuses:
                     if task_phase == phase_id:

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
@@ -16,6 +16,7 @@ from textual.widget import Widget
 from textual.widgets import Button, Static
 
 from ddev.ai.config.models import AgentConfig, ResolvedFlow
+from ddev.cli.meta.ai.tui.errors import compact_error_detail
 from ddev.cli.meta.ai.tui.screens.base import TogoScreen
 from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchInputValues
 from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
@@ -117,10 +118,11 @@ class FlowScreen(TogoScreen):
 
         self._apply_resume_state(state)
         if state.error is not None:
-            message = f"Cannot resume: {state.error} Delete the checkpoint file and launch from scratch."
+            detail = compact_error_detail(state.error).rstrip(".")
+            message = f"Cannot resume: {detail}. Delete the checkpoint file and launch from scratch."
         else:
             message = "Nothing left to resume — launch the flow instead."
-        self.notify(message, severity="warning")
+        self.notify(message, severity="warning", markup=False)
         return False
 
     def on_phase_selected(self, event: PhaseSelected) -> None:

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
@@ -20,6 +21,9 @@ from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchInputValues
 from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
 from ddev.cli.meta.ai.tui.status import RunStatus
 from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseSelected, PipelineGraph
+
+if TYPE_CHECKING:
+    from ddev.ai.runtime.checkpoints import ResumeState
 
 
 class FlowScreen(TogoScreen):
@@ -87,23 +91,37 @@ class FlowScreen(TogoScreen):
             if config.tools:
                 yield Static(" · ".join(config.tools), classes="flow-agent-tools")
 
-    def on_mount(self) -> None:
-        self._refresh_resume_state()
-
+    # Textual posts ScreenResume on push as well as pop, so this covers the initial open too.
     def on_screen_resume(self) -> None:
         """Re-read resume state whenever this screen becomes active again."""
-        self._refresh_resume_state()
+        self._apply_resume_state(self._read_resume_state())
 
-    def _refresh_resume_state(self) -> None:
-        """Show the Resume button only while a resumable run exists for this flow."""
+    def _read_resume_state(self) -> ResumeState:
         from ddev.cli.meta.ai.tui.runs import ai_runs_dir, flow_resume_state
 
         runs_dir = self._runs_dir or ai_runs_dir(self.togo_app.ddev_app.repo.path)
-        state = flow_resume_state(self.flow, runs_dir)
+        return flow_resume_state(self.flow, runs_dir)
+
+    def _apply_resume_state(self, state: ResumeState) -> None:
+        """Show the Resume button only while a resumable run exists for this flow."""
         try:
             self.query_one("#resume", Button).display = state.is_resumable
         except NoMatches:
             pass
+
+    def _confirm_resumable(self) -> bool:
+        """Re-read the checkpoint before committing to a resume, resyncing the UI if it went stale."""
+        state = self._read_resume_state()
+        if state.is_resumable:
+            return True
+
+        self._apply_resume_state(state)
+        if state.error is not None:
+            message = f"Cannot resume: {state.error} Delete the checkpoint file and launch from scratch."
+        else:
+            message = "Nothing left to resume — launch the flow instead."
+        self.notify(message, severity="warning")
+        return False
 
     def on_phase_selected(self, event: PhaseSelected) -> None:
         self.app.push_screen(PhaseConfigScreen(self.flow, event.phase_id))
@@ -131,15 +149,22 @@ class FlowScreen(TogoScreen):
         from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
         from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchModal
 
+        if not self._confirm_resumable():
+            return
+
         def _on_dismiss(values: LaunchInputValues | None) -> None:
-            if values is not None:
-                self.app.push_screen(
-                    ExecutionScreen(
-                        self.flow,
-                        runtime_variables=values,
-                        resume=True,
-                        runs_dir=self._runs_dir,
-                    )
+            # The state can go stale while the modal is open, and the dismiss callback runs before
+            # the ScreenResume refresh, so re-check rather than commit to a resume that will fail.
+            if values is None or not self._confirm_resumable():
+                return
+
+            self.app.push_screen(
+                ExecutionScreen(
+                    self.flow,
+                    runtime_variables=values,
+                    resume=True,
+                    runs_dir=self._runs_dir,
                 )
+            )
 
         self.app.push_screen(LaunchModal(self.flow), _on_dismiss)

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Button, Static
 
@@ -87,14 +88,22 @@ class FlowScreen(TogoScreen):
                 yield Static(" · ".join(config.tools), classes="flow-agent-tools")
 
     def on_mount(self) -> None:
-        from ddev.cli.meta.ai.tui.runs import ai_runs_dir, has_resumable_run
+        self._refresh_resume_state()
+
+    def on_screen_resume(self) -> None:
+        """Re-read resume state whenever this screen becomes active again."""
+        self._refresh_resume_state()
+
+    def _refresh_resume_state(self) -> None:
+        """Show the Resume button only while a resumable run exists for this flow."""
+        from ddev.cli.meta.ai.tui.runs import ai_runs_dir, flow_resume_state
 
         runs_dir = self._runs_dir or ai_runs_dir(self.togo_app.ddev_app.repo.path)
-        if has_resumable_run(self.flow, runs_dir):
-            try:
-                self.query_one("#resume").display = True
-            except Exception:
-                pass
+        state = flow_resume_state(self.flow, runs_dir)
+        try:
+            self.query_one("#resume", Button).display = state.is_resumable
+        except NoMatches:
+            pass
 
     def on_phase_selected(self, event: PhaseSelected) -> None:
         self.app.push_screen(PhaseConfigScreen(self.flow, event.phase_id))

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/main.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/main.py
@@ -12,7 +12,8 @@ from textual.containers import VerticalScroll
 from textual.widget import Widget
 from textual.widgets import Static
 
-from ddev.cli.meta.ai.tui.runs import ai_runs_dir, has_resumable_run
+from ddev.ai.config.models import ResolvedFlow
+from ddev.cli.meta.ai.tui.runs import ai_runs_dir, flow_resume_state
 from ddev.cli.meta.ai.tui.screens.base import TogoScreen
 from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
 
@@ -32,9 +33,16 @@ class MainScreen(TogoScreen):
         yield Static(f"DISCOVERED FLOWS · {len(results)}", classes="eyebrow")
         grid = VerticalScroll(id="flow-grid")
         for i, result in enumerate(results):
-            resumable = result.resolved is not None and has_resumable_run(result.resolved, self.runs_dir)
-            grid.compose_add_child(FlowCard(result=result, index=i, resumable=resumable))
+            grid.compose_add_child(FlowCard(result=result, index=i, resumable=self._is_resumable(result.resolved)))
         yield grid
+
+    def _is_resumable(self, flow: ResolvedFlow | None) -> bool:
+        return flow is not None and flow_resume_state(flow, self.runs_dir).is_resumable
+
+    def on_screen_resume(self) -> None:
+        """Re-read resume state whenever this screen becomes active again."""
+        for card in self.query(FlowCard):
+            card.resumable = self._is_resumable(card.flow)
 
     def on_flow_card_selected(self, event: FlowCard.Selected) -> None:
         if event.result.resolved is not None:

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/main.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/main.py
@@ -13,6 +13,7 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from ddev.ai.config.models import ResolvedFlow
+from ddev.ai.runtime.checkpoints import ResumeState
 from ddev.cli.meta.ai.tui.runs import ai_runs_dir, flow_resume_state
 from ddev.cli.meta.ai.tui.screens.base import TogoScreen
 from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
@@ -33,16 +34,16 @@ class MainScreen(TogoScreen):
         yield Static(f"DISCOVERED FLOWS · {len(results)}", classes="eyebrow")
         grid = VerticalScroll(id="flow-grid")
         for i, result in enumerate(results):
-            grid.compose_add_child(FlowCard(result=result, index=i, resumable=self._is_resumable(result.resolved)))
+            grid.compose_add_child(FlowCard(result=result, index=i, resume_state=self._resume_state(result.resolved)))
         yield grid
 
-    def _is_resumable(self, flow: ResolvedFlow | None) -> bool:
-        return flow is not None and flow_resume_state(flow, self.runs_dir).is_resumable
+    def _resume_state(self, flow: ResolvedFlow | None) -> ResumeState:
+        return flow_resume_state(flow, self.runs_dir) if flow is not None else ResumeState()
 
     def on_screen_resume(self) -> None:
         """Re-read resume state whenever this screen becomes active again."""
         for card in self.query(FlowCard):
-            card.resumable = self._is_resumable(card.flow)
+            card.resume_state = self._resume_state(card.flow)
 
     def on_flow_card_selected(self, event: FlowCard.Selected) -> None:
         if event.result.resolved is not None:

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/flow_card.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/flow_card.py
@@ -9,6 +9,7 @@ from rich.text import Text
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.message import Message
+from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
 
@@ -47,6 +48,10 @@ class FlowCard(Widget):
 
     BINDINGS = [Binding("enter", "select", "Select")]
 
+    # Recomposes rather than repaints: the resumable line lives in the footer child, which a
+    # repaint of the card would not rebuild.
+    resumable: reactive[bool] = reactive(False, init=False, recompose=True)
+
     class Selected(Message):
         """Posted when the card is activated (Enter or click)."""
 
@@ -60,7 +65,7 @@ class FlowCard(Widget):
         self.result = result
         self.flow = result.resolved
         self.index = index
-        self.resumable = resumable
+        self.set_reactive(FlowCard.resumable, resumable)
 
     @property
     def phase_count(self) -> int:

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/flow_card.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/flow_card.py
@@ -14,6 +14,7 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from ddev.ai.config.models import ConfigStatus, FlowResult
+from ddev.ai.runtime.checkpoints import ResumeState
 from ddev.cli.meta.ai.palette import ERROR, SUCCESS
 from ddev.cli.meta.ai.tui.widgets.pipeline_graph import COLOR_RUNNING
 
@@ -48,9 +49,9 @@ class FlowCard(Widget):
 
     BINDINGS = [Binding("enter", "select", "Select")]
 
-    # Recomposes rather than repaints: the resumable line lives in the footer child, which a
+    # Recomposes rather than repaints: the resume line lives in the footer child, which a
     # repaint of the card would not rebuild.
-    resumable: reactive[bool] = reactive(False, init=False, recompose=True)
+    resume_state: reactive[ResumeState] = reactive(ResumeState(), init=False, recompose=True)
 
     class Selected(Message):
         """Posted when the card is activated (Enter or click)."""
@@ -59,13 +60,18 @@ class FlowCard(Widget):
             super().__init__()
             self.result = result
 
-    def __init__(self, result: FlowResult, index: int, *, resumable: bool = False) -> None:
+    def __init__(self, result: FlowResult, index: int, *, resume_state: ResumeState | None = None) -> None:
         classes = "broken" if result.status is ConfigStatus.BROKEN else "valid"
         super().__init__(classes=classes)
         self.result = result
         self.flow = result.resolved
         self.index = index
-        self.set_reactive(FlowCard.resumable, resumable)
+        self.set_reactive(FlowCard.resume_state, resume_state or ResumeState())
+
+    @property
+    def resumable(self) -> bool:
+        """Whether the recorded run leaves something for a resume to do."""
+        return self.resume_state.is_resumable
 
     @property
     def phase_count(self) -> int:
@@ -97,7 +103,9 @@ class FlowCard(Widget):
             phase_word = "phase" if n == 1 else "phases"
             content.append("●", style=SUCCESS)
             content.append(f" {n} {phase_word}")
-            if self.resumable:
+            if self.resume_state.error is not None:
+                content.append("\n✕ checkpoint unreadable", style=ERROR)
+            elif self.resumable:
                 content.append("\n↻ resumable run available", style=COLOR_RUNNING)
         return content
 

--- a/ddev/tests/ai/runtime/test_checkpoints.py
+++ b/ddev/tests/ai/runtime/test_checkpoints.py
@@ -7,10 +7,12 @@ from pathlib import Path
 import pytest
 import yaml
 
+from ddev.ai.config.models import FlowEntry, ResolvedFlow
 from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
     CheckpointReadError,
     FailedCheckpoint,
+    ResumeState,
     SuccessCheckpoint,
 )
 
@@ -20,6 +22,21 @@ from .helpers import make_failed_checkpoint, make_success_checkpoint
 @pytest.fixture
 def manager(tmp_path: Path) -> CheckpointManager:
     return CheckpointManager(tmp_path / "checkpoints.yaml")
+
+
+def linear_flow() -> ResolvedFlow:
+    """Build a topologically sorted a → b → c flow."""
+    return ResolvedFlow(
+        name="demo",
+        agents={},
+        phases={},
+        flow=[
+            FlowEntry(phase="a"),
+            FlowEntry(phase="b", dependencies=["a"]),
+            FlowEntry(phase="c", dependencies=["b"]),
+        ],
+        variables={},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -34,6 +51,12 @@ def test_read_returns_empty_when_file_absent(manager: CheckpointManager):
 def test_read_returns_empty_when_file_is_empty(manager: CheckpointManager):
     manager._path.write_text("")
     assert manager.read() == {}
+
+
+def test_read_non_mapping_yaml_raises_checkpoint_read_error(manager: CheckpointManager):
+    manager._path.write_text("stale")
+    with pytest.raises(CheckpointReadError, match="must be a mapping"):
+        manager.read()
 
 
 def test_read_malformed_yaml_raises_checkpoint_read_error(manager: CheckpointManager):
@@ -168,19 +191,68 @@ def test_resolve_template_variable_non_memory_key(manager: CheckpointManager):
 
 
 # ---------------------------------------------------------------------------
-# successful_phases
+# resume_state
 # ---------------------------------------------------------------------------
 
 
-def test_successful_phases_empty_when_no_file(manager: CheckpointManager):
-    assert manager.successful_phases() == set()
+def test_resume_state_empty_when_no_file(manager: CheckpointManager):
+    """A flow that never ran has nothing to resume, so it has no frontier either."""
+    state = manager.resume_state(linear_flow())
+    assert state == ResumeState()
+    assert not state.is_resumable
 
 
-def test_successful_phases_returns_only_succeeded(manager: CheckpointManager):
+def test_resume_state_empty_when_file_is_empty(manager: CheckpointManager):
+    manager._path.write_text("")
+    assert manager.resume_state(linear_flow()) == ResumeState()
+
+
+def test_resume_state_partial_run_is_resumable(manager: CheckpointManager):
     manager.write_phase_checkpoint("a", make_success_checkpoint())
-    manager.write_phase_checkpoint("b", make_failed_checkpoint())
+    state = manager.resume_state(linear_flow())
+    assert state.completed == {"a"}
+    assert state.frontier == {"b"}
+    assert state.is_resumable
+
+
+def test_resume_state_fully_complete_run_is_not_resumable(manager: CheckpointManager):
+    manager.write_phase_checkpoint("a", make_success_checkpoint())
+    manager.write_phase_checkpoint("b", make_success_checkpoint())
     manager.write_phase_checkpoint("c", make_success_checkpoint())
-    assert manager.successful_phases() == {"a", "c"}
+    state = manager.resume_state(linear_flow())
+    assert state.completed == {"a", "b", "c"}
+    assert state.frontier == frozenset()
+    assert not state.is_resumable
+
+
+def test_resume_state_failed_phase_is_the_frontier(manager: CheckpointManager):
+    manager.write_phase_checkpoint("a", make_failed_checkpoint())
+    state = manager.resume_state(linear_flow())
+    assert state.completed == frozenset()
+    assert state.frontier == {"a"}
+    assert state.is_resumable
+
+
+def test_resume_state_closure_excludes_successes_behind_a_failure(manager: CheckpointManager):
+    """A phase that succeeded but whose ancestor failed is not dependency-closed, so it re-runs."""
+    manager.write_phase_checkpoint("a", make_failed_checkpoint())
+    manager.write_phase_checkpoint("b", make_success_checkpoint())
+    manager.write_phase_checkpoint("c", make_success_checkpoint())
+    state = manager.resume_state(linear_flow())
+    assert state.completed == frozenset()
+    assert state.frontier == {"a"}
+
+
+def test_resume_state_propagates_read_errors(manager: CheckpointManager):
+    manager._path.write_text("{ not: valid: yaml")
+    with pytest.raises(CheckpointReadError):
+        manager.resume_state(linear_flow())
+
+
+def test_resume_state_empty_flow_is_not_resumable(manager: CheckpointManager):
+    manager.write_phase_checkpoint("a", make_success_checkpoint())
+    empty_flow = ResolvedFlow(name="demo", agents={}, phases={}, flow=[], variables={})
+    assert not manager.resume_state(empty_flow).is_resumable
 
 
 def test_read_raises_on_invalid_checkpoint_entry(manager: CheckpointManager):

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -390,16 +390,22 @@ async def test_resume_dependency_closure_reruns_descendants_of_failure(linear_fl
     assert phases_by_name["c"]._is_resume_frontier is False
 
 
-async def test_resume_with_no_checkpoints_frontier_is_root(linear_flow, make_orchestrator):
-    """Ctrl+C before any checkpoint: all phases run, the root is the frontier."""
+async def test_resume_with_no_checkpoints_raises(linear_flow, make_orchestrator):
+    """Resuming a flow that never checkpointed is refused rather than run silently as a plain launch."""
     orchestrator, _, _ = make_orchestrator(linear_flow, resume=True)
-    await orchestrator.on_initialize()
+    with pytest.raises(ConfigError, match="no incomplete run was recorded"):
+        await orchestrator.on_initialize()
 
-    phases_by_name = {p.name: p for p in orchestrator._subscribers.get(PhaseTrigger, [])}
-    assert set(phases_by_name) == {"a", "b", "c"}
-    assert phases_by_name["a"]._is_resume_frontier is True
-    assert phases_by_name["b"]._is_resume_frontier is False
-    assert phases_by_name["c"]._is_resume_frontier is False
+
+async def test_resume_fully_completed_run_raises(linear_flow, make_orchestrator):
+    """Resuming an already-finished run is refused rather than reported as an instant success."""
+    _write_checkpoints(
+        linear_flow,
+        {"a": {"status": "success"}, "b": {"status": "success"}, "c": {"status": "success"}},
+    )
+    orchestrator, _, _ = make_orchestrator(linear_flow, resume=True)
+    with pytest.raises(ConfigError, match="every scheduled phase already completed"):
+        await orchestrator.on_initialize()
 
 
 async def test_no_resume_ignores_checkpoints(linear_flow, make_orchestrator):

--- a/ddev/tests/cli/meta/ai/tui/test_errors.py
+++ b/ddev/tests/cli/meta/ai/tui/test_errors.py
@@ -1,0 +1,48 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for tui/errors.py: compacting error text for single-line surfaces."""
+
+from __future__ import annotations
+
+from ddev.cli.meta.ai.tui.errors import BANNER_ERROR_MAX_CHARS, compact_error_detail
+
+
+def test_single_line_error_is_returned_unchanged() -> None:
+    assert compact_error_detail("Checkpoints must be a mapping.") == "Checkpoints must be a mapping."
+
+
+def test_only_the_first_non_empty_line_survives() -> None:
+    """A YAML parse error carries the offending source and a caret on later lines."""
+    error = 'Failed to load checkpoints: while parsing a flow mapping\n  in "<unicode string>", line 1\n    ^'
+    assert compact_error_detail(error) == "Failed to load checkpoints: while parsing a flow mapping"
+
+
+def test_leading_blank_lines_are_skipped() -> None:
+    assert compact_error_detail("\n\n  the real message  \n more") == "the real message"
+
+
+def test_long_line_is_truncated_with_an_ellipsis() -> None:
+    detail = compact_error_detail("x" * (BANNER_ERROR_MAX_CHARS + 50))
+    assert len(detail) == BANNER_ERROR_MAX_CHARS
+    assert detail.endswith("…")
+
+
+def test_max_chars_is_configurable() -> None:
+    assert compact_error_detail("abcdefghij", max_chars=5) == "abcd…"
+
+
+def test_blank_error_collapses_to_empty() -> None:
+    assert compact_error_detail("   \n  \n") == ""
+
+
+def test_pydantic_validation_text_loses_its_bracketed_fragments() -> None:
+    """The bracketed fragments that break Textual markup live on lines after the first."""
+    error = (
+        "Checkpoint for phase 'phase_0' is invalid: 4 validation errors\n"
+        "success.started_at\n"
+        "  Field required [type=missing, input_value={'status': 'success'}, input_type=dict]\n"
+    )
+    detail = compact_error_detail(error)
+    assert detail == "Checkpoint for phase 'phase_0' is invalid: 4 validation errors"
+    assert "input_value=" not in detail

--- a/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
@@ -176,14 +176,31 @@ def test_flow_resume_state_no_checkpoints_file(tmp_path: Path) -> None:
 
 
 def test_flow_resume_state_unreadable_checkpoints(tmp_path: Path) -> None:
-    """A corrupt checkpoints file reads as nothing to resume rather than crashing the grid."""
-    from ddev.cli.meta.ai.tui.runs import flow_slug
+    """A corrupt checkpoints file reports the reason rather than crashing the grid."""
+    from ddev.cli.meta.ai.tui.runs import flow_resume_state, flow_slug
 
     flow = _make_flow()
     run_dir = tmp_path / flow_slug(flow)
     run_dir.mkdir()
     (run_dir / "checkpoints.yaml").write_text("{ not: valid: yaml")
-    _assert_no_resume_state(flow, tmp_path)
+
+    state = flow_resume_state(flow, runs_dir=tmp_path)
+    assert not state.is_resumable
+    assert state.error is not None
+    assert "checkpoints.yaml" in state.error
+
+
+def test_flow_resume_state_distinguishes_corrupt_from_clean_slate(tmp_path: Path) -> None:
+    """An unreadable checkpoint is not reported as an absent one."""
+    from ddev.cli.meta.ai.tui.runs import flow_resume_state, flow_slug
+
+    corrupt = _make_flow(name="Corrupt")
+    run_dir = tmp_path / flow_slug(corrupt)
+    run_dir.mkdir()
+    (run_dir / "checkpoints.yaml").write_text("just a string, not a mapping")
+
+    assert flow_resume_state(corrupt, runs_dir=tmp_path).error is not None
+    assert flow_resume_state(_make_flow(name="Never Ran"), runs_dir=tmp_path).error is None
 
 
 def test_flow_resume_state_failed_checkpoint(tmp_path: Path) -> None:
@@ -678,6 +695,85 @@ async def test_resume_pushes_execution_screen_with_resume_flag(tmp_path: Path) -
         screen = pilot.app.screen
         assert isinstance(screen, ExecutionScreen)
         assert screen.resume is True
+
+
+async def test_resume_refuses_when_run_completes_while_modal_is_open(tmp_path: Path) -> None:
+    """The dismiss callback re-checks, so a run finished elsewhere cannot start a doomed resume."""
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchModal
+
+    flow = _make_flow(n_phases=2)
+    _write_incomplete_run(tmp_path, flow)
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        flow_screen = pilot.app.screen
+        await pilot.click("#resume")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, LaunchModal)
+
+        _provide_prd(pilot.app.screen, tmp_path)
+        _write_complete_run(tmp_path, flow)
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert not isinstance(pilot.app.screen, ExecutionScreen)
+        assert pilot.app.screen is flow_screen
+        assert not flow_screen.query_one("#resume", Button).display
+        assert "Nothing left to resume" in " ".join(n.message for n in pilot.app._notifications)
+
+
+async def test_resume_refuses_when_checkpoint_becomes_unreadable_while_modal_is_open(tmp_path: Path) -> None:
+    """A checkpoint corrupted mid-flight reports the remedy instead of a wrapped hook error."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+
+    flow = _make_flow(n_phases=2)
+    _write_incomplete_run(tmp_path, flow)
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        await pilot.click("#resume")
+        await pilot.pause()
+
+        _provide_prd(pilot.app.screen, tmp_path)
+        (tmp_path / flow_slug(flow) / "checkpoints.yaml").write_text("{ not: valid: yaml")
+        await pilot.click("#btn-launch")
+        await pilot.pause()
+
+        assert not isinstance(pilot.app.screen, ExecutionScreen)
+        notifications = " ".join(n.message for n in pilot.app._notifications)
+        assert "Cannot resume" in notifications
+        assert "Delete the checkpoint file" in notifications
+
+
+async def test_resume_refuses_before_opening_the_modal_when_nothing_to_resume(tmp_path: Path) -> None:
+    """A stale Resume button is refused up front rather than after collecting inputs."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.launch_modal import LaunchModal
+
+    flow = _make_flow(n_phases=2)
+    _write_incomplete_run(tmp_path, flow)
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        flow_screen = pilot.app.screen
+        assert flow_screen.query_one("#resume", Button).display
+
+        _write_complete_run(tmp_path, flow)
+        flow_screen._do_resume()
+        await pilot.pause()
+
+        assert not isinstance(pilot.app.screen, LaunchModal)
+        assert not flow_screen.query_one("#resume", Button).display
 
 
 async def test_resume_with_inputs_reopens_modal_and_passes_converted_values(tmp_path: Path) -> None:

--- a/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
@@ -751,6 +751,64 @@ async def test_resume_refuses_when_checkpoint_becomes_unreadable_while_modal_is_
         notifications = " ".join(n.message for n in pilot.app._notifications)
         assert "Cannot resume" in notifications
         assert "Delete the checkpoint file" in notifications
+        # One line, and the remedy follows a sentence rather than a YAML caret.
+        assert len(notifications.splitlines()) == 1
+        assert notifications.endswith("Delete the checkpoint file and launch from scratch.")
+
+
+# `run_test` disables notifications by default (`notifications=False`), so toasts are never
+# mounted and a message that Textual cannot render raises nothing. These two render for real.
+
+
+async def test_resume_refusal_toast_renders_schema_invalid_checkpoint_text(tmp_path: Path) -> None:
+    """A schema-invalid checkpoint must not take the app down when the refusal toast renders."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+
+    flow = _make_flow(n_phases=2)
+    _write_incomplete_run(tmp_path, flow)
+    app = _app()
+    async with app.run_test(size=(120, 50), notifications=True) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        flow_screen = pilot.app.screen
+        assert flow_screen.query_one("#resume", Button).display
+
+        # Valid YAML mapping, invalid checkpoint entry: pydantic reports bracketed fragments
+        # such as "[type=missing, input_value={'status': 'success'}]" that break content markup.
+        (tmp_path / flow_slug(flow) / "checkpoints.yaml").write_text("phase_0:\n  status: success\n")
+
+        flow_screen._do_resume()
+        for _ in range(4):
+            await pilot.pause()
+
+        assert app.is_running
+        assert not flow_screen.query_one("#resume", Button).display
+
+
+async def test_resume_refusal_toast_renders_unparsable_checkpoint_text(tmp_path: Path) -> None:
+    """The YAML-parse variant renders too, and its caret block never reaches the toast."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+
+    flow = _make_flow(n_phases=2)
+    _write_incomplete_run(tmp_path, flow)
+    app = _app()
+    async with app.run_test(size=(120, 50), notifications=True) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        flow_screen = pilot.app.screen
+        (tmp_path / flow_slug(flow) / "checkpoints.yaml").write_text("{ not: valid: yaml")
+
+        flow_screen._do_resume()
+        for _ in range(4):
+            await pilot.pause()
+
+        assert app.is_running
+        message = next(n.message for n in app._notifications)
+        assert "^" not in message
 
 
 async def test_resume_refuses_before_opening_the_modal_when_nothing_to_resume(tmp_path: Path) -> None:

--- a/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
@@ -56,29 +56,6 @@ def _make_flow(name: str = "Test Flow", n_phases: int = 2) -> ResolvedFlow:
     )
 
 
-def _make_flow_with_tools(name: str = "Tool Flow") -> ResolvedFlow:
-    """Create a flow whose agent has tools."""
-    agents = {
-        "analyst": AgentConfig.model_construct(provider="anthropic", model="claude-3-sonnet", tools=["read_file"])
-    }
-    phases = {
-        "analyse": PhaseConfig(
-            name="analyse",
-            agent="analyst",
-            tasks=[TaskConfig(name="read_task", prompt="analyse something")],
-        )
-    }
-    flow = [FlowEntry(phase="analyse")]
-    return ResolvedFlow(
-        name=name,
-        description="Tool flow",
-        agents=agents,
-        phases=phases,
-        flow=flow,
-        variables={},
-    )
-
-
 def _app() -> TogoApp:
     flow = _make_flow()
     ddev_app = SimpleNamespace(
@@ -102,28 +79,45 @@ def _provide_prd(screen, tmp_path: Path) -> str:
     return content
 
 
-def _incomplete_checkpoints_yaml(flow: ResolvedFlow) -> str:
-    """Return YAML with only the first scheduled phase as success."""
-    first_phase = flow.flow[0].phase
-    return f"""{first_phase}:
+def _success_checkpoint_yaml(phase: str) -> str:
+    """Return a success checkpoint block for one phase."""
+    return f"""{phase}:
   status: success
   started_at: '2024-01-01T00:00:00'
   finished_at: '2024-01-01T00:01:00'
   tokens:
     total_input: 100
     total_output: 100
-  memory_path: {first_phase}_memory.md
+  memory_path: {phase}_memory.md
 """
 
 
-def _write_incomplete_run(tmp_path: Path, flow: ResolvedFlow) -> Path:
-    """Create a run dir under tmp_path with an incomplete checkpoints.yaml."""
+def _write_run(tmp_path: Path, flow: ResolvedFlow, checkpoints_yaml: str) -> Path:
+    """Write *checkpoints_yaml* to the run dir for *flow* below tmp_path."""
     from ddev.cli.meta.ai.tui.runs import flow_slug
 
     run_dir = tmp_path / flow_slug(flow)
-    run_dir.mkdir(parents=True)
-    (run_dir / "checkpoints.yaml").write_text(_incomplete_checkpoints_yaml(flow))
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "checkpoints.yaml").write_text(checkpoints_yaml)
     return tmp_path
+
+
+def _write_incomplete_run(tmp_path: Path, flow: ResolvedFlow) -> Path:
+    """Create a run dir under tmp_path with only the first scheduled phase at success."""
+    return _write_run(tmp_path, flow, _success_checkpoint_yaml(flow.flow[0].phase))
+
+
+def _write_complete_run(tmp_path: Path, flow: ResolvedFlow) -> Path:
+    """Create a run dir under tmp_path with every scheduled phase at success."""
+    return _write_run(tmp_path, flow, "".join(_success_checkpoint_yaml(entry.phase) for entry in flow.flow))
+
+
+def _assert_no_resume_state(flow: ResolvedFlow, runs_dir: Path) -> None:
+    """Used to assert *flow* records nothing at all below *runs_dir*."""
+    from ddev.ai.runtime.checkpoints import ResumeState
+    from ddev.cli.meta.ai.tui.runs import flow_resume_state
+
+    assert flow_resume_state(flow, runs_dir=runs_dir) == ResumeState()
 
 
 # ---------------------------------------------------------------------------
@@ -142,83 +136,59 @@ def test_flow_slug_distinguishes_case_sensitive_names() -> None:
     assert lower.startswith("build-")
 
 
-def test_has_resumable_run_no_dir(tmp_path: Path) -> None:
+def test_flow_resume_state_no_dir(tmp_path: Path) -> None:
     """No run dir → not resumable."""
-    from ddev.cli.meta.ai.tui.runs import has_resumable_run
+    from ddev.cli.meta.ai.tui.runs import flow_resume_state
 
     flow = _make_flow()
-    assert not has_resumable_run(flow, runs_dir=tmp_path)
+    assert not flow_resume_state(flow, runs_dir=tmp_path).is_resumable
 
 
-def test_has_resumable_run_incomplete_checkpoints(tmp_path: Path) -> None:
+def test_flow_resume_state_incomplete_checkpoints(tmp_path: Path) -> None:
     """Run dir with incomplete checkpoints → resumable."""
-    from ddev.cli.meta.ai.tui.runs import has_resumable_run
+    from ddev.cli.meta.ai.tui.runs import flow_resume_state
 
     flow = _make_flow(n_phases=2)
     _write_incomplete_run(tmp_path, flow)
-    assert has_resumable_run(flow, runs_dir=tmp_path)
+    state = flow_resume_state(flow, runs_dir=tmp_path)
+    assert state.is_resumable
+    assert state.completed == {flow.flow[0].phase}
 
 
-def test_has_resumable_run_all_phases_complete(tmp_path: Path) -> None:
+def test_flow_resume_state_all_phases_complete(tmp_path: Path) -> None:
     """All scheduled phases at success → not resumable."""
-    from ddev.cli.meta.ai.tui.runs import flow_slug, has_resumable_run
+    from ddev.cli.meta.ai.tui.runs import flow_resume_state
 
     flow = _make_flow(n_phases=2)
-    run_dir = tmp_path / flow_slug(flow)
-    run_dir.mkdir()
-    # Both phases complete
-    checkpoints_yaml = ""
-    for entry in flow.flow:
-        checkpoints_yaml += f"""{entry.phase}:
-  status: success
-  started_at: '2024-01-01T00:00:00'
-  finished_at: '2024-01-01T00:01:00'
-  tokens:
-    total_input: 100
-    total_output: 100
-  memory_path: {entry.phase}_memory.md
-"""
-    (run_dir / "checkpoints.yaml").write_text(checkpoints_yaml)
-    assert not has_resumable_run(flow, runs_dir=tmp_path)
+    _write_complete_run(tmp_path, flow)
+    state = flow_resume_state(flow, runs_dir=tmp_path)
+    assert state.completed == {entry.phase for entry in flow.flow}
+    assert not state.is_resumable
 
 
-def test_has_resumable_run_no_checkpoints_file(tmp_path: Path) -> None:
+def test_flow_resume_state_no_checkpoints_file(tmp_path: Path) -> None:
     """Run dir exists but no checkpoints.yaml → not resumable."""
-    from ddev.cli.meta.ai.tui.runs import flow_slug, has_resumable_run
+    from ddev.cli.meta.ai.tui.runs import flow_slug
+
+    flow = _make_flow()
+    (tmp_path / flow_slug(flow)).mkdir()
+    _assert_no_resume_state(flow, tmp_path)
+
+
+def test_flow_resume_state_unreadable_checkpoints(tmp_path: Path) -> None:
+    """A corrupt checkpoints file reads as nothing to resume rather than crashing the grid."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug
 
     flow = _make_flow()
     run_dir = tmp_path / flow_slug(flow)
     run_dir.mkdir()
-    assert not has_resumable_run(flow, runs_dir=tmp_path)
+    (run_dir / "checkpoints.yaml").write_text("{ not: valid: yaml")
+    _assert_no_resume_state(flow, tmp_path)
 
 
-def test_has_resumable_run_uses_resolve_resume_state(tmp_path: Path, monkeypatch) -> None:
-    """has_resumable_run must decide via resolve_resume_state, not its own bespoke check.
-
-    This keeps the "should we show Resume?" decision and the orchestrator's actual
-    skip-already-done-phases decision on the exact same code path, so they can't
-    silently drift apart.
-    """
-    from ddev.cli.meta.ai.tui import runs
-
-    flow = _make_flow(n_phases=2)
-    _write_incomplete_run(tmp_path, flow)
-
-    calls = []
-
-    def _spy(config, checkpoint_manager):
-        calls.append(config)
-        return {flow.flow[0].phase}, {flow.flow[1].phase}
-
-    monkeypatch.setattr(runs, "resolve_resume_state", _spy)
-
-    assert runs.has_resumable_run(flow, runs_dir=tmp_path)
-    assert calls == [flow]
-
-
-def test_has_resumable_run_failed_checkpoint(tmp_path: Path) -> None:
+def test_flow_resume_state_failed_checkpoint(tmp_path: Path) -> None:
     """A phase checkpoint with status: failed is resumable (not complete)."""
-    from ddev.cli.meta.ai.tui.runs import flow_slug, has_resumable_run
+    from ddev.cli.meta.ai.tui.runs import flow_resume_state, flow_slug
 
     flow = _make_flow(n_phases=2)
     run_dir = tmp_path / flow_slug(flow)
@@ -236,7 +206,7 @@ def test_has_resumable_run_failed_checkpoint(tmp_path: Path) -> None:
         "    total_output: 0\n"
     )
     # A failed phase means the run is not successfully complete → resumable
-    assert has_resumable_run(flow, runs_dir=tmp_path)
+    assert flow_resume_state(flow, runs_dir=tmp_path).is_resumable
 
 
 # ---------------------------------------------------------------------------
@@ -527,6 +497,54 @@ async def test_resume_button_shown_with_incomplete_run(tmp_path: Path) -> None:
         await pilot.pause()
         resume_btn = pilot.app.screen.query_one("#resume", Button)
         assert resume_btn.display
+
+
+async def test_resume_button_appears_when_screen_resumes(tmp_path: Path) -> None:
+    """A run that fails while the screen is on the stack reveals Resume on return."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+
+    flow = _make_flow(n_phases=2)
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        flow_screen = pilot.app.screen
+        assert not flow_screen.query_one("#resume", Button).display
+
+        await pilot.app.push_screen(PhaseConfigScreen(flow, flow.flow[0].phase))
+        await pilot.pause()
+        _write_incomplete_run(tmp_path, flow)
+        pilot.app.pop_screen()
+        await pilot.pause()
+
+        assert pilot.app.screen is flow_screen
+        assert flow_screen.query_one("#resume", Button).display
+
+
+async def test_resume_button_hidden_again_when_run_completes(tmp_path: Path) -> None:
+    """A run that finishes while the screen is on the stack hides Resume on return."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+
+    flow = _make_flow(n_phases=2)
+    _write_incomplete_run(tmp_path, flow)
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        flow_screen = pilot.app.screen
+        assert flow_screen.query_one("#resume", Button).display
+
+        await pilot.app.push_screen(PhaseConfigScreen(flow, flow.flow[0].phase))
+        await pilot.pause()
+        _write_complete_run(tmp_path, flow)
+        pilot.app.pop_screen()
+        await pilot.pause()
+
+        assert not flow_screen.query_one("#resume", Button).display
 
 
 async def test_phase_config_agent_panel_renders_tools_and_prompt() -> None:

--- a/ddev/tests/cli/meta/ai/tui/test_main_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_main_screen.py
@@ -14,6 +14,22 @@ from ddev.ai.config.errors import ErrorKind, FlowError
 from ddev.ai.config.models import ConfigStatus, FlowResult
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_success_checkpoint(repo_path: Path, flow, phase: str) -> None:
+    """Record *phase* as successful in *flow*'s run directory below *repo_path*."""
+    from ddev.ai.runtime.checkpoints import CheckpointManager
+    from ddev.cli.meta.ai.tui.runs import ai_runs_dir, flow_slug
+    from tests.ai.runtime.helpers import make_success_checkpoint
+
+    run_dir = ai_runs_dir(repo_path) / flow_slug(flow)
+    manager = CheckpointManager(run_dir / "checkpoints.yaml")
+    manager.write_phase_checkpoint(phase, make_success_checkpoint(memory_path=f"{phase}_memory.md"))
+
+
+# ---------------------------------------------------------------------------
 # TogoApp: screen stack after mount
 # ---------------------------------------------------------------------------
 
@@ -348,7 +364,6 @@ async def test_resume_discovery_uses_repository_root_when_cwd_differs(tmp_path, 
     """Dashboard and flow details discover runs below the configured repository."""
     from textual.widgets import Button
 
-    from ddev.cli.meta.ai.tui.runs import flow_slug
     from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
     from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
 
@@ -357,19 +372,7 @@ async def test_resume_discovery_uses_repository_root_when_cwd_differs(tmp_path, 
     repo_path.mkdir()
     other_cwd.mkdir()
     flow = make_flow("Repo Flow", n_phases=2)
-    run_dir = repo_path / ".ddev" / "ai-runs" / flow_slug(flow)
-    run_dir.mkdir(parents=True)
-    (run_dir / "checkpoints.yaml").write_text(
-        """phase_0:
-  status: success
-  started_at: '2024-01-01T00:00:00'
-  finished_at: '2024-01-01T00:01:00'
-  tokens:
-    total_input: 1
-    total_output: 1
-  memory_path: phase_0_memory.md
-"""
-    )
+    _write_success_checkpoint(repo_path, flow, "phase_0")
     app = make_togo_app([flow])
     app.ddev_app.repo.path = str(repo_path)
     monkeypatch.chdir(other_cwd)
@@ -382,3 +385,63 @@ async def test_resume_discovery_uses_repository_root_when_cwd_differs(tmp_path, 
         await pilot.pause()
         assert isinstance(app.screen, FlowScreen)
         assert app.screen.query_one("#resume", Button).display
+
+
+# ---------------------------------------------------------------------------
+# Resumable label refresh
+# ---------------------------------------------------------------------------
+
+
+async def test_flow_card_resumable_label_refreshes_on_screen_resume(tmp_path, make_flow, make_togo_app):
+    """A run started during the session updates its tile without restarting the TUI."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    flow = make_flow("Repo Flow", n_phases=2)
+    app = make_togo_app([flow])
+    app.ddev_app.repo.path = str(repo_path)
+
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        card = app.screen.query_one(FlowCard)
+        assert not card.resumable
+
+        card.action_select()
+        await pilot.pause()
+        assert isinstance(app.screen, FlowScreen)
+        _write_success_checkpoint(repo_path, flow, "phase_0")
+        app.pop_screen()
+        await pilot.pause()
+
+        assert card.resumable
+        assert "↻ resumable run available" in str(card.query_one(".flow-card-footer").render())
+
+
+async def test_flow_card_resumable_label_clears_when_run_completes(tmp_path, make_flow, make_togo_app):
+    """A run that finishes during the session drops the resumable label from its tile."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    flow = make_flow("Repo Flow", n_phases=2)
+    _write_success_checkpoint(repo_path, flow, "phase_0")
+    app = make_togo_app([flow])
+    app.ddev_app.repo.path = str(repo_path)
+
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        card = app.screen.query_one(FlowCard)
+        assert card.resumable
+
+        card.action_select()
+        await pilot.pause()
+        assert isinstance(app.screen, FlowScreen)
+        _write_success_checkpoint(repo_path, flow, "phase_1")
+        app.pop_screen()
+        await pilot.pause()
+
+        assert not card.resumable
+        assert "resumable" not in str(card.query_one(".flow-card-footer").render())

--- a/ddev/tests/cli/meta/ai/tui/test_main_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_main_screen.py
@@ -12,6 +12,7 @@ from rich.text import Text
 
 from ddev.ai.config.errors import ErrorKind, FlowError
 from ddev.ai.config.models import ConfigStatus, FlowResult
+from ddev.ai.runtime.checkpoints import ResumeState
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -296,7 +297,7 @@ async def test_flow_card_keeps_resumable_footer_with_long_description(make_flow,
     async with app.run_test(size=(120, 50)) as pilot:
         await pilot.pause()
         card = app.screen.query_one("FlowCard")
-        card.resumable = True
+        card.resume_state = ResumeState(frontier=frozenset({"phase_1"}))
         await card.recompose()
         await pilot.pause()
 
@@ -304,6 +305,44 @@ async def test_flow_card_keeps_resumable_footer_with_long_description(make_flow,
         assert str(footer.render()).splitlines() == ["● 2 phases", "↻ resumable run available"]
         assert footer.region.height == 2
         assert footer.region.bottom <= card.content_region.bottom
+
+
+async def test_flow_card_footer_reports_an_unreadable_checkpoint(make_flow, make_togo_app) -> None:
+    """A corrupt checkpoint is surfaced on the tile instead of reading as a clean slate."""
+    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+    flow = make_flow("Corrupt Checkpoint", n_phases=2)
+    app = make_togo_app([flow])
+
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        card = app.screen.query_one(FlowCard)
+        card.resume_state = ResumeState(error="Failed to load checkpoints from checkpoints.yaml: boom")
+        await card.recompose()
+        await pilot.pause()
+
+        footer = str(card.query_one(".flow-card-footer").render())
+        assert footer.splitlines() == ["● 2 phases", "✕ checkpoint unreadable"]
+        assert not card.resumable
+
+
+async def test_flow_card_unreadable_checkpoint_supersedes_resumable_label(make_flow, make_togo_app) -> None:
+    """The footer never claims a resume is available while the checkpoint cannot be read."""
+    from ddev.cli.meta.ai.tui.widgets.flow_card import FlowCard
+
+    flow = make_flow("Corrupt And Frontier", n_phases=2)
+    app = make_togo_app([flow])
+
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        card = app.screen.query_one(FlowCard)
+        card.resume_state = ResumeState(frontier=frozenset({"phase_1"}), error="unreadable")
+        await card.recompose()
+        await pilot.pause()
+
+        footer = str(card.query_one(".flow-card-footer").render())
+        assert "resumable run available" not in footer
+        assert "✕ checkpoint unreadable" in footer
 
 
 async def test_flow_card_click_does_not_navigate_when_text_is_selected(monkeypatch, make_togo_app):


### PR DESCRIPTION
> This is PR 1 of 2 in a stacked series: 
> 1. #24777 **<- you are here**
> 2. #24702

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Recomputes a flow's resume state whenever a TUI screen becomes active again, and collapses the resume-state API onto a single entry point.

**Refresh on `ScreenResume`**

- `FlowScreen` reads and applies resume state from `on_screen_resume`, the event Textual posts to a screen that becomes active. Textual posts it on `push_screen` as well as `pop_screen`, so one handler covers both the first open and every return — there is no `on_mount` counterpart to keep in sync, and no duplicate read per open.
- `FlowCard` holds the resume state in a single `resume_state` reactive rather than parallel display flags, with `resumable` derived from it.
- Both the tile label and the Resume button now follow the state in **both** directions. The old code could only ever set `display = True`, so a stale button survived a completed run.

**One way to read resume state**

- `CheckpointManager.resume_state(resolved_flow)` reads the checkpoint file once and returns a `ResumeState` of `completed` and `frontier` phases. `is_resumable` is simply a non-empty frontier: a flow that never ran has nothing to start from, so resuming it is just a launch.
- Replaces `has_resumable_run`, `resume_completed_phases`, and the module-level `resolve_resume_state`. `runs.py` keeps only its real job — locating run directories — behind one `flow_resume_state(flow, runs_dir)`.
- A flow screen previously cost three checkpoint reads (emptiness check, closure, then the graph); it now costs one per open. The "is this resumable?" policy moves out of the TUI, which had been re-deriving orchestration semantics.
- `ConfigError` translation moves to `PhaseOrchestrator`, where the "delete it and restart" advice is actionable. The runtime module no longer imports the config error type.

**A corrupt checkpoint is reported, not hidden**

- `ResumeState` carries an `error`, so "nothing was recorded" and "the recording could not be read" stop collapsing onto the same value. `resume_state()` still raises `CheckpointReadError` and the orchestrator keeps its precise message; `flow_resume_state` converts it instead of discarding it, so one corrupt file still cannot crash a grid of flows.
- `FlowCard` renders a third footer state, `✕ checkpoint unreadable`. Previously a corrupt file was indistinguishable from a flow that had never run, which left the remedy undiscoverable from the TUI.

**Behaviour changes**

- Resuming with nothing left to resume is now **refused** rather than silently doing something else. Before, no checkpoints ran every phase exactly as a plain launch would, and an already-finished run skipped every phase, registered no processors, and reported instant success without doing any work. `PhaseOrchestrator` validates `is_resumable` — the same property the TUI uses — and raises with a reason distinguishing the two cases.
- The TUI refuses first, so that case is an inline message rather than a failed run. `Screen.dismiss` invokes the result callback before popping, so the launch modal's dismiss commits a tick ahead of the `ScreenResume` refresh — the app would compute the correct answer immediately after acting on the stale one. `_do_resume` re-checks both before opening the modal and in the dismiss callback, resyncs the button, and reports why. The orchestrator check remains the CLI backstop.
- `CheckpointManager.read()` raised an unhandled `AttributeError` on a checkpoint file holding valid YAML that is not a mapping. The TUI's bare `except Exception` had been masking it; narrowing that handler to `CheckpointReadError` surfaced it. `read()` now raises `CheckpointReadError` like it does for every other unreadable file, so a corrupt file can no longer crash the flow grid on startup.

### Motivation
<!-- What inspired you to submit this pull request? -->

Whether a flow can be resumed is derived from its checkpoint file, so the data on disk is always correct. The TUI only read it while first building a screen, which left the display stale for the rest of the session:

- A flow that failed mid-session kept showing no resumable label on its tile until the command was quit and rerun, because cards are built once at compose time and `MainScreen` is never popped.
- Returning to the flow screen after a failed run did not reveal the Resume button, because `FlowScreen` is resumed rather than re-mounted. The user had to navigate back to the grid and re-enter the flow so a fresh screen was built.

The result was confusing rather than broken — the resume genuinely worked, nothing in the UI said so.

Follow-up in [AI-7066](https://datadoghq.atlassian.net/browse/AI-7066): interrupting a run before any phase completes writes no checkpoint at all, so an interrupted run cannot be told apart from one that never started. Telling those apart needs a run marker written at start; it is not recoverable from what is on disk today.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7066]: https://datadoghq.atlassian.net/browse/AI-7066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
