### PR TITLE
Fix Cisco firewall dashboard typo

### DIFF
--- a/cisco_secure_firewall/assets/dashboards/cisco_secure_firewall_transparent_firewall.json
+++ b/cisco_secure_firewall/assets/dashboards/cisco_secure_firewall_transparent_firewall.json
@@ -46,7 +46,7 @@
             "id": 3979223334086134,
             "definition": {
                 "type": "note",
-                "content": "## Widgets\n\n1. Transparent Firewall Events Over Time \n2. Number Of Times Failure Occured \n3. Top 10 Source Interface \n4. Top 10 Source IPs of the Packet \n5. Top 10 Destination IPs of the Packet \n6. Log Details \n7. Number of Times Routing Failed \n8. Events by Protocol \n9. Top 10 Source IP \n10. Top 10 Destination IP \n11. Top 10 Source Interface \n12. Log Details \n13. Log Details ",
+                "content": "## Widgets\n\n1. Transparent Firewall Events Over Time \n2. Number Of Times Failure Occurred \n3. Top 10 Source Interface \n4. Top 10 Source IPs of the Packet \n5. Top 10 Destination IPs of the Packet \n6. Log Details \n7. Number of Times Routing Failed \n8. Events by Protocol \n9. Top 10 Source IP \n10. Top 10 Destination IP \n11. Top 10 Source Interface \n12. Log Details \n13. Log Details ",
                 "background_color": "white",
                 "font_size": "14",
                 "text_align": "left",
@@ -133,7 +133,7 @@
                     {
                         "id": 8203742635925598,
                         "definition": {
-                            "title": "Number Of Times Failure Occured",
+                            "title": "Number Of Times Failure Occurred",
                             "title_size": "16",
                             "title_align": "left",
                             "type": "query_value",

--- a/cisco_secure_firewall/changelog.d/24747.fixed
+++ b/cisco_secure_firewall/changelog.d/24747.fixed
@@ -1,1 +1,0 @@
-Fix the spelling of "occurred" in the transparent firewall dashboard.

--- a/cisco_secure_firewall/changelog.d/24747.fixed
+++ b/cisco_secure_firewall/changelog.d/24747.fixed
@@ -1,0 +1,1 @@
+Fix the spelling of "occurred" in the transparent firewall dashboard.


### PR DESCRIPTION
### What does this PR do?
Corrects the spelling of “occurred” in the Cisco Secure Firewall transparent firewall dashboard widget title and contents list.

### Motivation
Fixes #24218 so the shipped dashboard no longer displays the misspelling to users.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged