### PR TITLE
Retry the uv install in setup-ddev

### DIFF
--- a/.github/actions/setup-ddev/action.yml
+++ b/.github/actions/setup-ddev/action.yml
@@ -57,7 +57,20 @@ runs:
       shell: bash
       run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
+    # setup-uv resolves the uv version and its download URL from a manifest on
+    # raw.githubusercontent.com. That fetch has a 5s timeout and no retries, so a single
+    # transient network error fails the job with "fetch failed". At ~288 test jobs per run,
+    # a per-job failure rate of well under 1% still breaks roughly one run in six, so the
+    # attempt is retried once. A persistent failure still fails the job on the retry.
     - name: Install uv
+      id: install-uv
+      continue-on-error: true
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      with:
+        enable-cache: false
+
+    - name: Install uv (retry)
+      if: ${{ steps.install-uv.outcome == 'failure' }}
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         enable-cache: false


### PR DESCRIPTION
setup-uv fetches a version manifest from raw.githubusercontent.com to resolve both the uv version and the artifact download URL. Its fetch helper (src/utils/fetch.ts) uses a 5s timeout and performs no retries, so one transient network error aborts the step with "fetch failed" — as happened to the Cilium job in run 30476158752, which failed after 210ms.

The per-job rate is low (1 job in 1728 across the six most recent Master runs), but with 288 jobs per run that is roughly a 15% chance of at least one job failing per run, on a different integration each time. Retrying the step once drops that to well under 1%.

Pinning the uv version would not help: getArtifact reads the manifest for the download URL and checksum even when the version is already known.

### What does this PR do?
Add a retry on failure to reduce the chance of job failing from ~15% to ~0.01%.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
