### PR TITLE
Model WorkflowRun.status as nullable to match the GitHub API description

### DIFF
--- a/ddev/changelog.d/24746.fixed
+++ b/ddev/changelog.d/24746.fixed
@@ -1,0 +1,1 @@
+Model the workflow run ``status`` field as nullable so runs without a status parse instead of raising a validation error.

--- a/ddev/src/ddev/cli/release/test_agent/monitoring.py
+++ b/ddev/src/ddev/cli/release/test_agent/monitoring.py
@@ -117,7 +117,10 @@ async def collect_workflow_state(client: AsyncGitHubClient, workflow: Dispatched
     return WorkflowState(
         label=workflow.label,
         run_id=workflow.run_id,
-        status=run.status,
+        # GitHub declares `status` nullable, and a run without one has not reached a
+        # reportable state yet, which is what this monitor seeds runs with before its
+        # first poll.
+        status=run.status or 'queued',
         conclusion=run.conclusion,
         html_url=run.html_url or workflow.html_url,
         jobs=jobs,

--- a/ddev/src/ddev/utils/github_async/models/workflow.py
+++ b/ddev/src/ddev/utils/github_async/models/workflow.py
@@ -66,7 +66,9 @@ class WorkflowRun(BaseModel):
 
     The `workflow-run` schema declares `status` and `conclusion` as plain
     nullable strings with no `enum`, so they are intentionally kept as free-form
-    strings rather than modeled as a StrEnum.
+    strings rather than modeled as a StrEnum. `status` is also in the schema's
+    `required` list, so it is typed `str | None` with no default: the key is
+    always present and only its value may be null.
     Reference:
     https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run
     """
@@ -75,7 +77,7 @@ class WorkflowRun(BaseModel):
 
     id: int
     name: str | None = None
-    status: str
+    status: str | None
     conclusion: str | None = None
     html_url: str
     created_at: str | None = None

--- a/ddev/tests/utils/github_async/payloads.py
+++ b/ddev/tests/utils/github_async/payloads.py
@@ -20,7 +20,7 @@ def artifact(idx: int, expired: bool = False, **extra: Any) -> dict[str, Any]:
 def workflow_run_payload(
     id: int = 42,
     name: str = "CI",
-    status: str = "completed",
+    status: str | None = "completed",
     conclusion: str | None = "success",
     html_url: str = "https://github.com/owner/repo/actions/runs/42",
     created_at: str = "2024-01-01T00:00:00Z",

--- a/ddev/tests/utils/github_async/test_models.py
+++ b/ddev/tests/utils/github_async/test_models.py
@@ -10,8 +10,9 @@ from ddev.utils.github_async.models import (
     PullRequest,
     PullRequestRef,
     PullRequestState,
+    WorkflowRun,
 )
-from tests.utils.github_async.payloads import full_pull_request_payload
+from tests.utils.github_async.payloads import full_pull_request_payload, workflow_run_payload
 
 
 def test_pull_request_parses_full_response() -> None:
@@ -45,6 +46,14 @@ def test_pull_request_ignores_extra_fields() -> None:
     payload = full_pull_request_payload(mergeable_state="clean", additions=42, unknown_future_field={"nested": True})
     pr = PullRequest.model_validate(payload)
     assert pr.number == 42
+
+
+def test_workflow_run_parses_null_status() -> None:
+    """The `workflow-run` schema declares `status` nullable, so a null value must parse."""
+    run = WorkflowRun.model_validate(workflow_run_payload(status=None))
+
+    assert run.status is None
+    assert run.is_completed is False
 
 
 def test_models_subpackage_unknown_attribute_raises_attribute_error() -> None:


### PR DESCRIPTION
### What does this PR do?
Types `WorkflowRun.status` as `str | None` instead of `str`. The `workflow-run` schema in GitHub's OpenAPI description for the pinned API version (`GITHUB_API_VERSION = "2022-11-28"`) declares it as `{"type": "string", "nullable": true}` and lists it in `required`, so the key is always present but its value can be null. The field keeps no default, matching that contract.

`ddev/src/ddev/cli/release/test_agent/monitoring.py` is the only reader that needed a change: `WorkflowState.status` is typed `str`, so the passthrough now falls back to `'queued'`, the same placeholder the monitor already seeds runs with before its first poll. Every other reader compares against a literal and behaves correctly for `None`, including `WorkflowRun.is_completed`, which stays `False` and so keeps callers on the fail-closed "still running" path.

Left alone on purpose: `conclusion`, `created_at` and `updated_at` are also in the schema's `required` list while the model gives them `= None` defaults. That is the mirror-image inaccuracy, and removing the defaults would ripple into every test that constructs a `WorkflowRun` for no behaviour change.

Note this touches the same `WorkflowRun` class as open PR #24732, which adds fields lower down in the same model. Different lines, so it should merge cleanly, but whichever lands second may need a trivial rebase.

### Motivation
A run whose `status` comes back null raised a `pydantic.ValidationError` instead of parsing. Callers that read the field to decide whether a run has finished would surface that as a Pydantic traceback rather than their own error handling.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
