### PR TITLE
Count cached tokens in Togo input usage

### DIFF
--- a/ddev/src/ddev/ai/agent/types.py
+++ b/ddev/src/ddev/ai/agent/types.py
@@ -93,13 +93,18 @@ class ContextUsage:
 class TokenUsage:
     """Token accounting from a single API call."""
 
-    input_tokens: int  # tokens sent to the model (system_prompt + history)
+    input_tokens: int  # uncached input tokens
     output_tokens: int  # tokens the model generated
     cache_read_input_tokens: int  # tokens read from prompt cache
     cache_creation_input_tokens: int  # tokens written to prompt cache
     context_usage: ContextUsage | None = None  # None only for agents that don't provide context tracking
     web_search_requests: int = 0  # number of web search requests (billed separately from tokens)
     web_fetch_requests: int = 0  # number of web fetch requests (billed separately from tokens)
+
+    @property
+    def total_input_tokens(self) -> int:
+        """Return all input tokens processed, including prompt-cache reads and writes."""
+        return self.input_tokens + self.cache_read_input_tokens + self.cache_creation_input_tokens
 
 
 @dataclass(frozen=True)

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -269,7 +269,7 @@ class AgenticPhase(Phase):
         process: ReActProcess,
         context: dict[str, Any],
     ) -> tuple[str, int, int]:
-        """Run the final summary turn. Returns (memory_text, input_tokens, output_tokens)."""
+        """Run the final summary turn. Returns (memory_text, total_input_tokens, output_tokens)."""
         user_additions = None
         if self._config.checkpoint is not None:
             user_additions = render_inline(cast(str, self._config.checkpoint.memory_prompt), context)

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -276,7 +276,7 @@ class AgenticPhase(Phase):
         memory_prompt = self._checkpoint_manager.build_memory_prompt(user_additions)
 
         response = await process.run_once(memory_prompt)
-        return response.text, response.usage.input_tokens, response.usage.output_tokens
+        return response.text, response.usage.total_input_tokens, response.usage.output_tokens
 
     async def execute(self, context: dict[str, Any]) -> PhaseOutcome:
         self.before_react()

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -72,7 +72,7 @@ class ReActProcess:
         Args:
             response: The last agent response. If None, compaction is unconditional.
 
-        Returns (input_tokens, output_tokens) from the compaction API call.
+        Returns (total_input_tokens, output_tokens) from the compaction API call.
         Returns (0, 0) if history was already compact and no API call was made.
         """
         await self._callbacks.fire_before_compact(self._scope)

--- a/ddev/src/ddev/ai/react/process.py
+++ b/ddev/src/ddev/ai/react/process.py
@@ -86,7 +86,7 @@ class ReActProcess:
         await self._callbacks.fire_after_compact(self._scope)
         if compact_response is None:
             return 0, 0
-        return compact_response.usage.input_tokens, compact_response.usage.output_tokens
+        return compact_response.usage.total_input_tokens, compact_response.usage.output_tokens
 
     def _is_compact_needed(self, response: AgentResponse) -> bool:
         if self._compact_threshold_pct is None:
@@ -142,7 +142,7 @@ class ReActProcess:
 
             response = await self._agent.send(prompt, allowed_tools)
             iterations = 1
-            total_input = response.usage.input_tokens
+            total_input = response.usage.total_input_tokens
             total_output = response.usage.output_tokens
 
             await self._callbacks.fire_agent_response(self._scope, response, iterations)
@@ -180,7 +180,7 @@ class ReActProcess:
 
                 response = await self._agent.send(messages, allowed_tools)
                 iterations += 1
-                total_input += response.usage.input_tokens
+                total_input += response.usage.total_input_tokens
                 total_output += response.usage.output_tokens
 
                 await self._callbacks.fire_agent_response(self._scope, response, iterations)

--- a/ddev/tests/ai/agent/test_anthropic_agent.py
+++ b/ddev/tests/ai/agent/test_anthropic_agent.py
@@ -336,6 +336,7 @@ async def test_context_usage_fields() -> None:
 
     result = await agent.send("Hi")
 
+    assert result.usage.total_input_tokens == 1700
     ctx = result.usage.context_usage
     assert ctx.window_size == FAKE_CONTEXT_WINDOW
     assert ctx.used_tokens == 1700  # 1000 + 500 + 200

--- a/ddev/tests/ai/react/test_process.py
+++ b/ddev/tests/ai/react/test_process.py
@@ -132,6 +132,8 @@ def make_response(
     tool_calls: list[ToolCall] | None = None,
     input_tokens: int = 10,
     output_tokens: int = 5,
+    cache_read_input_tokens: int = 0,
+    cache_creation_input_tokens: int = 0,
     context_usage: ContextUsage | None = None,
 ) -> AgentResponse:
     return AgentResponse(
@@ -141,8 +143,8 @@ def make_response(
         usage=TokenUsage(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
+            cache_read_input_tokens=cache_read_input_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
             context_usage=context_usage,
         ),
     )
@@ -695,14 +697,27 @@ async def test_cancelled_error_notifies_and_reraises() -> None:
 
 async def test_total_tokens_summed_across_iterations() -> None:
     responses = [
-        make_response(StopReason.TOOL_USE, tool_calls=[make_tool_call()], input_tokens=100, output_tokens=50),
-        make_response(StopReason.END_TURN, input_tokens=200, output_tokens=80),
+        make_response(
+            StopReason.TOOL_USE,
+            tool_calls=[make_tool_call()],
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_input_tokens=1_000,
+            cache_creation_input_tokens=100,
+        ),
+        make_response(
+            StopReason.END_TURN,
+            input_tokens=200,
+            output_tokens=80,
+            cache_read_input_tokens=2_000,
+            cache_creation_input_tokens=200,
+        ),
     ]
     agent = MockAgent(responses)
 
     result = await make_process(agent).start("Task")
 
-    assert result.total_input_tokens == 300
+    assert result.total_input_tokens == 3_600
     assert result.total_output_tokens == 130
     assert result.iterations == 2
 
@@ -772,9 +787,15 @@ async def test_compact_delegates_to_agent_returns_zero_when_no_op() -> None:
 
 async def test_compact_returns_tokens_when_compaction_occurs() -> None:
     agent = MockAgent([])
-    agent.compact_response = make_response(StopReason.END_TURN, input_tokens=40, output_tokens=15)
+    agent.compact_response = make_response(
+        StopReason.END_TURN,
+        input_tokens=40,
+        output_tokens=15,
+        cache_read_input_tokens=400,
+        cache_creation_input_tokens=20,
+    )
     compact_in, compact_out = await make_process(agent).compact()
-    assert compact_in == 40
+    assert compact_in == 460
     assert compact_out == 15
 
 


### PR DESCRIPTION
### What does this PR do?

Updates Togo input-token rollups to include uncached input, prompt-cache reads, and prompt-cache creation tokens. The corrected total is used for ReAct iterations, compaction calls, and checkpoint-memory generation, so phase totals written to `checkpoints.yaml` reflect all input tokens processed.

Adds focused coverage for provider usage normalization, multi-turn accumulation, and compaction accounting.

### Motivation

Prompt caching caused Togo to significantly underreport input usage because phase rollups counted only the API `input_tokens` field while ignoring `cache_read_input_tokens` and `cache_creation_input_tokens`. This fixes the bug tracked in [AI-7081](https://datadoghq.atlassian.net/browse/AI-7081).

A broader refactor to preserve each token category throughout results and checkpoints is intentionally out of scope and tracked separately in [AI-7085](https://datadoghq.atlassian.net/browse/AI-7085).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

[AI-7081]: https://datadoghq.atlassian.net/browse/AI-7081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-7085]: https://datadoghq.atlassian.net/browse/AI-7085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ