### PR TITLE
Preserve Kueue resource tags for other metrics

### DIFF
--- a/kueue/changelog.d/24760.fixed
+++ b/kueue/changelog.d/24760.fixed
@@ -1,0 +1,1 @@
+Preserve resource tags for Kueue metrics mapped to ``other``.

--- a/kueue/datadog_checks/kueue/check.py
+++ b/kueue/datadog_checks/kueue/check.py
@@ -110,7 +110,9 @@ class KueueCheck(OpenMetricsBaseCheckV2, ConfigMixin):
                     )
                     cached_transformers[metric_name] = native_transformer
 
-                resource_tags = [tag for tag in tags if tag != f'resource:{resource}']
+                resource_tags = tags
+                if resource_name != OTHER_RESOURCE_NAME:
+                    resource_tags = [tag for tag in tags if tag != f'resource:{resource}']
                 resource_tags = self.rename_local_queue_tag(resource_tags)
                 native_transformer(metric, [(sample, resource_tags, hostname)], runtime_data)
 

--- a/kueue/tests/test_unit.py
+++ b/kueue/tests/test_unit.py
@@ -60,6 +60,9 @@ def test_check(dd_run_check, aggregator, instance, mock_http_response):
         aggregator.assert_metric(metric)
         aggregator.assert_metric_has_tag(metric, 'test:tag')
 
+    aggregator.assert_metric_has_tag('kueue.cluster_queue.resource_usage.other', 'resource:example.com/fpga')
+    assert 'resource:nvidia.com/gpu' not in _get_metric_tags(aggregator, 'kueue.cluster_queue.resource_usage.gpu')
+
     for metric, tags in EXPECTED_METRIC_TAGS.items():
         for tag in tags:
             aggregator.assert_metric_has_tag(metric, tag)


### PR DESCRIPTION
### What does this PR do?
Retains the original resource tag on Kueue metrics emitted as `other`.

### Motivation
Unmapped resources otherwise cannot be distinguished after sharing the `other` metric name.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged