### PR TITLE
Persist v2 TUF metadata to detect rollbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ datadog_checks_downloader/datadog_checks/downloader/data/repo/targets/*
 datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/*
 !datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/.gitignore
 !datadog_checks_downloader/datadog_checks/downloader/data/repo/metadata/root.json
+
+# Ignore persistent v2 TUF client metadata created by downloader invocations
+/datadog_checks_downloader/datadog_checks/downloader/data/v2/repositories/

--- a/datadog_checks_downloader/changelog.d/24708.security
+++ b/datadog_checks_downloader/changelog.d/24708.security
@@ -1,0 +1,1 @@
+Persist trusted TUF metadata so the v2 checks downloader detects repository rollbacks across invocations.

--- a/datadog_checks_downloader/datadog_checks/downloader/download_v2.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download_v2.py
@@ -31,6 +31,7 @@ from .exceptions import (
 logger = logging.getLogger(__name__)
 
 V2_REPOSITORY_URL = "https://agent-integration-wheels.datadoghq.com"
+V2_METADATA_ROOT = Path(__file__).parent / 'data' / 'v2' / 'repositories'
 
 # tuf.ngclient sets its own fetcher timeout; this applies only to the raw wheel urlopen().
 WHEEL_FETCH_TIMEOUT_SECONDS = 60
@@ -45,9 +46,15 @@ SHA256_HEX_RE = re.compile(r'^[0-9a-f]{64}$')
 class TUFPointerDownloader:
     """Downloads Datadog integration wheels from a v2 TUF repository."""
 
-    def __init__(self, repository_url: str, disable_verification: bool = False):
+    def __init__(
+        self,
+        repository_url: str,
+        disable_verification: bool = False,
+        metadata_root: Path | None = None,
+    ):
         self._repository_url = repository_url.rstrip('/')
         self._disable_verification = disable_verification
+        self._metadata_root = metadata_root or V2_METADATA_ROOT
 
         if disable_verification:
             logger.warning('Running with TUF verification disabled. Integrity is protected only by TLS (HTTPS).')
@@ -55,7 +62,24 @@ class TUFPointerDownloader:
     def _bootstrap_metadata_dir(self, metadata_dir: Path) -> None:
         dest = metadata_dir / 'root.json'
         metadata = importlib.resources.files('datadog_checks.downloader') / 'data' / 'v2' / 'metadata'
-        dest.write_bytes((metadata / 'root.json').read_bytes())
+        root_bytes = (metadata / 'root.json').read_bytes()
+        temp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(dir=metadata_dir, prefix='.root.', suffix='.tmp', delete=False) as temp:
+                temp_path = Path(temp.name)
+                temp.write(root_bytes)
+            temp_path.replace(dest)
+        finally:
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
+
+    def _prepare_metadata_dir(self) -> Path:
+        repository_id = hashlib.sha256(self._repository_url.encode()).hexdigest()
+        metadata_dir = self._metadata_root / repository_id / 'metadata'
+        metadata_dir.mkdir(parents=True, exist_ok=True)
+        if not (metadata_dir / 'root.json').exists():
+            self._bootstrap_metadata_dir(metadata_dir)
+        return metadata_dir
 
     def _make_updater(self, metadata_dir: Path, target_dir: Path) -> Updater:
         return Updater(
@@ -113,14 +137,12 @@ class TUFPointerDownloader:
 
     def get_pointer(self, project: str, version: str | None = None) -> dict:
         """Return the pointer JSON for *project* at *version* (or 'latest' when None)."""
+        metadata_dir = self._prepare_metadata_dir()
         with tempfile.TemporaryDirectory() as tmp:
-            metadata_dir = Path(tmp) / 'metadata'
             target_dir = Path(tmp) / 'targets'
-            metadata_dir.mkdir()
             target_dir.mkdir()
 
             target_path = self._target_path(project, version)
-            self._bootstrap_metadata_dir(metadata_dir)
             updater = self._make_updater(metadata_dir, target_dir)
             updater.refresh()
 

--- a/datadog_checks_downloader/tests/_v2_synth_repo.py
+++ b/datadog_checks_downloader/tests/_v2_synth_repo.py
@@ -59,7 +59,7 @@ def build_delegated_repo(
     delegated_role_name: str = 'pointers',
     paths: list[str] | None = None,
     path_hash_prefixes: list[str] | None = None,
-) -> None:
+) -> dict[str, SSlibSigner]:
     """Materialize a signed v2-style TUF repo with one delegated targets role."""
     if (paths is None) == (path_hash_prefixes is None):
         raise ValueError('exactly one of paths or path_hash_prefixes must be set')
@@ -137,6 +137,8 @@ def build_delegated_repo(
     root_md.sign(signers['root'])
     root_md.to_file(str(metadata_dir / '1.root.json'))
     root_md.to_file(str(metadata_dir / 'root.json'))
+
+    return signers
 
 
 class _ReuseTCPServer(TCPServer):

--- a/datadog_checks_downloader/tests/conftest.py
+++ b/datadog_checks_downloader/tests/conftest.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -61,6 +62,13 @@ def distribution_version(request):
 def pytest_generate_tests(metafunc):
     if "disable_verification" in metafunc.fixturenames:
         metafunc.parametrize("disable_verification", [False, True])
+
+
+@pytest.fixture(autouse=True)
+def temporary_v2_metadata_root(monkeypatch, tmp_path):
+    from datadog_checks.downloader import download_v2
+
+    monkeypatch.setattr(download_v2, 'V2_METADATA_ROOT', Path(tmp_path) / 'v2-metadata')
 
 
 @pytest.fixture(autouse=True)

--- a/datadog_checks_downloader/tests/test_v2_downloader.py
+++ b/datadog_checks_downloader/tests/test_v2_downloader.py
@@ -11,7 +11,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from tuf.api.exceptions import DownloadError
+from securesystemslib.signer import SSlibSigner
+from tuf.api.exceptions import BadVersionNumberError, DownloadError
+from tuf.api.metadata import Metadata, MetaFile, Timestamp
 
 from datadog_checks.downloader import cli
 from datadog_checks.downloader.download_v2 import (
@@ -29,7 +31,7 @@ from datadog_checks.downloader.exceptions import (
     TargetNotFoundError,
 )
 
-from ._v2_synth_repo import build_delegated_repo, serve_directory
+from ._v2_synth_repo import EXPIRY, SPEC_VERSION, build_delegated_repo, serve_directory
 
 pytestmark = pytest.mark.offline
 
@@ -343,25 +345,115 @@ def _patch_bootstrap_to_use(repo_root: Path, monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(TUFPointerDownloader, '_bootstrap_metadata_dir', fake_bootstrap)
 
 
+def _make_pointer_target(project: str, version: str) -> tuple[str, bytes, dict]:
+    wheel = b'synthetic wheel for delegation test'
+    wheel_name = f'{project.replace("-", "_")}-{version}-py3-none-any.whl'
+    pointer = {
+        'digest': hashlib.sha256(wheel).hexdigest(),
+        'length': len(wheel),
+        'version': version,
+        'repository': REPO_URL,
+        'wheel_path': f'/wheels/{project}/{wheel_name}',
+    }
+    return wheel_name, wheel, pointer
+
+
+def _write_timestamp(repo_root: Path, signer: SSlibSigner, version: int) -> None:
+    metadata = Metadata(
+        signed=Timestamp(
+            version=version,
+            spec_version=SPEC_VERSION,
+            expires=EXPIRY,
+            snapshot_meta=MetaFile(version=1),
+        )
+    )
+    metadata.sign(signer)
+    metadata.to_file(str(repo_root / 'metadata' / 'timestamp.json'))
+
+
+class TestMetadataPersistence:
+    def test_interrupted_bootstrap_does_not_leave_partial_root(self, monkeypatch, tmp_path):
+        metadata_dir = tmp_path / 'metadata'
+        metadata_dir.mkdir()
+        downloader = TUFPointerDownloader(REPO_URL, metadata_root=tmp_path)
+
+        def fail_replace(_source, _destination):
+            raise OSError('interrupted before atomic replace')
+
+        monkeypatch.setattr(Path, 'replace', fail_replace)
+        with pytest.raises(OSError, match='interrupted'):
+            downloader._bootstrap_metadata_dir(metadata_dir)
+
+        assert not (metadata_dir / 'root.json').exists()
+        assert not list(metadata_dir.iterdir())
+
+    def test_existing_trusted_root_is_not_overwritten(self, tmp_path):
+        state = tmp_path / 'client-state'
+        downloader = TUFPointerDownloader(REPO_URL, metadata_root=state)
+        repository_id = hashlib.sha256(REPO_URL.encode()).hexdigest()
+        metadata_dir = state / repository_id / 'metadata'
+        metadata_dir.mkdir(parents=True)
+        trusted_root = metadata_dir / 'root.json'
+        trusted_root.write_bytes(b'already trusted root')
+
+        assert downloader._prepare_metadata_dir() == metadata_dir
+        assert trusted_root.read_bytes() == b'already trusted root'
+
+    def test_persistent_metadata_rejects_rollback(self, monkeypatch, tmp_path):
+        target_path = f'{V2_POINTER_TARGET_PREFIX}/{PROJECT}/{VERSION}.json'
+        _, _, pointer = _make_pointer_target(PROJECT, VERSION)
+        repo = tmp_path / 'repo'
+        signers = build_delegated_repo(
+            repo,
+            delegated_targets={target_path: json.dumps(pointer).encode()},
+            delegated_role_name=V2_POINTER_TARGET_DELEGATION,
+            paths=[f'{V2_POINTER_TARGET_PREFIX}/{PROJECT}/*'],
+        )
+        timestamp_v1 = (repo / 'metadata' / 'timestamp.json').read_bytes()
+        _patch_bootstrap_to_use(repo, monkeypatch)
+
+        with serve_directory(repo) as url:
+            state = tmp_path / 'client-state'
+            assert TUFPointerDownloader(url, metadata_root=state).get_pointer(PROJECT, VERSION) == pointer
+
+            _write_timestamp(repo, signers['timestamp'], version=2)
+            assert TUFPointerDownloader(url, metadata_root=state).get_pointer(PROJECT, VERSION) == pointer
+
+            (repo / 'metadata' / 'timestamp.json').write_bytes(timestamp_v1)
+            with pytest.raises(BadVersionNumberError):
+                TUFPointerDownloader(url, metadata_root=state).get_pointer(PROJECT, VERSION)
+
+            fresh_state = tmp_path / 'fresh-client-state'
+            assert TUFPointerDownloader(url, metadata_root=fresh_state).get_pointer(PROJECT, VERSION) == pointer
+
+    def test_repository_urls_have_isolated_metadata(self, monkeypatch, tmp_path):
+        target_path = f'{V2_POINTER_TARGET_PREFIX}/{PROJECT}/{VERSION}.json'
+        _, _, pointer = _make_pointer_target(PROJECT, VERSION)
+        repo = tmp_path / 'repo'
+        signers = build_delegated_repo(
+            repo,
+            delegated_targets={target_path: json.dumps(pointer).encode()},
+            delegated_role_name=V2_POINTER_TARGET_DELEGATION,
+            paths=[f'{V2_POINTER_TARGET_PREFIX}/{PROJECT}/*'],
+        )
+        timestamp_v1 = (repo / 'metadata' / 'timestamp.json').read_bytes()
+        _patch_bootstrap_to_use(repo, monkeypatch)
+
+        with serve_directory(repo) as url_a, serve_directory(repo) as url_b:
+            state = tmp_path / 'shared-client-state'
+            _write_timestamp(repo, signers['timestamp'], version=2)
+            assert TUFPointerDownloader(url_a, metadata_root=state).get_pointer(PROJECT, VERSION) == pointer
+
+            (repo / 'metadata' / 'timestamp.json').write_bytes(timestamp_v1)
+            assert TUFPointerDownloader(url_b, metadata_root=state).get_pointer(PROJECT, VERSION) == pointer
+
+
 class TestDelegationTraversal:
     """Test v2 target resolution through delegated TUF metadata."""
 
-    @staticmethod
-    def _make_pointer_target(project: str, version: str) -> tuple[str, bytes, dict]:
-        wheel = b'synthetic wheel for delegation test'
-        wheel_name = f'{project.replace("-", "_")}-{version}-py3-none-any.whl'
-        pointer = {
-            'digest': hashlib.sha256(wheel).hexdigest(),
-            'length': len(wheel),
-            'version': version,
-            'repository': REPO_URL,
-            'wheel_path': f'/wheels/{project}/{wheel_name}',
-        }
-        return wheel_name, wheel, pointer
-
     def test_resolves_through_paths_delegation_without_naming_role(self, monkeypatch, tmp_path):
         project, version = 'datadog-postgres', '14.0.0'
-        _, _, pointer = self._make_pointer_target(project, version)
+        _, _, pointer = _make_pointer_target(project, version)
 
         repo = tmp_path / 'repo'
         build_delegated_repo(
@@ -379,7 +471,7 @@ class TestDelegationTraversal:
     def test_resolves_through_hash_prefix_delegation(self, monkeypatch, tmp_path):
         project, version = 'datadog-postgres', '14.0.0'
         target_path = f'{V2_POINTER_TARGET_PREFIX}/{project}/{version}.json'
-        _, _, pointer = self._make_pointer_target(project, version)
+        _, _, pointer = _make_pointer_target(project, version)
 
         prefix = hashlib.sha256(target_path.encode()).hexdigest()[:2]
 
@@ -398,7 +490,7 @@ class TestDelegationTraversal:
 
     def test_unmatched_target_path_raises_not_found(self, monkeypatch, tmp_path):
         project, version = 'datadog-postgres', '14.0.0'
-        _, _, pointer = self._make_pointer_target(project, version)
+        _, _, pointer = _make_pointer_target(project, version)
 
         repo = tmp_path / 'repo'
         build_delegated_repo(


### PR DESCRIPTION
### What does this PR do?

Persist trusted TUF metadata used by the v2 checks downloader across invocations. State is isolated by repository URL, while downloaded pointer targets remain temporary.

The bundled root bootstraps only new state, and is published atomically so an interrupted first invocation cannot leave a partial trusted root.

### Motivation

The v2 downloader previously created its TUF metadata directory inside a `TemporaryDirectory`. This discarded the highest trusted metadata versions after every invocation, preventing python-tuf from detecting a repository rollback on a later invocation.

Regression tests use a signed synthetic TUF repository to verify that:
- a client that has trusted timestamp version 2 rejects a valid version 1 rollback;
- fresh client state still accepts version 1; and
- different repository URLs have independent trust histories.

### Testing

- `ddev test -fs datadog_checks_downloader`
- `ddev --no-interactive test datadog_checks_downloader -- tests/test_v2_downloader.py tests/test_unit.py` (63 passed)
- `ddev test --lint datadog_checks_downloader`

#### Docker E2E

Built an Agent pinned to this PR in [DataDog/datadog-agent#54220](https://github.com/DataDog/datadog-agent/pull/54220) and installed the Debian package from the [Linux x64 CI build](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1905124986) in an Ubuntu container. Two real `agent integration install` cycles ran as `dd-agent`; after the first, the bundled bootstrap root was deliberately corrupted. The second install still succeeded through v2 without falling back to v1, confirming that it reused the persisted trusted metadata while pointer targets remained temporary.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

