### PR TITLE
[flink] add e2e coverage for task/operator-scope metrics

### DIFF
--- a/flink/tests/conftest.py
+++ b/flink/tests/conftest.py
@@ -4,15 +4,23 @@
 import copy
 import os
 from unittest import mock
+from urllib.request import urlopen
 
 import pytest
 
-from datadog_checks.dev import docker_run, get_docker_hostname, get_e2e_discovery_metadata, get_here
-from datadog_checks.dev.conditions import CheckEndpoints
+from datadog_checks.dev import docker_run, get_docker_hostname, get_e2e_discovery_metadata, get_here, run_command
+from datadog_checks.dev.conditions import CheckEndpoints, WaitFor
 from datadog_checks.flink import FlinkCheck
 
 JOBMANAGER_PORT = 9249
 TASKMANAGER_PORT = 9250
+
+
+def _task_metrics_present():
+    # Task/operator metric groups only exist once a job is actually scheduled
+    # onto the TaskManager, which lags job submission by a few seconds.
+    with urlopen(f"http://{get_docker_hostname()}:{TASKMANAGER_PORT}/metrics", timeout=5) as response:
+        return b'flink_taskmanager_job_task_numRecordsIn' in response.read()
 
 
 @pytest.fixture(scope='session')
@@ -23,8 +31,20 @@ def dd_environment():
         conditions=(
             CheckEndpoints(f"http://{get_docker_hostname()}:{JOBMANAGER_PORT}/metrics"),
             CheckEndpoints(f"http://{get_docker_hostname()}:{TASKMANAGER_PORT}/metrics"),
+            lambda: run_command(
+                [
+                    'docker',
+                    'exec',
+                    'flink-jobmanager',
+                    'flink',
+                    'run',
+                    '-d',
+                    '/opt/flink/examples/streaming/StateMachineExample.jar',
+                ],
+                check=True,
+            ),
+            WaitFor(_task_metrics_present, attempts=30, wait=2),
         ),
-        sleep=15,
     ):
         yield (
             {

--- a/flink/tests/test_e2e.py
+++ b/flink/tests/test_e2e.py
@@ -36,6 +36,23 @@ EXPECTED_TASKMANAGER_CORE_METRICS = [
     "flink.taskmanager.Status.JVM.Threads.Count",
 ]
 
+# Task/operator-scope metrics only exist once a job is running (see the
+# StateMachineExample.jar submission in conftest.py's dd_environment). This exercises
+# tag extraction (job_name, task_name, operator_name, subtask_index) and metric naming
+# against real Flink-emitted data, not the hand-written fixture in tests/fixtures/metrics.txt.
+# Counter-vs-gauge submission type (COUNTER_METRICS in metrics.py/check.py) is deliberately
+# NOT re-verified here: the real Agent's MonotonicCount sender computes a rate internally
+# and the e2e replay JSON reports the result as `gauge` regardless -- no e2e test in this
+# repo asserts MONOTONIC_COUNT for exactly that reason. That distinction is the unit test's job.
+EXPECTED_TASK_METRICS = [
+    "flink.task.numRecordsIn",
+    "flink.task.currentInputWatermark",
+]
+EXPECTED_OPERATOR_METRICS = [
+    "flink.operator.numRecordsIn",
+    "flink.operator.currentOutputWatermark",
+]
+
 
 def test_e2e_jobmanager_metrics(dd_agent_check, dd_environment):
     aggregator = dd_agent_check(dd_environment, rate=True)
@@ -46,12 +63,16 @@ def test_e2e_jobmanager_metrics(dd_agent_check, dd_environment):
 
 def test_e2e_discovery(dd_agent_check_discovery):
     # Both the jobmanager and taskmanager containers share the same `flink` image, so
-    # Autodiscovery finds and configures one instance per container.
+    # Autodiscovery finds and configures one instance per container. Task/operator-scope
+    # metrics are only exposed by the TaskManager's own endpoint (not the JobManager's),
+    # so this discovery-based check -- not test_e2e_jobmanager_metrics -- is what can see them.
     aggregator = dd_agent_check_discovery(rate=True, discovery_min_instances=2)
 
     for metric in EXPECTED_CORE_METRICS:
         aggregator.assert_metric(metric, at_least=1)
     for metric in EXPECTED_TASKMANAGER_CORE_METRICS:
+        aggregator.assert_metric(metric, at_least=1)
+    for metric in EXPECTED_TASK_METRICS + EXPECTED_OPERATOR_METRICS:
         aggregator.assert_metric(metric, at_least=1)
     aggregator.assert_service_check('flink.openmetrics.health', FlinkCheck.OK)
 


### PR DESCRIPTION
## Summary
- The Flink e2e suite only ever started a jobmanager+taskmanager with no job running, so it never exercised task/operator-scope metrics (`numRecordsIn`, watermarks, etc.) — only JVM-level metrics.
- Submits Flink's bundled `StateMachineExample.jar` (self-contained, no external deps, runs continuously) as part of `dd_environment` setup, gated by a `WaitFor` poll of the taskmanager's `/metrics` endpoint instead of a blind `sleep`.
- Extends `test_e2e_discovery` (not `test_e2e_jobmanager_metrics` — task/operator metrics are only exposed via the TaskManager's own endpoint) with presence assertions for representative task and operator metrics, now exercising real tag extraction (`job_name`, `task_name`, `operator_name`, `subtask_index`) against genuine Flink-emitted data instead of only the hand-written `tests/fixtures/metrics.txt` fixture used by unit tests.

**Stacked on #24740** (counter/gauge fix) since that's what makes `flink.task.numRecordsIn`/`flink.operator.numRecordsIn` submit correctly. This diff will include #24740's commits until that PR merges and this branch is rebased onto `master` — the actual new content here is only `flink/tests/conftest.py` and `flink/tests/test_e2e.py`.

Note: this does **not** assert `metric_type=MONOTONIC_COUNT` in e2e — the real Agent's `monotonic_count` sender computes its delta internally and the e2e replay JSON reports the result as `gauge` regardless, which is why no e2e test in this repo asserts that type. Counter-vs-gauge submission type is already covered by the unit test in #24740.

## Test plan
- [x] `ddev env test flink py3.13-1.19` — all e2e tests pass (`test_e2e_jobmanager_metrics`, `test_e2e_discovery`, `test_e2e_discovery_all_candidates`)
- [x] Re-ran with `--recreate` to check for flakiness in the new `WaitFor` gate — passed cleanly twice
- [x] `ddev test --fmt` / lint — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)