### PR TITLE
Return structured change records from GitRepository.changed_files

### DIFF
--- a/ddev/changelog.d/24776.added
+++ b/ddev/changelog.d/24776.added
@@ -1,0 +1,1 @@
+Report the type of each changed file from `GitRepository.changed_files`, and allow comparing two refs.

--- a/ddev/src/ddev/repo/core.py
+++ b/ddev/src/ddev/repo/core.py
@@ -10,10 +10,17 @@ from typing import TYPE_CHECKING, Dict, Iterable
 from ddev.integration.core import Integration
 from ddev.repo.constants import CONFIG_DIRECTORY, FULL_NAMES
 from ddev.utils.fs import Path
-from ddev.utils.git import GitRepository
+from ddev.utils.git import Comparison, GitRepository
 
 if TYPE_CHECKING:
     from ddev.repo.config import RepositoryConfig
+
+
+# Two questions, merged: what this branch changed against master, and what the working tree changed
+# against the last commit. They differ only when the working tree reverts something the branch
+# committed, in which case the first reports nothing and the second still reports the file. Asking
+# both keeps such a file selected. Narrow this to a single comparison with `IntegrationRegistry.comparing`.
+DEFAULT_COMPARISONS = (Comparison(base='origin/master'), Comparison(base='HEAD'))
 
 
 GIT_REMOTE_PATTERNS = (
@@ -135,9 +142,39 @@ class Repository:
 
 
 class IntegrationRegistry:
-    def __init__(self, repo: Repository):
+    def __init__(
+        self,
+        repo: Repository,
+        *,
+        comparisons: tuple[Comparison, ...] = DEFAULT_COMPARISONS,
+        cache: Dict[str, Integration] | None = None,
+    ):
+        """
+        `comparisons` are the points a `changed` selection is resolved against, unioned so a path
+        counts as changed if any of them reports it. `cache` is shared between a registry and the
+        views `comparing` derives from it, since an `Integration` does not depend on which
+        comparison selected it.
+        """
         self.__repo = repo
-        self.__cache: Dict[str, Integration] = {}
+        self.__comparisons = comparisons
+        self.__cache: Dict[str, Integration] = {} if cache is None else cache
+
+    def comparing(self, *, base: str, head: str | None = None) -> IntegrationRegistry:
+        """Return a registry that resolves a `changed` selection between exactly two points.
+
+        Without a `head` the comparison runs against the working tree.
+        """
+        return IntegrationRegistry(self.__repo, comparisons=(Comparison(base=base, head=head),), cache=self.__cache)
+
+    @cached_property
+    def changed_paths(self) -> set[str]:
+        """Every path affected by a change, across all of this registry's comparisons."""
+        return {
+            path
+            for comparison in self.__comparisons
+            for changed_file in self.repo.git.changed_files(comparison.base, comparison.head)
+            for path in changed_file.affected_paths
+        }
 
     @property
     def repo(self) -> Repository:
@@ -233,12 +270,8 @@ class IntegrationRegistry:
         Iterate over all integrations that have changes that could affect built distributions.
         """
         for integration in self.__iter_filtered(selection):
-            for changed_file in self.repo.git.changed_files():
-                if any(
-                    integration.requires_changelog_entry(self.repo.path / path) for path in changed_file.affected_paths
-                ):
-                    yield integration
-                    break
+            if any(integration.requires_changelog_entry(self.repo.path / path) for path in self.changed_paths):
+                yield integration
 
     def __iter_filtered(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
         selected = self.__finalize_selection(selection)
@@ -278,8 +311,4 @@ class IntegrationRegistry:
         return set() if 'all' in selection else set(selection)
 
     def __get_changed_root_entries(self) -> set[str]:
-        return {
-            path.split('/', 1)[0]
-            for changed_file in self.repo.git.changed_files()
-            for path in changed_file.affected_paths
-        }
+        return {path.split('/', 1)[0] for path in self.changed_paths}

--- a/ddev/src/ddev/repo/core.py
+++ b/ddev/src/ddev/repo/core.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 # against the last commit. They differ only when the working tree reverts something the branch
 # committed, in which case the first reports nothing and the second still reports the file. Asking
 # both keeps such a file selected. Narrow this to a single comparison with `IntegrationRegistry.comparing`.
-DEFAULT_COMPARISONS = (Comparison(base='origin/master'), Comparison(base='HEAD'))
+DEFAULT_COMPARISONS = (Comparison(), Comparison(base='HEAD'))
 
 
 GIT_REMOTE_PATTERNS = (

--- a/ddev/src/ddev/repo/core.py
+++ b/ddev/src/ddev/repo/core.py
@@ -233,8 +233,8 @@ class IntegrationRegistry:
         Iterate over all integrations that have changes that could affect built distributions.
         """
         for integration in self.__iter_filtered(selection):
-            for relative_path in self.repo.git.changed_files():
-                if integration.requires_changelog_entry(self.repo.path / relative_path):
+            for changed_file in self.repo.git.changed_files():
+                if integration.requires_changelog_entry(self.repo.path / changed_file.path):
                     yield integration
                     break
 
@@ -276,4 +276,4 @@ class IntegrationRegistry:
         return set() if 'all' in selection else set(selection)
 
     def __get_changed_root_entries(self) -> set[str]:
-        return {relative_path.split('/', 1)[0] for relative_path in self.repo.git.changed_files()}
+        return {changed_file.path.split('/', 1)[0] for changed_file in self.repo.git.changed_files()}

--- a/ddev/src/ddev/repo/core.py
+++ b/ddev/src/ddev/repo/core.py
@@ -234,7 +234,9 @@ class IntegrationRegistry:
         """
         for integration in self.__iter_filtered(selection):
             for changed_file in self.repo.git.changed_files():
-                if integration.requires_changelog_entry(self.repo.path / changed_file.path):
+                if any(
+                    integration.requires_changelog_entry(self.repo.path / path) for path in changed_file.affected_paths
+                ):
                     yield integration
                     break
 
@@ -276,4 +278,8 @@ class IntegrationRegistry:
         return set() if 'all' in selection else set(selection)
 
     def __get_changed_root_entries(self) -> set[str]:
-        return {changed_file.path.split('/', 1)[0] for changed_file in self.repo.git.changed_files()}
+        return {
+            path.split('/', 1)[0]
+            for changed_file in self.repo.git.changed_files()
+            for path in changed_file.affected_paths
+        }

--- a/ddev/src/ddev/utils/git.py
+++ b/ddev/src/ddev/utils/git.py
@@ -43,6 +43,18 @@ class ChangedFile:
     path: str
     previous_path: str | None = None
 
+    @property
+    def affected_paths(self) -> tuple[str, ...]:
+        """Every path this change touches.
+
+        A rename also affects its source, which lost the file. A copy leaves the source untouched,
+        so only the destination is affected.
+        """
+        if self.change_type is ChangeType.RENAMED and self.previous_path is not None:
+            return (self.path, self.previous_path)
+
+        return (self.path,)
+
 
 def is_git_warning_line(line: str) -> bool:
     """Return whether a line of git output is an ignorable warning rather than a record."""
@@ -238,30 +250,20 @@ class GitRepository:
     def changed_files(self, base: str = 'origin/master', head: str | None = None) -> list[ChangedFile]:
         """Return the files that changed between two points, deepest path first.
 
-        The comparison always starts at the merge base of `base` and `head`, so passing `C^1` as
-        the base gives exactly the changes `C` introduced.
-
-        Leaving `head` unset compares against the working tree, which additionally picks up
-        uncommitted and untracked changes. Passing a ref compares committed state only.
-
-        A path reported by more than one of those sources keeps the change type furthest from
-        `base`, so a file committed as added and then edited locally is still reported as added.
+        `--merge-base` starts the comparison where the two points diverged, so changes made on
+        `base` since then are not reported as ours. Without a `head` the comparison runs against
+        the working tree, which also picks up uncommitted and untracked files.
         """
-        changed: dict[str, ChangedFile] = {}
-        comparison = f'{base}...' if head is None else f'{base}...{head}'
-        for record in parse_name_status(self.capture('diff', '--name-status', comparison)):
-            changed.setdefault(record.path, record)
-
+        comparison = ['diff', '--name-status', '--merge-base', base]
         if head is not None:
-            return self.__sort_changed_files(changed.values())
+            comparison.append(head)
 
-        for record in parse_name_status(self.capture('diff', '--name-status', 'HEAD')):
-            changed.setdefault(record.path, record)
-
-        # Worktrees inside the repo root show up as untracked and are not changes to this checkout
-        for path in self.capture('ls-files', '--others', '--exclude-standard').splitlines():
-            if not self.is_worktree(self.repo_root / path):
-                changed.setdefault(path, ChangedFile(change_type=ChangeType.ADDED, path=path))
+        changed = {record.path: record for record in parse_name_status(self.capture(*comparison))}
+        if head is None:
+            # Worktrees inside the repo root show up as untracked and are not changes to this checkout
+            for path in self.capture('ls-files', '--others', '--exclude-standard').splitlines():
+                if not self.is_worktree(self.repo_root / path):
+                    changed.setdefault(path, ChangedFile(change_type=ChangeType.ADDED, path=path))
 
         return self.__sort_changed_files(changed.values())
 

--- a/ddev/src/ddev/utils/git.py
+++ b/ddev/src/ddev/utils/git.py
@@ -3,7 +3,78 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
+import enum
+from dataclasses import dataclass
+
 from ddev.utils.fs import Path
+
+
+class ChangeType(enum.Enum):
+    """The kind of change reported by `git diff --name-status`.
+
+    Values are the literal git status letters, so a status code maps straight onto a member.
+    """
+
+    ADDED = 'A'
+    MODIFIED = 'M'
+    DELETED = 'D'
+    RENAMED = 'R'
+    COPIED = 'C'
+
+
+# A type change (`T`) is a modification of an existing path. Any other single-path status is also
+# treated as a modification, so no changed path is lost.
+SINGLE_PATH_CHANGE_TYPES = {
+    'A': ChangeType.ADDED,
+    'M': ChangeType.MODIFIED,
+    'D': ChangeType.DELETED,
+    'T': ChangeType.MODIFIED,
+}
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    """A single change to one file.
+
+    For renames and copies, `path` is the destination and `previous_path` is the source.
+    """
+
+    change_type: ChangeType
+    path: str
+    previous_path: str | None = None
+
+
+def is_git_warning_line(line: str) -> bool:
+    """Return whether a line of git output is an ignorable warning rather than a record."""
+    return line.startswith('warning: ') or 'original line endings' in line
+
+
+def parse_name_status(output: str) -> list[ChangedFile]:
+    """Parse `git diff --name-status` output into change records.
+
+    Lines are tab separated: `<status>\\t<path>`, or `<status>\\t<source>\\t<destination>` for
+    renames and copies, whose status also carries a similarity score (`R100`). A line with the
+    wrong field count raises rather than being dropped, so a changed path is never lost silently.
+    """
+    changed: list[ChangedFile] = []
+    for line in output.splitlines():
+        if not line or is_git_warning_line(line):
+            continue
+
+        fields = line.split('\t')
+        status = fields[0][:1].upper()
+        if status in ('R', 'C'):
+            if len(fields) < 3:
+                raise ValueError(f'Malformed rename/copy diff line: {line!r}')
+            change_type = ChangeType.RENAMED if status == 'R' else ChangeType.COPIED
+            changed.append(ChangedFile(change_type=change_type, path=fields[2], previous_path=fields[1]))
+        else:
+            if len(fields) < 2:
+                raise ValueError(f'Malformed diff line: {line!r}')
+            change_type = SINGLE_PATH_CHANGE_TYPES.get(status, ChangeType.MODIFIED)
+            changed.append(ChangedFile(change_type=change_type, path=fields[1]))
+
+    return changed
 
 
 class GitCommit:
@@ -164,30 +235,35 @@ class GitRepository:
         # We force because, in very rare cases, we move tags
         self.capture('fetch', '--all', '--tags', '--force')
 
-    def changed_files(self) -> list[str]:
-        changed_files = set()
+    def changed_files(self, base: str = 'origin/master', head: str | None = None) -> list[ChangedFile]:
+        """Return the files that changed between two points, deepest path first.
 
-        # Committed e.g.:
-        # A   relative/path/to/file.added
-        # M   relative/path/to/file.modified
-        for line in self.capture('diff', '--name-status', 'origin/master...').splitlines():
-            if not self.__is_warning_line(line):
-                changed_files.add(line.split(maxsplit=1)[1])
+        The comparison always starts at the merge base of `base` and `head`, so passing `C^1` as
+        the base gives exactly the changes `C` introduced.
 
-        # Tracked
-        for line in self.capture('diff', '--name-only', 'HEAD').splitlines():
-            if not self.__is_warning_line(line):
-                changed_files.add(line)
+        Leaving `head` unset compares against the working tree, which additionally picks up
+        uncommitted and untracked changes. Passing a ref compares committed state only.
 
-        # Untracked
-        # Remove worktrees within the repo root as they can be untracked and should not be taken into account
-        changed_files.update(
-            untracked_file
-            for untracked_file in self.capture('ls-files', '--others', '--exclude-standard').splitlines()
-            if not self.is_worktree(self.repo_root / untracked_file)
-        )
+        A path reported by more than one of those sources keeps the change type furthest from
+        `base`, so a file committed as added and then edited locally is still reported as added.
+        """
+        changed: dict[str, ChangedFile] = {}
+        comparison = f'{base}...' if head is None else f'{base}...{head}'
+        for record in parse_name_status(self.capture('diff', '--name-status', comparison)):
+            changed.setdefault(record.path, record)
 
-        return sorted(changed_files, key=lambda relative_path: (-relative_path.count('/'), relative_path))
+        if head is not None:
+            return self.__sort_changed_files(changed.values())
+
+        for record in parse_name_status(self.capture('diff', '--name-status', 'HEAD')):
+            changed.setdefault(record.path, record)
+
+        # Worktrees inside the repo root show up as untracked and are not changes to this checkout
+        for path in self.capture('ls-files', '--others', '--exclude-standard').splitlines():
+            if not self.is_worktree(self.repo_root / path):
+                changed.setdefault(path, ChangedFile(change_type=ChangeType.ADDED, path=path))
+
+        return self.__sort_changed_files(changed.values())
 
     def filter_tags(self, pattern: str) -> list[str]:
         import re
@@ -234,5 +310,5 @@ class GitRepository:
         return self.capture('merge-base', ref_a, ref_b).splitlines()[0]
 
     @staticmethod
-    def __is_warning_line(line):
-        return line.startswith('warning: ') or 'original line endings' in line
+    def __sort_changed_files(changed_files):
+        return sorted(changed_files, key=lambda changed_file: (-changed_file.path.count('/'), changed_file.path))

--- a/ddev/src/ddev/utils/git.py
+++ b/ddev/src/ddev/utils/git.py
@@ -56,6 +56,14 @@ class ChangedFile:
         return (self.path,)
 
 
+@dataclass(frozen=True)
+class Comparison:
+    """The two points `GitRepository.changed_files` compares."""
+
+    base: str = 'origin/master'
+    head: str | None = None  # None compares against the working tree
+
+
 def is_git_warning_line(line: str) -> bool:
     """Return whether a line of git output is an ignorable warning rather than a record."""
     return line.startswith('warning: ') or 'original line endings' in line
@@ -250,11 +258,14 @@ class GitRepository:
     def changed_files(self, base: str = 'origin/master', head: str | None = None) -> list[ChangedFile]:
         """Return the files that changed between two points, deepest path first.
 
-        `--merge-base` starts the comparison where the two points diverged, so changes made on
-        `base` since then are not reported as ours. Without a `head` the comparison runs against
-        the working tree, which also picks up uncommitted and untracked files.
+        The comparison starts where the two points diverged, so changes made on `base` since then
+        are not reported as ours. Without a `head` it runs against the working tree, which also
+        picks up uncommitted and untracked files.
+
+        The divergence point is resolved separately rather than with `git diff --merge-base`, which
+        is fatal when a criss-cross history has more than one.
         """
-        comparison = ['diff', '--name-status', '--merge-base', base]
+        comparison = ['diff', '--name-status', self.merge_base(base, head or 'HEAD')]
         if head is not None:
             comparison.append(head)
 

--- a/ddev/src/ddev/utils/git.py
+++ b/ddev/src/ddev/utils/git.py
@@ -56,11 +56,14 @@ class ChangedFile:
         return (self.path,)
 
 
+DEFAULT_COMPARISON_BASE = 'origin/master'
+
+
 @dataclass(frozen=True)
 class Comparison:
     """The two points `GitRepository.changed_files` compares."""
 
-    base: str = 'origin/master'
+    base: str = DEFAULT_COMPARISON_BASE
     head: str | None = None  # None compares against the working tree
 
 
@@ -255,7 +258,7 @@ class GitRepository:
         # We force because, in very rare cases, we move tags
         self.capture('fetch', '--all', '--tags', '--force')
 
-    def changed_files(self, base: str = 'origin/master', head: str | None = None) -> list[ChangedFile]:
+    def changed_files(self, base: str = DEFAULT_COMPARISON_BASE, head: str | None = None) -> list[ChangedFile]:
         """Return the files that changed between two points, deepest path first.
 
         The comparison starts where the two points diverged, so changes made on `base` since then
@@ -324,10 +327,11 @@ class GitRepository:
 
         Warnings are skipped because `capture` folds stderr into stdout, so an ambiguous refname
         prints one ahead of the sha. The result is fed to other commands as a ref, where a warning
-        line would be taken for a commit.
+        line would be taken for a commit. Output that is nothing but warnings falls back to the
+        first line, which is all git can be said to have reported.
         """
-        output = self.capture('merge-base', ref_a, ref_b)
-        return next(line for line in output.splitlines() if not is_git_warning_line(line))
+        lines = self.capture('merge-base', ref_a, ref_b).splitlines()
+        return next((line for line in lines if not is_git_warning_line(line)), lines[0])
 
     @staticmethod
     def __sort_changed_files(changed_files):

--- a/ddev/src/ddev/utils/git.py
+++ b/ddev/src/ddev/utils/git.py
@@ -320,7 +320,14 @@ class GitRepository:
             self.__worktree_paths = None
 
     def merge_base(self, ref_a: str, ref_b: str | None = "HEAD") -> str:
-        return self.capture('merge-base', ref_a, ref_b).splitlines()[0]
+        """Return the commit where two refs diverged.
+
+        Warnings are skipped because `capture` folds stderr into stdout, so an ambiguous refname
+        prints one ahead of the sha. The result is fed to other commands as a ref, where a warning
+        line would be taken for a commit.
+        """
+        output = self.capture('merge-base', ref_a, ref_b)
+        return next(line for line in output.splitlines() if not is_git_warning_line(line))
 
     @staticmethod
     def __sort_changed_files(changed_files):

--- a/ddev/tests/cli/release/test_changelog.py
+++ b/ddev/tests/cli/release/test_changelog.py
@@ -1,12 +1,37 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from collections.abc import Callable
 from functools import partial
 
 import pytest
 
 from ddev.repo.core import Repository
 from tests.helpers.changelog import reset_fragments_dir
+
+
+def git_capture(changed: list[str], *, subject: str = 'Foo') -> Callable[..., str]:
+    """Return a `GitRepository.capture` replacement that answers by command rather than call order.
+
+    Every changed path is reported as modified by any diff, so a test does not have to know how
+    many comparisons `IntegrationRegistry.changed_paths` makes.
+    """
+    sha = '0' * 40
+
+    def capture(*args: str) -> str:
+        match args[0]:
+            case 'merge-base':
+                return f'{sha}\n'
+            case 'diff':
+                return '\n'.join(f'M\t{path}' for path in changed)
+            case 'ls-files':
+                return ''
+            case 'log':
+                return f'{sha}\n{subject}'
+            case _:
+                raise AssertionError(f'unexpected git command: {args}')
+
+    return capture
 
 
 class TestFix:
@@ -182,16 +207,7 @@ class TestNew:
         repo = Repository(repo_with_towncrier.path.name, str(repo_with_towncrier.path))
         repo.git.capture('add', '.')
         repo.git.capture('commit', '-m', 'test')
-        mocker.patch(
-            'ddev.utils.git.GitRepository.capture',
-            side_effect=[
-                'M\tddev/pyproject.toml',
-                '',
-                'M\tddev/pyproject.toml',
-                '',
-                '0000000000000000000000000000000000000000\nFoo',
-            ],
-        )
+        mocker.patch('ddev.utils.git.GitRepository.capture', side_effect=git_capture(['ddev/pyproject.toml']))
         mocker.patch('ddev.utils.git.GitRepository.worktrees', return_value=[])
         return repo_with_towncrier.path / 'ddev' / 'changelog.d'
 
@@ -242,14 +258,7 @@ class TestNew:
         assert fragment_file.read_text() == "Foo"
 
     def test_start_no_changelog(self, ddev, fragments_dir, helpers, mocker):
-        mocker.patch(
-            'ddev.utils.git.GitRepository.capture',
-            side_effect=[
-                'M\ttests/conftest.py',
-                '',
-                '0000000000000000000000000000000000000000\nFoo',
-            ],
-        )
+        mocker.patch('ddev.utils.git.GitRepository.capture', side_effect=git_capture(['tests/conftest.py']))
         edit_patch = mocker.patch('click.edit', return_value=None)
         result = ddev('release', 'changelog', 'new', 'added')
 

--- a/ddev/tests/cli/release/test_changelog.py
+++ b/ddev/tests/cli/release/test_changelog.py
@@ -185,11 +185,9 @@ class TestNew:
         mocker.patch(
             'ddev.utils.git.GitRepository.capture',
             side_effect=[
-                'M ddev/pyproject.toml',
+                'M\tddev/pyproject.toml',
                 '',
-                '',
-                'M ddev/pyproject.toml',
-                '',
+                'M\tddev/pyproject.toml',
                 '',
                 '0000000000000000000000000000000000000000\nFoo',
             ],
@@ -247,8 +245,7 @@ class TestNew:
         mocker.patch(
             'ddev.utils.git.GitRepository.capture',
             side_effect=[
-                'M tests/conftest.py',
-                '',
+                'M\ttests/conftest.py',
                 '',
                 '0000000000000000000000000000000000000000\nFoo',
             ],

--- a/ddev/tests/helpers/api.py
+++ b/ddev/tests/helpers/api.py
@@ -26,11 +26,10 @@ def error(exception_class, message='', **kwargs):
 
 
 def changed_file_processes(files: list[str]):
-    # This returns subprocess calls used in `ddev.utils.git.GitRepository.get_changed_files`
-    # for tests that have to mock subprocess calls
+    # This returns subprocess calls used in `ddev.utils.git.GitRepository.changed_files`
+    # for tests that have to mock subprocess calls: the diff, then the untracked-file listing.
     return [
-        CompletedProcess([], 0, stdout='\n'.join(f'M {f}' for f in files)),
-        CompletedProcess([], 0, stdout=''),
+        CompletedProcess([], 0, stdout='\n'.join(f'M\t{f}' for f in files)),
         CompletedProcess([], 0, stdout=''),
     ]
 

--- a/ddev/tests/helpers/api.py
+++ b/ddev/tests/helpers/api.py
@@ -26,10 +26,17 @@ def error(exception_class, message='', **kwargs):
 
 
 def changed_file_processes(files: list[str]):
-    # This returns subprocess calls used in `ddev.utils.git.GitRepository.changed_files`
-    # for tests that have to mock subprocess calls: the diff, then the untracked-file listing.
+    # This returns the subprocess calls behind `IntegrationRegistry.changed_paths` for tests that
+    # have to mock them: a merge base, a diff and an untracked-file listing for every entry in
+    # `DEFAULT_COMPARISONS`. The files are reported against the first comparison, which leaves the
+    # working tree clean for the second.
+    merge_base = CompletedProcess([], 0, stdout='0000000000000000000000000000000000000000\n')
     return [
+        merge_base,
         CompletedProcess([], 0, stdout='\n'.join(f'M\t{f}' for f in files)),
+        CompletedProcess([], 0, stdout=''),
+        merge_base,
+        CompletedProcess([], 0, stdout=''),
         CompletedProcess([], 0, stdout=''),
     ]
 

--- a/ddev/tests/repo/test_core.py
+++ b/ddev/tests/repo/test_core.py
@@ -261,46 +261,6 @@ class TestIntegrationsIteration:
 
         assert [integration.name for integration in integrations] == ["tekton"]
 
-    def test_integrations_iteration_changed_includes_a_rename_source(self, repository):
-        # Moving a file between integrations changes both: the source lost it and the destination
-        # gained it, so both must be selected.
-        repo = Repository(repository.path.name, str(repository.path))
-
-        # The file has to already exist on the comparison base, otherwise the diff reports a plain
-        # addition rather than a rename.
-        repo.git.capture('mv', 'tekton/README.md', 'nginx/moved_from_tekton.md')
-        repo.git.capture('commit', '-m', 'move a file to another integration')
-
-        integrations = list(repo.integrations.iter(['changed']))
-
-        assert sorted(integration.name for integration in integrations) == ['nginx', 'tekton']
-
-    def test_integrations_iteration_changed_keeps_a_committed_change_reverted_in_the_working_tree(self, repository):
-        repo = Repository(repository.path.name, str(repository.path))
-
-        readme = repo.path / 'tekton' / 'README.md'
-        original_content = readme.read_text()
-        readme.write_text(f'{original_content}\ncommitted change\n')
-        repo.git.capture('add', 'tekton/README.md')
-        repo.git.capture('commit', '-m', 'change a file')
-
-        # Nothing differs from the merge base any more, but the branch still changes the file
-        readme.write_text(original_content)
-
-        integrations = list(repo.integrations.iter(['changed']))
-
-        assert [integration.name for integration in integrations] == ['tekton']
-
-    def test_integrations_iteration_changed_against_head_ignores_committed_changes(self, repository):
-        repo = Repository(repository.path.name, str(repository.path))
-
-        (repo.path / 'tekton' / 'foo.txt').touch()
-        repo.git.capture('add', 'tekton/foo.txt')
-        repo.git.capture('commit', '-m', 'add a file')
-
-        assert list(repo.integrations.comparing(base='HEAD').iter(['changed'])) == []
-        assert [integration.name for integration in repo.integrations.iter(['changed'])] == ['tekton']
-
     @pytest.mark.parametrize(
         "method_name, integration_filter",
         iter_test_params,
@@ -318,6 +278,49 @@ class TestIntegrationsIteration:
         assert list(iter_method(selection)) == integrations
 
 
+def test_iter_changed_includes_a_rename_source(repository):
+    # Moving a file between integrations changes both: the source lost it and the destination
+    # gained it, so both must be selected.
+    repo = Repository(repository.path.name, str(repository.path))
+
+    # The file has to already exist on the comparison base, otherwise the diff reports a plain
+    # addition rather than a rename.
+    repo.git.capture('mv', 'tekton/README.md', 'nginx/moved_from_tekton.md')
+    repo.git.capture('commit', '-m', 'move a file to another integration')
+
+    integrations = list(repo.integrations.iter(['changed']))
+
+    assert sorted(integration.name for integration in integrations) == ['nginx', 'tekton']
+
+
+def test_iter_changed_keeps_a_committed_change_reverted_in_the_working_tree(repository):
+    repo = Repository(repository.path.name, str(repository.path))
+
+    readme = repo.path / 'tekton' / 'README.md'
+    original_content = readme.read_text()
+    readme.write_text(f'{original_content}\ncommitted change\n')
+    repo.git.capture('add', 'tekton/README.md')
+    repo.git.capture('commit', '-m', 'change a file')
+
+    # Nothing differs from the merge base any more, but the branch still changes the file
+    readme.write_text(original_content)
+
+    integrations = list(repo.integrations.iter(['changed']))
+
+    assert [integration.name for integration in integrations] == ['tekton']
+
+
+def test_iter_changed_against_head_ignores_committed_changes(repository):
+    repo = Repository(repository.path.name, str(repository.path))
+
+    (repo.path / 'tekton' / 'foo.txt').touch()
+    repo.git.capture('add', 'tekton/foo.txt')
+    repo.git.capture('commit', '-m', 'add a file')
+
+    assert list(repo.integrations.comparing(base='HEAD').iter(['changed'])) == []
+    assert [integration.name for integration in repo.integrations.iter(['changed'])] == ['tekton']
+
+
 def test_iter_changed_code_selects_both_sides_of_a_rename(repository):
     repo = Repository(repository.path.name, str(repository.path))
 
@@ -332,8 +335,11 @@ def test_iter_changed_code_selects_both_sides_of_a_rename(repository):
 def test_iter_changed_code_ignores_files_that_need_no_entry(repository):
     repo = Repository(repository.path.name, str(repository.path))
 
-    (repo.path / 'tekton' / 'tests' / 'test_unit.py').touch()
+    # The file is already tracked, so it has to be written to for git to report it at all
+    target = repo.path / 'tekton' / 'tests' / 'test_unit.py'
+    target.write_text(f'{target.read_text()}\n# change\n')
 
+    assert 'tekton/tests/test_unit.py' in repo.integrations.changed_paths
     assert list(repo.integrations.iter_changed_code()) == []
 
 

--- a/ddev/tests/repo/test_core.py
+++ b/ddev/tests/repo/test_core.py
@@ -275,6 +275,32 @@ class TestIntegrationsIteration:
 
         assert sorted(integration.name for integration in integrations) == ['nginx', 'tekton']
 
+    def test_integrations_iteration_changed_keeps_a_committed_change_reverted_in_the_working_tree(self, repository):
+        repo = Repository(repository.path.name, str(repository.path))
+
+        readme = repo.path / 'tekton' / 'README.md'
+        original_content = readme.read_text()
+        readme.write_text(f'{original_content}\ncommitted change\n')
+        repo.git.capture('add', 'tekton/README.md')
+        repo.git.capture('commit', '-m', 'change a file')
+
+        # Nothing differs from the merge base any more, but the branch still changes the file
+        readme.write_text(original_content)
+
+        integrations = list(repo.integrations.iter(['changed']))
+
+        assert [integration.name for integration in integrations] == ['tekton']
+
+    def test_integrations_iteration_changed_against_head_ignores_committed_changes(self, repository):
+        repo = Repository(repository.path.name, str(repository.path))
+
+        (repo.path / 'tekton' / 'foo.txt').touch()
+        repo.git.capture('add', 'tekton/foo.txt')
+        repo.git.capture('commit', '-m', 'add a file')
+
+        assert list(repo.integrations.comparing(base='HEAD').iter(['changed'])) == []
+        assert [integration.name for integration in repo.integrations.iter(['changed'])] == ['tekton']
+
     @pytest.mark.parametrize(
         "method_name, integration_filter",
         iter_test_params,
@@ -290,6 +316,25 @@ class TestIntegrationsIteration:
 
         assert [integration.name for integration in integrations] == integration_names
         assert list(iter_method(selection)) == integrations
+
+
+def test_iter_changed_code_selects_both_sides_of_a_rename(repository):
+    repo = Repository(repository.path.name, str(repository.path))
+
+    repo.git.capture('mv', 'tekton/datadog_checks/tekton/__about__.py', 'nginx/datadog_checks/nginx/moved.py')
+    repo.git.capture('commit', '-m', 'move a shipped file to another integration')
+
+    integrations = list(repo.integrations.iter_changed_code())
+
+    assert sorted(integration.name for integration in integrations) == ['nginx', 'tekton']
+
+
+def test_iter_changed_code_ignores_files_that_need_no_entry(repository):
+    repo = Repository(repository.path.name, str(repository.path))
+
+    (repo.path / 'tekton' / 'tests' / 'test_unit.py').touch()
+
+    assert list(repo.integrations.iter_changed_code()) == []
 
 
 class TestIterationChanged:

--- a/ddev/tests/repo/test_core.py
+++ b/ddev/tests/repo/test_core.py
@@ -261,6 +261,20 @@ class TestIntegrationsIteration:
 
         assert [integration.name for integration in integrations] == ["tekton"]
 
+    def test_integrations_iteration_changed_includes_a_rename_source(self, repository):
+        # Moving a file between integrations changes both: the source lost it and the destination
+        # gained it, so both must be selected.
+        repo = Repository(repository.path.name, str(repository.path))
+
+        # The file has to already exist on the comparison base, otherwise the diff reports a plain
+        # addition rather than a rename.
+        repo.git.capture('mv', 'tekton/README.md', 'nginx/moved_from_tekton.md')
+        repo.git.capture('commit', '-m', 'move a file to another integration')
+
+        integrations = list(repo.integrations.iter(['changed']))
+
+        assert sorted(integration.name for integration in integrations) == ['nginx', 'tekton']
+
     @pytest.mark.parametrize(
         "method_name, integration_filter",
         iter_test_params,

--- a/ddev/tests/utils/test_git.py
+++ b/ddev/tests/utils/test_git.py
@@ -8,6 +8,7 @@ import pytest
 
 from ddev.repo.core import Repository
 from ddev.utils.fs import Path
+from ddev.utils.git import ChangedFile, ChangeType, parse_name_status
 from tests.helpers.git import ClonedRepo
 
 
@@ -191,12 +192,91 @@ def test_changed_files(repository):
     zoo_subdir.mkdir()
     (zoo_subdir / "foo.txt").touch()
 
-    changed_files = ["zoo/sub/foo.txt", "zoo/bar.txt", "pyproject.toml"]
+    changed_files = [
+        ChangedFile(ChangeType.ADDED, "zoo/sub/foo.txt"),
+        ChangedFile(ChangeType.ADDED, "zoo/bar.txt"),
+        ChangedFile(ChangeType.MODIFIED, "pyproject.toml"),
+    ]
     assert repo.git.changed_files() == changed_files
 
     (zoo_subdir / "baz.txt").touch()
-    changed_files.insert(0, "zoo/sub/baz.txt")
+    changed_files.insert(0, ChangedFile(ChangeType.ADDED, "zoo/sub/baz.txt"))
     assert repo.git.changed_files() == changed_files
+
+
+def test_changed_files_between_refs_ignores_the_working_tree(repository):
+    repo = Repository(repository.path.name, str(repository.path))
+
+    (repo.path / "committed.txt").touch()
+    repo.git.capture("add", "committed.txt")
+    repo.git.capture("commit", "-m", "test commit")
+    head = repo.git.capture("rev-parse", "HEAD").strip()
+
+    # Uncommitted, so it must not appear when an explicit head is given
+    (repo.path / "untracked.txt").touch()
+
+    assert repo.git.changed_files(f"{head}^1", head) == [ChangedFile(ChangeType.ADDED, "committed.txt")]
+    assert ChangedFile(ChangeType.ADDED, "untracked.txt") in repo.git.changed_files()
+
+
+def test_changed_files_reports_renames_with_their_source(repository):
+    repo = Repository(repository.path.name, str(repository.path))
+
+    original = repo.path / "renamed_from.txt"
+    original.write_text("some content worth detecting as a rename\n" * 10)
+    repo.git.capture("add", "renamed_from.txt")
+    repo.git.capture("commit", "-m", "add file")
+    base = repo.git.capture("rev-parse", "HEAD").strip()
+
+    repo.git.capture("mv", "renamed_from.txt", "renamed_to.txt")
+    repo.git.capture("commit", "-m", "rename file")
+    head = repo.git.capture("rev-parse", "HEAD").strip()
+
+    assert repo.git.changed_files(base, head) == [
+        ChangedFile(ChangeType.RENAMED, "renamed_to.txt", previous_path="renamed_from.txt")
+    ]
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        pytest.param("", [], id="empty"),
+        pytest.param("A\tadded.py", [ChangedFile(ChangeType.ADDED, "added.py")], id="added"),
+        pytest.param("D\tgone.py", [ChangedFile(ChangeType.DELETED, "gone.py")], id="deleted"),
+        pytest.param("T\tlink.py", [ChangedFile(ChangeType.MODIFIED, "link.py")], id="type-change-is-a-modification"),
+        pytest.param("X\todd.py", [ChangedFile(ChangeType.MODIFIED, "odd.py")], id="unknown-status-is-a-modification"),
+        pytest.param(
+            "R100\told.py\tnew.py",
+            [ChangedFile(ChangeType.RENAMED, "new.py", previous_path="old.py")],
+            id="rename-keeps-the-source",
+        ),
+        pytest.param(
+            "C75\tsource.py\tcopy.py",
+            [ChangedFile(ChangeType.COPIED, "copy.py", previous_path="source.py")],
+            id="copy-keeps-the-source",
+        ),
+        pytest.param("warning: CRLF\nM\treal.py", [ChangedFile(ChangeType.MODIFIED, "real.py")], id="skips-warnings"),
+        pytest.param(
+            "M\tpath with spaces.py",
+            [ChangedFile(ChangeType.MODIFIED, "path with spaces.py")],
+            id="paths-may-contain-spaces",
+        ),
+    ],
+)
+def test_parse_name_status(output, expected):
+    assert parse_name_status(output) == expected
+
+
+@pytest.mark.parametrize(
+    ("output", "message"),
+    [
+        pytest.param("M", "Malformed diff line", id="missing-path"),
+        pytest.param("R100\tonly_one_path.py", "Malformed rename/copy diff line", id="rename-missing-destination"),
+    ],
+)
+def test_parse_name_status_rejects_malformed_lines(output, message):
+    with pytest.raises(ValueError, match=message):
+        parse_name_status(output)
 
 
 def test_filtered_tags(repository):

--- a/ddev/tests/utils/test_git.py
+++ b/ddev/tests/utils/test_git.py
@@ -219,6 +219,23 @@ def test_changed_files_between_refs_ignores_the_working_tree(repository):
     assert ChangedFile(ChangeType.ADDED, "untracked.txt") in repo.git.changed_files()
 
 
+def test_changed_files_ignores_changes_made_on_the_base_after_divergence(repository):
+    repo = Repository(repository.path.name, str(repository.path))
+
+    base = repo.git.capture("rev-parse", "HEAD").strip()
+    (repo.path / "mine.txt").touch()
+    repo.git.capture("add", "mine.txt")
+    repo.git.capture("commit", "-m", "my work")
+    head = repo.git.capture("rev-parse", "HEAD").strip()
+
+    repo.git.capture("checkout", "-b", "base-branch", base)
+    (repo.path / "theirs.txt").touch()
+    repo.git.capture("add", "theirs.txt")
+    repo.git.capture("commit", "-m", "their work")
+
+    assert repo.git.changed_files("base-branch", head) == [ChangedFile(ChangeType.ADDED, "mine.txt")]
+
+
 def test_changed_files_reports_renames_with_their_source(repository):
     repo = Repository(repository.path.name, str(repository.path))
 

--- a/ddev/tests/utils/test_git.py
+++ b/ddev/tests/utils/test_git.py
@@ -342,6 +342,20 @@ def test_fetch_tags(repository, mocker):
     ]
 
 
+def test_merge_base_skips_warning_lines(repository):
+    repo = Repository(repository.path.name, str(repository.path))
+    head = repo.git.capture('rev-parse', 'HEAD').strip()
+
+    # A branch and a tag of the same name make git print `warning: refname 'ambiguous' is
+    # ambiguous.` ahead of the sha, and `capture` folds it into the output
+    repo.git.capture('branch', 'ambiguous')
+    repo.git.capture('tag', 'ambiguous')
+    try:
+        assert repo.git.merge_base('ambiguous') == head
+    finally:
+        repo.git.capture('branch', '--delete', 'ambiguous')
+
+
 def test_get_merge_base(repository):
     repo = Repository(repository.path.name, str(repository.path))
     base_commit = repo.git.latest_commit()

--- a/ddev/tests/utils/test_git.py
+++ b/ddev/tests/utils/test_git.py
@@ -268,6 +268,27 @@ def test_parse_name_status(output, expected):
 
 
 @pytest.mark.parametrize(
+    ("changed_file", "expected"),
+    [
+        pytest.param(ChangedFile(ChangeType.MODIFIED, "a.py"), ("a.py",), id="modified"),
+        pytest.param(ChangedFile(ChangeType.DELETED, "a.py"), ("a.py",), id="deleted"),
+        pytest.param(
+            ChangedFile(ChangeType.RENAMED, "new/a.py", previous_path="old/a.py"),
+            ("new/a.py", "old/a.py"),
+            id="rename-affects-its-source-too",
+        ),
+        pytest.param(
+            ChangedFile(ChangeType.COPIED, "new/a.py", previous_path="old/a.py"),
+            ("new/a.py",),
+            id="copy-leaves-the-source-untouched",
+        ),
+    ],
+)
+def test_affected_paths(changed_file, expected):
+    assert changed_file.affected_paths == expected
+
+
+@pytest.mark.parametrize(
     ("output", "message"),
     [
         pytest.param("M", "Malformed diff line", id="missing-path"),


### PR DESCRIPTION
> **Stack** (bottom to top)
> 1. #24809 Cache worktree lookups in `GitRepository`
> 2. **#24776 Return structured change records from `GitRepository.changed_files`** :arrow_left: you are here
> 3. #24687 Build deterministic Dispatcher test batching plans
>
> Merge from the bottom up. This PR targets #24809's branch, so the diff here is only the change-record work.

### What does this PR do?

Makes `GitRepository.changed_files` report *what* changed rather than just which paths, and makes the question it answers explicit.

**Change records.** Adds `ChangedFile`, `ChangeType` and a strict `--name-status` parser. Renames and copies keep their source in `previous_path`, and `ChangedFile.affected_paths` returns every path a change touches, so a rename selects both the directory it left and the one it landed in. A malformed line raises instead of being dropped, so a changed path is never lost silently.

This fixes a latent bug: the old parser did `line.split(maxsplit=1)[1]`, so a rename line `R100\told.py\tnew.py` yielded the single bogus path `"old.py\tnew.py"`, whose first segment is the *source*. Committing a rename therefore selected only the old directory, while leaving it staged selected only the new one, because that path came from `--name-only`, which reports the destination alone.

**Explicit comparisons.** `changed_files(base, head)` compares exactly two points. `IntegrationRegistry` holds which comparisons a `changed` selection resolves against:

```python
repo.integrations.iter_testable(['changed'])                       # what this branch changed
repo.integrations.comparing(base='HEAD').iter_testable(['changed'])  # only the working tree
```

`DEFAULT_COMPARISONS` asks both `origin/master` and `HEAD` and unions the result, which is what the previous three-command implementation computed, so `ddev test`, `ddev status`, every `validate` subcommand and `changelog new` keep today's answer. The two are only ever different when the working tree reverts something the branch committed; in that case the merge-base comparison alone reports nothing while the branch still changes the file. Narrowing to one comparison is now a caller's explicit choice rather than the default.

`changed_paths` is cached per registry, which also removes a `changed_files()` call per integration in `iter_changed_code` (up to 226 on this repo).

**Merge base resolution.** The comparison resolves the merge base itself rather than using `git diff --merge-base`, which is fatal when a criss-cross history has more than one (`fatal: multiple merge bases found`). The old `<base>...<head>` form warned and carried on; resolving explicitly keeps that behaviour and picks the same commit git would, with byte-identical output.

### Motivation

Dispatcher needs to ask "I am testing commit A to merge into B, what changed?", and `changed_files` could only ever compare against `origin/master` blended with local state. Making the two points explicit answers that, and returning records rather than bare paths is what lets a rename select both of the directories it affects, which is required for correct test selection.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
