### PR TITLE
[Backport 7.82.x] kafka_consumer: store broker_timestamps as marshal instead of json

### DIFF
--- a/kafka_consumer/changelog.d/24471.fixed
+++ b/kafka_consumer/changelog.d/24471.fixed
@@ -1,0 +1,1 @@
+Reduce cluster-check-runner memory churn by persisting the DSM broker timestamps cache in a compact binary format (marshal) instead of serializing it as JSON on every run.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -1,10 +1,12 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import base64
 import ctypes
 import ctypes.util
 import heapq
 import json
+import marshal
 import platform
 from collections import defaultdict
 from time import time
@@ -320,9 +322,7 @@ class KafkaCheck(AgentCheck):
 
         broker_timestamps = defaultdict(dict)
         try:
-            for topic_partition, content in json.loads(self.read_persistent_cache(persistent_cache_key)).items():
-                for offset, timestamp in content.items():
-                    broker_timestamps[topic_partition][int(offset)] = timestamp
+            broker_timestamps.update(marshal.loads(base64.b64decode(self.read_persistent_cache(persistent_cache_key))))
         except Exception as e:
             self.log.warning('Could not read broker timestamps from cache: %s', str(e))
         self.broker_timestamps = broker_timestamps
@@ -353,11 +353,12 @@ class KafkaCheck(AgentCheck):
                 _visvalingam_whyatt(timestamps, max(2, self._max_timestamps // 2))
 
     def _save_broker_timestamps(self, broker_timestamps, persistent_cache_key):
-        """Persist broker timestamps to disk, but only periodically to avoid per-run json churn."""
+        """Persist broker timestamps to disk periodically."""
         now = time()
         if now - self.broker_timestamps_last_save < BROKER_TIMESTAMPS_SAVE_INTERVAL:
             return
-        self.write_persistent_cache(persistent_cache_key, json.dumps(broker_timestamps))
+        blob = marshal.dumps(dict(broker_timestamps))
+        self.write_persistent_cache(persistent_cache_key, base64.b64encode(blob).decode('ascii'))
         self.broker_timestamps_last_save = now
 
     def report_highwater_offsets(self, highwater_offsets, contexts_limit, cluster_id):

--- a/kafka_consumer/tests/test_integration.py
+++ b/kafka_consumer/tests/test_integration.py
@@ -1,8 +1,9 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import json
+import base64
 import logging
+import marshal
 from collections import defaultdict
 from contextlib import nullcontext as does_not_raise
 
@@ -27,7 +28,7 @@ def mocked_read_persistent_cache(cache_key):
     cached_offsets["dc_0"][40] = 200
     cached_offsets["dc_1"][25] = 150
     cached_offsets["dc_1"][40] = 200
-    return json.dumps(cached_offsets)
+    return base64.b64encode(marshal.dumps(dict(cached_offsets))).decode('ascii')
 
 
 def mocked_time():

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -1,8 +1,10 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import base64
 import json
 import logging
+import marshal
 from contextlib import nullcontext as does_not_raise
 
 import mock
@@ -12,6 +14,16 @@ from datadog_checks.kafka_consumer import KafkaCheck
 from datadog_checks.kafka_consumer.client import KafkaClient
 
 pytestmark = [pytest.mark.unit]
+
+
+def encode_broker_timestamps(cache):
+    """Encode a broker_timestamps dict the way the check persists it (marshal+base64)."""
+    return base64.b64encode(marshal.dumps(cache)).decode('ascii')
+
+
+def written_broker_timestamps(check):
+    """Decode the broker_timestamps blob the check wrote to its persistent cache (marshal+base64)."""
+    return marshal.loads(base64.b64decode(check.write_persistent_cache.call_args[0][1]))
 
 
 def fake_get_partition_offsets(partitions, offset=-1):
@@ -504,16 +516,16 @@ def test_check_clears_cache_on_partial_reset(kafka_instance, check, dd_run_check
     kafka_consumer_check.client = mock_client
 
     # Cache has entries below (5, 50) and above (200) the new highwater of 100 — all must be cleared.
-    initial_cache = {"topic1_0": {"5": 1.0, "50": 2.0, "200": 3.0}}
-    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=json.dumps(initial_cache))
+    initial_cache = {"topic1_0": {5: 1.0, 50: 2.0, 200: 3.0}}
+    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=encode_broker_timestamps(initial_cache))
     kafka_consumer_check.write_persistent_cache = mock.Mock()
 
     dd_run_check(kafka_consumer_check)
 
-    written = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    written = written_broker_timestamps(kafka_consumer_check)
     timestamps = written["topic1_0"]
     assert len(timestamps) == 1
-    assert "100" in timestamps
+    assert 100 in timestamps
 
 
 @pytest.mark.parametrize(
@@ -522,7 +534,7 @@ def test_check_clears_cache_on_partial_reset(kafka_instance, check, dd_run_check
     [
         pytest.param(
             4,
-            {"topic1_0": {"10": 1000.0, "20": 2000.0, "30": 3000.0}},
+            {"topic1_0": {10: 1000.0, 20: 2000.0, 30: 3000.0}},
             40,
             4000.0,
             25,
@@ -532,7 +544,7 @@ def test_check_clears_cache_on_partial_reset(kafka_instance, check, dd_run_check
         ),
         pytest.param(
             4,
-            {"topic1_0": {"10": 1000.0, "20": 2000.0, "30": 3000.0}},
+            {"topic1_0": {10: 1000.0, 20: 2000.0, 30: 3000.0}},
             40,
             4000.0,
             10,
@@ -542,7 +554,7 @@ def test_check_clears_cache_on_partial_reset(kafka_instance, check, dd_run_check
         ),
         pytest.param(
             4,
-            {"topic1_0": {"10": 1000.0, "20": 2000.0, "30": 3000.0}},
+            {"topic1_0": {10: 1000.0, 20: 2000.0, 30: 3000.0}},
             40,
             4000.0,
             40,
@@ -552,7 +564,7 @@ def test_check_clears_cache_on_partial_reset(kafka_instance, check, dd_run_check
         ),
         pytest.param(
             6,
-            {"topic1_0": {"10": 1000.0, "20": 2000.0, "30": 3000.0, "40": 4000.0, "50": 5000.0}},
+            {"topic1_0": {10: 1000.0, 20: 2000.0, 30: 3000.0, 40: 4000.0, 50: 5000.0}},
             60,
             6000.0,
             35,
@@ -588,13 +600,13 @@ def test_check_compacts_timestamps_and_preserves_lag_accuracy(
     mock_client.get_partition_offsets = lambda partitions, offset=-1: [("topic1", 0, highwater_offset)]
     kafka_consumer_check.client = mock_client
 
-    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=json.dumps(initial_cache))
+    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=encode_broker_timestamps(initial_cache))
     kafka_consumer_check.write_persistent_cache = mock.Mock()
 
     with mock.patch('datadog_checks.kafka_consumer.kafka_consumer.time', return_value=highwater_time):
         dd_run_check(kafka_consumer_check)
 
-    written = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    written = written_broker_timestamps(kafka_consumer_check)
     assert len(written["topic1_0"]) == expected_cache_size
     aggregator.assert_metric("kafka.estimated_consumer_lag", value=expected_lag, count=1)
 
@@ -614,17 +626,17 @@ def test_check_prunes_timestamps_below_earliest_consumer_offset(kafka_instance, 
 
     # Pre-seed the cache with 3 entries. Adding the new highwater at 40 fills the 4-entry
     # budget and triggers compaction+pruning with the earliest consumer offset (25) as the floor.
-    initial_cache = {"topic1_0": {"10": 1.0, "20": 2.0, "30": 3.0}}
-    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=json.dumps(initial_cache))
+    initial_cache = {"topic1_0": {10: 1.0, 20: 2.0, 30: 3.0}}
+    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=encode_broker_timestamps(initial_cache))
     kafka_consumer_check.write_persistent_cache = mock.Mock()
 
     dd_run_check(kafka_consumer_check)
 
-    written = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    written = written_broker_timestamps(kafka_consumer_check)
     timestamps = written["topic1_0"]
-    assert "10" not in timestamps  # pruned: below the anchor; no consumer will interpolate here
-    assert "20" in timestamps  # anchor: largest sample at/below consumer floor of 25
-    assert "40" in timestamps  # new highwater sample
+    assert 10 not in timestamps  # pruned: below the anchor; no consumer will interpolate here
+    assert 20 in timestamps  # anchor: largest sample at/below consumer floor of 25
+    assert 40 in timestamps  # new highwater sample
 
 
 def test_report_lag_in_time_interpolates_consumer_between_samples(kafka_instance, check, aggregator):
@@ -752,16 +764,16 @@ def test_check_prunes_floor_uses_minimum_offset_across_groups(kafka_instance, ch
 
     # With floor=5 (correct min), nothing below 5 exists, so no pruning; VW keeps {10, 40}.
     # With floor=25 (wrong, single-group), entry 10 would be pruned; VW keeps {20, 40} instead.
-    initial_cache = {"topic1_0": {"10": 1.0, "20": 2.0, "30": 3.0}}
-    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=json.dumps(initial_cache))
+    initial_cache = {"topic1_0": {10: 1.0, 20: 2.0, 30: 3.0}}
+    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=encode_broker_timestamps(initial_cache))
     kafka_consumer_check.write_persistent_cache = mock.Mock()
 
     dd_run_check(kafka_consumer_check)
 
-    written = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    written = written_broker_timestamps(kafka_consumer_check)
     timestamps = written["topic1_0"]
-    assert "10" in timestamps  # floor=5 means nothing below 10 exists, so 10 is the oldest endpoint
-    assert "40" in timestamps
+    assert 10 in timestamps  # floor=5 means nothing below 10 exists, so 10 is the oldest endpoint
+    assert 40 in timestamps
 
 
 def test_check_prunes_anchor_at_floor_boundary(kafka_instance, check, dd_run_check):
@@ -779,17 +791,17 @@ def test_check_prunes_anchor_at_floor_boundary(kafka_instance, check, dd_run_che
     mock_client.get_partition_offsets = lambda partitions, offset=-1: [("topic1", 0, 40)]
     kafka_consumer_check.client = mock_client
 
-    initial_cache = {"topic1_0": {"10": 1.0, "20": 2.0, "30": 3.0}}
-    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=json.dumps(initial_cache))
+    initial_cache = {"topic1_0": {10: 1.0, 20: 2.0, 30: 3.0}}
+    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=encode_broker_timestamps(initial_cache))
     kafka_consumer_check.write_persistent_cache = mock.Mock()
 
     dd_run_check(kafka_consumer_check)
 
-    written = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    written = written_broker_timestamps(kafka_consumer_check)
     timestamps = written["topic1_0"]
-    assert "10" not in timestamps  # pruned: below the anchor
-    assert "20" in timestamps  # correct anchor (strict-< floor means 30 is not below 30)
-    assert "40" in timestamps  # new highwater
+    assert 10 not in timestamps  # pruned: below the anchor
+    assert 20 in timestamps  # correct anchor (strict-< floor means 30 is not below 30)
+    assert 40 in timestamps  # new highwater
 
 
 def test_check_keeps_sole_entry_below_floor_as_anchor(kafka_instance, check, dd_run_check):
@@ -805,16 +817,16 @@ def test_check_keeps_sole_entry_below_floor_as_anchor(kafka_instance, check, dd_
     mock_client.get_partition_offsets = lambda partitions, offset=-1: [("topic1", 0, 40)]
     kafka_consumer_check.client = mock_client
 
-    initial_cache = {"topic1_0": {"20": 2.0, "30": 3.0}}
-    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=json.dumps(initial_cache))
+    initial_cache = {"topic1_0": {20: 2.0, 30: 3.0}}
+    kafka_consumer_check.read_persistent_cache = mock.Mock(return_value=encode_broker_timestamps(initial_cache))
     kafka_consumer_check.write_persistent_cache = mock.Mock()
 
     dd_run_check(kafka_consumer_check)
 
-    written = json.loads(kafka_consumer_check.write_persistent_cache.call_args[0][1])
+    written = written_broker_timestamps(kafka_consumer_check)
     timestamps = written["topic1_0"]
-    assert "20" in timestamps  # sole entry below floor — kept as the anchor
-    assert "40" in timestamps  # new highwater
+    assert 20 in timestamps  # sole entry below floor — kept as the anchor
+    assert 40 in timestamps  # new highwater
 
 
 def test_count_consumer_contexts(check, kafka_instance):


### PR DESCRIPTION
### What does this PR do?

Backports #24471 to `7.82.x`. It persists the `kafka_consumer` DSM `broker_timestamps` cache with base64-wrapped `marshal` instead of JSON, while preserving the branch’s existing in-memory cache and five-minute persistence interval.

### Motivation

Reduce serialization allocation churn for cluster-check runners monitoring Kafka clusters with high partition cardinality, mitigating the OOM behavior described in the original PR.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e) — backported the original unit and integration coverage. Local execution was unavailable because the installed `ddev` version does not recognize this branch’s Python distribution source; CI validation is pending.
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required. — `qa/required`, matching #24471.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged