### PR TITLE
Include logical_database with pg_extension payload_row

### DIFF
--- a/postgres/changelog.d/24709.added
+++ b/postgres/changelog.d/24709.added
@@ -1,0 +1,1 @@
+Include logical_database with pg_extension payload_row

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -32,7 +32,8 @@ from .util import payload_pg_version
 
 # PG_EXTENSION_INFO_QUERY is used to collect extension names and versions from
 # the pg_extension table. Schema names and roles are retrieved from their re-
-# spective catalog tables.
+# spective catalog tables. Extensions are installed per logical database, so
+# each row records the database the query ran against.
 PG_EXTENSION_INFO_QUERY = """
 SELECT
 e.oid::text AS id,
@@ -40,7 +41,8 @@ e.extname AS name,
 r.rolname AS owner,
 ns.nspname AS schema_name,
 e.extrelocatable AS relocatable,
-e.extversion AS version
+e.extversion AS version,
+current_database() AS logical_database
 FROM pg_extension e
 LEFT JOIN pg_namespace ns on e.extnamespace = ns.oid
      JOIN pg_roles r ON e.extowner = r.oid;

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -43,8 +43,17 @@ def test_collect_extensions(integration_check, dbm_instance, aggregator):
     assert event['dbms'] == "postgres"
     assert event['kind'] == "pg_extension"
     assert len(event["metadata"]) > 0
-    assert set(event["metadata"][0].keys()) == {'id', 'name', 'owner', 'relocatable', 'schema_name', 'version'}
+    assert set(event["metadata"][0].keys()) == {
+        'id',
+        'name',
+        'owner',
+        'relocatable',
+        'schema_name',
+        'version',
+        'logical_database',
+    }
     assert type(event["metadata"][0]["id"]) is str
+    assert all(row['logical_database'] == dbm_instance['dbname'] for row in event['metadata'])
     assert next((k for k in event['metadata'] if k['name'].startswith('plpgsql')), None) is not None
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Includes the current logical database with pg_extension payloads.

### Motivation
<!-- What inspired you to submit this pull request? -->
We need the logical database to fully scope the parent schema when saving this resource. The change is intentionally limited in scope to not fetch from all logical databases at this time.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
