### PR TITLE
Support wheel dispatch from existing release tags

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -24,6 +24,11 @@ on:
         description: "Branch that contains source-repo-ref, used to determine stable vs pre-release behavior"
         required: false
         type: string
+      create-tags:
+        description: "Create and push release tags before dispatching; disable when the legacy pipeline already created tags"
+        required: false
+        type: boolean
+        default: true
       dry-run:
         description: >-
           When true, print what would be released and where without pushing tags
@@ -52,7 +57,7 @@ env:
 
 jobs:
   prepare:
-    name: Tag releases and build dispatch batches
+    name: Prepare releases and build dispatch batches
     runs-on: ubuntu-latest
 
     outputs:
@@ -74,8 +79,8 @@ jobs:
           sparse-checkout: .github
           path: tooling
 
-      # Source tree to tag and validate. ddev release tag operates on HEAD of
-      # this checkout, so it must be at the ref the caller asked to release.
+      # Source tree to detect and validate. When tag creation is enabled, ddev
+      # release tag operates on HEAD, so this must be the requested release ref.
       - name: Checkout source repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -122,6 +127,7 @@ jobs:
         id: prepare
         working-directory: source
         env:
+          CREATE_TAGS: ${{ inputs.create-tags }}
           DRY_RUN: ${{ inputs.dry-run }}
           SELECTED_PACKAGES: ${{ inputs.packages }}
           SOURCE_REPO: ${{ inputs.source-repo || 'integrations-core' }}
@@ -132,7 +138,7 @@ jobs:
       # Only mint a write token when validated local tags need to be pushed.
       # Dry runs and no-op reruns therefore do not consume App token quota.
       - name: Get source tag token via dd-octo-sts
-        if: steps.prepare.outputs.has_new_tags == 'true' && !inputs.dry-run
+        if: inputs.create-tags && steps.prepare.outputs.has_new_tags == 'true' && !inputs.dry-run
         id: source-octo-sts
         uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         with:
@@ -140,7 +146,7 @@ jobs:
           policy: self.release.tag-push
 
       - name: Configure source tag credentials
-        if: steps.prepare.outputs.has_new_tags == 'true' && !inputs.dry-run
+        if: inputs.create-tags && steps.prepare.outputs.has_new_tags == 'true' && !inputs.dry-run
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.source-repo-ref || github.sha }}
@@ -152,7 +158,7 @@ jobs:
           clean: false # Preserve the local tags created during preparation
 
       - name: Push release tags
-        if: steps.prepare.outputs.has_new_tags == 'true' && !inputs.dry-run
+        if: inputs.create-tags && steps.prepare.outputs.has_new_tags == 'true' && !inputs.dry-run
         working-directory: source
         env:
           NEW_TAGS: ${{ steps.prepare.outputs.new_tags }}

--- a/.github/workflows/scripts/release_prepare.py
+++ b/.github/workflows/scripts/release_prepare.py
@@ -1,7 +1,7 @@
 """Prepare a release: tag packages, detect the release list, and validate readiness.
 
 Environment variables:
-  TARGET            'prod' pushes tags; 'dev' (default) creates them locally only
+  CREATE_TAGS       When false, never create tags and detect packages only from existing tags
   DRY_RUN           When true, tags are created locally but never pushed
   SELECTED_PACKAGES JSON array of packages to tag, 'all', or empty to tag all
   SOURCE_REPO       Source repository name (integrations-core, integrations-extras, marketplace)
@@ -201,15 +201,28 @@ def _validate(
 
 
 def main() -> None:
+    create_tags = parse_bool_env("CREATE_TAGS", default=True)
     dry_run = parse_bool_env("DRY_RUN", default=False)
     selected = os.environ.get("SELECTED_PACKAGES", "")
     source_repo = os.environ.get("SOURCE_REPO", "integrations-core")
     ref = os.environ.get("REF", "")
     is_stable_release = _parse_is_stable_release()
 
-    new_tags = _tag(dry_run, selected)
+    new_tags = _tag(dry_run, selected) if create_tags else []
 
     packages, mode = _detect(selected)
+    if not create_tags and not selected.strip() and not packages:
+        print(
+            "Release preparation failed: no release tags point at the supplied source ref. "
+            "The legacy release pipeline must push tags before dispatching this workflow.",
+            file=sys.stderr,
+        )
+        write_summary(
+            "## Wheel Release\n\n"
+            "> ⚠️ No release tags point at the supplied source ref. "
+            "Confirm the legacy tag push completed before retrying.\n"
+        )
+        sys.exit(1)
 
     set_outputs(
         packages=json.dumps(packages),

--- a/.github/workflows/scripts/tests/test_script_release_prepare.py
+++ b/.github/workflows/scripts/tests/test_script_release_prepare.py
@@ -249,6 +249,7 @@ class TestMain:
         runner_temp.mkdir()
 
         env = {
+            "CREATE_TAGS": "true",
             "DRY_RUN": "false",
             "SELECTED_PACKAGES": "",
             "SOURCE_REPO": "integrations-extras",
@@ -319,6 +320,55 @@ class TestMain:
         assert outputs["has_packages"] == "true"
         assert outputs["has_new_tags"] == "false"
         assert json.loads(outputs["new_tags"]) == []
+
+    def test_create_tags_false_skips_tagging_and_detects_existing_tags(self, monkeypatch, tmp_path):
+        github_output, _, _ = self._setup_env(
+            monkeypatch,
+            tmp_path,
+            extra={"CREATE_TAGS": "false"},
+        )
+        pkgs = ["postgres"]
+        with patch("release_prepare._tag") as mock_tag, \
+             patch("release_prepare.get_all_packages", return_value=pkgs), \
+             patch("release_prepare.resolve_packages", return_value=(pkgs, "auto-detect from tags at HEAD")), \
+             patch("release_prepare.validate_packages", return_value=_stable_result()):
+            release_prepare.main()
+        mock_tag.assert_not_called()
+        outputs = self._read_outputs(github_output)
+        assert json.loads(outputs["packages"]) == pkgs
+        assert json.loads(outputs["new_tags"]) == []
+        assert outputs["has_new_tags"] == "false"
+
+    def test_create_tags_false_auto_detect_with_no_tags_fails(self, monkeypatch, tmp_path, capsys):
+        self._setup_env(monkeypatch, tmp_path, extra={"CREATE_TAGS": "false"})
+        with patch("release_prepare._tag") as mock_tag, \
+             patch("release_prepare.get_all_packages", return_value=["postgres"]), \
+             patch(
+                 "release_prepare.resolve_packages",
+                 return_value=([], "auto-detect from tags at HEAD"),
+             ), \
+             pytest.raises(SystemExit) as exc_info:
+            release_prepare.main()
+        assert exc_info.value.code == 1
+        assert "no release tags point at the supplied source ref" in capsys.readouterr().err.lower()
+        mock_tag.assert_not_called()
+
+    def test_create_tags_false_allows_explicit_packages_without_tags(self, monkeypatch, tmp_path):
+        github_output, _, _ = self._setup_env(
+            monkeypatch,
+            tmp_path,
+            extra={"CREATE_TAGS": "false", "SELECTED_PACKAGES": '["postgres"]'},
+        )
+        with patch("release_prepare._tag") as mock_tag, \
+             patch("release_prepare.get_all_packages", return_value=["postgres"]), \
+             patch(
+                 "release_prepare.resolve_packages",
+                 return_value=(["postgres"], 'manual (["postgres"])'),
+             ), \
+             patch("release_prepare.validate_packages", return_value=_stable_result()):
+            release_prepare.main()
+        mock_tag.assert_not_called()
+        assert json.loads(self._read_outputs(github_output)["packages"]) == ["postgres"]
 
     def test_tag_failure_exits_before_detect(self, monkeypatch, tmp_path):
         self._setup_env(monkeypatch, tmp_path)


### PR DESCRIPTION
## Summary

- add a backward-compatible `create-tags` input to the shared wheel release workflow, defaulting to `true`
- support a no-tag mode that detects packages from release tags already pointing at the requested source ref
- fail closed when automatic no-tag detection finds no releasable packages
- preserve explicit-package recovery and the existing integrations-core tag-creation behavior

## Why

Legacy GitLab must remain the sole release-tag creator for integrations-extras and marketplace. Those repositories will dispatch this reusable workflow only after signing and pushing tags at the exact source SHA.

## Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/ -q` — 134 passed
- `python -m compileall -q .`
- `git diff --check`
- actionlint: only the same two pre-existing SC2086 findings present on `origin/master`; no new workflow finding

## Rollout

Merge this PR before enabling either source-repository handoff. Existing callers are unchanged because `create-tags` defaults to `true`.

Coordinated PRs:
- integrations-extras: https://github.com/DataDog/integrations-extras/pull/3077
- marketplace: https://github.com/DataDog/marketplace/pull/1696
- marketplace-internal-ci: https://github.com/DataDog/marketplace-internal-ci/pull/3
- investigation/design: https://github.com/DataDog/agent-integrations-tuf/pull/91
