### PR TITLE
Drop the -x flag from the config model validation commands in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,8 @@ Extract duplicated logic when it represents the same concept and a shared helper
 Don't modify files in `**/config_models/*.py` directly. To change those files, edit `assets/configuration/spec.yaml` and then run:
 
 ```shell
-ddev -x validate config -s <INTEGRATION_NAME>
-ddev -x validate models -s <INTEGRATION_NAME>
+ddev validate config -s <INTEGRATION_NAME>
+ddev validate models -s <INTEGRATION_NAME>
 ```
 
 ## Development Workflow


### PR DESCRIPTION
### What does this PR do?
Drops the `-x` flag from the config model validation commands in `AGENTS.md`:

```shell
ddev validate config -s <INTEGRATION_NAME>
ddev validate models -s <INTEGRATION_NAME>
```

### Motivation
`-x`/`--here` resolves the repo as `Repository('local', Path.cwd())` instead of going through config (`ddev/src/ddev/cli/application.py:123`). That has two side effects agents shouldn't be opting into by default:

- The repo name becomes `local` rather than `core`, and plenty of commands branch on that name. `validate version` and `validate licenses` skip outright unless the name is `core`, `validate openmetrics` skips unless it's `core`/`extras`, and `validate ci`, `codeowners`, `labeler` and `metadata` all compute `is_core = app.repo.name == 'core'` and check different things. Under `-x` those either no-op or run in a different mode, which reads as a pass.
- `Repository.__init__` uses the path verbatim with no walk up to the git root, so `-x` only works from a repo root and breaks from any subdirectory.

`validate config` and `validate models` themselves don't branch on the repo name, so the flag wasn't buying anything here either way.

The thing `-x` was presumably standing in for is "make `ddev` act on this checkout, not whatever the global config points at". That's what `ddev config override` is for, and the worktree rule under Development Workflow already tells you to run it. It writes a `.ddev.toml` that `ddev` picks up by walking up from the current directory, so `core` points at the checkout you're in, from any subdirectory, and the repo name stays `core`. So no behaviour is lost by removing the flag.

Note the same `ddev -x validate ...` line is baked into the header of every generated `config_models` file, via `get_config_models_documentation()` in `datadog_checks_dev/datadog_checks/dev/tooling/utils.py` and `ddev/src/ddev/cli/create/_naming.py`. Left alone here since fixing it means regenerating ~900 files.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
