### PR TITLE
[AI-7066] Record cancelled phase checkpoints

### DIFF
--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -17,7 +17,6 @@ from ddev.ai.react.process import ReActProcess
 from ddev.ai.runtime.checkpoints import (
     CancelledCheckpoint,
     CheckpointManager,
-    CheckpointStatus,
     CheckpointTokenInfo,
     FailedCheckpoint,
     GoalValidationRecord,
@@ -47,7 +46,7 @@ Treat the on-disk state as the source of truth and bring it to a correct, comple
 
 RESUME_NOTICE_ERROR = """
 
-The previous attempt recorded this error:
+The previous attempt recorded this before stopping:
 
 {error}"""
 
@@ -286,8 +285,14 @@ class AgenticPhase(Phase):
         system_prompt = render_inline(self._agent_config.system_prompt, context, self._resolver)
         if self._is_resume_frontier:
             prior = (context.get("checkpoints") or {}).get(self._phase_id)
-            error = prior.error if prior is not None and prior.status == CheckpointStatus.FAILED else None
-            system_prompt += build_resume_notice(error)
+            match prior:
+                case FailedCheckpoint():
+                    notice_error = prior.error
+                case CancelledCheckpoint():
+                    notice_error = prior.reason
+                case _:
+                    notice_error = None
+            system_prompt += build_resume_notice(notice_error)
         try:
             process = self._process_factory.create(
                 scope=self._scope,

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -312,17 +312,14 @@ class AgenticPhase(Phase):
 
     def build_failed_checkpoint(self, error: BaseException) -> FailedCheckpoint:
         """Include partial token and goal progress in a failed checkpoint."""
-        checkpoint = super().build_failed_checkpoint(error)
-        checkpoint.tokens = CheckpointTokenInfo(
-            total_input=self._total_input_tokens,
-            total_output=self._total_output_tokens,
-        )
-        checkpoint.goal_validations = self._goal_attempt_log or None
-        return checkpoint
+        return self._with_partial_progress(super().build_failed_checkpoint(error))
 
     def build_cancelled_checkpoint(self, error: asyncio.CancelledError) -> CancelledCheckpoint:
         """Include partial token and goal progress in a cancelled checkpoint."""
-        checkpoint = super().build_cancelled_checkpoint(error)
+        return self._with_partial_progress(super().build_cancelled_checkpoint(error))
+
+    def _with_partial_progress[T: FailedCheckpoint | CancelledCheckpoint](self, checkpoint: T) -> T:
+        """Attach tokens and goal progress accumulated before an interrupted phase stopped."""
         checkpoint.tokens = CheckpointTokenInfo(
             total_input=self._total_input_tokens,
             total_output=self._total_output_tokens,

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any, cast
 
 from ddev.ai.agent.scope import AgentRole, AgentScope
@@ -14,6 +15,7 @@ from ddev.ai.phases.goal import GOAL_TASK_SUFFIX, GoalValidationError, run_goal_
 from ddev.ai.phases.template import render_inline
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.runtime.checkpoints import (
+    CancelledCheckpoint,
     CheckpointManager,
     CheckpointStatus,
     CheckpointTokenInfo,
@@ -311,6 +313,16 @@ class AgenticPhase(Phase):
     def build_failed_checkpoint(self, error: BaseException) -> FailedCheckpoint:
         """Include partial token and goal progress in a failed checkpoint."""
         checkpoint = super().build_failed_checkpoint(error)
+        checkpoint.tokens = CheckpointTokenInfo(
+            total_input=self._total_input_tokens,
+            total_output=self._total_output_tokens,
+        )
+        checkpoint.goal_validations = self._goal_attempt_log or None
+        return checkpoint
+
+    def build_cancelled_checkpoint(self, error: asyncio.CancelledError) -> CancelledCheckpoint:
+        """Include partial token and goal progress in a cancelled checkpoint."""
+        checkpoint = super().build_cancelled_checkpoint(error)
         checkpoint.tokens = CheckpointTokenInfo(
             total_input=self._total_input_tokens,
             total_output=self._total_output_tokens,

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -144,13 +144,9 @@ class Phase(AsyncProcessor[PhaseTrigger]):
 
             outcome = await self.execute(context)
         except asyncio.CancelledError as error:
-            try:
-                self._checkpoint_manager.write_phase_checkpoint(
-                    self._phase_id,
-                    self.build_cancelled_checkpoint(error),
-                )
-            except Exception:
-                self._logger.exception("Failed to write cancellation checkpoint for phase %s", self._phase_id)
+            self._write_checkpoint_safely(
+                self.build_cancelled_checkpoint(error), "Failed to write cancellation checkpoint for phase %s"
+            )
             raise
 
         checkpoint = SuccessCheckpoint(
@@ -180,6 +176,15 @@ class Phase(AsyncProcessor[PhaseTrigger]):
             tokens=CheckpointTokenInfo(total_input=0, total_output=0),
         )
 
+    def _write_checkpoint_safely(
+        self, checkpoint: FailedCheckpoint | CancelledCheckpoint, failure_message: str
+    ) -> None:
+        """Persist a checkpoint, logging rather than raising if the write itself fails."""
+        try:
+            self._checkpoint_manager.write_phase_checkpoint(self._phase_id, checkpoint)
+        except Exception:
+            self._logger.exception(failure_message, self._phase_id)
+
     async def on_success(self, message: PhaseTrigger) -> None:
         """Emit PhaseTrigger to unblock dependent phases."""
         self.submit_message(
@@ -201,19 +206,14 @@ class Phase(AsyncProcessor[PhaseTrigger]):
     async def on_error(self, error: MessageProcessingError | ProcessorHookError) -> None:
         """Persist and publish a phase failure."""
         original_error = error.original_exception
-        try:
-            self._checkpoint_manager.write_phase_checkpoint(
-                self._phase_id,
-                self.build_failed_checkpoint(original_error),
+        self._write_checkpoint_safely(
+            self.build_failed_checkpoint(original_error), "Failed to write failure checkpoint for phase %s"
+        )
+        await self._callbacks.fire_phase_error(self._phase_id, original_error)
+        self.submit_message(
+            PhaseFailedMessage(
+                id=f"{self._phase_id}_failed",
+                phase_id=self._phase_id,
+                error=str(original_error),
             )
-        except Exception:
-            self._logger.exception("Failed to write failure checkpoint for phase %s", self._phase_id)
-        finally:
-            await self._callbacks.fire_phase_error(self._phase_id, original_error)
-            self.submit_message(
-                PhaseFailedMessage(
-                    id=f"{self._phase_id}_failed",
-                    phase_id=self._phase_id,
-                    error=str(original_error),
-                )
-            )
+        )

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from abc import abstractmethod
 from collections.abc import Callable
@@ -15,6 +16,7 @@ from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.config.models import PhaseConfig, RuntimeVariables
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.runtime.checkpoints import (
+    CancelledCheckpoint,
     CheckpointManager,
     CheckpointTokenInfo,
     FailedCheckpoint,
@@ -129,17 +131,27 @@ class Phase(AsyncProcessor[PhaseTrigger]):
     async def process_message(self, message: PhaseTrigger) -> None:
         """Immutable pipeline skeleton. Not intended to be overridden — implement execute() instead."""
         self._started_at = datetime.now(UTC)
-        await self._callbacks.fire_phase_start(self._phase_id)
+        try:
+            await self._callbacks.fire_phase_start(self._phase_id)
 
-        context: dict[str, Any] = {
-            **self._flow_variables,
-            **self._runtime_variables,
-            "phase_name": self._phase_id,
-            "checkpoints": self._checkpoint_manager.read(),
-        }
-        self._resolver = self._checkpoint_manager.resolve_template_variable
+            context: dict[str, Any] = {
+                **self._flow_variables,
+                **self._runtime_variables,
+                "phase_name": self._phase_id,
+                "checkpoints": self._checkpoint_manager.read(),
+            }
+            self._resolver = self._checkpoint_manager.resolve_template_variable
 
-        outcome = await self.execute(context)
+            outcome = await self.execute(context)
+        except asyncio.CancelledError as error:
+            try:
+                self._checkpoint_manager.write_phase_checkpoint(
+                    self._phase_id,
+                    self.build_cancelled_checkpoint(error),
+                )
+            except Exception:
+                self._logger.exception("Failed to write cancellation checkpoint for phase %s", self._phase_id)
+            raise
 
         checkpoint = SuccessCheckpoint(
             started_at=self._started_at.isoformat(),
@@ -156,6 +168,17 @@ class Phase(AsyncProcessor[PhaseTrigger]):
         self._checkpoint_manager.write_memory(self._phase_id, outcome.memory_text)
         self._checkpoint_manager.write_phase_checkpoint(self._phase_id, checkpoint)
         await self._callbacks.fire_phase_finish(self._phase_id)
+
+    def build_cancelled_checkpoint(self, error: asyncio.CancelledError) -> CancelledCheckpoint:
+        """Build a checkpoint for a phase interrupted by cancellation."""
+        if self._started_at is None:  # pragma: no cover - process_message sets this before cancellation is possible
+            raise RuntimeError("Cannot build a cancellation checkpoint before the phase starts")
+        return CancelledCheckpoint(
+            started_at=self._started_at.isoformat(),
+            finished_at=datetime.now(UTC).isoformat(),
+            reason=str(error) or None,
+            tokens=CheckpointTokenInfo(total_input=0, total_output=0),
+        )
 
     async def on_success(self, message: PhaseTrigger) -> None:
         """Emit PhaseTrigger to unblock dependent phases."""

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -24,6 +24,7 @@ class CheckpointReadError(Exception):
 class CheckpointStatus(StrEnum):
     SUCCESS = "success"
     FAILED = "failed"
+    CANCELLED = "cancelled"
 
 
 class CheckpointTokenInfo(BaseModel):
@@ -60,7 +61,21 @@ class FailedCheckpoint(BaseModel):
     goal_validations: list[GoalValidationRecord] | None = None
 
 
-PhaseCheckpoint = Annotated[SuccessCheckpoint | FailedCheckpoint, Field(discriminator="status")]
+class CancelledCheckpoint(BaseModel):
+    """Checkpoint written when a started phase is cancelled before completion."""
+
+    status: Literal[CheckpointStatus.CANCELLED] = CheckpointStatus.CANCELLED
+    started_at: str
+    finished_at: str
+    reason: str | None = None
+    tokens: CheckpointTokenInfo
+    goal_validations: list[GoalValidationRecord] | None = None
+
+
+PhaseCheckpoint = Annotated[
+    SuccessCheckpoint | FailedCheckpoint | CancelledCheckpoint,
+    Field(discriminator="status"),
+]
 
 # TypeAdapter provides model_validate() for annotated union types that aren't BaseModel subclasses.
 CheckpointAdapter: TypeAdapter[PhaseCheckpoint] = TypeAdapter(PhaseCheckpoint)

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import asyncio
 import json
 from pathlib import Path
 
@@ -19,6 +20,7 @@ from ddev.ai.phases.template import render_inline
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.runtime.agent_log import AgentLogger
 from ddev.ai.runtime.checkpoints import (
+    CancelledCheckpoint,
     CheckpointManager,
     CheckpointTokenInfo,
     FailedCheckpoint,
@@ -613,6 +615,29 @@ async def test_on_error_writes_tokens_and_goal_validations_to_checkpoint(flow_di
     assert cp.tokens == CheckpointTokenInfo(total_input=42, total_output=17)
     assert cp.goal_validations == [GoalValidationRecord(task="t1", attempts=2, final_valid=False)]
     assert cp.error == "something went wrong"
+
+
+async def test_cancellation_writes_partial_tokens_and_goal_validations(flow_dir, monkeypatch, message_queue):
+    worker = MockAgent([make_response("done", 0, 0)])
+    phase, mgr = make_agent_phase(flow_dir, worker, monkeypatch, message_queue)
+
+    phase._total_input_tokens = 42
+    phase._total_output_tokens = 17
+    phase._goal_attempt_log = [GoalValidationRecord(task="t1", attempts=2, final_valid=False)]
+
+    async def cancel(_context):
+        raise asyncio.CancelledError("maximum runtime reached")
+
+    monkeypatch.setattr(phase, "execute", cancel)
+
+    with pytest.raises(asyncio.CancelledError, match="maximum runtime reached"):
+        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    checkpoint = mgr.read()["p1"]
+    assert isinstance(checkpoint, CancelledCheckpoint)
+    assert checkpoint.tokens == CheckpointTokenInfo(total_input=42, total_output=17)
+    assert checkpoint.goal_validations == [GoalValidationRecord(task="t1", attempts=2, final_valid=False)]
+    assert checkpoint.reason == "maximum runtime reached"
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -875,7 +875,35 @@ async def test_resume_frontier_phase_injects_notice_without_error(flow_dir, monk
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     assert "RESUMED RUN" in captured["system_prompt"]
-    assert "previous attempt recorded this error" not in captured["system_prompt"]
+    assert "previous attempt recorded this before stopping" not in captured["system_prompt"]
+
+
+async def test_resume_frontier_phase_injects_notice_with_cancellation_reason(flow_dir, monkeypatch, message_queue):
+    """A frontier phase with a prior cancelled checkpoint gets the resume notice plus the reason."""
+    mock_agent = MockAgent([make_response("done", 100, 50), make_response("summary", 10, 5)])
+    captured: dict = {}
+    phase, mgr = make_agent_phase(
+        flow_dir,
+        mock_agent,
+        monkeypatch,
+        message_queue,
+        resume_frontier=frozenset({"p1"}),
+        captured_worker_kwargs=captured,
+    )
+    mgr.write_phase_checkpoint(
+        "p1",
+        CancelledCheckpoint(
+            started_at="2026-01-01T00:00:00+00:00",
+            finished_at="2026-01-01T00:00:05+00:00",
+            reason="Orchestrator exceeded max_timeout of 0.05s",
+            tokens=CheckpointTokenInfo(total_input=0, total_output=0),
+        ),
+    )
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert "RESUMED RUN" in captured["system_prompt"]
+    assert "Orchestrator exceeded max_timeout of 0.05s" in captured["system_prompt"]
 
 
 async def test_non_frontier_phase_gets_no_resume_notice(flow_dir, monkeypatch, message_queue):

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import asyncio
+import logging
 from datetime import UTC, datetime
 
 import pytest
@@ -285,16 +286,41 @@ async def test_process_message_writes_cancelled_checkpoint_and_reraises(
     assert message_queue.empty()
 
 
-async def test_cancellation_checkpoint_failure_does_not_mask_cancellation(
+async def test_process_message_writes_cancelled_checkpoint_with_no_reason(
     flow_dir, flow_context, message_queue, monkeypatch
+):
+    """A bare CancelledError (e.g. a plain Ctrl+C) carries no message, so reason stays None."""
+    phase, mgr = _make_stub_phase(flow_dir, flow_context, message_queue)
+
+    async def cancel(_context):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(phase, "execute", cancel)
+
+    with pytest.raises(asyncio.CancelledError):
+        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    checkpoint = mgr.read()["p1"]
+    assert isinstance(checkpoint, CancelledCheckpoint)
+    assert checkpoint.reason is None
+
+
+async def test_cancellation_checkpoint_failure_does_not_mask_cancellation(
+    flow_dir, flow_context, message_queue, monkeypatch, caplog
 ):
     phase, mgr = _make_stub_phase(flow_dir, flow_context, message_queue)
 
     async def cancel(_context):
         raise asyncio.CancelledError("stop")
 
-    monkeypatch.setattr(phase, "execute", cancel)
-    monkeypatch.setattr(mgr, "write_phase_checkpoint", lambda *_: (_ for _ in ()).throw(OSError("read only")))
+    def fail_to_write(*_args):
+        raise OSError("read only")
 
-    with pytest.raises(asyncio.CancelledError, match="stop"):
-        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+    monkeypatch.setattr(phase, "execute", cancel)
+    monkeypatch.setattr(mgr, "write_phase_checkpoint", fail_to_write)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(asyncio.CancelledError, match="stop"):
+            await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    assert any("Failed to write cancellation checkpoint for phase p1" in r.getMessage() for r in caplog.records)

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -2,13 +2,17 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import asyncio
 from datetime import UTC, datetime
+
+import pytest
 
 from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
 from ddev.ai.config.models import PhaseConfig
 from ddev.ai.phases.base import FlowContext, Phase, PhaseOutcome
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.runtime.checkpoints import (
+    CancelledCheckpoint,
     CheckpointManager,
     CheckpointTokenInfo,
     FailedCheckpoint,
@@ -257,3 +261,40 @@ async def test_process_message_writes_memory_and_checkpoint(flow_dir, flow_conte
     assert checkpoint.goal_validations == [GoalValidationRecord(task="t1", attempts=1, final_valid=True)]
     assert checkpoint.started_at
     assert checkpoint.finished_at
+
+
+async def test_process_message_writes_cancelled_checkpoint_and_reraises(
+    flow_dir, flow_context, message_queue, monkeypatch
+):
+    phase, mgr = _make_stub_phase(flow_dir, flow_context, message_queue)
+
+    async def cancel(_context):
+        raise asyncio.CancelledError("maximum runtime reached")
+
+    monkeypatch.setattr(phase, "execute", cancel)
+
+    with pytest.raises(asyncio.CancelledError, match="maximum runtime reached"):
+        await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    checkpoint = mgr.read()["p1"]
+    assert isinstance(checkpoint, CancelledCheckpoint)
+    assert checkpoint.reason == "maximum runtime reached"
+    assert checkpoint.started_at
+    assert checkpoint.finished_at
+    assert checkpoint.tokens == CheckpointTokenInfo(total_input=0, total_output=0)
+    assert message_queue.empty()
+
+
+async def test_cancellation_checkpoint_failure_does_not_mask_cancellation(
+    flow_dir, flow_context, message_queue, monkeypatch
+):
+    phase, mgr = _make_stub_phase(flow_dir, flow_context, message_queue)
+
+    async def cancel(_context):
+        raise asyncio.CancelledError("stop")
+
+    monkeypatch.setattr(phase, "execute", cancel)
+    monkeypatch.setattr(mgr, "write_phase_checkpoint", lambda *_: (_ for _ in ()).throw(OSError("read only")))
+
+    with pytest.raises(asyncio.CancelledError, match="stop"):
+        await phase.process_message(PhaseTrigger(id="start", phase_id=None))

--- a/ddev/tests/ai/runtime/helpers.py
+++ b/ddev/tests/ai/runtime/helpers.py
@@ -5,6 +5,7 @@
 from typing import Any
 
 from ddev.ai.runtime.checkpoints import (
+    CancelledCheckpoint,
     CheckpointAdapter,
     CheckpointStatus,
     CheckpointTokenInfo,
@@ -38,3 +39,7 @@ def make_success_checkpoint(**kwargs: Any) -> SuccessCheckpoint:
 
 def make_failed_checkpoint(**kwargs: Any) -> FailedCheckpoint:
     return make_checkpoint(CheckpointStatus.FAILED, kwargs)
+
+
+def make_cancelled_checkpoint(**kwargs: Any) -> CancelledCheckpoint:
+    return make_checkpoint(CheckpointStatus.CANCELLED, kwargs)

--- a/ddev/tests/ai/runtime/test_checkpoints.py
+++ b/ddev/tests/ai/runtime/test_checkpoints.py
@@ -7,12 +7,14 @@ from pathlib import Path
 import pytest
 import yaml
 
+from ddev.ai.config.models import FlowEntry, ResolvedFlow
 from ddev.ai.runtime.checkpoints import (
     CancelledCheckpoint,
     CheckpointManager,
     CheckpointReadError,
     FailedCheckpoint,
     SuccessCheckpoint,
+    resolve_resume_state,
 )
 
 from .helpers import make_cancelled_checkpoint, make_failed_checkpoint, make_success_checkpoint
@@ -195,3 +197,25 @@ def test_read_raises_on_invalid_checkpoint_entry(manager: CheckpointManager):
     manager._path.write_text(yaml.dump(raw))
     with pytest.raises(CheckpointReadError, match="phase 'b'"):
         manager.read()
+
+
+# ---------------------------------------------------------------------------
+# resolve_resume_state
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_resume_state_cancelled_checkpoint_stays_in_frontier(manager: CheckpointManager):
+    """A cancelled phase did not succeed, so it belongs in the resume frontier, not completed."""
+    manager.write_phase_checkpoint("p1", make_cancelled_checkpoint(reason="maximum runtime reached"))
+    flow = ResolvedFlow(
+        name="test-flow",
+        agents={},
+        phases={},
+        flow=[FlowEntry(phase="p1"), FlowEntry(phase="p2", dependencies=["p1"])],
+        variables={},
+    )
+
+    completed, frontier = resolve_resume_state(flow, manager)
+
+    assert completed == set()
+    assert frontier == {"p1"}

--- a/ddev/tests/ai/runtime/test_checkpoints.py
+++ b/ddev/tests/ai/runtime/test_checkpoints.py
@@ -8,13 +8,14 @@ import pytest
 import yaml
 
 from ddev.ai.runtime.checkpoints import (
+    CancelledCheckpoint,
     CheckpointManager,
     CheckpointReadError,
     FailedCheckpoint,
     SuccessCheckpoint,
 )
 
-from .helpers import make_failed_checkpoint, make_success_checkpoint
+from .helpers import make_cancelled_checkpoint, make_failed_checkpoint, make_success_checkpoint
 
 
 @pytest.fixture
@@ -86,9 +87,12 @@ def test_write_creates_parent_dirs(tmp_path: Path):
 def test_write_multiple_phases(manager: CheckpointManager):
     manager.write_phase_checkpoint("phase1", make_success_checkpoint())
     manager.write_phase_checkpoint("phase2", make_failed_checkpoint())
+    manager.write_phase_checkpoint("phase3", make_cancelled_checkpoint(reason="maximum runtime reached"))
     data = manager.read()
     assert isinstance(data["phase1"], SuccessCheckpoint)
     assert isinstance(data["phase2"], FailedCheckpoint)
+    assert isinstance(data["phase3"], CancelledCheckpoint)
+    assert data["phase3"].reason == "maximum runtime reached"
 
 
 def test_write_overwrites_existing_phase(manager: CheckpointManager):
@@ -180,6 +184,7 @@ def test_successful_phases_returns_only_succeeded(manager: CheckpointManager):
     manager.write_phase_checkpoint("a", make_success_checkpoint())
     manager.write_phase_checkpoint("b", make_failed_checkpoint())
     manager.write_phase_checkpoint("c", make_success_checkpoint())
+    manager.write_phase_checkpoint("d", make_cancelled_checkpoint())
     assert manager.successful_phases() == {"a", "c"}
 
 

--- a/ddev/tests/ai/runtime/test_orchestrator.py
+++ b/ddev/tests/ai/runtime/test_orchestrator.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any
@@ -18,7 +19,7 @@ from ddev.ai.constants import CORE_PHASES_DIR, CORE_PHASES_PACKAGE
 from ddev.ai.phases.base import Phase, PhaseOutcome
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.registry import PhaseRegistry
-from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointStatus
+from ddev.ai.runtime.checkpoints import CancelledCheckpoint, CheckpointManager, CheckpointStatus
 from ddev.ai.runtime.orchestrator import PhaseOrchestrator
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.event_bus.exceptions import FatalProcessingError, HookName, OrchestratorHookError
@@ -272,6 +273,35 @@ def test_run_executes_phases_in_dependency_order(tmp_path, make_orchestrator):
     checkpoints = mgr.read()
     assert checkpoints["a"].status == CheckpointStatus.SUCCESS
     assert checkpoints["b"].status == CheckpointStatus.SUCCESS
+
+
+def test_max_timeout_writes_cancelled_checkpoint_for_running_phase(tmp_path, make_orchestrator):
+    core = tmp_path / "timeout_core"
+    write(
+        core / "f.yaml",
+        "- type: phase\n  config:\n    name: waiting\n    class: WaitingPhase\n"
+        "- type: flow\n  config:\n    name: demo\n    flow:\n      - phase: waiting\n",
+    )
+
+    class WaitingPhase(Phase):
+        async def execute(self, context):
+            await asyncio.Event().wait()
+            return PhaseOutcome(memory_text="unreachable")
+
+    checkpoint_path = tmp_path / "timeout-checkpoints.yaml"
+    orchestrator, _, _ = make_orchestrator(
+        core,
+        grace_period=0.01,
+        runtime_variables={"max_timeout": "0.05"},
+        register_phases={"WaitingPhase": WaitingPhase},
+        checkpoint_path=checkpoint_path,
+    )
+
+    orchestrator.run()
+
+    checkpoint = CheckpointManager(checkpoint_path).read()["waiting"]
+    assert isinstance(checkpoint, CancelledCheckpoint)
+    assert checkpoint.reason == "Orchestrator exceeded max_timeout of 0.05s"
 
 
 def test_run_raises_runtime_error_when_phase_fails(tmp_path, make_orchestrator):

--- a/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_flow_screen.py
@@ -239,6 +239,29 @@ def test_has_resumable_run_failed_checkpoint(tmp_path: Path) -> None:
     assert has_resumable_run(flow, runs_dir=tmp_path)
 
 
+def test_has_resumable_run_cancelled_checkpoint(tmp_path: Path) -> None:
+    """A phase checkpoint with status: cancelled is resumable (not complete)."""
+    from ddev.cli.meta.ai.tui.runs import flow_slug, has_resumable_run
+
+    flow = _make_flow(n_phases=2)
+    run_dir = tmp_path / flow_slug(flow)
+    run_dir.mkdir()
+    # Write a cancelled checkpoint for the first phase only
+    first_phase = flow.flow[0].phase
+    (run_dir / "checkpoints.yaml").write_text(
+        f"{first_phase}:\n"
+        "  status: cancelled\n"
+        "  started_at: '2024-01-01T00:00:00'\n"
+        "  finished_at: '2024-01-01T00:01:00'\n"
+        "  reason: Orchestrator exceeded max_timeout\n"
+        "  tokens:\n"
+        "    total_input: 0\n"
+        "    total_output: 0\n"
+    )
+    # A cancelled phase means the run was interrupted before completing → resumable
+    assert has_resumable_run(flow, runs_dir=tmp_path)
+
+
 # ---------------------------------------------------------------------------
 # FlowScreen structure
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> This is PR 1 of 3 in a stacked series: 
> 1. #24731 **<- you are here**
> 2. #24729
> 3. #24748 

### What does this PR do?

- Adds a `cancelled` checkpoint status for phases that started but were interrupted before completing.
- Persists the phase start and finish times, cancellation reason, recorded token usage, and goal-validation progress.
- Re-raises `asyncio.CancelledError` unchanged after checkpointing, preserving the existing cancellation behavior. A checkpoint write failure is logged without masking the cancellation.
- Keeps resume behavior unchanged: only successful checkpoints are reused, so cancelled phases run again.

### Motivation

Previously, a phase cancelled by the orchestrator's maximum timeout had no checkpoint. Downstream consumers therefore could not distinguish a phase that never started from one that ran—potentially modifying files and consuming tokens—before being cancelled.

Recording cancellation as durable phase state provides that distinction without adding termination reasons to the event bus. It also gives the deterministic run-outcome and TUI work in the follow-up PR accurate backend state to report.

Coverage includes checkpoint serialization, cancellation propagation, checkpoint-write failures, partial agentic accounting, and an orchestrator maximum-timeout integration test.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
