### PR TITLE
Preserve supported fields in dashboard exports

### DIFF
--- a/datadog_checks_dev/changelog.d/24764.fixed
+++ b/datadog_checks_dev/changelog.d/24764.fixed
@@ -1,0 +1,1 @@
+Preserve supported dashboard fields when exporting integration dashboard assets.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
@@ -4,6 +4,7 @@
 import json
 import os
 import re
+from typing import Any
 
 import click
 import requests
@@ -15,7 +16,29 @@ from datadog_checks.dev.tooling.utils import get_valid_integrations, write_manif
 
 BOARD_ID_PATTERN = r'{site}/[^/]+/([^/]+)'
 DASHBOARD_API = 'https://api.{site}/api/v1/dashboard/{board_id}'
-REQUIRED_FIELDS = ["layout_type", "title", "description", "template_variables", "widgets"]
+SUPPORTED_FIELDS = (
+    'title',
+    'layout_type',
+    'widgets',
+    'description',
+    'is_read_only',
+    'restricted_roles',
+    'template_variables',
+    'notify_list',
+    'template_variable_presets',
+    'tags',
+    'experience_type',
+    'pause_auto_refresh',
+    'default_timeframe',
+    'tabs',
+    'reflow_type',
+)
+
+
+def _prepare_dashboard_payload(payload: dict[str, Any], author: str) -> dict[str, Any]:
+    dashboard_payload = {field: payload[field] for field in SUPPORTED_FIELDS if field in payload}
+    dashboard_payload['author_name'] = author
+    return dashboard_payload
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Dashboard utilities')
@@ -75,8 +98,7 @@ def export(ctx, url, integration, author):
         abort(str(e).replace(api_key, '*' * len(api_key)).replace(app_key, '*' * len(app_key)))
 
     payload = response.json()
-    new_payload = {field: payload[field] for field in REQUIRED_FIELDS}
-    new_payload['author_name'] = author
+    new_payload = _prepare_dashboard_payload(payload, author)
 
     output = json.dumps(new_payload, indent=4, sort_keys=True)
 

--- a/datadog_checks_dev/tests/tooling/commands/meta/test_dashboard.py
+++ b/datadog_checks_dev/tests/tooling/commands/meta/test_dashboard.py
@@ -1,0 +1,67 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.dev.tooling.commands.meta.dashboard import _prepare_dashboard_payload
+
+
+def test_prepare_dashboard_payload_preserves_supported_fields() -> None:
+    payload = {
+        'title': 'Tabbed dashboard',
+        'layout_type': 'ordered',
+        'widgets': [{'id': 123, 'definition': {'type': 'note'}}],
+        'description': 'Description',
+        'is_read_only': False,
+        'restricted_roles': ['role-id'],
+        'template_variables': [],
+        'notify_list': [],
+        'template_variable_presets': [],
+        'tags': ['team:integrations'],
+        'experience_type': 'default',
+        'pause_auto_refresh': False,
+        'default_timeframe': {'live_span': '1h'},
+        'tabs': [{'id': 'c9dc725c-aca0-4b48-899c-6215191842d9', 'name': 'Overview', 'widget_ids': [123]}],
+        'reflow_type': 'fixed',
+        'id': 'abc-def-ghi',
+        'author_name': 'Original author',
+        'author_handle': 'original.author@datadoghq.com',
+        'url': '/dashboard/abc-def-ghi/tabbed-dashboard',
+        'created_at': '2026-08-03T12:00:00Z',
+        'modified_at': '2026-08-03T13:00:00Z',
+        'unsupported_field': True,
+    }
+
+    exported_payload = _prepare_dashboard_payload(payload, 'Datadog')
+
+    assert exported_payload == {
+        'title': 'Tabbed dashboard',
+        'layout_type': 'ordered',
+        'widgets': [{'id': 123, 'definition': {'type': 'note'}}],
+        'description': 'Description',
+        'is_read_only': False,
+        'restricted_roles': ['role-id'],
+        'template_variables': [],
+        'notify_list': [],
+        'template_variable_presets': [],
+        'tags': ['team:integrations'],
+        'experience_type': 'default',
+        'pause_auto_refresh': False,
+        'default_timeframe': {'live_span': '1h'},
+        'tabs': [{'id': 'c9dc725c-aca0-4b48-899c-6215191842d9', 'name': 'Overview', 'widget_ids': [123]}],
+        'reflow_type': 'fixed',
+        'author_name': 'Datadog',
+    }
+
+
+def test_prepare_dashboard_payload_omits_missing_optional_fields() -> None:
+    payload = {
+        'title': 'Minimal dashboard',
+        'layout_type': 'free',
+        'widgets': [],
+    }
+
+    assert _prepare_dashboard_payload(payload, 'Example author') == {
+        'title': 'Minimal dashboard',
+        'layout_type': 'free',
+        'widgets': [],
+        'author_name': 'Example author',
+    }


### PR DESCRIPTION
### What does this PR do?

Updates `ddev meta dash export` to preserve the top-level dashboard fields currently supported by APW, including tabs, default timeframes, and reflow settings. The exporter continues to omit the top-level dashboard ID, response-only metadata, and unknown fields.

Adds focused unit coverage for tabbed dashboards, supported optional fields, metadata filtering, and minimal dashboard payloads.

### Motivation

The documented OOTB dashboard workflow recommends this exporter, but its legacy five-field allowlist silently strips newer supported fields. This caused multi-tab dashboards to lose their tab configuration when converted into integration dashboard assets.

Context: https://dd.slack.com/archives/C04SZSJ0NG7/p1785767829362089

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged