### PR TITLE
Add a clickhouse_cluster tag alongside clickhouse_node

### DIFF
--- a/clickhouse/changelog.d/24711.added
+++ b/clickhouse/changelog.d/24711.added
@@ -1,0 +1,1 @@
+Add a `clickhouse_cluster` tag to ClickHouse DBM metrics and events.

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -23,7 +23,13 @@ from .query_errors import ClickhouseQueryErrors
 from .statement_samples import ClickhouseStatementSamples
 from .statements import ClickhouseStatementMetrics
 from .table_metrics import ClickhouseTableMetrics
-from .utils import ErrorSanitizer, cluster_aware_query
+from .utils import (
+    CLUSTER_MACRO_QUERY,
+    CLUSTER_NAME_QUERY,
+    CLUSTER_TAG,
+    ErrorSanitizer,
+    cluster_aware_query,
+)
 
 try:
     import datadog_agent
@@ -60,6 +66,8 @@ class ClickhouseCheck(DatabaseCheck):
         self._resolved_hostname = None
         self._database_hostname = None
         self._dbms_version = None
+        self._cluster_name = None
+        self._cluster_name_resolved = False
 
         # Track last emission time for database instance metadata (rate limiting)
         self._database_instance_last_emitted = 0
@@ -242,6 +250,12 @@ class ClickhouseCheck(DatabaseCheck):
     def check(self, _):
         self.connect()
         self._server_version = self.select_version()
+
+        # Must run before the query manager is built and before the DBM jobs are handed
+        # self.tags below, since both snapshot the tag list.
+        if self.cluster_name:
+            self.tag_manager.set_tag(CLUSTER_TAG, self.cluster_name, replace=True)
+
         if self._query_manager is None or self._query_manager_version != self._server_version:
             self._query_manager = self._build_query_manager()
             self._query_manager_version = self._server_version
@@ -356,6 +370,32 @@ class ClickhouseCheck(DatabaseCheck):
         if self._database_hostname is None:
             self._database_hostname = resolve_db_host(self._config.server)
         return self._database_hostname
+
+    @property
+    def cluster_name(self) -> str | None:
+        """The cluster this instance belongs to, or None when it cannot be determined.
+
+        Requires a live client, so this resolves on the first check run rather than at
+        init. The "not found" outcome is cached too: a deployment without a cluster
+        should not re-query on every run.
+        """
+        if not self._cluster_name_resolved:
+            self._cluster_name = self._resolve_cluster_name()
+            self._cluster_name_resolved = True
+        return self._cluster_name
+
+    def _resolve_cluster_name(self) -> str | None:
+        for query in (CLUSTER_MACRO_QUERY, CLUSTER_NAME_QUERY):
+            try:
+                rows = self.execute_query_raw(query)
+            except Exception as e:
+                self.log.debug('Unable to resolve cluster name with %r: %s', query, e)
+                continue
+            if rows and rows[0] and rows[0][0]:
+                return str(rows[0][0])
+        # Deliberately no 'default' fallback: an absent tag is better than a wrong one.
+        self.log.debug('No ClickHouse cluster name found; %s tag will not be emitted', CLUSTER_TAG)
+        return None
 
     @property
     def database_identifier_template(self) -> str:

--- a/clickhouse/datadog_checks/clickhouse/utils.py
+++ b/clickhouse/datadog_checks/clickhouse/utils.py
@@ -30,6 +30,36 @@ def compact_query(query):
 # Tag added to per-node metrics when collecting from all replicas in single endpoint mode.
 CLUSTER_NODE_TAG = 'clickhouse_node'
 
+# Tag identifying the cluster this instance belongs to, one level above CLUSTER_NODE_TAG.
+CLUSTER_TAG = 'clickhouse_cluster'
+
+# The {cluster} macro used by ON CLUSTER DDL. Tried first because it is only ever set when an
+# operator deliberately configured a cluster, which makes it the highest-signal source.
+# Raises on the server side when the macro is undefined.
+CLUSTER_MACRO_QUERY = "SELECT getMacro('cluster')"
+
+# Sample clusters that ClickHouse ships in its own default config (present through at least 21.x,
+# gone by 24.8). They are indistinguishable from real clusters in system.clusters and would
+# otherwise mislabel every stock instance, so they are excluded by name.
+BUILTIN_SAMPLE_CLUSTERS = (
+    'test_cluster_one_shard_three_replicas_localhost',
+    'test_cluster_two_shards',
+    'test_cluster_two_shards_internal_replication',
+    'test_cluster_two_shards_localhost',
+    'test_shard_localhost',
+    'test_shard_localhost_secure',
+    'test_unavailable_shard',
+)
+
+# Fallback covering ClickHouse Cloud (returns 'default') and any deployment with remote_servers
+# configured but no {cluster} macro. ORDER BY keeps the result stable when a node is a member of
+# more than one cluster.
+CLUSTER_NAME_QUERY = (
+    "SELECT cluster FROM system.clusters WHERE is_local AND cluster NOT IN ({}) ORDER BY cluster LIMIT 1".format(
+        ', '.join(f"'{name}'" for name in BUILTIN_SAMPLE_CLUSTERS)
+    )
+)
+
 
 def cluster_aware_query(base: dict) -> dict:
     """Build a cluster-aware variant that reads all replicas and tags each row per node.

--- a/clickhouse/datadog_checks/clickhouse/utils.py
+++ b/clickhouse/datadog_checks/clickhouse/utils.py
@@ -35,8 +35,10 @@ CLUSTER_TAG = 'clickhouse_cluster'
 
 # The {cluster} macro used by ON CLUSTER DDL. Tried first because it is only ever set when an
 # operator deliberately configured a cluster, which makes it the highest-signal source.
-# Raises on the server side when the macro is undefined.
-CLUSTER_MACRO_QUERY = "SELECT getMacro('cluster')"
+# Read from system.macros rather than getMacro('cluster'): the function raises server-side when the
+# macro is undefined, which increments FailedQuery/FailedSelectQuery and pollutes the customer's
+# clickhouse.query.failed metrics. Selecting from the table returns zero rows instead, no error.
+CLUSTER_MACRO_QUERY = "SELECT substitution FROM system.macros WHERE macro = 'cluster'"
 
 # Sample clusters that ClickHouse ships in its own default config (present through at least 21.x,
 # gone by 24.8). They are indistinguishable from real clusters in system.clusters and would
@@ -59,10 +61,12 @@ CLUSTER_GROUP_PREFIX = 'all_groups.'
 
 # Fallback covering ClickHouse Cloud (returns 'default') and any deployment with remote_servers
 # configured but no {cluster} macro. ORDER BY keeps the result stable when a node is a member of
-# more than one cluster.
+# more than one cluster. The prefix filter uses startsWith rather than LIKE '<prefix>%': ClickHouse
+# compiles a re2 regex for that LIKE pattern (bumping RegexpCreated, which surfaces as
+# clickhouse.compilation.regex), whereas startsWith is a plain prefix comparison.
 CLUSTER_NAME_QUERY = (
     "SELECT cluster FROM system.clusters "
-    "WHERE is_local AND cluster NOT IN ({excluded}) AND cluster NOT LIKE '{prefix}%' "
+    "WHERE is_local AND cluster NOT IN ({excluded}) AND NOT startsWith(cluster, '{prefix}') "
     "ORDER BY cluster LIMIT 1".format(
         excluded=', '.join(f"'{name}'" for name in BUILTIN_SAMPLE_CLUSTERS),
         prefix=CLUSTER_GROUP_PREFIX,

--- a/clickhouse/datadog_checks/clickhouse/utils.py
+++ b/clickhouse/datadog_checks/clickhouse/utils.py
@@ -51,12 +51,21 @@ BUILTIN_SAMPLE_CLUSTERS = (
     'test_unavailable_shard',
 )
 
+# ClickHouse Cloud exposes an internal 'all_groups.<cluster>' entry spanning every service group
+# alongside the real cluster, and both are is_local. It sorts first alphabetically, so without this
+# filter Cloud instances would be tagged all_groups.default while their data is actually collected
+# from 'default' via clusterAllReplicas.
+CLUSTER_GROUP_PREFIX = 'all_groups.'
+
 # Fallback covering ClickHouse Cloud (returns 'default') and any deployment with remote_servers
 # configured but no {cluster} macro. ORDER BY keeps the result stable when a node is a member of
 # more than one cluster.
 CLUSTER_NAME_QUERY = (
-    "SELECT cluster FROM system.clusters WHERE is_local AND cluster NOT IN ({}) ORDER BY cluster LIMIT 1".format(
-        ', '.join(f"'{name}'" for name in BUILTIN_SAMPLE_CLUSTERS)
+    "SELECT cluster FROM system.clusters "
+    "WHERE is_local AND cluster NOT IN ({excluded}) AND cluster NOT LIKE '{prefix}%' "
+    "ORDER BY cluster LIMIT 1".format(
+        excluded=', '.join(f"'{name}'" for name in BUILTIN_SAMPLE_CLUSTERS),
+        prefix=CLUSTER_GROUP_PREFIX,
     )
 )
 

--- a/clickhouse/tests/advanced_metrics.py
+++ b/clickhouse/tests/advanced_metrics.py
@@ -304,6 +304,9 @@ BASE_METRICS = [
 
 # These are the common metrics that are not always available.
 OPTIONAL_METRICS = [
+    # JIT execution counter; only appears once a compiled function is actually run, so it is optional.
+    'clickhouse.compilation.function.execute.count',
+    'clickhouse.compilation.function.execute.total',
     'clickhouse.asynchronous_metrics.AsynchronousHeavyMetricsCalculationTimeSpent',
     'clickhouse.asynchronous_metrics.AsynchronousHeavyMetricsUpdateInterval',
     'clickhouse.asynchronous_metrics.AsynchronousMetricsCalculationTimeSpent',

--- a/clickhouse/tests/metrics.py
+++ b/clickhouse/tests/metrics.py
@@ -91,6 +91,9 @@ OPTIONAL_METRICS = [
     'clickhouse.cache_dictionary.update_queue.keys',
     'clickhouse.compilation.llvm.attempt.count',
     'clickhouse.compilation.llvm.attempt.total',
+    # JIT execution counter; only appears once a compiled function is actually run, so it is optional.
+    'clickhouse.compilation.function.execute.count',
+    'clickhouse.compilation.function.execute.total',
     'clickhouse.compilation.size.count',
     'clickhouse.compilation.size.total',
     'clickhouse.compilation.time',

--- a/clickhouse/tests/test_clickhouse.py
+++ b/clickhouse/tests/test_clickhouse.py
@@ -4,6 +4,7 @@
 import pytest
 
 from datadog_checks.clickhouse import ClickhouseCheck
+from datadog_checks.clickhouse.utils import CLUSTER_TAG
 from datadog_checks.dev.utils import get_metadata_metrics
 
 from . import common
@@ -46,19 +47,21 @@ def test_custom_queries(aggregator, instance, dd_run_check):
     check = ClickhouseCheck('clickhouse', {}, [instance])
     dd_run_check(check)
 
-    aggregator.assert_metric(
-        'clickhouse.settings.changed',
-        metric_type=0,
-        tags=[
-            'server:{}'.format(instance['server']),
-            'port:{}'.format(instance['port']),
-            'db:default',
-            'foo:bar',
-            'test:clickhouse',
-            'database_hostname:{}'.format(check.database_hostname),
-            'database_instance:{}:{}:default'.format(instance['server'], instance['port']),
-        ],
-    )
+    expected_tags = [
+        'server:{}'.format(instance['server']),
+        'port:{}'.format(instance['port']),
+        'db:default',
+        'foo:bar',
+        'test:clickhouse',
+        'database_hostname:{}'.format(check.database_hostname),
+        'database_instance:{}:{}:default'.format(instance['server'], instance['port']),
+    ]
+    # ClickHouse ships a built-in is_local `default` cluster on some versions (and Cloud reports one
+    # too), so every metric carries the clickhouse_cluster tag when a cluster resolves.
+    if check.cluster_name:
+        expected_tags.append('{}:{}'.format(CLUSTER_TAG, check.cluster_name))
+
+    aggregator.assert_metric('clickhouse.settings.changed', metric_type=0, tags=expected_tags)
 
 
 @pytest.mark.skipif(

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -7,7 +7,13 @@ from clickhouse_connect.driver.exceptions import Error, OperationalError
 
 from datadog_checks.base import ConfigurationError
 from datadog_checks.clickhouse import ClickhouseCheck, advanced_queries, queries
-from datadog_checks.clickhouse.utils import cluster_aware_query
+from datadog_checks.clickhouse.utils import (
+    BUILTIN_SAMPLE_CLUSTERS,
+    CLUSTER_MACRO_QUERY,
+    CLUSTER_NAME_QUERY,
+    CLUSTER_TAG,
+    cluster_aware_query,
+)
 
 from .utils import ensure_csv_safe, parse_described_metrics, raise_error
 
@@ -455,3 +461,113 @@ def test_get_queries_uses_base_queries_for_direct_connection(instance, use_advan
     check._server_version = '24.8'
 
     assert all('clusterAllReplicas' not in q['query'] for q in check.get_queries())
+
+
+def make_cluster_name_check(query_results):
+    """Build a check whose execute_query_raw replays query_results keyed by SQL."""
+    check = ClickhouseCheck('clickhouse', {}, [BASE_INSTANCE])
+
+    def execute(query):
+        result = query_results[query]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    check.execute_query_raw = mock.Mock(side_effect=execute)
+    return check
+
+
+def test_cluster_name_prefers_the_macro():
+    check = make_cluster_name_check({CLUSTER_MACRO_QUERY: [['macro_cluster']]})
+
+    assert check.cluster_name == 'macro_cluster'
+    # system.clusters must not be consulted once the macro answers.
+    check.execute_query_raw.assert_called_once_with(CLUSTER_MACRO_QUERY)
+
+
+@pytest.mark.parametrize(
+    'macro_result',
+    [
+        pytest.param([], id='no-rows'),
+        pytest.param([['']], id='empty-value'),
+        pytest.param(Error('No macro cluster in config'), id='macro-undefined'),
+    ],
+)
+def test_cluster_name_falls_back_to_system_clusters(macro_result):
+    check = make_cluster_name_check({CLUSTER_MACRO_QUERY: macro_result, CLUSTER_NAME_QUERY: [['prod_cluster']]})
+
+    assert check.cluster_name == 'prod_cluster'
+
+
+def test_cluster_name_query_excludes_builtin_sample_clusters():
+    """ClickHouse <=21.x ships test_* clusters in its default config.
+
+    They are is_local and would otherwise mislabel every stock instance, so the
+    fallback query filters them out by name rather than picking one.
+    """
+    for name in BUILTIN_SAMPLE_CLUSTERS:
+        assert f"'{name}'" in CLUSTER_NAME_QUERY
+
+    assert 'test_cluster_two_shards_localhost' in BUILTIN_SAMPLE_CLUSTERS
+    assert 'test_shard_localhost' in BUILTIN_SAMPLE_CLUSTERS
+
+
+def test_cluster_name_absent_when_both_sources_fail():
+    check = make_cluster_name_check(
+        {
+            CLUSTER_MACRO_QUERY: Error('No macro cluster in config'),
+            CLUSTER_NAME_QUERY: [],
+        }
+    )
+
+    # No 'default' fallback: a wrong cluster name is worse than an absent one.
+    assert check.cluster_name is None
+
+
+def test_cluster_name_is_cached_including_the_absent_case():
+    check = make_cluster_name_check({CLUSTER_MACRO_QUERY: [], CLUSTER_NAME_QUERY: []})
+
+    assert check.cluster_name is None
+    assert check.cluster_name is None
+
+    assert check.execute_query_raw.call_count == 2  # one attempt per source, not per access
+
+
+def test_check_tags_with_cluster(instance):
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
+        cluster_name.return_value = 'prod_cluster'
+        with mock.patch('clickhouse_connect.get_client'):
+            check.check({})
+
+    assert f'{CLUSTER_TAG}:prod_cluster' in check.tags
+
+
+def test_can_connect_carries_cluster_tag_from_the_second_run(aggregator, instance):
+    """The tag needs a live client, so connect() on the first run predates it.
+
+    The tag persists on the tag manager afterwards, so every later run — and every
+    other surface on the first run, since they all follow the resolution point —
+    does carry it.
+    """
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
+        cluster_name.return_value = 'prod_cluster'
+        with mock.patch('clickhouse_connect.get_client'):
+            check.check({})
+            first_run_tags = list(check.tags)
+            check.check({})
+
+    assert f'{CLUSTER_TAG}:prod_cluster' not in aggregator.service_checks('clickhouse.can_connect')[0].tags
+    assert f'{CLUSTER_TAG}:prod_cluster' in first_run_tags
+    aggregator.assert_service_check('clickhouse.can_connect', tags=check.tags)
+
+
+def test_check_omits_cluster_tag_when_unresolved(instance):
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
+        cluster_name.return_value = None
+        with mock.patch('clickhouse_connect.get_client'):
+            check.check({})
+
+    assert not any(tag.startswith(f'{CLUSTER_TAG}:') for tag in check.tags)

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -489,9 +489,9 @@ def test_cluster_name_prefers_the_macro():
 @pytest.mark.parametrize(
     'macro_result',
     [
-        pytest.param([], id='no-rows'),
+        pytest.param([], id='macro-not-set'),
         pytest.param([['']], id='empty-value'),
-        pytest.param(Error('No macro cluster in config'), id='macro-undefined'),
+        pytest.param(Error('query failed'), id='query-error'),
     ],
 )
 def test_cluster_name_falls_back_to_system_clusters(macro_result):
@@ -520,13 +520,13 @@ def test_cluster_name_query_excludes_cloud_group_pseudo_cluster():
     tagged all_groups.default while their data comes from 'default' via
     clusterAllReplicas.
     """
-    assert f"cluster NOT LIKE '{CLUSTER_GROUP_PREFIX}%'" in CLUSTER_NAME_QUERY
+    assert f"NOT startsWith(cluster, '{CLUSTER_GROUP_PREFIX}')" in CLUSTER_NAME_QUERY
 
 
 def test_cluster_name_absent_when_both_sources_fail():
     check = make_cluster_name_check(
         {
-            CLUSTER_MACRO_QUERY: Error('No macro cluster in config'),
+            CLUSTER_MACRO_QUERY: Error('query failed'),
             CLUSTER_NAME_QUERY: [],
         }
     )

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -9,6 +9,7 @@ from datadog_checks.base import ConfigurationError
 from datadog_checks.clickhouse import ClickhouseCheck, advanced_queries, queries
 from datadog_checks.clickhouse.utils import (
     BUILTIN_SAMPLE_CLUSTERS,
+    CLUSTER_GROUP_PREFIX,
     CLUSTER_MACRO_QUERY,
     CLUSTER_NAME_QUERY,
     CLUSTER_TAG,
@@ -510,6 +511,16 @@ def test_cluster_name_query_excludes_builtin_sample_clusters():
 
     assert 'test_cluster_two_shards_localhost' in BUILTIN_SAMPLE_CLUSTERS
     assert 'test_shard_localhost' in BUILTIN_SAMPLE_CLUSTERS
+
+
+def test_cluster_name_query_excludes_cloud_group_pseudo_cluster():
+    """ClickHouse Cloud reports both 'all_groups.default' and 'default' as is_local.
+
+    The group entry sorts first, so without the filter Cloud instances would be
+    tagged all_groups.default while their data comes from 'default' via
+    clusterAllReplicas.
+    """
+    assert f"cluster NOT LIKE '{CLUSTER_GROUP_PREFIX}%'" in CLUSTER_NAME_QUERY
 
 
 def test_cluster_name_absent_when_both_sources_fail():


### PR DESCRIPTION
### What does this PR do?

Adds a `clickhouse_cluster` tag alongside the `clickhouse_node` tag introduced, giving ClickHouse DBM telemetry a dimension one level above node so
per-node data can be rolled up per cluster.

The cluster is resolved once per check instance and attached with
`tag_manager.set_tag`, in `check()` before the query manager is built. That single
insertion point covers every surface, because they all read `self.tags` (or
`_tags_no_db` derived from it) after that point:

- standard system-table metrics (via `QueryManager(tags=self.tags)`)
- query metrics payload `tags`, and FQT event `ddtags`
- query samples, query completions, query errors `ddtags`
- parts, merges, mutations, replication, detached-parts `ddtags`
- database instance metadata `tags`

Unlike node, cluster does **not** need a per-row field: the DBM jobs read either
local system tables or `clusterAllReplicas('<cluster>', system.*)`, which spans
exactly one named cluster. It therefore rides the existing payload
`tags`/`ddtags` plumbing and **needs no backend change** — the metrics processor
already forwards payload tags verbatim (`clickhouseQueryRowsToMetrics` appends
`payloadTags` with no allowlist), and the cardinality-limit merges only collapse
row fields.

Resolution order:

1. `getMacro('cluster')` — the `{cluster}` macro used by `ON CLUSTER` DDL. Tried
   first because it is only ever set when an operator deliberately configured a
   cluster, which makes it the highest-signal source.
2. `system.clusters` filtered to `is_local`, **excluding the sample clusters
   ClickHouse ships in its own default config** (`test_shard_localhost`,
   `test_cluster_two_shards_localhost` and friends). Those are `is_local` and
   present through at least 21.x, so without the exclusion every stock instance
   on those versions would be mislabelled — this was caught by the existing
   integration suite, which tagged everything
   `clickhouse_cluster:test_cluster_two_shards_localhost`.
3. Neither answered — **no tag is emitted**. There is deliberately no `default`
   fallback; an absent tag is better than a wrong one.

The result is cached, including the "not found" outcome, so a deployment without
a cluster does not re-query on every run.

One known wrinkle: resolution needs a live client, so the `can_connect` service
check submitted inside `connect()` on the very first run predates the tag. Every
other surface on that run has it, and runs 2+ have it everywhere. There is a test
pinning this behaviour.

### Motivation

`clickhouse_node` lets DBM data be split per node, but nodes cannot be rolled up:
an org running several ClickHouse clusters has no way to aggregate or filter by
cluster. This adds that dimension.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
