### PR TITLE
Palo Alto Networks Cortex XSOAR integration with SIEM category tag

### DIFF
--- a/palo_alto_networks_cortex_xsoar/manifest.json
+++ b/palo_alto_networks_cortex_xsoar/manifest.json
@@ -59,6 +59,7 @@
       "Category::Log Collection",
       "Category::Automation",
       "Category::Cloud",
+      "Category::SIEM",
       "Offering::Integration",
       "Submitted Data Type::Metrics",
       "Submitted Data Type::Logs"


### PR DESCRIPTION
Add SIEM category to Palo Alto Networks Cortex XSOAR integration

## Summary
Adds the `Category::SIEM` classifier to the Palo Alto Networks Cortex XSOAR integration manifest so the integration is discoverable under the SIEM category in the Datadog marketplace/integrations catalog.

## Changes
- Add `Category::SIEM` to the `classifier_tags` in `palo_alto_networks_cortex_xsoar/manifest.json`

