### PR TITLE
Add fallback control for configuration discovery port candidates

### DIFF
--- a/datadog_checks_base/changelog.d/24706.added
+++ b/datadog_checks_base/changelog.d/24706.added
@@ -1,0 +1,1 @@
+Allow disabling fallback ports for configuration discovery candidates.

--- a/datadog_checks_base/datadog_checks/base/utils/discovery/discovery.py
+++ b/datadog_checks_base/datadog_checks/base/utils/discovery/discovery.py
@@ -46,8 +46,11 @@ class Discovery:
         return self._filter.get_items(items)
 
 
-def candidate_ports(service: Service, hints: Iterable[int]) -> Iterator[Port]:
-    """Yield hinted ports first, then remaining service ports."""
+def candidate_ports(service: Service, hints: Iterable[int], *, fallback: bool = True) -> Iterator[Port]:
+    """Yield hinted ports first, then remaining service ports.
+
+    Set `fallback` to false to yield only hinted service ports.
+    """
     by_number = {port.number: port for port in service.ports}
     seen: set[int] = set()
 
@@ -55,6 +58,9 @@ def candidate_ports(service: Service, hints: Iterable[int]) -> Iterator[Port]:
         if hint in by_number and hint not in seen:
             seen.add(hint)
             yield by_number[hint]
+
+    if not fallback:
+        return
 
     for port in service.ports:
         if port.number not in seen:

--- a/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
+++ b/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
@@ -209,6 +209,21 @@ def test_candidate_ports_prefers_hints_and_deduplicates():
     ]
 
 
+def test_candidate_ports_can_disable_fallback():
+    service = Service(
+        id='svc',
+        host='127.0.0.1',
+        ports=(
+            Port(number=8080, name='http'),
+            Port(number=9090, name='metrics'),
+            Port(number=8081, name='admin'),
+        ),
+    )
+
+    assert list(candidate_ports(service, [9090, 9090, 1234], fallback=False)) == [Port(number=9090, name='metrics')]
+    assert list(candidate_ports(service, [1234], fallback=False)) == []
+
+
 @pytest.mark.parametrize(
     "ports, names, expected",
     [


### PR DESCRIPTION
### What does this PR do?

Currently, candidate_ports only supports port hints. These indicate which ports to start discovery probing from, and if probing fails on the hinted ports, it will continue to other ports exposed by the service. This is useful since many services have configurable metrics ports which are not fixed and can be freely chosen.

However, some other services have well-known ports for their endpoints which the integration needs to connect to and the vast majority of users use these well-known ports. If such services also need special configs to enable metrics, and have other ports which generate errors on probing, the result of using the fall back is that a common configuration of the service will generate errors on probing.

To cleanly support those cases, add a fallback control to configuration discovery port candidate generation. `candidate_ports` now accepts a keyword-only `fallback` argument; when set to `False`, it yields only hinted service ports and does not fall back to probing every exposed container port.

This parameter will be used by the strategy in a separate PR. This PR only changes `datadog_checks_base`and is kept separate as requested on earlier similar PRs.

### Motivation

Will be used by zk but it's generic and could be useful for others too in the future.
https://datadoghq.atlassian.net/browse/DSCVR-523

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
