### PR TITLE
Send size diffs to Datadog from the master disk usage workflow

### DIFF
--- a/.github/workflows/measure-disk-usage-master.yml
+++ b/.github/workflows/measure-disk-usage-master.yml
@@ -58,6 +58,30 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ddev -v size status --commit "${{ github.sha }}" --format json --to-dd-key ${{ steps.dd-sts.outputs.api_key }} --compressed
 
+      # Resolved explicitly rather than using github.event.before, which is all-zeros on the first push to a
+      # branch and points at a discarded commit after a force-push. Passing a rev like "<sha>^" instead is not an
+      # option either: ddev size diff fetches each commit by hash into a temporary clone.
+      - name: Resolve parent commit
+        id: parent
+        run: echo "sha=$(git rev-parse '${{ github.sha }}^')" >> "$GITHUB_OUTPUT"
+
+      # Supplementary telemetry: a failure here must not mask the absolute size metrics sent above.
+      - name: Measure disk usage difference (Uncompressed)
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          ddev -v size diff "${{ steps.parent.outputs.sha }}" "${{ github.sha }}"
+          --to-dd-key ${{ steps.dd-sts.outputs.api_key }}
+
+      - name: Measure disk usage difference (Compressed)
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          ddev -v size diff "${{ steps.parent.outputs.sha }}" "${{ github.sha }}"
+          --to-dd-key ${{ steps.dd-sts.outputs.api_key }} --compressed
+
       - name: Upload JSON uncompressed sizes artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/ddev/changelog.d/24768.added
+++ b/ddev/changelog.d/24768.added
@@ -1,0 +1,1 @@
+Add `--to-dd-org` and `--to-dd-key` to `ddev size diff` to send per-module size deltas to Datadog as `datadog.agent_integrations.size_diff`.

--- a/ddev/src/ddev/cli/size/diff.py
+++ b/ddev/src/ddev/cli/size/diff.py
@@ -27,6 +27,7 @@ from .utils.common_funcs import (
     get_valid_versions,
     plot_treemap,
     print_table,
+    send_diff_metrics_to_dd,
 )
 
 console = Console(stderr=True)
@@ -38,6 +39,8 @@ MINIMUM_LENGTH_COMMIT = 7
 @click.argument("first_commit")
 @click.argument("second_commit")
 @click.option("--python", "version", help="Python version (e.g 3.12).  If not specified, all versions will be analyzed")
+@click.option("--to-dd-org", type=str, help="Send metrics to Datadog using the specified organization name.")
+@click.option("--to-dd-key", type=str, help="Send metrics to datadoghq.com using the specified API key.")
 @common_params  # platform, compressed, format, show_gui
 @click.pass_obj
 def diff(
@@ -50,6 +53,8 @@ def diff(
     format: list[str],
     show_gui: bool,
     wheels_storage: str,
+    to_dd_org: Optional[str],
+    to_dd_key: Optional[str],
 ) -> None:
     """
     Compare the size of integrations and dependencies between two commits.
@@ -81,6 +86,8 @@ def diff(
             for fmt in format:
                 if fmt not in ["png", "csv", "markdown", "json"]:
                     raise ValueError(f"Invalid format: {fmt}. Only png, csv, markdown, and json are supported.")
+        if to_dd_org and to_dd_key:
+            raise click.BadParameter("Specify either --to-dd-org or --to-dd-key, not both")
         repo_url = app.repo.path
 
         with GitRepo(repo_url) as gitRepo:
@@ -121,6 +128,10 @@ def diff(
                     )
                 if format:
                     export_format(app, format, modules_plat_ver, "diff", platform, version, compressed)
+                # An empty list means no module changed size between the two commits, so there is nothing to send.
+                if (to_dd_org or to_dd_key) and modules_plat_ver:
+                    # Deltas are attributed to the later commit, which is the one that introduced them.
+                    send_diff_metrics_to_dd(app, second_commit, modules_plat_ver, to_dd_org, to_dd_key, compressed)
             except Exception as e:
                 progress.stop()
                 app.abort(str(e))

--- a/ddev/src/ddev/cli/size/utils/common_funcs.py
+++ b/ddev/src/ddev/cli/size/utils/common_funcs.py
@@ -862,6 +862,82 @@ def draw_treemap_rects_with_labels(
             )
 
 
+def initialize_dd_client(app: Application, org: str | None, key: str | None) -> None:
+    """
+    Resolves Datadog credentials from a configured org or a raw API key and initializes the API client.
+    """
+    config_file_info = app.config.orgs.get(org, {}) if org else {'api_key': key, 'site': 'datadoghq.com'}
+
+    if "api_key" not in config_file_info:
+        raise RuntimeError("No API key found in config file")
+    if "site" not in config_file_info:
+        raise RuntimeError("No site found in config file")
+
+    initialize(
+        api_key=config_file_info["api_key"],
+        api_host=f"https://api.{config_file_info['site']}",
+    )
+
+
+def build_module_tags(
+    item: FileDataEntryPlatformVersion, size_type: str, message: str, tickets: list[str], prs: list[str]
+) -> list[str]:
+    """
+    Builds the tag list shared by the per-module size and size_diff metrics.
+    """
+    return [
+        f"name:{item['Name']}",
+        f"type:{item['Type']}",
+        f"name_type:{item['Type']}({item['Name']})",
+        f"python_version:{item['Python_Version']}",
+        f"module_version:{item['Version']}",
+        f"platform:{item['Platform']}",
+        "team:agent-integrations",
+        f"compression:{size_type}",
+        f"metrics_version:{METRIC_VERSION}",
+        f"jira_ticket:{tickets[0]}",
+        f"pr_number:{prs[-1]}",
+        f"commit_message:{message}",
+    ]
+
+
+def send_diff_metrics_to_dd(
+    app: Application,
+    commit: str,
+    modules: list[FileDataEntryPlatformVersion],
+    org: str | None,
+    key: str | None,
+    compressed: bool,
+) -> None:
+    """
+    Sends per-module size deltas to Datadog as datadog.agent_integrations.size_diff.
+
+    Args:
+        commit: The later of the two compared commits. The deltas are attributed to it, so the size change
+            lands on the commit that introduced it.
+        modules: Formatted diff entries, whose Size_Bytes are deltas and may be negative.
+    """
+    size_type = "compressed" if compressed else "uncompressed"
+
+    initialize_dd_client(app, org, key)
+
+    timestamp, message, tickets, prs = get_commit_data(commit)
+
+    metrics = [
+        {
+            "metric": "datadog.agent_integrations.size_diff",
+            "type": "gauge",
+            "points": [(timestamp, item["Size_Bytes"])],
+            "tags": build_module_tags(item, size_type, message, tickets, prs),
+        }
+        for item in modules
+    ]
+
+    app.display(f"Sending {len(metrics)} size diff metrics to Datadog...")
+    app.display_debug(f"Sending size diff metrics: {metrics}")
+    api.Metric.send(metrics=metrics)
+
+
 def send_metrics_to_dd(
     app: Application,
     commit: str,
@@ -873,12 +949,7 @@ def send_metrics_to_dd(
     metric_name = "datadog.agent_integrations"
     size_type = "compressed" if compressed else "uncompressed"
 
-    config_file_info = app.config.orgs.get(org, {}) if org else {'api_key': key, 'site': 'datadoghq.com'}
-
-    if "api_key" not in config_file_info:
-        raise RuntimeError("No API key found in config file")
-    if "site" not in config_file_info:
-        raise RuntimeError("No site found in config file")
+    initialize_dd_client(app, org, key)
 
     timestamp, message, tickets, prs = get_commit_data(commit)
 
@@ -897,20 +968,7 @@ def send_metrics_to_dd(
                 "metric": f"{metric_name}.size",
                 "type": "gauge",
                 "points": [(timestamp, item["Size_Bytes"])],
-                "tags": [
-                    f"name:{item['Name']}",
-                    f"type:{item['Type']}",
-                    f"name_type:{item['Type']}({item['Name']})",
-                    f"python_version:{item['Python_Version']}",
-                    f"module_version:{item['Version']}",
-                    f"platform:{item['Platform']}",
-                    "team:agent-integrations",
-                    f"compression:{size_type}",
-                    f"metrics_version:{METRIC_VERSION}",
-                    f"jira_ticket:{tickets[0]}",
-                    f"pr_number:{prs[-1]}",
-                    f"commit_message:{message}",
-                ],
+                "tags": build_module_tags(item, size_type, message, tickets, prs),
             }
         )
 
@@ -960,11 +1018,6 @@ def send_metrics_to_dd(
                 ],
             }
         )
-
-    initialize(
-        api_key=config_file_info["api_key"],
-        api_host=f"https://api.{config_file_info['site']}",
-    )
 
     # Format the sizes dictionary into a human-readable summary
     summary_lines = []

--- a/ddev/tests/cli/size/test_diff.py
+++ b/ddev/tests/cli/size/test_diff.py
@@ -224,3 +224,148 @@ def test_diff_invalid_platform_and_version(ddev):
     ):
         result = ddev("size", "diff", "commit1", "commit2", "--platform", "linux", "--python", "2.10", "--compressed")
         assert result.exit_code != 0
+
+
+def test_diff_sends_metrics_to_dd(ddev, mock_size_diff_dependencies):
+    with patch("ddev.cli.size.diff.send_diff_metrics_to_dd") as mock_send:
+        result = ddev(
+            "size",
+            "diff",
+            "commit1",
+            "commit2",
+            "--platform",
+            "linux-aarch64",
+            "--python",
+            "3.12",
+            "--to-dd-key",
+            "fake_key",
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_send.assert_called_once()
+    app, commit, modules, org, key, compressed = mock_send.call_args.args
+    # Deltas must be attributed to the later of the two commits.
+    assert commit == "commit2"
+    assert org is None
+    assert key == "fake_key"
+    assert compressed is False
+    assert modules
+
+
+def test_diff_sends_compressed_metrics_to_dd(ddev, mock_size_diff_dependencies):
+    with patch("ddev.cli.size.diff.send_diff_metrics_to_dd") as mock_send:
+        result = ddev(
+            "size",
+            "diff",
+            "commit1",
+            "commit2",
+            "--platform",
+            "linux-aarch64",
+            "--python",
+            "3.12",
+            "--to-dd-key",
+            "fake_key",
+            "--compressed",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert mock_send.call_args.args[5] is True
+
+
+def test_diff_no_dd_credentials_does_not_send(ddev, mock_size_diff_dependencies):
+    with patch("ddev.cli.size.diff.send_diff_metrics_to_dd") as mock_send:
+        result = ddev("size", "diff", "commit1", "commit2", "--platform", "linux-aarch64", "--python", "3.12")
+
+    assert result.exit_code == 0, result.output
+    mock_send.assert_not_called()
+
+
+def test_diff_org_and_key_are_mutually_exclusive(ddev, mock_size_diff_dependencies):
+    with patch("ddev.cli.size.diff.send_diff_metrics_to_dd") as mock_send:
+        result = ddev("size", "diff", "commit1", "commit2", "--to-dd-org", "default", "--to-dd-key", "fake_key")
+
+    assert result.exit_code != 0
+    mock_send.assert_not_called()
+
+
+def test_diff_no_differences_does_not_send(ddev):
+    fake_repo = MagicMock()
+    fake_repo.repo_dir = "fake_repo"
+    fake_repo.get_commit_metadata.return_value = ("Feb 1 2025", "", "")
+
+    with (
+        patch("ddev.cli.size.diff.GitRepo.__enter__", return_value=fake_repo),
+        patch("ddev.cli.size.diff.GitRepo.__exit__", return_value=None),
+        patch("ddev.cli.size.diff.get_valid_platforms", return_value={"linux-aarch64"}),
+        patch("ddev.cli.size.diff.get_valid_versions", return_value={"3.12"}),
+        patch.object(fake_repo, "checkout_commit"),
+        patch("ddev.cli.size.utils.common_funcs.tempfile.mkdtemp", return_value="fake_repo"),
+        patch(
+            "ddev.cli.size.diff.get_files",
+            return_value=[{"Name": "path1.py", "Version": "1.0.0", "Size_Bytes": 1000, "Type": "Integration"}],
+        ),
+        patch(
+            "ddev.cli.size.diff.get_dependencies",
+            return_value=[{"Name": "dep1", "Version": "2.0.0", "Size_Bytes": 2000, "Type": "Dependency"}],
+        ),
+        patch("ddev.cli.size.diff.send_diff_metrics_to_dd") as mock_send,
+    ):
+        result = ddev(
+            "size",
+            "diff",
+            "commit1",
+            "commit2",
+            "--platform",
+            "linux-aarch64",
+            "--python",
+            "3.12",
+            "--to-dd-key",
+            "fake_key",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "No size differences were detected" in result.output
+    mock_send.assert_not_called()
+
+
+def test_send_diff_metrics_to_dd_metric_shape():
+    from ddev.cli.size.utils.common_funcs import send_diff_metrics_to_dd
+
+    modules = [
+        {
+            "Name": "dep1",
+            "Version": "1.0.0 -> 1.1.0",
+            "Type": "Dependency",
+            "Size_Bytes": 500,
+            "Size": "+500 B",
+            "Platform": "linux-aarch64",
+            "Python_Version": "3.12",
+        },
+        {
+            "Name": "path1.py (DELETED)",
+            "Version": "1.0.0",
+            "Type": "Integration",
+            "Size_Bytes": -1000,
+            "Size": "-1000 B",
+            "Platform": "linux-aarch64",
+            "Python_Version": "3.12",
+        },
+    ]
+
+    with (
+        patch("ddev.cli.size.utils.common_funcs.initialize"),
+        patch(
+            "ddev.cli.size.utils.common_funcs.get_commit_data",
+            return_value=(1700000000, "Bump dep1 (#123)", ["AI-1"], ["123"]),
+        ),
+        patch("ddev.cli.size.utils.common_funcs.api.Metric.send") as mock_metric_send,
+    ):
+        send_diff_metrics_to_dd(MagicMock(), "commit2", modules, None, "fake_key", False)
+
+    metrics = mock_metric_send.call_args.kwargs["metrics"]
+    assert len(metrics) == 2
+    assert {m["metric"] for m in metrics} == {"datadog.agent_integrations.size_diff"}
+    assert [m["points"] for m in metrics] == [[(1700000000, 500)], [(1700000000, -1000)]]
+    assert "name:dep1" in metrics[0]["tags"]
+    assert "compression:uncompressed" in metrics[0]["tags"]
+    assert "pr_number:123" in metrics[0]["tags"]


### PR DESCRIPTION
### What does this PR do?

Teaches `ddev size diff` to send its results to Datadog, and wires it into the master disk usage workflow.

- Adds `--to-dd-org` / `--to-dd-key` to `ddev size diff`, mirroring the options `ddev size status` already has. The two are mutually exclusive.
- Emits one `datadog.agent_integrations.size_diff` gauge point per module whose size changed, tagged identically to the existing `datadog.agent_integrations.size` metric (`name`, `type`, `name_type`, `python_version`, `module_version`, `platform`, `team`, `compression`, `metrics_version`, `jira_ticket`, `pr_number`, `commit_message`). Values are deltas and may be negative.
- Deltas are attributed to the **later** of the two compared commits, so a size change lands on the commit that introduced it.
- Adds two steps to `measure-disk-usage-master.yml` that diff each pushed commit against its parent, one uncompressed and one compressed, matching the existing status steps.

Refactoring along the way: the credential resolution and the per-module tag list were duplicated between the two send paths, so they are now `initialize_dd_client()` and `build_module_tags()`. `send_metrics_to_dd` is otherwise unchanged, and `METRIC_VERSION` stays at `2` since this adds a metric rather than changing the shape of an existing one.

Two things worth a reviewer's attention:

- **CI cost.** `diff` checks out both commits and resolves dependencies for every platform × Python version, twice per invocation. Two invocations means four full resolutions, which will likely be the slowest part of this workflow.

The parent commit is resolved with an explicit `git rev-parse '<sha>^'` step rather than using `github.event.before`, which is all-zeros on the first push to a branch and points at a discarded commit after a force-push. Passing a rev like `<sha>^` directly is not an option either, since `GitRepo.checkout_commit` fetches each commit by hash.

Both diff steps are `continue-on-error: true`. This is supplementary telemetry, and a failure here should not mask the absolute size metrics the workflow already sends successfully.

### Motivation

The workflow reports absolute sizes per master commit but nothing about what changed. Answering "which commit grew the wheel, and by how much" currently means diffing two absolute-size series by hand. Sending the deltas directly makes per-commit size regressions queryable and monitorable.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
