### PR TITLE
[AI-7074] Show deterministic outcomes for Togo runs

### DIFF
--- a/ddev/src/ddev/ai/callbacks/callbacks.py
+++ b/ddev/src/ddev/ai/callbacks/callbacks.py
@@ -7,6 +7,7 @@ from typing import Any, Protocol
 from ddev.ai.agent.scope import AgentScope
 from ddev.ai.agent.types import AgentResponse, ToolCall
 from ddev.ai.react.types import ReActResult
+from ddev.ai.runtime.outcome import RunOutcome
 from ddev.ai.tools.core.types import ToolResult
 
 # ---------------------------------------------------------------------------
@@ -100,6 +101,12 @@ class OnRunErrorCallback(Protocol):
     async def __call__(self) -> None: ...
 
 
+class OnRunFinishedCallback(Protocol):
+    """Called once after a non-cancelled run ends with its deterministic outcome."""
+
+    async def __call__(self, outcome: RunOutcome) -> None: ...
+
+
 class OnBeforeGoalCheckCallback(Protocol):
     """Called immediately before each reviewer agent run for a task with a goal."""
 
@@ -147,6 +154,7 @@ class CallbackSet:
         self._on_phase_finish: list[OnPhaseFinishCallback] = []
         self._on_phase_error: list[OnPhaseErrorCallback] = []
         self._on_run_error: list[OnRunErrorCallback] = []
+        self._on_run_finished: list[OnRunFinishedCallback] = []
         self._on_before_goal_check: list[OnBeforeGoalCheckCallback] = []
         self._on_after_goal_check: list[OnAfterGoalCheckCallback] = []
 
@@ -248,6 +256,13 @@ class CallbackSet:
     async def fire_run_error(self) -> None:
         await self._fire(self._on_run_error)
 
+    def on_run_finished(self, func: OnRunFinishedCallback) -> OnRunFinishedCallback:
+        self._on_run_finished.append(func)
+        return func
+
+    async def fire_run_finished(self, outcome: RunOutcome) -> None:
+        await self._fire(self._on_run_finished, outcome)
+
     def on_before_goal_check(self, func: OnBeforeGoalCheckCallback) -> OnBeforeGoalCheckCallback:
         self._on_before_goal_check.append(func)
         return func
@@ -326,6 +341,10 @@ class Callbacks:
     async def fire_run_error(self) -> None:
         for s in self._sets:
             await s.fire_run_error()
+
+    async def fire_run_finished(self, outcome: RunOutcome) -> None:
+        for s in self._sets:
+            await s.fire_run_finished(outcome)
 
     async def fire_before_goal_check(self, phase_id: str, task_name: str, attempt: int) -> None:
         for s in self._sets:

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -200,6 +200,7 @@ class Phase(AsyncProcessor[PhaseTrigger]):
             started_at=self._started_at.isoformat() if self._started_at else None,
             finished_at=datetime.now(UTC).isoformat(),
             error=str(error),
+            error_type=type(error).__name__,
             tokens=CheckpointTokenInfo(total_input=0, total_output=0),
         )
 

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -57,6 +57,7 @@ class FailedCheckpoint(BaseModel):
     started_at: str | None
     finished_at: str
     error: str
+    error_type: str | None = None
     tokens: CheckpointTokenInfo
     goal_validations: list[GoalValidationRecord] | None = None
 

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -89,12 +89,27 @@ class CheckpointManager:
         self._path = path
 
     @property
-    def root(self) -> Path:
-        """Directory that holds checkpoints.yaml, per-phase memory files, and any side artifacts."""
+    def run_dir(self) -> Path:
+        """Directory containing all artifacts for this run."""
         return self._path.parent
 
+    @property
+    def root(self) -> Path:
+        """Directory that holds checkpoints.yaml, per-phase memory files, and any side artifacts."""
+        return self.run_dir
+
+    @property
+    def outcome_path(self) -> Path:
+        """Path where the deterministic run outcome is persisted."""
+        return self.run_dir / "run.yaml"
+
+    @property
+    def agent_log_root(self) -> Path:
+        """Directory under which per-agent logs are persisted."""
+        return self.run_dir
+
     def _ensure_dir(self) -> None:
-        self.root.mkdir(parents=True, exist_ok=True)
+        self.run_dir.mkdir(parents=True, exist_ok=True)
 
     def read(self) -> dict[str, PhaseCheckpoint]:
         """Return validated checkpoints keyed by phase_id.
@@ -135,11 +150,11 @@ class CheckpointManager:
     @property
     def memory_dir(self) -> Path:
         """Directory where memory files and per-phase sidecar artifacts are written."""
-        return self._path.parent
+        return self.run_dir
 
     def memory_path(self, phase_id: str) -> Path:
         """Return the resolved path to a phase's memory file."""
-        return (self.root / f"{phase_id}_memory.md").resolve()
+        return (self.run_dir / f"{phase_id}_memory.md").resolve()
 
     def write_memory(self, phase_id: str, text: str) -> None:
         """Write agent-authored text to this phase's memory file."""

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -106,8 +106,9 @@ class PhaseOrchestrator(EventBusOrchestrator):
         except Exception as e:
             try:
                 await self._record_outcome(e)
-            except RunOutcomeError:
+            except RunOutcomeError as outcome_error:
                 self._logger.exception("Failed to record the outcome for a failed flow")
+                e.add_note(f"Outcome recording also failed: {outcome_error}")
             raise
         else:
             await self._record_outcome(None)
@@ -231,8 +232,8 @@ def _checkpoint_finished_at(checkpoint: PhaseCheckpoint) -> datetime:
     """Return an aware timestamp suitable for filtering checkpoints from older attempts."""
     try:
         finished_at = datetime.fromisoformat(checkpoint.finished_at)
-    except ValueError:
-        return datetime.min.replace(tzinfo=UTC)
+    except ValueError as e:
+        raise ValueError(f"Checkpoint has invalid finished_at timestamp {checkpoint.finished_at!r}") from e
 
     if finished_at.tzinfo is None:
         return finished_at.replace(tzinfo=UTC)

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -2,7 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import asyncio
 import logging
+from datetime import UTC, datetime
 from pathlib import Path
 
 from ddev.ai.agent.registry import AgentProviderRegistry
@@ -12,7 +14,15 @@ from ddev.ai.phases.base import FlowContext
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.registry import PhaseRegistry
 from ddev.ai.runtime.agent_log import AgentLogger
-from ddev.ai.runtime.checkpoints import CheckpointManager, resolve_resume_state
+from ddev.ai.runtime.checkpoints import CheckpointManager, PhaseCheckpoint, resolve_resume_state
+from ddev.ai.runtime.outcome import (
+    RunOutcome,
+    RunOutcomeBuildError,
+    RunOutcomeError,
+    RunOutcomePersistenceError,
+    RunOutcomeStore,
+    build_run_outcome,
+)
 from ddev.ai.runtime.resources import RunResources
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.event_bus.exceptions import FatalProcessingError, OrchestratorHookError
@@ -56,34 +66,109 @@ class PhaseOrchestrator(EventBusOrchestrator):
         )
         self._resolved_flow = resolved_flow
         self._phase_registry = phase_registry
-        self._checkpoint_path = checkpoint_path
         self._runtime_variables = runtime_variables
         self._provider_registry = provider_registry
         self._file_access_policy = file_access_policy
         self._callbacks: Callbacks = callbacks or Callbacks()
         self._resume = resume
+        self._checkpoint_manager = CheckpointManager(checkpoint_path)
+        self._outcome_store = RunOutcomeStore(self._checkpoint_manager.root)
         self._agent_logger: AgentLogger | None = None
         self._failed_phase: str | None = None
         self._failed_error: str | None = None
+        self._started_at: datetime | None = None
+        self._resume_completed: set[str] = set()
+        self._outcome: RunOutcome | None = None
 
     @property
     def failed_phase(self) -> str | None:
         return self._failed_phase
 
+    @property
+    def outcome(self) -> RunOutcome | None:
+        """Return the deterministic outcome after the run ends."""
+        return self._outcome
+
+    def run(self) -> None:
+        """Run the flow and record its deterministic outcome."""
+        asyncio.run(self._run_with_outcome())
+
+    async def run_async(self) -> None:
+        """Run the flow on the caller's event loop and record its deterministic outcome."""
+        await self._run_with_outcome()
+
+    async def _run_with_outcome(self) -> None:
+        self._started_at = datetime.now(UTC)
+        try:
+            await super().run_async()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            try:
+                await self._record_outcome(e)
+            except RunOutcomeError:
+                self._logger.exception("Failed to record the outcome for a failed flow")
+            raise
+        else:
+            await self._record_outcome(None)
+        finally:
+            if self._agent_logger is not None:
+                self._agent_logger.close()
+
+    async def _record_outcome(self, exception: BaseException | None) -> None:
+        try:
+            finished_at = datetime.now(UTC)
+            started_at = self._started_at or finished_at
+            checkpoints = self._current_run_checkpoints(started_at)
+            outcome = build_run_outcome(
+                resolved_flow=self._resolved_flow,
+                checkpoints=checkpoints,
+                skipped_on_resume=self._resume_completed,
+                started_at=started_at,
+                finished_at=finished_at,
+                run_dir=self._checkpoint_manager.root,
+                resumed=self._resume,
+                exception=exception,
+                failed_phase=self._failed_phase,
+            )
+        except Exception as e:
+            raise RunOutcomeBuildError(f"Failed to build the flow outcome: {e}") from e
+
+        self._outcome = outcome
+        persistence_error: RunOutcomePersistenceError | None = None
+        persistence_cause: Exception | None = None
+        try:
+            self._outcome_store.write(outcome)
+        except Exception as e:
+            persistence_cause = e
+            persistence_error = RunOutcomePersistenceError(f"Failed to persist the flow outcome: {e}")
+
+        await self._callbacks.fire_run_finished(outcome)
+        if persistence_error is not None:
+            raise persistence_error from persistence_cause
+
+    def _current_run_checkpoints(self, started_at: datetime) -> dict[str, PhaseCheckpoint]:
+        checkpoints = self._checkpoint_manager.read()
+        return {
+            phase_id: checkpoint
+            for phase_id, checkpoint in checkpoints.items()
+            if phase_id in self._resume_completed or _checkpoint_finished_at(checkpoint) >= started_at
+        }
+
     async def on_initialize(self) -> None:
         """Construct phases from the resolved flow and submit the start PhaseTrigger."""
-        checkpoint_manager = CheckpointManager(self._checkpoint_path)
         dependency_map: dict[str, list[str]] = {entry.phase: entry.dependencies for entry in self._resolved_flow.flow}
 
         completed, frontier = (
-            resolve_resume_state(self._resolved_flow, checkpoint_manager) if self._resume else (set(), set())
+            resolve_resume_state(self._resolved_flow, self._checkpoint_manager) if self._resume else (set(), set())
         )
+        self._resume_completed = completed
         if self._resume:
             self._logger.info(
                 "Resuming: %d phase(s) completed, re-running frontier %r", len(completed), sorted(frontier)
             )
 
-        self._agent_logger = AgentLogger(checkpoint_manager.root)
+        self._agent_logger = AgentLogger(self._checkpoint_manager.root)
         run_callbacks = self._callbacks.with_set(self._agent_logger.as_callback_set())
 
         self._resources = RunResources(
@@ -110,7 +195,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
                 config=phase_config,
                 deps=dependency_map[entry.phase],
                 resources=self._resources,
-                checkpoint_manager=checkpoint_manager,
+                checkpoint_manager=self._checkpoint_manager,
                 context=context,
             )
             self.register_processor(phase, [PhaseTrigger])
@@ -134,11 +219,21 @@ class PhaseOrchestrator(EventBusOrchestrator):
         raise FatalProcessingError(str(error)) from error.original_exception
 
     async def on_finalize(self, exception: Exception | None) -> None:
-        if self._agent_logger is not None:
-            self._agent_logger.close()
         if exception is not None and self._failed_phase is not None:
             self._logger.error(
                 "Pipeline aborted: phase '%s' failed: %s",
                 self._failed_phase,
                 self._failed_error or "<unknown>",
             )
+
+
+def _checkpoint_finished_at(checkpoint: PhaseCheckpoint) -> datetime:
+    try:
+        finished_at = datetime.fromisoformat(checkpoint.finished_at)
+    except ValueError:
+        return datetime.min.replace(tzinfo=UTC)
+
+    if finished_at.tzinfo is None:
+        return finished_at.replace(tzinfo=UTC)
+
+    return finished_at

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -72,7 +72,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
         self._callbacks: Callbacks = callbacks or Callbacks()
         self._resume = resume
         self._checkpoint_manager = CheckpointManager(checkpoint_path)
-        self._outcome_store = RunOutcomeStore(self._checkpoint_manager.root)
+        self._outcome_store = RunOutcomeStore(self._checkpoint_manager.outcome_path)
         self._agent_logger: AgentLogger | None = None
         self._failed_phase: str | None = None
         self._failed_error: str | None = None
@@ -126,7 +126,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
                 skipped_on_resume=self._resume_completed,
                 started_at=started_at,
                 finished_at=finished_at,
-                run_dir=self._checkpoint_manager.root,
+                run_dir=self._checkpoint_manager.run_dir,
                 resumed=self._resume,
                 exception=exception,
                 failed_phase=self._failed_phase,
@@ -168,7 +168,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
                 "Resuming: %d phase(s) completed, re-running frontier %r", len(completed), sorted(frontier)
             )
 
-        self._agent_logger = AgentLogger(self._checkpoint_manager.root)
+        self._agent_logger = AgentLogger(self._checkpoint_manager.agent_log_root)
         run_callbacks = self._callbacks.with_set(self._agent_logger.as_callback_set())
 
         self._resources = RunResources(
@@ -228,6 +228,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
 
 
 def _checkpoint_finished_at(checkpoint: PhaseCheckpoint) -> datetime:
+    """Return an aware timestamp suitable for filtering checkpoints from older attempts."""
     try:
         finished_at = datetime.fromisoformat(checkpoint.finished_at)
     except ValueError:

--- a/ddev/src/ddev/ai/runtime/orchestrator.py
+++ b/ddev/src/ddev/ai/runtime/orchestrator.py
@@ -79,6 +79,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
         self._started_at: datetime | None = None
         self._resume_completed: set[str] = set()
         self._outcome: RunOutcome | None = None
+        self._outcome_recording_error: RunOutcomeError | None = None
 
     @property
     def failed_phase(self) -> str | None:
@@ -88,6 +89,11 @@ class PhaseOrchestrator(EventBusOrchestrator):
     def outcome(self) -> RunOutcome | None:
         """Return the deterministic outcome after the run ends."""
         return self._outcome
+
+    @property
+    def outcome_recording_error(self) -> RunOutcomeError | None:
+        """Return the error that prevented the outcome from being recorded for a failed run, if any."""
+        return self._outcome_recording_error
 
     def run(self) -> None:
         """Run the flow and record its deterministic outcome."""
@@ -108,6 +114,7 @@ class PhaseOrchestrator(EventBusOrchestrator):
                 await self._record_outcome(e)
             except RunOutcomeError as outcome_error:
                 self._logger.exception("Failed to record the outcome for a failed flow")
+                self._outcome_recording_error = outcome_error
                 e.add_note(f"Outcome recording also failed: {outcome_error}")
             raise
         else:

--- a/ddev/src/ddev/ai/runtime/outcome.py
+++ b/ddev/src/ddev/ai/runtime/outcome.py
@@ -257,8 +257,8 @@ def _original_exception(exception: BaseException | None) -> BaseException | None
 class RunOutcomeStore:
     """Persist the latest deterministic outcome for a flow run."""
 
-    def __init__(self, run_dir: Path) -> None:
-        self.path = run_dir / "run.yaml"
+    def __init__(self, path: Path) -> None:
+        self.path = path
 
     def write(self, outcome: RunOutcome) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)

--- a/ddev/src/ddev/ai/runtime/outcome.py
+++ b/ddev/src/ddev/ai/runtime/outcome.py
@@ -1,0 +1,275 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum, auto
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from ddev.ai.config.models import ResolvedFlow
+from ddev.ai.runtime.checkpoints import (
+    CancelledCheckpoint,
+    CheckpointStatus,
+    FailedCheckpoint,
+    GoalValidationRecord,
+    PhaseCheckpoint,
+)
+
+
+class RunOutcomeReadError(Exception):
+    """Raised when a persisted run outcome cannot be read."""
+
+
+class RunOutcomeError(Exception):
+    """Raised when reporting a flow run fails."""
+
+
+class RunOutcomeBuildError(RunOutcomeError):
+    """Raised when the deterministic outcome cannot be built."""
+
+
+class RunOutcomePersistenceError(RunOutcomeError):
+    """Raised when a built outcome cannot be persisted."""
+
+
+class RunVerdict(StrEnum):
+    SUCCEEDED = auto()
+    FAILED = auto()
+    INCOMPLETE = auto()
+
+
+class FailureKind(StrEnum):
+    NONE = auto()
+    PHASE_ERROR = auto()
+    GOAL_NOT_MET = auto()
+    AGENT_ERROR = auto()
+    CONFIG_ERROR = auto()
+    TIMEOUT = auto()
+    UNKNOWN = auto()
+
+
+class PhaseReportStatus(StrEnum):
+    SUCCEEDED = auto()
+    FAILED = auto()
+    CANCELLED = auto()
+    NOT_RUN = auto()
+    SKIPPED_ON_RESUME = auto()
+
+
+class PhaseReport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    phase_id: str
+    status: PhaseReportStatus
+    started_at: str | None
+    finished_at: str | None
+    duration_seconds: float | None
+    input_tokens: int
+    output_tokens: int
+    goal_validations: list[GoalValidationRecord] | None
+    error: str | None
+    error_type: str | None
+    cancellation_reason: str | None = None
+
+
+class RunOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    flow_name: str
+    verdict: RunVerdict
+    failure_kind: FailureKind
+    failed_phase: str | None
+    error: str | None
+    error_type: str | None
+    started_at: str
+    finished_at: str
+    duration_seconds: float
+    phases: list[PhaseReport]
+    recorded_input_tokens: int
+    recorded_output_tokens: int
+    resumed: bool
+    skipped_on_resume: list[str]
+    run_dir: str
+    summary: str | None = None
+    summary_input_tokens: int = 0
+    summary_output_tokens: int = 0
+    summary_error: str | None = None
+
+
+GOAL_ERROR_TYPES = frozenset({"GoalAttemptsExhausted", "GoalParseError", "GoalValidationError"})
+AGENT_ERROR_TYPES = frozenset({"AgentError", "AgentConnectionError", "AgentRateLimitError", "AgentAPIError"})
+CONFIG_ERROR_TYPES = frozenset({"ConfigError", "ResourceUnavailableError"})
+
+
+def classify_failure(
+    verdict: RunVerdict,
+    error_type: str | None,
+    failed_phase: str | None,
+) -> FailureKind:
+    """Classify a deterministic verdict using persisted exception metadata."""
+    if verdict is RunVerdict.SUCCEEDED:
+        return FailureKind.NONE
+    if verdict is RunVerdict.INCOMPLETE:
+        return FailureKind.TIMEOUT
+    if error_type in GOAL_ERROR_TYPES:
+        return FailureKind.GOAL_NOT_MET
+    if error_type in AGENT_ERROR_TYPES:
+        return FailureKind.AGENT_ERROR
+    if error_type in CONFIG_ERROR_TYPES:
+        return FailureKind.CONFIG_ERROR
+    if failed_phase is not None:
+        return FailureKind.PHASE_ERROR
+    return FailureKind.UNKNOWN
+
+
+def build_run_outcome(
+    *,
+    resolved_flow: ResolvedFlow,
+    checkpoints: dict[str, PhaseCheckpoint],
+    skipped_on_resume: set[str],
+    started_at: datetime,
+    finished_at: datetime,
+    run_dir: Path,
+    resumed: bool,
+    exception: BaseException | None,
+    failed_phase: str | None,
+) -> RunOutcome:
+    """Build a run outcome from the flow definition and durable checkpoints."""
+    reports = [
+        _build_phase_report(entry.phase, checkpoints.get(entry.phase), entry.phase in skipped_on_resume)
+        for entry in resolved_flow.flow
+    ]
+    succeeded = {report.phase_id for report in reports if report.status is PhaseReportStatus.SUCCEEDED}
+    skipped = {report.phase_id for report in reports if report.status is PhaseReportStatus.SKIPPED_ON_RESUME}
+    failed = [report for report in reports if report.status is PhaseReportStatus.FAILED]
+    scheduled = {entry.phase for entry in resolved_flow.flow}
+
+    if failed or exception is not None:
+        verdict = RunVerdict.FAILED
+    elif succeeded | skipped == scheduled:
+        verdict = RunVerdict.SUCCEEDED
+    else:
+        verdict = RunVerdict.INCOMPLETE
+
+    failed_report = next((report for report in failed if report.phase_id == failed_phase), None)
+    if failed_report is None and failed:
+        failed_report = failed[0]
+    original_exception = _original_exception(exception)
+    error = (
+        failed_report.error
+        if failed_report is not None
+        else str(original_exception)
+        if original_exception is not None
+        else None
+    )
+    error_type = (
+        failed_report.error_type
+        if failed_report is not None
+        else type(original_exception).__name__
+        if original_exception is not None
+        else None
+    )
+    resolved_failed_phase = failed_report.phase_id if failed_report is not None else failed_phase
+
+    return RunOutcome(
+        flow_name=resolved_flow.name,
+        verdict=verdict,
+        failure_kind=classify_failure(verdict, error_type, resolved_failed_phase),
+        failed_phase=resolved_failed_phase,
+        error=error,
+        error_type=error_type,
+        started_at=started_at.isoformat(),
+        finished_at=finished_at.isoformat(),
+        duration_seconds=max(0.0, (finished_at - started_at).total_seconds()),
+        phases=reports,
+        recorded_input_tokens=sum(report.input_tokens for report in reports),
+        recorded_output_tokens=sum(report.output_tokens for report in reports),
+        resumed=resumed,
+        skipped_on_resume=[entry.phase for entry in resolved_flow.flow if entry.phase in skipped_on_resume],
+        run_dir=str(run_dir),
+    )
+
+
+def _build_phase_report(
+    phase_id: str,
+    checkpoint: PhaseCheckpoint | None,
+    skipped_on_resume: bool,
+) -> PhaseReport:
+    if checkpoint is None:
+        return PhaseReport(
+            phase_id=phase_id,
+            status=PhaseReportStatus.NOT_RUN,
+            started_at=None,
+            finished_at=None,
+            duration_seconds=None,
+            input_tokens=0,
+            output_tokens=0,
+            goal_validations=None,
+            error=None,
+            error_type=None,
+            cancellation_reason=None,
+        )
+
+    status = (
+        PhaseReportStatus.SKIPPED_ON_RESUME
+        if skipped_on_resume
+        else PhaseReportStatus.SUCCEEDED
+        if checkpoint.status is CheckpointStatus.SUCCESS
+        else PhaseReportStatus.CANCELLED
+        if checkpoint.status is CheckpointStatus.CANCELLED
+        else PhaseReportStatus.FAILED
+    )
+    return PhaseReport(
+        phase_id=phase_id,
+        status=status,
+        started_at=checkpoint.started_at,
+        finished_at=checkpoint.finished_at,
+        duration_seconds=_duration_seconds(checkpoint.started_at, checkpoint.finished_at),
+        input_tokens=checkpoint.tokens.total_input,
+        output_tokens=checkpoint.tokens.total_output,
+        goal_validations=checkpoint.goal_validations,
+        error=checkpoint.error if isinstance(checkpoint, FailedCheckpoint) else None,
+        error_type=checkpoint.error_type if isinstance(checkpoint, FailedCheckpoint) else None,
+        cancellation_reason=checkpoint.reason if isinstance(checkpoint, CancelledCheckpoint) else None,
+    )
+
+
+def _duration_seconds(started_at: str | None, finished_at: str | None) -> float | None:
+    if started_at is None or finished_at is None:
+        return None
+    try:
+        return max(0.0, (datetime.fromisoformat(finished_at) - datetime.fromisoformat(started_at)).total_seconds())
+    except ValueError:
+        return None
+
+
+def _original_exception(exception: BaseException | None) -> BaseException | None:
+    while exception is not None and exception.__cause__ is not None:
+        exception = exception.__cause__
+    return exception
+
+
+class RunOutcomeStore:
+    """Persist the latest deterministic outcome for a flow run."""
+
+    def __init__(self, run_dir: Path) -> None:
+        self.path = run_dir / "run.yaml"
+
+    def write(self, outcome: RunOutcome) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(
+            yaml.dump(outcome.model_dump(mode="json"), default_flow_style=False, sort_keys=False),
+            encoding="utf-8",
+        )
+
+    def read(self) -> RunOutcome:
+        try:
+            payload = yaml.safe_load(self.path.read_text(encoding="utf-8"))
+            return RunOutcome.model_validate(payload)
+        except (OSError, yaml.YAMLError, ValidationError) as e:
+            raise RunOutcomeReadError(f"Failed to read run outcome from {self.path}: {e}") from e

--- a/ddev/src/ddev/ai/runtime/outcome.py
+++ b/ddev/src/ddev/ai/runtime/outcome.py
@@ -95,15 +95,16 @@ class RunOutcome(BaseModel):
     resumed: bool
     skipped_on_resume: list[str]
     run_dir: str
-    summary: str | None = None
-    summary_input_tokens: int = 0
-    summary_output_tokens: int = 0
-    summary_error: str | None = None
 
 
 GOAL_ERROR_TYPES = frozenset({"GoalAttemptsExhausted", "GoalParseError", "GoalValidationError"})
 AGENT_ERROR_TYPES = frozenset({"AgentError", "AgentConnectionError", "AgentRateLimitError", "AgentAPIError"})
 CONFIG_ERROR_TYPES = frozenset({"ConfigError", "ResourceUnavailableError"})
+CHECKPOINT_REPORT_STATUSES = {
+    CheckpointStatus.SUCCESS: PhaseReportStatus.SUCCEEDED,
+    CheckpointStatus.FAILED: PhaseReportStatus.FAILED,
+    CheckpointStatus.CANCELLED: PhaseReportStatus.CANCELLED,
+}
 
 
 def classify_failure(
@@ -160,21 +161,20 @@ def build_run_outcome(
     if failed_report is None and failed:
         failed_report = failed[0]
     original_exception = _original_exception(exception)
-    error = (
-        failed_report.error
-        if failed_report is not None
-        else str(original_exception)
-        if original_exception is not None
-        else None
-    )
-    error_type = (
-        failed_report.error_type
-        if failed_report is not None
-        else type(original_exception).__name__
-        if original_exception is not None
-        else None
-    )
-    resolved_failed_phase = failed_report.phase_id if failed_report is not None else failed_phase
+    error: str | None
+    error_type: str | None
+    resolved_failed_phase: str | None
+    if failed_report is not None:
+        error = failed_report.error
+        error_type = failed_report.error_type
+        resolved_failed_phase = failed_report.phase_id
+    elif original_exception is not None:
+        error = str(original_exception)
+        error_type = type(original_exception).__name__
+        resolved_failed_phase = failed_phase
+    else:
+        error = error_type = None
+        resolved_failed_phase = failed_phase
 
     return RunOutcome(
         flow_name=resolved_flow.name,
@@ -215,15 +215,7 @@ def _build_phase_report(
             cancellation_reason=None,
         )
 
-    status = (
-        PhaseReportStatus.SKIPPED_ON_RESUME
-        if skipped_on_resume
-        else PhaseReportStatus.SUCCEEDED
-        if checkpoint.status is CheckpointStatus.SUCCESS
-        else PhaseReportStatus.CANCELLED
-        if checkpoint.status is CheckpointStatus.CANCELLED
-        else PhaseReportStatus.FAILED
-    )
+    status = PhaseReportStatus.SKIPPED_ON_RESUME if skipped_on_resume else CHECKPOINT_REPORT_STATUSES[checkpoint.status]
     return PhaseReport(
         phase_id=phase_id,
         status=status,
@@ -249,8 +241,8 @@ def _duration_seconds(started_at: str | None, finished_at: str | None) -> float 
 
 
 def _original_exception(exception: BaseException | None) -> BaseException | None:
-    while exception is not None and exception.__cause__ is not None:
-        exception = exception.__cause__
+    if exception is not None and exception.__cause__ is not None:
+        return exception.__cause__
     return exception
 
 

--- a/ddev/src/ddev/cli/meta/ai/palette.py
+++ b/ddev/src/ddev/cli/meta/ai/palette.py
@@ -34,6 +34,7 @@ STATUS_RUNNING = "#86B8DE"
 STATUS_PENDING = "#8F8B94"
 STATUS_DONE = SUCCESS
 STATUS_FAILED = ERROR
+STATUS_CANCELLED = WARNING
 STATUS_CONNECTOR = "#4A4650"
 
 # Per-role identity colors used to tell speakers apart in the log.

--- a/ddev/src/ddev/cli/meta/ai/tui/app.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/app.py
@@ -44,7 +44,7 @@ from ddev.cli.meta.ai.tui.theme import togo_markdown_theme, togo_theme
 
 if TYPE_CHECKING:
     from ddev.ai.config.engine import ConfigurationEngine
-    from ddev.ai.runtime.outcome import RunOutcome
+    from ddev.ai.runtime.outcome import RunOutcome, RunOutcomeError
     from ddev.cli.application import Application
 
 
@@ -56,6 +56,9 @@ class OrchestratorLike(Protocol):
 
     @property
     def outcome(self) -> RunOutcome | None: ...
+
+    @property
+    def outcome_recording_error(self) -> RunOutcomeError | None: ...
 
     async def run_async(self) -> None: ...
 

--- a/ddev/src/ddev/cli/meta/ai/tui/app.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/app.py
@@ -19,7 +19,7 @@ from textual.reactive import reactive
 
 from ddev.ai.agent.registry import AgentProviderRegistry
 from ddev.ai.phases.registry import PhaseRegistry
-from ddev.cli.meta.ai.palette import STATUS_DONE, STATUS_FAILED, STATUS_PENDING, STATUS_RUNNING
+from ddev.cli.meta.ai.palette import STATUS_CANCELLED, STATUS_DONE, STATUS_FAILED, STATUS_PENDING, STATUS_RUNNING
 from ddev.cli.meta.ai.tui.messages import (
     AfterCompact,
     AfterGoalCheck,
@@ -36,12 +36,15 @@ from ddev.cli.meta.ai.tui.messages import (
     PhaseFinished,
     PhaseStarted,
     RunErrored,
+    RunFinished,
+    RunOutcomeErrored,
 )
 from ddev.cli.meta.ai.tui.status import ExecutionStatus
 from ddev.cli.meta.ai.tui.theme import togo_markdown_theme, togo_theme
 
 if TYPE_CHECKING:
     from ddev.ai.config.engine import ConfigurationEngine
+    from ddev.ai.runtime.outcome import RunOutcome
     from ddev.cli.application import Application
 
 
@@ -50,6 +53,9 @@ class OrchestratorLike(Protocol):
 
     @property
     def failed_phase(self) -> str | None: ...
+
+    @property
+    def outcome(self) -> RunOutcome | None: ...
 
     async def run_async(self) -> None: ...
 
@@ -102,6 +108,7 @@ class TogoApp(App):
             "status-pending": STATUS_PENDING,
             "status-done": STATUS_DONE,
             "status-failed": STATUS_FAILED,
+            "status-cancelled": STATUS_CANCELLED,
         }
 
     def on_mount(self) -> None:
@@ -159,6 +166,12 @@ class TogoApp(App):
         self._record(msg)
 
     async def on_run_errored(self, msg: RunErrored) -> None:
+        self._record(msg)
+
+    async def on_run_finished(self, msg: RunFinished) -> None:
+        self._record(msg)
+
+    async def on_run_outcome_errored(self, msg: RunOutcomeErrored) -> None:
         self._record(msg)
 
     async def on_agent_started(self, msg: AgentStarted) -> None:

--- a/ddev/src/ddev/cli/meta/ai/tui/bridge.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/bridge.py
@@ -17,6 +17,7 @@ from ddev.ai.agent.scope import AgentScope
 from ddev.ai.agent.types import AgentResponse, ToolCall
 from ddev.ai.callbacks.callbacks import CallbackSet
 from ddev.ai.react.types import ReActResult
+from ddev.ai.runtime.outcome import RunOutcome
 from ddev.ai.tools.core.types import ToolResult
 from ddev.cli.meta.ai.tui.messages import (
     AfterCompact,
@@ -34,6 +35,7 @@ from ddev.cli.meta.ai.tui.messages import (
     PhaseFinished,
     PhaseStarted,
     RunErrored,
+    RunFinished,
 )
 
 
@@ -76,6 +78,10 @@ def build_app_callback_set(app: BridgeApp) -> CallbackSet:
     @cb.on_run_error
     async def _() -> None:
         _target().post_message(RunErrored())
+
+    @cb.on_run_finished
+    async def _(outcome: RunOutcome) -> None:
+        _target().post_message(RunFinished(outcome))
 
     @cb.on_before_agent_send
     async def _(scope: AgentScope, prompt: str, iteration: int) -> None:

--- a/ddev/src/ddev/cli/meta/ai/tui/messages.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/messages.py
@@ -13,6 +13,7 @@ from textual.message import Message
 from ddev.ai.agent.scope import AgentScope
 from ddev.ai.agent.types import AgentResponse, ToolCall
 from ddev.ai.react.types import ReActResult
+from ddev.ai.runtime.outcome import RunOutcome, RunOutcomeError
 from ddev.ai.tools.core.types import ToolResult
 
 
@@ -43,6 +44,23 @@ class PhaseErrored(Message):
 
 class RunErrored(Message):
     """Fired when orchestration stops because a phase failed."""
+
+
+class RunFinished(Message):
+    """Fired after a non-cancelled run has a deterministic outcome."""
+
+    def __init__(self, outcome: RunOutcome) -> None:
+        super().__init__()
+        self.outcome = outcome
+
+
+class RunOutcomeErrored(Message):
+    """Fired when the flow ended but its outcome could not be built or persisted."""
+
+    def __init__(self, error: RunOutcomeError, outcome: RunOutcome | None) -> None:
+        super().__init__()
+        self.error = error
+        self.outcome = outcome
 
 
 class ExecutionFailed(Message):

--- a/ddev/src/ddev/cli/meta/ai/tui/messages.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/messages.py
@@ -63,6 +63,14 @@ class RunOutcomeErrored(Message):
         self.outcome = outcome
 
 
+class OutcomeRecordingErrored(Message):
+    """Fired when a failed run's outcome could not be built or persisted after the phase failure."""
+
+    def __init__(self, error: RunOutcomeError) -> None:
+        super().__init__()
+        self.error = error
+
+
 class ExecutionFailed(Message):
     """Fired when execution exits through an unexpected exception."""
 

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/ending.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/ending.py
@@ -43,14 +43,11 @@ class EndingScreen(TogoScreen):
     def compose_body(self) -> Iterator[Widget]:
         error = Static(self._error_text(), id="ending-error", classes="panel")
         error.display = self.outcome.verdict is RunVerdict.FAILED
-        summary = Static("", id="ending-summary", classes="panel")
-        summary.display = False
         yield VerticalScroll(
             Static(self._verdict_text(), id="ending-verdict", classes=f"verdict-{self.outcome.verdict.value}"),
             Static(self._stats_text(), id="ending-stats"),
             Static(self._phase_table(), id="ending-phases", classes="panel"),
             error,
-            summary,
             id="ending-content",
         )
 

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/ending.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/ending.py
@@ -1,0 +1,130 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Deterministic ending screen shown after a Togo flow run."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from rich.table import Table
+from rich.text import Text
+from textual.binding import Binding
+from textual.containers import VerticalScroll
+from textual.widget import Widget
+from textual.widgets import Static
+
+from ddev.ai.runtime.outcome import PhaseReport, PhaseReportStatus, RunOutcome, RunVerdict
+from ddev.cli.meta.ai.tui.screens.base import TogoScreen
+from ddev.cli.meta.ai.tui.screens.formatting import compact_error_detail
+
+PHASE_GLYPHS = {
+    PhaseReportStatus.SUCCEEDED: "○",
+    PhaseReportStatus.FAILED: "✕",
+    PhaseReportStatus.CANCELLED: "◌",
+    PhaseReportStatus.NOT_RUN: "●",
+    PhaseReportStatus.SKIPPED_ON_RESUME: "◌",
+}
+
+
+class EndingScreen(TogoScreen):
+    """Show the deterministic result and per-phase accounting for a flow run."""
+
+    BINDINGS = [
+        Binding("escape", "back", "Back", priority=True),
+        Binding("ctrl+c", "copy_selection", "Copy"),
+    ]
+
+    def __init__(self, outcome: RunOutcome) -> None:
+        super().__init__()
+        self.outcome = outcome
+        self._togo_title = f"{outcome.flow_name} · Run outcome"
+
+    def compose_body(self) -> Iterator[Widget]:
+        error = Static(self._error_text(), id="ending-error", classes="panel")
+        error.display = self.outcome.verdict is RunVerdict.FAILED
+        summary = Static("", id="ending-summary", classes="panel")
+        summary.display = False
+        yield VerticalScroll(
+            Static(self._verdict_text(), id="ending-verdict", classes=f"verdict-{self.outcome.verdict.value}"),
+            Static(self._stats_text(), id="ending-stats"),
+            Static(self._phase_table(), id="ending-phases", classes="panel"),
+            error,
+            summary,
+            id="ending-content",
+        )
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_copy_selection(self) -> None:
+        self.copy_selection()
+
+    def _verdict_text(self) -> Text:
+        completed = sum(
+            phase.status in (PhaseReportStatus.SUCCEEDED, PhaseReportStatus.SKIPPED_ON_RESUME)
+            for phase in self.outcome.phases
+        )
+        total = len(self.outcome.phases)
+        if self.outcome.verdict is RunVerdict.SUCCEEDED:
+            return Text(f"✓ Flow completed — {total} phases")
+        if self.outcome.verdict is RunVerdict.FAILED:
+            location = f" in {self.outcome.failed_phase}" if self.outcome.failed_phase else ""
+            return Text(f"✕ Flow failed{location} — {self.outcome.failure_kind.value.replace('_', ' ')}")
+        return Text(f"◌ Flow incomplete — {completed} of {total} phases completed")
+
+    def _stats_text(self) -> Text:
+        succeeded = sum(phase.status is PhaseReportStatus.SUCCEEDED for phase in self.outcome.phases)
+        failed = sum(phase.status is PhaseReportStatus.FAILED for phase in self.outcome.phases)
+        cancelled = sum(phase.status is PhaseReportStatus.CANCELLED for phase in self.outcome.phases)
+        return Text(
+            f"Duration {_format_duration(self.outcome.duration_seconds)}  ·  "
+            f"{succeeded} succeeded  ·  {failed} failed  ·  {cancelled} cancelled  ·  "
+            f"{self.outcome.recorded_input_tokens:,} input / "
+            f"{self.outcome.recorded_output_tokens:,} output tokens recorded"
+        )
+
+    def _phase_table(self) -> Table:
+        table = Table(expand=True, box=None, show_header=True, header_style="bold")
+        table.add_column("")
+        table.add_column("Phase")
+        table.add_column("Status")
+        table.add_column("Duration", justify="right")
+        table.add_column("Tokens (in/out)", justify="right")
+        table.add_column("Goal attempts", justify="right")
+        for phase in self.outcome.phases:
+            table.add_row(
+                PHASE_GLYPHS[phase.status],
+                phase.phase_id,
+                phase.status.value.replace("_", " "),
+                _format_duration(phase.duration_seconds),
+                f"{phase.input_tokens:,} / {phase.output_tokens:,}",
+                _goal_attempts(phase),
+            )
+        return table
+
+    def _error_text(self) -> Text:
+        error_type = self.outcome.error_type or "Unknown error"
+        detail = compact_error_detail(self.outcome.error or error_type, self.outcome.failed_phase)
+        location = f"Phase: {self.outcome.failed_phase}\n" if self.outcome.failed_phase else ""
+        hint = (
+            f"\nSelect {self.outcome.failed_phase} on the execution screen for the full log."
+            if self.outcome.failed_phase
+            else ""
+        )
+        return Text(f"{location}{error_type}: {detail}{hint}")
+
+
+def _format_duration(seconds: float | None) -> str:
+    if seconds is None:
+        return "—"
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, remainder = divmod(int(seconds), 60)
+    return f"{minutes}m {remainder:02d}s"
+
+
+def _goal_attempts(phase: PhaseReport) -> str:
+    if not phase.goal_validations:
+        return "—"
+    return str(sum(record.attempts for record in phase.goal_validations))

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -178,6 +178,11 @@ class ExecutionScreen(TogoScreen):
 
             self.app.push_screen(EndingScreen(self._outcome))
 
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        if action == "show_outcome":
+            return self._outcome is not None
+        return super().check_action(action, parameters)
+
     def action_back(self) -> None:
         if not self.togo_app.execution_status.is_active:
             self.app.pop_screen()
@@ -268,9 +273,6 @@ class ExecutionScreen(TogoScreen):
         except NoMatches:
             pass
 
-    def _compact_error_detail(self, error: BaseException, phase_id: str | None = None) -> str:
-        return compact_error_detail(error, phase_id)
-
     def _show_error_banner(self, message: str, *, warning: bool = False) -> None:
         try:
             widget = self.query_one("#execution-error", Static)
@@ -281,7 +283,7 @@ class ExecutionScreen(TogoScreen):
         widget.display = True
 
     def _show_run_error(self, error: BaseException, phase_id: str | None = None) -> None:
-        detail = self._compact_error_detail(error, phase_id)
+        detail = compact_error_detail(error, phase_id)
         title = f"Run failed in {phase_id}" if phase_id is not None else "Run failed"
         hint = f"Select {phase_id} to view the full error." if phase_id is not None else ""
         message = f"{title}: {detail}"
@@ -301,7 +303,7 @@ class ExecutionScreen(TogoScreen):
             return
 
         lines = [f"Run failed — {len(ordered_errors)} phases failed"]
-        lines.extend(f"{phase_id}: {self._compact_error_detail(error, phase_id)}" for phase_id, error in ordered_errors)
+        lines.extend(f"{phase_id}: {compact_error_detail(error, phase_id)}" for phase_id, error in ordered_errors)
         lines.append("Select a failed phase to view its full error.")
         self._show_error_banner("\n".join(lines))
 
@@ -337,6 +339,7 @@ class ExecutionScreen(TogoScreen):
 
     def _accept_outcome(self, outcome: RunOutcome) -> None:
         self._outcome = outcome
+        self.refresh_bindings()
         self._apply_outcome_statuses(outcome)
         self.togo_app.execution_status = {
             RunVerdict.SUCCEEDED: ExecutionStatus.COMPLETED,
@@ -441,7 +444,7 @@ class ExecutionScreen(TogoScreen):
         if msg.outcome is not None:
             if self._outcome is None:
                 self._accept_outcome(msg.outcome)
-            detail = self._compact_error_detail(msg.error)
+            detail = compact_error_detail(msg.error)
             self._show_error_banner(
                 f"The flow outcome is available, but it could not be persisted: {detail}",
                 warning=True,
@@ -449,7 +452,7 @@ class ExecutionScreen(TogoScreen):
             return
 
         self.togo_app.execution_status = ExecutionStatus.OUTCOME_ERROR
-        detail = self._compact_error_detail(msg.error)
+        detail = compact_error_detail(msg.error)
         self._show_error_banner(
             f"The flow ended, but its outcome could not be determined: {detail}",
             warning=True,

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -13,14 +13,22 @@ from typing import TYPE_CHECKING
 
 from textual import events, work
 from textual.binding import Binding
+from textual.containers import Horizontal
 from textual.css.query import NoMatches
 from textual.widget import Widget
-from textual.widgets import Static
+from textual.widgets import Button, Static
 from textual.worker import Worker
 
 from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.config.models import ResolvedFlow, RuntimeVariables
 from ddev.ai.react.process import TOOL_RESULTS_SENTINEL
+from ddev.ai.runtime.outcome import (
+    PhaseReportStatus,
+    RunOutcome,
+    RunOutcomeBuildError,
+    RunOutcomeError,
+    RunVerdict,
+)
 from ddev.cli.meta.ai.rendering import (
     render_agent_error_line,
     render_agent_finish_line,
@@ -54,9 +62,12 @@ from ddev.cli.meta.ai.tui.messages import (
     PhaseFinished,
     PhaseStarted,
     RunErrored,
+    RunFinished,
+    RunOutcomeErrored,
 )
 from ddev.cli.meta.ai.tui.runs import ai_runs_dir, flow_slug, resume_completed_phases
 from ddev.cli.meta.ai.tui.screens.base import TogoScreen
+from ddev.cli.meta.ai.tui.screens.formatting import compact_error_detail
 from ddev.cli.meta.ai.tui.screens.phase_config import PhaseConfigScreen
 from ddev.cli.meta.ai.tui.screens.phase_error_modal import PhaseErrorModal
 from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogEntry, PhaseLogScreen
@@ -69,8 +80,6 @@ if TYPE_CHECKING:
 
 type OrchestratorBuilder = Callable[[Callbacks], OrchestratorLike]
 
-BANNER_ERROR_MAX_CHARS = 200
-
 
 class ExecutionScreen(TogoScreen):
     """Live execution screen: pipeline graph plus per-phase drill-down logs."""
@@ -78,6 +87,7 @@ class ExecutionScreen(TogoScreen):
     BINDINGS = [
         Binding("escape", "back", "Back", priority=True),
         Binding("ctrl+c", "copy_or_cancel_run", "Copy / Cancel"),
+        Binding("s", "show_outcome", "Summary"),
     ]
 
     def __init__(
@@ -108,6 +118,7 @@ class ExecutionScreen(TogoScreen):
         self._orchestrator: OrchestratorLike | None = None
         self._run_worker: Worker[None] | None = None
         self._phase_errors: dict[str, BaseException] = {}
+        self._outcome: RunOutcome | None = None
         # Records every renderable produced by the run — used by tests and to
         # populate phase log screens opened after the fact.
         self._output_renders: list[PhaseLogEntry] = []
@@ -120,6 +131,12 @@ class ExecutionScreen(TogoScreen):
         pipeline = PipelineGraph(self.flow, self._phase_statuses, id="pipeline")
         pipeline.border_title = "Pipeline"
         yield pipeline
+        actions = Horizontal(
+            Button("View summary", id="view-summary", variant="primary"),
+            id="execution-actions",
+        )
+        actions.display = self._outcome is not None
+        yield actions
 
     def on_mount(self) -> None:
         self.togo_app.bridge_target = self
@@ -155,6 +172,12 @@ class ExecutionScreen(TogoScreen):
         if not self.copy_selection():
             self.action_cancel_run()
 
+    def action_show_outcome(self) -> None:
+        if self._outcome is not None:
+            from ddev.cli.meta.ai.tui.screens.ending import EndingScreen
+
+            self.app.push_screen(EndingScreen(self._outcome))
+
     def action_back(self) -> None:
         if not self.togo_app.execution_status.is_active:
             self.app.pop_screen()
@@ -173,6 +196,11 @@ class ExecutionScreen(TogoScreen):
             event.stop()
             self.action_back()
 
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "view-summary":
+            event.stop()
+            self.action_show_outcome()
+
     @work(exit_on_error=False)
     async def _run_orchestrator(self) -> None:
         from ddev.cli.meta.ai.tui.bridge import build_app_callback_set
@@ -187,11 +215,19 @@ class ExecutionScreen(TogoScreen):
                 orchestrator = self._build_real_orchestrator(callbacks)
             self._orchestrator = orchestrator
             await orchestrator.run_async()
-            self.togo_app.execution_status = ExecutionStatus.COMPLETED
+            if orchestrator.outcome is None:
+                self.post_message(
+                    RunOutcomeErrored(
+                        RunOutcomeBuildError("The orchestrator returned without producing a run outcome"),
+                        None,
+                    )
+                )
         except asyncio.CancelledError:
             if self.togo_app.bridge_target is self:
                 self.togo_app.execution_status = ExecutionStatus.IDLE
             raise
+        except RunOutcomeError as error:
+            self.post_message(RunOutcomeErrored(error, orchestrator.outcome if orchestrator is not None else None))
         except Exception as error:
             if orchestrator is None or orchestrator.failed_phase is None:
                 self.post_message(ExecutionFailed(error))
@@ -233,20 +269,15 @@ class ExecutionScreen(TogoScreen):
             pass
 
     def _compact_error_detail(self, error: BaseException, phase_id: str | None = None) -> str:
-        detail = next((line.strip() for line in str(error).splitlines() if line.strip()), type(error).__name__)
-        if phase_id is not None:
-            detail = detail.removeprefix(f"Phase '{phase_id}' failed: ")
-            detail = detail.removeprefix(f"Phase '{phase_id}': ")
-        if len(detail) > BANNER_ERROR_MAX_CHARS:
-            detail = f"{detail[: BANNER_ERROR_MAX_CHARS - 1].rstrip()}…"
-        return detail
+        return compact_error_detail(error, phase_id)
 
-    def _show_error_banner(self, message: str) -> None:
+    def _show_error_banner(self, message: str, *, warning: bool = False) -> None:
         try:
             widget = self.query_one("#execution-error", Static)
         except NoMatches:
             return
         widget.update(message)
+        widget.set_class(warning, "outcome-warning")
         widget.display = True
 
     def _show_run_error(self, error: BaseException, phase_id: str | None = None) -> None:
@@ -279,6 +310,45 @@ class ExecutionScreen(TogoScreen):
         for (task_phase, task_name), status in list(self._task_statuses.items()):
             if task_phase == phase_id and status in (RunStatus.RUNNING, RunStatus.PENDING):
                 self._task_statuses[(task_phase, task_name)] = RunStatus.FAILED
+
+    def _apply_outcome_statuses(self, outcome: RunOutcome) -> None:
+        phase_statuses = {
+            PhaseReportStatus.SUCCEEDED: RunStatus.DONE,
+            PhaseReportStatus.SKIPPED_ON_RESUME: RunStatus.DONE,
+            PhaseReportStatus.FAILED: RunStatus.FAILED,
+            PhaseReportStatus.CANCELLED: RunStatus.CANCELLED,
+            PhaseReportStatus.NOT_RUN: RunStatus.PENDING,
+        }
+        for report in outcome.phases:
+            self._stop_phase_thinking(report.phase_id)
+            self._phase_statuses[report.phase_id] = phase_statuses[report.status]
+            for (task_phase, task_name), status in list(self._task_statuses.items()):
+                if task_phase != report.phase_id:
+                    continue
+                if report.status in (PhaseReportStatus.SUCCEEDED, PhaseReportStatus.SKIPPED_ON_RESUME):
+                    self._task_statuses[(task_phase, task_name)] = RunStatus.DONE
+                elif report.status is PhaseReportStatus.FAILED:
+                    self._task_statuses[(task_phase, task_name)] = RunStatus.FAILED
+                elif report.status is PhaseReportStatus.CANCELLED and status is RunStatus.RUNNING:
+                    self._task_statuses[(task_phase, task_name)] = RunStatus.CANCELLED
+                elif report.status is PhaseReportStatus.NOT_RUN:
+                    self._task_statuses[(task_phase, task_name)] = RunStatus.PENDING
+        self._update_display()
+
+    def _accept_outcome(self, outcome: RunOutcome) -> None:
+        self._outcome = outcome
+        self._apply_outcome_statuses(outcome)
+        self.togo_app.execution_status = {
+            RunVerdict.SUCCEEDED: ExecutionStatus.COMPLETED,
+            RunVerdict.FAILED: ExecutionStatus.FAILED,
+            RunVerdict.INCOMPLETE: ExecutionStatus.INCOMPLETE,
+        }[outcome.verdict]
+        try:
+            actions = self.query_one("#execution-actions", Horizontal)
+            actions.display = True
+            actions.query_one("#view-summary", Button).focus()
+        except NoMatches:
+            pass
 
     def register_phase_log_screen(self, screen: PhaseLogScreen) -> None:
         self._open_phase_log_screens.setdefault(screen.phase_id, []).append(screen)
@@ -363,6 +433,27 @@ class ExecutionScreen(TogoScreen):
             self._show_phase_error_summary()
         else:
             self._show_error_banner("Run failed.")
+
+    def on_run_finished(self, msg: RunFinished) -> None:
+        self._accept_outcome(msg.outcome)
+
+    def on_run_outcome_errored(self, msg: RunOutcomeErrored) -> None:
+        if msg.outcome is not None:
+            if self._outcome is None:
+                self._accept_outcome(msg.outcome)
+            detail = self._compact_error_detail(msg.error)
+            self._show_error_banner(
+                f"The flow outcome is available, but it could not be persisted: {detail}",
+                warning=True,
+            )
+            return
+
+        self.togo_app.execution_status = ExecutionStatus.OUTCOME_ERROR
+        detail = self._compact_error_detail(msg.error)
+        self._show_error_banner(
+            f"The flow ended, but its outcome could not be determined: {detail}",
+            warning=True,
+        )
 
     def on_execution_failed(self, msg: ExecutionFailed) -> None:
         self.togo_app.execution_status = ExecutionStatus.FAILED

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -58,6 +58,7 @@ from ddev.cli.meta.ai.tui.messages import (
     BeforeGoalCheck,
     ContextCleared,
     ExecutionFailed,
+    OutcomeRecordingErrored,
     PhaseErrored,
     PhaseFinished,
     PhaseStarted,
@@ -134,6 +135,7 @@ class ExecutionScreen(TogoScreen):
         self._run_worker: Worker[None] | None = None
         self._phase_errors: dict[str, BaseException] = {}
         self._outcome: RunOutcome | None = None
+        self._error_banner_text: str | None = None
         # Records every renderable produced by the run — used by tests and to
         # populate phase log screens opened after the fact.
         self._output_renders: list[PhaseLogEntry] = []
@@ -253,6 +255,10 @@ class ExecutionScreen(TogoScreen):
         except Exception as error:
             if orchestrator is None or orchestrator.failed_phase is None:
                 self.post_message(ExecutionFailed(error))
+            else:
+                recording_error = orchestrator.outcome_recording_error
+                if recording_error is not None:
+                    self.post_message(OutcomeRecordingErrored(recording_error))
 
     def _build_real_orchestrator(self, callbacks: Callbacks) -> PhaseOrchestrator:
         """Construct the real PhaseOrchestrator for production use."""
@@ -291,6 +297,7 @@ class ExecutionScreen(TogoScreen):
             pass
 
     def _show_error_banner(self, message: str, *, warning: bool = False) -> None:
+        self._error_banner_text = message
         try:
             widget = self.query_one("#execution-error", Static)
         except NoMatches:
@@ -298,6 +305,11 @@ class ExecutionScreen(TogoScreen):
         widget.update(message)
         widget.set_class(warning, "outcome-warning")
         widget.display = True
+
+    def _append_error_banner(self, message: str, *, warning: bool = False) -> None:
+        """Add a line to the error banner instead of replacing whatever it already shows."""
+        combined = f"- {self._error_banner_text}\n- {message}" if self._error_banner_text else message
+        self._show_error_banner(combined, warning=warning)
 
     def _show_run_error(self, error: BaseException, phase_id: str | None = None) -> None:
         detail = compact_error_detail(error, phase_id)
@@ -466,6 +478,10 @@ class ExecutionScreen(TogoScreen):
     def on_execution_failed(self, msg: ExecutionFailed) -> None:
         self.togo_app.execution_status = ExecutionStatus.FAILED
         self._show_run_error(msg.error)
+
+    def on_outcome_recording_errored(self, msg: OutcomeRecordingErrored) -> None:
+        detail = compact_error_detail(msg.error)
+        self._append_error_banner(f"The flow outcome could not be recorded: {detail}", warning=True)
 
     def on_phase_selected(self, msg: PhaseSelected) -> None:
         status = self._phase_statuses.get(msg.phase_id, RunStatus.PENDING)

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -80,6 +80,21 @@ if TYPE_CHECKING:
 
 type OrchestratorBuilder = Callable[[Callbacks], OrchestratorLike]
 
+PHASE_REPORT_RUN_STATUSES = {
+    PhaseReportStatus.SUCCEEDED: RunStatus.DONE,
+    PhaseReportStatus.SKIPPED_ON_RESUME: RunStatus.DONE,
+    PhaseReportStatus.FAILED: RunStatus.FAILED,
+    PhaseReportStatus.CANCELLED: RunStatus.CANCELLED,
+    PhaseReportStatus.NOT_RUN: RunStatus.PENDING,
+}
+
+
+def _task_status_for(report_status: PhaseReportStatus, current_status: RunStatus) -> RunStatus | None:
+    """Return the reconciled task status, preserving tasks not started before cancellation."""
+    if report_status is PhaseReportStatus.CANCELLED and current_status is not RunStatus.RUNNING:
+        return None
+    return PHASE_REPORT_RUN_STATUSES[report_status]
+
 
 class ExecutionScreen(TogoScreen):
     """Live execution screen: pipeline graph plus per-phase drill-down logs."""
@@ -227,6 +242,8 @@ class ExecutionScreen(TogoScreen):
                         None,
                     )
                 )
+            else:
+                self.post_message(RunFinished(orchestrator.outcome))
         except asyncio.CancelledError:
             if self.togo_app.bridge_target is self:
                 self.togo_app.execution_status = ExecutionStatus.IDLE
@@ -314,27 +331,14 @@ class ExecutionScreen(TogoScreen):
                 self._task_statuses[(task_phase, task_name)] = RunStatus.FAILED
 
     def _apply_outcome_statuses(self, outcome: RunOutcome) -> None:
-        phase_statuses = {
-            PhaseReportStatus.SUCCEEDED: RunStatus.DONE,
-            PhaseReportStatus.SKIPPED_ON_RESUME: RunStatus.DONE,
-            PhaseReportStatus.FAILED: RunStatus.FAILED,
-            PhaseReportStatus.CANCELLED: RunStatus.CANCELLED,
-            PhaseReportStatus.NOT_RUN: RunStatus.PENDING,
-        }
         for report in outcome.phases:
             self._stop_phase_thinking(report.phase_id)
-            self._phase_statuses[report.phase_id] = phase_statuses[report.status]
+            self._phase_statuses[report.phase_id] = PHASE_REPORT_RUN_STATUSES[report.status]
             for (task_phase, task_name), status in list(self._task_statuses.items()):
                 if task_phase != report.phase_id:
                     continue
-                if report.status in (PhaseReportStatus.SUCCEEDED, PhaseReportStatus.SKIPPED_ON_RESUME):
-                    self._task_statuses[(task_phase, task_name)] = RunStatus.DONE
-                elif report.status is PhaseReportStatus.FAILED:
-                    self._task_statuses[(task_phase, task_name)] = RunStatus.FAILED
-                elif report.status is PhaseReportStatus.CANCELLED and status is RunStatus.RUNNING:
-                    self._task_statuses[(task_phase, task_name)] = RunStatus.CANCELLED
-                elif report.status is PhaseReportStatus.NOT_RUN:
-                    self._task_statuses[(task_phase, task_name)] = RunStatus.PENDING
+                if task_status := _task_status_for(report.status, status):
+                    self._task_statuses[(task_phase, task_name)] = task_status
         self._update_display()
 
     def _accept_outcome(self, outcome: RunOutcome) -> None:
@@ -438,7 +442,8 @@ class ExecutionScreen(TogoScreen):
             self._show_error_banner("Run failed.")
 
     def on_run_finished(self, msg: RunFinished) -> None:
-        self._accept_outcome(msg.outcome)
+        if self._outcome is None:
+            self._accept_outcome(msg.outcome)
 
     def on_run_outcome_errored(self, msg: RunOutcomeErrored) -> None:
         if msg.outcome is not None:

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/formatting.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/formatting.py
@@ -1,0 +1,17 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+BANNER_ERROR_MAX_CHARS = 200
+
+
+def compact_error_detail(error: BaseException | str, phase_id: str | None = None) -> str:
+    """Return the first useful error line, compacted for summary views."""
+    fallback = type(error).__name__ if isinstance(error, BaseException) else "Unknown error"
+    detail = next((line.strip() for line in str(error).splitlines() if line.strip()), fallback)
+    if phase_id is not None:
+        detail = detail.removeprefix(f"Phase '{phase_id}' failed: ")
+        detail = detail.removeprefix(f"Phase '{phase_id}': ")
+    if len(detail) > BANNER_ERROR_MAX_CHARS:
+        detail = f"{detail[: BANNER_ERROR_MAX_CHARS - 1].rstrip()}…"
+    return detail

--- a/ddev/src/ddev/cli/meta/ai/tui/status.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/status.py
@@ -15,7 +15,9 @@ class ExecutionStatus(StrEnum):
     RUNNING = auto()
     FINISHING = auto()
     COMPLETED = auto()
+    INCOMPLETE = auto()
     FAILED = auto()
+    OUTCOME_ERROR = auto()
 
     @property
     def is_active(self) -> bool:
@@ -30,6 +32,7 @@ class RunStatus(StrEnum):
     RUNNING = auto()
     DONE = auto()
     FAILED = auto()
+    CANCELLED = auto()
 
     @property
     def has_started(self) -> bool:

--- a/ddev/src/ddev/cli/meta/ai/tui/theme.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/theme.py
@@ -17,6 +17,7 @@ from ddev.cli.meta.ai.palette import (
     ROLE_GOAL_REVIEWER,
     ROLE_PHASE,
     SECONDARY,
+    STATUS_CANCELLED,
     STATUS_DONE,
     STATUS_FAILED,
     STATUS_PENDING,
@@ -52,6 +53,7 @@ togo_theme = Theme(
         "status-pending": STATUS_PENDING,
         "status-done": STATUS_DONE,
         "status-failed": STATUS_FAILED,
+        "status-cancelled": STATUS_CANCELLED,
     },
 )
 

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -646,11 +646,6 @@ MarkdownH3 {
     margin-bottom: 1;
 }
 
-#ending-summary {
-    display: none;
-    height: auto;
-}
-
 /* ── Modal / dialog / badge / prompt ──────────────────────────────────── */
 
 ModalScreen {

--- a/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
+++ b/ddev/src/ddev/cli/meta/ai/tui/togo.tcss
@@ -140,6 +140,11 @@ TogoHeader {
     color: $status-done;
 }
 
+#header-right.status-incomplete,
+#header-right.status-outcome_error {
+    color: $warning;
+}
+
 #header-right.status-failed {
     color: $status-failed;
 }
@@ -485,6 +490,11 @@ MarkdownH3 {
     margin: 0 0 1 0;
 }
 
+#execution-error.outcome-warning {
+    border: round $warning;
+    color: $warning;
+}
+
 #pipeline {
     layers: connectors nodes;
     width: 1fr;
@@ -496,6 +506,14 @@ MarkdownH3 {
     background: $surface;
     padding: 1 2;
     overflow: auto auto;
+}
+
+#execution-actions {
+    display: none;
+    width: 100%;
+    height: auto;
+    align-horizontal: right;
+    padding: 0 1 1 1;
 }
 
 #pipeline-connectors {
@@ -530,6 +548,11 @@ MarkdownH3 {
 .phase-node.status-failed {
     border: round $status-failed;
     color: $status-failed;
+}
+
+.phase-node.status-cancelled {
+    border: round $status-cancelled;
+    color: $status-cancelled;
 }
 
 .phase-node:focus {
@@ -570,6 +593,62 @@ MarkdownH3 {
     border: round $status-running;
     padding: 0 1;
     background: $surface;
+}
+
+/* ── Run ending view ──────────────────────────────────────────────────── */
+
+#ending-content {
+    width: 1fr;
+    height: 1fr;
+}
+
+#ending-verdict {
+    height: auto;
+    border: round $border;
+    background: $panel;
+    text-style: bold;
+    padding: 1 2;
+    margin-bottom: 1;
+}
+
+#ending-verdict.verdict-succeeded {
+    border: round $status-done;
+    color: $status-done;
+}
+
+#ending-verdict.verdict-failed {
+    border: round $status-failed;
+    color: $status-failed;
+}
+
+#ending-verdict.verdict-incomplete {
+    border: round $warning;
+    color: $warning;
+}
+
+#ending-stats {
+    height: auto;
+    color: $text-muted;
+    margin: 0 1 1 1;
+}
+
+#ending-phases {
+    height: auto;
+    min-height: 8;
+    margin-bottom: 1;
+}
+
+#ending-error {
+    display: none;
+    height: auto;
+    border: round $error;
+    color: $error;
+    margin-bottom: 1;
+}
+
+#ending-summary {
+    display: none;
+    height: auto;
 }
 
 /* ── Modal / dialog / badge / prompt ──────────────────────────────────── */

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/header.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/header.py
@@ -32,7 +32,9 @@ EXECUTION_STATUS_TEXT = {
     ExecutionStatus.RUNNING: "● running",
     ExecutionStatus.FINISHING: "◌ finishing",
     ExecutionStatus.COMPLETED: "✓ completed",
+    ExecutionStatus.INCOMPLETE: "◌ incomplete",
     ExecutionStatus.FAILED: "✕ failed",
+    ExecutionStatus.OUTCOME_ERROR: "! outcome unavailable",
 }
 
 

--- a/ddev/src/ddev/cli/meta/ai/tui/widgets/pipeline_graph.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/widgets/pipeline_graph.py
@@ -19,13 +19,21 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from ddev.ai.config.models import ResolvedFlow
-from ddev.cli.meta.ai.palette import STATUS_CONNECTOR, STATUS_DONE, STATUS_FAILED, STATUS_PENDING, STATUS_RUNNING
+from ddev.cli.meta.ai.palette import (
+    STATUS_CANCELLED,
+    STATUS_CONNECTOR,
+    STATUS_DONE,
+    STATUS_FAILED,
+    STATUS_PENDING,
+    STATUS_RUNNING,
+)
 from ddev.cli.meta.ai.tui.status import RunStatus
 
 COLOR_DONE = STATUS_DONE
 COLOR_RUNNING = STATUS_RUNNING
 COLOR_PENDING = STATUS_PENDING
 COLOR_FAILED = STATUS_FAILED
+COLOR_CANCELLED = STATUS_CANCELLED
 COLOR_CONNECTOR = STATUS_CONNECTOR
 GRAPH_COLUMN_GAP = 6
 GRAPH_ROW_GAP = 5
@@ -44,6 +52,7 @@ NODE_GLYPHS: dict[RunStatus, tuple[str, str]] = {
     RunStatus.DONE: ("○", COLOR_DONE),
     RunStatus.RUNNING: ("◉", COLOR_RUNNING),
     RunStatus.FAILED: ("✕", COLOR_FAILED),
+    RunStatus.CANCELLED: ("◌", COLOR_CANCELLED),
 }
 
 

--- a/ddev/tests/ai/callbacks/test_callbacks.py
+++ b/ddev/tests/ai/callbacks/test_callbacks.py
@@ -8,6 +8,7 @@ from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.agent.types import AgentResponse, StopReason, TokenUsage, ToolCall
 from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
 from ddev.ai.react.types import ReActResult
+from ddev.ai.runtime.outcome import RunOutcome
 from ddev.ai.tools.core.types import ToolResult
 
 # ---------------------------------------------------------------------------
@@ -189,6 +190,20 @@ async def test_fire_agent_error_swallows_handler_exception(scope: AgentScope) ->
 
     await cb.fire_agent_error(scope, ValueError("original error"))
     assert fired == [True]
+
+
+async def test_run_finished_registered_and_fired() -> None:
+    cb = CallbackSet()
+    received: list[RunOutcome] = []
+    outcome = RunOutcome.model_construct(flow_name="demo")
+
+    @cb.on_run_finished
+    async def handler(run_outcome: RunOutcome) -> None:
+        received.append(run_outcome)
+
+    await Callbacks([cb]).fire_run_finished(outcome)
+
+    assert received == [outcome]
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -120,6 +120,7 @@ async def test_on_error_writes_failed_checkpoint(flow_dir, flow_context, message
     checkpoint = mgr.read()["p1"]
     assert isinstance(checkpoint, FailedCheckpoint)
     assert checkpoint.error == "boom"
+    assert checkpoint.error_type == "RuntimeError"
     assert checkpoint.started_at is None  # not started yet
 
 

--- a/ddev/tests/ai/runtime/test_checkpoints.py
+++ b/ddev/tests/ai/runtime/test_checkpoints.py
@@ -97,6 +97,30 @@ def test_write_multiple_phases(manager: CheckpointManager):
     assert data["phase3"].reason == "maximum runtime reached"
 
 
+def test_failed_checkpoint_error_type_round_trips(manager: CheckpointManager):
+    manager.write_phase_checkpoint(
+        "phase1",
+        make_failed_checkpoint(error_type="GoalAttemptsExhausted"),
+    )
+
+    checkpoint = manager.read()["phase1"]
+
+    assert isinstance(checkpoint, FailedCheckpoint)
+    assert checkpoint.error_type == "GoalAttemptsExhausted"
+
+
+def test_failed_checkpoint_without_error_type_still_parses(manager: CheckpointManager):
+    manager.write_phase_checkpoint("phase1", make_failed_checkpoint())
+    raw = yaml.safe_load(manager._path.read_text())
+    raw["phase1"].pop("error_type")
+    manager._path.write_text(yaml.dump(raw))
+
+    checkpoint = manager.read()["phase1"]
+
+    assert isinstance(checkpoint, FailedCheckpoint)
+    assert checkpoint.error_type is None
+
+
 def test_write_overwrites_existing_phase(manager: CheckpointManager):
     manager.write_phase_checkpoint("phase1", make_failed_checkpoint())
     manager.write_phase_checkpoint("phase1", make_success_checkpoint())

--- a/ddev/tests/ai/runtime/test_checkpoints.py
+++ b/ddev/tests/ai/runtime/test_checkpoints.py
@@ -25,6 +25,13 @@ def manager(tmp_path: Path) -> CheckpointManager:
     return CheckpointManager(tmp_path / "checkpoints.yaml")
 
 
+def test_run_artifact_locations_are_derived_from_checkpoint_path(manager: CheckpointManager, tmp_path: Path) -> None:
+    # This tests that run artifacts are written where we expect them to be in the rest of this test suite.
+    assert manager.run_dir == tmp_path
+    assert manager.outcome_path == tmp_path / "run.yaml"
+    assert manager.agent_log_root == tmp_path
+
+
 # ---------------------------------------------------------------------------
 # read
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -293,7 +293,7 @@ def test_run_executes_phases_in_dependency_order(tmp_path, make_orchestrator):
     assert checkpoints["b"].status == CheckpointStatus.SUCCESS
     assert orchestrator.outcome is not None
     assert orchestrator.outcome.verdict is RunVerdict.SUCCEEDED
-    assert RunOutcomeStore(tmp_path).read() == orchestrator.outcome
+    assert RunOutcomeStore(tmp_path / "run.yaml").read() == orchestrator.outcome
     assert finished == [orchestrator.outcome]
 
 

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -449,8 +449,14 @@ def test_outcome_recording_failure_does_not_mask_run_failure(tmp_path, make_orch
     else:
         monkeypatch.setattr(orchestrator._outcome_store, "write", MagicMock(side_effect=OSError("disk full")))
 
-    with pytest.raises(FatalProcessingError, match="original failure"):
+    with pytest.raises(FatalProcessingError, match="original failure") as exc_info:
         orchestrator.run()
+
+    operation = "build" if failure_point == "build" else "persist"
+    detail = "checkpoint unreadable" if failure_point == "build" else "disk full"
+    assert exc_info.value.__notes__ == [
+        f"Outcome recording also failed: Failed to {operation} the flow outcome: {detail}"
+    ]
 
 
 async def test_outcome_build_failure_after_success_is_reported_distinctly(core_dir, make_orchestrator, monkeypatch):
@@ -489,6 +495,38 @@ async def test_outcome_persistence_failure_retains_and_publishes_outcome(
     assert orchestrator.outcome.verdict is RunVerdict.INCOMPLETE
     assert finished == [orchestrator.outcome]
     assert not (tmp_path / "run.yaml").exists()
+
+
+def test_current_run_checkpoints_excludes_stale_checkpoint(core_dir, make_orchestrator):
+    orchestrator, _, _ = make_orchestrator(core_dir)
+    orchestrator._checkpoint_manager.write_phase_checkpoint(
+        "a",
+        make_checkpoint(
+            CheckpointStatus.SUCCESS,
+            {
+                "started_at": "2026-01-01T00:00:00+00:00",
+                "finished_at": "2026-01-01T00:01:00+00:00",
+            },
+        ),
+    )
+
+    checkpoints = orchestrator._current_run_checkpoints(datetime(2026, 1, 2, tzinfo=UTC))
+
+    assert checkpoints == {}
+
+
+async def test_invalid_checkpoint_timestamp_fails_outcome_build(core_dir, make_orchestrator):
+    orchestrator, _, _ = make_orchestrator(core_dir)
+    orchestrator._started_at = datetime.now(UTC)
+    orchestrator._checkpoint_manager.write_phase_checkpoint(
+        "a",
+        make_checkpoint(CheckpointStatus.SUCCESS, {"finished_at": "not-a-timestamp"}),
+    )
+
+    with pytest.raises(RunOutcomeBuildError, match="invalid finished_at timestamp 'not-a-timestamp'"):
+        await orchestrator._record_outcome(None)
+
+    assert orchestrator.outcome is None
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -21,6 +22,15 @@ from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.registry import PhaseRegistry
 from ddev.ai.runtime.checkpoints import CancelledCheckpoint, CheckpointManager, CheckpointStatus
 from ddev.ai.runtime.orchestrator import PhaseOrchestrator
+from ddev.ai.runtime.outcome import (
+    FailureKind,
+    PhaseReportStatus,
+    RunOutcome,
+    RunOutcomeBuildError,
+    RunOutcomePersistenceError,
+    RunOutcomeStore,
+    RunVerdict,
+)
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.event_bus.exceptions import FatalProcessingError, HookName, OrchestratorHookError
 
@@ -258,11 +268,19 @@ def test_run_executes_phases_in_dependency_order(tmp_path, make_orchestrator):
             return PhaseOutcome(memory_text=f"{self._phase_id} done")
 
     checkpoint_path = tmp_path / "checkpoints.yaml"
+    callback_set = CallbackSet()
+    finished: list[RunOutcome] = []
+
+    @callback_set.on_run_finished
+    async def on_run_finished(outcome: RunOutcome) -> None:
+        finished.append(outcome)
+
     orchestrator, _, _ = make_orchestrator(
         core,
         grace_period=0.1,
         register_phases={"RecordingPhase": RecordingPhase},
         checkpoint_path=checkpoint_path,
+        callbacks=Callbacks([callback_set]),
     )
 
     orchestrator.run()  # must not raise
@@ -273,6 +291,10 @@ def test_run_executes_phases_in_dependency_order(tmp_path, make_orchestrator):
     checkpoints = mgr.read()
     assert checkpoints["a"].status == CheckpointStatus.SUCCESS
     assert checkpoints["b"].status == CheckpointStatus.SUCCESS
+    assert orchestrator.outcome is not None
+    assert orchestrator.outcome.verdict is RunVerdict.SUCCEEDED
+    assert RunOutcomeStore(tmp_path).read() == orchestrator.outcome
+    assert finished == [orchestrator.outcome]
 
 
 def test_max_timeout_writes_cancelled_checkpoint_for_running_phase(tmp_path, make_orchestrator):
@@ -332,6 +354,141 @@ def test_run_raises_runtime_error_when_phase_fails(tmp_path, make_orchestrator):
 
     with pytest.raises(FatalProcessingError, match="Phase 'failing' failed"):
         orchestrator.run()
+
+    assert orchestrator.outcome is not None
+    assert orchestrator.outcome.verdict is RunVerdict.FAILED
+    assert orchestrator.outcome.failed_phase == "failing"
+    assert orchestrator.outcome.error_type == "RuntimeError"
+
+
+def test_run_records_normal_incomplete_return_as_timeout(tmp_path, make_orchestrator):
+    core = tmp_path / "timeout_core"
+    write(
+        core / "f.yaml",
+        "- type: phase\n  config:\n    name: slow\n    class: SlowPhase\n"
+        "- type: flow\n  config:\n    name: demo\n"
+        "    flow:\n      - phase: slow\n",
+    )
+
+    class SlowPhase(Phase):
+        async def execute(self, context):
+            await asyncio.sleep(5)
+            return PhaseOutcome(memory_text="too late")
+
+    orchestrator, _, _ = make_orchestrator(
+        core,
+        grace_period=0.05,
+        runtime_variables={"max_timeout": "0.2"},
+        register_phases={"SlowPhase": SlowPhase},
+    )
+
+    orchestrator.run()
+
+    assert orchestrator.outcome is not None
+    assert orchestrator.outcome.verdict is RunVerdict.INCOMPLETE
+    assert orchestrator.outcome.failure_kind is FailureKind.TIMEOUT
+    assert orchestrator.outcome.phases[0].status is PhaseReportStatus.CANCELLED
+    assert orchestrator.outcome.phases[0].cancellation_reason == "Orchestrator exceeded max_timeout of 0.2s"
+
+
+async def test_cancelled_run_does_not_record_outcome(tmp_path, make_orchestrator):
+    core = tmp_path / "cancelled_core"
+    write(
+        core / "f.yaml",
+        "- type: phase\n  config:\n    name: slow\n    class: SlowPhase\n"
+        "- type: flow\n  config:\n    name: demo\n"
+        "    flow:\n      - phase: slow\n",
+    )
+
+    class SlowPhase(Phase):
+        async def execute(self, context):
+            await asyncio.sleep(5)
+            return PhaseOutcome(memory_text="too late")
+
+    orchestrator, _, _ = make_orchestrator(
+        core,
+        grace_period=0.1,
+        register_phases={"SlowPhase": SlowPhase},
+    )
+    task = asyncio.create_task(orchestrator.run_async())
+    await asyncio.sleep(0.05)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert orchestrator.outcome is None
+    assert not (tmp_path / "run.yaml").exists()
+
+
+@pytest.mark.parametrize("failure_point", ["build", "persist"])
+def test_outcome_recording_failure_does_not_mask_run_failure(tmp_path, make_orchestrator, monkeypatch, failure_point):
+    core = tmp_path / "outcome_failure_core"
+    write(
+        core / "f.yaml",
+        "- type: phase\n  config:\n    name: failing\n    class: FailingPhase\n"
+        "- type: flow\n  config:\n    name: demo\n"
+        "    flow:\n      - phase: failing\n",
+    )
+
+    class FailingPhase(Phase):
+        async def execute(self, context):
+            raise RuntimeError("original failure")
+
+    orchestrator, _, _ = make_orchestrator(
+        core,
+        grace_period=0.1,
+        register_phases={"FailingPhase": FailingPhase},
+    )
+    if failure_point == "build":
+        monkeypatch.setattr(
+            orchestrator,
+            "_current_run_checkpoints",
+            MagicMock(side_effect=OSError("checkpoint unreadable")),
+        )
+    else:
+        monkeypatch.setattr(orchestrator._outcome_store, "write", MagicMock(side_effect=OSError("disk full")))
+
+    with pytest.raises(FatalProcessingError, match="original failure"):
+        orchestrator.run()
+
+
+async def test_outcome_build_failure_after_success_is_reported_distinctly(core_dir, make_orchestrator, monkeypatch):
+    orchestrator, _, _ = make_orchestrator(core_dir)
+    orchestrator._started_at = datetime.now(UTC)
+    monkeypatch.setattr(
+        orchestrator,
+        "_current_run_checkpoints",
+        MagicMock(side_effect=OSError("checkpoint unreadable")),
+    )
+
+    with pytest.raises(RunOutcomeBuildError, match="checkpoint unreadable"):
+        await orchestrator._record_outcome(None)
+
+    assert orchestrator.outcome is None
+
+
+async def test_outcome_persistence_failure_retains_and_publishes_outcome(
+    tmp_path, core_dir, make_orchestrator, monkeypatch
+):
+    callback_set = CallbackSet()
+    finished: list[RunOutcome] = []
+
+    @callback_set.on_run_finished
+    async def on_run_finished(outcome: RunOutcome) -> None:
+        finished.append(outcome)
+
+    orchestrator, _, _ = make_orchestrator(core_dir, callbacks=Callbacks([callback_set]))
+    orchestrator._started_at = datetime.now(UTC)
+    monkeypatch.setattr(orchestrator._outcome_store, "write", MagicMock(side_effect=OSError("disk full")))
+
+    with pytest.raises(RunOutcomePersistenceError, match="disk full"):
+        await orchestrator._record_outcome(None)
+
+    assert orchestrator.outcome is not None
+    assert orchestrator.outcome.verdict is RunVerdict.INCOMPLETE
+    assert finished == [orchestrator.outcome]
+    assert not (tmp_path / "run.yaml").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/runtime/test_outcome.py
+++ b/ddev/tests/ai/runtime/test_outcome.py
@@ -166,7 +166,7 @@ def test_classify_failure(error_type: str, expected: FailureKind):
 
 
 def test_run_outcome_store_round_trips_and_overwrites(tmp_path: Path):
-    store = RunOutcomeStore(tmp_path)
+    store = RunOutcomeStore(tmp_path / "run.yaml")
     first = build_outcome(tmp_path, checkpoints={"inspect": make_success_checkpoint()})
     second = build_outcome(
         tmp_path,

--- a/ddev/tests/ai/runtime/test_outcome.py
+++ b/ddev/tests/ai/runtime/test_outcome.py
@@ -7,11 +7,19 @@ from pathlib import Path
 
 import pytest
 
+from ddev.ai.agent.exceptions import AgentAPIError, AgentConnectionError, AgentError, AgentRateLimitError
 from ddev.ai.config.errors import ConfigError
 from ddev.ai.config.models import FlowEntry, ResolvedFlow
+from ddev.ai.phases.goal import GoalAttemptsExhausted, GoalParseError, GoalValidationError
+from ddev.ai.phases.resources import ResourceUnavailableError
+from ddev.ai.runtime.checkpoints import CheckpointReadError
 from ddev.ai.runtime.outcome import (
+    AGENT_ERROR_TYPES,
+    CONFIG_ERROR_TYPES,
+    GOAL_ERROR_TYPES,
     FailureKind,
     PhaseReportStatus,
+    RunOutcomeReadError,
     RunOutcomeStore,
     RunVerdict,
     build_run_outcome,
@@ -152,17 +160,60 @@ def test_wrapped_startup_failure_uses_original_exception(tmp_path: Path):
     assert outcome.error_type == "ConfigError"
 
 
+def test_wrapped_startup_failure_preserves_actionable_exception_in_multi_level_chain(tmp_path: Path):
+    parse_error = ValueError("raw parser detail")
+    checkpoint_error = CheckpointReadError("checkpoint unreadable")
+    checkpoint_error.__cause__ = parse_error
+    config_error = ConfigError("Cannot resume: delete the unreadable checkpoints file and restart.")
+    config_error.__cause__ = checkpoint_error
+    wrapper = RuntimeError("orchestration failed")
+    wrapper.__cause__ = config_error
+
+    outcome = build_outcome(tmp_path, exception=wrapper)
+
+    assert outcome.failure_kind is FailureKind.CONFIG_ERROR
+    assert outcome.error == "Cannot resume: delete the unreadable checkpoints file and restart."
+    assert outcome.error_type == "ConfigError"
+
+
 @pytest.mark.parametrize(
-    "error_type, expected",
+    "error_types, error_classes",
     [
-        pytest.param("GoalValidationError", FailureKind.GOAL_NOT_MET, id="goal"),
-        pytest.param("AgentAPIError", FailureKind.AGENT_ERROR, id="agent"),
-        pytest.param("ConfigError", FailureKind.CONFIG_ERROR, id="config"),
-        pytest.param("UnexpectedError", FailureKind.PHASE_ERROR, id="phase"),
+        pytest.param(
+            GOAL_ERROR_TYPES,
+            [GoalValidationError, GoalParseError, GoalAttemptsExhausted],
+            id="goal",
+        ),
+        pytest.param(
+            AGENT_ERROR_TYPES,
+            [AgentError, AgentConnectionError, AgentRateLimitError, AgentAPIError],
+            id="agent",
+        ),
+        pytest.param(
+            CONFIG_ERROR_TYPES,
+            [ConfigError, ResourceUnavailableError],
+            id="config",
+        ),
     ],
 )
-def test_classify_failure(error_type: str, expected: FailureKind):
-    assert classify_failure(RunVerdict.FAILED, error_type, "phase") is expected
+def test_classified_error_names_match_exception_classes(
+    error_types: frozenset[str], error_classes: list[type[Exception]]
+):
+    assert error_types == {error_class.__name__ for error_class in error_classes}
+
+
+@pytest.mark.parametrize(
+    "error_type, failed_phase, expected",
+    [
+        pytest.param("GoalValidationError", "phase", FailureKind.GOAL_NOT_MET, id="goal"),
+        pytest.param("AgentAPIError", "phase", FailureKind.AGENT_ERROR, id="agent"),
+        pytest.param("ConfigError", "phase", FailureKind.CONFIG_ERROR, id="config"),
+        pytest.param("UnexpectedError", "phase", FailureKind.PHASE_ERROR, id="phase"),
+        pytest.param(None, None, FailureKind.UNKNOWN, id="unknown"),
+    ],
+)
+def test_classify_failure(error_type: str | None, failed_phase: str | None, expected: FailureKind):
+    assert classify_failure(RunVerdict.FAILED, error_type, failed_phase) is expected
 
 
 def test_run_outcome_store_round_trips_and_overwrites(tmp_path: Path):
@@ -180,3 +231,13 @@ def test_run_outcome_store_round_trips_and_overwrites(tmp_path: Path):
     store.write(second)
 
     assert store.read() == second
+
+
+@pytest.mark.parametrize("contents", [None, "["], ids=["missing", "corrupt"])
+def test_run_outcome_store_reports_read_errors(tmp_path: Path, contents: str | None):
+    path = tmp_path / "run.yaml"
+    if contents is not None:
+        path.write_text(contents, encoding="utf-8")
+
+    with pytest.raises(RunOutcomeReadError, match="Failed to read run outcome"):
+        RunOutcomeStore(path).read()

--- a/ddev/tests/ai/runtime/test_outcome.py
+++ b/ddev/tests/ai/runtime/test_outcome.py
@@ -1,0 +1,182 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from ddev.ai.config.errors import ConfigError
+from ddev.ai.config.models import FlowEntry, ResolvedFlow
+from ddev.ai.runtime.outcome import (
+    FailureKind,
+    PhaseReportStatus,
+    RunOutcomeStore,
+    RunVerdict,
+    build_run_outcome,
+    classify_failure,
+)
+
+from .helpers import make_cancelled_checkpoint, make_failed_checkpoint, make_success_checkpoint
+
+
+def make_flow() -> ResolvedFlow:
+    return ResolvedFlow(
+        name="demo",
+        description="Demo flow",
+        inputs=[],
+        agents={},
+        phases={},
+        flow=[
+            FlowEntry(phase="inspect"),
+            FlowEntry(phase="write", dependencies=["inspect"]),
+        ],
+        variables={},
+    )
+
+
+def build_outcome(
+    tmp_path: Path,
+    *,
+    checkpoints=None,
+    exception: BaseException | None = None,
+    failed_phase: str | None = None,
+    skipped_on_resume: set[str] | None = None,
+):
+    started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return build_run_outcome(
+        resolved_flow=make_flow(),
+        checkpoints=checkpoints or {},
+        skipped_on_resume=skipped_on_resume or set(),
+        started_at=started_at,
+        finished_at=started_at + timedelta(seconds=75),
+        run_dir=tmp_path,
+        resumed=bool(skipped_on_resume),
+        exception=exception,
+        failed_phase=failed_phase,
+    )
+
+
+def test_all_successful_checkpoints_produce_succeeded_outcome(tmp_path: Path):
+    outcome = build_outcome(
+        tmp_path,
+        checkpoints={
+            "inspect": make_success_checkpoint(),
+            "write": make_success_checkpoint(),
+        },
+    )
+
+    assert outcome.verdict is RunVerdict.SUCCEEDED
+    assert outcome.failure_kind is FailureKind.NONE
+    assert outcome.recorded_input_tokens == 20
+    assert outcome.recorded_output_tokens == 40
+    assert outcome.duration_seconds == 75
+
+
+def test_missing_success_checkpoint_produces_incomplete_timeout_outcome(tmp_path: Path):
+    outcome = build_outcome(
+        tmp_path,
+        checkpoints={"inspect": make_success_checkpoint()},
+    )
+
+    assert outcome.verdict is RunVerdict.INCOMPLETE
+    assert outcome.failure_kind is FailureKind.TIMEOUT
+    assert [phase.status for phase in outcome.phases] == [
+        PhaseReportStatus.SUCCEEDED,
+        PhaseReportStatus.NOT_RUN,
+    ]
+
+
+def test_cancelled_checkpoint_produces_cancelled_incomplete_outcome(tmp_path: Path):
+    outcome = build_outcome(
+        tmp_path,
+        checkpoints={
+            "inspect": make_cancelled_checkpoint(reason="Orchestrator exceeded max_timeout of 1.0s"),
+        },
+    )
+
+    assert outcome.verdict is RunVerdict.INCOMPLETE
+    assert outcome.failure_kind is FailureKind.TIMEOUT
+    assert [phase.status for phase in outcome.phases] == [
+        PhaseReportStatus.CANCELLED,
+        PhaseReportStatus.NOT_RUN,
+    ]
+    assert outcome.phases[0].cancellation_reason == "Orchestrator exceeded max_timeout of 1.0s"
+    assert outcome.phases[0].error is None
+
+
+def test_failed_checkpoint_produces_failed_outcome_with_original_error_type(tmp_path: Path):
+    outcome = build_outcome(
+        tmp_path,
+        checkpoints={
+            "inspect": make_success_checkpoint(),
+            "write": make_failed_checkpoint(error="goal failed", error_type="GoalAttemptsExhausted"),
+        },
+        exception=RuntimeError("wrapped run failure"),
+        failed_phase="write",
+    )
+
+    assert outcome.verdict is RunVerdict.FAILED
+    assert outcome.failure_kind is FailureKind.GOAL_NOT_MET
+    assert outcome.failed_phase == "write"
+    assert outcome.error == "goal failed"
+    assert outcome.error_type == "GoalAttemptsExhausted"
+
+
+def test_resume_skipped_phase_counts_as_successful_completion(tmp_path: Path):
+    outcome = build_outcome(
+        tmp_path,
+        checkpoints={
+            "inspect": make_success_checkpoint(),
+            "write": make_success_checkpoint(),
+        },
+        skipped_on_resume={"inspect"},
+    )
+
+    assert outcome.verdict is RunVerdict.SUCCEEDED
+    assert outcome.phases[0].status is PhaseReportStatus.SKIPPED_ON_RESUME
+    assert outcome.skipped_on_resume == ["inspect"]
+    assert outcome.resumed is True
+
+
+def test_wrapped_startup_failure_uses_original_exception(tmp_path: Path):
+    wrapper = RuntimeError("orchestration failed")
+    wrapper.__cause__ = ConfigError("invalid flow input")
+
+    outcome = build_outcome(tmp_path, exception=wrapper)
+
+    assert outcome.verdict is RunVerdict.FAILED
+    assert outcome.failure_kind is FailureKind.CONFIG_ERROR
+    assert outcome.error == "invalid flow input"
+    assert outcome.error_type == "ConfigError"
+
+
+@pytest.mark.parametrize(
+    "error_type, expected",
+    [
+        pytest.param("GoalValidationError", FailureKind.GOAL_NOT_MET, id="goal"),
+        pytest.param("AgentAPIError", FailureKind.AGENT_ERROR, id="agent"),
+        pytest.param("ConfigError", FailureKind.CONFIG_ERROR, id="config"),
+        pytest.param("UnexpectedError", FailureKind.PHASE_ERROR, id="phase"),
+    ],
+)
+def test_classify_failure(error_type: str, expected: FailureKind):
+    assert classify_failure(RunVerdict.FAILED, error_type, "phase") is expected
+
+
+def test_run_outcome_store_round_trips_and_overwrites(tmp_path: Path):
+    store = RunOutcomeStore(tmp_path)
+    first = build_outcome(tmp_path, checkpoints={"inspect": make_success_checkpoint()})
+    second = build_outcome(
+        tmp_path,
+        checkpoints={
+            "inspect": make_success_checkpoint(),
+            "write": make_success_checkpoint(),
+        },
+    )
+
+    store.write(first)
+    store.write(second)
+
+    assert store.read() == second

--- a/ddev/tests/cli/meta/ai/tui/conftest.py
+++ b/ddev/tests/cli/meta/ai/tui/conftest.py
@@ -27,11 +27,22 @@ from ddev.ai.config.models import (
     TaskConfig,
 )
 from ddev.ai.phases.registry import PhaseRegistry
+from ddev.ai.runtime.outcome import RunOutcome
 from ddev.cli.meta.ai.tui.app import TogoApp
 from ddev.cli.meta.ai.tui.theme import togo_theme
 
 LARGE_TERMINAL = (120, 50)
 STATUS_VARIABLE_KEYS = ("status-running", "status-pending", "status-done", "status-failed", "status-cancelled")
+
+
+class OrchestratorStub:
+    """Minimal test implementation of the execution screen's orchestrator contract."""
+
+    failed_phase: str | None = None
+    outcome: RunOutcome | None = None
+
+    async def run_async(self) -> None:
+        pass
 
 
 def export_screenshot_text(app: App[Any]) -> str:

--- a/ddev/tests/cli/meta/ai/tui/conftest.py
+++ b/ddev/tests/cli/meta/ai/tui/conftest.py
@@ -31,7 +31,7 @@ from ddev.cli.meta.ai.tui.app import TogoApp
 from ddev.cli.meta.ai.tui.theme import togo_theme
 
 LARGE_TERMINAL = (120, 50)
-STATUS_VARIABLE_KEYS = ("status-running", "status-pending", "status-done", "status-failed")
+STATUS_VARIABLE_KEYS = ("status-running", "status-pending", "status-done", "status-failed", "status-cancelled")
 
 
 def export_screenshot_text(app: App[Any]) -> str:

--- a/ddev/tests/cli/meta/ai/tui/test_bridge.py
+++ b/ddev/tests/cli/meta/ai/tui/test_bridge.py
@@ -12,6 +12,7 @@ from ddev.ai.agent.types import AgentResponse as AgentResponsePayload
 from ddev.ai.agent.types import StopReason, TokenUsage, ToolCall
 from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
 from ddev.ai.react.types import ReActResult
+from ddev.ai.runtime.outcome import RunOutcome
 from ddev.ai.tools.core.types import ToolResult
 from ddev.cli.meta.ai.tui.bridge import build_app_callback_set
 from ddev.cli.meta.ai.tui.messages import (
@@ -30,6 +31,7 @@ from ddev.cli.meta.ai.tui.messages import (
     PhaseFinished,
     PhaseStarted,
     RunErrored,
+    RunFinished,
 )
 
 # ---------------------------------------------------------------------------
@@ -78,6 +80,7 @@ class StubOrchestrator:
         await self.cb_set.fire_phase_finish("phase1")
         await self.cb_set.fire_phase_error("phase1", ValueError("phase boom"))
         await self.cb_set.fire_run_error()
+        await self.cb_set.fire_run_finished(RunOutcome.model_construct(flow_name="demo"))
         await self.cb_set.fire_agent_start(SCOPE, "sys_prompt", ["bash", "python"])
         await self.cb_set.fire_agent_response(SCOPE, _make_response(), 1)
         await self.cb_set.fire_tool_call(SCOPE, tool_call, result, 1)
@@ -157,6 +160,12 @@ async def test_run_errored_signal(received_from_stub):
     assert len(msgs) == 1
 
 
+async def test_run_finished_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, RunFinished)]
+    assert len(msgs) == 1
+    assert msgs[0].outcome.flow_name == "demo"
+
+
 async def test_agent_started_payload(received_from_stub):
     msgs = [m for m in received_from_stub if isinstance(m, AgentStarted)]
     assert len(msgs) == 1
@@ -231,7 +240,7 @@ async def test_after_goal_check_payload(received_from_stub):
     assert msgs[0].reason == "looks good"
 
 
-async def test_all_14_messages_delivered(make_togo_app):
+async def test_all_15_messages_delivered(make_togo_app):
     """Every bridge event type delivers exactly one message to the sink."""
     app = make_togo_app([])
     async with app.run_test() as pilot:
@@ -240,7 +249,7 @@ async def test_all_14_messages_delivered(make_togo_app):
         app.run_flow(stub)
         await pilot.pause(0.3)
 
-    assert len(app.received) == 14
+    assert len(app.received) == 15
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/cli/meta/ai/tui/test_ending.py
+++ b/ddev/tests/cli/meta/ai/tui/test_ending.py
@@ -9,10 +9,9 @@ from ddev.ai.runtime.outcome import (
     RunOutcome,
     RunVerdict,
 )
-from ddev.cli.meta.ai.tui.messages import RunFinished
 from ddev.cli.meta.ai.tui.status import ExecutionStatus, RunStatus
 
-from .conftest import export_screenshot_text
+from .conftest import OrchestratorStub, export_screenshot_text
 
 
 def make_phase(
@@ -172,23 +171,28 @@ async def test_failed_ending_screen_renders_error_details(make_togo_app):
 
 
 async def test_execution_screen_offers_summary_without_opening_it_automatically(make_flow, make_togo_app):
+    import asyncio
+
     from textual.containers import Horizontal
-    from textual.widgets import Button
+    from textual.widgets import Button, Static
 
     from ddev.cli.meta.ai.tui.screens.ending import EndingScreen
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
 
-    class NoopOrchestrator:
+    release = asyncio.Event()
+    outcome = make_outcome(RunVerdict.SUCCEEDED)
+
+    class ControlledOrchestrator(OrchestratorStub):
         failed_phase = None
-        outcome = None
+        outcome: RunOutcome | None = None
 
         async def run_async(self) -> None:
-            pass
+            await release.wait()
+            self.outcome = outcome
 
     flow = make_flow()
     app = make_togo_app([flow])
-    screen = ExecutionScreen(flow, orchestrator_builder=lambda callbacks: NoopOrchestrator())
-    outcome = make_outcome(RunVerdict.SUCCEEDED)
+    screen = ExecutionScreen(flow, orchestrator_builder=lambda callbacks: ControlledOrchestrator())
 
     async with app.run_test() as pilot:
         await pilot.pause()
@@ -197,11 +201,12 @@ async def test_execution_screen_offers_summary_without_opening_it_automatically(
         assert screen.query_one("#execution-actions", Horizontal).display is False
         assert screen.check_action("show_outcome", ()) is False
 
-        screen.on_run_finished(RunFinished(outcome))
+        release.set()
         await pilot.pause()
 
         assert app.screen is screen
         assert app.execution_status is ExecutionStatus.COMPLETED
+        assert screen.query_one("#execution-error", Static).display is False
         assert screen.query_one("#execution-actions", Horizontal).display is True
         assert screen.check_action("show_outcome", ()) is True
         assert screen.query_one("#view-summary", Button).has_focus
@@ -220,6 +225,8 @@ async def test_execution_screen_offers_summary_without_opening_it_automatically(
 
 
 async def test_run_finishing_does_not_interrupt_an_open_phase_log(make_flow, make_togo_app):
+    import asyncio
+
     from textual.containers import Horizontal
     from textual.widgets import Button
 
@@ -227,15 +234,20 @@ async def test_run_finishing_does_not_interrupt_an_open_phase_log(make_flow, mak
     from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen
     from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseSelected
 
-    class NoopOrchestrator:
+    release = asyncio.Event()
+    outcome = make_outcome(RunVerdict.SUCCEEDED)
+
+    class ControlledOrchestrator(OrchestratorStub):
         failed_phase = None
+        outcome: RunOutcome | None = None
 
         async def run_async(self) -> None:
-            pass
+            await release.wait()
+            self.outcome = outcome
 
     flow = make_flow()
     app = make_togo_app([flow])
-    screen = ExecutionScreen(flow, orchestrator_builder=lambda callbacks: NoopOrchestrator())
+    screen = ExecutionScreen(flow, orchestrator_builder=lambda callbacks: ControlledOrchestrator())
 
     async with app.run_test() as pilot:
         await pilot.pause()
@@ -248,7 +260,7 @@ async def test_run_finishing_does_not_interrupt_an_open_phase_log(make_flow, mak
         phase_log = app.screen
         assert isinstance(phase_log, PhaseLogScreen)
 
-        screen.on_run_finished(RunFinished(make_outcome(RunVerdict.SUCCEEDED)))
+        release.set()
         await pilot.pause()
 
         assert app.screen is phase_log

--- a/ddev/tests/cli/meta/ai/tui/test_ending.py
+++ b/ddev/tests/cli/meta/ai/tui/test_ending.py
@@ -195,6 +195,7 @@ async def test_execution_screen_offers_summary_without_opening_it_automatically(
         await app.push_screen(screen)
         await pilot.pause()
         assert screen.query_one("#execution-actions", Horizontal).display is False
+        assert screen.check_action("show_outcome", ()) is False
 
         screen.on_run_finished(RunFinished(outcome))
         await pilot.pause()
@@ -202,6 +203,7 @@ async def test_execution_screen_offers_summary_without_opening_it_automatically(
         assert app.screen is screen
         assert app.execution_status is ExecutionStatus.COMPLETED
         assert screen.query_one("#execution-actions", Horizontal).display is True
+        assert screen.check_action("show_outcome", ()) is True
         assert screen.query_one("#view-summary", Button).has_focus
 
         await pilot.click("#view-summary")

--- a/ddev/tests/cli/meta/ai/tui/test_ending.py
+++ b/ddev/tests/cli/meta/ai/tui/test_ending.py
@@ -1,0 +1,258 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from ddev.ai.runtime.outcome import (
+    FailureKind,
+    PhaseReport,
+    PhaseReportStatus,
+    RunOutcome,
+    RunVerdict,
+)
+from ddev.cli.meta.ai.tui.messages import RunFinished
+from ddev.cli.meta.ai.tui.status import ExecutionStatus, RunStatus
+
+from .conftest import export_screenshot_text
+
+
+def make_phase(
+    phase_id: str,
+    status: PhaseReportStatus,
+    *,
+    error: str | None = None,
+    error_type: str | None = None,
+) -> PhaseReport:
+    return PhaseReport(
+        phase_id=phase_id,
+        status=status,
+        started_at="2026-01-01T00:00:00+00:00" if status is not PhaseReportStatus.NOT_RUN else None,
+        finished_at="2026-01-01T00:00:10+00:00" if status is not PhaseReportStatus.NOT_RUN else None,
+        duration_seconds=10 if status is not PhaseReportStatus.NOT_RUN else None,
+        input_tokens=100 if status is not PhaseReportStatus.NOT_RUN else 0,
+        output_tokens=50 if status is not PhaseReportStatus.NOT_RUN else 0,
+        goal_validations=None,
+        error=error,
+        error_type=error_type,
+    )
+
+
+def make_outcome(
+    verdict: RunVerdict,
+    *,
+    phases: list[PhaseReport] | None = None,
+    failed_phase: str | None = None,
+    error: str | None = None,
+    error_type: str | None = None,
+) -> RunOutcome:
+    phase_reports = phases or [
+        make_phase("phase_0", PhaseReportStatus.SUCCEEDED),
+        make_phase("phase_1", PhaseReportStatus.SUCCEEDED),
+    ]
+    return RunOutcome(
+        flow_name="Test Flow",
+        verdict=verdict,
+        failure_kind=(
+            FailureKind.NONE
+            if verdict is RunVerdict.SUCCEEDED
+            else FailureKind.TIMEOUT
+            if verdict is RunVerdict.INCOMPLETE
+            else FailureKind.PHASE_ERROR
+        ),
+        failed_phase=failed_phase,
+        error=error,
+        error_type=error_type,
+        started_at="2026-01-01T00:00:00+00:00",
+        finished_at="2026-01-01T00:00:20+00:00",
+        duration_seconds=20,
+        phases=phase_reports,
+        recorded_input_tokens=sum(phase.input_tokens for phase in phase_reports),
+        recorded_output_tokens=sum(phase.output_tokens for phase in phase_reports),
+        resumed=False,
+        skipped_on_resume=[],
+        run_dir="/tmp/test-run",
+    )
+
+
+async def test_succeeded_ending_screen_renders_verdict_stats_and_phases(make_togo_app):
+    from ddev.cli.meta.ai.tui.screens.ending import EndingScreen
+
+    app = make_togo_app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = EndingScreen(make_outcome(RunVerdict.SUCCEEDED))
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        rendered = export_screenshot_text(app)
+        stats = screen.query_one("#ending-stats").render().plain
+
+    assert "Flow completed — 2 phases" in rendered
+    assert "200 input / 100 output tokens recorded" in stats
+    assert "phase_0" in rendered
+    assert "phase_1" in rendered
+
+
+async def test_incomplete_ending_screen_reports_partial_completion(make_togo_app):
+    from ddev.cli.meta.ai.tui.screens.ending import EndingScreen
+
+    outcome = make_outcome(
+        RunVerdict.INCOMPLETE,
+        phases=[
+            make_phase("phase_0", PhaseReportStatus.SUCCEEDED),
+            make_phase("phase_1", PhaseReportStatus.NOT_RUN),
+        ],
+    )
+    app = make_togo_app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.push_screen(EndingScreen(outcome))
+        await pilot.pause()
+
+        rendered = export_screenshot_text(app)
+
+    assert "Flow incomplete — 1 of 2 phases completed" in rendered
+    assert "not run" in rendered
+
+
+async def test_incomplete_ending_screen_shows_cancelled_phase(make_togo_app):
+    from ddev.cli.meta.ai.tui.screens.ending import EndingScreen
+
+    outcome = make_outcome(
+        RunVerdict.INCOMPLETE,
+        phases=[
+            make_phase("phase_0", PhaseReportStatus.CANCELLED),
+            make_phase("phase_1", PhaseReportStatus.NOT_RUN),
+        ],
+    )
+    app = make_togo_app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = EndingScreen(outcome)
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        rendered = export_screenshot_text(app)
+        stats = screen.query_one("#ending-stats").render().plain
+
+    assert "cancelled" in rendered
+    assert "1 cancelled" in stats
+
+
+async def test_failed_ending_screen_renders_error_details(make_togo_app):
+    from ddev.cli.meta.ai.tui.screens.ending import EndingScreen
+
+    outcome = make_outcome(
+        RunVerdict.FAILED,
+        phases=[
+            make_phase("phase_0", PhaseReportStatus.SUCCEEDED),
+            make_phase(
+                "phase_1",
+                PhaseReportStatus.FAILED,
+                error="goal could not be satisfied",
+                error_type="GoalAttemptsExhausted",
+            ),
+        ],
+        failed_phase="phase_1",
+        error="goal could not be satisfied",
+        error_type="GoalAttemptsExhausted",
+    )
+    app = make_togo_app()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = EndingScreen(outcome)
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        rendered = export_screenshot_text(app)
+        error = screen.query_one("#ending-error").render().plain
+
+    assert "Flow failed in phase_1" in rendered
+    assert "GoalAttemptsExhausted" in error
+    assert "goal could not be satisfied" in error
+
+
+async def test_execution_screen_offers_summary_without_opening_it_automatically(make_flow, make_togo_app):
+    from textual.containers import Horizontal
+    from textual.widgets import Button
+
+    from ddev.cli.meta.ai.tui.screens.ending import EndingScreen
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+
+    class NoopOrchestrator:
+        failed_phase = None
+        outcome = None
+
+        async def run_async(self) -> None:
+            pass
+
+    flow = make_flow()
+    app = make_togo_app([flow])
+    screen = ExecutionScreen(flow, orchestrator_builder=lambda callbacks: NoopOrchestrator())
+    outcome = make_outcome(RunVerdict.SUCCEEDED)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.push_screen(screen)
+        await pilot.pause()
+        assert screen.query_one("#execution-actions", Horizontal).display is False
+
+        screen.on_run_finished(RunFinished(outcome))
+        await pilot.pause()
+
+        assert app.screen is screen
+        assert app.execution_status is ExecutionStatus.COMPLETED
+        assert screen.query_one("#execution-actions", Horizontal).display is True
+        assert screen.query_one("#view-summary", Button).has_focus
+
+        await pilot.click("#view-summary")
+        await pilot.pause()
+        assert isinstance(app.screen, EndingScreen)
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.screen is screen
+
+        await pilot.press("s")
+        await pilot.pause()
+        assert isinstance(app.screen, EndingScreen)
+
+
+async def test_run_finishing_does_not_interrupt_an_open_phase_log(make_flow, make_togo_app):
+    from textual.containers import Horizontal
+    from textual.widgets import Button
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen
+    from ddev.cli.meta.ai.tui.widgets.pipeline_graph import PhaseSelected
+
+    class NoopOrchestrator:
+        failed_phase = None
+
+        async def run_async(self) -> None:
+            pass
+
+    flow = make_flow()
+    app = make_togo_app([flow])
+    screen = ExecutionScreen(flow, orchestrator_builder=lambda callbacks: NoopOrchestrator())
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.push_screen(screen)
+        await pilot.pause()
+        phase_id = flow.flow[0].phase
+        screen._phase_statuses[phase_id] = RunStatus.RUNNING
+        screen.on_phase_selected(PhaseSelected(phase_id))
+        await pilot.pause()
+        phase_log = app.screen
+        assert isinstance(phase_log, PhaseLogScreen)
+
+        screen.on_run_finished(RunFinished(make_outcome(RunVerdict.SUCCEEDED)))
+        await pilot.pause()
+
+        assert app.screen is phase_log
+        assert screen.query_one("#execution-actions", Horizontal).display is True
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.screen is screen
+        assert screen.query_one("#view-summary", Button).has_focus

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -30,7 +30,7 @@ from ddev.ai.runtime.outcome import (
 from ddev.cli.meta.ai.tui.app import TogoApp
 from ddev.cli.meta.ai.tui.status import RunStatus
 
-from .conftest import StaticConfigurationEngine, export_screenshot_text
+from .conftest import OrchestratorStub, StaticConfigurationEngine, export_screenshot_text
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -186,7 +186,7 @@ def _make_outcome(
     )
 
 
-class _FakeOrchestrator:
+class _FakeOrchestrator(OrchestratorStub):
     """Scripted fake orchestrator for tests — no API key, no real agents.
 
     Fires a deterministic sequence of callback events (phase/agent/tool/goal)
@@ -467,7 +467,7 @@ async def test_execution_screen_uses_injectable_builder():
     def _builder(cb: Callbacks) -> Any:
         received_callbacks.append(cb)
 
-        class _Noop:
+        class _Noop(OrchestratorStub):
             async def run_async(self) -> None:
                 pass
 
@@ -1052,7 +1052,7 @@ async def test_phase_log_shows_thinking_block_until_agent_response():
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
     from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen, ThinkingBlock
 
-    class _IdleOrchestrator:
+    class _IdleOrchestrator(OrchestratorStub):
         async def run_async(self) -> None:
             pass
 
@@ -1091,7 +1091,7 @@ async def test_sentinel_send_shows_thinking_without_prompt_block():
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
     from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogScreen, ThinkingBlock
 
-    class _IdleOrchestrator:
+    class _IdleOrchestrator(OrchestratorStub):
         async def run_async(self) -> None:
             pass
 
@@ -1127,7 +1127,7 @@ async def test_phase_log_replays_entries_before_active_thinking_block():
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
     from ddev.cli.meta.ai.tui.screens.phase_log import PhaseLogBlock, PhaseLogScreen, ThinkingBlock
 
-    class _IdleOrchestrator:
+    class _IdleOrchestrator(OrchestratorStub):
         async def run_async(self) -> None:
             pass
 
@@ -1328,7 +1328,7 @@ async def test_execution_finishes_phases_before_reporting_success() -> None:
 
     release = asyncio.Event()
 
-    class ControlledOrchestrator:
+    class ControlledOrchestrator(OrchestratorStub):
         failed_phase = None
 
         def __init__(self, callbacks: Any) -> None:
@@ -1370,7 +1370,7 @@ async def test_execution_failure_during_finalization_never_reports_success() -> 
 
     release = asyncio.Event()
 
-    class FailingFinalizer:
+    class FailingFinalizer(OrchestratorStub):
         failed_phase = None
 
         def __init__(self, callbacks: Any) -> None:
@@ -1411,7 +1411,7 @@ async def test_phase_log_header_keeps_running_status() -> None:
 
     release = asyncio.Event()
 
-    class RunningPhase:
+    class RunningPhase(OrchestratorStub):
         failed_phase = None
 
         def __init__(self, callbacks: Any) -> None:
@@ -1446,13 +1446,24 @@ async def test_phase_log_header_keeps_running_status() -> None:
 
 
 async def test_incomplete_outcome_reconciles_cancelled_phase_and_stops_thinking() -> None:
+    import asyncio
+
     from ddev.cli.meta.ai.tui.messages import RunFinished
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
     from ddev.cli.meta.ai.tui.status import ExecutionStatus
 
+    release = asyncio.Event()
+
+    class ControlledOrchestrator(OrchestratorStub):
+        failed_phase = None
+        outcome = None
+
+        async def run_async(self) -> None:
+            await release.wait()
+
     flow = _make_flow()
     app = _app(flow)
-    screen = ExecutionScreen(flow, orchestrator_builder=_make_builder())
+    screen = ExecutionScreen(flow, orchestrator_builder=lambda callbacks: ControlledOrchestrator())
     outcome = _make_outcome(
         DEMO_PHASES,
         verdict=RunVerdict.INCOMPLETE,
@@ -1468,6 +1479,7 @@ async def test_incomplete_outcome_reconciles_cancelled_phase_and_stops_thinking(
         await pilot.pause()
         screen._phase_statuses = {"phase_1": RunStatus.RUNNING, "phase_2": RunStatus.RUNNING}
         screen._task_statuses[("phase_1", "task_one")] = RunStatus.RUNNING
+        screen._task_statuses[("phase_1", "not_started")] = RunStatus.PENDING
         screen._task_statuses[("phase_2", "task_two")] = RunStatus.RUNNING
         screen._active_thinking["phase_1"]["agent:phase:1"] = "thinking"
 
@@ -1480,6 +1492,7 @@ async def test_incomplete_outcome_reconciles_cancelled_phase_and_stops_thinking(
             "phase_2": RunStatus.PENDING,
         }
         assert screen._task_statuses[("phase_1", "task_one")] is RunStatus.CANCELLED
+        assert screen._task_statuses[("phase_1", "not_started")] is RunStatus.PENDING
         assert screen._task_statuses[("phase_2", "task_two")] is RunStatus.PENDING
         assert screen._active_thinking["phase_1"] == {}
 
@@ -1491,7 +1504,7 @@ async def test_outcome_build_error_is_not_reported_as_flow_failure() -> None:
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
     from ddev.cli.meta.ai.tui.status import ExecutionStatus
 
-    class OutcomeBuildFailure:
+    class OutcomeBuildFailure(OrchestratorStub):
         failed_phase = None
         outcome = None
 
@@ -1522,7 +1535,7 @@ async def test_outcome_persistence_error_keeps_flow_verdict_and_summary() -> Non
 
     outcome = _make_outcome(DEMO_PHASES)
 
-    class OutcomePersistenceFailure:
+    class OutcomePersistenceFailure(OrchestratorStub):
         failed_phase = None
 
         def __init__(self, callbacks: Any) -> None:
@@ -1563,7 +1576,7 @@ async def test_cancel_stops_worker_without_crash():
 
     cancelled = asyncio.Event()
 
-    class _InfiniteDemo:
+    class _InfiniteDemo(OrchestratorStub):
         failed_phase = None
 
         def __init__(self, cb: Any) -> None:
@@ -1598,7 +1611,7 @@ async def test_execution_ctrl_c_copies_selection_before_cancelling(monkeypatch):
 
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
 
-    class _InfiniteDemo:
+    class _InfiniteDemo(OrchestratorStub):
         async def run_async(self) -> None:
             await asyncio.sleep(999)
 
@@ -1629,7 +1642,7 @@ async def test_unmount_cancels_worker():
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
     from ddev.cli.meta.ai.tui.screens.main import MainScreen
 
-    class _InfiniteDemo:
+    class _InfiniteDemo(OrchestratorStub):
         failed_phase = None
 
         def __init__(self, cb: Any) -> None:
@@ -1662,7 +1675,7 @@ async def test_escape_requires_confirmation_before_cancelling_active_run():
 
     cancelled = asyncio.Event()
 
-    class _InfiniteDemo:
+    class _InfiniteDemo(OrchestratorStub):
         failed_phase = None
 
         async def run_async(self) -> None:
@@ -1705,7 +1718,7 @@ async def test_back_pops_immediately_after_run_finishes():
     from ddev.cli.meta.ai.tui.screens.main import MainScreen
     from ddev.cli.meta.ai.tui.widgets.header import ExecutionStatusBadge
 
-    class _FinishedDemo:
+    class _FinishedDemo(OrchestratorStub):
         failed_phase = None
 
         async def run_async(self) -> None:
@@ -1781,7 +1794,7 @@ async def test_phase_error_callback_only_marks_reported_failed_phase() -> None:
 
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
 
-    class ConcurrentFailure:
+    class ConcurrentFailure(OrchestratorStub):
         failed_phase = "phase_1"
 
         def __init__(self, callbacks: Any) -> None:
@@ -1816,7 +1829,7 @@ async def test_orchestrator_exception_without_failed_phase_is_not_attributed() -
 
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
 
-    class UnknownFailure:
+    class UnknownFailure(OrchestratorStub):
         failed_phase = None
 
         def __init__(self, callbacks: Any) -> None:
@@ -1933,7 +1946,7 @@ async def test_resume_flag_passed_to_orchestrator():
     flow = _make_flow()
 
     def _builder(cb: Any) -> Any:
-        class _Noop:
+        class _Noop(OrchestratorStub):
             async def run_async(self) -> None:
                 pass
 
@@ -1967,7 +1980,7 @@ final_review:
 """
     )
 
-    class Noop:
+    class Noop(OrchestratorStub):
         failed_phase = None
 
         async def run_async(self) -> None:
@@ -2005,7 +2018,7 @@ async def test_resume_transitions_to_finishing_after_remaining_phase(tmp_path: P
     )
     release = asyncio.Event()
 
-    class ResumeOrchestrator:
+    class ResumeOrchestrator(OrchestratorStub):
         failed_phase = None
 
         def __init__(self, callbacks: Any) -> None:
@@ -2054,6 +2067,7 @@ def _setup_default_builder_mocks(tmp_path: Path):
 
     mock_orch_instance = MagicMock()
     mock_orch_instance.run_async = AsyncMock()
+    mock_orch_instance.outcome = None
     return fake_ddev_app, mock_orch_instance
 
 
@@ -2239,6 +2253,7 @@ async def test_launch_from_flow_screen_no_runtime_error(tmp_path: Path) -> None:
 
     mock_orch_instance = MagicMock()
     mock_orch_instance.run_async = AsyncMock()
+    mock_orch_instance.outcome = None
 
     with patch("ddev.ai.runtime.orchestrator.PhaseOrchestrator") as MockOrch:
         MockOrch.return_value = mock_orch_instance

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -18,6 +18,15 @@ from textual.widgets import Input
 from ddev.ai.agent.registry import AgentProviderRegistry
 from ddev.ai.config.models import AgentConfig, FlowConfig, FlowEntry, PhaseConfig, ResolvedFlow, TaskConfig
 from ddev.ai.phases.registry import PhaseRegistry
+from ddev.ai.runtime.outcome import (
+    FailureKind,
+    PhaseReport,
+    PhaseReportStatus,
+    RunOutcome,
+    RunOutcomeBuildError,
+    RunOutcomePersistenceError,
+    RunVerdict,
+)
 from ddev.cli.meta.ai.tui.app import TogoApp
 from ddev.cli.meta.ai.tui.status import RunStatus
 
@@ -137,6 +146,46 @@ def _make_react_result(response: Any) -> Any:
     )
 
 
+def _make_outcome(
+    phases: list[tuple[str, list[str]]],
+    *,
+    verdict: RunVerdict = RunVerdict.SUCCEEDED,
+    statuses: dict[str, PhaseReportStatus] | None = None,
+) -> RunOutcome:
+    reports = [
+        PhaseReport(
+            phase_id=phase_id,
+            status=(statuses or {}).get(phase_id, PhaseReportStatus.SUCCEEDED),
+            started_at="2026-01-01T00:00:00+00:00",
+            finished_at="2026-01-01T00:00:01+00:00",
+            duration_seconds=1,
+            input_tokens=0,
+            output_tokens=0,
+            goal_validations=None,
+            error=None,
+            error_type=None,
+        )
+        for phase_id, _ in phases
+    ]
+    return RunOutcome(
+        flow_name="Test Flow",
+        verdict=verdict,
+        failure_kind=FailureKind.NONE if verdict is RunVerdict.SUCCEEDED else FailureKind.TIMEOUT,
+        failed_phase=None,
+        error=None,
+        error_type=None,
+        started_at="2026-01-01T00:00:00+00:00",
+        finished_at="2026-01-01T00:00:01+00:00",
+        duration_seconds=1,
+        phases=reports,
+        recorded_input_tokens=0,
+        recorded_output_tokens=0,
+        resumed=False,
+        skipped_on_resume=[],
+        run_dir="/tmp/test-run",
+    )
+
+
 class _FakeOrchestrator:
     """Scripted fake orchestrator for tests — no API key, no real agents.
 
@@ -157,11 +206,18 @@ class _FakeOrchestrator:
         self._phases = phases
         self._fail_on_phase = fail_on_phase
         self.failed_phase: str | None = None
+        self._outcome: RunOutcome | None = None
+
+    @property
+    def outcome(self) -> RunOutcome | None:
+        return self._outcome
 
     async def run_async(self) -> None:
         """Fire the scripted event sequence through the callbacks."""
         for phase_id, task_names in self._phases:
             await self._run_phase(phase_id, task_names)
+        self._outcome = _make_outcome(self._phases)
+        await self._callbacks.fire_run_finished(self._outcome)
 
     async def _run_phase(self, phase_id: str, task_names: list[str]) -> None:
         from ddev.ai.agent.scope import AgentRole, AgentScope
@@ -1277,11 +1333,14 @@ async def test_execution_finishes_phases_before_reporting_success() -> None:
 
         def __init__(self, callbacks: Any) -> None:
             self.callbacks = callbacks
+            self.outcome: RunOutcome | None = None
 
         async def run_async(self) -> None:
             for phase_id, _ in DEMO_PHASES:
                 await self.callbacks.fire_phase_finish(phase_id)
             await release.wait()
+            self.outcome = _make_outcome(DEMO_PHASES)
+            await self.callbacks.fire_run_finished(self.outcome)
 
     flow = _make_flow()
     app = _app(flow)
@@ -1357,10 +1416,13 @@ async def test_phase_log_header_keeps_running_status() -> None:
 
         def __init__(self, callbacks: Any) -> None:
             self.callbacks = callbacks
+            self.outcome: RunOutcome | None = None
 
         async def run_async(self) -> None:
             await self.callbacks.fire_phase_start("phase_1")
             await release.wait()
+            self.outcome = _make_outcome(DEMO_PHASES)
+            await self.callbacks.fire_run_finished(self.outcome)
 
     flow = _make_flow()
     app = _app(flow)
@@ -1381,6 +1443,109 @@ async def test_phase_log_header_keeps_running_status() -> None:
         release.set()
         await pilot.pause()
         assert "✓ completed" in export_screenshot_text(app)
+
+
+async def test_incomplete_outcome_reconciles_cancelled_phase_and_stops_thinking() -> None:
+    from ddev.cli.meta.ai.tui.messages import RunFinished
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.status import ExecutionStatus
+
+    flow = _make_flow()
+    app = _app(flow)
+    screen = ExecutionScreen(flow, orchestrator_builder=_make_builder())
+    outcome = _make_outcome(
+        DEMO_PHASES,
+        verdict=RunVerdict.INCOMPLETE,
+        statuses={
+            "phase_1": PhaseReportStatus.CANCELLED,
+            "phase_2": PhaseReportStatus.NOT_RUN,
+        },
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.push_screen(screen)
+        await pilot.pause()
+        screen._phase_statuses = {"phase_1": RunStatus.RUNNING, "phase_2": RunStatus.RUNNING}
+        screen._task_statuses[("phase_1", "task_one")] = RunStatus.RUNNING
+        screen._task_statuses[("phase_2", "task_two")] = RunStatus.RUNNING
+        screen._active_thinking["phase_1"]["agent:phase:1"] = "thinking"
+
+        screen.on_run_finished(RunFinished(outcome))
+        await pilot.pause()
+
+        assert app.execution_status is ExecutionStatus.INCOMPLETE
+        assert screen._phase_statuses == {
+            "phase_1": RunStatus.CANCELLED,
+            "phase_2": RunStatus.PENDING,
+        }
+        assert screen._task_statuses[("phase_1", "task_one")] is RunStatus.CANCELLED
+        assert screen._task_statuses[("phase_2", "task_two")] is RunStatus.PENDING
+        assert screen._active_thinking["phase_1"] == {}
+
+
+async def test_outcome_build_error_is_not_reported_as_flow_failure() -> None:
+    from textual.containers import Horizontal
+    from textual.widgets import Static
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.status import ExecutionStatus
+
+    class OutcomeBuildFailure:
+        failed_phase = None
+        outcome = None
+
+        async def run_async(self) -> None:
+            raise RunOutcomeBuildError("checkpoint unreadable")
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=lambda _: OutcomeBuildFailure())
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        banner = screen.query_one("#execution-error", Static)
+        assert app.execution_status is ExecutionStatus.OUTCOME_ERROR
+        assert "outcome could not be determined" in banner.render().plain
+        assert "checkpoint unreadable" in banner.render().plain
+        assert screen.query_one("#execution-actions", Horizontal).display is False
+
+
+async def test_outcome_persistence_error_keeps_flow_verdict_and_summary() -> None:
+    from textual.containers import Horizontal
+    from textual.widgets import Static
+
+    from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
+    from ddev.cli.meta.ai.tui.status import ExecutionStatus
+
+    outcome = _make_outcome(DEMO_PHASES)
+
+    class OutcomePersistenceFailure:
+        failed_phase = None
+
+        def __init__(self, callbacks: Any) -> None:
+            self.callbacks = callbacks
+            self.outcome = outcome
+
+        async def run_async(self) -> None:
+            await self.callbacks.fire_run_finished(self.outcome)
+            raise RunOutcomePersistenceError("disk full")
+
+    flow = _make_flow()
+    app = _app(flow)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = ExecutionScreen(flow, orchestrator_builder=OutcomePersistenceFailure)
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        banner = screen.query_one("#execution-error", Static)
+        assert app.execution_status is ExecutionStatus.COMPLETED
+        assert "outcome is available" in banner.render().plain
+        assert "disk full" in banner.render().plain
+        assert screen.query_one("#execution-actions", Horizontal).display is True
 
 
 # ---------------------------------------------------------------------------
@@ -1845,10 +2010,13 @@ async def test_resume_transitions_to_finishing_after_remaining_phase(tmp_path: P
 
         def __init__(self, callbacks: Any) -> None:
             self.callbacks = callbacks
+            self.outcome: RunOutcome | None = None
 
         async def run_async(self) -> None:
             await self.callbacks.fire_phase_finish("phase_2")
             await release.wait()
+            self.outcome = _make_outcome(DEMO_PHASES)
+            await self.callbacks.fire_run_finished(self.outcome)
 
     app = _app(flow)
     async with app.run_test() as pilot:

--- a/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
@@ -631,7 +631,7 @@ async def test_valid_launch_dismissal_pushes_execution_screen(tmp_path: Path) ->
         _provide_prd(pilot.app.screen, tmp_path)
         await pilot.click("#btn-launch")
         await pilot.pause()
-        assert any(isinstance(screen, ExecutionScreen) for screen in pilot.app.screen_stack)
+        assert isinstance(pilot.app.screen, ExecutionScreen)
 
 
 async def test_launch_dismissal_passes_runtime_variables_and_timeout(tmp_path: Path) -> None:

--- a/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
@@ -631,7 +631,7 @@ async def test_valid_launch_dismissal_pushes_execution_screen(tmp_path: Path) ->
         _provide_prd(pilot.app.screen, tmp_path)
         await pilot.click("#btn-launch")
         await pilot.pause()
-        assert isinstance(pilot.app.screen, ExecutionScreen)
+        assert any(isinstance(screen, ExecutionScreen) for screen in pilot.app.screen_stack)
 
 
 async def test_launch_dismissal_passes_runtime_variables_and_timeout(tmp_path: Path) -> None:
@@ -651,7 +651,7 @@ async def test_launch_dismissal_passes_runtime_variables_and_timeout(tmp_path: P
         pilot.app.screen.query_one("#input-max_timeout", Input).value = "120"
         await pilot.click("#btn-launch")
         await pilot.pause()
-        screen: ExecutionScreen = pilot.app.screen  # type: ignore[assignment]
+        screen = next(screen for screen in pilot.app.screen_stack if isinstance(screen, ExecutionScreen))
         assert screen.runtime_variables == {"prd": prd, "max_timeout": "120"}
 
 
@@ -680,8 +680,7 @@ async def test_resume_pushes_execution_screen_with_resume_flag(tmp_path: Path) -
         _provide_prd(pilot.app.screen, tmp_path)
         await pilot.click("#btn-launch")
         await pilot.pause()
-        screen = pilot.app.screen
-        assert isinstance(screen, ExecutionScreen)
+        screen = next(screen for screen in pilot.app.screen_stack if isinstance(screen, ExecutionScreen))
         assert screen.resume is True
 
 
@@ -712,7 +711,6 @@ async def test_resume_with_inputs_reopens_modal_and_passes_converted_values(tmp_
         prd = _provide_prd(pilot.app.screen, tmp_path)
         await pilot.click("#btn-launch")
         await pilot.pause()
-        screen = pilot.app.screen
-        assert isinstance(screen, ExecutionScreen)
+        screen = next(screen for screen in pilot.app.screen_stack if isinstance(screen, ExecutionScreen))
         assert screen.resume is True
         assert screen.runtime_variables == {"token": "fresh-value", "prd": prd}

--- a/ddev/tests/cli/meta/ai/tui/test_navigation.py
+++ b/ddev/tests/cli/meta/ai/tui/test_navigation.py
@@ -149,5 +149,5 @@ async def test_execution_screen_mounts_with_placeholder_regions(make_flow, make_
         assert isinstance(pilot.app.screen, MainScreen)
         await pilot.app.push_screen(ExecutionScreen(flow))
         await pilot.pause()
-        assert isinstance(pilot.app.screen, ExecutionScreen)
-        pilot.app.screen.query_one("#pipeline", PipelineGraph)
+        screen = next(screen for screen in pilot.app.screen_stack if isinstance(screen, ExecutionScreen))
+        screen.query_one("#pipeline", PipelineGraph)

--- a/ddev/tests/cli/meta/ai/tui/test_navigation.py
+++ b/ddev/tests/cli/meta/ai/tui/test_navigation.py
@@ -149,5 +149,6 @@ async def test_execution_screen_mounts_with_placeholder_regions(make_flow, make_
         assert isinstance(pilot.app.screen, MainScreen)
         await pilot.app.push_screen(ExecutionScreen(flow))
         await pilot.pause()
-        screen = next(screen for screen in pilot.app.screen_stack if isinstance(screen, ExecutionScreen))
+        screen = pilot.app.screen
+        assert isinstance(screen, ExecutionScreen)
         screen.query_one("#pipeline", PipelineGraph)

--- a/ddev/tests/cli/meta/ai/tui/test_shell.py
+++ b/ddev/tests/cli/meta/ai/tui/test_shell.py
@@ -188,7 +188,9 @@ async def test_togo_header_idle_badge_is_empty(ddev_app: Any) -> None:
     [
         (ExecutionStatus.FINISHING, "◌ finishing"),
         (ExecutionStatus.COMPLETED, "✓ completed"),
+        (ExecutionStatus.INCOMPLETE, "◌ incomplete"),
         (ExecutionStatus.FAILED, "✕ failed"),
+        (ExecutionStatus.OUTCOME_ERROR, "! outcome unavailable"),
     ],
 )
 async def test_togo_header_stable_execution_badges(ddev_app: Any, status: ExecutionStatus, label: str) -> None:

--- a/ddev/tests/cli/meta/ai/tui/test_theme.py
+++ b/ddev/tests/cli/meta/ai/tui/test_theme.py
@@ -19,7 +19,9 @@ def test_togo_theme_tokens():
     assert togo_theme.secondary == SECONDARY
     assert togo_theme.accent == ACCENT
     assert togo_theme.dark is True
-    assert {"status-running", "status-pending", "status-done", "status-failed"} <= set(togo_theme.variables)
+    assert {"status-running", "status-pending", "status-done", "status-failed", "status-cancelled"} <= set(
+        togo_theme.variables
+    )
 
 
 def test_togo_app_css_path_set():
@@ -52,9 +54,12 @@ async def test_togo_app_css_loads_without_error(make_togo_app):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("key", ["status-running", "status-pending", "status-done", "status-failed"])
+@pytest.mark.parametrize(
+    "key",
+    ["status-running", "status-pending", "status-done", "status-failed", "status-cancelled"],
+)
 def test_get_theme_variable_defaults_returns_status_key(key, make_togo_app):
-    """TogoApp.get_theme_variable_defaults() includes all four status keys."""
+    """TogoApp.get_theme_variable_defaults() includes every status key."""
     defaults = make_togo_app([]).get_theme_variable_defaults()
     assert key in defaults
 
@@ -62,7 +67,7 @@ def test_get_theme_variable_defaults_returns_status_key(key, make_togo_app):
 def test_get_theme_variable_defaults_values_match_theme(make_togo_app):
     """Default values match the corresponding togo_theme variables."""
     defaults = make_togo_app([]).get_theme_variable_defaults()
-    for key in ("status-running", "status-pending", "status-done", "status-failed"):
+    for key in ("status-running", "status-pending", "status-done", "status-failed", "status-cancelled"):
         assert defaults[key] == togo_theme.variables[key]
 
 


### PR DESCRIPTION
> This is PR 2 of 3 in a stacked series: 
> 1. #24731 
> 2. #24729 **<- you are here**
> 3. #24748 

### What does this PR do?

This PR builds on the cancelled phase checkpoints introduced in [#24731](https://github.com/DataDog/integrations-core/pull/24731).

- Adds a deterministic outcome for each non-user-cancelled Togo run and persists it as `run.yaml`, including the overall verdict, per-phase status and timing, recorded token usage, goal attempts, cancellation details, and failure metadata.
- Distinguishes a fully completed flow from one that returns normally with unfinished work, such as when `max_timeout` is reached. Run verdicts are succeeded, failed, or incomplete; phase reports distinguish succeeded, failed, cancelled, not-run, and skipped-on-resume phases.
- Preserves the original exception type in failed checkpoints so outcomes can classify failures without parsing error messages. Existing checkpoints without this field remain valid.
- Exposes the outcome directly on the orchestrator contract used by the TUI.
- Adds explicit outcome build and persistence errors without conflating them with flow failures:
  - An outcome error never masks an already-failing flow.
  - If outcome construction fails after a normally ending flow, the TUI reports that the outcome is unavailable rather than saying the flow failed.
  - If persistence fails after the outcome was built, the in-memory outcome and summary remain available and the TUI shows a warning without changing the flow verdict.
- Reconciles the execution graph from the final outcome. Timed-out active phases become cancelled, phases that never started remain pending/not run, and no terminal run retains a running spinner. Cancelled phases remain selectable so their partial logs are accessible.
- Adds an opt-in summary screen. A **View summary** button appears and receives focus on the execution screen when the outcome is ready, with `s` as a keyboard shortcut; the summary is not opened automatically and finishing a run does not interrupt an open phase log.
- Keeps user cancellation behavior unchanged: cancellation still propagates and does not create a finished-run outcome, while [#24731](https://github.com/DataDog/integrations-core/pull/24731) records the in-flight phase as cancelled.

Screenshot of the summary screen:

<img width="1284" height="942" alt="Deterministic Togo run summary" src="https://github.com/user-attachments/assets/fe53bc15-fb07-42f6-a7bc-ee6a7e369ce9" />

### Motivation

The event-bus orchestrator can return normally after its maximum runtime expires even though some phases never completed. The Togo execution screen previously treated every normal return as success, so a timed-out flow could appear completed and callers had no durable, structured record explaining what actually ran.

This change derives the result at the Togo runtime boundary from the resolved flow and durable checkpoints. The generic event bus remains unchanged, while the CLI gains an accurate distinction between completed, failed, cancelled, and never-started work; reliable phase-level accounting; and a summary users can open when they are ready without losing their place in the live logs.

Coverage includes successful, failed, timed-out, cancelled, resumed, outcome-build-error, outcome-persistence-error, and TUI reconciliation paths.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
