### PR TITLE
Add batch and job progress aggregate to the test gatherer

### DIFF
--- a/ddev/changelog.d/24774.added
+++ b/ddev/changelog.d/24774.added
@@ -1,0 +1,1 @@
+Adds the batch and job progress aggregate (`DispatcherProgress`) to the test gatherer.

--- a/ddev/src/ddev/cli/ci/tests/messages.py
+++ b/ddev/src/ddev/cli/ci/tests/messages.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum, auto
 from typing import TYPE_CHECKING
 
-from ddev.cli.ci.tests.status import Status, batch_status
+from ddev.cli.ci.tests.status import Status
 from ddev.event_bus.orchestrator import BaseMessage
 from ddev.utils.junit import TestStatus
 
@@ -154,8 +154,12 @@ class WorkflowStatus:
 
     @property
     def status(self) -> Status:
-        """Batch-level label, from the same rule the aggregate uses."""
-        return batch_status(result.status for result in self.results)
+        """Batch-level label: FAILURE if any job failed, else SUCCESS if any passed, else SKIPPED."""
+        if self.failed_count > 0:
+            return Status.FAILURE
+        if self.success_count > 0:
+            return Status.SUCCESS
+        return Status.SKIPPED
 
 
 @dataclass

--- a/ddev/src/ddev/cli/ci/tests/messages.py
+++ b/ddev/src/ddev/cli/ci/tests/messages.py
@@ -15,6 +15,7 @@ from ddev.utils.junit import TestStatus
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from ddev.cli.ci.tests.progress import DispatcherProgress
     from ddev.utils.github_async.models import WorkflowJob
     from ddev.utils.junit import JUnitReport, JUnitTestCase
 
@@ -163,8 +164,14 @@ class WorkflowStatus:
 
 @dataclass
 class TestBatch(BaseMessage):
-    """Dispatched to trigger a matrix of test jobs."""
+    """Dispatched to trigger a matrix of test jobs.
 
+    ``batch_id`` is the logical batch identity (e.g. ``batch-01``). It is assigned during planning,
+    stays stable across workflow attempts, and is distinct from ``BaseMessage.id``, which identifies
+    one message instance.
+    """
+
+    batch_id: str
     job_list: list[BatchJob]
     jobs_count: int
     integrations: list[str]
@@ -172,8 +179,13 @@ class TestBatch(BaseMessage):
 
 @dataclass
 class BatchFinished(BaseMessage):
-    """Emitted when a GitHub Actions test workflow has completed."""
+    """Emitted when a GitHub Actions test workflow has completed.
 
+    ``batch_id`` carries the logical identity of the ``TestBatch`` this run came from, letting the
+    gatherer resolve the batch in its plan.
+    """
+
+    batch_id: str
     status: Status
     run_id: int
     workflow_url: str
@@ -186,14 +198,19 @@ class BatchFinished(BaseMessage):
 class UpdatePRComment(BaseMessage):
     """Emitted per finished batch to request a PR comment update.
 
-    ``revision`` is the gatherer's monotonic counter (one per consumed ``BatchFinished``); the
-    PR-updater renders the latest and rejects stale revisions. ``done`` is ``True`` only on the
-    revision that completes the final expected batch.
+    ``revision`` is the gatherer's monotonic counter (revision ``0`` is the initial plan, then one per
+    consumed ``BatchFinished``); the PR-updater renders the latest and rejects stale revisions.
+    ``done`` is ``True`` only on the revision that completes the final expected batch.
+
+    ``progress`` is the complete immutable snapshot of the aggregate at this revision and is the only
+    payload the PR updater needs; the ``workflows`` list and its derived counters are the earlier flat
+    view, kept until the updater is migrated.
     """
 
     revision: int
     done: bool
     workflows: list[WorkflowStatus]
+    progress: DispatcherProgress
 
     @property
     def passed(self) -> int:

--- a/ddev/src/ddev/cli/ci/tests/messages.py
+++ b/ddev/src/ddev/cli/ci/tests/messages.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum, auto
 from typing import TYPE_CHECKING
 
-from ddev.cli.ci.tests.status import Status
+from ddev.cli.ci.tests.status import Status, batch_status
 from ddev.event_bus.orchestrator import BaseMessage
 from ddev.utils.junit import TestStatus
 
@@ -154,12 +154,8 @@ class WorkflowStatus:
 
     @property
     def status(self) -> Status:
-        """Batch-level label: FAILURE if any job failed, else SUCCESS if any passed, else SKIPPED."""
-        if self.failed_count > 0:
-            return Status.FAILURE
-        if self.success_count > 0:
-            return Status.SUCCESS
-        return Status.SKIPPED
+        """Batch-level label, from the same rule the aggregate uses."""
+        return batch_status(result.status for result in self.results)
 
 
 @dataclass

--- a/ddev/src/ddev/cli/ci/tests/messages.py
+++ b/ddev/src/ddev/cli/ci/tests/messages.py
@@ -162,9 +162,8 @@ class WorkflowStatus:
 class TestBatch(BaseMessage):
     """Dispatched to trigger a matrix of test jobs.
 
-    ``batch_id`` is the logical batch identity (e.g. ``batch-01``). It is assigned during planning,
-    stays stable across workflow attempts, and is distinct from ``BaseMessage.id``, which identifies
-    one message instance.
+    ``batch_id`` is the logical batch identity (e.g. ``batch-01``): assigned during planning, stable
+    across workflow attempts, and distinct from ``BaseMessage.id``, which identifies one message.
     """
 
     batch_id: str
@@ -177,8 +176,8 @@ class TestBatch(BaseMessage):
 class BatchFinished(BaseMessage):
     """Emitted when a GitHub Actions test workflow has completed.
 
-    ``batch_id`` carries the logical identity of the ``TestBatch`` this run came from, letting the
-    gatherer resolve the batch in its plan.
+    ``batch_id`` is the identity of the ``TestBatch`` this run came from, so the gatherer can resolve
+    it in the plan.
     """
 
     batch_id: str
@@ -194,12 +193,9 @@ class BatchFinished(BaseMessage):
 class UpdatePRComment(BaseMessage):
     """Emitted per finished batch to request a PR comment update.
 
-    ``revision`` is ordering metadata: the gatherer's monotonic counter, revision ``0`` being the
-    initial plan and then one per consumed ``BatchFinished``. The PR updater renders the latest and
-    rejects stale revisions.
-
-    ``progress`` is the whole payload — the complete immutable snapshot of the aggregate at this
-    revision, including whether the run is done and every count the comment needs.
+    ``revision`` is ordering metadata: revision ``0`` is the initial plan, then one per consumed
+    ``BatchFinished``. The updater renders the latest and rejects stale revisions. ``progress`` is
+    the whole payload, including whether the run is done and every count the comment needs.
     """
 
     revision: int

--- a/ddev/src/ddev/cli/ci/tests/messages.py
+++ b/ddev/src/ddev/cli/ci/tests/messages.py
@@ -194,33 +194,13 @@ class BatchFinished(BaseMessage):
 class UpdatePRComment(BaseMessage):
     """Emitted per finished batch to request a PR comment update.
 
-    ``revision`` is the gatherer's monotonic counter (revision ``0`` is the initial plan, then one per
-    consumed ``BatchFinished``); the PR-updater renders the latest and rejects stale revisions.
-    ``done`` is ``True`` only on the revision that completes the final expected batch.
+    ``revision`` is ordering metadata: the gatherer's monotonic counter, revision ``0`` being the
+    initial plan and then one per consumed ``BatchFinished``. The PR updater renders the latest and
+    rejects stale revisions.
 
-    ``progress`` is the complete immutable snapshot of the aggregate at this revision and is the only
-    payload the PR updater needs; the ``workflows`` list and its derived counters are the earlier flat
-    view, kept until the updater is migrated.
+    ``progress`` is the whole payload — the complete immutable snapshot of the aggregate at this
+    revision, including whether the run is done and every count the comment needs.
     """
 
     revision: int
-    done: bool
-    workflows: list[WorkflowStatus]
     progress: DispatcherProgress
-
-    @property
-    def passed(self) -> int:
-        return sum(workflow.success_count for workflow in self.workflows)
-
-    @property
-    def failed(self) -> int:
-        return sum(workflow.failed_count for workflow in self.workflows)
-
-    @property
-    def skipped(self) -> int:
-        return sum(workflow.skipped_count for workflow in self.workflows)
-
-    @property
-    def complete(self) -> int:
-        """Total jobs finished so far (passed + failed + skipped across all gathered batches)."""
-        return sum(len(workflow.results) for workflow in self.workflows)

--- a/ddev/src/ddev/cli/ci/tests/progress.py
+++ b/ddev/src/ddev/cli/ci/tests/progress.py
@@ -10,7 +10,8 @@ jobs, and each job contains its executions in attempt order.
 These objects are the only domain language the PR updater consumes. They deliberately contain no
 GitHub API models: the runner turns API responses into execution facts, the gatherer normalizes them
 into the objects below, and the renderer works from a complete immutable snapshot. ``conclusion`` is
-the one raw GitHub value retained, kept as a plain string for diagnosis and rendering.
+the one GitHub value retained — as its ``WorkflowJobConclusion`` enum, never a bare string — because
+it distinguishes outcomes (cancelled, timed out, action required) that ``Status`` collapses.
 
 ``BatchJob`` (in ``messages``) is the authoritative planned-job representation, so there is no
 separate planned-job type here. Although it is not frozen, every component treats each instance as
@@ -20,7 +21,7 @@ immutable after planning.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, StrEnum, auto
 from typing import TYPE_CHECKING
 
 from ddev.cli.ci.tests.status import Status
@@ -30,7 +31,21 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from ddev.cli.ci.tests.messages import BatchJob
+    from ddev.utils.github_async.models.workflow import WorkflowJobConclusion
     from ddev.utils.junit import JUnitReport, JUnitTestCase
+
+
+class ProgressError(StrEnum):
+    """Why a batch or execution is unavailable, as a closed set the renderer can branch on.
+
+    A free-form message would force the PR updater to match on prose. The subject is already on the
+    object carrying the error, so the member alone says everything: ``NO_ARTIFACTS`` on a job
+    attempt means that job's artifacts, ``TIMED_OUT`` on a batch means that batch.
+    """
+
+    TIMED_OUT = auto()
+    NO_JOB_RESULTS = auto()
+    NO_ARTIFACTS = auto()
 
 
 class ExecutionState(Enum):
@@ -52,20 +67,24 @@ class ExecutionState(Enum):
 class JobAttemptProgress:
     """One observed execution of one planned job.
 
-    ``attempt`` is the workflow attempt that produced this execution; ``status`` is ``None`` while no
-    outcome is available; ``failed_steps`` holds every failing step name, since a job can fail more
-    than one step; ``reports`` holds the complete parsed JUnit reports for the execution; ``error``
-    records an unavailable or processing error, such as a job or artifact that never showed up.
+    An attempt exists only because the job ran, so ``status`` is always known — a job whose outcome
+    is undetermined has no attempt, not an attempt with an empty status. ``attempt`` is its 1-based
+    position in the job's history; ``failed_steps`` holds every failing step name, since a job can
+    fail more than one step; ``reports`` holds the complete parsed JUnit reports; ``error`` records
+    what was unavailable, such as artifacts that never showed up.
+
+    ``job_id``, ``conclusion`` and ``job_url`` come from the correlated workflow job and are ``None``
+    only when GitHub never reported one, which today means the batch timed out.
     """
 
     attempt: int
     job_id: int | None
-    status: Status | None
-    conclusion: str | None
+    status: Status
+    conclusion: WorkflowJobConclusion | None
     failed_steps: tuple[str, ...]
     job_url: str | None
     reports: tuple[JUnitReport, ...]
-    error: str | None = None
+    error: ProgressError | None = None
 
     @property
     def failed_tests(self) -> list[JUnitTestCase]:
@@ -121,7 +140,7 @@ class BatchProgress:
     retries_remaining: int
     retrying_jobs: tuple[BatchJob, ...]
     jobs: tuple[JobProgress, ...]
-    error: str | None = None
+    error: ProgressError | None = None
 
 
 @dataclass(frozen=True)
@@ -153,8 +172,8 @@ class DispatcherProgress:
 
     @property
     def complete(self) -> int:
-        """Planned jobs whose latest execution has an outcome."""
-        return sum(1 for job in self._jobs if job.latest is not None and job.latest.status is not None)
+        """Planned jobs that have run: an attempt carries an outcome by construction."""
+        return sum(1 for job in self._jobs if job.latest is not None)
 
     @property
     def total(self) -> int:

--- a/ddev/src/ddev/cli/ci/tests/progress.py
+++ b/ddev/src/ddev/cli/ci/tests/progress.py
@@ -6,10 +6,8 @@
 ``DispatcherProgress`` -> ``BatchProgress`` -> ``JobProgress`` -> ``JobAttemptProgress``: batches,
 their planned jobs, and each job's executions in attempt order.
 
-No GitHub API models are exposed. ``conclusion`` is the exception, kept as its enum because it
-distinguishes outcomes (cancelled, timed out, action required) that ``Status`` collapses.
-``BatchJob`` (in ``messages``) is the planned-job representation, treated as immutable after
-planning.
+``conclusion`` is the one GitHub value kept, as its enum, because it distinguishes outcomes
+(cancelled, timed out, action required) that ``Status`` collapses.
 """
 
 from __future__ import annotations
@@ -30,10 +28,7 @@ if TYPE_CHECKING:
 
 
 class ProgressError(StrEnum):
-    """Why a batch or execution is unavailable, as a closed set to branch on rather than prose.
-
-    The subject is the object carrying the error: ``NO_ARTIFACTS`` on an attempt means that job's.
-    """
+    """Why a batch or execution is unavailable, as a closed set to branch on rather than prose."""
 
     TIMED_OUT = auto()
     NO_JOB_RESULTS = auto()
@@ -43,8 +38,7 @@ class ProgressError(StrEnum):
 class ExecutionState(Enum):
     """Where an execution is in its lifecycle, orthogonal to its outcome (``Status``).
 
-    ``RUNNING`` and ``RETRYING`` become reachable with the retry work; until then a batch is
-    ``PLANNED`` until its ``BatchFinished`` arrives.
+    ``RUNNING`` and ``RETRYING`` become reachable with the retry work.
     """
 
     PLANNED = "planned"
@@ -58,9 +52,8 @@ class JobAttemptProgress:
     """One observed execution of one planned job.
 
     An attempt exists only because the job ran, so ``status`` is always known: an undetermined job
-    has no attempt. ``attempt`` is its 1-based position in the job's history, ``failed_steps`` holds
-    every failing step (a job can fail more than one). ``job_id``, ``conclusion`` and ``job_url``
-    are ``None`` only when GitHub never reported the job, which today means the batch timed out.
+    has no attempt. ``attempt`` is its 1-based position in the job's history. ``job_id``,
+    ``conclusion`` and ``job_url`` are ``None`` when GitHub never reported the job.
     """
 
     attempt: int
@@ -88,8 +81,7 @@ class JobAttemptProgress:
 class JobProgress:
     """One logical planned job throughout execution.
 
-    ``attempts`` is its history in attempt order, and can be sparse: a job that already succeeded
-    does not run again in a failed-job rerun.
+    ``attempts`` can be sparse: a job that already succeeded does not run again in a failed-job rerun.
     """
 
     job: BatchJob
@@ -110,9 +102,8 @@ class JobProgress:
 class BatchProgress:
     """One logical batch, from planning through its terminal outcome.
 
-    ``batch_id`` is the stable logical identity, unrelated to any message id. ``run_id`` and
-    ``workflow_url`` are filled once GitHub has a run. ``status`` stays ``None`` until ``FINISHED``.
-    ``jobs`` covers every planned job, including those with no attempt yet.
+    ``status`` is the workflow's own, not a roll-up of ``jobs_progress``: a workflow can fail in a
+    step no tracked job covers. It stays ``None`` until ``FINISHED``.
     """
 
     batch_id: str
@@ -124,7 +115,7 @@ class BatchProgress:
     max_attempts: int
     retries_remaining: int
     retrying_jobs: tuple[BatchJob, ...]
-    jobs: tuple[JobProgress, ...]
+    jobs_progress: tuple[JobProgress, ...]
     error: ProgressError | None = None
 
 
@@ -132,11 +123,9 @@ class BatchProgress:
 class DispatcherProgress:
     """The complete point-in-time aggregate across all batches.
 
-    Carries all state known at its revision, including batches that have not started, so the PR
-    updater can render the newest snapshot and discard the rest. ``revision`` is absent by design:
-    it is ordering metadata owned by ``UpdatePRComment``.
-
-    The counters derive from ``JobProgress.latest`` only, so a job retried to success counts once.
+    Carries all state known at its revision, so the PR updater renders the newest snapshot and
+    discards the rest. The counters derive from ``JobProgress.latest`` only, so a job retried to
+    success counts once.
     """
 
     batches: tuple[BatchProgress, ...]
@@ -157,16 +146,16 @@ class DispatcherProgress:
     @property
     def complete(self) -> int:
         """Planned jobs that have run."""
-        return sum(1 for job in self._jobs if job.latest is not None)
+        return sum(1 for job in self._jobs_progress if job.latest is not None)
 
     @property
     def total(self) -> int:
         """Every planned job, run or not."""
-        return sum(1 for _ in self._jobs)
+        return sum(1 for _ in self._jobs_progress)
 
     @property
-    def _jobs(self) -> Iterator[JobProgress]:
-        return (job for batch in self.batches for job in batch.jobs)
+    def _jobs_progress(self) -> Iterator[JobProgress]:
+        return (job for batch in self.batches for job in batch.jobs_progress)
 
     def _count(self, status: Status) -> int:
-        return sum(1 for job in self._jobs if job.latest is not None and job.latest.status == status)
+        return sum(1 for job in self._jobs_progress if job.latest is not None and job.latest.status == status)

--- a/ddev/src/ddev/cli/ci/tests/progress.py
+++ b/ddev/src/ddev/cli/ci/tests/progress.py
@@ -3,19 +3,13 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 """Aggregate state the gatherer owns and the PR updater renders.
 
-The hierarchy is ``DispatcherProgress`` -> ``BatchProgress`` -> ``JobProgress`` ->
-``JobAttemptProgress``: the dispatcher snapshot contains batches, each batch contains its planned
-jobs, and each job contains its executions in attempt order.
+``DispatcherProgress`` -> ``BatchProgress`` -> ``JobProgress`` -> ``JobAttemptProgress``: batches,
+their planned jobs, and each job's executions in attempt order.
 
-These objects are the only domain language the PR updater consumes. They deliberately contain no
-GitHub API models: the runner turns API responses into execution facts, the gatherer normalizes them
-into the objects below, and the renderer works from a complete immutable snapshot. ``conclusion`` is
-the one GitHub value retained — as its ``WorkflowJobConclusion`` enum, never a bare string — because
-it distinguishes outcomes (cancelled, timed out, action required) that ``Status`` collapses.
-
-``BatchJob`` (in ``messages``) is the authoritative planned-job representation, so there is no
-separate planned-job type here. Although it is not frozen, every component treats each instance as
-immutable after planning.
+No GitHub API models are exposed. ``conclusion`` is the exception, kept as its enum because it
+distinguishes outcomes (cancelled, timed out, action required) that ``Status`` collapses.
+``BatchJob`` (in ``messages``) is the planned-job representation, treated as immutable after
+planning.
 """
 
 from __future__ import annotations
@@ -36,11 +30,9 @@ if TYPE_CHECKING:
 
 
 class ProgressError(StrEnum):
-    """Why a batch or execution is unavailable, as a closed set the renderer can branch on.
+    """Why a batch or execution is unavailable, as a closed set to branch on rather than prose.
 
-    A free-form message would force the PR updater to match on prose. The subject is already on the
-    object carrying the error, so the member alone says everything: ``NO_ARTIFACTS`` on a job
-    attempt means that job's artifacts, ``TIMED_OUT`` on a batch means that batch.
+    The subject is the object carrying the error: ``NO_ARTIFACTS`` on an attempt means that job's.
     """
 
     TIMED_OUT = auto()
@@ -49,12 +41,10 @@ class ProgressError(StrEnum):
 
 
 class ExecutionState(Enum):
-    """Where an execution is in its lifecycle.
+    """Where an execution is in its lifecycle, orthogonal to its outcome (``Status``).
 
-    Orthogonal to :class:`~ddev.cli.ci.tests.status.Status`, which is the normalized outcome: a
-    batch that is not ``FINISHED`` has no final status. ``RUNNING`` and ``RETRYING`` become
-    reachable with the retry work (``BatchAttemptFinished``); until then a batch is ``PLANNED``
-    until its ``BatchFinished`` arrives.
+    ``RUNNING`` and ``RETRYING`` become reachable with the retry work; until then a batch is
+    ``PLANNED`` until its ``BatchFinished`` arrives.
     """
 
     PLANNED = "planned"
@@ -67,14 +57,10 @@ class ExecutionState(Enum):
 class JobAttemptProgress:
     """One observed execution of one planned job.
 
-    An attempt exists only because the job ran, so ``status`` is always known — a job whose outcome
-    is undetermined has no attempt, not an attempt with an empty status. ``attempt`` is its 1-based
-    position in the job's history; ``failed_steps`` holds every failing step name, since a job can
-    fail more than one step; ``reports`` holds the complete parsed JUnit reports; ``error`` records
-    what was unavailable, such as artifacts that never showed up.
-
-    ``job_id``, ``conclusion`` and ``job_url`` come from the correlated workflow job and are ``None``
-    only when GitHub never reported one, which today means the batch timed out.
+    An attempt exists only because the job ran, so ``status`` is always known: an undetermined job
+    has no attempt. ``attempt`` is its 1-based position in the job's history, ``failed_steps`` holds
+    every failing step (a job can fail more than one). ``job_id``, ``conclusion`` and ``job_url``
+    are ``None`` only when GitHub never reported the job, which today means the batch timed out.
     """
 
     attempt: int
@@ -88,7 +74,7 @@ class JobAttemptProgress:
 
     @property
     def failed_tests(self) -> list[JUnitTestCase]:
-        """Every failed/errored test case across this execution's reports, flattened for rendering."""
+        """Every failed/errored test case across this execution's reports."""
         return [
             case
             for report in self.reports
@@ -102,8 +88,8 @@ class JobAttemptProgress:
 class JobProgress:
     """One logical planned job throughout execution.
 
-    ``attempts`` is the retained history in attempt order. It can be sparse, because a job that
-    already succeeded does not run again in a failed-job rerun.
+    ``attempts`` is its history in attempt order, and can be sparse: a job that already succeeded
+    does not run again in a failed-job rerun.
     """
 
     job: BatchJob
@@ -111,7 +97,7 @@ class JobProgress:
 
     @property
     def latest(self) -> JobAttemptProgress | None:
-        """The most recent execution — the only attempt that counts toward final totals."""
+        """The most recent execution: the only attempt that counts toward totals."""
         return self.attempts[-1] if self.attempts else None
 
     @property
@@ -124,10 +110,9 @@ class JobProgress:
 class BatchProgress:
     """One logical batch, from planning through its terminal outcome.
 
-    ``batch_id`` is Dispatcher's stable logical identity, unrelated to any message id. ``run_id`` and
-    ``workflow_url`` are filled once GitHub has a run for the batch. ``status`` stays ``None`` until
-    ``state`` is ``FINISHED``. ``jobs`` always covers every planned job, including those with no
-    observed attempt yet.
+    ``batch_id`` is the stable logical identity, unrelated to any message id. ``run_id`` and
+    ``workflow_url`` are filled once GitHub has a run. ``status`` stays ``None`` until ``FINISHED``.
+    ``jobs`` covers every planned job, including those with no attempt yet.
     """
 
     batch_id: str
@@ -147,12 +132,11 @@ class BatchProgress:
 class DispatcherProgress:
     """The complete point-in-time aggregate across all batches.
 
-    Every snapshot carries all state known at its revision — including batches that have not started
-    — so the PR updater can render the newest one and discard the rest. ``revision`` is deliberately
-    absent: it is message-ordering metadata owned by ``UpdatePRComment``.
+    Carries all state known at its revision, including batches that have not started, so the PR
+    updater can render the newest snapshot and discard the rest. ``revision`` is absent by design:
+    it is ordering metadata owned by ``UpdatePRComment``.
 
-    The counters below derive from ``JobProgress.latest`` only, so a job retried to success counts
-    once, as passed.
+    The counters derive from ``JobProgress.latest`` only, so a job retried to success counts once.
     """
 
     batches: tuple[BatchProgress, ...]
@@ -172,12 +156,12 @@ class DispatcherProgress:
 
     @property
     def complete(self) -> int:
-        """Planned jobs that have run: an attempt carries an outcome by construction."""
+        """Planned jobs that have run."""
         return sum(1 for job in self._jobs if job.latest is not None)
 
     @property
     def total(self) -> int:
-        """Every planned job across every batch, whether it has run or not."""
+        """Every planned job, run or not."""
         return sum(1 for _ in self._jobs)
 
     @property

--- a/ddev/src/ddev/cli/ci/tests/progress.py
+++ b/ddev/src/ddev/cli/ci/tests/progress.py
@@ -1,0 +1,169 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Aggregate state the gatherer owns and the PR updater renders.
+
+The hierarchy is ``DispatcherProgress`` -> ``BatchProgress`` -> ``JobProgress`` ->
+``JobAttemptProgress``: the dispatcher snapshot contains batches, each batch contains its planned
+jobs, and each job contains its executions in attempt order.
+
+These objects are the only domain language the PR updater consumes. They deliberately contain no
+GitHub API models: the runner turns API responses into execution facts, the gatherer normalizes them
+into the objects below, and the renderer works from a complete immutable snapshot. ``conclusion`` is
+the one raw GitHub value retained, kept as a plain string for diagnosis and rendering.
+
+``BatchJob`` (in ``messages``) is the authoritative planned-job representation, so there is no
+separate planned-job type here. Although it is not frozen, every component treats each instance as
+immutable after planning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from ddev.cli.ci.tests.status import Status
+from ddev.utils.junit import TestStatus
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ddev.cli.ci.tests.messages import BatchJob
+    from ddev.utils.junit import JUnitReport, JUnitTestCase
+
+
+class ExecutionState(Enum):
+    """Where an execution is in its lifecycle.
+
+    Orthogonal to :class:`~ddev.cli.ci.tests.status.Status`, which is the normalized outcome: a
+    batch that is not ``FINISHED`` has no final status. ``RUNNING`` and ``RETRYING`` become
+    reachable with the retry work (``BatchAttemptFinished``); until then a batch is ``PLANNED``
+    until its ``BatchFinished`` arrives.
+    """
+
+    PLANNED = "planned"
+    RUNNING = "running"
+    RETRYING = "retrying"
+    FINISHED = "finished"
+
+
+@dataclass(frozen=True)
+class JobAttemptProgress:
+    """One observed execution of one planned job.
+
+    ``attempt`` is the workflow attempt that produced this execution; ``status`` is ``None`` while no
+    outcome is available; ``failed_steps`` holds every failing step name, since a job can fail more
+    than one step; ``reports`` holds the complete parsed JUnit reports for the execution; ``error``
+    records an unavailable or processing error, such as a job or artifact that never showed up.
+    """
+
+    attempt: int
+    job_id: int | None
+    status: Status | None
+    conclusion: str | None
+    failed_steps: tuple[str, ...]
+    job_url: str | None
+    reports: tuple[JUnitReport, ...]
+    error: str | None = None
+
+    @property
+    def failed_tests(self) -> list[JUnitTestCase]:
+        """Every failed/errored test case across this execution's reports, flattened for rendering."""
+        return [
+            case
+            for report in self.reports
+            for suite in report.test_suites
+            for case in suite.test_cases
+            if case.status in (TestStatus.FAILED, TestStatus.ERROR)
+        ]
+
+
+@dataclass(frozen=True)
+class JobProgress:
+    """One logical planned job throughout execution.
+
+    ``attempts`` is the retained history in attempt order. It can be sparse, because a job that
+    already succeeded does not run again in a failed-job rerun.
+    """
+
+    job: BatchJob
+    attempts: tuple[JobAttemptProgress, ...]
+
+    @property
+    def latest(self) -> JobAttemptProgress | None:
+        """The most recent execution — the only attempt that counts toward final totals."""
+        return self.attempts[-1] if self.attempts else None
+
+    @property
+    def retry_count(self) -> int:
+        """Executions minus one. Not ``run_attempt - 1``: histories can be sparse."""
+        return max(0, len(self.attempts) - 1)
+
+
+@dataclass(frozen=True)
+class BatchProgress:
+    """One logical batch, from planning through its terminal outcome.
+
+    ``batch_id`` is Dispatcher's stable logical identity, unrelated to any message id. ``run_id`` and
+    ``workflow_url`` are filled once GitHub has a run for the batch. ``status`` stays ``None`` until
+    ``state`` is ``FINISHED``. ``jobs`` always covers every planned job, including those with no
+    observed attempt yet.
+    """
+
+    batch_id: str
+    run_id: int | None
+    workflow_url: str | None
+    state: ExecutionState
+    status: Status | None
+    current_attempt: int | None
+    max_attempts: int
+    retries_remaining: int
+    retrying_jobs: tuple[BatchJob, ...]
+    jobs: tuple[JobProgress, ...]
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class DispatcherProgress:
+    """The complete point-in-time aggregate across all batches.
+
+    Every snapshot carries all state known at its revision — including batches that have not started
+    — so the PR updater can render the newest one and discard the rest. ``revision`` is deliberately
+    absent: it is message-ordering metadata owned by ``UpdatePRComment``.
+
+    The counters below derive from ``JobProgress.latest`` only, so a job retried to success counts
+    once, as passed.
+    """
+
+    batches: tuple[BatchProgress, ...]
+    done: bool
+
+    @property
+    def passed(self) -> int:
+        return self._count(Status.SUCCESS)
+
+    @property
+    def failed(self) -> int:
+        return self._count(Status.FAILURE)
+
+    @property
+    def skipped(self) -> int:
+        return self._count(Status.SKIPPED)
+
+    @property
+    def complete(self) -> int:
+        """Planned jobs whose latest execution has an outcome."""
+        return sum(1 for job in self._jobs if job.latest is not None and job.latest.status is not None)
+
+    @property
+    def total(self) -> int:
+        """Every planned job across every batch, whether it has run or not."""
+        return sum(1 for _ in self._jobs)
+
+    @property
+    def _jobs(self) -> Iterator[JobProgress]:
+        return (job for batch in self.batches for job in batch.jobs)
+
+    def _count(self, status: Status) -> int:
+        return sum(1 for job in self._jobs if job.latest is not None and job.latest.status == status)

--- a/ddev/src/ddev/cli/ci/tests/status.py
+++ b/ddev/src/ddev/cli/ci/tests/status.py
@@ -29,10 +29,9 @@ class Status(StrEnum):
 
 
 def batch_status(statuses: Iterable[Status]) -> Status:
-    """Collapse the statuses of a batch's jobs into the batch's own label.
+    """Collapse a batch's job statuses into its own label: failure wins, then success, else skipped.
 
-    Failure wins, then success, else skipped. Callers that can distinguish "every job was skipped"
-    from "no job reported anything" must handle the empty case themselves.
+    Callers that must tell "all skipped" from "nothing reported" handle the empty case themselves.
     """
     known = set(statuses)
     if Status.FAILURE in known:

--- a/ddev/src/ddev/cli/ci/tests/status.py
+++ b/ddev/src/ddev/cli/ci/tests/status.py
@@ -12,8 +12,12 @@ collapses a GitHub conclusion into it.
 from __future__ import annotations
 
 from enum import StrEnum, auto
+from typing import TYPE_CHECKING
 
 from ddev.utils.github_async.models.workflow import WorkflowJobConclusion
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class Status(StrEnum):
@@ -22,6 +26,20 @@ class Status(StrEnum):
     SUCCESS = auto()
     FAILURE = auto()
     SKIPPED = auto()
+
+
+def batch_status(statuses: Iterable[Status]) -> Status:
+    """Collapse the statuses of a batch's jobs into the batch's own label.
+
+    Failure wins, then success, else skipped. Callers that can distinguish "every job was skipped"
+    from "no job reported anything" must handle the empty case themselves.
+    """
+    known = set(statuses)
+    if Status.FAILURE in known:
+        return Status.FAILURE
+    if Status.SUCCESS in known:
+        return Status.SUCCESS
+    return Status.SKIPPED
 
 
 def conclusion_to_status(conclusion: str | None) -> Status:

--- a/ddev/src/ddev/cli/ci/tests/status.py
+++ b/ddev/src/ddev/cli/ci/tests/status.py
@@ -12,12 +12,8 @@ collapses a GitHub conclusion into it.
 from __future__ import annotations
 
 from enum import StrEnum, auto
-from typing import TYPE_CHECKING
 
 from ddev.utils.github_async.models.workflow import WorkflowJobConclusion
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
 
 
 class Status(StrEnum):
@@ -26,19 +22,6 @@ class Status(StrEnum):
     SUCCESS = auto()
     FAILURE = auto()
     SKIPPED = auto()
-
-
-def batch_status(statuses: Iterable[Status]) -> Status:
-    """Collapse a batch's job statuses into its own label: failure wins, then success, else skipped.
-
-    Callers that must tell "all skipped" from "nothing reported" handle the empty case themselves.
-    """
-    known = set(statuses)
-    if Status.FAILURE in known:
-        return Status.FAILURE
-    if Status.SUCCESS in known:
-        return Status.SUCCESS
-    return Status.SKIPPED
 
 
 def conclusion_to_status(conclusion: str | None) -> Status:

--- a/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
@@ -54,10 +54,13 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
 
     It is constructed with the complete batch plan, keeps an in-memory registry of every job's full
     result across all batches and, on each finished batch, emits an ``UpdatePRComment`` carrying a
-    monotonically increasing ``revision`` and the whole accumulated state — as a ``DispatcherProgress``
-    snapshot covering every planned batch, including those still to run. ``done`` is derived from that
-    snapshot: it is set once no planned batch is left unfinished. It does not post to GitHub —
+    monotonically increasing ``revision`` and a ``DispatcherProgress`` snapshot covering every planned
+    batch, including those still to run. That snapshot is the message's whole payload; ``done`` is
+    derived from it, set once no planned batch is left unfinished. It does not post to GitHub —
     rendering the comment (and rejecting stale revisions) is a separate consumer's job.
+
+    ``WorkflowStatus``/``JobResult`` are kept as the local registry of what each batch reported. They
+    are not published: the snapshot is what consumers read.
 
     Every registry is keyed by ``batch_id``, the batch's logical identity, which stays stable across
     workflow attempts while ``run_id`` and the message id do not.
@@ -106,7 +109,7 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
                 self._logger.warning("Duplicate BatchFinished ignored", extra=log_extra)
                 return
             if results:
-                # The flat view counts job outcomes, so a run that reported none has no entry there;
+                # The registry records job outcomes, so a run that reported none has no entry there;
                 # the aggregate is where a batch that finished empty is recorded as failed.
                 self._results_by_batch[message.batch_id] = results
                 self._status_by_batch[message.batch_id] = status
@@ -141,8 +144,6 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         return UpdatePRComment(
             id=message_id,
             revision=revision,
-            done=done,
-            workflows=list(self._status_by_batch.values()),
             progress=DispatcherProgress(batches=tuple(self._progress_by_batch.values()), done=done),
         )
 

--- a/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
@@ -24,8 +24,9 @@ from ddev.cli.ci.tests.progress import (
     ExecutionState,
     JobAttemptProgress,
     JobProgress,
+    ProgressError,
 )
-from ddev.cli.ci.tests.status import Status, conclusion_to_status
+from ddev.cli.ci.tests.status import Status, batch_status, conclusion_to_status
 from ddev.event_bus.orchestrator import SyncProcessor
 from ddev.utils.github_async.models.workflow import WorkflowJobConclusion
 from ddev.utils.junit import parse_junit_dir
@@ -54,9 +55,12 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
     It is constructed with the complete batch plan, keeps an in-memory registry of every job's full
     result across all batches and, on each finished batch, emits an ``UpdatePRComment`` carrying a
     monotonically increasing ``revision`` and the whole accumulated state — as a ``DispatcherProgress``
-    snapshot covering every planned batch, including those still to run. ``done`` is set once the final
-    expected batch has been received. It does not post to GitHub — rendering the comment (and rejecting
-    stale revisions) is a separate consumer's job.
+    snapshot covering every planned batch, including those still to run. ``done`` is derived from that
+    snapshot: it is set once no planned batch is left unfinished. It does not post to GitHub —
+    rendering the comment (and rejecting stale revisions) is a separate consumer's job.
+
+    Every registry is keyed by ``batch_id``, the batch's logical identity, which stays stable across
+    workflow attempts while ``run_id`` and the message id do not.
 
     This task makes no GitHub API calls — it works exclusively from the artifacts the runner
     already downloaded to ``BatchFinished.artifacts_path``.
@@ -65,8 +69,7 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
     def __init__(self, name: str, output_base_path: Path, batches: list[TestBatch]) -> None:
         super().__init__(name)
         self._output_base_path = output_base_path
-        self._expected_batches = len(batches)
-        self._received_batches = 0
+        self._revision = 0
         self._status_by_batch: dict[str, WorkflowStatus] = {}
         self._results_by_batch: dict[str, list[JobResult]] = {}
         # The whole plan, in planning order: every batch is present from the start so each snapshot
@@ -80,36 +83,37 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
     def process_message(self, message: BatchFinished) -> None:
         log_extra = {"batch_id": message.batch_id, "run_id": message.run_id}
         if not message.batch_jobs:
+            # Still terminal, and still worth a revision: the batch has stopped and the comment must
+            # say so, otherwise it renders as planned forever and ``done`` is never reached.
             self._logger.warning("BatchFinished carried no jobs; nothing to gather", extra=log_extra)
-            # No revision is emitted, but the batch is terminal: it must not keep rendering as planned.
-            with self._lock:
-                self._finish_without_jobs(message)
-            return
 
         # Parse and organize artifacts outside the lock — these touch only this batch's own files.
         gathered = [self._gather_job(batch_job_result, message) for batch_job_result in message.batch_jobs]
         results = [result for result, _ in gathered]
         status = self._build_workflow_status(message, results)
-        progress = self._finished_batch_progress(message, gathered)
 
         # Register the batch, bump the revision, and emit the update all under the lock so two batches
         # finishing at once cannot build a comment from half-updated shared state.
         with self._lock:
-            if message.batch_id not in self._progress_by_batch:
+            planned = self._progress_by_batch.get(message.batch_id)
+            if planned is None:
                 self._logger.warning("BatchFinished for an unplanned batch ignored", extra=log_extra)
                 return
-            # Keyed by batch id (stable across retries; run_id changes on a re-run). A duplicate is
-            # ignored so it can't re-count the batch and inflate the revision — this check is
-            # authoritative only inside the lock. (Retry-replace semantics come with the retry work.)
-            if message.id in self._results_by_batch:
+            # The aggregate is the single record of what has been gathered, so a batch already in a
+            # terminal state is a duplicate. Ignoring it keeps it from inflating the revision — the
+            # check is authoritative only inside the lock. (Retry semantics come with the retry work.)
+            if planned.state is ExecutionState.FINISHED:
                 self._logger.warning("Duplicate BatchFinished ignored", extra=log_extra)
                 return
-            self._results_by_batch[message.id] = results
-            self._status_by_batch[message.id] = status
-            self._progress_by_batch[message.batch_id] = progress
-            self._received_batches += 1
-            revision = self._received_batches
-            done = revision >= self._expected_batches
+            if results:
+                # The flat view counts job outcomes, so a run that reported none has no entry there;
+                # the aggregate is where a batch that finished empty is recorded as failed.
+                self._results_by_batch[message.batch_id] = results
+                self._status_by_batch[message.batch_id] = status
+            self._progress_by_batch[message.batch_id] = self._finished_batch_progress(planned, message, gathered)
+            self._revision += 1
+            revision = self._revision
+            done = all(batch.state is ExecutionState.FINISHED for batch in self._progress_by_batch.values())
             self.submit_message(self.build_update_message(message.id, revision, done))
 
         self._logger.info(
@@ -119,14 +123,15 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             extra=log_extra,
         )
 
-    def build_initial_update(self) -> UpdatePRComment:
+    def build_initial_update(self, message_id: str) -> UpdatePRComment:
         """Revision ``0``: the complete plan, before any batch has been dispatched.
 
-        Follows the same event-bus path as every later revision, so the PR updater needs no separate
-        startup call.
+        Returned rather than submitted, because a processor can only submit once the event bus has
+        attached its queue. The dispatcher entry point publishes it when it starts the bus, so the
+        PR updater receives the plan on the same channel as every later revision.
         """
         with self._lock:
-            return self.build_update_message("initial", revision=0, done=False)
+            return self.build_update_message(message_id, revision=0, done=False)
 
     def build_update_message(self, message_id: str, revision: int, done: bool) -> UpdatePRComment:
         """Build an ``UpdatePRComment`` for *revision* from all accumulated results.
@@ -168,14 +173,14 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         batch_job = batch_job_result.job
         status, failed_steps = self._job_status(batch_job_result, message)
 
-        error: str | None = None
+        error: ProgressError | None = None
         reports: tuple[JUnitReport, ...] = ()
         job_artifacts_path = Path(batch_job_result.artifact_name_path) if batch_job_result.artifact_name_path else None
         if job_artifacts_path is not None:
             reports = tuple(parse_junit_dir(job_artifacts_path))
             self._organize_artifacts(job_artifacts_path, batch_job)
         else:
-            error = f"No artifact directory found for job {batch_job.name!r}"
+            error = ProgressError.NO_ARTIFACTS
             self._logger.warning(
                 "No artifact directory found for job %s", batch_job.name, extra={"run_id": message.run_id}
             )
@@ -190,7 +195,8 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         )
         workflow_job = batch_job_result.workflow_job
         attempt = JobAttemptProgress(
-            # One attempt per job until the retry work lands; the runner reports no attempt number yet.
+            # Provisional: the job's real position in its history is only known once the attempt is
+            # appended to the registered plan, under the lock.
             attempt=1,
             job_id=None if workflow_job is None else workflow_job.id,
             status=status,
@@ -208,11 +214,12 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         job's own workflow-job conclusion decides. A missing workflow job is unexpected and raises — the
         runner correlates every job before emitting, so a miss is a bug, not a state to paper over.
 
-        All steps concluding in failure are collected: a workflow can run on-failure steps, so more than
-        one step may fail for a single job.
+        ``failed_steps`` holds real step names only. A timed-out batch has none — the timeout is not a
+        step, and is recorded as the batch's ``error`` instead. All steps concluding in failure are
+        collected: a workflow can run on-failure steps, so more than one step may fail for a job.
         """
         if message.timed_out:
-            return (Status.FAILURE, ["timed out"])
+            return (Status.FAILURE, [])
 
         workflow_job = batch_job_result.workflow_job
         if workflow_job is None:
@@ -243,57 +250,68 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         shutil.copy2(source, destination)
         self._logger.debug("Organized artifact %s -> %s", source, destination)
 
-    def _finish_without_jobs(self, message: BatchFinished) -> None:
-        """Mark a batch that reported no job results terminal, with the reason recorded.
-
-        Must be called while holding ``self._lock``. No revision is emitted: nothing was gathered.
-        """
-        planned = self._progress_by_batch.get(message.batch_id)
-        if planned is None:
-            return
-        self._progress_by_batch[message.batch_id] = dataclasses.replace(
-            planned,
-            run_id=message.run_id,
-            workflow_url=message.workflow_url,
-            state=ExecutionState.FINISHED,
-            status=Status.FAILURE,
-            current_attempt=1,
-            error="Batch reported no job results",
-        )
-
     def _finished_batch_progress(
-        self, message: BatchFinished, gathered: list[tuple[JobResult, JobAttemptProgress]]
+        self,
+        planned: BatchProgress,
+        message: BatchFinished,
+        gathered: list[tuple[JobResult, JobAttemptProgress]],
     ) -> BatchProgress:
-        """The batch's terminal aggregate, built from the executions reported on the message.
+        """The batch's terminal aggregate: the registered plan with this run's executions appended.
 
-        The batch label follows the same precedence as ``WorkflowStatus.status``: failed if any job
-        failed, else passed if any job passed, else skipped.
+        Built from *planned* rather than from the message alone, so the batch keeps every job it was
+        planned with. A run that reports only a subset — which is what a failed-job rerun does — adds
+        attempts to the jobs it covers and leaves the rest as they were, instead of dropping them.
+
+        Must be called while holding ``self._lock``: it reads a registered ``BatchProgress``.
         """
-        jobs = tuple(
-            JobProgress(job=batch_job_result.job, attempts=(attempt,))
+        reported_jobs = {batch_job_result.job.name: batch_job_result.job for batch_job_result in message.batch_jobs}
+        attempts = {
+            batch_job_result.job.name: attempt
             for batch_job_result, (_, attempt) in zip(message.batch_jobs, gathered, strict=True)
-        )
-        statuses = {job.latest.status for job in jobs if job.latest is not None}
-        if Status.FAILURE in statuses:
-            status = Status.FAILURE
-        elif Status.SUCCESS in statuses:
-            status = Status.SUCCESS
-        else:
-            status = Status.SKIPPED
+        }
+
+        jobs = []
+        for job in planned.jobs:
+            attempt = attempts.pop(job.job.name, None)
+            if attempt is None:
+                jobs.append(job)
+                continue
+            # The attempt number is the execution's position in this job's own history.
+            numbered = dataclasses.replace(attempt, attempt=len(job.attempts) + 1)
+            jobs.append(dataclasses.replace(job, attempts=(*job.attempts, numbered)))
+        for name, attempt in attempts.items():
+            # A job the plan never mentioned is a runner bug, but dropping its result would hide it.
+            self._logger.warning(
+                "Gathered a job that is not in the batch plan", extra={"batch_id": message.batch_id, "job": name}
+            )
+            jobs.append(JobProgress(job=reported_jobs[name], attempts=(attempt,)))
+
+        statuses = [job.latest.status for job in jobs if job.latest is not None]
+        attempts_run = max((len(job.attempts) for job in jobs), default=0)
 
         return BatchProgress(
             batch_id=message.batch_id,
             run_id=message.run_id,
             workflow_url=message.workflow_url,
             state=ExecutionState.FINISHED,
-            status=status,
-            current_attempt=1,
+            # A batch that ran but reported nothing has no job status to collapse, and failed.
+            status=batch_status(statuses) if statuses else Status.FAILURE,
+            # The batch ran, so it is on at least its first attempt even if no job reported one.
+            current_attempt=max(attempts_run, 1),
             max_attempts=1,
             retries_remaining=0,
             retrying_jobs=(),
-            jobs=jobs,
-            error="Batch timed out" if message.timed_out else None,
+            jobs=tuple(jobs),
+            error=self._batch_error(message, statuses),
         )
+
+    @staticmethod
+    def _batch_error(message: BatchFinished, statuses: list[Status]) -> ProgressError | None:
+        if message.timed_out:
+            return ProgressError.TIMED_OUT
+        if not statuses:
+            return ProgressError.NO_JOB_RESULTS
+        return None
 
     @staticmethod
     def _build_workflow_status(message: BatchFinished, results: list[JobResult]) -> WorkflowStatus:

--- a/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
@@ -52,21 +52,16 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
     Reads ``BatchFinished`` messages, analyzes the downloaded artifacts on disk, builds per-job
     ``JobResult`` records, and organizes coverage/JUnit files for later publishing.
 
-    It is constructed with the complete batch plan, keeps an in-memory registry of every job's full
-    result across all batches and, on each finished batch, emits an ``UpdatePRComment`` carrying a
-    monotonically increasing ``revision`` and a ``DispatcherProgress`` snapshot covering every planned
-    batch, including those still to run. That snapshot is the message's whole payload; ``done`` is
-    derived from it, set once no planned batch is left unfinished. It does not post to GitHub —
-    rendering the comment (and rejecting stale revisions) is a separate consumer's job.
+    It is constructed with the complete batch plan and, on each finished batch, emits an
+    ``UpdatePRComment`` carrying a monotonic ``revision`` and a ``DispatcherProgress`` snapshot of
+    every planned batch, including those still to run. ``done`` is derived from that snapshot, set
+    once no batch is left unfinished. Rendering the comment is a separate consumer's job.
 
-    ``WorkflowStatus``/``JobResult`` are kept as the local registry of what each batch reported. They
-    are not published: the snapshot is what consumers read.
+    ``WorkflowStatus``/``JobResult`` are the local registry of what each batch reported; they are not
+    published. Every registry is keyed by ``batch_id``, which stays stable across workflow attempts
+    while ``run_id`` and the message id do not.
 
-    Every registry is keyed by ``batch_id``, the batch's logical identity, which stays stable across
-    workflow attempts while ``run_id`` and the message id do not.
-
-    This task makes no GitHub API calls — it works exclusively from the artifacts the runner
-    already downloaded to ``BatchFinished.artifacts_path``.
+    Makes no GitHub API calls: it works only from the artifacts the runner already downloaded.
     """
 
     def __init__(self, name: str, output_base_path: Path, batches: list[TestBatch]) -> None:
@@ -75,8 +70,7 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         self._revision = 0
         self._status_by_batch: dict[str, WorkflowStatus] = {}
         self._results_by_batch: dict[str, list[JobResult]] = {}
-        # The whole plan, in planning order: every batch is present from the start so each snapshot
-        # covers batches that have not run yet, not only the ones already gathered.
+        # The whole plan, in planning order, so each snapshot covers batches that have not run yet.
         self._progress_by_batch: dict[str, BatchProgress] = {
             batch.batch_id: self._planned_batch(batch) for batch in batches
         }
@@ -86,31 +80,29 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
     def process_message(self, message: BatchFinished) -> None:
         log_extra = {"batch_id": message.batch_id, "run_id": message.run_id}
         if not message.batch_jobs:
-            # Still terminal, and still worth a revision: the batch has stopped and the comment must
-            # say so, otherwise it renders as planned forever and ``done`` is never reached.
+            # Still terminal and still worth a revision, or it renders as planned forever.
             self._logger.warning("BatchFinished carried no jobs; nothing to gather", extra=log_extra)
 
-        # Parse and organize artifacts outside the lock — these touch only this batch's own files.
+        # Outside the lock: these touch only this batch's own files.
         gathered = [self._gather_job(batch_job_result, message) for batch_job_result in message.batch_jobs]
         results = [result for result, _ in gathered]
         status = self._build_workflow_status(message, results)
 
-        # Register the batch, bump the revision, and emit the update all under the lock so two batches
-        # finishing at once cannot build a comment from half-updated shared state.
+        # Register, bump the revision, and emit under one lock, so two batches finishing at once
+        # cannot build a comment from half-updated state.
         with self._lock:
             planned = self._progress_by_batch.get(message.batch_id)
             if planned is None:
                 self._logger.warning("BatchFinished for an unplanned batch ignored", extra=log_extra)
                 return
-            # The aggregate is the single record of what has been gathered, so a batch already in a
-            # terminal state is a duplicate. Ignoring it keeps it from inflating the revision — the
-            # check is authoritative only inside the lock. (Retry semantics come with the retry work.)
+            # The aggregate is the record of what was gathered, so an already-terminal batch is a
+            # duplicate; ignoring it keeps it from inflating the revision.
             if planned.state is ExecutionState.FINISHED:
                 self._logger.warning("Duplicate BatchFinished ignored", extra=log_extra)
                 return
             if results:
-                # The registry records job outcomes, so a run that reported none has no entry there;
-                # the aggregate is where a batch that finished empty is recorded as failed.
+                # The registry records job outcomes; a run that reported none belongs only in the
+                # aggregate, which can say it finished empty.
                 self._results_by_batch[message.batch_id] = results
                 self._status_by_batch[message.batch_id] = status
             self._progress_by_batch[message.batch_id] = self._finished_batch_progress(planned, message, gathered)
@@ -129,18 +121,14 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
     def build_initial_update(self, message_id: str) -> UpdatePRComment:
         """Revision ``0``: the complete plan, before any batch has been dispatched.
 
-        Returned rather than submitted, because a processor can only submit once the event bus has
-        attached its queue. The dispatcher entry point publishes it when it starts the bus, so the
-        PR updater receives the plan on the same channel as every later revision.
+        Returned rather than submitted: a processor can only submit once the bus has attached its
+        queue, so the dispatcher entry point publishes this when it starts the bus.
         """
         with self._lock:
             return self.build_update_message(message_id, revision=0, done=False)
 
     def build_update_message(self, message_id: str, revision: int, done: bool) -> UpdatePRComment:
-        """Build an ``UpdatePRComment`` for *revision* from all accumulated results.
-
-        Must be called while holding ``self._lock`` when reading live shared state.
-        """
+        """Build an ``UpdatePRComment`` for *revision*. Hold ``self._lock`` when state is live."""
         return UpdatePRComment(
             id=message_id,
             revision=revision,
@@ -149,7 +137,7 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
 
     @staticmethod
     def _planned_batch(batch: TestBatch) -> BatchProgress:
-        """A batch as planned: known jobs, no execution yet, and no retry budget until retries land."""
+        """A batch as planned: known jobs, no execution, no retry budget until retries land."""
         return BatchProgress(
             batch_id=batch.batch_id,
             run_id=None,
@@ -168,8 +156,8 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
     ) -> tuple[JobResult, JobAttemptProgress]:
         """Build a job's records from its correlated workflow job and its artifacts on disk.
 
-        Both the flat ``JobResult`` and the aggregate's ``JobAttemptProgress`` come from this single
-        pass, so reports are parsed and artifacts organized exactly once per job.
+        ``JobResult`` and ``JobAttemptProgress`` come from one pass, so reports are parsed and
+        artifacts organized exactly once per job.
         """
         batch_job = batch_job_result.job
         status, failed_steps = self._job_status(batch_job_result, message)
@@ -196,8 +184,7 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         )
         workflow_job = batch_job_result.workflow_job
         attempt = JobAttemptProgress(
-            # Provisional: the job's real position in its history is only known once the attempt is
-            # appended to the registered plan, under the lock.
+            # Provisional: the real position is known only when appended to the plan, under the lock.
             attempt=1,
             job_id=None if workflow_job is None else workflow_job.id,
             status=status,
@@ -211,13 +198,12 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
 
     @staticmethod
     def _job_status(batch_job_result: BatchJobResult, message: BatchFinished) -> tuple[Status, list[str]]:
-        """Per-job (status, failed_steps). Deterministic: timed-out batches fail every job; otherwise the
-        job's own workflow-job conclusion decides. A missing workflow job is unexpected and raises — the
-        runner correlates every job before emitting, so a miss is a bug, not a state to paper over.
+        """Per-job (status, failed_steps). A timed-out batch fails every job; otherwise the job's own
+        conclusion decides. A missing workflow job raises: the runner correlates every job before
+        emitting, so a miss is a bug.
 
-        ``failed_steps`` holds real step names only. A timed-out batch has none — the timeout is not a
-        step, and is recorded as the batch's ``error`` instead. All steps concluding in failure are
-        collected: a workflow can run on-failure steps, so more than one step may fail for a job.
+        ``failed_steps`` holds real step names only, so a timeout (recorded as the batch's ``error``)
+        contributes none. All failing steps are collected: on-failure steps mean there can be several.
         """
         if message.timed_out:
             return (Status.FAILURE, [])
@@ -230,10 +216,8 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         return (conclusion_to_status(workflow_job.conclusion), failed_steps)
 
     def _organize_artifacts(self, job_artifacts_path: Path, batch_job: BatchJob) -> None:
-        """Copy coverage and JUnit files into the organized output tree with unique names.
-
-        The prefix is the job's target/environment/platform — the same fields as
-        ``BatchJob.artifact_name`` and the uniqueness key for a job within a batch.
+        """Copy coverage and JUnit files into the output tree, prefixed by the job's
+        target/environment/platform — the same fields that make ``BatchJob.artifact_name`` unique.
         """
         prefix = f"{batch_job.target}-{batch_job.environment}-{batch_job.platform}"
 
@@ -259,11 +243,10 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
     ) -> BatchProgress:
         """The batch's terminal aggregate: the registered plan with this run's executions appended.
 
-        Built from *planned* rather than from the message alone, so the batch keeps every job it was
-        planned with. A run that reports only a subset — which is what a failed-job rerun does — adds
-        attempts to the jobs it covers and leaves the rest as they were, instead of dropping them.
+        Built from *planned*, not from the message alone, so a run reporting only a subset — what a
+        failed-job rerun does — adds attempts to the jobs it covers and leaves the rest untouched.
 
-        Must be called while holding ``self._lock``: it reads a registered ``BatchProgress``.
+        Must be called while holding ``self._lock``.
         """
         reported_jobs = {batch_job_result.job.name: batch_job_result.job for batch_job_result in message.batch_jobs}
         attempts = {
@@ -277,11 +260,11 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             if attempt is None:
                 jobs.append(job)
                 continue
-            # The attempt number is the execution's position in this job's own history.
+            # The attempt number is the execution's position in this job's history.
             numbered = dataclasses.replace(attempt, attempt=len(job.attempts) + 1)
             jobs.append(dataclasses.replace(job, attempts=(*job.attempts, numbered)))
         for name, attempt in attempts.items():
-            # A job the plan never mentioned is a runner bug, but dropping its result would hide it.
+            # An unplanned job is a runner bug, but dropping its result would hide it.
             self._logger.warning(
                 "Gathered a job that is not in the batch plan", extra={"batch_id": message.batch_id, "job": name}
             )
@@ -295,9 +278,9 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             run_id=message.run_id,
             workflow_url=message.workflow_url,
             state=ExecutionState.FINISHED,
-            # A batch that ran but reported nothing has no job status to collapse, and failed.
+            # Nothing reported means nothing to collapse, and a failed batch.
             status=batch_status(statuses) if statuses else Status.FAILURE,
-            # The batch ran, so it is on at least its first attempt even if no job reported one.
+            # The batch ran, so it is on at least its first attempt.
             current_attempt=max(attempts_run, 1),
             max_attempts=1,
             retries_remaining=0,

--- a/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
@@ -8,7 +8,7 @@ import logging
 import shutil
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ddev.cli.ci.tests.messages import (
     BatchFinished,
@@ -26,7 +26,7 @@ from ddev.cli.ci.tests.progress import (
     JobProgress,
     ProgressError,
 )
-from ddev.cli.ci.tests.status import Status, batch_status, conclusion_to_status
+from ddev.cli.ci.tests.status import Status, conclusion_to_status
 from ddev.event_bus.orchestrator import SyncProcessor
 from ddev.utils.github_async.models.workflow import WorkflowJobConclusion
 from ddev.utils.junit import parse_junit_dir
@@ -48,20 +48,10 @@ JUNIT_GLOB = "test-*.xml"
 
 
 class TaskTestGatherer(SyncProcessor[BatchFinished]):
-    """
-    Reads ``BatchFinished`` messages, analyzes the downloaded artifacts on disk, builds per-job
-    ``JobResult`` records, and organizes coverage/JUnit files for later publishing.
+    """Builds each batch's results from the artifacts the runner downloaded, organizes the coverage
+    and JUnit files, and publishes a ``DispatcherProgress`` snapshot per finished batch.
 
-    It is constructed with the complete batch plan and, on each finished batch, emits an
-    ``UpdatePRComment`` carrying a monotonic ``revision`` and a ``DispatcherProgress`` snapshot of
-    every planned batch, including those still to run. ``done`` is derived from that snapshot, set
-    once no batch is left unfinished. Rendering the comment is a separate consumer's job.
-
-    ``WorkflowStatus``/``JobResult`` are the local registry of what each batch reported; they are not
-    published. Every registry is keyed by ``batch_id``, which stays stable across workflow attempts
-    while ``run_id`` and the message id do not.
-
-    Makes no GitHub API calls: it works only from the artifacts the runner already downloaded.
+    Registries are keyed by ``batch_id``: it is stable across workflow attempts, ``run_id`` is not.
     """
 
     def __init__(self, name: str, output_base_path: Path, batches: list[TestBatch]) -> None:
@@ -83,7 +73,12 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             # Still terminal and still worth a revision, or it renders as planned forever.
             self._logger.warning("BatchFinished carried no jobs; nothing to gather", extra=log_extra)
 
-        # Outside the lock: these touch only this batch's own files.
+        # Rejected before gathering: gathering writes into the shared output tree, where a batch that
+        # is not in the plan could overwrite the files another batch publishes.
+        with self._lock:
+            if not self._accepts(message.batch_id, log_extra):
+                return
+
         gathered = [self._gather_job(batch_job_result, message) for batch_job_result in message.batch_jobs]
         results = [result for result, _ in gathered]
         status = self._build_workflow_status(message, results)
@@ -91,18 +86,11 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         # Register, bump the revision, and emit under one lock, so two batches finishing at once
         # cannot build a comment from half-updated state.
         with self._lock:
-            planned = self._progress_by_batch.get(message.batch_id)
-            if planned is None:
-                self._logger.warning("BatchFinished for an unplanned batch ignored", extra=log_extra)
+            # Re-checked: another thread may have gathered this batch while this one parsed.
+            if not self._accepts(message.batch_id, log_extra):
                 return
-            # The aggregate is the record of what was gathered, so an already-terminal batch is a
-            # duplicate; ignoring it keeps it from inflating the revision.
-            if planned.state is ExecutionState.FINISHED:
-                self._logger.warning("Duplicate BatchFinished ignored", extra=log_extra)
-                return
+            planned = self._progress_by_batch[message.batch_id]
             if results:
-                # The registry records job outcomes; a run that reported none belongs only in the
-                # aggregate, which can say it finished empty.
                 self._results_by_batch[message.batch_id] = results
                 self._status_by_batch[message.batch_id] = status
             self._progress_by_batch[message.batch_id] = self._finished_batch_progress(planned, message, gathered)
@@ -117,6 +105,17 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             done,
             extra=log_extra,
         )
+
+    def _accepts(self, batch_id: str, log_extra: dict[str, Any]) -> bool:
+        """Whether this batch is in the plan and not already gathered. Hold ``self._lock``."""
+        planned = self._progress_by_batch.get(batch_id)
+        if planned is None:
+            self._logger.warning("BatchFinished for an unplanned batch ignored", extra=log_extra)
+            return False
+        if planned.state is ExecutionState.FINISHED:
+            self._logger.warning("Duplicate BatchFinished ignored", extra=log_extra)
+            return False
+        return True
 
     def build_initial_update(self, message_id: str) -> UpdatePRComment:
         """Revision ``0``: the complete plan, before any batch has been dispatched.
@@ -148,7 +147,7 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             max_attempts=1,
             retries_remaining=0,
             retrying_jobs=(),
-            jobs=tuple(JobProgress(job=job, attempts=()) for job in batch.job_list),
+            jobs_progress=tuple(JobProgress(job=job, attempts=()) for job in batch.job_list),
         )
 
     def _gather_job(
@@ -182,15 +181,20 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             failed_steps=failed_steps,
             reports=reports,
         )
-        workflow_job = batch_job_result.workflow_job
+        job_id = conclusion = job_url = None
+        if (workflow_job := batch_job_result.workflow_job) is not None:
+            job_id = workflow_job.id
+            conclusion = workflow_job.conclusion
+            job_url = workflow_job.html_url
+
         attempt = JobAttemptProgress(
             # Provisional: the real position is known only when appended to the plan, under the lock.
             attempt=1,
-            job_id=None if workflow_job is None else workflow_job.id,
+            job_id=job_id,
             status=status,
-            conclusion=None if workflow_job is None else workflow_job.conclusion,
+            conclusion=conclusion,
             failed_steps=tuple(failed_steps),
-            job_url=None if workflow_job is None else workflow_job.html_url,
+            job_url=job_url,
             reports=reports,
             error=error,
         )
@@ -246,54 +250,52 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         Built from *planned*, not from the message alone, so a run reporting only a subset — what a
         failed-job rerun does — adds attempts to the jobs it covers and leaves the rest untouched.
 
+        The batch's own status is the workflow's, not a roll-up of these jobs: a workflow also runs
+        setup and finalization steps that can fail while every tracked job passes.
+
         Must be called while holding ``self._lock``.
         """
-        reported_jobs = {batch_job_result.job.name: batch_job_result.job for batch_job_result in message.batch_jobs}
         attempts = {
             batch_job_result.job.name: attempt
             for batch_job_result, (_, attempt) in zip(message.batch_jobs, gathered, strict=True)
         }
 
         jobs = []
-        for job in planned.jobs:
+        for job in planned.jobs_progress:
             attempt = attempts.pop(job.job.name, None)
             if attempt is None:
                 jobs.append(job)
                 continue
-            # The attempt number is the execution's position in this job's history.
+            # Renumbered here because the position in the job's history is only known now.
             numbered = dataclasses.replace(attempt, attempt=len(job.attempts) + 1)
             jobs.append(dataclasses.replace(job, attempts=(*job.attempts, numbered)))
-        for name, attempt in attempts.items():
-            # An unplanned job is a runner bug, but dropping its result would hide it.
+        for name in attempts:
+            # Reported but never planned: recorded so it can be investigated, kept out of the totals.
             self._logger.warning(
                 "Gathered a job that is not in the batch plan", extra={"batch_id": message.batch_id, "job": name}
             )
-            jobs.append(JobProgress(job=reported_jobs[name], attempts=(attempt,)))
 
-        statuses = [job.latest.status for job in jobs if job.latest is not None]
         attempts_run = max((len(job.attempts) for job in jobs), default=0)
-
         return BatchProgress(
             batch_id=message.batch_id,
             run_id=message.run_id,
             workflow_url=message.workflow_url,
             state=ExecutionState.FINISHED,
-            # Nothing reported means nothing to collapse, and a failed batch.
-            status=batch_status(statuses) if statuses else Status.FAILURE,
+            status=message.status,
             # The batch ran, so it is on at least its first attempt.
             current_attempt=max(attempts_run, 1),
             max_attempts=1,
             retries_remaining=0,
             retrying_jobs=(),
-            jobs=tuple(jobs),
-            error=self._batch_error(message, statuses),
+            jobs_progress=tuple(jobs),
+            error=self._batch_error(message, jobs),
         )
 
     @staticmethod
-    def _batch_error(message: BatchFinished, statuses: list[Status]) -> ProgressError | None:
+    def _batch_error(message: BatchFinished, jobs: list[JobProgress]) -> ProgressError | None:
         if message.timed_out:
             return ProgressError.TIMED_OUT
-        if not statuses:
+        if not any(job.latest is not None for job in jobs):
             return ProgressError.NO_JOB_RESULTS
         return None
 

--- a/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
+import dataclasses
 import logging
 import shutil
 import threading
@@ -17,12 +18,20 @@ from ddev.cli.ci.tests.messages import (
     UpdatePRComment,
     WorkflowStatus,
 )
+from ddev.cli.ci.tests.progress import (
+    BatchProgress,
+    DispatcherProgress,
+    ExecutionState,
+    JobAttemptProgress,
+    JobProgress,
+)
 from ddev.cli.ci.tests.status import Status, conclusion_to_status
 from ddev.event_bus.orchestrator import SyncProcessor
 from ddev.utils.github_async.models.workflow import WorkflowJobConclusion
 from ddev.utils.junit import parse_junit_dir
 
 if TYPE_CHECKING:
+    from ddev.cli.ci.tests.messages import TestBatch
     from ddev.utils.junit import JUnitReport
 
 # Expected layout of the extracted ``test-result.zip`` tree (defined by ``test-batch.yaml``):
@@ -42,47 +51,62 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
     Reads ``BatchFinished`` messages, analyzes the downloaded artifacts on disk, builds per-job
     ``JobResult`` records, and organizes coverage/JUnit files for later publishing.
 
-    It keeps an in-memory registry of every job's full result across all batches and, on each finished
-    batch, emits an ``UpdatePRComment`` carrying a monotonically increasing ``revision`` and the whole
-    accumulated state. ``done`` is set once the final expected batch has been received. It does not post
-    to GitHub — rendering the comment (and rejecting stale revisions) is a separate consumer's job.
+    It is constructed with the complete batch plan, keeps an in-memory registry of every job's full
+    result across all batches and, on each finished batch, emits an ``UpdatePRComment`` carrying a
+    monotonically increasing ``revision`` and the whole accumulated state — as a ``DispatcherProgress``
+    snapshot covering every planned batch, including those still to run. ``done`` is set once the final
+    expected batch has been received. It does not post to GitHub — rendering the comment (and rejecting
+    stale revisions) is a separate consumer's job.
 
     This task makes no GitHub API calls — it works exclusively from the artifacts the runner
     already downloaded to ``BatchFinished.artifacts_path``.
     """
 
-    def __init__(self, name: str, output_base_path: Path, expected_batches: int) -> None:
+    def __init__(self, name: str, output_base_path: Path, batches: list[TestBatch]) -> None:
         super().__init__(name)
         self._output_base_path = output_base_path
-        self._expected_batches = expected_batches
+        self._expected_batches = len(batches)
         self._received_batches = 0
         self._status_by_batch: dict[str, WorkflowStatus] = {}
         self._results_by_batch: dict[str, list[JobResult]] = {}
+        # The whole plan, in planning order: every batch is present from the start so each snapshot
+        # covers batches that have not run yet, not only the ones already gathered.
+        self._progress_by_batch: dict[str, BatchProgress] = {
+            batch.batch_id: self._planned_batch(batch) for batch in batches
+        }
         self._lock = threading.Lock()
         self._logger = logging.getLogger(f"{__name__}.{name}")
 
     def process_message(self, message: BatchFinished) -> None:
+        log_extra = {"batch_id": message.batch_id, "run_id": message.run_id}
         if not message.batch_jobs:
-            self._logger.warning("BatchFinished carried no jobs; nothing to gather", extra={"run_id": message.run_id})
+            self._logger.warning("BatchFinished carried no jobs; nothing to gather", extra=log_extra)
+            # No revision is emitted, but the batch is terminal: it must not keep rendering as planned.
+            with self._lock:
+                self._finish_without_jobs(message)
             return
 
         # Parse and organize artifacts outside the lock — these touch only this batch's own files.
-        results = [self._job_result(batch_job_result, message) for batch_job_result in message.batch_jobs]
+        gathered = [self._gather_job(batch_job_result, message) for batch_job_result in message.batch_jobs]
+        results = [result for result, _ in gathered]
         status = self._build_workflow_status(message, results)
+        progress = self._finished_batch_progress(message, gathered)
 
         # Register the batch, bump the revision, and emit the update all under the lock so two batches
         # finishing at once cannot build a comment from half-updated shared state.
         with self._lock:
+            if message.batch_id not in self._progress_by_batch:
+                self._logger.warning("BatchFinished for an unplanned batch ignored", extra=log_extra)
+                return
             # Keyed by batch id (stable across retries; run_id changes on a re-run). A duplicate is
             # ignored so it can't re-count the batch and inflate the revision — this check is
             # authoritative only inside the lock. (Retry-replace semantics come with the retry work.)
             if message.id in self._results_by_batch:
-                self._logger.warning(
-                    "Duplicate BatchFinished ignored", extra={"batch_id": message.id, "run_id": message.run_id}
-                )
+                self._logger.warning("Duplicate BatchFinished ignored", extra=log_extra)
                 return
             self._results_by_batch[message.id] = results
             self._status_by_batch[message.id] = status
+            self._progress_by_batch[message.batch_id] = progress
             self._received_batches += 1
             revision = self._received_batches
             done = revision >= self._expected_batches
@@ -92,8 +116,17 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             "Batch gathered, UpdatePRComment revision %s emitted (done=%s)",
             revision,
             done,
-            extra={"run_id": message.run_id},
+            extra=log_extra,
         )
+
+    def build_initial_update(self) -> UpdatePRComment:
+        """Revision ``0``: the complete plan, before any batch has been dispatched.
+
+        Follows the same event-bus path as every later revision, so the PR updater needs no separate
+        startup call.
+        """
+        with self._lock:
+            return self.build_update_message("initial", revision=0, done=False)
 
     def build_update_message(self, message_id: str, revision: int, done: bool) -> UpdatePRComment:
         """Build an ``UpdatePRComment`` for *revision* from all accumulated results.
@@ -101,25 +134,53 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         Must be called while holding ``self._lock`` when reading live shared state.
         """
         return UpdatePRComment(
-            id=message_id, revision=revision, done=done, workflows=list(self._status_by_batch.values())
+            id=message_id,
+            revision=revision,
+            done=done,
+            workflows=list(self._status_by_batch.values()),
+            progress=DispatcherProgress(batches=tuple(self._progress_by_batch.values()), done=done),
         )
 
-    def _job_result(self, batch_job_result: BatchJobResult, message: BatchFinished) -> JobResult:
-        """Build a job's ``JobResult`` from its correlated workflow job and artifacts on disk."""
+    @staticmethod
+    def _planned_batch(batch: TestBatch) -> BatchProgress:
+        """A batch as planned: known jobs, no execution yet, and no retry budget until retries land."""
+        return BatchProgress(
+            batch_id=batch.batch_id,
+            run_id=None,
+            workflow_url=None,
+            state=ExecutionState.PLANNED,
+            status=None,
+            current_attempt=None,
+            max_attempts=1,
+            retries_remaining=0,
+            retrying_jobs=(),
+            jobs=tuple(JobProgress(job=job, attempts=()) for job in batch.job_list),
+        )
+
+    def _gather_job(
+        self, batch_job_result: BatchJobResult, message: BatchFinished
+    ) -> tuple[JobResult, JobAttemptProgress]:
+        """Build a job's records from its correlated workflow job and its artifacts on disk.
+
+        Both the flat ``JobResult`` and the aggregate's ``JobAttemptProgress`` come from this single
+        pass, so reports are parsed and artifacts organized exactly once per job.
+        """
         batch_job = batch_job_result.job
         status, failed_steps = self._job_status(batch_job_result, message)
 
+        error: str | None = None
         reports: tuple[JUnitReport, ...] = ()
         job_artifacts_path = Path(batch_job_result.artifact_name_path) if batch_job_result.artifact_name_path else None
         if job_artifacts_path is not None:
             reports = tuple(parse_junit_dir(job_artifacts_path))
             self._organize_artifacts(job_artifacts_path, batch_job)
         else:
+            error = f"No artifact directory found for job {batch_job.name!r}"
             self._logger.warning(
                 "No artifact directory found for job %s", batch_job.name, extra={"run_id": message.run_id}
             )
 
-        return JobResult(
+        result = JobResult(
             integration=batch_job.target,
             environment=batch_job.environment,
             platform=batch_job.platform,
@@ -127,6 +188,19 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             failed_steps=failed_steps,
             reports=reports,
         )
+        workflow_job = batch_job_result.workflow_job
+        attempt = JobAttemptProgress(
+            # One attempt per job until the retry work lands; the runner reports no attempt number yet.
+            attempt=1,
+            job_id=None if workflow_job is None else workflow_job.id,
+            status=status,
+            conclusion=None if workflow_job is None else workflow_job.conclusion,
+            failed_steps=tuple(failed_steps),
+            job_url=None if workflow_job is None else workflow_job.html_url,
+            reports=reports,
+            error=error,
+        )
+        return (result, attempt)
 
     @staticmethod
     def _job_status(batch_job_result: BatchJobResult, message: BatchFinished) -> tuple[Status, list[str]]:
@@ -169,13 +243,65 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         shutil.copy2(source, destination)
         self._logger.debug("Organized artifact %s -> %s", source, destination)
 
+    def _finish_without_jobs(self, message: BatchFinished) -> None:
+        """Mark a batch that reported no job results terminal, with the reason recorded.
+
+        Must be called while holding ``self._lock``. No revision is emitted: nothing was gathered.
+        """
+        planned = self._progress_by_batch.get(message.batch_id)
+        if planned is None:
+            return
+        self._progress_by_batch[message.batch_id] = dataclasses.replace(
+            planned,
+            run_id=message.run_id,
+            workflow_url=message.workflow_url,
+            state=ExecutionState.FINISHED,
+            status=Status.FAILURE,
+            current_attempt=1,
+            error="Batch reported no job results",
+        )
+
+    def _finished_batch_progress(
+        self, message: BatchFinished, gathered: list[tuple[JobResult, JobAttemptProgress]]
+    ) -> BatchProgress:
+        """The batch's terminal aggregate, built from the executions reported on the message.
+
+        The batch label follows the same precedence as ``WorkflowStatus.status``: failed if any job
+        failed, else passed if any job passed, else skipped.
+        """
+        jobs = tuple(
+            JobProgress(job=batch_job_result.job, attempts=(attempt,))
+            for batch_job_result, (_, attempt) in zip(message.batch_jobs, gathered, strict=True)
+        )
+        statuses = {job.latest.status for job in jobs if job.latest is not None}
+        if Status.FAILURE in statuses:
+            status = Status.FAILURE
+        elif Status.SUCCESS in statuses:
+            status = Status.SUCCESS
+        else:
+            status = Status.SKIPPED
+
+        return BatchProgress(
+            batch_id=message.batch_id,
+            run_id=message.run_id,
+            workflow_url=message.workflow_url,
+            state=ExecutionState.FINISHED,
+            status=status,
+            current_attempt=1,
+            max_attempts=1,
+            retries_remaining=0,
+            retrying_jobs=(),
+            jobs=jobs,
+            error="Batch timed out" if message.timed_out else None,
+        )
+
     @staticmethod
     def _build_workflow_status(message: BatchFinished, results: list[JobResult]) -> WorkflowStatus:
         success_count = sum(1 for result in results if result.status == Status.SUCCESS)
         failed_count = sum(1 for result in results if result.status == Status.FAILURE)
         skipped_count = sum(1 for result in results if result.status == Status.SKIPPED)
         return WorkflowStatus(
-            batch_id=message.id,
+            batch_id=message.batch_id,
             url=message.workflow_url,
             id=message.run_id,
             success_count=success_count,

--- a/ddev/src/ddev/cli/ci/tests/task_test_runner.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_runner.py
@@ -47,7 +47,7 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
 
     async def process_message(self, message: TestBatch) -> None:
         inputs = self._build_inputs(message)
-        log_extra: dict[str, Any] = {"batch_id": message.id}
+        log_extra: dict[str, Any] = {"batch_id": message.batch_id}
 
         dispatch = await self._client.create_workflow_dispatch(
             self._options.owner,
@@ -68,7 +68,7 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
         check = await self._client.create_check_run(
             self._options.owner,
             self._options.repo,
-            name=f"test-batch/{message.id}",
+            name=f"test-batch/{message.batch_id}",
             head_sha=self._options.base_sha,
             status="in_progress",
             details_url=workflow_url,
@@ -98,6 +98,7 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
 
             finished = BatchFinished(
                 id=message.id,
+                batch_id=message.batch_id,
                 status=conclusion_to_status(raw),
                 run_id=run_id,
                 workflow_url=workflow_url,
@@ -142,7 +143,7 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
 
     def _build_inputs(self, message: TestBatch) -> dict[str, str]:
         return {
-            "batch_id": message.id,
+            "batch_id": message.batch_id,
             "checkout_sha": self._options.checkout_sha,
             "integrations": json.dumps(message.integrations),
             "job_list": json.dumps([self._job_input(job) for job in message.job_list]),

--- a/ddev/tests/cli/ci/tests/test_messages.py
+++ b/ddev/tests/cli/ci/tests/test_messages.py
@@ -145,23 +145,13 @@ def test_workflow_status_label() -> None:
     assert _workflow("b4", 4, 3, 0, 1, _results(success=3, skipped=1)).status == Status.SUCCESS
 
 
-def test_update_pr_comment_aggregates() -> None:
-    b1 = _workflow("b1", 1, 4, 0, 0, [_job("postgres", Status.SUCCESS)] * 4)
-    b2 = _workflow("b2", 2, 3, 1, 0, [_job("mysql", Status.FAILURE)] + [_job("disk", Status.SUCCESS)] * 3)
-    b3 = _workflow("b3", 3, 3, 0, 1, [_job("consul", Status.SKIPPED)] + [_job("nginx", Status.SUCCESS)] * 3)
-    update = UpdatePRComment(
-        id="m1",
-        revision=3,
-        done=True,
-        workflows=[b1, b2, b3],
-        progress=DispatcherProgress(batches=(), done=True),
-    )
-
-    assert (update.passed, update.failed, update.skipped, update.complete) == (10, 1, 1, 12)
-
-
-def test_update_pr_comment_carries_the_progress_snapshot() -> None:
+def test_update_pr_comment_carries_only_the_revision_and_the_snapshot() -> None:
+    # The message is ordering metadata plus the aggregate: every count and the done flag live on the
+    # snapshot, so there is no second copy for a consumer to disagree with.
     progress = DispatcherProgress(batches=(), done=False)
-    update = UpdatePRComment(id="m1", revision=0, done=False, workflows=[], progress=progress)
+    update = UpdatePRComment(id="m1", revision=0, progress=progress)
 
+    assert (update.id, update.revision) == ("m1", 0)
     assert update.progress is progress
+    assert not hasattr(update, "workflows")
+    assert not hasattr(update, "done")

--- a/ddev/tests/cli/ci/tests/test_messages.py
+++ b/ddev/tests/cli/ci/tests/test_messages.py
@@ -129,20 +129,12 @@ def _workflow(batch_id: str, run_id: int, success: int, failed: int, skipped: in
     )
 
 
-def _results(success: int = 0, failed: int = 0, skipped: int = 0) -> list[JobResult]:
-    return (
-        [_job("postgres", Status.SUCCESS)] * success
-        + [_job("mysql", Status.FAILURE)] * failed
-        + [_job("consul", Status.SKIPPED)] * skipped
-    )
-
-
 def test_workflow_status_label() -> None:
-    assert _workflow("b1", 1, 2, 0, 0, _results(success=2)).status == Status.SUCCESS
-    assert _workflow("b2", 2, 1, 1, 0, _results(success=1, failed=1)).status == Status.FAILURE
-    assert _workflow("b3", 3, 0, 0, 2, _results(skipped=2)).status == Status.SKIPPED
+    assert _workflow("b1", 1, 2, 0, 0, []).status == Status.SUCCESS
+    assert _workflow("b2", 2, 1, 1, 0, []).status == Status.FAILURE
+    assert _workflow("b3", 3, 0, 0, 2, []).status == Status.SKIPPED
     # A batch with passes and skips (no failures) reads as success.
-    assert _workflow("b4", 4, 3, 0, 1, _results(success=3, skipped=1)).status == Status.SUCCESS
+    assert _workflow("b4", 4, 3, 0, 1, []).status == Status.SUCCESS
 
 
 def test_update_pr_comment_carries_only_the_revision_and_the_snapshot() -> None:

--- a/ddev/tests/cli/ci/tests/test_messages.py
+++ b/ddev/tests/cli/ci/tests/test_messages.py
@@ -146,8 +146,7 @@ def test_workflow_status_label() -> None:
 
 
 def test_update_pr_comment_carries_only_the_revision_and_the_snapshot() -> None:
-    # The message is ordering metadata plus the aggregate: every count and the done flag live on the
-    # snapshot, so there is no second copy for a consumer to disagree with.
+    # Ordering metadata plus the aggregate: no second copy of the counts or the done flag.
     progress = DispatcherProgress(batches=(), done=False)
     update = UpdatePRComment(id="m1", revision=0, progress=progress)
 

--- a/ddev/tests/cli/ci/tests/test_messages.py
+++ b/ddev/tests/cli/ci/tests/test_messages.py
@@ -18,6 +18,7 @@ from ddev.cli.ci.tests.messages import (
     UpdatePRComment,
     WorkflowStatus,
 )
+from ddev.cli.ci.tests.progress import DispatcherProgress
 from ddev.cli.ci.tests.status import Status
 from ddev.utils.github_async.models import WorkflowJob
 
@@ -140,6 +141,19 @@ def test_update_pr_comment_aggregates() -> None:
     b1 = _workflow("b1", 1, 4, 0, 0, [_job("postgres", Status.SUCCESS)] * 4)
     b2 = _workflow("b2", 2, 3, 1, 0, [_job("mysql", Status.FAILURE)] + [_job("disk", Status.SUCCESS)] * 3)
     b3 = _workflow("b3", 3, 3, 0, 1, [_job("consul", Status.SKIPPED)] + [_job("nginx", Status.SUCCESS)] * 3)
-    update = UpdatePRComment(id="m1", revision=3, done=True, workflows=[b1, b2, b3])
+    update = UpdatePRComment(
+        id="m1",
+        revision=3,
+        done=True,
+        workflows=[b1, b2, b3],
+        progress=DispatcherProgress(batches=(), done=True),
+    )
 
     assert (update.passed, update.failed, update.skipped, update.complete) == (10, 1, 1, 12)
+
+
+def test_update_pr_comment_carries_the_progress_snapshot() -> None:
+    progress = DispatcherProgress(batches=(), done=False)
+    update = UpdatePRComment(id="m1", revision=0, done=False, workflows=[], progress=progress)
+
+    assert update.progress is progress

--- a/ddev/tests/cli/ci/tests/test_messages.py
+++ b/ddev/tests/cli/ci/tests/test_messages.py
@@ -129,12 +129,20 @@ def _workflow(batch_id: str, run_id: int, success: int, failed: int, skipped: in
     )
 
 
+def _results(success: int = 0, failed: int = 0, skipped: int = 0) -> list[JobResult]:
+    return (
+        [_job("postgres", Status.SUCCESS)] * success
+        + [_job("mysql", Status.FAILURE)] * failed
+        + [_job("consul", Status.SKIPPED)] * skipped
+    )
+
+
 def test_workflow_status_label() -> None:
-    assert _workflow("b1", 1, 2, 0, 0, []).status == Status.SUCCESS
-    assert _workflow("b2", 2, 1, 1, 0, []).status == Status.FAILURE
-    assert _workflow("b3", 3, 0, 0, 2, []).status == Status.SKIPPED
+    assert _workflow("b1", 1, 2, 0, 0, _results(success=2)).status == Status.SUCCESS
+    assert _workflow("b2", 2, 1, 1, 0, _results(success=1, failed=1)).status == Status.FAILURE
+    assert _workflow("b3", 3, 0, 0, 2, _results(skipped=2)).status == Status.SKIPPED
     # A batch with passes and skips (no failures) reads as success.
-    assert _workflow("b4", 4, 3, 0, 1, []).status == Status.SUCCESS
+    assert _workflow("b4", 4, 3, 0, 1, _results(success=3, skipped=1)).status == Status.SUCCESS
 
 
 def test_update_pr_comment_aggregates() -> None:

--- a/ddev/tests/cli/ci/tests/test_progress.py
+++ b/ddev/tests/cli/ci/tests/test_progress.py
@@ -21,9 +21,17 @@ from ddev.cli.ci.tests.progress import (
     ExecutionState,
     JobAttemptProgress,
     JobProgress,
+    ProgressError,
 )
 from ddev.cli.ci.tests.status import Status
+from ddev.utils.github_async.models.workflow import WorkflowJobConclusion
 from ddev.utils.junit import JUnitCounts, JUnitReport, JUnitResult, JUnitResultKind, JUnitTestCase, JUnitTestSuite
+
+CONCLUSIONS = {
+    Status.SUCCESS: WorkflowJobConclusion.SUCCESS,
+    Status.FAILURE: WorkflowJobConclusion.FAILURE,
+    Status.SKIPPED: WorkflowJobConclusion.SKIPPED,
+}
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -42,12 +50,12 @@ def _batch_job(name: str = "j1", target: str = "ntp") -> BatchJob:
     )
 
 
-def _attempt(attempt: int = 1, status: Status | None = Status.SUCCESS, **overrides) -> JobAttemptProgress:
+def _attempt(attempt: int = 1, status: Status = Status.SUCCESS, **overrides) -> JobAttemptProgress:
     defaults = {
         "attempt": attempt,
         "job_id": 8100 + attempt,
         "status": status,
-        "conclusion": None if status is None else str(status),
+        "conclusion": CONCLUSIONS[status],
         "failed_steps": (),
         "job_url": f"https://github.com/o/r/actions/runs/1/job/{8100 + attempt}",
         "reports": (),
@@ -197,11 +205,12 @@ def test_planned_jobs_count_toward_total_but_not_complete() -> None:
     assert progress.total == 3
 
 
-def test_an_attempt_without_an_outcome_is_not_complete() -> None:
-    # An in-flight execution has no normalized status yet, so it cannot be counted anywhere.
-    progress = DispatcherProgress(batches=(_batch(_job(_attempt(status=None)), status=None),), done=False)
-    assert (progress.passed, progress.failed, progress.skipped, progress.complete) == (0, 0, 0, 0)
-    assert progress.total == 1
+def test_an_execution_missing_its_artifacts_still_counts() -> None:
+    # The job ran and GitHub reported an outcome; only its artifacts are missing. It is complete and
+    # counted under that outcome — the error qualifies the execution, it does not erase it.
+    attempt = _attempt(status=Status.SUCCESS, error=ProgressError.NO_ARTIFACTS)
+    progress = DispatcherProgress(batches=(_batch(_job(attempt)),), done=True)
+    assert (progress.passed, progress.complete, progress.total) == (1, 1, 1)
 
 
 def test_empty_progress_counts_zero() -> None:

--- a/ddev/tests/cli/ci/tests/test_progress.py
+++ b/ddev/tests/cli/ci/tests/test_progress.py
@@ -1,0 +1,234 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Tests for the aggregate progress objects the gatherer publishes to the PR updater.
+
+These types are pure data: no GitHub calls, no filesystem. What is worth testing is the derived
+reporting rules the design doc pins down — a logical job's history can be sparse, only its latest
+execution counts, and a planned job with no execution yet is not complete.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from ddev.cli.ci.tests.messages import BatchJob, Platform
+from ddev.cli.ci.tests.progress import (
+    BatchProgress,
+    DispatcherProgress,
+    ExecutionState,
+    JobAttemptProgress,
+    JobProgress,
+)
+from ddev.cli.ci.tests.status import Status
+from ddev.utils.junit import JUnitCounts, JUnitReport, JUnitResult, JUnitResultKind, JUnitTestCase, JUnitTestSuite
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _batch_job(name: str = "j1", target: str = "ntp") -> BatchJob:
+    return BatchJob(
+        name=name,
+        target=target,
+        runner="ubuntu-latest",
+        environment="py3.13",
+        platform=Platform.LINUX,
+        unit_tests=True,
+        e2e_tests=False,
+    )
+
+
+def _attempt(attempt: int = 1, status: Status | None = Status.SUCCESS, **overrides) -> JobAttemptProgress:
+    defaults = {
+        "attempt": attempt,
+        "job_id": 8100 + attempt,
+        "status": status,
+        "conclusion": None if status is None else str(status),
+        "failed_steps": (),
+        "job_url": f"https://github.com/o/r/actions/runs/1/job/{8100 + attempt}",
+        "reports": (),
+    }
+    defaults.update(overrides)
+    return JobAttemptProgress(**defaults)
+
+
+def _case(name: str, kind: JUnitResultKind | None) -> JUnitTestCase:
+    results = () if kind is None else (JUnitResult(kind=kind),)
+    return JUnitTestCase(classname="tests.test_check", name=name, time=0.1, results=results)
+
+
+def _report(*cases: JUnitTestCase, suites: int = 1) -> JUnitReport:
+    counts = JUnitCounts(tests=len(cases), failures=0, errors=0, skipped=0)
+    suite = JUnitTestSuite(name="pytest", reported_counts=counts, time=1.0, timestamp=None, hostname=None)
+    return JUnitReport(
+        name="pytest",
+        test_suites=tuple(dataclasses.replace(suite, test_cases=cases) for _ in range(suites)),
+    )
+
+
+def _job(*attempts: JobAttemptProgress, name: str = "j1", target: str = "ntp") -> JobProgress:
+    return JobProgress(job=_batch_job(name, target), attempts=attempts)
+
+
+def _batch(*jobs: JobProgress, batch_id: str = "batch-01", **overrides) -> BatchProgress:
+    defaults = {
+        "batch_id": batch_id,
+        "run_id": 1,
+        "workflow_url": "https://github.com/o/r/actions/runs/1",
+        "state": ExecutionState.FINISHED,
+        "status": Status.SUCCESS,
+        "current_attempt": 1,
+        "max_attempts": 1,
+        "retries_remaining": 0,
+        "retrying_jobs": (),
+        "jobs": jobs,
+    }
+    defaults.update(overrides)
+    return BatchProgress(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# JobProgress
+# ---------------------------------------------------------------------------
+
+
+def test_latest_is_none_without_attempts() -> None:
+    job = _job()
+    assert job.latest is None
+    assert job.retry_count == 0
+
+
+def test_latest_is_the_last_attempt() -> None:
+    job = _job(_attempt(1, Status.FAILURE), _attempt(2, Status.SUCCESS))
+    assert job.latest is not None
+    assert job.latest.attempt == 2
+    assert job.latest.status == Status.SUCCESS
+    assert job.retry_count == 1
+
+
+def test_retry_count_is_execution_count_minus_one_over_a_sparse_history() -> None:
+    # A logical job may execute in attempts 1 and 3 without executing in attempt 2: retry count is
+    # execution count minus one, never ``run_attempt - 1``.
+    job = _job(_attempt(1, Status.FAILURE), _attempt(3, Status.SUCCESS))
+    assert job.retry_count == 1
+    assert job.latest is not None
+    assert job.latest.attempt == 3
+
+
+def test_failed_tests_flattens_failures_and_errors_across_suites() -> None:
+    attempt = _attempt(
+        status=Status.FAILURE,
+        reports=(
+            _report(
+                _case("test_ok", None),
+                _case("test_bad", JUnitResultKind.FAILURE),
+                _case("test_boom", JUnitResultKind.ERROR),
+                _case("test_skip", JUnitResultKind.SKIPPED),
+                suites=2,
+            ),
+        ),
+    )
+    assert [case.name for case in attempt.failed_tests] == ["test_bad", "test_boom"] * 2
+
+
+def test_failed_tests_is_empty_without_reports() -> None:
+    assert _attempt().failed_tests == []
+
+
+# ---------------------------------------------------------------------------
+# DispatcherProgress counters
+# ---------------------------------------------------------------------------
+
+
+def test_counters_use_only_the_latest_attempt() -> None:
+    # The retried job failed on attempt 1 and passed on attempt 2: it counts once, as passed.
+    progress = DispatcherProgress(
+        batches=(_batch(_job(_attempt(1, Status.FAILURE), _attempt(2, Status.SUCCESS))),),
+        done=True,
+    )
+    assert (progress.passed, progress.failed, progress.skipped) == (1, 0, 0)
+    assert progress.complete == 1
+    assert progress.total == 1
+
+
+def test_counters_sum_across_batches_and_statuses() -> None:
+    progress = DispatcherProgress(
+        batches=(
+            _batch(
+                _job(_attempt(status=Status.SUCCESS), name="j1"),
+                _job(_attempt(status=Status.FAILURE), name="j2"),
+                batch_id="batch-01",
+            ),
+            _batch(
+                _job(_attempt(status=Status.SKIPPED), name="j3"),
+                _job(_attempt(status=Status.SUCCESS), name="j4"),
+                batch_id="batch-02",
+            ),
+        ),
+        done=True,
+    )
+    assert (progress.passed, progress.failed, progress.skipped) == (2, 1, 1)
+    assert (progress.complete, progress.total) == (4, 4)
+
+
+def test_planned_jobs_count_toward_total_but_not_complete() -> None:
+    progress = DispatcherProgress(
+        batches=(
+            _batch(_job(_attempt(status=Status.SUCCESS), name="j1"), batch_id="batch-01"),
+            _batch(
+                _job(name="j2"),
+                _job(name="j3"),
+                batch_id="batch-02",
+                state=ExecutionState.PLANNED,
+                status=None,
+                run_id=None,
+                workflow_url=None,
+                current_attempt=None,
+            ),
+        ),
+        done=False,
+    )
+    assert (progress.passed, progress.failed, progress.skipped) == (1, 0, 0)
+    assert progress.complete == 1
+    assert progress.total == 3
+
+
+def test_an_attempt_without_an_outcome_is_not_complete() -> None:
+    # An in-flight execution has no normalized status yet, so it cannot be counted anywhere.
+    progress = DispatcherProgress(batches=(_batch(_job(_attempt(status=None)), status=None),), done=False)
+    assert (progress.passed, progress.failed, progress.skipped, progress.complete) == (0, 0, 0, 0)
+    assert progress.total == 1
+
+
+def test_empty_progress_counts_zero() -> None:
+    progress = DispatcherProgress(batches=(), done=False)
+    assert (progress.passed, progress.failed, progress.skipped, progress.complete, progress.total) == (0, 0, 0, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Immutability and defaults
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("instance", "field_name", "value"),
+    [
+        (_attempt(), "status", Status.FAILURE),
+        (_job(), "attempts", ()),
+        (_batch(), "state", ExecutionState.PLANNED),
+        (DispatcherProgress(batches=(), done=False), "done", True),
+    ],
+    ids=["attempt", "job", "batch", "dispatcher"],
+)
+def test_progress_objects_are_immutable(instance: object, field_name: str, value: object) -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(instance, field_name, value)
+
+
+def test_error_defaults_to_none() -> None:
+    assert _attempt().error is None
+    assert _batch().error is None

--- a/ddev/tests/cli/ci/tests/test_progress.py
+++ b/ddev/tests/cli/ci/tests/test_progress.py
@@ -92,7 +92,7 @@ def _batch(*jobs: JobProgress, batch_id: str = "batch-01", **overrides) -> Batch
         "max_attempts": 1,
         "retries_remaining": 0,
         "retrying_jobs": (),
-        "jobs": jobs,
+        "jobs_progress": jobs,
     }
     defaults.update(overrides)
     return BatchProgress(**defaults)

--- a/ddev/tests/cli/ci/tests/test_progress.py
+++ b/ddev/tests/cli/ci/tests/test_progress.py
@@ -3,9 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 """Tests for the aggregate progress objects the gatherer publishes to the PR updater.
 
-These types are pure data: no GitHub calls, no filesystem. What is worth testing is the derived
-reporting rules the design doc pins down — a logical job's history can be sparse, only its latest
-execution counts, and a planned job with no execution yet is not complete.
+These types are pure data, so what is worth testing is the derived reporting rules: a job's history
+can be sparse, only its latest execution counts, and a planned job with no execution is not complete.
 """
 
 from __future__ import annotations
@@ -119,8 +118,7 @@ def test_latest_is_the_last_attempt() -> None:
 
 
 def test_retry_count_is_execution_count_minus_one_over_a_sparse_history() -> None:
-    # A logical job may execute in attempts 1 and 3 without executing in attempt 2: retry count is
-    # execution count minus one, never ``run_attempt - 1``.
+    # A job can execute in attempts 1 and 3 but not 2, so the count is executions minus one.
     job = _job(_attempt(1, Status.FAILURE), _attempt(3, Status.SUCCESS))
     assert job.retry_count == 1
     assert job.latest is not None
@@ -206,8 +204,7 @@ def test_planned_jobs_count_toward_total_but_not_complete() -> None:
 
 
 def test_an_execution_missing_its_artifacts_still_counts() -> None:
-    # The job ran and GitHub reported an outcome; only its artifacts are missing. It is complete and
-    # counted under that outcome — the error qualifies the execution, it does not erase it.
+    # Only the artifacts are missing: the error qualifies the execution, it does not erase it.
     attempt = _attempt(status=Status.SUCCESS, error=ProgressError.NO_ARTIFACTS)
     progress = DispatcherProgress(batches=(_batch(_job(attempt)),), done=True)
     assert (progress.passed, progress.complete, progress.total) == (1, 1, 1)

--- a/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
@@ -26,6 +26,7 @@ from ddev.cli.ci.tests.messages import (
     Platform,
     TestBatch,
     UpdatePRComment,
+    WorkflowStatus,
 )
 from ddev.cli.ci.tests.progress import ExecutionState, ProgressError
 from ddev.cli.ci.tests.status import Status
@@ -167,16 +168,25 @@ def _batch_progress(update: UpdatePRComment, batch_id: str):
 
 def _totals(update: UpdatePRComment) -> tuple[int, int, int, int]:
     """The update's aggregate (passed, failed, skipped, complete) job counts."""
-    return (update.passed, update.failed, update.skipped, update.complete)
+    progress = update.progress
+    return (progress.passed, progress.failed, progress.skipped, progress.complete)
 
 
 def _failed_ids(result: JobResult) -> list[str]:
     return [case.identifier for case in result.failed_tests]
 
 
-def _find_result(update: UpdatePRComment, integration: str) -> JobResult:
+def _registry(gatherer: TaskTestGatherer) -> list[WorkflowStatus]:
+    """Every batch the gatherer has recorded, in the order it recorded them."""
+    return list(gatherer._status_by_batch.values())
+
+
+def _find_result(gatherer: TaskTestGatherer, integration: str) -> JobResult:
     return next(
-        result for workflow in update.workflows for result in workflow.results if result.integration == integration
+        result
+        for results in gatherer._results_by_batch.values()
+        for result in results
+        if result.integration == integration
     )
 
 
@@ -201,9 +211,8 @@ def test_happy_path_organizes_artifacts_and_emits_update(tmp_path: Path) -> None
     update = messages[0]
     assert isinstance(update, UpdatePRComment)
     assert update.revision == 1
-    assert update.done is True
-    assert len(update.workflows) == 1
-    status = update.workflows[0]
+    assert update.progress.done is True
+    [status] = _registry(gatherer)
     assert status.id == 100
     assert status.success_count == 1
     assert status.failed_count == 0
@@ -232,7 +241,8 @@ def test_failure_path_records_failed_steps_and_reports(tmp_path: Path) -> None:
         )
     )
 
-    status = _drain_queue(gatherer.queue)[0].workflows[0]
+    _drain_queue(gatherer.queue)
+    [status] = _registry(gatherer)
     assert status.failed_count == 1
 
     result = gatherer._results_by_batch["batch-1"][0]
@@ -273,7 +283,8 @@ def test_timed_out_batch_marks_all_jobs_failed(tmp_path: Path) -> None:
     batch_jobs = [_batch_job_result(job) for job in jobs]
     gatherer.process_message(_batch_finished("", status="failure", run_id=300, batch_jobs=batch_jobs, timed_out=True))
 
-    status = _drain_queue(gatherer.queue)[0].workflows[0]
+    _drain_queue(gatherer.queue)
+    [status] = _registry(gatherer)
     assert status.failed_count == 2
     # The timeout is the batch's, not a step of any job: no step name is invented for it.
     assert {tuple(result.failed_steps) for result in status.results} == {()}
@@ -293,7 +304,8 @@ def test_multiple_jobs_aggregate_into_one_workflow_status(tmp_path: Path) -> Non
     ]
     gatherer.process_message(_batch_finished(artifacts, status="failure", batch_jobs=batch_jobs))
 
-    status = _drain_queue(gatherer.queue)[0].workflows[0]
+    _drain_queue(gatherer.queue)
+    [status] = _registry(gatherer)
     assert status.success_count == 1
     assert status.failed_count == 1
     failed = [result.integration for result in status.results if result.status == "failure"]
@@ -338,8 +350,8 @@ def test_emits_update_per_batch_done_on_last(tmp_path: Path) -> None:
     first = _drain_queue(gatherer.queue)
     assert len(first) == 1
     assert first[0].revision == 1
-    assert first[0].done is False
-    assert {status.id for status in first[0].workflows} == {100}
+    assert first[0].progress.done is False
+    assert {batch.run_id for batch in first[0].progress.batches if batch.run_id is not None} == {100}
 
     artifacts2 = tmp_path / "artifacts" / "200"
     j1_dir2 = _make_job_tree(artifacts2, "j1")
@@ -356,8 +368,9 @@ def test_emits_update_per_batch_done_on_last(tmp_path: Path) -> None:
     second = _drain_queue(gatherer.queue)
     assert len(second) == 1
     assert second[0].revision == 2
-    assert second[0].done is True
-    assert {status.id for status in second[0].workflows} == {100, 200}
+    assert second[0].progress.done is True
+    assert {batch.run_id for batch in second[0].progress.batches} == {100, 200}
+    assert {status.id for status in _registry(gatherer)} == {100, 200}
 
 
 def test_multiple_failing_steps_all_collected(tmp_path: Path) -> None:
@@ -459,14 +472,14 @@ def test_missing_workflow_job_raises(tmp_path: Path) -> None:
         )
 
 
-def test_empty_batch_jobs_has_no_entry_in_the_flat_view(tmp_path: Path) -> None:
-    # Nothing was gathered, so the per-job registry stays empty — the batch's fate lives in the
-    # aggregate, which can say "finished with no results" where a counts-only view cannot.
+def test_empty_batch_jobs_has_no_entry_in_the_registry(tmp_path: Path) -> None:
+    # Nothing was gathered, so the registry stays empty — the batch's fate lives in the aggregate,
+    # which can say "finished with no results" where a counts-only record cannot.
     gatherer = _make_gatherer(tmp_path)
     gatherer.process_message(_batch_finished("", batch_jobs=[]))
 
     assert gatherer._results_by_batch == {}
-    assert _drain_queue(gatherer.queue)[0].workflows == []
+    assert _registry(gatherer) == []
 
 
 def test_empty_batch_jobs_still_terminates_the_batch(tmp_path: Path) -> None:
@@ -493,7 +506,7 @@ def test_empty_batch_does_not_block_completion(tmp_path: Path) -> None:
     gatherer = _make_gatherer(tmp_path, _one_job_plan("b1", "b2"))
 
     gatherer.process_message(_batch_finished("", id="b1", run_id=100, batch_jobs=[]))
-    assert _drain_queue(gatherer.queue)[0].done is False
+    assert _drain_queue(gatherer.queue)[0].progress.done is False
 
     gatherer.process_message(
         _batch_finished(
@@ -505,7 +518,6 @@ def test_empty_batch_does_not_block_completion(tmp_path: Path) -> None:
     )
 
     final = _drain_queue(gatherer.queue)[0]
-    assert final.done is True
     assert final.progress.done is True
     assert _batch_progress(final, "b1").error == ProgressError.NO_JOB_RESULTS
 
@@ -564,7 +576,7 @@ def test_duplicate_is_detected_by_batch_id_not_message_id(tmp_path: Path) -> Non
     updates = _drain_queue(gatherer.queue)
     assert [update.revision for update in updates] == [1]
     assert gatherer._revision == 1
-    assert len(updates[0].workflows) == 1
+    assert len(_registry(gatherer)) == 1
 
 
 def test_no_emission_without_batch_finished(tmp_path: Path) -> None:
@@ -581,8 +593,7 @@ def test_build_update_message(tmp_path: Path) -> None:
     assert isinstance(message, UpdatePRComment)
     assert message.id == "final"
     assert message.revision == 2
-    assert message.done is True
-    assert message.workflows == []
+    # done is stamped on the snapshot, which is the message's only payload.
     assert message.progress.done is True
 
 
@@ -596,8 +607,8 @@ def test_initial_update_is_revision_zero_over_the_whole_plan(tmp_path: Path) -> 
     gatherer = _make_gatherer(tmp_path, plan)
 
     update = gatherer.build_initial_update("initial")
-    assert (update.id, update.revision, update.done) == ("initial", 0, False)
-    assert update.workflows == []
+    assert (update.id, update.revision) == ("initial", 0)
+    assert _registry(gatherer) == []
 
     progress = update.progress
     assert progress.done is False
@@ -633,8 +644,9 @@ def test_finished_batch_leaves_other_batches_planned(tmp_path: Path) -> None:
     assert (update.progress.complete, update.progress.total) == (1, 2)
 
 
-def test_progress_and_workflows_agree(tmp_path: Path) -> None:
-    # Both views are built from the same gathered jobs; they must never disagree on counts.
+def test_progress_and_registry_agree(tmp_path: Path) -> None:
+    # The published snapshot and the local registry are built from the same gathered jobs in one pass;
+    # they must never disagree on counts, or the registry stops being a usable cross-check.
     artifacts = tmp_path / "artifacts" / "100"
     j1_dir = _make_job_tree(artifacts, "j1", environment="py3.12")
     j2_dir = _make_job_tree(artifacts, "j2", environment="py3.13", junit=JUNIT_FAILING)
@@ -654,7 +666,7 @@ def test_progress_and_workflows_agree(tmp_path: Path) -> None:
     )
 
     update = _drain_queue(gatherer.queue)[0]
-    workflow = update.workflows[0]
+    [workflow] = _registry(gatherer)
     assert (update.progress.passed, update.progress.failed, update.progress.skipped) == (
         workflow.success_count,
         workflow.failed_count,
@@ -707,7 +719,7 @@ def test_concurrent_batches_produce_one_revision_each(tmp_path: Path) -> None:
 
     updates = _drain_queue(gatherer.queue)
     assert sorted(update.revision for update in updates) == [1, 2, 3, 4, 5]
-    assert [update.done for update in updates].count(True) == 1
+    assert [update.progress.done for update in updates].count(True) == 1
 
     final = max(updates, key=lambda update: update.revision)
     assert {batch.state for batch in final.progress.batches} == {ExecutionState.FINISHED}
@@ -829,7 +841,7 @@ def test_dispatcher_scenario_three_batches(tmp_path: Path) -> None:
     gatherer.process_message(_batch_finished(a1, id="b1", run_id=1, batch_jobs=batch_01))
     rev1 = _drain_queue(gatherer.queue)
     assert len(rev1) == 1
-    assert (rev1[0].revision, rev1[0].done) == (1, False)
+    assert (rev1[0].revision, rev1[0].progress.done) == (1, False)
     assert _totals(rev1[0]) == (4, 0, 0, 4)
 
     # Batch-02 (steps 13-14): 3 pass + 1 fail (mysql py3.12 linux).
@@ -843,7 +855,7 @@ def test_dispatcher_scenario_three_batches(tmp_path: Path) -> None:
     gatherer.process_message(_batch_finished(a2, id="b2", run_id=2, batch_jobs=batch_02))
     rev2 = _drain_queue(gatherer.queue)
     assert len(rev2) == 1
-    assert (rev2[0].revision, rev2[0].done) == (2, False)
+    assert (rev2[0].revision, rev2[0].progress.done) == (2, False)
     assert _totals(rev2[0]) == (7, 1, 0, 8)
 
     # Batch-03 (steps 15-16): 3 pass + 1 skip. Terminal — revision 3, done.
@@ -858,30 +870,31 @@ def test_dispatcher_scenario_three_batches(tmp_path: Path) -> None:
     rev3 = _drain_queue(gatherer.queue)
     assert len(rev3) == 1
     final = rev3[0]
-    assert (final.revision, final.done) == (3, True)
+    assert (final.revision, final.progress.done) == (3, True)
     assert _totals(final) == (10, 1, 1, 12)
 
-    # Every batch's workflow is present with its batch id, URL, and the full per-job registry.
-    assert {workflow.id for workflow in final.workflows} == {1, 2, 3}
-    assert {workflow.batch_id for workflow in final.workflows} == {"b1", "b2", "b3"}
-    assert all(workflow.url for workflow in final.workflows)
-    assert sum(len(workflow.results) for workflow in final.workflows) == 12
+    # The gatherer's registry holds every batch with its id, URL, and the full per-job results.
+    registry = _registry(gatherer)
+    assert {workflow.id for workflow in registry} == {1, 2, 3}
+    assert {workflow.batch_id for workflow in registry} == {"b1", "b2", "b3"}
+    assert all(workflow.url for workflow in registry)
+    assert sum(len(workflow.results) for workflow in registry) == 12
 
     # Batch-level labels for the "Batch-0X : passed/failed" comment line (b3 is success: 3 pass + 1 skip).
-    labels = {workflow.batch_id: workflow.status for workflow in final.workflows}
+    labels = {workflow.batch_id: workflow.status for workflow in registry}
     assert labels == {"b1": "success", "b2": "failure", "b3": "success"}
 
     # The failing job surfaces its failed step and failing test.
-    mysql = _find_result(final, "mysql")
+    mysql = _find_result(gatherer, "mysql")
     assert mysql.status == "failure"
     assert mysql.failed_steps == ["Run unit tests"]
     assert FAILING_TEST_ID in _failed_ids(mysql)
 
     # The skipped job is recorded as skipped.
-    assert _find_result(final, "consul").status == "skipped"
+    assert _find_result(gatherer, "consul").status == "skipped"
 
-    # The same run, as the aggregate the PR updater renders: 12 planned jobs, all complete, and the
-    # per-batch labels and links matching the flat view exactly.
+    # The same run as the published snapshot, which is what the PR updater renders: 12 planned jobs,
+    # all complete, with per-batch labels and links matching the registry exactly.
     progress = final.progress
     assert progress.done is True
     assert (progress.passed, progress.failed, progress.skipped) == (10, 1, 1)

--- a/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
@@ -12,11 +12,23 @@ of every job's result — not just failures.
 from __future__ import annotations
 
 import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 
-from ddev.cli.ci.tests.messages import BatchFinished, BatchJob, BatchJobResult, JobResult, Platform, UpdatePRComment
+from ddev.cli.ci.tests.messages import (
+    BatchFinished,
+    BatchJob,
+    BatchJobResult,
+    JobResult,
+    Platform,
+    TestBatch,
+    UpdatePRComment,
+)
+from ddev.cli.ci.tests.progress import ExecutionState
+from ddev.cli.ci.tests.status import Status
 from ddev.cli.ci.tests.task_test_gatherer import TaskTestGatherer
 from ddev.event_bus.orchestrator import BaseMessage
 from ddev.utils.github_async.models import JobStep, WorkflowJob
@@ -103,6 +115,7 @@ def _batch_job_result(
 def _batch_finished(artifacts_path: Path | str, **overrides) -> BatchFinished:
     defaults = {
         "id": "batch-1",
+        "batch_id": overrides.get("id", "batch-1"),
         "status": "success",
         "run_id": 100,
         "workflow_url": "https://github.com/o/r/actions/runs/100",
@@ -120,10 +133,36 @@ def _drain_queue(queue: asyncio.Queue[BaseMessage]) -> list[BaseMessage]:
     return messages
 
 
-def _make_gatherer(tmp_path: Path, expected_batches: int = 1) -> TaskTestGatherer:
-    gatherer = TaskTestGatherer("gatherer", output_base_path=tmp_path / "out", expected_batches=expected_batches)
+def _test_batch(batch_id: str, jobs: list[BatchJob]) -> TestBatch:
+    """One planned batch. Its message id is deliberately not its batch id — they are different layers."""
+    return TestBatch(
+        id=f"msg-{batch_id}",
+        batch_id=batch_id,
+        job_list=jobs,
+        jobs_count=len(jobs),
+        integrations=sorted({job.target for job in jobs}),
+    )
+
+
+def _make_gatherer(tmp_path: Path, plan: dict[str, list[BatchJob]] | None = None) -> TaskTestGatherer:
+    """Gatherer primed with the complete plan, given as ``{batch_id: planned jobs}``."""
+    if plan is None:
+        plan = {"batch-1": [_batch_job("j1")]}
+    gatherer = TaskTestGatherer(
+        "gatherer",
+        output_base_path=tmp_path / "out",
+        batches=[_test_batch(batch_id, jobs) for batch_id, jobs in plan.items()],
+    )
     gatherer.queue = asyncio.Queue()
     return gatherer
+
+
+def _one_job_plan(*batch_ids: str) -> dict[str, list[BatchJob]]:
+    return {batch_id: [_batch_job("j1")] for batch_id in batch_ids}
+
+
+def _batch_progress(update: UpdatePRComment, batch_id: str):
+    return next(batch for batch in update.progress.batches if batch.batch_id == batch_id)
 
 
 def _totals(update: UpdatePRComment) -> tuple[int, int, int, int]:
@@ -285,7 +324,7 @@ def test_same_integration_different_platforms_do_not_overwrite(tmp_path: Path) -
 
 
 def test_emits_update_per_batch_done_on_last(tmp_path: Path) -> None:
-    gatherer = _make_gatherer(tmp_path, expected_batches=2)
+    gatherer = _make_gatherer(tmp_path, _one_job_plan("b1", "b2"))
 
     artifacts1 = tmp_path / "artifacts" / "100"
     j1_dir = _make_job_tree(artifacts1, "j1")
@@ -432,6 +471,39 @@ def test_empty_batch_jobs_is_skipped(tmp_path: Path) -> None:
     assert gatherer._received_batches == 0
 
 
+def test_empty_batch_jobs_still_terminates_the_batch(tmp_path: Path) -> None:
+    # No revision is emitted (nothing was gathered), but the batch must not keep rendering as planned:
+    # it is terminal, unsuccessful, and carries the reason.
+    gatherer = _make_gatherer(tmp_path)
+    gatherer.process_message(_batch_finished("", run_id=100, batch_jobs=[]))
+
+    batch = gatherer.build_initial_update().progress.batches[0]
+    assert batch.state == ExecutionState.FINISHED
+    assert batch.status == Status.FAILURE
+    assert batch.run_id == 100
+    assert batch.error == "Batch reported no job results"
+
+
+def test_unplanned_batch_is_ignored(tmp_path: Path) -> None:
+    # A BatchFinished whose batch_id is not in the plan is a contract violation: it must not be
+    # counted, must not inflate the revision, and must not appear in the snapshot.
+    artifacts = tmp_path / "artifacts" / "100"
+    job_dir = _make_job_tree(artifacts, "j1")
+
+    gatherer = _make_gatherer(tmp_path)
+    gatherer.process_message(
+        _batch_finished(
+            artifacts,
+            id="unknown",
+            batch_jobs=[_batch_job_result(_batch_job("j1"), _workflow_job("j1", "success"), job_dir)],
+        )
+    )
+
+    assert _drain_queue(gatherer.queue) == []
+    assert gatherer._received_batches == 0
+    assert [batch.batch_id for batch in gatherer.build_initial_update().progress.batches] == ["batch-1"]
+
+
 def test_duplicate_batch_finished_is_ignored(tmp_path: Path) -> None:
     # A duplicate BatchFinished for a run_id already gathered must not re-count the batch or inflate
     # the revision (invariant 2: one revision per consumed batch).
@@ -468,11 +540,157 @@ def test_build_update_message(tmp_path: Path) -> None:
     assert message.revision == 2
     assert message.done is True
     assert message.workflows == []
+    assert message.progress.done is True
+
+
+# ---------------------------------------------------------------------------
+# Aggregate progress
+# ---------------------------------------------------------------------------
+
+
+def test_initial_update_is_revision_zero_over_the_whole_plan(tmp_path: Path) -> None:
+    plan = {"b1": [_batch_job("j1"), _batch_job("j2", target="kafka")], "b2": [_batch_job("j3", target="redis")]}
+    gatherer = _make_gatherer(tmp_path, plan)
+
+    update = gatherer.build_initial_update()
+    assert (update.revision, update.done) == (0, False)
+    assert update.workflows == []
+
+    progress = update.progress
+    assert progress.done is False
+    assert [batch.batch_id for batch in progress.batches] == ["b1", "b2"]
+    assert all(batch.state == ExecutionState.PLANNED for batch in progress.batches)
+    assert all(
+        batch.status is None and batch.run_id is None and batch.current_attempt is None
+        for batch in progress.batches
+    )
+    assert [len(batch.jobs) for batch in progress.batches] == [2, 1]
+    assert all(job.attempts == () and job.latest is None for batch in progress.batches for job in batch.jobs)
+    assert (progress.total, progress.complete) == (3, 0)
+
+
+def test_finished_batch_leaves_other_batches_planned(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts" / "100"
+    job_dir = _make_job_tree(artifacts, "j1")
+    gatherer = _make_gatherer(tmp_path, _one_job_plan("b1", "b2"))
+
+    gatherer.process_message(
+        _batch_finished(
+            artifacts,
+            id="b1",
+            run_id=100,
+            batch_jobs=[_batch_job_result(_batch_job("j1"), _workflow_job("j1", "success"), job_dir)],
+        )
+    )
+
+    update = _drain_queue(gatherer.queue)[0]
+    assert update.progress.done is False
+    assert _batch_progress(update, "b1").state == ExecutionState.FINISHED
+    assert _batch_progress(update, "b2").state == ExecutionState.PLANNED
+    # The unfinished batch is planned, not complete — but it is still counted in the total.
+    assert (update.progress.complete, update.progress.total) == (1, 2)
+
+
+def test_progress_and_workflows_agree(tmp_path: Path) -> None:
+    # Both views are built from the same gathered jobs; they must never disagree on counts.
+    artifacts = tmp_path / "artifacts" / "100"
+    j1_dir = _make_job_tree(artifacts, "j1", environment="py3.12")
+    j2_dir = _make_job_tree(artifacts, "j2", environment="py3.13", junit=JUNIT_FAILING)
+
+    gatherer = _make_gatherer(tmp_path, {"batch-1": [_batch_job("j1"), _batch_job("j2", target="kafka")]})
+    gatherer.process_message(
+        _batch_finished(
+            artifacts,
+            status="failure",
+            batch_jobs=[
+                _batch_job_result(_batch_job("j1", environment="py3.12"), _workflow_job("j1", "success"), j1_dir),
+                _batch_job_result(
+                    _batch_job("j2", target="kafka", environment="py3.13"), _workflow_job("j2", "failure"), j2_dir
+                ),
+            ],
+        )
+    )
+
+    update = _drain_queue(gatherer.queue)[0]
+    workflow = update.workflows[0]
+    assert (update.progress.passed, update.progress.failed, update.progress.skipped) == (
+        workflow.success_count,
+        workflow.failed_count,
+        workflow.skipped_count,
+    )
+    assert _batch_progress(update, "batch-1").status == workflow.status
+
+
+def test_timed_out_batch_is_recorded_on_the_batch(tmp_path: Path) -> None:
+    gatherer = _make_gatherer(tmp_path)
+    gatherer.process_message(
+        _batch_finished(
+            "",
+            status="failure",
+            timed_out=True,
+            batch_jobs=[_batch_job_result(_batch_job("j1"))],
+        )
+    )
+
+    batch = _batch_progress(_drain_queue(gatherer.queue)[0], "batch-1")
+    assert batch.status == Status.FAILURE
+    assert batch.error == "Batch timed out"
+    assert batch.jobs[0].latest is not None
+    assert batch.jobs[0].latest.failed_steps == ("timed out",)
+
+
+def test_concurrent_batches_produce_one_revision_each(tmp_path: Path) -> None:
+    # Batches run concurrently, so BatchFinished messages can be processed on different threads. Each
+    # must yield exactly one revision and land in the snapshot: no lost batch, no repeated revision.
+    plan = {f"b{index}": [_scenario_batch_job(f"int{index}")] for index in range(1, 6)}
+    gatherer = _make_gatherer(tmp_path, plan)
+
+    messages = []
+    for index in range(1, 6):
+        artifacts = tmp_path / "artifacts" / str(index)
+        jobs = [_scenario_job(artifacts, f"int{index}", "success", JUNIT_PASSING, run_id=index)]
+        messages.append(_batch_finished(artifacts, id=f"b{index}", run_id=index, batch_jobs=jobs))
+
+    barrier = threading.Barrier(len(messages))
+
+    def gather(message) -> None:
+        barrier.wait()
+        gatherer.process_message(message)
+
+    with ThreadPoolExecutor(max_workers=len(messages)) as pool:
+        for future in [pool.submit(gather, message) for message in messages]:
+            future.result()
+
+    updates = _drain_queue(gatherer.queue)
+    assert sorted(update.revision for update in updates) == [1, 2, 3, 4, 5]
+    assert [update.done for update in updates].count(True) == 1
+
+    final = max(updates, key=lambda update: update.revision)
+    assert {batch.state for batch in final.progress.batches} == {ExecutionState.FINISHED}
+    assert (final.progress.passed, final.progress.complete, final.progress.total) == (5, 5, 5)
+
+
+def test_missing_artifact_dir_is_recorded_as_an_attempt_error(tmp_path: Path) -> None:
+    gatherer = _make_gatherer(tmp_path)
+    gatherer.process_message(
+        _batch_finished("", batch_jobs=[_batch_job_result(_batch_job("j1"), _workflow_job("j1", "success"), None)])
+    )
+
+    attempt = _batch_progress(_drain_queue(gatherer.queue)[0], "batch-1").jobs[0].latest
+    assert attempt is not None
+    assert attempt.error == "No artifact directory found for job 'j1'"
+    assert attempt.reports == ()
 
 
 # ---------------------------------------------------------------------------
 # dispatcher.md scenario: 12 jobs, 3 batches of 4
 # ---------------------------------------------------------------------------
+
+
+def _scenario_batch_job(
+    target: str, platform: Platform = Platform.LINUX, runner: str = "ubuntu-latest"
+) -> BatchJob:
+    return _batch_job(target, target=target, environment="py3.12", platform=platform, runner=runner)
 
 
 def _scenario_job(
@@ -486,14 +704,28 @@ def _scenario_job(
     runner: str = "ubuntu-latest",
     failed_step: str | None = None,
 ) -> BatchJobResult:
-    job = _batch_job(target, target=target, environment="py3.12", platform=platform, runner=runner)
+    job = _scenario_batch_job(target, platform, runner)
     job_dir = _make_job_tree(artifacts, target, environment="py3.12", junit=junit, e2e=False)
     workflow_job = _workflow_job(target, conclusion, failed_step=failed_step, run_id=run_id)
     return _batch_job_result(job, workflow_job, job_dir)
 
 
+def _scenario_plan() -> dict[str, list[BatchJob]]:
+    """The plan the dispatcher builds before the event bus starts: 12 jobs across 3 batches of 4."""
+    return {
+        "b1": [
+            _scenario_batch_job("postgres"),
+            _scenario_batch_job("redis"),
+            _scenario_batch_job("ntp", Platform.WINDOWS, "windows-latest"),
+            _scenario_batch_job("kafka"),
+        ],
+        "b2": [_scenario_batch_job(target) for target in ("disk", "snmp", "http_check", "mysql")],
+        "b3": [_scenario_batch_job(target) for target in ("nginx", "kubelet", "vault", "consul")],
+    }
+
+
 def test_dispatcher_scenario_three_batches(tmp_path: Path) -> None:
-    gatherer = _make_gatherer(tmp_path, expected_batches=3)
+    gatherer = _make_gatherer(tmp_path, _scenario_plan())
 
     # Batch-01 (steps 10-11): 4 jobs pass.
     a1 = tmp_path / "artifacts" / "1"
@@ -559,10 +791,40 @@ def test_dispatcher_scenario_three_batches(tmp_path: Path) -> None:
     # The skipped job is recorded as skipped.
     assert _find_result(final, "consul").status == "skipped"
 
+    # The same run, as the aggregate the PR updater renders: 12 planned jobs, all complete, and the
+    # per-batch labels and links matching the flat view exactly.
+    progress = final.progress
+    assert progress.done is True
+    assert (progress.passed, progress.failed, progress.skipped) == (10, 1, 1)
+    assert (progress.complete, progress.total) == (12, 12)
+    assert [batch.batch_id for batch in progress.batches] == ["b1", "b2", "b3"]
+    assert {batch.state for batch in progress.batches} == {ExecutionState.FINISHED}
+    assert {batch.batch_id: batch.status for batch in progress.batches} == {
+        "b1": Status.SUCCESS,
+        "b2": Status.FAILURE,
+        "b3": Status.SUCCESS,
+    }
+    assert {batch.run_id for batch in progress.batches} == {1, 2, 3}
+    assert all(batch.workflow_url for batch in progress.batches)
+
+    # No retries have run, so every job has exactly one execution and no retry state is reported.
+    all_jobs = [job for batch in progress.batches for job in batch.jobs]
+    assert all(job.retry_count == 0 for job in all_jobs)
+    assert all(batch.retrying_jobs == () and batch.retries_remaining == 0 for batch in progress.batches)
+
+    # The failing job's attempt carries its conclusion, failed step, job link, and failing test.
+    mysql_attempt = next(job.latest for job in all_jobs if job.job.target == "mysql")
+    assert mysql_attempt is not None
+    assert mysql_attempt.status == Status.FAILURE
+    assert mysql_attempt.conclusion == "failure"
+    assert mysql_attempt.failed_steps == ("Run unit tests",)
+    assert mysql_attempt.job_id == 1
+    assert [case.identifier for case in mysql_attempt.failed_tests] == [FAILING_TEST_ID]
+
 
 def test_dispatcher_scenario_revisions_are_monotonic(tmp_path: Path) -> None:
     # Each consumed BatchFinished yields exactly one revision, strictly increasing (invariant #2).
-    gatherer = _make_gatherer(tmp_path, expected_batches=3)
+    gatherer = _make_gatherer(tmp_path, {f"b{index}": [_scenario_batch_job(f"int{index}")] for index in (1, 2, 3)})
     revisions: list[int] = []
     for index in (1, 2, 3):
         artifacts = tmp_path / "artifacts" / str(index)

--- a/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
@@ -135,7 +135,7 @@ def _drain_queue(queue: asyncio.Queue[BaseMessage]) -> list[BaseMessage]:
 
 
 def _test_batch(batch_id: str, jobs: list[BatchJob]) -> TestBatch:
-    """One planned batch. Its message id is deliberately not its batch id — they are different layers."""
+    """One planned batch. Its message id is deliberately not its batch id: different layers."""
     return TestBatch(
         id=f"msg-{batch_id}",
         batch_id=batch_id,
@@ -473,8 +473,7 @@ def test_missing_workflow_job_raises(tmp_path: Path) -> None:
 
 
 def test_empty_batch_jobs_has_no_entry_in_the_registry(tmp_path: Path) -> None:
-    # Nothing was gathered, so the registry stays empty — the batch's fate lives in the aggregate,
-    # which can say "finished with no results" where a counts-only record cannot.
+    # Nothing gathered, so the registry stays empty; only the aggregate can say "finished empty".
     gatherer = _make_gatherer(tmp_path)
     gatherer.process_message(_batch_finished("", batch_jobs=[]))
 
@@ -483,8 +482,7 @@ def test_empty_batch_jobs_has_no_entry_in_the_registry(tmp_path: Path) -> None:
 
 
 def test_empty_batch_jobs_still_terminates_the_batch(tmp_path: Path) -> None:
-    # The batch must not keep rendering as planned: it is terminal, unsuccessful, and carries the
-    # reason — and it still emits a revision, so the comment reflects that it stopped.
+    # Terminal, unsuccessful, and carrying the reason — and still emitting a revision.
     gatherer = _make_gatherer(tmp_path)
     gatherer.process_message(_batch_finished("", run_id=100, batch_jobs=[]))
 
@@ -523,8 +521,7 @@ def test_empty_batch_does_not_block_completion(tmp_path: Path) -> None:
 
 
 def test_unplanned_batch_is_ignored(tmp_path: Path) -> None:
-    # A BatchFinished whose batch_id is not in the plan is a contract violation: it must not be
-    # counted, must not inflate the revision, and must not appear in the snapshot.
+    # An unplanned batch_id must not be counted, inflate the revision, or reach the snapshot.
     artifacts = tmp_path / "artifacts" / "100"
     job_dir = _make_job_tree(artifacts, "j1")
 
@@ -563,8 +560,7 @@ def test_duplicate_batch_finished_is_ignored(tmp_path: Path) -> None:
 
 
 def test_duplicate_is_detected_by_batch_id_not_message_id(tmp_path: Path) -> None:
-    # Two messages can carry the same batch with different message ids (a re-delivery). Identity is
-    # the batch's, so the second must not count as a second batch.
+    # A re-delivery carries the same batch under a new message id: still one batch.
     artifacts = tmp_path / "artifacts" / "100"
     job_dir = _make_job_tree(artifacts, "j1")
     job = _batch_job_result(_batch_job("j1"), _workflow_job("j1", "success"), job_dir)
@@ -645,8 +641,7 @@ def test_finished_batch_leaves_other_batches_planned(tmp_path: Path) -> None:
 
 
 def test_progress_and_registry_agree(tmp_path: Path) -> None:
-    # The published snapshot and the local registry are built from the same gathered jobs in one pass;
-    # they must never disagree on counts, or the registry stops being a usable cross-check.
+    # Both are built from the same gathered jobs in one pass, so they must agree on counts.
     artifacts = tmp_path / "artifacts" / "100"
     j1_dir = _make_job_tree(artifacts, "j1", environment="py3.12")
     j2_dir = _make_job_tree(artifacts, "j2", environment="py3.13", junit=JUNIT_FAILING)
@@ -696,8 +691,7 @@ def test_timed_out_batch_is_recorded_on_the_batch(tmp_path: Path) -> None:
 
 
 def test_concurrent_batches_produce_one_revision_each(tmp_path: Path) -> None:
-    # Batches run concurrently, so BatchFinished messages can be processed on different threads. Each
-    # must yield exactly one revision and land in the snapshot: no lost batch, no repeated revision.
+    # Concurrent batches land on different threads: one revision each, no loss, no repeat.
     plan = {f"b{index}": [_scenario_batch_job(f"int{index}")] for index in range(1, 6)}
     gatherer = _make_gatherer(tmp_path, plan)
 
@@ -739,9 +733,8 @@ def test_missing_artifact_dir_is_recorded_as_an_attempt_error(tmp_path: Path) ->
 
 
 def test_second_run_appends_an_attempt_and_keeps_untouched_jobs(tmp_path: Path) -> None:
-    # What a failed-job rerun looks like: the batch reports only the job it re-ran. The rerun job
-    # gains a second attempt; the job it did not re-run keeps the one it had, and the batch keeps
-    # both. (The duplicate guard is bypassed directly — replaying a batch is the retry work's job.)
+    # A failed-job rerun reports only the job it re-ran: that job gains a second attempt, the other
+    # keeps its own, and the batch keeps both. (Bypasses the duplicate guard, which retries will own.)
     artifacts = tmp_path / "artifacts" / "100"
     passing = _make_job_tree(artifacts, "j1")
     failing = _make_job_tree(artifacts, "j2", junit=JUNIT_FAILING, e2e=False)

--- a/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
@@ -561,8 +561,7 @@ def test_initial_update_is_revision_zero_over_the_whole_plan(tmp_path: Path) -> 
     assert [batch.batch_id for batch in progress.batches] == ["b1", "b2"]
     assert all(batch.state == ExecutionState.PLANNED for batch in progress.batches)
     assert all(
-        batch.status is None and batch.run_id is None and batch.current_attempt is None
-        for batch in progress.batches
+        batch.status is None and batch.run_id is None and batch.current_attempt is None for batch in progress.batches
     )
     assert [len(batch.jobs) for batch in progress.batches] == [2, 1]
     assert all(job.attempts == () and job.latest is None for batch in progress.batches for job in batch.jobs)
@@ -687,9 +686,7 @@ def test_missing_artifact_dir_is_recorded_as_an_attempt_error(tmp_path: Path) ->
 # ---------------------------------------------------------------------------
 
 
-def _scenario_batch_job(
-    target: str, platform: Platform = Platform.LINUX, runner: str = "ubuntu-latest"
-) -> BatchJob:
+def _scenario_batch_job(target: str, platform: Platform = Platform.LINUX, runner: str = "ubuntu-latest") -> BatchJob:
     return _batch_job(target, target=target, environment="py3.12", platform=platform, runner=runner)
 
 

--- a/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
@@ -27,7 +27,7 @@ from ddev.cli.ci.tests.messages import (
     TestBatch,
     UpdatePRComment,
 )
-from ddev.cli.ci.tests.progress import ExecutionState
+from ddev.cli.ci.tests.progress import ExecutionState, ProgressError
 from ddev.cli.ci.tests.status import Status
 from ddev.cli.ci.tests.task_test_gatherer import TaskTestGatherer
 from ddev.event_bus.orchestrator import BaseMessage
@@ -268,16 +268,15 @@ def test_full_report_keeps_passing_tests(tmp_path: Path) -> None:
 
 
 def test_timed_out_batch_marks_all_jobs_failed(tmp_path: Path) -> None:
-    gatherer = _make_gatherer(tmp_path)
-    batch_jobs = [
-        _batch_job_result(_batch_job("j1", environment="py3.12")),
-        _batch_job_result(_batch_job("j2", target="kafka", environment="py3.13")),
-    ]
+    jobs = [_batch_job("j1", environment="py3.12"), _batch_job("j2", target="kafka", environment="py3.13")]
+    gatherer = _make_gatherer(tmp_path, {"batch-1": jobs})
+    batch_jobs = [_batch_job_result(job) for job in jobs]
     gatherer.process_message(_batch_finished("", status="failure", run_id=300, batch_jobs=batch_jobs, timed_out=True))
 
     status = _drain_queue(gatherer.queue)[0].workflows[0]
     assert status.failed_count == 2
-    assert {tuple(result.failed_steps) for result in status.results} == {("timed out",)}
+    # The timeout is the batch's, not a step of any job: no step name is invented for it.
+    assert {tuple(result.failed_steps) for result in status.results} == {()}
 
 
 def test_multiple_jobs_aggregate_into_one_workflow_status(tmp_path: Path) -> None:
@@ -285,12 +284,12 @@ def test_multiple_jobs_aggregate_into_one_workflow_status(tmp_path: Path) -> Non
     j1_dir = _make_job_tree(artifacts, "j1", environment="py3.12", junit=JUNIT_PASSING)
     j2_dir = _make_job_tree(artifacts, "j2", environment="py3.13", junit=JUNIT_FAILING)
 
-    gatherer = _make_gatherer(tmp_path)
+    j1 = _batch_job("j1", environment="py3.12")
+    j2 = _batch_job("j2", target="kafka", environment="py3.13")
+    gatherer = _make_gatherer(tmp_path, {"batch-1": [j1, j2]})
     batch_jobs = [
-        _batch_job_result(_batch_job("j1", environment="py3.12"), _workflow_job("j1", "success"), j1_dir),
-        _batch_job_result(
-            _batch_job("j2", target="kafka", environment="py3.13"), _workflow_job("j2", "failure"), j2_dir
-        ),
+        _batch_job_result(j1, _workflow_job("j1", "success"), j1_dir),
+        _batch_job_result(j2, _workflow_job("j2", "failure"), j2_dir),
     ]
     gatherer.process_message(_batch_finished(artifacts, status="failure", batch_jobs=batch_jobs))
 
@@ -306,14 +305,12 @@ def test_same_integration_different_platforms_do_not_overwrite(tmp_path: Path) -
     j1_dir = _make_job_tree(artifacts, "j1", e2e=False)
     j2_dir = _make_job_tree(artifacts, "j2", e2e=False)
 
-    gatherer = _make_gatherer(tmp_path)
+    j1 = _batch_job("j1", platform=Platform.LINUX, runner="ubuntu-latest")
+    j2 = _batch_job("j2", platform=Platform.WINDOWS, runner="windows-latest")
+    gatherer = _make_gatherer(tmp_path, {"batch-1": [j1, j2]})
     batch_jobs = [
-        _batch_job_result(
-            _batch_job("j1", platform=Platform.LINUX, runner="ubuntu-latest"), _workflow_job("j1", "success"), j1_dir
-        ),
-        _batch_job_result(
-            _batch_job("j2", platform=Platform.WINDOWS, runner="windows-latest"), _workflow_job("j2", "success"), j2_dir
-        ),
+        _batch_job_result(j1, _workflow_job("j1", "success"), j1_dir),
+        _batch_job_result(j2, _workflow_job("j2", "success"), j2_dir),
     ]
     gatherer.process_message(_batch_finished(artifacts, batch_jobs=batch_jobs))
 
@@ -462,26 +459,55 @@ def test_missing_workflow_job_raises(tmp_path: Path) -> None:
         )
 
 
-def test_empty_batch_jobs_is_skipped(tmp_path: Path) -> None:
+def test_empty_batch_jobs_has_no_entry_in_the_flat_view(tmp_path: Path) -> None:
+    # Nothing was gathered, so the per-job registry stays empty — the batch's fate lives in the
+    # aggregate, which can say "finished with no results" where a counts-only view cannot.
     gatherer = _make_gatherer(tmp_path)
     gatherer.process_message(_batch_finished("", batch_jobs=[]))
 
-    assert _drain_queue(gatherer.queue) == []
     assert gatherer._results_by_batch == {}
-    assert gatherer._received_batches == 0
+    assert _drain_queue(gatherer.queue)[0].workflows == []
 
 
 def test_empty_batch_jobs_still_terminates_the_batch(tmp_path: Path) -> None:
-    # No revision is emitted (nothing was gathered), but the batch must not keep rendering as planned:
-    # it is terminal, unsuccessful, and carries the reason.
+    # The batch must not keep rendering as planned: it is terminal, unsuccessful, and carries the
+    # reason — and it still emits a revision, so the comment reflects that it stopped.
     gatherer = _make_gatherer(tmp_path)
     gatherer.process_message(_batch_finished("", run_id=100, batch_jobs=[]))
 
-    batch = gatherer.build_initial_update().progress.batches[0]
+    update = _drain_queue(gatherer.queue)[0]
+    assert update.revision == 1
+    batch = update.progress.batches[0]
     assert batch.state == ExecutionState.FINISHED
     assert batch.status == Status.FAILURE
     assert batch.run_id == 100
-    assert batch.error == "Batch reported no job results"
+    assert batch.error == ProgressError.NO_JOB_RESULTS
+    # Its planned jobs are still listed, with no execution: 1 planned, 0 complete.
+    assert (update.progress.total, update.progress.complete) == (1, 0)
+
+
+def test_empty_batch_does_not_block_completion(tmp_path: Path) -> None:
+    # A batch that reports nothing is finished, so the run as a whole can still reach done.
+    artifacts = tmp_path / "artifacts" / "200"
+    job_dir = _make_job_tree(artifacts, "j1")
+    gatherer = _make_gatherer(tmp_path, _one_job_plan("b1", "b2"))
+
+    gatherer.process_message(_batch_finished("", id="b1", run_id=100, batch_jobs=[]))
+    assert _drain_queue(gatherer.queue)[0].done is False
+
+    gatherer.process_message(
+        _batch_finished(
+            artifacts,
+            id="b2",
+            run_id=200,
+            batch_jobs=[_batch_job_result(_batch_job("j1"), _workflow_job("j1", "success", run_id=200), job_dir)],
+        )
+    )
+
+    final = _drain_queue(gatherer.queue)[0]
+    assert final.done is True
+    assert final.progress.done is True
+    assert _batch_progress(final, "b1").error == ProgressError.NO_JOB_RESULTS
 
 
 def test_unplanned_batch_is_ignored(tmp_path: Path) -> None:
@@ -500,12 +526,12 @@ def test_unplanned_batch_is_ignored(tmp_path: Path) -> None:
     )
 
     assert _drain_queue(gatherer.queue) == []
-    assert gatherer._received_batches == 0
-    assert [batch.batch_id for batch in gatherer.build_initial_update().progress.batches] == ["batch-1"]
+    assert gatherer._revision == 0
+    assert [batch.batch_id for batch in gatherer.build_initial_update("initial").progress.batches] == ["batch-1"]
 
 
 def test_duplicate_batch_finished_is_ignored(tmp_path: Path) -> None:
-    # A duplicate BatchFinished for a run_id already gathered must not re-count the batch or inflate
+    # A duplicate BatchFinished for a batch already gathered must not re-count the batch or inflate
     # the revision (invariant 2: one revision per consumed batch).
     artifacts = tmp_path / "artifacts" / "100"
     job_dir = _make_job_tree(artifacts, "j1")
@@ -521,7 +547,24 @@ def test_duplicate_batch_finished_is_ignored(tmp_path: Path) -> None:
 
     gatherer.process_message(batch)
     assert _drain_queue(gatherer.queue) == []
-    assert gatherer._received_batches == 1
+    assert gatherer._revision == 1
+
+
+def test_duplicate_is_detected_by_batch_id_not_message_id(tmp_path: Path) -> None:
+    # Two messages can carry the same batch with different message ids (a re-delivery). Identity is
+    # the batch's, so the second must not count as a second batch.
+    artifacts = tmp_path / "artifacts" / "100"
+    job_dir = _make_job_tree(artifacts, "j1")
+    job = _batch_job_result(_batch_job("j1"), _workflow_job("j1", "success"), job_dir)
+
+    gatherer = _make_gatherer(tmp_path)
+    gatherer.process_message(_batch_finished(artifacts, id="msg-a", batch_id="batch-1", batch_jobs=[job]))
+    gatherer.process_message(_batch_finished(artifacts, id="msg-b", batch_id="batch-1", batch_jobs=[job]))
+
+    updates = _drain_queue(gatherer.queue)
+    assert [update.revision for update in updates] == [1]
+    assert gatherer._revision == 1
+    assert len(updates[0].workflows) == 1
 
 
 def test_no_emission_without_batch_finished(tmp_path: Path) -> None:
@@ -529,7 +572,7 @@ def test_no_emission_without_batch_finished(tmp_path: Path) -> None:
     gatherer = _make_gatherer(tmp_path)
     assert _drain_queue(gatherer.queue) == []
     assert gatherer._results_by_batch == {}
-    assert gatherer._received_batches == 0
+    assert gatherer._revision == 0
 
 
 def test_build_update_message(tmp_path: Path) -> None:
@@ -552,8 +595,8 @@ def test_initial_update_is_revision_zero_over_the_whole_plan(tmp_path: Path) -> 
     plan = {"b1": [_batch_job("j1"), _batch_job("j2", target="kafka")], "b2": [_batch_job("j3", target="redis")]}
     gatherer = _make_gatherer(tmp_path, plan)
 
-    update = gatherer.build_initial_update()
-    assert (update.revision, update.done) == (0, False)
+    update = gatherer.build_initial_update("initial")
+    assert (update.id, update.revision, update.done) == ("initial", 0, False)
     assert update.workflows == []
 
     progress = update.progress
@@ -633,9 +676,11 @@ def test_timed_out_batch_is_recorded_on_the_batch(tmp_path: Path) -> None:
 
     batch = _batch_progress(_drain_queue(gatherer.queue)[0], "batch-1")
     assert batch.status == Status.FAILURE
-    assert batch.error == "Batch timed out"
+    assert batch.error == ProgressError.TIMED_OUT
     assert batch.jobs[0].latest is not None
-    assert batch.jobs[0].latest.failed_steps == ("timed out",)
+    # The job never reported a step, and GitHub never reported the job at all.
+    assert batch.jobs[0].latest.failed_steps == ()
+    assert batch.jobs[0].latest.conclusion is None
 
 
 def test_concurrent_batches_produce_one_revision_each(tmp_path: Path) -> None:
@@ -677,8 +722,55 @@ def test_missing_artifact_dir_is_recorded_as_an_attempt_error(tmp_path: Path) ->
 
     attempt = _batch_progress(_drain_queue(gatherer.queue)[0], "batch-1").jobs[0].latest
     assert attempt is not None
-    assert attempt.error == "No artifact directory found for job 'j1'"
+    assert attempt.error == ProgressError.NO_ARTIFACTS
     assert attempt.reports == ()
+
+
+def test_second_run_appends_an_attempt_and_keeps_untouched_jobs(tmp_path: Path) -> None:
+    # What a failed-job rerun looks like: the batch reports only the job it re-ran. The rerun job
+    # gains a second attempt; the job it did not re-run keeps the one it had, and the batch keeps
+    # both. (The duplicate guard is bypassed directly — replaying a batch is the retry work's job.)
+    artifacts = tmp_path / "artifacts" / "100"
+    passing = _make_job_tree(artifacts, "j1")
+    failing = _make_job_tree(artifacts, "j2", junit=JUNIT_FAILING, e2e=False)
+    j1, j2 = _batch_job("j1"), _batch_job("j2", target="kafka")
+    gatherer = _make_gatherer(tmp_path, {"batch-1": [j1, j2]})
+
+    gatherer.process_message(
+        _batch_finished(
+            artifacts,
+            status="failure",
+            batch_jobs=[
+                _batch_job_result(j1, _workflow_job("j1", "success"), passing),
+                _batch_job_result(j2, _workflow_job("j2", "failure"), failing),
+            ],
+        )
+    )
+    _drain_queue(gatherer.queue)
+
+    rerun_dir = _make_job_tree(tmp_path / "artifacts" / "101", "j2")
+    rerun = _batch_finished(
+        artifacts,
+        id="msg-2",
+        batch_id="batch-1",
+        run_id=101,
+        batch_jobs=[_batch_job_result(j2, _workflow_job("j2", "success"), rerun_dir)],
+    )
+    gatherer._progress_by_batch["batch-1"] = gatherer._finished_batch_progress(
+        gatherer._progress_by_batch["batch-1"], rerun, [gatherer._gather_job(rerun.batch_jobs[0], rerun)]
+    )
+
+    batch = gatherer._progress_by_batch["batch-1"]
+    assert batch.batch_id == "batch-1"
+    by_name = {job.job.name: job for job in batch.jobs}
+    assert sorted(by_name) == ["j1", "j2"]
+    assert by_name["j1"].retry_count == 0
+    assert by_name["j2"].retry_count == 1
+    assert [attempt.attempt for attempt in by_name["j2"].attempts] == [1, 2]
+    assert [attempt.status for attempt in by_name["j2"].attempts] == [Status.FAILURE, Status.SUCCESS]
+    # Only the latest attempt counts, so the batch reads as passed and the totals do not double.
+    assert batch.status == Status.SUCCESS
+    assert batch.current_attempt == 2
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
@@ -12,6 +12,7 @@ of every job's result — not just failures.
 from __future__ import annotations
 
 import asyncio
+import shutil
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -484,7 +485,7 @@ def test_empty_batch_jobs_has_no_entry_in_the_registry(tmp_path: Path) -> None:
 def test_empty_batch_jobs_still_terminates_the_batch(tmp_path: Path) -> None:
     # Terminal, unsuccessful, and carrying the reason — and still emitting a revision.
     gatherer = _make_gatherer(tmp_path)
-    gatherer.process_message(_batch_finished("", run_id=100, batch_jobs=[]))
+    gatherer.process_message(_batch_finished("", status="failure", run_id=100, batch_jobs=[]))
 
     update = _drain_queue(gatherer.queue)[0]
     assert update.revision == 1
@@ -537,6 +538,8 @@ def test_unplanned_batch_is_ignored(tmp_path: Path) -> None:
     assert _drain_queue(gatherer.queue) == []
     assert gatherer._revision == 0
     assert [batch.batch_id for batch in gatherer.build_initial_update("initial").progress.batches] == ["batch-1"]
+    # Nor may it write into the output tree the planned batches publish from.
+    assert not (tmp_path / "out").exists()
 
 
 def test_duplicate_batch_finished_is_ignored(tmp_path: Path) -> None:
@@ -554,9 +557,13 @@ def test_duplicate_batch_finished_is_ignored(tmp_path: Path) -> None:
     assert len(first) == 1
     assert first[0].revision == 1
 
+    # Removed so the replay has to recreate it to be caught organizing artifacts a second time.
+    shutil.rmtree(tmp_path / "out")
+
     gatherer.process_message(batch)
     assert _drain_queue(gatherer.queue) == []
     assert gatherer._revision == 1
+    assert not (tmp_path / "out").exists()
 
 
 def test_duplicate_is_detected_by_batch_id_not_message_id(tmp_path: Path) -> None:
@@ -613,8 +620,8 @@ def test_initial_update_is_revision_zero_over_the_whole_plan(tmp_path: Path) -> 
     assert all(
         batch.status is None and batch.run_id is None and batch.current_attempt is None for batch in progress.batches
     )
-    assert [len(batch.jobs) for batch in progress.batches] == [2, 1]
-    assert all(job.attempts == () and job.latest is None for batch in progress.batches for job in batch.jobs)
+    assert [len(batch.jobs_progress) for batch in progress.batches] == [2, 1]
+    assert all(job.attempts == () and job.latest is None for batch in progress.batches for job in batch.jobs_progress)
     assert (progress.total, progress.complete) == (3, 0)
 
 
@@ -667,7 +674,55 @@ def test_progress_and_registry_agree(tmp_path: Path) -> None:
         workflow.failed_count,
         workflow.skipped_count,
     )
-    assert _batch_progress(update, "batch-1").status == workflow.status
+    # The batch label is the workflow's, not a roll-up of the jobs the registry counted.
+    assert _batch_progress(update, "batch-1").status == Status.FAILURE
+
+
+def test_batch_status_comes_from_the_workflow_not_from_its_jobs(tmp_path: Path) -> None:
+    # A workflow also runs steps no tracked job covers (setup, finalization). When one of those fails
+    # the batch failed, even though every job it tracked passed.
+    artifacts = tmp_path / "artifacts" / "100"
+    job_dir = _make_job_tree(artifacts, "j1")
+
+    gatherer = _make_gatherer(tmp_path)
+    gatherer.process_message(
+        _batch_finished(
+            artifacts,
+            status="failure",
+            batch_jobs=[_batch_job_result(_batch_job("j1"), _workflow_job("j1", "success"), job_dir)],
+        )
+    )
+
+    update = _drain_queue(gatherer.queue)[0]
+    batch = _batch_progress(update, "batch-1")
+    assert batch.status == Status.FAILURE
+    assert [job.latest.status for job in batch.jobs_progress] == [Status.SUCCESS]
+    # The job counters still report the job as passed: the discrepancy is the signal.
+    assert (update.progress.passed, update.progress.failed) == (1, 0)
+
+
+def test_unplanned_job_is_warned_about_but_left_out_of_the_totals(tmp_path: Path) -> None:
+    # A job the plan never mentioned would mangle the totals, so it is logged and dropped.
+    artifacts = tmp_path / "artifacts" / "100"
+    planned_dir = _make_job_tree(artifacts, "j1")
+    stray_dir = _make_job_tree(artifacts, "j2")
+    gatherer = _make_gatherer(tmp_path)
+
+    gatherer.process_message(
+        _batch_finished(
+            artifacts,
+            batch_jobs=[
+                _batch_job_result(_batch_job("j1"), _workflow_job("j1", "success"), planned_dir),
+                _batch_job_result(_batch_job("j2", target="kafka"), _workflow_job("j2", "failure"), stray_dir),
+            ],
+        )
+    )
+
+    update = _drain_queue(gatherer.queue)[0]
+    batch = _batch_progress(update, "batch-1")
+    assert [job.job.name for job in batch.jobs_progress] == ["j1"]
+    assert (update.progress.total, update.progress.complete) == (1, 1)
+    assert (update.progress.passed, update.progress.failed) == (1, 0)
 
 
 def test_timed_out_batch_is_recorded_on_the_batch(tmp_path: Path) -> None:
@@ -684,10 +739,10 @@ def test_timed_out_batch_is_recorded_on_the_batch(tmp_path: Path) -> None:
     batch = _batch_progress(_drain_queue(gatherer.queue)[0], "batch-1")
     assert batch.status == Status.FAILURE
     assert batch.error == ProgressError.TIMED_OUT
-    assert batch.jobs[0].latest is not None
+    assert batch.jobs_progress[0].latest is not None
     # The job never reported a step, and GitHub never reported the job at all.
-    assert batch.jobs[0].latest.failed_steps == ()
-    assert batch.jobs[0].latest.conclusion is None
+    assert batch.jobs_progress[0].latest.failed_steps == ()
+    assert batch.jobs_progress[0].latest.conclusion is None
 
 
 def test_concurrent_batches_produce_one_revision_each(tmp_path: Path) -> None:
@@ -726,7 +781,7 @@ def test_missing_artifact_dir_is_recorded_as_an_attempt_error(tmp_path: Path) ->
         _batch_finished("", batch_jobs=[_batch_job_result(_batch_job("j1"), _workflow_job("j1", "success"), None)])
     )
 
-    attempt = _batch_progress(_drain_queue(gatherer.queue)[0], "batch-1").jobs[0].latest
+    attempt = _batch_progress(_drain_queue(gatherer.queue)[0], "batch-1").jobs_progress[0].latest
     assert attempt is not None
     assert attempt.error == ProgressError.NO_ARTIFACTS
     assert attempt.reports == ()
@@ -767,7 +822,7 @@ def test_second_run_appends_an_attempt_and_keeps_untouched_jobs(tmp_path: Path) 
 
     batch = gatherer._progress_by_batch["batch-1"]
     assert batch.batch_id == "batch-1"
-    by_name = {job.job.name: job for job in batch.jobs}
+    by_name = {job.job.name: job for job in batch.jobs_progress}
     assert sorted(by_name) == ["j1", "j2"]
     assert by_name["j1"].retry_count == 0
     assert by_name["j2"].retry_count == 1
@@ -845,7 +900,7 @@ def test_dispatcher_scenario_three_batches(tmp_path: Path) -> None:
         _scenario_job(a2, "http_check", "success", JUNIT_PASSING, run_id=2),
         _scenario_job(a2, "mysql", "failure", JUNIT_FAILING, run_id=2, failed_step="Run unit tests"),
     ]
-    gatherer.process_message(_batch_finished(a2, id="b2", run_id=2, batch_jobs=batch_02))
+    gatherer.process_message(_batch_finished(a2, id="b2", status="failure", run_id=2, batch_jobs=batch_02))
     rev2 = _drain_queue(gatherer.queue)
     assert len(rev2) == 1
     assert (rev2[0].revision, rev2[0].progress.done) == (2, False)
@@ -903,7 +958,7 @@ def test_dispatcher_scenario_three_batches(tmp_path: Path) -> None:
     assert all(batch.workflow_url for batch in progress.batches)
 
     # No retries have run, so every job has exactly one execution and no retry state is reported.
-    all_jobs = [job for batch in progress.batches for job in batch.jobs]
+    all_jobs = [job for batch in progress.batches for job in batch.jobs_progress]
     assert all(job.retry_count == 0 for job in all_jobs)
     assert all(batch.retrying_jobs == () and batch.retries_remaining == 0 for batch in progress.batches)
 

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -122,7 +122,7 @@ def drain_queue(queue: asyncio.Queue[BaseMessage]) -> list[BaseMessage]:
 
 
 def make_batch(batch_id: str = "batch-err") -> TestBatch:
-    return TestBatch(id=batch_id, job_list=[make_job()], jobs_count=1, integrations=["ntp"])
+    return TestBatch(id=batch_id, batch_id=batch_id, job_list=[make_job()], jobs_count=1, integrations=["ntp"])
 
 
 async def run_happy_path(tmp_path: Path) -> tuple[FakeAsyncGitHubClient, BatchFinished]:
@@ -130,6 +130,9 @@ async def run_happy_path(tmp_path: Path) -> tuple[FakeAsyncGitHubClient, BatchFi
 
     The two jobs share a target/environment/platform, so their artifact names collide with each other
     and never match the generic ``artifact-N`` uploads: correlation therefore finds no match.
+
+    The batch's message id and its logical ``batch_id`` differ on purpose, so the assertions on the
+    workflow input, the check-run name, and the emitted ``BatchFinished`` show which one is used.
     """
     fake = FakeAsyncGitHubClient()
     fake.mock_response("get_workflow_run", make_workflow_run("completed", "success"))
@@ -137,7 +140,11 @@ async def run_happy_path(tmp_path: Path) -> tuple[FakeAsyncGitHubClient, BatchFi
     runner = make_runner(fake, tmp_path)
 
     batch = TestBatch(
-        id="batch-1", job_list=[make_job("j1"), make_job("j2")], jobs_count=2, integrations=["ntp", "kafka"]
+        id="msg-1",
+        batch_id="batch-1",
+        job_list=[make_job("j1"), make_job("j2")],
+        jobs_count=2,
+        integrations=["ntp", "kafka"],
     )
     await runner.process_message(batch)
 
@@ -255,7 +262,9 @@ async def test_downloads_all_batch_artifacts(tmp_path: Path) -> None:
 async def test_emits_batch_finished_with_run_metadata(tmp_path: Path) -> None:
     _, finished = await run_happy_path(tmp_path)
 
-    assert finished.id == "batch-1"
+    assert finished.id == "msg-1"
+    # The logical batch identity is carried explicitly, not inferred from the message id.
+    assert finished.batch_id == "batch-1"
     assert finished.status == "success"
     assert finished.run_id == 123
     assert finished.workflow_url == "https://github.com/o/r/actions/runs/123"
@@ -309,7 +318,9 @@ async def test_process_message_correlates_batch_jobs(tmp_path: Path) -> None:
     mock_jobs(fake, [make_workflow_job("j1", "success"), make_workflow_job("j2", "failure")])
     runner = make_runner(fake, tmp_path)
 
-    await runner.process_message(TestBatch(id="batch-c", job_list=[j1, j2], jobs_count=2, integrations=["ntp"]))
+    await runner.process_message(
+        TestBatch(id="batch-c", batch_id="batch-c", job_list=[j1, j2], jobs_count=2, integrations=["ntp"])
+    )
 
     finished = drain_queue(runner.queue)[0]
     assert isinstance(finished, BatchFinished)
@@ -339,7 +350,9 @@ async def test_process_message_batch_job_without_workflow_match(tmp_path: Path) 
     # list_workflow_jobs defaults to an empty page.
     runner = make_runner(fake, tmp_path)
 
-    await runner.process_message(TestBatch(id="batch-d", job_list=[job], jobs_count=1, integrations=["ntp"]))
+    await runner.process_message(
+        TestBatch(id="batch-d", batch_id="batch-d", job_list=[job], jobs_count=1, integrations=["ntp"])
+    )
 
     finished = drain_queue(runner.queue)[0]
     assert isinstance(finished, BatchFinished)
@@ -359,7 +372,9 @@ async def test_process_message_batch_job_without_artifacts(tmp_path: Path) -> No
     mock_jobs(fake, [make_workflow_job("j1", "success")])
     runner = make_runner(fake, tmp_path)
 
-    await runner.process_message(TestBatch(id="batch-e", job_list=[job], jobs_count=1, integrations=["ntp"]))
+    await runner.process_message(
+        TestBatch(id="batch-e", batch_id="batch-e", job_list=[job], jobs_count=1, integrations=["ntp"])
+    )
 
     finished = drain_queue(runner.queue)[0]
     assert isinstance(finished, BatchFinished)
@@ -398,7 +413,9 @@ async def test_process_message_failure_path(tmp_path: Path) -> None:
     mock_artifacts(fake, [make_artifact(1)])
     runner = make_runner(fake, tmp_path)
 
-    await runner.process_message(TestBatch(id="batch-2", job_list=[make_job()], jobs_count=1, integrations=["ntp"]))
+    await runner.process_message(
+        TestBatch(id="batch-2", batch_id="batch-2", job_list=[make_job()], jobs_count=1, integrations=["ntp"])
+    )
 
     submitted = drain_queue(runner.queue)
     assert len(submitted) == 1
@@ -442,7 +459,9 @@ async def test_process_message_polls_until_completed(tmp_path: Path) -> None:
     mock_artifacts(fake, [])
     runner = make_runner(fake, tmp_path)
 
-    await runner.process_message(TestBatch(id="batch-3", job_list=[make_job()], jobs_count=1, integrations=["ntp"]))
+    await runner.process_message(
+        TestBatch(id="batch-3", batch_id="batch-3", job_list=[make_job()], jobs_count=1, integrations=["ntp"])
+    )
 
     assert len(fake.calls_to("get_workflow_run")) == 4
     submitted = drain_queue(runner.queue)
@@ -465,7 +484,9 @@ async def test_process_message_skips_expired_artifacts(tmp_path: Path) -> None:
     )
     runner = make_runner(fake, tmp_path)
 
-    await runner.process_message(TestBatch(id="batch-4", job_list=[make_job()], jobs_count=1, integrations=["ntp"]))
+    await runner.process_message(
+        TestBatch(id="batch-4", batch_id="batch-4", job_list=[make_job()], jobs_count=1, integrations=["ntp"])
+    )
 
     # Only the non-expired artifact with a download URL should be fetched.
     download_calls = fake.calls_to("download_artifact")


### PR DESCRIPTION
### What does this PR do?

Adds the aggregate state layer the [Dispatcher execution and PR reporting design](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/6968444162/Dispatcher+execution+and+PR+reporting+design#Aggregate-state) specifies, inside the test gatherer:

- New `ddev/src/ddev/cli/ci/tests/progress.py` with the frozen `DispatcherProgress` -> `BatchProgress` -> `JobProgress` -> `JobAttemptProgress` hierarchy. Job/batch counters derive from `JobProgress.latest` only. No GitHub API model is exposed except `conclusion`, kept as its `WorkflowJobConclusion` enum because it distinguishes outcomes (cancelled, timed out, action required) that `Status` collapses. Errors are a closed `ProgressError` enum, not prose the renderer would have to match on.
- `TaskTestGatherer` is constructed with the complete batch plan and seeds every batch as `PLANNED`. `UpdatePRComment` carries exactly two things: `revision`, the ordering metadata the snapshot deliberately does not hold, and `progress`, the complete snapshot covering batches that have not run yet, not only the ones already gathered. A finished batch is merged into its registered plan: it keeps every job it was planned with, and executions are appended to each job's history rather than replacing it.
- Every registry is keyed by `batch_id`, and `done` is derived from the snapshot (no planned batch left unfinished) instead of a separate received-batch counter. Duplicate detection is the aggregate's own terminal state, so a re-delivered batch cannot inflate the revision even under a different message id.
- `TestBatch` and `BatchFinished` carry an explicit `batch_id`, so `BaseMessage.id` stops doubling as the logical batch identity. The runner passes it through to the workflow input, the check-run name, and the emitted `BatchFinished`.
- The batch-status rule (failure > success > skipped) is now one shared `batch_status` helper in `status.py`, used by both `WorkflowStatus.status` and the aggregate.

Retry execution is out of scope (`BatchAttemptFinished`, `rerun-failed-jobs`, attempt polling, `WorkflowJob.run_attempt`). Where the aggregate can derive a retry-shaped value it does — `attempt` is the execution's position in the job's own history, `current_attempt` the deepest history in the batch — so a failed-job rerun that reports only a subset of jobs already produces the right shape. `max_attempts`, `retries_remaining` and `retrying_jobs` are the only values still asserted rather than derived: they are fixed at their no-retry values so the PR updater's contract does not change when the retry work lands.

Two deliberate notes for review:

- `JobResult` and `WorkflowStatus` are kept and still populated as the gatherer's local registry of what each batch reported. They are not duplicates of the aggregate: `_gather_job` builds both from the same inputs (`BatchJobResult.workflow_job`, the parsed JUnit reports, `BatchFinished`) in one pass, so the DTOs derive from those inputs rather than from these classes. They are simply no longer published, which is why the message lost `done`, `workflows` and its four counter properties.
- `build_initial_update()` returns revision `0` rather than submitting it, because a processor can only submit once the event bus has attached its queue. Its caller lands with the dispatcher entry point, which publishes it when it starts the bus.

One known gap, unchanged from current behavior: a `BatchJobResult` with no correlated workflow job still raises instead of rendering as an unavailable result.

### Motivation

The PR updater must render one monotonic comment from a complete, immutable snapshot. The previous payload (`workflows: list[WorkflowStatus]`) was a flat per-batch counter view built only from batches that had already finished, with no place for planned batches, no attempt history, and no separation between message identity and batch identity. This prepares the information the PR updater needs without it having to deal with GitHub API details or fields it does not use.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

