### PR TITLE
Clarify managed_authentication client_id comment for Postgres

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -1344,8 +1344,10 @@ files:
 
             enabled: Set to `true` to enable Azure AD authentication.
             auth_type: The authentication method. Use `managed_identity` (default) or `workload_identity` for AKS.
-            client_id: The client ID of the managed identity or app registration. Required for `managed_identity`.
-              Optional for `workload_identity` (defaults to the `AZURE_CLIENT_ID` environment variable).
+            client_id: The managed identity's Client ID (also called the Application (client) ID in
+              the Azure Portal). This is different from the Object (principal) ID. Required for
+              `managed_identity`. Optional for `workload_identity` (defaults to the `AZURE_CLIENT_ID`
+              environment variable).
             tenant_id: The Azure AD tenant ID. Only used for `workload_identity`
               (defaults to the `AZURE_TENANT_ID` environment variable).
             identity_scope: The permission scope for the identity token.
@@ -1362,7 +1364,8 @@ files:
                 The authentication method. Use `managed_identity` (default) or `workload_identity` for AKS.
             - name: client_id
               description: |
-                The client ID of the managed identity or application registration.
+                The managed identity's Client ID (also called the Application (client) ID in the
+                Azure Portal). This is different from the Object (principal) ID.
                 Required for `managed_identity` auth. Optional for `workload_identity`,
                 where it defaults to the `AZURE_CLIENT_ID` environment variable.
               type: string

--- a/postgres/changelog.d/24720.fixed
+++ b/postgres/changelog.d/24720.fixed
@@ -1,0 +1,1 @@
+Clarify that the managed_authentication client_id is the managed identity's Client ID, not its Object ID.

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -63,7 +63,7 @@ class ManagedAuthentication1(BaseModel):
     )
     client_id: Optional[str] = Field(
         None,
-        description='The client ID of the managed identity or application registration.\nRequired for `managed_identity` auth. Optional for `workload_identity`,\nwhere it defaults to the `AZURE_CLIENT_ID` environment variable.\n',
+        description="The managed identity's Client ID (also called the Application (client) ID in the\nAzure Portal). This is different from the Object (principal) ID.\nRequired for `managed_identity` auth. Optional for `workload_identity`,\nwhere it defaults to the `AZURE_CLIENT_ID` environment variable.\n",
     )
     enabled: Optional[bool] = Field(None, examples=[False])
     identity_scope: Optional[str] = Field(

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -772,8 +772,10 @@ instances:
         ##
         ## enabled: Set to `true` to enable Azure AD authentication.
         ## auth_type: The authentication method. Use `managed_identity` (default) or `workload_identity` for AKS.
-        ## client_id: The client ID of the managed identity or app registration. Required for `managed_identity`.
-        ##   Optional for `workload_identity` (defaults to the `AZURE_CLIENT_ID` environment variable).
+        ## client_id: The managed identity's Client ID (also called the Application (client) ID in
+        ##   the Azure Portal). This is different from the Object (principal) ID. Required for
+        ##   `managed_identity`. Optional for `workload_identity` (defaults to the `AZURE_CLIENT_ID`
+        ##   environment variable).
         ## tenant_id: The Azure AD tenant ID. Only used for `workload_identity`
         ##   (defaults to the `AZURE_TENANT_ID` environment variable).
         ## identity_scope: The permission scope for the identity token.


### PR DESCRIPTION
### What does this PR do?
Clarifies the `client_id` field description in the postgres `managed_authentication` config block (`spec.yaml` and the generated `conf.yaml.example`). The comment now explicitly disambiguates the managed identity's **Client ID** (also called the **Application (client) ID** in the Azure Portal) from the **Object (principal) ID**, which is a different value entirely.

### Motivation
The previous wording — "The client ID of the managed identity or app registration" — conflated two distinct Azure identity concepts without calling out where to find the right value or how it differs from a similarly-named one. This ambiguity is the likely root cause of at least one `AADSTS700016` Azure AD authentication failure, where the wrong identifier (Object/principal ID instead of Client ID) was supplied. A companion public-docs fix already addressed the same ambiguity in the managed authentication guide with equivalent wording. Related to SDBM-2844.

This is a comment-only change with no behavior impact.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged