### PR TITLE
Add high availability support to Slurm

### DIFF
--- a/slurm/changelog.d/24717.added
+++ b/slurm/changelog.d/24717.added
@@ -1,0 +1,1 @@
+Add high availability (HA) support.

--- a/slurm/datadog_checks/slurm/check.py
+++ b/slurm/datadog_checks/slurm/check.py
@@ -70,6 +70,7 @@ class ProcessPidMatch:
 class SlurmCheck(AgentCheck, ConfigMixin):
     # This will be the prefix of every metric and service check the integration sends
     __NAMESPACE__ = 'slurm'
+    HA_SUPPORTED = True
 
     def get_slurm_command(self, cmd_name, params):
         cmd_path = self.instance.get(f'{cmd_name}_path', os.path.join(self.slurm_binaries_dir, cmd_name))


### PR DESCRIPTION
### What does this PR do?

Declares `HA_SUPPORTED = True` on `SlurmCheck` to enable the Agent High Availability feature for the Slurm integration.

### Motivation

Slurm's controller-side collection (`sinfo`, `sdiag`, `sacct`, `sshare`, `squeue`) queries the central `slurmctld`. When the Agent runs on both the primary and backup `slurmctld` controllers for redundancy, both would report the same cluster-wide metrics. Enabling HA lets those controller Agents form an active/standby pair (shared `config_id` + `ha_agent.enabled` in `datadog.yaml`) so the check runs only on the active Agent, with automatic failover, avoiding duplicate collection.

Note on scope: HA is scoped per Agent (via `config_id` in `datadog.yaml`), not per instance or per collector. Deploy the HA pair on the `slurmctld` controller hosts. Worker-node collection (`scontrol` job/PID data) runs on separate worker hosts, which are not part of the controller HA pair and keep collecting independently. There is no per-collector HA toggle.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add \`qa/required\` if this PR needs QA validation, or \`qa/skip-qa\` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the \`backport/<branch-name>\` label to the PR and it will automatically open a backport PR once this one is merged