### PR TITLE
[flink] Document extra_metrics for custom/user metrics

### DIFF
--- a/flink/README.md
+++ b/flink/README.md
@@ -60,6 +60,47 @@ No additional installation is needed on your server.
 
 3. Restart Flink and the Agent.
 
+Flink jobs can register their own [custom/user metrics][16] (for example, an
+operator-scoped counter your operator code emits). By default, this
+integration only collects the metrics documented in [metadata.csv][11] --
+job-specific custom metrics are not collected out of the box. Collect them
+with the `extra_metrics` option, mapping the exact raw Prometheus metric name
+Flink exposes to the Datadog metric name you want:
+
+```yaml
+instances:
+  - openmetrics_endpoint: http://<FLINK_HOST>:9249/metrics
+    extra_metrics:
+      - flink_taskmanager_job_task_operator_messageLatency: operator.messageLatency
+```
+
+<div class="alert alert-info">These custom Flink metrics are considered standard metrics in Datadog.</div>
+
+You can also match multiple metrics at once with a regular expression, for
+example to collect everything under a given Flink scope:
+
+```yaml
+    extra_metrics:
+      - ^flink_taskmanager_job_task_operator_.+
+```
+
+Metrics collected this way are submitted under Flink's raw Prometheus metric
+name (for example `flink.flink_taskmanager_job_task_operator_messageLatency`)
+rather than a curated Datadog name, since a regular expression can match more
+than one metric and therefore can't be mapped to a single custom name.
+
+If a custom metric's exposed type is wrong (for example, Flink reports one of
+your operator's counters as a `gauge`), force the correct type the same way:
+
+```yaml
+    extra_metrics:
+      - flink_taskmanager_job_task_operator_customEventsTotal:
+          name: operator.customEventsTotal
+          type: counter
+```
+
+See the [sample flink.d/conf.yaml][8] for the full `extra_metrics` syntax.
+
 #### Metric collection - Datadog HTTP Reporter (legacy)
 
 <!-- partial
@@ -198,3 +239,4 @@ Need help? Contact [Datadog support][12].
 [12]: https://docs.datadoghq.com/help/
 [13]: https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/deployment/advanced/logging/
 [15]: https://nightlies.apache.org/flink/flink-docs-stable/docs/deployment/metric_reporters/#prometheus
+[16]: https://nightlies.apache.org/flink/flink-docs-stable/docs/ops/metrics/#registering-metrics

--- a/flink/README.md
+++ b/flink/README.md
@@ -86,8 +86,8 @@ example to collect everything under a given Flink scope:
 
 Metrics collected this way are submitted under Flink's raw Prometheus metric
 name (for example `flink.flink_taskmanager_job_task_operator_messageLatency`)
-rather than a curated Datadog name, since a regular expression can match more
-than one metric and therefore can't be mapped to a single custom name.
+rather than a curated Datadog name. A regular expression can match more than
+one metric, so it cannot be mapped to a single custom name.
 
 If a custom metric's exposed type is wrong (for example, Flink reports one of
 your operator's counters as a `gauge`), force the correct type the same way:

--- a/flink/README.md
+++ b/flink/README.md
@@ -60,10 +60,10 @@ No additional installation is needed on your server.
 
 3. Restart Flink and the Agent.
 
-Flink jobs can register their own [custom/user metrics][16] (for example, an
+Flink jobs can register their own [custom metrics][16] (for example, an
 operator-scoped counter your operator code emits). By default, this
-integration only collects the metrics documented in [metadata.csv][11] --
-job-specific custom metrics are not collected out of the box. Collect them
+integration collects only the metrics documented in [metadata.csv][11], so
+job-specific custom metrics are not collected. Collect them
 with the `extra_metrics` option, mapping the exact raw Prometheus metric name
 Flink exposes to the Datadog metric name you want:
 

--- a/flink/changelog.d/24741.fixed
+++ b/flink/changelog.d/24741.fixed
@@ -1,0 +1,1 @@
+Document how to collect Flink custom/user metrics via `extra_metrics` in OpenMetrics collection mode.

--- a/flink/changelog.d/24741.fixed
+++ b/flink/changelog.d/24741.fixed
@@ -1,1 +1,0 @@
-Document how to collect Flink custom/user metrics via `extra_metrics` in OpenMetrics collection mode.

--- a/flink/tests/fixtures/metrics.txt
+++ b/flink/tests/fixtures/metrics.txt
@@ -58,3 +58,15 @@ flink_taskmanager_job_task_operator_numRecordsIn{host="taskmanager-0",tm_id="tm-
 # HELP flink_taskmanager_job_task_operator_currentInputWatermark currentInputWatermark (scope: taskmanager_job_task_operator)
 # TYPE flink_taskmanager_job_task_operator_currentInputWatermark gauge
 flink_taskmanager_job_task_operator_currentInputWatermark{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",operator_name="Source",subtask_index="0",} 1735689600000.0
+# A job-defined custom/user metric, not present in METRIC_MAP -- exercises the
+# `extra_metrics` opt-in path (see tests/test_unit.py).
+# HELP flink_taskmanager_job_task_operator_messageLatency messageLatency (scope: taskmanager_job_task_operator)
+# TYPE flink_taskmanager_job_task_operator_messageLatency counter
+flink_taskmanager_job_task_operator_messageLatency{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",operator_name="Source",subtask_index="0",} 7.0
+# A job-defined custom/user metric whose exposed TYPE is wrong (declared gauge,
+# semantically a counter) -- same failure mode as Bug 1, but on a metric this
+# integration has no way to know about ahead of time. Exercises the
+# `extra_metrics` `type:` override (see tests/test_unit.py).
+# HELP flink_taskmanager_job_task_operator_customEventsTotal customEventsTotal (scope: taskmanager_job_task_operator)
+# TYPE flink_taskmanager_job_task_operator_customEventsTotal gauge
+flink_taskmanager_job_task_operator_customEventsTotal{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",operator_name="Source",subtask_index="0",} 9.0

--- a/flink/tests/fixtures/metrics.txt
+++ b/flink/tests/fixtures/metrics.txt
@@ -59,9 +59,12 @@ flink_taskmanager_job_task_operator_numRecordsIn{host="taskmanager-0",tm_id="tm-
 # TYPE flink_taskmanager_job_task_operator_currentInputWatermark gauge
 flink_taskmanager_job_task_operator_currentInputWatermark{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",operator_name="Source",subtask_index="0",} 1735689600000.0
 # A job-defined custom/user metric, not present in METRIC_MAP -- exercises the
-# `extra_metrics` opt-in path (see tests/test_unit.py).
+# `extra_metrics` opt-in path (see tests/test_unit.py). TYPE is `gauge`: Flink's
+# Prometheus reporter maps every metric (Counter, Gauge, Meter alike) to a
+# Prometheus gauge collector, so the raw scrape never actually says `counter`
+# even when the underlying Flink metric is one.
 # HELP flink_taskmanager_job_task_operator_messageLatency messageLatency (scope: taskmanager_job_task_operator)
-# TYPE flink_taskmanager_job_task_operator_messageLatency counter
+# TYPE flink_taskmanager_job_task_operator_messageLatency gauge
 flink_taskmanager_job_task_operator_messageLatency{host="taskmanager-0",tm_id="tm-1",job_name="wordcount",operator_name="Source",subtask_index="0",} 7.0
 # A job-defined custom/user metric whose exposed TYPE is wrong (declared gauge,
 # semantically a counter) -- same failure mode as Bug 1, but on a metric this

--- a/flink/tests/test_unit.py
+++ b/flink/tests/test_unit.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import copy
+
 import pytest
 
 from datadog_checks.flink import FlinkCheck
@@ -8,6 +10,8 @@ from datadog_checks.flink import FlinkCheck
 from .common import METRICS, TAGS
 
 pytestmark = [pytest.mark.unit]
+
+OPERATOR_TAGS = TAGS + ["tm_id:tm-1", "job_name:wordcount", "operator_name:Source", "subtask_index:0"]
 
 
 def test_check(dd_run_check, aggregator, check, mock_metrics):
@@ -27,3 +31,64 @@ def test_check(dd_run_check, aggregator, check, mock_metrics):
 def test_service_checks(dd_run_check, aggregator, check, mock_metrics):
     dd_run_check(check)
     aggregator.assert_service_check('flink.openmetrics.health', FlinkCheck.OK, tags=TAGS)
+
+
+def test_custom_metric_not_collected_by_default(dd_run_check, aggregator, check, mock_metrics):
+    """A job-defined custom metric (not in METRIC_MAP) is silently dropped without `extra_metrics`."""
+    dd_run_check(check)
+    aggregator.assert_metric("flink.operator.messageLatency", count=0)
+    aggregator.assert_metric("flink.flink_taskmanager_job_task_operator_messageLatency", count=0)
+
+
+def test_custom_metric_collected_via_extra_metrics(dd_run_check, aggregator, instance, mock_metrics):
+    """`extra_metrics` with an explicit rename collects the custom metric under a clean DD name."""
+    instance = copy.deepcopy(instance)
+    instance["extra_metrics"] = [{"flink_taskmanager_job_task_operator_messageLatency": "operator.messageLatency"}]
+    check = FlinkCheck('flink', {}, [instance])
+    dd_run_check(check)
+
+    aggregator.assert_metric(
+        "flink.operator.messageLatency.count",
+        value=7.0,
+        metric_type=aggregator.MONOTONIC_COUNT,
+        tags=OPERATOR_TAGS,
+    )
+
+
+def test_custom_metric_collected_via_extra_metrics_regex(dd_run_check, aggregator, instance, mock_metrics):
+    """A regex `extra_metrics` entry also collects the metric, but under its raw Prometheus name --
+    regex entries can't be renamed (see the `extra_metrics` docs in the README)."""
+    instance = copy.deepcopy(instance)
+    instance["extra_metrics"] = ["^flink_taskmanager_job_task_operator_messageLatency$"]
+    check = FlinkCheck('flink', {}, [instance])
+    dd_run_check(check)
+
+    aggregator.assert_metric(
+        "flink.flink_taskmanager_job_task_operator_messageLatency.count",
+        value=7.0,
+        metric_type=aggregator.MONOTONIC_COUNT,
+        tags=OPERATOR_TAGS,
+    )
+
+
+def test_custom_metric_type_override_via_extra_metrics(dd_run_check, aggregator, instance, mock_metrics):
+    """`extra_metrics`' `type:` override fixes a wrong exposed type (same failure mode as Bug 1 --
+    counters exposed as `gauge` -- but on a custom metric this integration can't know about ahead of time)."""
+    instance = copy.deepcopy(instance)
+    instance["extra_metrics"] = [
+        {
+            "flink_taskmanager_job_task_operator_customEventsTotal": {
+                "name": "operator.customEventsTotal",
+                "type": "counter",
+            }
+        }
+    ]
+    check = FlinkCheck('flink', {}, [instance])
+    dd_run_check(check)
+
+    aggregator.assert_metric(
+        "flink.operator.customEventsTotal.count",
+        value=9.0,
+        metric_type=aggregator.MONOTONIC_COUNT,
+        tags=OPERATOR_TAGS,
+    )

--- a/flink/tests/test_unit.py
+++ b/flink/tests/test_unit.py
@@ -41,16 +41,18 @@ def test_custom_metric_not_collected_by_default(dd_run_check, aggregator, check,
 
 
 def test_custom_metric_collected_via_extra_metrics(dd_run_check, aggregator, instance, mock_metrics):
-    """`extra_metrics` with an explicit rename collects the custom metric under a clean DD name."""
+    """`extra_metrics` with an explicit rename collects the custom metric under a clean DD name.
+    No `type:` override is given, so it's submitted as a gauge -- Flink's Prometheus reporter
+    always exposes custom metrics as `# TYPE ... gauge`, regardless of their real Flink type."""
     instance = copy.deepcopy(instance)
     instance["extra_metrics"] = [{"flink_taskmanager_job_task_operator_messageLatency": "operator.messageLatency"}]
     check = FlinkCheck('flink', {}, [instance])
     dd_run_check(check)
 
     aggregator.assert_metric(
-        "flink.operator.messageLatency.count",
+        "flink.operator.messageLatency",
         value=7.0,
-        metric_type=aggregator.MONOTONIC_COUNT,
+        metric_type=aggregator.GAUGE,
         tags=OPERATOR_TAGS,
     )
 
@@ -64,9 +66,9 @@ def test_custom_metric_collected_via_extra_metrics_regex(dd_run_check, aggregato
     dd_run_check(check)
 
     aggregator.assert_metric(
-        "flink.flink_taskmanager_job_task_operator_messageLatency.count",
+        "flink.flink_taskmanager_job_task_operator_messageLatency",
         value=7.0,
-        metric_type=aggregator.MONOTONIC_COUNT,
+        metric_type=aggregator.GAUGE,
         tags=OPERATOR_TAGS,
     )
 


### PR DESCRIPTION
## What does this PR do?

Documents how to collect Flink custom/user metrics in OpenMetrics collection mode via the `extra_metrics` option, and adds unit test coverage.

## Motivation

Following the OpenMetrics-based collection mode added in #23857, [review feedback](https://github.com/DataDog/integrations-core/pull/23857#issuecomment-5130059299) flagged that job-defined custom/user metrics (e.g. an operator-scoped counter) are silently dropped in the new mode, since `METRIC_MAP` is a closed list with no wildcard/regex fallback. These are still collected today via the legacy Datadog HTTP Reporter.

## Additional notes

`OpenMetricsBaseCheckV2`'s stock `extra_metrics` option already covers this, no `check.py`/`metrics.py` changes needed — confirmed against `ray`, `torchserve`, and `nvidia_triton`, which document the identical pattern for the same scenario, including the "considered standard metrics in Datadog" framing this README reuses. @steveny91 — flagging that line for your confirmation, since it mirrors those three integrations' docs rather than something I've independently verified against Flink's own billing classification.

This documents `extra_metrics`' name-rename, regex, and type-override forms (the last covering the same "wrong exposed type" failure mode reported separately for curated metrics, but here for a user's own custom metric) and adds a unit test for each. Also validated live against a real Flink 1.18 cluster (via `ddev env`) with a running job: confirmed real built-in task metrics not in `METRIC_MAP` are silently dropped today, and that `extra_metrics` recovers them exactly as documented.

### Future improvement (not in this PR)

Flink's raw Prometheus names already carry a `flink_` prefix identical to `__NAMESPACE__`, so a bare regex `extra_metrics` entry submits under an awkward doubled name (`flink.flink_taskmanager_..._messageLatency`). `n8n` solves the same structural issue with `raw_metric_prefix: 'n8n_'` in its `check.py`. Adopting that for Flink would mean rewriting every `METRIC_MAP` key (~90 entries) to drop the `flink_` prefix — a bigger, separate change, flagged here as a possible follow-up rather than bundled into this fix.

## Review checklist

- [x] PR title follows [conventions](https://datadoghq.dev/integrations-core/guidelines/pr/#pull-request-title)
- [x] Feature or bugfix has tests
- [ ] Corresponding documentation has been updated if needed -- covered by this PR's own README changes
