### PR TITLE
Rename Cluster Monitoring section to Kafka Console in kafka_consumer README

### DIFF
--- a/kafka_consumer/README.md
+++ b/kafka_consumer/README.md
@@ -58,7 +58,7 @@ instances:
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
 
-### Cluster Monitoring (Preview)
+### Kafka Console (Preview)
 
 When `enable_cluster_monitoring` is enabled, the integration collects cluster-wide metrics for [Data Streams Monitoring][18] in addition to consumer lag:
 
@@ -183,7 +183,7 @@ Depending on your Kafka cluster's Kerberos setup, you may need to configure the 
 [14]: https://www.datadoghq.com/blog/collecting-kafka-performance-metrics
 [15]: https://www.datadoghq.com/blog/monitor-kafka-with-datadog
 [17]: https://docs.datadoghq.com/containers/kubernetes/integrations/
-[18]: /data-streams
+[18]: /data-streams/kafka
 [19]: /integrations/kafka?search=kafka
 [20]: /containers/cluster_agent/clusterchecks/
 [21]: /data_streams/messages/

--- a/kafka_consumer/README.md
+++ b/kafka_consumer/README.md
@@ -58,7 +58,7 @@ instances:
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
 
-### Kafka Console (Preview)
+### Kafka Console
 
 When `enable_cluster_monitoring` is enabled, the integration collects cluster-wide metrics for [Data Streams Monitoring][18] in addition to consumer lag:
 


### PR DESCRIPTION
### What does this PR do?
Renames the "Cluster Monitoring (Preview)" section in the `kafka_consumer` README to "Kafka Console (Preview)" and updates the Data Streams Monitoring doc link to point to `/data-streams/kafka` instead of `/data-streams`.

### Motivation
Keep the README aligned with the current product naming and documentation link.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged