### PR TITLE
Set public Palo Alto Networks Cortex XSOAR integration

### DIFF
--- a/palo_alto_networks_cortex_xsoar/manifest.json
+++ b/palo_alto_networks_cortex_xsoar/manifest.json
@@ -3,7 +3,7 @@
   "app_uuid": "e4f68beb-6472-490c-ba02-72ded5b9c203",
   "app_id": "palo-alto-networks-cortex-xsoar",
   "owner": "saas-integrations",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?
Makes the Palo Alto Networks Cortex XSOAR integration publicly visible for its GA release. This flips `display_on_public_website` to `true` in the integration manifest so the tile appears on the public Datadog integrations website.

