### PR TITLE
Suppress MSAL and urllib3 log noise during Azure AD token acquisition

### DIFF
--- a/datadog_checks_base/changelog.d/24719.fixed
+++ b/datadog_checks_base/changelog.d/24719.fixed
@@ -1,0 +1,1 @@
+Reduce excessive log volume from MSAL and urllib3 during Azure AD managed authentication token requests.

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -169,6 +169,17 @@ def init_logging():
     urllib_logger.setLevel(logging.WARN)
     urllib_logger.propagate = True
 
+    # MSAL (used by azure-identity's WorkloadIdentityCredential/ClientAssertionCredential for
+    # Azure AD managed authentication) and its direct urllib3 usage log verbosely at DEBUG,
+    # emitting several Agent log events per token request regardless of outcome
+    msal_logger = logging.getLogger("msal")
+    msal_logger.setLevel(logging.WARN)
+    msal_logger.propagate = True
+
+    msal_urllib3_logger = logging.getLogger("urllib3.connectionpool")
+    msal_urllib3_logger.setLevel(logging.WARN)
+    msal_urllib3_logger.propagate = True
+
 
 def get_check_logger(default_logger=None):
     """

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -171,13 +171,15 @@ def init_logging():
 
     # MSAL (used by azure-identity's WorkloadIdentityCredential/ClientAssertionCredential for
     # Azure AD managed authentication) and its direct urllib3 usage log verbosely at DEBUG,
-    # emitting several Agent log events per token request regardless of outcome
+    # emitting several Agent log events per token request regardless of outcome.
+    # Cap at WARN by default, but never loosen a stricter configured log_level (e.g. ERROR).
+    msal_suppression_level = max(rootLogger.level, logging.WARN)
     msal_logger = logging.getLogger("msal")
-    msal_logger.setLevel(logging.WARN)
+    msal_logger.setLevel(msal_suppression_level)
     msal_logger.propagate = True
 
     msal_urllib3_logger = logging.getLogger("urllib3.connectionpool")
-    msal_urllib3_logger.setLevel(logging.WARN)
+    msal_urllib3_logger.setLevel(msal_suppression_level)
     msal_urllib3_logger.propagate = True
 
 

--- a/datadog_checks_base/tests/test_log.py
+++ b/datadog_checks_base/tests/test_log.py
@@ -49,6 +49,19 @@ def test_init_logging_suppresses_noisy_third_party_loggers():
     assert logging.getLogger("urllib3.connectionpool").level == logging.WARNING
 
 
+def test_init_logging_preserves_stricter_configured_log_level():
+    from datadog_checks.base.stubs import datadog_agent
+
+    datadog_agent._config['log_level'] = 'error'
+    try:
+        init_logging()
+
+        assert logging.getLogger("msal").level == logging.ERROR
+        assert logging.getLogger("urllib3.connectionpool").level == logging.ERROR
+    finally:
+        datadog_agent._config.pop('log_level', None)
+
+
 def test_get_check_logger(caplog):
     class FooConfig(object):
         def __init__(self):

--- a/datadog_checks_base/tests/test_log.py
+++ b/datadog_checks_base/tests/test_log.py
@@ -41,6 +41,14 @@ def test_logging_capture_warnings():
         assert "hello-world" in msg
 
 
+def test_init_logging_suppresses_noisy_third_party_loggers():
+    init_logging()
+
+    assert logging.getLogger("requests.packages.urllib3").level == logging.WARNING
+    assert logging.getLogger("msal").level == logging.WARNING
+    assert logging.getLogger("urllib3.connectionpool").level == logging.WARNING
+
+
 def test_get_check_logger(caplog):
     class FooConfig(object):
         def __init__(self):

--- a/datadog_checks_base/tests/test_log.py
+++ b/datadog_checks_base/tests/test_log.py
@@ -52,6 +52,11 @@ def test_init_logging_suppresses_noisy_third_party_loggers():
 def test_init_logging_preserves_stricter_configured_log_level():
     from datadog_checks.base.stubs import datadog_agent
 
+    root_logger = logging.getLogger()
+    original_root_level = root_logger.level
+    original_msal_level = logging.getLogger("msal").level
+    original_urllib3_level = logging.getLogger("urllib3.connectionpool").level
+
     datadog_agent._config['log_level'] = 'error'
     try:
         init_logging()
@@ -60,6 +65,9 @@ def test_init_logging_preserves_stricter_configured_log_level():
         assert logging.getLogger("urllib3.connectionpool").level == logging.ERROR
     finally:
         datadog_agent._config.pop('log_level', None)
+        root_logger.setLevel(original_root_level)
+        logging.getLogger("msal").setLevel(original_msal_level)
+        logging.getLogger("urllib3.connectionpool").setLevel(original_urllib3_level)
 
 
 def test_get_check_logger(caplog):


### PR DESCRIPTION
### What does this PR do?
Suppresses verbose DEBUG-level logging from MSAL's own loggers (`msal`) and its direct `urllib3.connectionpool` usage, which are emitted on every Azure AD token acquisition.

### Motivation
Fixes excessive log volume during Azure AD Workload Identity token acquisition (multiple DEBUG log records per token call, on every call regardless of outcome).


### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged