### PR TITLE
Add CHECKPOINTED status to phase nodes to separate it from PENDING

### DIFF
--- a/ddev/src/ddev/cli/meta/ai/palette.py
+++ b/ddev/src/ddev/cli/meta/ai/palette.py
@@ -34,6 +34,7 @@ STATUS_RUNNING = "#86B8DE"
 STATUS_PENDING = "#8F8B94"
 STATUS_DONE = SUCCESS
 STATUS_FAILED = ERROR
+STATUS_CHECKPOINTED = "#6E9480"
 STATUS_CONNECTOR = "#4A4650"
 
 # Per-role identity colors used to tell speakers apart in the log.

--- a/ddev/src/ddev/cli/meta/ai/tui/app.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/app.py
@@ -19,7 +19,6 @@ from textual.reactive import reactive
 
 from ddev.ai.agent.registry import AgentProviderRegistry
 from ddev.ai.phases.registry import PhaseRegistry
-from ddev.cli.meta.ai.palette import STATUS_DONE, STATUS_FAILED, STATUS_PENDING, STATUS_RUNNING
 from ddev.cli.meta.ai.tui.messages import (
     AfterCompact,
     AfterGoalCheck,
@@ -38,7 +37,7 @@ from ddev.cli.meta.ai.tui.messages import (
     RunErrored,
 )
 from ddev.cli.meta.ai.tui.status import ExecutionStatus
-from ddev.cli.meta.ai.tui.theme import togo_markdown_theme, togo_theme
+from ddev.cli.meta.ai.tui.theme import STATUS_VARIABLE_KEYS, togo_markdown_theme, togo_theme
 
 if TYPE_CHECKING:
     from ddev.ai.config.engine import ConfigurationEngine
@@ -97,12 +96,7 @@ class TogoApp(App):
 
     def get_theme_variable_defaults(self) -> dict[str, str]:
         """Provide parse-time defaults for status variables so $status-* resolves in CSS."""
-        return {
-            "status-running": STATUS_RUNNING,
-            "status-pending": STATUS_PENDING,
-            "status-done": STATUS_DONE,
-            "status-failed": STATUS_FAILED,
-        }
+        return {key: togo_theme.variables[key] for key in STATUS_VARIABLE_KEYS}
 
     def on_mount(self) -> None:
         from ddev.cli.meta.ai.tui.screens.main import MainScreen

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -125,10 +125,10 @@ class ExecutionScreen(TogoScreen):
         if self.resume:
             runs_dir = self._runs_dir or ai_runs_dir(self.togo_app.ddev_app.repo.path)
             for phase_id in flow_resume_state(self.flow, runs_dir).completed:
-                self._phase_statuses[phase_id] = RunStatus.DONE
+                self._phase_statuses[phase_id] = RunStatus.CHECKPOINTED
                 for task_phase, task_name in self._task_statuses:
                     if task_phase == phase_id:
-                        self._task_statuses[(task_phase, task_name)] = RunStatus.DONE
+                        self._task_statuses[(task_phase, task_name)] = RunStatus.CHECKPOINTED
         self._update_display()
         self.togo_app.execution_status = ExecutionStatus.RUNNING
         self._transition_to_finishing_if_phases_done()
@@ -340,8 +340,9 @@ class ExecutionScreen(TogoScreen):
         self._transition_to_finishing_if_phases_done()
 
     def _transition_to_finishing_if_phases_done(self) -> None:
+        """A resumed run settles once every phase is either done here or carried over from a checkpoint."""
         if self.togo_app.execution_status is ExecutionStatus.RUNNING and all(
-            status is RunStatus.DONE for status in self._phase_statuses.values()
+            status in (RunStatus.DONE, RunStatus.CHECKPOINTED) for status in self._phase_statuses.values()
         ):
             self.togo_app.execution_status = ExecutionStatus.FINISHING
 

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
@@ -50,13 +50,20 @@ class FlowScreen(TogoScreen):
         with Horizontal(id="flow-body"):
             yield from self._compose_overview()
 
-            graph = PipelineGraph(
-                self.flow,
-                {entry.phase: RunStatus.PENDING for entry in self.flow.flow},
-                id="flow-pipeline",
-            )
-            graph.border_title = "Pipeline"
-            yield graph
+            with Vertical(id="flow-pipeline-column"):
+                graph = PipelineGraph(
+                    self.flow,
+                    self._preview_statuses(frozenset()),
+                    id="flow-pipeline",
+                )
+                graph.border_title = "Pipeline"
+                yield graph
+
+                legend = Static(
+                    "◇ completed in a previous run · skipped on resume", id="pipeline-legend", classes="desc"
+                )
+                legend.display = False
+                yield legend
 
         with Horizontal(id="actions"):
             yield Button("Back", id="back")
@@ -97,6 +104,13 @@ class FlowScreen(TogoScreen):
         """Re-read resume state whenever this screen becomes active again."""
         self._apply_resume_state(self._read_resume_state())
 
+    def _preview_statuses(self, completed: frozenset[str]) -> dict[str, RunStatus]:
+        """Map the flow's phases to preview statuses, marking dependency-closed successes as checkpointed."""
+        return {
+            entry.phase: RunStatus.CHECKPOINTED if entry.phase in completed else RunStatus.PENDING
+            for entry in self.flow.flow
+        }
+
     def _read_resume_state(self) -> ResumeState:
         from ddev.cli.meta.ai.tui.runs import ai_runs_dir, flow_resume_state
 
@@ -104,9 +118,11 @@ class FlowScreen(TogoScreen):
         return flow_resume_state(self.flow, runs_dir)
 
     def _apply_resume_state(self, state: ResumeState) -> None:
-        """Show the Resume button only while a resumable run exists for this flow."""
+        """Drive the Resume button, pipeline preview, and legend from a single resume-state read."""
         try:
             self.query_one("#resume", Button).display = state.is_resumable
+            self.query_one("#flow-pipeline", PipelineGraph).update_statuses(self._preview_statuses(state.completed))
+            self.query_one("#pipeline-legend", Static).display = bool(state.completed)
         except NoMatches:
             pass
 

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/flow.py
@@ -26,6 +26,9 @@ from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseSelected, PipelineG
 if TYPE_CHECKING:
     from ddev.ai.runtime.checkpoints import ResumeState
 
+PIPELINE_LEGEND = "◇ completed in a previous run · skipped on resume"
+CHECKPOINT_UNREADABLE_LEGEND = "✕ checkpoint unreadable · delete it and launch the flow from scratch"
+
 
 class FlowScreen(TogoScreen):
     """Show resolved flow details and controls for launching or resuming execution."""
@@ -59,9 +62,7 @@ class FlowScreen(TogoScreen):
                 graph.border_title = "Pipeline"
                 yield graph
 
-                legend = Static(
-                    "◇ completed in a previous run · skipped on resume", id="pipeline-legend", classes="desc"
-                )
+                legend = Static(PIPELINE_LEGEND, id="pipeline-legend", classes="desc")
                 legend.display = False
                 yield legend
 
@@ -122,9 +123,16 @@ class FlowScreen(TogoScreen):
         try:
             self.query_one("#resume", Button).display = state.is_resumable
             self.query_one("#flow-pipeline", PipelineGraph).update_statuses(self._preview_statuses(state.completed))
-            self.query_one("#pipeline-legend", Static).display = bool(state.completed)
+            self._apply_legend(self.query_one("#pipeline-legend", Static), state)
         except NoMatches:
             pass
+
+    def _apply_legend(self, legend: Static, state: ResumeState) -> None:
+        """Explain the checkpointed glyphs, or report a checkpoint file that could not be read."""
+        unreadable = state.error is not None
+        legend.update(CHECKPOINT_UNREADABLE_LEGEND if unreadable else PIPELINE_LEGEND)
+        legend.set_class(unreadable, "legend-error")
+        legend.display = unreadable or bool(state.completed)
 
     def _confirm_resumable(self) -> bool:
         """Re-read the checkpoint before committing to a resume, resyncing the UI if it went stale."""

--- a/ddev/src/ddev/cli/meta/ai/tui/status.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/status.py
@@ -30,7 +30,9 @@ class RunStatus(StrEnum):
     RUNNING = auto()
     DONE = auto()
     FAILED = auto()
+    CHECKPOINTED = auto()
 
     @property
     def has_started(self) -> bool:
-        return self is not RunStatus.PENDING
+        """Whether this phase produced output in the current run."""
+        return self not in (RunStatus.PENDING, RunStatus.CHECKPOINTED)

--- a/ddev/src/ddev/cli/meta/ai/tui/theme.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/theme.py
@@ -17,6 +17,7 @@ from ddev.cli.meta.ai.palette import (
     ROLE_GOAL_REVIEWER,
     ROLE_PHASE,
     SECONDARY,
+    STATUS_CHECKPOINTED,
     STATUS_DONE,
     STATUS_FAILED,
     STATUS_PENDING,
@@ -52,8 +53,11 @@ togo_theme = Theme(
         "status-pending": STATUS_PENDING,
         "status-done": STATUS_DONE,
         "status-failed": STATUS_FAILED,
+        "status-checkpointed": STATUS_CHECKPOINTED,
     },
 )
+
+STATUS_VARIABLE_KEYS = tuple(key for key in togo_theme.variables if key.startswith("status-"))
 
 # Rich's built-in Markdown element styles (``markdown.code``, ``markdown.block_quote``, etc.)
 # default to fully saturated named colors (bright cyan, magenta, yellow) on a literal black

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -287,17 +287,27 @@ Collapsible {
     height: auto;
 }
 
-#flow-pipeline {
-    layers: connectors nodes;
+#flow-pipeline-column {
     width: 1fr;
     height: 1fr;
     margin: 0 0 1 0;
+}
+
+#flow-pipeline {
+    layers: connectors nodes;
+    height: 1fr;
     border: round $border;
     border-title-color: $secondary;
     border-title-align: left;
     background: $surface;
     padding: 1 2;
     overflow: auto auto;
+}
+
+#pipeline-legend {
+    height: auto;
+    color: $text-muted;
+    margin: 1 0 0 0;
 }
 
 #phase-configuration {
@@ -525,6 +535,10 @@ MarkdownH3 {
 .phase-node.status-done {
     border: round $status-done;
     color: $status-done;
+}
+
+.phase-node.status-checkpointed {
+    color: $status-checkpointed;
 }
 
 .phase-node.status-failed {

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -310,6 +310,10 @@ Collapsible {
     margin: 1 0 0 0;
 }
 
+#pipeline-legend.legend-error {
+    color: $status-failed;
+}
+
 #phase-configuration {
     height: 1fr;
     margin: 0 0 1 0;

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/pipeline_graph.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/pipeline_graph.py
@@ -19,13 +19,21 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from ddev.ai.config.models import ResolvedFlow
-from ddev.cli.meta.ai.palette import STATUS_CONNECTOR, STATUS_DONE, STATUS_FAILED, STATUS_PENDING, STATUS_RUNNING
+from ddev.cli.meta.ai.palette import (
+    STATUS_CHECKPOINTED,
+    STATUS_CONNECTOR,
+    STATUS_DONE,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_RUNNING,
+)
 from ddev.cli.meta.ai.tui.status import RunStatus
 
 COLOR_DONE = STATUS_DONE
 COLOR_RUNNING = STATUS_RUNNING
 COLOR_PENDING = STATUS_PENDING
 COLOR_FAILED = STATUS_FAILED
+COLOR_CHECKPOINTED = STATUS_CHECKPOINTED
 COLOR_CONNECTOR = STATUS_CONNECTOR
 GRAPH_COLUMN_GAP = 6
 GRAPH_ROW_GAP = 5
@@ -44,6 +52,7 @@ NODE_GLYPHS: dict[RunStatus, tuple[str, str]] = {
     RunStatus.DONE: ("○", COLOR_DONE),
     RunStatus.RUNNING: ("◉", COLOR_RUNNING),
     RunStatus.FAILED: ("✕", COLOR_FAILED),
+    RunStatus.CHECKPOINTED: ("◇", COLOR_CHECKPOINTED),
 }
 
 

--- a/ddev/tests/cli/meta/ai/tui/conftest.py
+++ b/ddev/tests/cli/meta/ai/tui/conftest.py
@@ -28,10 +28,9 @@ from ddev.ai.config.models import (
 )
 from ddev.ai.phases.registry import PhaseRegistry
 from ddev.cli.meta.ai.tui.app import TogoApp
-from ddev.cli.meta.ai.tui.theme import togo_theme
+from ddev.cli.meta.ai.tui.theme import STATUS_VARIABLE_KEYS, togo_theme
 
 LARGE_TERMINAL = (120, 50)
-STATUS_VARIABLE_KEYS = ("status-running", "status-pending", "status-done", "status-failed")
 
 
 def export_screenshot_text(app: App[Any]) -> str:

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -1779,7 +1779,7 @@ async def test_resume_flag_passed_to_orchestrator():
 
 
 async def test_resume_initializes_completed_phase_statuses(tmp_path: Path) -> None:
-    """Dependency-closed checkpoint successes render done before resumed work starts."""
+    """Dependency-closed checkpoint successes render checkpointed, not done, before resumed work starts."""
     from ddev.cli.meta.ai.tui.runs import flow_slug
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
 
@@ -1815,8 +1815,51 @@ final_review:
         await app.push_screen(screen)
         await pilot.pause()
 
-        assert screen._phase_statuses["research"] is RunStatus.DONE
+        assert screen._phase_statuses["research"] is RunStatus.CHECKPOINTED
         assert screen._phase_statuses["final_review"] is RunStatus.PENDING
+        assert all(
+            status is RunStatus.CHECKPOINTED
+            for (phase, _task), status in screen._task_statuses.items()
+            if phase == "research"
+        )
+
+
+async def test_resume_distinguishes_carried_over_phases_from_freshly_run_ones(tmp_path: Path) -> None:
+    """A phase skipped on resume keeps the checkpointed glyph while a phase that runs turns done."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    flow = _make_flow()
+    run_dir = tmp_path / flow_slug(flow)
+    run_dir.mkdir()
+    (run_dir / "checkpoints.yaml").write_text(
+        """phase_1:
+  status: success
+  started_at: '2024-01-01T00:00:00'
+  finished_at: '2024-01-01T00:01:00'
+  tokens: {total_input: 1, total_output: 1}
+  memory_path: phase_1_memory.md
+"""
+    )
+
+    class ResumeOrchestrator:
+        failed_phase = None
+
+        def __init__(self, callbacks: Any) -> None:
+            self.callbacks = callbacks
+
+        async def run_async(self) -> None:
+            await self.callbacks.fire_phase_finish("phase_2")
+
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, resume=True, runs_dir=tmp_path, orchestrator_builder=ResumeOrchestrator)
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        assert screen._phase_statuses["phase_1"] is RunStatus.CHECKPOINTED
+        assert screen._phase_statuses["phase_2"] is RunStatus.DONE
 
 
 async def test_resume_transitions_to_finishing_after_remaining_phase(tmp_path: Path) -> None:

--- a/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from textual.containers import Horizontal
-from textual.widgets import Button, Input
+from textual.widgets import Button, Input, Static
 
 from ddev.ai.agent.registry import AgentProviderRegistry
 from ddev.ai.config.models import (
@@ -45,6 +45,29 @@ def _make_flow(name: str = "Test Flow", n_phases: int = 2) -> ResolvedFlow:
         for i in range(n_phases)
     }
     flow = [FlowEntry(phase=f"phase_{i}") for i in range(n_phases)]
+    return ResolvedFlow(
+        name=name,
+        description=f"Description for {name}",
+        inputs=FlowConfig(name="test", flow=[]).inputs,
+        agents=agents,
+        phases=phases,
+        flow=flow,
+        variables={},
+    )
+
+
+def _make_chain_flow(name: str = "Chain Flow", n_phases: int = 3) -> ResolvedFlow:
+    """Create a ResolvedFlow whose phases form a linear dependency chain."""
+    agents = {"agent_a": AgentConfig.model_construct(provider="anthropic", tools=[])}
+    phases = {
+        f"phase_{i}": PhaseConfig(
+            name=f"phase_{i}",
+            agent="agent_a",
+            tasks=[TaskConfig(name=f"task_{i}", prompt="do something")],
+        )
+        for i in range(n_phases)
+    }
+    flow = [FlowEntry(phase=f"phase_{i}", dependencies=[f"phase_{i - 1}"] if i > 0 else []) for i in range(n_phases)]
     return ResolvedFlow(
         name=name,
         description=f"Description for {name}",
@@ -516,12 +539,14 @@ async def test_resume_button_shown_with_incomplete_run(tmp_path: Path) -> None:
         assert resume_btn.display
 
 
-async def test_resume_button_appears_when_screen_resumes(tmp_path: Path) -> None:
-    """A run that fails while the screen is on the stack reveals Resume on return."""
+async def test_resume_affordances_appear_when_screen_resumes(tmp_path: Path) -> None:
+    """A run that fails while the screen is on the stack reveals Resume and checkpointed phases on return."""
     from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
     from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+    from ddev.cli.meta.ai.tui.status import RunStatus
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseNode
 
-    flow = _make_flow(n_phases=2)
+    flow = _make_chain_flow(n_phases=2)
     app = _app()
     async with app.run_test(size=(120, 50)) as pilot:
         await pilot.pause()
@@ -529,6 +554,7 @@ async def test_resume_button_appears_when_screen_resumes(tmp_path: Path) -> None
         await pilot.pause()
         flow_screen = pilot.app.screen
         assert not flow_screen.query_one("#resume", Button).display
+        assert not flow_screen.query_one("#pipeline-legend", Static).display
 
         await pilot.app.push_screen(PhaseConfigScreen(flow, flow.flow[0].phase))
         await pilot.pause()
@@ -538,14 +564,20 @@ async def test_resume_button_appears_when_screen_resumes(tmp_path: Path) -> None
 
         assert pilot.app.screen is flow_screen
         assert flow_screen.query_one("#resume", Button).display
+        assert flow_screen.query_one("#pipeline-legend", Static).display
+        nodes = {node.phase_id: node.status for node in flow_screen.query(PhaseNode)}
+        assert nodes["phase_0"] is RunStatus.CHECKPOINTED
+        assert nodes["phase_1"] is RunStatus.PENDING
 
 
-async def test_resume_button_hidden_again_when_run_completes(tmp_path: Path) -> None:
-    """A run that finishes while the screen is on the stack hides Resume on return."""
+async def test_resume_affordances_hidden_again_when_run_completes(tmp_path: Path) -> None:
+    """A run that finishes while the screen is on the stack hides Resume and marks every phase checkpointed."""
     from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
     from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+    from ddev.cli.meta.ai.tui.status import RunStatus
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseNode
 
-    flow = _make_flow(n_phases=2)
+    flow = _make_chain_flow(n_phases=2)
     _write_incomplete_run(tmp_path, flow)
     app = _app()
     async with app.run_test(size=(120, 50)) as pilot:
@@ -562,6 +594,64 @@ async def test_resume_button_hidden_again_when_run_completes(tmp_path: Path) -> 
         await pilot.pause()
 
         assert not flow_screen.query_one("#resume", Button).display
+        nodes = {node.phase_id: node.status for node in flow_screen.query(PhaseNode)}
+        assert nodes["phase_0"] is RunStatus.CHECKPOINTED
+        assert nodes["phase_1"] is RunStatus.CHECKPOINTED
+
+
+# ---------------------------------------------------------------------------
+# Pipeline preview: checkpointed phases
+# ---------------------------------------------------------------------------
+
+
+async def test_flow_screen_pipeline_marks_checkpointed_phases(tmp_path: Path) -> None:
+    """Phases already succeeded in a resumable run render as CHECKPOINTED; the rest stay PENDING."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.status import RunStatus
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseNode
+
+    flow = _make_chain_flow(n_phases=3)
+    _write_run(tmp_path, flow, "".join(_success_checkpoint_yaml(p) for p in ("phase_0", "phase_1")))
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        nodes = {node.phase_id: node.status for node in pilot.app.screen.query(PhaseNode)}
+        assert nodes["phase_0"] is RunStatus.CHECKPOINTED
+        assert nodes["phase_1"] is RunStatus.CHECKPOINTED
+        assert nodes["phase_2"] is RunStatus.PENDING
+
+
+async def test_flow_screen_pipeline_all_pending_when_never_run() -> None:
+    """A never-run flow shows every phase pending and hides the legend."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+    from ddev.cli.meta.ai.tui.status import RunStatus
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseNode
+
+    flow = _make_chain_flow(n_phases=2)
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow))
+        await pilot.pause()
+        nodes = pilot.app.screen.query(PhaseNode)
+        assert all(node.status is RunStatus.PENDING for node in nodes)
+        assert not pilot.app.screen.query_one("#pipeline-legend", Static).display
+
+
+async def test_flow_screen_pipeline_legend_shown_with_checkpointed_phases(tmp_path: Path) -> None:
+    """The legend appears only once at least one phase is checkpointed."""
+    from ddev.cli.meta.ai.tui.screens.flow import FlowScreen
+
+    flow = _make_chain_flow(n_phases=2)
+    _write_incomplete_run(tmp_path, flow)
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        assert pilot.app.screen.query_one("#pipeline-legend", Static).display
 
 
 async def test_phase_config_agent_panel_renders_tools_and_prompt() -> None:

--- a/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
@@ -654,6 +654,58 @@ async def test_flow_screen_pipeline_legend_shown_with_checkpointed_phases(tmp_pa
         assert pilot.app.screen.query_one("#pipeline-legend", Static).display
 
 
+async def test_flow_screen_legend_reports_an_unreadable_checkpoint(tmp_path: Path) -> None:
+    """A corrupt checkpoint states the remedy on the flow screen instead of leaving it silent."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug
+    from ddev.cli.meta.ai.tui.screens.flow import CHECKPOINT_UNREADABLE_LEGEND, FlowScreen
+
+    flow = _make_chain_flow(n_phases=2)
+    run_dir = tmp_path / flow_slug(flow)
+    run_dir.mkdir()
+    (run_dir / "checkpoints.yaml").write_text("{ not: valid: yaml")
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+
+        legend = pilot.app.screen.query_one("#pipeline-legend", Static)
+        assert legend.display
+        assert str(legend.render()) == CHECKPOINT_UNREADABLE_LEGEND
+        assert legend.has_class("legend-error")
+        assert not pilot.app.screen.query_one("#resume", Button).display
+
+
+async def test_flow_screen_legend_returns_to_checkpoint_text_when_file_is_repaired(tmp_path: Path) -> None:
+    """The legend follows the state in both directions rather than latching on the error."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug
+    from ddev.cli.meta.ai.tui.screens.flow import PIPELINE_LEGEND, FlowScreen
+    from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
+
+    flow = _make_chain_flow(n_phases=2)
+    run_dir = tmp_path / flow_slug(flow)
+    run_dir.mkdir()
+    (run_dir / "checkpoints.yaml").write_text("{ not: valid: yaml")
+    app = _app()
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.app.push_screen(FlowScreen(flow, runs_dir=tmp_path))
+        await pilot.pause()
+        flow_screen = pilot.app.screen
+        assert flow_screen.query_one("#pipeline-legend", Static).has_class("legend-error")
+
+        await pilot.app.push_screen(PhaseConfigScreen(flow, flow.flow[0].phase))
+        await pilot.pause()
+        _write_incomplete_run(tmp_path, flow)
+        pilot.app.pop_screen()
+        await pilot.pause()
+
+        legend = flow_screen.query_one("#pipeline-legend", Static)
+        assert legend.display
+        assert str(legend.render()) == PIPELINE_LEGEND
+        assert not legend.has_class("legend-error")
+
+
 async def test_phase_config_agent_panel_renders_tools_and_prompt() -> None:
     """PhaseConfigScreen shows agent tools and system prompt inline."""
     from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen

--- a/ddev/tests/cli/meta/ai/tui/test_theme.py
+++ b/ddev/tests/cli/meta/ai/tui/test_theme.py
@@ -9,7 +9,7 @@ import pytest
 
 from ddev.cli.meta.ai.palette import ACCENT, PRIMARY, SECONDARY
 from ddev.cli.meta.ai.tui.app import TogoApp
-from ddev.cli.meta.ai.tui.theme import togo_theme
+from ddev.cli.meta.ai.tui.theme import STATUS_VARIABLE_KEYS, togo_theme
 
 
 def test_togo_theme_tokens():
@@ -52,9 +52,9 @@ async def test_togo_app_css_loads_without_error(make_togo_app):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("key", ["status-running", "status-pending", "status-done", "status-failed"])
+@pytest.mark.parametrize("key", STATUS_VARIABLE_KEYS)
 def test_get_theme_variable_defaults_returns_status_key(key, make_togo_app):
-    """TogoApp.get_theme_variable_defaults() includes all four status keys."""
+    """TogoApp.get_theme_variable_defaults() includes all status keys."""
     defaults = make_togo_app([]).get_theme_variable_defaults()
     assert key in defaults
 
@@ -62,7 +62,7 @@ def test_get_theme_variable_defaults_returns_status_key(key, make_togo_app):
 def test_get_theme_variable_defaults_values_match_theme(make_togo_app):
     """Default values match the corresponding togo_theme variables."""
     defaults = make_togo_app([]).get_theme_variable_defaults()
-    for key in ("status-running", "status-pending", "status-done", "status-failed"):
+    for key in STATUS_VARIABLE_KEYS:
         assert defaults[key] == togo_theme.variables[key]
 
 

--- a/ddev/tests/cli/meta/ai/tui/test_theme.py
+++ b/ddev/tests/cli/meta/ai/tui/test_theme.py
@@ -52,7 +52,15 @@ async def test_togo_app_css_loads_without_error(make_togo_app):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("key", STATUS_VARIABLE_KEYS)
+EXPECTED_STATUS_KEYS = ("status-running", "status-pending", "status-done", "status-failed", "status-checkpointed")
+
+
+def test_status_variable_keys_cover_every_expected_status():
+    """STATUS_VARIABLE_KEYS tracks the status palette without silently losing a key."""
+    assert set(STATUS_VARIABLE_KEYS) == set(EXPECTED_STATUS_KEYS)
+
+
+@pytest.mark.parametrize("key", EXPECTED_STATUS_KEYS)
 def test_get_theme_variable_defaults_returns_status_key(key, make_togo_app):
     """TogoApp.get_theme_variable_defaults() includes all status keys."""
     defaults = make_togo_app([]).get_theme_variable_defaults()
@@ -62,7 +70,7 @@ def test_get_theme_variable_defaults_returns_status_key(key, make_togo_app):
 def test_get_theme_variable_defaults_values_match_theme(make_togo_app):
     """Default values match the corresponding togo_theme variables."""
     defaults = make_togo_app([]).get_theme_variable_defaults()
-    for key in STATUS_VARIABLE_KEYS:
+    for key in EXPECTED_STATUS_KEYS:
         assert defaults[key] == togo_theme.variables[key]
 
 


### PR DESCRIPTION
> This is PR 2 of 2 in a stacked series: 
> 1. #24701
> 2. #24702 **<- you are here**

### What does this PR do?

Adds a `CHECKPOINTED` phase status to the Togo TUI, distinct from both `PENDING` and `DONE`. Phases that succeeded in a previous run — the ones a resume skips — render with a `◇` glyph in muted green, so they no longer look identical to phases that never ran, nor to phases that just executed.

**Flow screen preview**

- The pipeline preview marks dependency-closed successes as checkpointed; everything else stays pending.
- A legend appears below the pipeline only when at least one phase is checkpointed.

<img width="1683" height="1043" alt="image" src="https://github.com/user-attachments/assets/c8387177-7c29-4249-87bd-a236f9974c1c" />

**Execution screen**

- The status carries through to the run. `ExecutionScreen` marked phases restored from a checkpoint as `DONE`, so the preview promised `◇ completed in a previous run` and the execution screen then rendered those same phases as `○` done — indistinguishable from work that ran in this session. That is the conflation the status exists to remove, and it survived on the screen the user watches for the whole run.
- The graph needed no new code: the glyph, colour, CSS class, and `update_statuses` toggling were already in place; only the assignment was missing.
- The all-green check that moves a run to `FINISHING` now accepts either terminal value, without which a resumed run would never settle.
- This also makes `RunStatus.has_started` reachable. It excludes `CHECKPOINTED`, but nothing produced that value outside the flow preview, so the guard was dead — reverting it left the suite green. Selecting a carried-over phase now opens its configuration rather than a log this run never wrote.

### Motivation

Before this change, `FlowScreen` painted every phase `PENDING` regardless of resume state, so the Resume button could appear while the preview gave no indication of what it would actually skip.

Separating the status from `PENDING` only solves half of that. A resume also has to stay honest once it starts: if the phases the preview marked as skipped turn solid green the moment the run begins, the user cannot tell what the resume actually did. Both screens now agree on what was carried over and what was executed.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
