### PR TITLE
Smoke test the dependency promotion notice (do not merge)

### DIFF
--- a/.deps/gate-test.md
+++ b/.deps/gate-test.md
@@ -4,3 +4,5 @@ It lives under `.deps/` so the gate treats the PR as changing dependencies, but
 `.deps/` is not one of the resolution inputs in `.builders/inputs_hash.py`, so no
 wheel rebuild is triggered. Delete this file and close the PR once the notice has
 been checked.
+
+Second commit, to check the notice is edited in place rather than duplicated.

--- a/.deps/gate-test.md
+++ b/.deps/gate-test.md
@@ -1,0 +1,8 @@
+Throwaway file used to smoke-test the dependency-wheel-promotion gate notice.
+
+It lives under `.deps/` so the gate treats the PR as changing dependencies, but
+`.deps/` is not one of the resolution inputs in `.builders/inputs_hash.py`, so no
+wheel rebuild is triggered. Delete this file and close the PR once the notice has
+been checked.
+
+Second commit, to check the notice is edited in place rather than duplicated.

--- a/.deps/gate-test.md
+++ b/.deps/gate-test.md
@@ -1,0 +1,6 @@
+Throwaway file used to smoke-test the dependency-wheel-promotion gate notice.
+
+It lives under `.deps/` so the gate treats the PR as changing dependencies, but
+`.deps/` is not one of the resolution inputs in `.builders/inputs_hash.py`, so no
+wheel rebuild is triggered. Delete this file and close the PR once the notice has
+been checked.

--- a/.deps/gate-test.md
+++ b/.deps/gate-test.md
@@ -1,8 +1,0 @@
-Throwaway file used to smoke-test the dependency-wheel-promotion gate notice.
-
-It lives under `.deps/` so the gate treats the PR as changing dependencies, but
-`.deps/` is not one of the resolution inputs in `.builders/inputs_hash.py`, so no
-wheel rebuild is triggered. Delete this file and close the PR once the notice has
-been checked.
-
-Second commit, to check the notice is edited in place rather than duplicated.


### PR DESCRIPTION
### What does this PR do?

Adds a throwaway file under `.deps/` so the `dependency-wheel-promotion` gate treats this as a dependency PR and posts its notice comment. Nothing here is meant to be merged.

`.deps/` is not one of the resolution inputs in `.builders/inputs_hash.py`, so this does not trigger a wheel rebuild.

### Motivation

The notice comment added in #24718 only runs from the base branch, since the gate is a `pull_request_target` workflow. It could not be exercised on its own PR, so this is the first chance to see it rendered.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged