### PR TITLE
[flink] submit Counter metrics as monotonic_count, not gauge

### DIFF
--- a/flink/changelog.d/24740.fixed
+++ b/flink/changelog.d/24740.fixed
@@ -1,0 +1,1 @@
+Submit Flink Counter metrics (`numRecordsIn`, `numRecordsOut`, etc.) as `count` instead of `gauge` in the OpenMetrics-based collection mode.

--- a/flink/datadog_checks/flink/check.py
+++ b/flink/datadog_checks/flink/check.py
@@ -2,9 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import re
+
 from datadog_checks.base import OpenMetricsBaseCheckV2
 
-from .metrics import METRIC_MAP
+from .metrics import COUNTER_METRICS, METRIC_MAP
 
 
 class FlinkCheck(OpenMetricsBaseCheckV2):
@@ -19,6 +21,10 @@ class FlinkCheck(OpenMetricsBaseCheckV2):
     __NAMESPACE__ = 'flink'
     DEFAULT_METRIC_LIMIT = 0
 
+    def __init__(self, name, init_config, instances):
+        super().__init__(name, init_config, instances)
+        self.check_initializations.append(self._configure_counter_transformers)
+
     def get_default_config(self):
         # Flink's Prometheus reporter labels every series with `host` to
         # identify the source JobManager/TaskManager. That label collides
@@ -27,5 +33,27 @@ class FlinkCheck(OpenMetricsBaseCheckV2):
         return {
             'hostname_label': 'host',
             'exclude_labels': ['host'],
-            'metrics': [METRIC_MAP],
+            # Counters are handled separately below: Flink's Prometheus reporter
+            # always describes them as `# TYPE ... gauge`, so the default
+            # (payload-trusting) transform would submit them as gauges.
+            'metrics': [{k: v for k, v in METRIC_MAP.items() if k not in COUNTER_METRICS}],
         }
+
+    def _configure_counter_transformers(self):
+        # Registered as a custom transformer (rather than a `metrics` config entry)
+        # because forcing OpenMetricsBaseCheckV2's built-in `counter` type would
+        # append a `.count` suffix to the metric name, breaking parity with the
+        # names Flink's legacy DatadogHttpReporterFactory-based reporter already
+        # uses. Fully anchored: e.g. `numRecordsIn` is a substring of
+        # `numRecordsInPerSecond`, which must stay a gauge.
+        pattern = r'^(?:{})$'.format('|'.join(re.escape(name) for name in COUNTER_METRICS))
+        for scraper in self.scrapers.values():
+            scraper.metric_transformer.add_custom_transformer(pattern, self._transform_counter, pattern=True)
+
+    def _transform_counter(self, metric, sample_data, runtime_data):
+        metric_name = METRIC_MAP[metric.name]
+        flush_first_value = runtime_data['flush_first_value']
+        for sample, tags, hostname in sample_data:
+            self.monotonic_count(
+                metric_name, sample.value, tags=tags, hostname=hostname, flush_first_value=flush_first_value
+            )

--- a/flink/datadog_checks/flink/metrics.py
+++ b/flink/datadog_checks/flink/metrics.py
@@ -117,3 +117,32 @@ METRIC_MAP = {
     'flink_taskmanager_job_task_operator_numRecordsOutPerSecond': 'operator.numRecordsOutPerSec',
     'flink_taskmanager_job_task_operator_numSplitsProcessed': 'operator.numSplitsProcessed',
 }
+
+# Raw Prometheus names that are Flink Counters (per Flink's own metric type docs:
+# https://nightlies.apache.org/flink/flink-docs-stable/docs/ops/metrics/). Flink's
+# `flink-metrics-prometheus` reporter maps Counter, Gauge, and Meter alike to a
+# Prometheus Gauge collector -- "Prometheus counters cannot be decremented" -- so
+# every metric's scraped `# TYPE` line reads `gauge` regardless of its real Flink
+# type. That line can't be used to tell them apart; this list has to be hardcoded
+# from Flink's documented semantics and submitted as `monotonic_count` explicitly
+# (see check.py). Restarts/checkpoint counts are deliberately excluded: Flink itself
+# classifies those as Gauge, since they can reset on a JobManager failover.
+COUNTER_METRICS = frozenset(
+    {
+        'flink_taskmanager_job_task_numRecordsIn',
+        'flink_taskmanager_job_task_numRecordsOut',
+        'flink_taskmanager_job_task_numBytesOut',
+        'flink_taskmanager_job_task_numBuffersOut',
+        'flink_taskmanager_job_task_numLateRecordsDropped',
+        'flink_taskmanager_job_task_Shuffle_Netty_Input_numBytesInLocal',
+        'flink_taskmanager_job_task_Shuffle_Netty_Input_numBytesInRemote',
+        'flink_taskmanager_job_task_Shuffle_Netty_Input_numBuffersInLocal',
+        'flink_taskmanager_job_task_Shuffle_Netty_Input_numBuffersInRemote',
+        'flink_taskmanager_job_task_operator_numRecordsIn',
+        'flink_taskmanager_job_task_operator_numRecordsOut',
+        'flink_taskmanager_job_task_operator_numLateRecordsDropped',
+        'flink_taskmanager_job_task_operator_numSplitsProcessed',
+        'flink_taskmanager_job_task_operator_commitsSucceeded',
+        'flink_taskmanager_job_task_operator_commitsFailed',
+    }
+)

--- a/flink/tests/common.py
+++ b/flink/tests/common.py
@@ -55,3 +55,29 @@ METRICS = [
         "tags": TAGS + ["tm_id:tm-1", "job_name:wordcount", "task_name:Source: KafkaSource", "subtask_index:0"],
     },
 ]
+
+_TASK_TAGS = TAGS + ["tm_id:tm-1", "job_name:wordcount", "task_name:Source: KafkaSource", "subtask_index:0"]
+_OPERATOR_TAGS = TAGS + ["tm_id:tm-1", "job_name:wordcount", "operator_name:Source", "subtask_index:0"]
+
+# Flink Counters (see metrics.py's COUNTER_METRICS). Flink's Prometheus reporter
+# always describes these as `# TYPE ... gauge` in the raw scrape (see
+# fixtures/metrics.txt), so asserting MONOTONIC_COUNT here is what actually locks
+# in the bug 1 fix -- without the type_override wiring in check.py, these would
+# be submitted (and fail this assertion) as GAUGE.
+COUNTER_METRICS = [
+    {"name": "task.numRecordsIn", "value": 12345.0, "tags": _TASK_TAGS},
+    {"name": "task.numRecordsOut", "value": 12345.0, "tags": _TASK_TAGS},
+    {"name": "task.numBytesOut", "value": 999999.0, "tags": _TASK_TAGS},
+    {"name": "task.numBuffersOut", "value": 500.0, "tags": _TASK_TAGS},
+    {"name": "task.numLateRecordsDropped", "value": 3.0, "tags": _TASK_TAGS},
+    {"name": "task.Shuffle.Netty.Input.numBytesInLocal", "value": 1000.0, "tags": _TASK_TAGS},
+    {"name": "task.Shuffle.Netty.Input.numBytesInRemote", "value": 2000.0, "tags": _TASK_TAGS},
+    {"name": "task.Shuffle.Netty.Input.numBuffersInLocal", "value": 10.0, "tags": _TASK_TAGS},
+    {"name": "task.Shuffle.Netty.Input.numBuffersInRemote", "value": 20.0, "tags": _TASK_TAGS},
+    {"name": "operator.numRecordsIn", "value": 12345.0, "tags": _OPERATOR_TAGS},
+    {"name": "operator.numRecordsOut", "value": 6789.0, "tags": _OPERATOR_TAGS},
+    {"name": "operator.numLateRecordsDropped", "value": 1.0, "tags": _OPERATOR_TAGS},
+    {"name": "operator.numSplitsProcessed", "value": 7.0, "tags": _OPERATOR_TAGS},
+    {"name": "operator.commitsSucceeded", "value": 15.0, "tags": _OPERATOR_TAGS},
+    {"name": "operator.commitsFailed", "value": 0.0, "tags": _OPERATOR_TAGS},
+]

--- a/flink/tests/fixtures/metrics.txt
+++ b/flink/tests/fixtures/metrics.txt
@@ -52,9 +52,45 @@ flink_taskmanager_job_task_numRecordsOut{host="taskmanager-0",tm_id="tm-1",job_n
 # HELP flink_taskmanager_job_task_numRecordsOutPerSecond numRecordsOutPerSecond (scope: taskmanager_job_task)
 # TYPE flink_taskmanager_job_task_numRecordsOutPerSecond gauge
 flink_taskmanager_job_task_numRecordsOutPerSecond{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",task_name="Source: KafkaSource",subtask_index="0",} 42.5
+# HELP flink_taskmanager_job_task_numBytesOut numBytesOut (scope: taskmanager_job_task)
+# TYPE flink_taskmanager_job_task_numBytesOut gauge
+flink_taskmanager_job_task_numBytesOut{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",task_name="Source: KafkaSource",subtask_index="0",} 999999.0
+# HELP flink_taskmanager_job_task_numBuffersOut numBuffersOut (scope: taskmanager_job_task)
+# TYPE flink_taskmanager_job_task_numBuffersOut gauge
+flink_taskmanager_job_task_numBuffersOut{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",task_name="Source: KafkaSource",subtask_index="0",} 500.0
+# HELP flink_taskmanager_job_task_numLateRecordsDropped numLateRecordsDropped (scope: taskmanager_job_task)
+# TYPE flink_taskmanager_job_task_numLateRecordsDropped gauge
+flink_taskmanager_job_task_numLateRecordsDropped{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",task_name="Source: KafkaSource",subtask_index="0",} 3.0
+# HELP flink_taskmanager_job_task_Shuffle_Netty_Input_numBytesInLocal numBytesInLocal (scope: taskmanager_job_task)
+# TYPE flink_taskmanager_job_task_Shuffle_Netty_Input_numBytesInLocal gauge
+flink_taskmanager_job_task_Shuffle_Netty_Input_numBytesInLocal{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",task_name="Source: KafkaSource",subtask_index="0",} 1000.0
+# HELP flink_taskmanager_job_task_Shuffle_Netty_Input_numBytesInRemote numBytesInRemote (scope: taskmanager_job_task)
+# TYPE flink_taskmanager_job_task_Shuffle_Netty_Input_numBytesInRemote gauge
+flink_taskmanager_job_task_Shuffle_Netty_Input_numBytesInRemote{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",task_name="Source: KafkaSource",subtask_index="0",} 2000.0
+# HELP flink_taskmanager_job_task_Shuffle_Netty_Input_numBuffersInLocal numBuffersInLocal (scope: taskmanager_job_task)
+# TYPE flink_taskmanager_job_task_Shuffle_Netty_Input_numBuffersInLocal gauge
+flink_taskmanager_job_task_Shuffle_Netty_Input_numBuffersInLocal{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",task_name="Source: KafkaSource",subtask_index="0",} 10.0
+# HELP flink_taskmanager_job_task_Shuffle_Netty_Input_numBuffersInRemote numBuffersInRemote (scope: taskmanager_job_task)
+# TYPE flink_taskmanager_job_task_Shuffle_Netty_Input_numBuffersInRemote gauge
+flink_taskmanager_job_task_Shuffle_Netty_Input_numBuffersInRemote{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",task_name="Source: KafkaSource",subtask_index="0",} 20.0
 # HELP flink_taskmanager_job_task_operator_numRecordsIn numRecordsIn (scope: taskmanager_job_task_operator)
 # TYPE flink_taskmanager_job_task_operator_numRecordsIn gauge
 flink_taskmanager_job_task_operator_numRecordsIn{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",operator_name="Source",subtask_index="0",} 12345.0
+# HELP flink_taskmanager_job_task_operator_numRecordsOut numRecordsOut (scope: taskmanager_job_task_operator)
+# TYPE flink_taskmanager_job_task_operator_numRecordsOut gauge
+flink_taskmanager_job_task_operator_numRecordsOut{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",operator_name="Source",subtask_index="0",} 6789.0
+# HELP flink_taskmanager_job_task_operator_numLateRecordsDropped numLateRecordsDropped (scope: taskmanager_job_task_operator)
+# TYPE flink_taskmanager_job_task_operator_numLateRecordsDropped gauge
+flink_taskmanager_job_task_operator_numLateRecordsDropped{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",operator_name="Source",subtask_index="0",} 1.0
+# HELP flink_taskmanager_job_task_operator_numSplitsProcessed numSplitsProcessed (scope: taskmanager_job_task_operator)
+# TYPE flink_taskmanager_job_task_operator_numSplitsProcessed gauge
+flink_taskmanager_job_task_operator_numSplitsProcessed{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",operator_name="Source",subtask_index="0",} 7.0
+# HELP flink_taskmanager_job_task_operator_commitsSucceeded commitsSucceeded (scope: taskmanager_job_task_operator)
+# TYPE flink_taskmanager_job_task_operator_commitsSucceeded gauge
+flink_taskmanager_job_task_operator_commitsSucceeded{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",operator_name="Source",subtask_index="0",} 15.0
+# HELP flink_taskmanager_job_task_operator_commitsFailed commitsFailed (scope: taskmanager_job_task_operator)
+# TYPE flink_taskmanager_job_task_operator_commitsFailed gauge
+flink_taskmanager_job_task_operator_commitsFailed{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",operator_name="Source",subtask_index="0",} 0.0
 # HELP flink_taskmanager_job_task_operator_currentInputWatermark currentInputWatermark (scope: taskmanager_job_task_operator)
 # TYPE flink_taskmanager_job_task_operator_currentInputWatermark gauge
 flink_taskmanager_job_task_operator_currentInputWatermark{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",operator_name="Source",subtask_index="0",} 1735689600000.0

--- a/flink/tests/test_unit.py
+++ b/flink/tests/test_unit.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
+
 from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.flink import FlinkCheck
 

--- a/flink/tests/test_unit.py
+++ b/flink/tests/test_unit.py
@@ -2,10 +2,10 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
-
+from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.flink import FlinkCheck
 
-from .common import METRICS, TAGS
+from .common import COUNTER_METRICS, METRICS, TAGS
 
 pytestmark = [pytest.mark.unit]
 
@@ -22,6 +22,18 @@ def test_check(dd_run_check, aggregator, check, mock_metrics):
         )
 
     aggregator.assert_no_duplicate_all()
+
+
+def test_counters_submitted_as_monotonic_count(dd_run_check, aggregator, check, mock_metrics):
+    dd_run_check(check)
+
+    for expected_metric in COUNTER_METRICS:
+        aggregator.assert_metric(
+            name=f"flink.{expected_metric['name']}",
+            value=expected_metric["value"],
+            metric_type=AggregatorStub.MONOTONIC_COUNT,
+            tags=expected_metric["tags"],
+        )
 
 
 def test_service_checks(dd_run_check, aggregator, check, mock_metrics):


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the OpenMetrics-based Flink collection mode added in #23857: Flink Counter metrics (throughput counters like `numRecordsIn`/`numRecordsOut`, byte/buffer counters, checkpoint commit counters, etc.) were submitted to Datadog as `gauge` instead of `count`, so a job restart would show a drop instead of holding steady.

Root cause: Flink's `flink-metrics-prometheus` reporter maps Counter, Gauge, and Meter metrics alike to a Prometheus Gauge collector ("Prometheus counters cannot be decremented" — [Flink docs](https://nightlies.apache.org/flink/flink-docs-stable/docs/deployment/metric_reporters/#prometheus)), so every metric's scraped `# TYPE` line reads `gauge` regardless of its real Flink type. The check's `OpenMetricsBaseCheckV2` config trusted that line, so it had no way to tell counters apart from gauges.

Reported by @thepoppingone and @simon-frei-kpler on #23857:
- https://github.com/DataDog/integrations-core/pull/23857#issuecomment-5129657035
- https://github.com/DataDog/integrations-core/pull/23857#issuecomment-5130059299

### Fix

Hardcodes the 15 raw metric names Flink's own [metric type docs](https://nightlies.apache.org/flink/flink-docs-stable/docs/ops/metrics/) classify as Counter (`COUNTER_METRICS` in `metrics.py`) and submits them via `monotonic_count` through a custom transformer, registered against a fully-anchored pattern so sibling Meter metrics (e.g. `numRecordsInPerSecond`, a substring superset of `numRecordsIn`) aren't misclassified.

Existing metric names are preserved exactly (no `.count` suffix) — `OpenMetricsBaseCheckV2`'s built-in `counter` type would otherwise append one, which would break parity with the metric names Flink's legacy `DatadogHttpReporterFactory`-based push reporter already uses for the same metrics.

Deliberately left as `gauge`: `jobmanager.job.numRestarts` and the `numberOf*Checkpoints`/`totalNumberOfCheckpoints` metrics. Despite the names, Flink's own docs classify these as Gauge — they're backed by in-memory state that can reset on a JobManager failover, so forcing `monotonic_count` on them would produce incorrect deltas.

### Testing

- Added `metric_type=` assertions in `test_unit.py` for all 15 fixed counters (verified they fail as GAUGE without the fix, pass as MONOTONIC_COUNT with it).
- Extended the `metrics.txt` fixture to cover the 8 counters not previously present in it.
- Validated live: ran a real Flink 1.18 cluster (jobmanager+taskmanager) with a continuously-running streaming job, confirmed the raw scrape genuinely emits `# TYPE ... gauge` for these counters, then ran a real Datadog Agent dev container against it end-to-end — all 15 counters submitted as `count` with correct deltas, sibling `*PerSecond` gauges unaffected, checkpoint/restart metrics correctly left untouched.

## Motivation

See linked comments above. Any dashboard/monitor built expecting count/rate semantics on Flink throughput metrics gets misleading gauge values.

## Review checklist
- [x] PR title is written as a CHANGELOG entry ([see why](https://datadoghq.dev/integrations-core/guidelines/pr/#pr-title))
- [x] Changes are tested (unit + live validation, see above)
- [x] Add a new changelog fragment in the `changelog.d` folder

## Additional Notes

Independent of, and does not block or depend on, the separate custom-metrics (`extra_metrics`) fix also being worked for the same PR's comment thread — no code overlap beyond an additive test in `test_unit.py`.