### PR TITLE
envoy: tag global rate limit counters with stat_prefix

### DIFF
--- a/envoy/changelog.d/24735.added
+++ b/envoy/changelog.d/24735.added
@@ -1,0 +1,1 @@
+Tag ``cluster.ratelimit`` counters with ``stat_prefix`` so global rate limit filters configured with a stat prefix are collected instead of dropped as an unknown tag.

--- a/envoy/datadog_checks/envoy/metrics.py
+++ b/envoy/datadog_checks/envoy/metrics.py
@@ -928,10 +928,6 @@ METRICS = {
         ),
         'method': 'monotonic_count',
     },
-    # The empty second tag configuration is required, not an oversight: it is what puts a
-    # zero-length option in this branch's tag list so counters emitted without a
-    # `stat_prefix` still parse. The prefix is read from the branch, so every counter here
-    # is tagged when one is present. `cluster.ext_authz` relies on the same arrangement.
     'cluster.ratelimit.failure_mode_allowed': {
         'tags': (
             ('envoy_cluster', ),

--- a/envoy/datadog_checks/envoy/metrics.py
+++ b/envoy/datadog_checks/envoy/metrics.py
@@ -907,7 +907,7 @@ METRICS = {
     'cluster.ratelimit.ok': {
         'tags': (
             ('envoy_cluster', ),
-            (),
+            ('stat_prefix', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -915,7 +915,7 @@ METRICS = {
     'cluster.ratelimit.error': {
         'tags': (
             ('envoy_cluster', ),
-            (),
+            ('stat_prefix', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -923,11 +923,15 @@ METRICS = {
     'cluster.ratelimit.over_limit': {
         'tags': (
             ('envoy_cluster', ),
-            (),
+            ('stat_prefix', ),
             (),
         ),
         'method': 'monotonic_count',
     },
+    # The empty second tag configuration is required, not an oversight: it is what puts a
+    # zero-length option in this branch's tag list so counters emitted without a
+    # `stat_prefix` still parse. The prefix is read from the branch, so every counter here
+    # is tagged when one is present. `cluster.ext_authz` relies on the same arrangement.
     'cluster.ratelimit.failure_mode_allowed': {
         'tags': (
             ('envoy_cluster', ),

--- a/envoy/tests/fixtures/legacy/stat_prefix_ratelimit
+++ b/envoy/tests/fixtures/legacy/stat_prefix_ratelimit
@@ -1,0 +1,8 @@
+cluster.foo.ratelimit.error: 0
+cluster.foo.ratelimit.failure_mode_allowed: 1
+cluster.foo.ratelimit.ok: 2
+cluster.foo.ratelimit.over_limit: 3
+cluster.foo.ratelimit.bar.error: 4
+cluster.foo.ratelimit.bar.failure_mode_allowed: 5
+cluster.foo.ratelimit.bar.ok: 6
+cluster.foo.ratelimit.bar.over_limit: 7

--- a/envoy/tests/legacy/common.py
+++ b/envoy/tests/legacy/common.py
@@ -63,6 +63,13 @@ EXT_PROC_METRICS = [
     "envoy.http.ext_proc.send_immediate_resp_upstream_ignored",
 ]
 
+GLOBAL_RATE_LIMIT_METRICS = [
+    "envoy.cluster.ratelimit.error",
+    "envoy.cluster.ratelimit.failure_mode_allowed",
+    "envoy.cluster.ratelimit.ok",
+    "envoy.cluster.ratelimit.over_limit",
+]
+
 LOCAL_RATE_LIMIT_METRICS = [
     "envoy.http_local_rate_limit.enabled",
     "envoy.http_local_rate_limit.enforced",

--- a/envoy/tests/legacy/test_integration.py
+++ b/envoy/tests/legacy/test_integration.py
@@ -12,12 +12,13 @@ from .common import (
     ADAPTIVE_CONCURRENCY_STAT_PREFIX_TAG,
     ENVOY_VERSION,
     EXT_AUTHZ_METRICS,
+    GLOBAL_RATE_LIMIT_METRICS,
     INSTANCES,
     RBAC_METRICS,
 )
 
 CHECK_NAME = 'envoy'
-UNIQUE_METRICS = EXT_AUTHZ_METRICS + RBAC_METRICS
+UNIQUE_METRICS = EXT_AUTHZ_METRICS + GLOBAL_RATE_LIMIT_METRICS + RBAC_METRICS
 
 pytestmark = [
     pytest.mark.integration,
@@ -34,7 +35,7 @@ def test_success(aggregator, check, dd_run_check):
     metrics_collected = 0
     for metric in METRICS:
         collected_metrics = aggregator.metrics(METRIC_PREFIX + metric)
-        # The ext_auth and rbac metrics are excluded because the stats_prefix is not always present.
+        # The ext_auth, rate limit and rbac metrics are excluded because the stats_prefix is not always present.
         # They're tested in a different test.
         if collected_metrics and collected_metrics[0].name not in UNIQUE_METRICS:
             expected_tags = [t for t in METRICS[metric]['tags'] if t]

--- a/envoy/tests/legacy/test_unit.py
+++ b/envoy/tests/legacy/test_unit.py
@@ -21,6 +21,7 @@ from .common import (
     EXT_AUTHZ_METRICS,
     EXT_PROC_METRICS,
     FLAVOR,
+    GLOBAL_RATE_LIMIT_METRICS,
     HOST,
     INSTANCES,
     LOCAL_RATE_LIMIT_METRICS,
@@ -271,6 +272,12 @@ def test_metadata_not_collected(datadog_agent, check):
             ['stat_prefix:bar'],
         ),
         (
+            './legacy/stat_prefix_ratelimit',
+            GLOBAL_RATE_LIMIT_METRICS,
+            ['cluster_name:foo', 'envoy_cluster:foo'],
+            ['stat_prefix:bar'],
+        ),
+        (
             './legacy/stat_prefix_ext_proc',
             EXT_PROC_METRICS,
             ['stat_prefix:bar'],
@@ -291,6 +298,7 @@ def test_metadata_not_collected(datadog_agent, check):
     ],
     ids=[
         "stats_prefix_ext_authz",
+        "stats_prefix_ratelimit",
         "stats_prefix_ext_proc",
         "rbac_enforce_metrics",
         "rbac_shadow_metrics",


### PR DESCRIPTION
### What does this PR do?

Gives the four `cluster.ratelimit.*` counters a `stat_prefix` tag configuration, so counters emitted by an HTTP global rate limit filter configured with `stat_prefix` are collected and tagged rather than discarded.

The HTTP global rate limit filter accepts a [`stat_prefix`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ratelimit/v3/rate_limit.proto#envoy-v3-api-field-extensions-filters-http-ratelimit-v3-ratelimit-stat-prefix), documented as "Optional additional prefix to use when emitting statistics. This allows to distinguish emitted statistics between configured `ratelimit` filters in an HTTP filter chain." Envoy inserts it between `ratelimit` and the counter name in `StatNames::createPoolStatName`:

```cpp
return absl::StrCat("ratelimit",
                    stat_prefix.empty() ? EMPTY_STRING : absl::StrCat(".", stat_prefix), ".",
                    name);
```

Those counters are charged to the upstream cluster's stats scope, so a prefixed filter emits `cluster.<cluster>.ratelimit.<stat_prefix>.ok` where an unprefixed one emits `cluster.<cluster>.ratelimit.ok`.

`cluster.ratelimit.*` declared no tag configuration for that position, so `<stat_prefix>` was collected into the tag builder, ended up in `unknown_tags`, and `parse_metric` raised `UnknownTags`. The legacy check's handler logs at debug level and `continue`s, so the counter was dropped. The fix mirrors the arrangement `cluster.ext_authz.*` already uses for the same situation.

One detail worth flagging for review: `cluster.ratelimit.failure_mode_allowed` keeps an empty tag configuration in the prefix position on purpose, and I added a comment saying so. `make_metric_tree` collects each branch's tag configurations and `_parse_metric` derives `minimum_tag_length` from the shortest one, so if every counter under `cluster.ratelimit` declared `('stat_prefix', )` the branch would no longer admit a zero-length match and **unprefixed** counters would start failing with `UnknownMetric`. I hit exactly that on my first attempt. Because tags are read from the branch rather than the individual entry, `failure_mode_allowed` is still tagged when a prefix is present. `cluster.ext_authz` depends on the same arrangement today, via `cluster.ext_authz.failure_mode_allowed`.

`tests/legacy/test_integration.py::test_success` asserts that every declared tag configuration is present on the collected metrics, which cannot hold for a prefix only some filters set — the `api_v3` fixture's rate limit filter has none, so the job failed on `cluster.ratelimit.error` until I excluded these counters. `EXT_AUTHZ_METRICS` and `RBAC_METRICS` are already excluded from that assertion for exactly this reason, so the global rate limit counters join them, and both forms stay covered by `test_stats_prefix_optional_tags`. The metrics still count toward the job's `metrics_collected` total.

Verified against `parse_metric` for all four counters in both forms:

| Raw Envoy stat | Parsed metric | `stat_prefix` tag |
| --- | --- | --- |
| `cluster.foo.ratelimit.ok` | `envoy.cluster.ratelimit.ok` | none |
| `cluster.foo.ratelimit.bar.ok` | `envoy.cluster.ratelimit.ok` | `bar` |
| `cluster.foo.ratelimit.over_limit` | `envoy.cluster.ratelimit.over_limit` | none |
| `cluster.foo.ratelimit.bar.over_limit` | `envoy.cluster.ratelimit.over_limit` | `bar` |

`error` and `failure_mode_allowed` behave the same way, and `cluster.ext_authz.*` is unchanged in both forms.

No metric names change, so `metadata.csv` needs no update. Only the OpenMetrics V2 path remains untagged, because Envoy ships no default tag extractor for this prefix under a cluster scope — its `well_known_names.cc` entry, `addTokenized(RATELIMIT_PREFIX, "ratelimit.$.**")`, is anchored at the start of the name and so only matches the network rate limit filter, with no counterpart to the `cluster.*.ext_authz.$.**` extractor. That is an upstream Envoy gap and out of scope here.

### Motivation

We run three global rate limit filters in one HTTP filter chain at different stages on our edge Envoy fleet, and their `ok` and `over_limit` counters all collapse onto the same series because they share an upstream cluster. `stat_prefix` is the documented way to tell them apart, but setting it made the counters disappear from Datadog instead of gaining a dimension, which is worse than the merged view we started from.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
  - Requesting **`qa/required`**: this changes data the Agent emits for anyone setting `stat_prefix` on a global rate limit filter. I can't apply labels from a fork, so a maintainer will need to add it — `validate-all` fails until then.

**Two things need a maintainer**, both permission limits rather than open work: adding the `qa/required` label, and taking this out of draft (`markPullRequestReadyForReview` is blocked for my account). Tests, lint and validations all pass on both Envoy environments.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
