### PR TITLE
Merge instance rename_labels with the KrakenD defaults

### DIFF
--- a/krakend/changelog.d/24754.changed
+++ b/krakend/changelog.d/24754.changed
@@ -1,0 +1,1 @@
+Apply the default label renames even when an instance overrides `rename_labels`.

--- a/krakend/datadog_checks/krakend/check.py
+++ b/krakend/datadog_checks/krakend/check.py
@@ -74,5 +74,7 @@ class KrakendCheck(OpenMetricsBaseCheckV2):
             # Only rename the version label when go_metrics are enabled, as
             # documented in the tile.
             rename_labels["version"] = "go_version"
-        # `config` comes first so a user-provided `rename_labels` still wins over ours.
-        return ChainMap(config, {"rename_labels": rename_labels}, super().get_config_with_defaults(config))
+        # Merge per label rather than letting the instance replace the whole mapping, so an
+        # instance that renames one label does not lose the renames it did not mention.
+        rename_labels.update(config.get("rename_labels") or {})
+        return ChainMap({"rename_labels": rename_labels}, super().get_config_with_defaults(config))

--- a/krakend/tests/test_unit.py
+++ b/krakend/tests/test_unit.py
@@ -10,6 +10,7 @@ import pytest
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.krakend import KrakendCheck
+from datadog_checks.krakend.check import RENAME_LABELS_MAP
 from tests.helpers import get_metrics_from_metadata
 from tests.types import InstanceBuilder
 
@@ -145,12 +146,53 @@ def test_default_rename_labels(
     assert final_config["rename_labels"] == expected_rename_labels
 
 
-def test_user_rename_labels_take_precedence(check: KrakendCheck, instance: InstanceBuilder):
-    instance_config = instance() | {"rename_labels": {"pod": "pod_name"}}
+@pytest.mark.parametrize(
+    "instance_rename_labels, expected_rename_labels",
+    [
+        (
+            {"pod": "pod_name"},
+            {
+                "service_version": "krakend.service_version",
+                "service_name": "krakend.service_name",
+                "version": "go_version",
+                "pod": "pod_name",
+            },
+        ),
+        (
+            {"service_name": "gateway"},
+            {
+                "service_version": "krakend.service_version",
+                "service_name": "gateway",
+                "version": "go_version",
+            },
+        ),
+    ],
+    ids=["extra_label", "overrides_a_default"],
+)
+def test_instance_rename_labels_merge_with_defaults(
+    check: KrakendCheck,
+    instance: InstanceBuilder,
+    instance_rename_labels: dict[str, str],
+    expected_rename_labels: dict[str, str],
+):
+    instance_config = instance() | {"rename_labels": instance_rename_labels}
 
     final_config = check.get_config_with_defaults(instance_config)
 
-    assert final_config["rename_labels"] == {"pod": "pod_name"}
+    assert final_config["rename_labels"] == expected_rename_labels
+
+
+def test_instance_rename_labels_are_not_mutated(check: KrakendCheck, instance: InstanceBuilder):
+    instance_rename_labels = {"pod": "pod_name"}
+    instance_config = instance() | {"rename_labels": instance_rename_labels}
+
+    check.get_config_with_defaults(instance_config)
+
+    assert instance_rename_labels == {"pod": "pod_name"}
+    assert RENAME_LABELS_MAP == {
+        "service_version": "krakend.service_version",
+        "service_name": "krakend.service_name",
+    }
 
 
 def test_service_check_emitted(ready_check: KrakendCheck, aggregator: AggregatorStub):


### PR DESCRIPTION
> Rebased onto master now that [#22751](https://github.com/DataDog/integrations-core/pull/22751) and [#24752](https://github.com/DataDog/integrations-core/pull/24752) have merged. No longer stacked.

### What does this PR do?

Merges an instance's `rename_labels` into the check's defaults per label, instead of letting it replace the whole mapping.

```python
rename_labels.update(config.get("rename_labels") or {})
```

An instance that renames one label now keeps the renames it did not mention. An instance that renames a label the check already handles still wins for that label.

### Motivation

`rename_labels` reaches the scraper through a `ChainMap`, which resolves each top-level key by returning the first map's whole value. It never merges nested dicts. So an instance setting `rename_labels` for its own purposes silently dropped `service_name -> krakend.service_name`, `service_version -> krakend.service_version`, and `version -> go_version`.

That matters because the tile documents those renames as always applied. Anyone who set `rename_labels` lost the `krakend.service_name` and `krakend.service_version` tags with no warning.

Marked `changed` rather than `fixed`: for an instance that already sets `rename_labels`, the raw `service_name` and `version` tags stop being emitted and the renamed ones appear instead, so existing dashboards or monitors keyed on the raw labels would need updating.

Covered by `test_instance_rename_labels_merge_with_defaults` (parametrized over adding a new label and overriding one of the defaults) and `test_instance_rename_labels_are_not_mutated`, which pins that neither the instance dict nor `RENAME_LABELS_MAP` is mutated. Confirmed both merge cases fail without the change.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

