### PR TITLE
Don't use MD5 in vSphere

### DIFF
--- a/vsphere/changelog.d/24765.fixed
+++ b/vsphere/changelog.d/24765.fixed
@@ -1,1 +1,1 @@
-Use SHA-256 instead of MD5 for vSphere alarm events for FIPS compatibility.
+Use SHA-256 instead of MD5 for vSphere alarm events.

--- a/vsphere/changelog.d/24765.fixed
+++ b/vsphere/changelog.d/24765.fixed
@@ -1,0 +1,1 @@
+Use SHA-256 instead of MD5 for vSphere alarm events for FIPS compatibility.

--- a/vsphere/datadog_checks/vsphere/event.py
+++ b/vsphere/datadog_checks/vsphere/event.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 import re
 from datetime import datetime
-from hashlib import md5
+from hashlib import sha256
 
 from pyVmomi import vim
 
@@ -149,9 +149,9 @@ class VSphereEvent(object):
 
         def get_agg_key(alarm_event):
             return 'h:{0}|dc:{1}|a:{2}'.format(
-                md5(alarm_event.entity.name.encode('utf-8')).hexdigest()[:10],
-                md5(alarm_event.datacenter.name.encode('utf-8')).hexdigest()[:10],
-                md5(alarm_event.alarm.name.encode('utf-8')).hexdigest()[:10],
+                sha256(alarm_event.entity.name.encode('utf-8')).hexdigest()[:10],
+                sha256(alarm_event.datacenter.name.encode('utf-8')).hexdigest()[:10],
+                sha256(alarm_event.alarm.name.encode('utf-8')).hexdigest()[:10],
             )
 
         host_name = self.hostname

--- a/vsphere/tests/test_event.py
+++ b/vsphere/tests/test_event.py
@@ -98,6 +98,7 @@ def test_events_collection_one_event(aggregator, realtime_instance, dd_run_check
     )
     assert len(aggregator.events) == 1
     assert aggregator.events[0]['msg_title'] == "[Triggered] alarm1 on VM vm1 is now red"
+    assert aggregator.events[0]['event_object'] == 'h:7b11e3d1b4|dc:66a9ee1b16|a:73e47c07e2'
     assert check.latest_event_query == time1 + dt.timedelta(seconds=1)
 
 


### PR DESCRIPTION
### What does this PR do?

Replace MD5 with SHA-256 when constructing vSphere alarm event object keys. Even though we can use MD5 for non-security related purposes, it's easier and safer to get rid of it.

The MD5 hash is never actually used (which might be a long-standing bug) so this isn't a breaking change.

Sequence of events:
* The MD5 hash is generated in [`get_agg_get`](https://github.com/DataDog/integrations-core/blob/e8d9e0a132952cc027b0044f13c5511a337854ea/vsphere/datadog_checks/vsphere/event.py#L150-L155)
* It's in the event payload [with the `event_object` key](https://github.com/DataDog/integrations-core/blob/e8d9e0a132952cc027b0044f13c5511a337854ea/vsphere/datadog_checks/vsphere/event.py#L184-L185)
 * But then `aggregation_key` [is used in the base check](https://github.com/DataDog/integrations-core/blob/e8d9e0a132952cc027b0044f13c5511a337854ea/datadog_checks_base/datadog_checks/base/checks/base.py#L1718)!
 * And the C side [continues with `aggregation_key`](https://github.com/DataDog/datadog-agent/blob/83b0223d2cedd970f6e2647dc99bc05fbcc759cc/rtloader/common/builtins/aggregator.c#L327) and never picks up `event_object`!

Ideally we'd fix the key too but I wanted to keep this PR focused on the original goal, the FIPS 140-3 update.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
