### PR TITLE
Add composable deterministic task validation

### DIFF
--- a/ddev/src/ddev/ai/config/models.py
+++ b/ddev/src/ddev/ai/config/models.py
@@ -317,7 +317,7 @@ class TaskConfig(BaseModel):
     prompt_ref: str | None = None
     goal: str | None = None
     goal_ref: str | None = None
-    max_goal_attempts: int = 5
+    max_validation_attempts: int = Field(default=5, ge=1)
     clear_context_before: bool = False
     compact_context_before: bool = False
 
@@ -337,11 +337,6 @@ class TaskConfig(BaseModel):
     def goal_consistency(self) -> TaskConfig:
         if self.goal is not None and self.goal_ref is not None:
             raise ValueError("At most one of 'goal' or 'goal_ref' may be set")
-        has_goal = self.goal is not None or self.goal_ref is not None
-        if not has_goal and "max_goal_attempts" in self.model_fields_set:
-            raise ValueError("'max_goal_attempts' may only be set when 'goal' or 'goal_ref' is set")
-        if has_goal and self.max_goal_attempts < 1:
-            raise ValueError("'max_goal_attempts' must be at least 1")
         return self
 
 

--- a/ddev/src/ddev/ai/flows/openmetrics/phases.yaml
+++ b/ddev/src/ddev/ai/flows/openmetrics/phases.yaml
@@ -21,12 +21,12 @@
       - name: rename
         prompt_ref: phase1_rename
         goal_ref: phase1_rename_goal
-        max_goal_attempts: 3
+        max_validation_attempts: 3
       - name: metadata
         prompt_ref: phase1_metadata
         clear_context_before: true
         goal_ref: phase1_metadata_goal
-        max_goal_attempts: 3
+        max_validation_attempts: 3
     checkpoint:
       memory_prompt_ref: phase1_memory
 
@@ -49,7 +49,7 @@
         prompt_ref: phase2_code
         clear_context_before: true
         goal_ref: phase2_code_goal
-        max_goal_attempts: 3
+        max_validation_attempts: 3
     checkpoint:
       memory_prompt_ref: phase2_memory
 
@@ -68,7 +68,7 @@
       - name: write_tests
         prompt_ref: phase3_tests
         goal_ref: phase3_tests_goal
-        max_goal_attempts: 3
+        max_validation_attempts: 3
     checkpoint:
       memory_prompt_ref: phase3_memory
 

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -10,7 +10,11 @@ from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.config.errors import ConfigError
 from ddev.ai.config.models import AgentConfig, PhaseConfig, TaskConfig
 from ddev.ai.phases.base import FlowContext, Phase, PhaseOutcome
-from ddev.ai.phases.goal import GOAL_TASK_SUFFIX, GoalValidationError, run_goal_loop
+from ddev.ai.phases.goal import (
+    GOAL_TASK_SUFFIX,
+    TaskValidationError,
+    run_validation_loop,
+)
 from ddev.ai.phases.template import render_inline
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.runtime.checkpoints import (
@@ -18,11 +22,11 @@ from ddev.ai.runtime.checkpoints import (
     CheckpointStatus,
     CheckpointTokenInfo,
     FailedCheckpoint,
-    GoalValidationRecord,
+    TaskValidationRecord,
 )
 
 if TYPE_CHECKING:
-    from ddev.ai.phases.goal import GoalLoopOutcome
+    from ddev.ai.phases.goal import DeterministicCheck, ValidationLoopOutcome
     from ddev.ai.phases.resources import PhaseResources
     from ddev.ai.react.factory import ReActProcessFactory
     from ddev.ai.react.types import ReActResult
@@ -80,7 +84,7 @@ class AgenticPhase(Phase):
         self._agent_config = agent_config
         self._process_factory = process_factory
         self._scope = AgentScope(owner_id=phase_id, role=AgentRole.PHASE, phase_id=phase_id)
-        self._goal_attempt_log: list[GoalValidationRecord] = []
+        self._validation_log: list[TaskValidationRecord] = []
         self._total_input_tokens: int = 0
         self._total_output_tokens: int = 0
 
@@ -124,6 +128,10 @@ class AgenticPhase(Phase):
     def after_react(self) -> None:
         """Called once after all tasks complete. Override for phase-specific teardown."""
 
+    def deterministic_checks(self, task: TaskConfig, context: dict[str, Any]) -> tuple[DeterministicCheck, ...]:
+        """Return the deterministic checks that must pass before task acceptance."""
+        return ()
+
     async def run_tasks(
         self,
         process: ReActProcess,
@@ -150,13 +158,14 @@ class AgenticPhase(Phase):
         await self._manage_context(process, task, last_result)
 
         has_goal = self._task_has_goal(task)
+        deterministic_checks = self.deterministic_checks(task, context)
         prompt = self._render_task_prompt(task, context, has_goal)
         result = await self._start_task(process, prompt)
 
-        if not has_goal:
+        if not has_goal and not deterministic_checks:
             return result
 
-        return await self._run_goal_validation(process, task, context, prompt, result)
+        return await self._run_validation(process, task, context, prompt, result, deterministic_checks)
 
     async def _manage_context(
         self,
@@ -210,17 +219,18 @@ class AgenticPhase(Phase):
         self._add_tokens(result.total_input_tokens, result.total_output_tokens)
         return result
 
-    async def _run_goal_validation(
+    async def _run_validation(
         self,
         process: ReActProcess,
         task: TaskConfig,
         context: dict[str, Any],
         prompt: str,
         result: ReActResult,
+        deterministic_checks: tuple[DeterministicCheck, ...],
     ) -> ReActResult:
-        goal_text = render_inline(cast(str, task.goal), context, self._resolver)
+        goal_text = render_inline(task.goal, context, self._resolver) if task.goal is not None else None
         try:
-            outcome: GoalLoopOutcome = await run_goal_loop(
+            outcome: ValidationLoopOutcome = await run_validation_loop(
                 task=task,
                 goal_text=goal_text,
                 rendered_task_prompt=prompt,
@@ -231,25 +241,26 @@ class AgenticPhase(Phase):
                 callbacks=self._callbacks,
                 phase_id=self._phase_id,
                 compact_if_needed=lambda r: self._compact_if_needed(process, r),
+                deterministic_checks=deterministic_checks,
             )
-        except GoalValidationError as e:
-            self._record_goal_attempt(task, e.attempts, final_valid=False)
+        except TaskValidationError as e:
+            self._record_validation(task, e.attempts, final_valid=False)
             self._add_tokens(e.input_tokens, e.output_tokens)
             raise
 
-        self._record_goal_attempt(task, outcome.attempts, final_valid=True)
+        self._record_validation(task, outcome.attempts, final_valid=True)
         self._add_tokens(outcome.total_input_tokens, outcome.total_output_tokens)
         return outcome.final_result
 
-    def _record_goal_attempt(
+    def _record_validation(
         self,
         task: TaskConfig,
         attempts: int,
         *,
         final_valid: bool,
     ) -> None:
-        self._goal_attempt_log.append(
-            GoalValidationRecord(
+        self._validation_log.append(
+            TaskValidationRecord(
                 task=task.name,
                 attempts=attempts,
                 final_valid=final_valid,
@@ -305,15 +316,15 @@ class AgenticPhase(Phase):
             memory_text=memory_text,
             total_input_tokens=self._total_input_tokens + mem_in,
             total_output_tokens=self._total_output_tokens + mem_out,
-            goal_validations=self._goal_attempt_log or None,
+            task_validations=self._validation_log or None,
         )
 
     def build_failed_checkpoint(self, error: BaseException) -> FailedCheckpoint:
-        """Include partial token and goal progress in a failed checkpoint."""
+        """Include partial token and task-validation progress in a failed checkpoint."""
         checkpoint = super().build_failed_checkpoint(error)
         checkpoint.tokens = CheckpointTokenInfo(
             total_input=self._total_input_tokens,
             total_output=self._total_output_tokens,
         )
-        checkpoint.goal_validations = self._goal_attempt_log or None
+        checkpoint.task_validations = self._validation_log or None
         return checkpoint

--- a/ddev/src/ddev/ai/phases/agentic_phase.py
+++ b/ddev/src/ddev/ai/phases/agentic_phase.py
@@ -14,6 +14,7 @@ from ddev.ai.phases.goal import (
     GOAL_TASK_SUFFIX,
     TaskValidationError,
     run_validation_loop,
+    validate_check_names,
 )
 from ddev.ai.phases.template import render_inline
 from ddev.ai.react.process import ReActProcess
@@ -159,6 +160,7 @@ class AgenticPhase(Phase):
 
         has_goal = self._task_has_goal(task)
         deterministic_checks = self.deterministic_checks(task, context)
+        validate_check_names(deterministic_checks)
         prompt = self._render_task_prompt(task, context, has_goal)
         result = await self._start_task(process, prompt)
 

--- a/ddev/src/ddev/ai/phases/base.py
+++ b/ddev/src/ddev/ai/phases/base.py
@@ -18,7 +18,6 @@ from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
     CheckpointTokenInfo,
     FailedCheckpoint,
-    GoalValidationRecord,
     SuccessCheckpoint,
 )
 from ddev.event_bus.exceptions import MessageProcessingError, ProcessorHookError
@@ -26,6 +25,7 @@ from ddev.event_bus.orchestrator import AsyncProcessor, BaseMessage
 
 if TYPE_CHECKING:
     from ddev.ai.phases.resources import PhaseResources
+    from ddev.ai.runtime.checkpoints import TaskValidationRecord
 
 
 @dataclass(frozen=True)
@@ -44,7 +44,7 @@ class PhaseOutcome:
     memory_text: str
     total_input_tokens: int = 0
     total_output_tokens: int = 0
-    goal_validations: list[GoalValidationRecord] | None = None
+    task_validations: list[TaskValidationRecord] | None = None
     checkpoint_data: dict[str, Any] = field(default_factory=dict)
 
 
@@ -149,7 +149,7 @@ class Phase(AsyncProcessor[PhaseTrigger]):
                 total_output=outcome.total_output_tokens,
             ),
             memory_path=str(self._checkpoint_manager.memory_path(self._phase_id)),
-            goal_validations=outcome.goal_validations,
+            task_validations=outcome.task_validations,
             phase_data=outcome.checkpoint_data,
         )
 

--- a/ddev/src/ddev/ai/phases/goal.py
+++ b/ddev/src/ddev/ai/phases/goal.py
@@ -5,7 +5,8 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Awaitable, Callable
+from collections import Counter
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 
 from ddev.ai.agent.scope import AgentRole, AgentScope
@@ -72,7 +73,16 @@ Your work will be checked by an independent reviewer using only this summary
 and the files you produced.
 """
 
-GOAL_RETRY_PROMPT_TEMPLATE = """\
+VALIDATION_RETRY_PROMPT_TEMPLATE = """\
+A validation check found that your work is incomplete.{goal_section}
+
+Validation reason: {reason}
+
+Address only the issue above. If you believe the validation is wrong, explain
+why clearly in your final summary (do not silently ignore it).
+"""
+
+REVIEWER_RETRY_PROMPT_TEMPLATE = """\
 A reviewer checked your work against this goal and reported it failed:
 
 Goal: {goal}
@@ -97,8 +107,8 @@ GOAL_PARSE_RETRY_PROMPT = (
 )
 
 
-class GoalValidationError(Exception):
-    """Base class for goal-validation failures. Carries the token cost and attempt count."""
+class TaskValidationError(Exception):
+    """Base class for task-validation failures. Carries the token cost and attempt count."""
 
     def __init__(self, message: str, input_tokens: int = 0, output_tokens: int = 0) -> None:
         super().__init__(message)
@@ -107,16 +117,16 @@ class GoalValidationError(Exception):
         self.attempts: int = 0
 
 
-class GoalParseError(GoalValidationError):
+class ReviewerParseError(TaskValidationError):
     """Reviewer failed to return valid JSON after the parse-retry."""
 
 
-class GoalAttemptsExhausted(GoalValidationError):
-    """Reviewer rejected the work on every attempt up to max_goal_attempts."""
+class ValidationAttemptsExhausted(TaskValidationError):
+    """Validation rejected every candidate up to max_validation_attempts."""
 
 
 @dataclass(frozen=True)
-class GoalCheckResult:
+class ReviewerCheckResult:
     valid: bool
     reason: str
     input_tokens: int
@@ -126,11 +136,76 @@ class GoalCheckResult:
 
 
 @dataclass(frozen=True)
-class GoalLoopOutcome:
+class ValidationLoopOutcome:
     final_result: ReActResult
     attempts: int
     total_input_tokens: int
     total_output_tokens: int
+
+
+@dataclass(frozen=True)
+class DeterministicCheck:
+    """A named, repeatable artifact check that does not require a model reviewer."""
+
+    name: str
+    run: Callable[[], str | None]
+
+
+@dataclass(frozen=True)
+class DeterministicCheckFailure:
+    """A repairable failure returned by one deterministic check."""
+
+    name: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class DeterministicCheckReport:
+    """The ordered composition of every failure from one deterministic pass."""
+
+    failures: tuple[DeterministicCheckFailure, ...]
+
+    @property
+    def valid(self) -> bool:
+        return not self.failures
+
+    def failure_reason(self) -> str | None:
+        """Render every failure in declaration order, or ``None`` when all checks passed."""
+        if self.valid:
+            return None
+        sections = [f"## {failure.name}\n{failure.reason}" for failure in self.failures]
+        return "Deterministic checks failed:\n\n" + "\n\n".join(sections)
+
+
+def run_deterministic_checks(checks: Sequence[DeterministicCheck]) -> DeterministicCheckReport:
+    """Run every named deterministic check and compose all repairable failures."""
+    names = [check.name.strip() for check in checks]
+    if invalid_names := [check.name for check, name in zip(checks, names, strict=True) if not name]:
+        raise ValueError(f"Deterministic check names must not be blank: {invalid_names!r}")
+    duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
+    if duplicates:
+        raise ValueError(f"Deterministic check names must be unique: {duplicates}")
+
+    failures: list[DeterministicCheckFailure] = []
+    for check, name in zip(checks, names, strict=True):
+        reason = check.run()
+        if reason is None:
+            continue
+        if not reason.strip():
+            raise ValueError(f"Deterministic check {name!r} returned a blank failure reason")
+        failures.append(DeterministicCheckFailure(name=name, reason=reason))
+    return DeterministicCheckReport(failures=tuple(failures))
+
+
+def build_validation_retry_prompt(goal_text: str | None, reason: str) -> str:
+    """Build worker feedback for a deterministic-check failure."""
+    goal_section = f"\n\nGoal: {goal_text}" if goal_text is not None else ""
+    return VALIDATION_RETRY_PROMPT_TEMPLATE.format(goal_section=goal_section, reason=reason)
+
+
+def build_reviewer_retry_prompt(goal_text: str, reviewer_verdict: str) -> str:
+    """Build worker feedback for a reviewer-rejected goal, including its findings."""
+    return REVIEWER_RETRY_PROMPT_TEMPLATE.format(goal=goal_text, reviewer_verdict=reviewer_verdict)
 
 
 def build_reviewer_user_message(
@@ -183,7 +258,7 @@ def build_reviewer_reset_retry_message(
 
 def _select_reviewer_message(
     *,
-    previous_check: GoalCheckResult | None,
+    previous_check: ReviewerCheckResult | None,
     rendered_task_prompt: str,
     goal_text: str,
     worker_summary: str,
@@ -280,11 +355,11 @@ def parse_reviewer_verdict(text: str) -> dict[str, object] | None:
 async def _run_reviewer_once(
     reviewer_process: ReActProcess,
     user_message: str,
-) -> GoalCheckResult:
+) -> ReviewerCheckResult:
     """Send ``user_message`` to the reviewer and parse its JSON output.
 
     On parse failure, ask the reviewer once more for valid JSON. If that
-    second response still does not parse, raise GoalParseError.
+    second response still does not parse, raise ReviewerParseError.
     """
     result = await reviewer_process.start(user_message)
     in_tokens = result.total_input_tokens
@@ -301,14 +376,14 @@ async def _run_reviewer_once(
         raw_output = retry_result.final_response.text or ""
         parsed = parse_reviewer_verdict(raw_output)
         if parsed is None:
-            raise GoalParseError(
+            raise ReviewerParseError(
                 "Reviewer did not return valid JSON after one parse-retry. "
                 f"Last raw output: {retry_result.final_response.text!r}",
                 input_tokens=in_tokens,
                 output_tokens=out_tokens,
             )
 
-    return GoalCheckResult(
+    return ReviewerCheckResult(
         valid=bool(parsed["valid"]),
         reason=str(parsed.get("reason", "")),
         input_tokens=in_tokens,
@@ -318,81 +393,10 @@ async def _run_reviewer_once(
     )
 
 
-async def _drive_goal_loop(
-    *,
-    phase_id: str,
-    task: TaskConfig,
-    goal_text: str,
-    rendered_task_prompt: str,
-    worker_process: ReActProcess,
-    initial_result: ReActResult,
-    reviewer_process: ReActProcess,
-    callbacks: Callbacks,
-    compact_if_needed: Callable[[ReActResult], Awaitable[tuple[int, int]]],
-) -> GoalLoopOutcome:
-    total_in = total_out = 0
-    attempts = 0
-    worker_result = initial_result
-    previous_check: GoalCheckResult | None = None
-
-    try:
-        while True:
-            attempts += 1
-            await callbacks.fire_before_goal_check(phase_id, task.name, attempts)
-
-            worker_summary = worker_result.final_response.text or "(no summary provided)"
-            user_message, needs_reset = _select_reviewer_message(
-                previous_check=previous_check,
-                rendered_task_prompt=rendered_task_prompt,
-                goal_text=goal_text,
-                worker_summary=worker_summary,
-            )
-            if needs_reset:
-                await reviewer_process.reset()
-
-            check = await _run_reviewer_once(reviewer_process, user_message)
-            previous_check = check
-            total_in += check.input_tokens
-            total_out += check.output_tokens
-
-            await callbacks.fire_after_goal_check(phase_id, task.name, attempts, check.valid, check.reason)
-
-            if check.valid:
-                return GoalLoopOutcome(
-                    final_result=worker_result,
-                    attempts=attempts,
-                    total_input_tokens=total_in,
-                    total_output_tokens=total_out,
-                )
-
-            if attempts >= task.max_goal_attempts:
-                raise GoalAttemptsExhausted(
-                    f"Task {task.name!r} failed goal validation after "
-                    f"{attempts} attempts. Last reviewer reason: {check.reason}"
-                )
-
-            compact_in, compact_out = await compact_if_needed(worker_result)
-            total_in += compact_in
-            total_out += compact_out
-
-            retry_prompt = GOAL_RETRY_PROMPT_TEMPLATE.format(
-                goal=goal_text,
-                reviewer_verdict=check.verdict_json,
-            )
-            worker_result = await worker_process.start(retry_prompt)
-            total_in += worker_result.total_input_tokens
-            total_out += worker_result.total_output_tokens
-    except GoalValidationError as e:
-        e.input_tokens += total_in
-        e.output_tokens += total_out
-        e.attempts = attempts
-        raise
-
-
-async def run_goal_loop(
+async def run_validation_loop(
     *,
     task: TaskConfig,
-    goal_text: str,
+    goal_text: str | None,
     rendered_task_prompt: str,
     worker_process: ReActProcess,
     initial_result: ReActResult,
@@ -401,36 +405,99 @@ async def run_goal_loop(
     callbacks: Callbacks,
     phase_id: str,
     compact_if_needed: Callable[[ReActResult], Awaitable[tuple[int, int]]],
-) -> GoalLoopOutcome:
-    """Drive the reviewer + worker-retry loop for a single task with a goal.
+    deterministic_checks: Sequence[DeterministicCheck] = (),
+) -> ValidationLoopOutcome:
+    """Validate and repair a task with deterministic checks, an optional reviewer, or both."""
+    total_in = total_out = 0
+    attempts = 0
+    worker_result = initial_result
+    reviewer_process: ReActProcess | None = None
+    previous_check: ReviewerCheckResult | None = None
 
-    The reviewer runs as a scoped ``GOAL_REVIEWER`` process; its per-run activity
-    is captured by the run-wide logging callbacks bound to ``process_factory``.
-    The phase callbacks see only the bracketing before/after_goal_check events.
-    """
-    reviewer_scope = AgentScope(
-        owner_id=f"{phase_id}.goal.{task.name}",
-        role=AgentRole.GOAL_REVIEWER,
-        phase_id=phase_id,
-    )
-    reviewer_config = parent_agent_config.model_copy(update={"tools": filter_read_only(parent_agent_config.tools)})
     try:
-        reviewer_process = process_factory.create(
-            scope=reviewer_scope,
-            agent_config=reviewer_config,
-            system_prompt=GOAL_REVIEWER_SYSTEM_PROMPT,
-        )
-    except Exception as e:
-        raise RuntimeError(f"Failed to create reviewer process for task {task.name}: {e}") from e
+        while True:
+            attempts += 1
+            failure_reason = run_deterministic_checks(deterministic_checks).failure_reason()
+            reviewer_verdict: str | None = None
 
-    return await _drive_goal_loop(
-        phase_id=phase_id,
-        task=task,
-        goal_text=goal_text,
-        rendered_task_prompt=rendered_task_prompt,
-        worker_process=worker_process,
-        initial_result=initial_result,
-        reviewer_process=reviewer_process,
-        callbacks=callbacks,
-        compact_if_needed=compact_if_needed,
-    )
+            if failure_reason is None:
+                if goal_text is None:
+                    return ValidationLoopOutcome(
+                        final_result=worker_result,
+                        attempts=attempts,
+                        total_input_tokens=total_in,
+                        total_output_tokens=total_out,
+                    )
+                if reviewer_process is None:
+                    reviewer_scope = AgentScope(
+                        owner_id=f"{phase_id}.goal.{task.name}",
+                        role=AgentRole.GOAL_REVIEWER,
+                        phase_id=phase_id,
+                    )
+                    reviewer_config = parent_agent_config.model_copy(
+                        update={"tools": filter_read_only(parent_agent_config.tools)}
+                    )
+                    try:
+                        reviewer_process = process_factory.create(
+                            scope=reviewer_scope,
+                            agent_config=reviewer_config,
+                            system_prompt=GOAL_REVIEWER_SYSTEM_PROMPT,
+                        )
+                    except Exception as e:
+                        raise RuntimeError(f"Failed to create reviewer process for task {task.name}: {e}") from e
+
+                worker_summary = worker_result.final_response.text or "(no summary provided)"
+                user_message, needs_reset = _select_reviewer_message(
+                    previous_check=previous_check,
+                    rendered_task_prompt=rendered_task_prompt,
+                    goal_text=goal_text,
+                    worker_summary=worker_summary,
+                )
+                if needs_reset:
+                    await reviewer_process.reset()
+
+                await callbacks.fire_before_goal_check(phase_id, task.name, attempts)
+                reviewer_result = await _run_reviewer_once(reviewer_process, user_message)
+                previous_check = reviewer_result
+                total_in += reviewer_result.input_tokens
+                total_out += reviewer_result.output_tokens
+                await callbacks.fire_after_goal_check(
+                    phase_id,
+                    task.name,
+                    attempts,
+                    reviewer_result.valid,
+                    reviewer_result.reason,
+                )
+                if reviewer_result.valid:
+                    return ValidationLoopOutcome(
+                        final_result=worker_result,
+                        attempts=attempts,
+                        total_input_tokens=total_in,
+                        total_output_tokens=total_out,
+                    )
+                failure_reason = reviewer_result.reason
+                reviewer_verdict = reviewer_result.verdict_json
+
+            if attempts >= task.max_validation_attempts:
+                raise ValidationAttemptsExhausted(
+                    f"Task {task.name!r} failed validation after "
+                    f"{attempts} attempts. Last validation reason: {failure_reason}"
+                )
+
+            compact_in, compact_out = await compact_if_needed(worker_result)
+            total_in += compact_in
+            total_out += compact_out
+
+            if reviewer_verdict is not None:
+                assert goal_text is not None
+                retry_prompt = build_reviewer_retry_prompt(goal_text, reviewer_verdict)
+            else:
+                retry_prompt = build_validation_retry_prompt(goal_text, failure_reason)
+            worker_result = await worker_process.start(retry_prompt)
+            total_in += worker_result.total_input_tokens
+            total_out += worker_result.total_output_tokens
+    except TaskValidationError as e:
+        e.input_tokens += total_in
+        e.output_tokens += total_out
+        e.attempts = attempts
+        raise

--- a/ddev/src/ddev/ai/phases/goal.py
+++ b/ddev/src/ddev/ai/phases/goal.py
@@ -125,6 +125,10 @@ class ValidationAttemptsExhausted(TaskValidationError):
     """Validation rejected every candidate up to max_validation_attempts."""
 
 
+class ReviewerProcessError(TaskValidationError):
+    """The lazy goal-reviewer process could not be created."""
+
+
 @dataclass(frozen=True)
 class ReviewerCheckResult:
     valid: bool
@@ -177,8 +181,11 @@ class DeterministicCheckReport:
         return "Deterministic checks failed:\n\n" + "\n\n".join(sections)
 
 
-def run_deterministic_checks(checks: Sequence[DeterministicCheck]) -> DeterministicCheckReport:
-    """Run every named deterministic check and compose all repairable failures."""
+def validate_check_names(checks: Sequence[DeterministicCheck]) -> None:
+    """Validate that check names are non-blank and unique.
+
+    Raises ValueError if any check name is blank or duplicated.
+    """
     names = [check.name.strip() for check in checks]
     if invalid_names := [check.name for check, name in zip(checks, names, strict=True) if not name]:
         raise ValueError(f"Deterministic check names must not be blank: {invalid_names!r}")
@@ -186,8 +193,14 @@ def run_deterministic_checks(checks: Sequence[DeterministicCheck]) -> Determinis
     if duplicates:
         raise ValueError(f"Deterministic check names must be unique: {duplicates}")
 
+
+def run_deterministic_checks(checks: Sequence[DeterministicCheck]) -> DeterministicCheckReport:
+    """Run every named deterministic check and compose all repairable failures."""
+    validate_check_names(checks)
+
     failures: list[DeterministicCheckFailure] = []
-    for check, name in zip(checks, names, strict=True):
+    for check in checks:
+        name = check.name.strip()
         reason = check.run()
         if reason is None:
             continue
@@ -393,6 +406,30 @@ async def _run_reviewer_once(
     )
 
 
+def build_reviewer_process(
+    *,
+    task: TaskConfig,
+    parent_agent_config: AgentConfig,
+    process_factory: ReActProcessFactory,
+    phase_id: str,
+) -> ReActProcess:
+    """Create the lazy goal-reviewer process for one task."""
+    reviewer_scope = AgentScope(
+        owner_id=f"{phase_id}.goal.{task.name}",
+        role=AgentRole.GOAL_REVIEWER,
+        phase_id=phase_id,
+    )
+    reviewer_config = parent_agent_config.model_copy(update={"tools": filter_read_only(parent_agent_config.tools)})
+    try:
+        return process_factory.create(
+            scope=reviewer_scope,
+            agent_config=reviewer_config,
+            system_prompt=GOAL_REVIEWER_SYSTEM_PROMPT,
+        )
+    except Exception as e:
+        raise ReviewerProcessError(f"Failed to create reviewer process for task {task.name}: {e}") from e
+
+
 async def run_validation_loop(
     *,
     task: TaskConfig,
@@ -418,7 +455,7 @@ async def run_validation_loop(
         while True:
             attempts += 1
             failure_reason = run_deterministic_checks(deterministic_checks).failure_reason()
-            reviewer_verdict: str | None = None
+            reviewer_feedback: tuple[str, str] | None = None
 
             if failure_reason is None:
                 if goal_text is None:
@@ -429,22 +466,12 @@ async def run_validation_loop(
                         total_output_tokens=total_out,
                     )
                 if reviewer_process is None:
-                    reviewer_scope = AgentScope(
-                        owner_id=f"{phase_id}.goal.{task.name}",
-                        role=AgentRole.GOAL_REVIEWER,
+                    reviewer_process = build_reviewer_process(
+                        task=task,
+                        parent_agent_config=parent_agent_config,
+                        process_factory=process_factory,
                         phase_id=phase_id,
                     )
-                    reviewer_config = parent_agent_config.model_copy(
-                        update={"tools": filter_read_only(parent_agent_config.tools)}
-                    )
-                    try:
-                        reviewer_process = process_factory.create(
-                            scope=reviewer_scope,
-                            agent_config=reviewer_config,
-                            system_prompt=GOAL_REVIEWER_SYSTEM_PROMPT,
-                        )
-                    except Exception as e:
-                        raise RuntimeError(f"Failed to create reviewer process for task {task.name}: {e}") from e
 
                 worker_summary = worker_result.final_response.text or "(no summary provided)"
                 user_message, needs_reset = _select_reviewer_message(
@@ -476,7 +503,7 @@ async def run_validation_loop(
                         total_output_tokens=total_out,
                     )
                 failure_reason = reviewer_result.reason
-                reviewer_verdict = reviewer_result.verdict_json
+                reviewer_feedback = (goal_text, reviewer_result.verdict_json)
 
             if attempts >= task.max_validation_attempts:
                 raise ValidationAttemptsExhausted(
@@ -488,11 +515,11 @@ async def run_validation_loop(
             total_in += compact_in
             total_out += compact_out
 
-            if reviewer_verdict is not None:
-                assert goal_text is not None
-                retry_prompt = build_reviewer_retry_prompt(goal_text, reviewer_verdict)
-            else:
-                retry_prompt = build_validation_retry_prompt(goal_text, failure_reason)
+            retry_prompt = (
+                build_reviewer_retry_prompt(*reviewer_feedback)
+                if reviewer_feedback is not None
+                else build_validation_retry_prompt(goal_text, failure_reason)
+            )
             worker_result = await worker_process.start(retry_prompt)
             total_in += worker_result.total_input_tokens
             total_out += worker_result.total_output_tokens

--- a/ddev/src/ddev/ai/runtime/checkpoints.py
+++ b/ddev/src/ddev/ai/runtime/checkpoints.py
@@ -31,7 +31,7 @@ class CheckpointTokenInfo(BaseModel):
     total_output: int
 
 
-class GoalValidationRecord(BaseModel):
+class TaskValidationRecord(BaseModel):
     task: str
     attempts: int
     final_valid: bool
@@ -45,7 +45,7 @@ class SuccessCheckpoint(BaseModel):
     finished_at: str
     tokens: CheckpointTokenInfo
     memory_path: str
-    goal_validations: list[GoalValidationRecord] | None = None
+    task_validations: list[TaskValidationRecord] | None = None
     phase_data: dict[str, Any] = {}
 
 
@@ -57,7 +57,7 @@ class FailedCheckpoint(BaseModel):
     finished_at: str
     error: str
     tokens: CheckpointTokenInfo
-    goal_validations: list[GoalValidationRecord] | None = None
+    task_validations: list[TaskValidationRecord] | None = None
 
 
 PhaseCheckpoint = Annotated[SuccessCheckpoint | FailedCheckpoint, Field(discriminator="status")]

--- a/ddev/tests/ai/config/test_models.py
+++ b/ddev/tests/ai/config/test_models.py
@@ -48,14 +48,9 @@ def test_task_goal_consistency_both_set():
         TaskConfig(name="t", prompt="p", goal="g", goal_ref="r")
 
 
-def test_task_max_goal_attempts_without_goal():
+def test_task_max_validation_attempts_below_one():
     with pytest.raises(ValidationError):
-        TaskConfig(name="t", prompt="p", max_goal_attempts=3)
-
-
-def test_task_max_goal_attempts_below_one():
-    with pytest.raises(ValidationError):
-        TaskConfig(name="t", prompt="p", goal="g", max_goal_attempts=0)
+        TaskConfig(name="t", prompt="p", max_validation_attempts=0)
 
 
 def test_task_name_pattern_rejects_invalid():

--- a/ddev/tests/ai/phases/helpers.py
+++ b/ddev/tests/ai/phases/helpers.py
@@ -143,6 +143,7 @@ def make_agent_phase(
     goal_runtime_builder: Callable[[str], AgentRuntime] | None = None,
     agent_config: AgentConfig | None = None,
     resume_frontier: frozenset[str] = frozenset(),
+    phase_cls: type[AgenticPhase] = AgenticPhase,
 ) -> tuple[AgenticPhase, CheckpointManager]:
     """Build an AgenticPhase ready for process_message-driven tests."""
     effective_agent_config = agent_config or make_agent_config(tools=[])
@@ -169,7 +170,7 @@ def make_agent_phase(
         captured_kwargs=captured_worker_kwargs,
         goal_runtime_builder=goal_runtime_builder,
     )
-    phase = AgenticPhase(
+    phase = phase_cls(
         phase_id=phase_id,
         dependencies=dependencies or [],
         config=config,

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -14,6 +14,7 @@ from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.config.errors import ConfigError
 from ddev.ai.config.models import CheckpointConfig, PhaseConfig, TaskConfig
 from ddev.ai.phases.agentic_phase import AgenticPhase
+from ddev.ai.phases.goal import DeterministicCheck
 from ddev.ai.phases.messages import PhaseFailedMessage, PhaseTrigger
 from ddev.ai.phases.template import render_inline
 from ddev.ai.react.process import ReActProcess
@@ -22,8 +23,8 @@ from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
     CheckpointTokenInfo,
     FailedCheckpoint,
-    GoalValidationRecord,
     SuccessCheckpoint,
+    TaskValidationRecord,
 )
 from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.registry import ToolRegistry
@@ -415,8 +416,45 @@ async def test_spawn_subagent_wiring(flow_dir, flow_context, monkeypatch, messag
 
 
 # ---------------------------------------------------------------------------
-# Goal validation integration tests
+# Task validation integration tests
 # ---------------------------------------------------------------------------
+
+
+async def test_phase_supports_deterministic_checks_without_goal(flow_dir, monkeypatch, message_queue):
+    failures = iter(["`required_field` is missing", None])
+
+    class DeterministicOnlyPhase(AgenticPhase):
+        def deterministic_checks(self, task: TaskConfig, context: dict[str, object]) -> tuple[DeterministicCheck, ...]:
+            return (DeterministicCheck(name="artifact schema", run=lambda: next(failures)),)
+
+    def unexpected_reviewer(_owner_id: str) -> AgentRuntime:
+        raise AssertionError("deterministic-only validation must not create a reviewer")
+
+    worker = MockAgent(
+        [
+            make_response("initial work", 10, 5),
+            make_response("fixed work", 8, 4),
+            make_response("summary", 3, 2),
+        ]
+    )
+    phase, mgr = make_agent_phase(
+        flow_dir,
+        worker,
+        monkeypatch,
+        message_queue,
+        tasks=[TaskConfig(name="t1", prompt="Do it.", max_validation_attempts=2)],
+        goal_runtime_builder=unexpected_reviewer,
+        phase_cls=DeterministicOnlyPhase,
+    )
+
+    await phase.process_message(PhaseTrigger(id="start", phase_id=None))
+
+    checkpoint = mgr.read()["p1"]
+    assert isinstance(checkpoint, SuccessCheckpoint)
+    assert checkpoint.task_validations == [TaskValidationRecord(task="t1", attempts=2, final_valid=True)]
+    assert worker.send_calls[0] == "Do it."
+    assert "`required_field` is missing" in worker.send_calls[1]
+    assert "Goal:" not in worker.send_calls[1]
 
 
 async def test_phase_with_goal_passes_first_attempt(flow_dir, monkeypatch, message_queue):
@@ -448,7 +486,7 @@ async def test_phase_with_goal_passes_first_attempt(flow_dir, monkeypatch, messa
 
     cp = mgr.read()["p1"]
     assert isinstance(cp, SuccessCheckpoint)
-    assert cp.goal_validations == [GoalValidationRecord(task="t1", attempts=1, final_valid=True)]
+    assert cp.task_validations == [TaskValidationRecord(task="t1", attempts=1, final_valid=True)]
     assert worker.send_calls[0].startswith("Do it.")
     assert "independent reviewer" in worker.send_calls[0]
     assert cp.tokens == CheckpointTokenInfo(total_input=100 + 7 + 10, total_output=50 + 3 + 5)
@@ -482,17 +520,17 @@ async def test_phase_with_goal_exhausts_attempts_fails_phase(flow_dir, monkeypat
         worker,
         monkeypatch,
         message_queue,
-        tasks=[TaskConfig(name="t1", prompt="Do it.", goal="g", max_goal_attempts=2)],
+        tasks=[TaskConfig(name="t1", prompt="Do it.", goal="g", max_validation_attempts=2)],
         goal_runtime_builder=goal_builder,
     )
 
-    from ddev.ai.phases.goal import GoalAttemptsExhausted
+    from ddev.ai.phases.goal import ValidationAttemptsExhausted
 
-    with pytest.raises(GoalAttemptsExhausted):
+    with pytest.raises(ValidationAttemptsExhausted):
         await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     assert mgr.read() == {}
-    assert phase._goal_attempt_log == [GoalValidationRecord(task="t1", attempts=2, final_valid=False)]
+    assert phase._validation_log == [TaskValidationRecord(task="t1", attempts=2, final_valid=False)]
 
     # The reviewer ran (and succeeded as an agent) on each attempt; its per-run
     # log exists. The goal-loop verdict itself lives in the phase checkpoint.
@@ -533,20 +571,20 @@ async def test_phase_goal_partial_progress_preserved_on_exhaustion(flow_dir, mon
         monkeypatch,
         message_queue,
         tasks=[
-            TaskConfig(name="t1", prompt="First.", goal="check t1", max_goal_attempts=2),
-            TaskConfig(name="t2", prompt="Second.", goal="check t2", max_goal_attempts=2),
+            TaskConfig(name="t1", prompt="First.", goal="check t1", max_validation_attempts=2),
+            TaskConfig(name="t2", prompt="Second.", goal="check t2", max_validation_attempts=2),
         ],
         goal_runtime_builder=goal_builder,
     )
 
-    from ddev.ai.phases.goal import GoalAttemptsExhausted
+    from ddev.ai.phases.goal import ValidationAttemptsExhausted
 
-    with pytest.raises(GoalAttemptsExhausted):
+    with pytest.raises(ValidationAttemptsExhausted):
         await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    assert phase._goal_attempt_log == [
-        GoalValidationRecord(task="t1", attempts=1, final_valid=True),
-        GoalValidationRecord(task="t2", attempts=2, final_valid=False),
+    assert phase._validation_log == [
+        TaskValidationRecord(task="t1", attempts=1, final_valid=True),
+        TaskValidationRecord(task="t2", attempts=2, final_valid=False),
     ]
 
 
@@ -575,21 +613,21 @@ async def test_goal_exhaustion_tokens_captured_on_phase(flow_dir, monkeypatch, m
         worker,
         monkeypatch,
         message_queue,
-        tasks=[TaskConfig(name="t1", prompt="Do it.", goal="g", max_goal_attempts=2)],
+        tasks=[TaskConfig(name="t1", prompt="Do it.", goal="g", max_validation_attempts=2)],
         goal_runtime_builder=goal_builder,
     )
 
-    from ddev.ai.phases.goal import GoalAttemptsExhausted
+    from ddev.ai.phases.goal import ValidationAttemptsExhausted
 
-    with pytest.raises(GoalAttemptsExhausted):
+    with pytest.raises(ValidationAttemptsExhausted):
         await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
     assert phase._total_input_tokens == 10 + 8 + 10 + 8
     assert phase._total_output_tokens == 5 + 4 + 5 + 4
 
 
-async def test_on_error_writes_tokens_and_goal_validations_to_checkpoint(flow_dir, monkeypatch, message_queue):
-    """on_error includes token counts and goal_validations in the failure checkpoint."""
+async def test_on_error_writes_tokens_and_task_validations_to_checkpoint(flow_dir, monkeypatch, message_queue):
+    """on_error includes token counts and task validations in the failure checkpoint."""
     from ddev.ai.phases.messages import PhaseTrigger
     from ddev.event_bus.exceptions import MessageProcessingError
 
@@ -598,7 +636,7 @@ async def test_on_error_writes_tokens_and_goal_validations_to_checkpoint(flow_di
 
     phase._total_input_tokens = 42
     phase._total_output_tokens = 17
-    phase._goal_attempt_log = [GoalValidationRecord(task="t1", attempts=2, final_valid=False)]
+    phase._validation_log = [TaskValidationRecord(task="t1", attempts=2, final_valid=False)]
     phase._started_at = None
 
     err = MessageProcessingError(
@@ -611,7 +649,7 @@ async def test_on_error_writes_tokens_and_goal_validations_to_checkpoint(flow_di
     cp = mgr.read()["p1"]
     assert isinstance(cp, FailedCheckpoint)
     assert cp.tokens == CheckpointTokenInfo(total_input=42, total_output=17)
-    assert cp.goal_validations == [GoalValidationRecord(task="t1", attempts=2, final_valid=False)]
+    assert cp.task_validations == [TaskValidationRecord(task="t1", attempts=2, final_valid=False)]
     assert cp.error == "something went wrong"
 
 
@@ -768,8 +806,8 @@ async def test_compact_context_before_on_first_task_is_noop(flow_dir, monkeypatc
 
 
 async def test_goal_parse_error_logged_and_tokens_captured(flow_dir, monkeypatch, message_queue):
-    """GoalParseError is treated the same as GoalAttemptsExhausted: logged with final_valid=False."""
-    from ddev.ai.phases.goal import GoalParseError
+    """Reviewer parse errors are logged with final_valid=False."""
+    from ddev.ai.phases.goal import ReviewerParseError
 
     worker = MockAgent([make_response("worker done", 10, 5)])
 
@@ -793,10 +831,10 @@ async def test_goal_parse_error_logged_and_tokens_captured(flow_dir, monkeypatch
         goal_runtime_builder=goal_builder,
     )
 
-    with pytest.raises(GoalParseError):
+    with pytest.raises(ReviewerParseError):
         await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 
-    assert phase._goal_attempt_log == [GoalValidationRecord(task="t1", attempts=1, final_valid=False)]
+    assert phase._validation_log == [TaskValidationRecord(task="t1", attempts=1, final_valid=False)]
     assert phase._total_input_tokens == 10 + 8 + 6
     assert phase._total_output_tokens == 5 + 4 + 3
 

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -12,8 +12,8 @@ from ddev.ai.runtime.checkpoints import (
     CheckpointManager,
     CheckpointTokenInfo,
     FailedCheckpoint,
-    GoalValidationRecord,
     SuccessCheckpoint,
+    TaskValidationRecord,
 )
 from ddev.event_bus.exceptions import HookName, MessageProcessingError, ProcessorHookError
 
@@ -240,7 +240,7 @@ async def test_process_message_writes_memory_and_checkpoint(flow_dir, flow_conte
         memory_text="stub-memory-body",
         total_input_tokens=123,
         total_output_tokens=45,
-        goal_validations=[GoalValidationRecord(task="t1", attempts=1, final_valid=True)],
+        task_validations=[TaskValidationRecord(task="t1", attempts=1, final_valid=True)],
         checkpoint_data={"custom_field": "custom_value", "count": 7},
     )
     phase, mgr = _make_stub_phase(flow_dir, flow_context, message_queue, outcome=outcome)
@@ -254,6 +254,6 @@ async def test_process_message_writes_memory_and_checkpoint(flow_dir, flow_conte
     assert checkpoint.tokens == CheckpointTokenInfo(total_input=123, total_output=45)
     assert checkpoint.memory_path == str(mgr.memory_path("p1"))
     assert checkpoint.phase_data == {"custom_field": "custom_value", "count": 7}
-    assert checkpoint.goal_validations == [GoalValidationRecord(task="t1", attempts=1, final_valid=True)]
+    assert checkpoint.task_validations == [TaskValidationRecord(task="t1", attempts=1, final_valid=True)]
     assert checkpoint.started_at
     assert checkpoint.finished_at

--- a/ddev/tests/ai/phases/test_goal.py
+++ b/ddev/tests/ai/phases/test_goal.py
@@ -14,13 +14,15 @@ from ddev.ai.config.models import AgentConfig, TaskConfig
 from ddev.ai.phases.goal import (
     GOAL_REVIEWER_RESET_THRESHOLD_PCT,
     GOAL_REVIEWER_SYSTEM_PROMPT,
-    GoalAttemptsExhausted,
-    GoalCheckResult,
-    GoalParseError,
+    DeterministicCheck,
+    ReviewerCheckResult,
+    ReviewerParseError,
+    ValidationAttemptsExhausted,
     _select_reviewer_message,
     build_reviewer_user_message,
     parse_reviewer_verdict,
-    run_goal_loop,
+    run_deterministic_checks,
+    run_validation_loop,
 )
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.react.types import ReActResult
@@ -155,7 +157,7 @@ def test_select_reviewer_message(
 ) -> None:
     previous_check = None
     if has_previous_check:
-        previous_check = GoalCheckResult(
+        previous_check = ReviewerCheckResult(
             valid=False,
             reason="missing X",
             input_tokens=20,
@@ -179,7 +181,7 @@ def test_select_reviewer_message(
 
 
 # ---------------------------------------------------------------------------
-# Helpers used by run_goal_loop tests
+# Helpers used by run_validation_loop tests
 # ---------------------------------------------------------------------------
 
 
@@ -227,11 +229,11 @@ async def _noop_compact(_):
 
 
 # ---------------------------------------------------------------------------
-# run_goal_loop
+# run_validation_loop
 # ---------------------------------------------------------------------------
 
 
-async def test_run_goal_loop_passes_on_first_attempt(tmp_path):
+async def test_run_validation_loop_passes_on_first_attempt(tmp_path):
     worker_process, worker_agent = _make_worker_process([])
     initial_result = ReActResult(
         final_response=make_response("did things"),
@@ -246,7 +248,7 @@ async def test_run_goal_loop_passes_on_first_attempt(tmp_path):
         callbacks=Callbacks([run_logger.as_callback_set()]),
     )
 
-    outcome = await run_goal_loop(
+    outcome = await run_validation_loop(
         task=TaskConfig(name="t1", prompt="x", goal="verify"),
         goal_text="verify",
         rendered_task_prompt="TASK",
@@ -274,7 +276,7 @@ async def test_run_goal_loop_passes_on_first_attempt(tmp_path):
     assert {"start", "finish"} <= events
 
 
-async def test_run_goal_loop_inherits_parent_config_with_read_only_tools(tmp_path):
+async def test_run_validation_loop_inherits_parent_config_with_read_only_tools(tmp_path):
     worker_process, _ = _make_worker_process([])
     initial_result = ReActResult(
         final_response=make_response("did things"),
@@ -291,7 +293,7 @@ async def test_run_goal_loop_inherits_parent_config_with_read_only_tools(tmp_pat
         max_tokens=999,
     )
 
-    await run_goal_loop(
+    await run_validation_loop(
         task=TaskConfig(name="t1", prompt="x", goal="verify"),
         goal_text="verify",
         rendered_task_prompt="TASK",
@@ -313,7 +315,7 @@ async def test_run_goal_loop_inherits_parent_config_with_read_only_tools(tmp_pat
     assert builder_calls[0]["owner_id"] == "p1.goal.t1"
 
 
-async def test_run_goal_loop_one_retry_then_pass(tmp_path):
+async def test_run_validation_loop_one_retry_then_pass(tmp_path):
     worker_process, worker_agent = _make_worker_process([make_response("fixed it", 30, 15)])
     initial_result = ReActResult(
         final_response=make_response("initial work"),
@@ -331,7 +333,7 @@ async def test_run_goal_loop_one_retry_then_pass(tmp_path):
         ]
     )
 
-    outcome = await run_goal_loop(
+    outcome = await run_validation_loop(
         task=TaskConfig(name="t1", prompt="x", goal="g"),
         goal_text="g",
         rendered_task_prompt="TASK",
@@ -361,7 +363,7 @@ async def test_run_goal_loop_one_retry_then_pass(tmp_path):
     assert outcome.total_output_tokens == 10 + 12 + 15
 
 
-async def test_run_goal_loop_resets_large_reviewer_context_before_retry(tmp_path):
+async def test_run_validation_loop_resets_large_reviewer_context_before_retry(tmp_path):
     worker_process, _ = _make_worker_process([make_response("fixed it", 30, 15)])
     initial_result = ReActResult(
         final_response=make_response("initial work"),
@@ -378,7 +380,7 @@ async def test_run_goal_loop_resets_large_reviewer_context_before_retry(tmp_path
         ]
     )
 
-    outcome = await run_goal_loop(
+    outcome = await run_validation_loop(
         task=TaskConfig(name="t1", prompt="x", goal="g"),
         goal_text="GOAL",
         rendered_task_prompt="TASK",
@@ -404,7 +406,161 @@ async def test_run_goal_loop_resets_large_reviewer_context_before_retry(tmp_path
     assert "## Worker repair summary\nfixed it" in retry_message
 
 
-async def test_run_goal_loop_exhausts_attempts(tmp_path):
+async def test_run_validation_loop_repairs_deterministic_failure_before_calling_reviewer() -> None:
+    worker_process, worker_agent = _make_worker_process([make_response("fixed it", 30, 15)])
+    initial_result = ReActResult(
+        final_response=make_response("initial work"),
+        iterations=1,
+        total_input_tokens=100,
+        total_output_tokens=50,
+        context_usage=None,
+    )
+    factory, builder_calls, reviewer_agent = _reviewer_factory([make_response(make_goal_verdict(True), 20, 10)])
+    calls: list[str] = []
+    schema_failures = iter(["`required_field` is missing", None])
+    coverage_failures = iter(["`resource` is missing from the manifest", None])
+
+    def check_artifact_schema() -> str | None:
+        calls.append("artifact schema")
+        return next(schema_failures)
+
+    def check_resource_coverage() -> str | None:
+        calls.append("resource coverage")
+        return next(coverage_failures)
+
+    def check_configuration() -> None:
+        calls.append("configuration")
+        return None
+
+    outcome = await run_validation_loop(
+        task=TaskConfig(name="t1", prompt="x", goal="g"),
+        goal_text="g",
+        rendered_task_prompt="TASK",
+        worker_process=worker_process,
+        initial_result=initial_result,
+        parent_agent_config=make_agent_config(tools=[]),
+        process_factory=factory,
+        callbacks=Callbacks(),
+        phase_id="p1",
+        compact_if_needed=_noop_compact,
+        deterministic_checks=(
+            DeterministicCheck(name="artifact schema", run=check_artifact_schema),
+            DeterministicCheck(name="resource coverage", run=check_resource_coverage),
+            DeterministicCheck(name="configuration", run=check_configuration),
+        ),
+    )
+
+    assert outcome.attempts == 2
+    assert outcome.final_result.final_response.text == "fixed it"
+    assert len(worker_agent.send_calls) == 1
+    assert "Deterministic checks failed" in worker_agent.send_calls[0]
+    assert "## artifact schema" in worker_agent.send_calls[0]
+    assert "`required_field` is missing" in worker_agent.send_calls[0]
+    assert "## resource coverage" in worker_agent.send_calls[0]
+    assert "`resource` is missing from the manifest" in worker_agent.send_calls[0]
+    assert "## configuration" not in worker_agent.send_calls[0]
+    assert len(reviewer_agent.send_calls) == 1
+    assert len(builder_calls) == 1
+    assert calls == [
+        "artifact schema",
+        "resource coverage",
+        "configuration",
+        "artifact schema",
+        "resource coverage",
+        "configuration",
+    ]
+    assert outcome.total_input_tokens == 30 + 20
+    assert outcome.total_output_tokens == 15 + 10
+
+
+async def test_run_validation_loop_deterministic_exhaustion_never_creates_reviewer() -> None:
+    worker_process, worker_agent = _make_worker_process([])
+    initial_result = ReActResult(
+        final_response=make_response("initial work"),
+        iterations=1,
+        total_input_tokens=100,
+        total_output_tokens=50,
+        context_usage=None,
+    )
+    factory, builder_calls, reviewer_agent = _reviewer_factory([])
+
+    with pytest.raises(ValidationAttemptsExhausted, match=r"(?s)Last validation reason.*required_field") as exc_info:
+        await run_validation_loop(
+            task=TaskConfig(name="t1", prompt="x", goal="g", max_validation_attempts=1),
+            goal_text="g",
+            rendered_task_prompt="TASK",
+            worker_process=worker_process,
+            initial_result=initial_result,
+            parent_agent_config=make_agent_config(tools=[]),
+            process_factory=factory,
+            callbacks=Callbacks(),
+            phase_id="p1",
+            compact_if_needed=_noop_compact,
+            deterministic_checks=(
+                DeterministicCheck(name="artifact schema", run=lambda: "`required_field` is missing"),
+            ),
+        )
+
+    assert exc_info.value.attempts == 1
+    assert worker_agent.send_calls == []
+    assert reviewer_agent.send_calls == []
+    assert builder_calls == []
+
+
+async def test_run_validation_loop_accepts_passing_deterministic_checks_without_goal() -> None:
+    worker_process, worker_agent = _make_worker_process([])
+    initial_result = ReActResult(
+        final_response=make_response("initial work"),
+        iterations=1,
+        total_input_tokens=100,
+        total_output_tokens=50,
+        context_usage=None,
+    )
+    factory, builder_calls, reviewer_agent = _reviewer_factory([])
+
+    outcome = await run_validation_loop(
+        task=TaskConfig(name="t1", prompt="x"),
+        goal_text=None,
+        rendered_task_prompt="TASK",
+        worker_process=worker_process,
+        initial_result=initial_result,
+        parent_agent_config=make_agent_config(tools=[]),
+        process_factory=factory,
+        callbacks=Callbacks(),
+        phase_id="p1",
+        compact_if_needed=_noop_compact,
+        deterministic_checks=(DeterministicCheck(name="artifact schema", run=lambda: None),),
+    )
+
+    assert outcome.attempts == 1
+    assert outcome.final_result is initial_result
+    assert worker_agent.send_calls == []
+    assert reviewer_agent.send_calls == []
+    assert builder_calls == []
+
+
+def test_run_deterministic_checks_rejects_duplicate_names_before_running_checks() -> None:
+    calls: list[str] = []
+    checks = (
+        DeterministicCheck(name="duplicate", run=lambda: calls.append("first")),
+        DeterministicCheck(name="duplicate", run=lambda: calls.append("second")),
+    )
+
+    with pytest.raises(ValueError, match="must be unique.*duplicate"):
+        run_deterministic_checks(checks)
+
+    assert calls == []
+
+
+def test_run_deterministic_checks_propagates_checker_exceptions() -> None:
+    def broken_check() -> None:
+        raise RuntimeError("catalog is unreadable")
+
+    with pytest.raises(RuntimeError, match="catalog is unreadable"):
+        run_deterministic_checks((DeterministicCheck(name="broken", run=broken_check),))
+
+
+async def test_run_validation_loop_exhausts_attempts(tmp_path):
     worker_process, _ = _make_worker_process([make_response("attempt 2", 10, 5)])
     initial_result = ReActResult(
         final_response=make_response("attempt 1"),
@@ -420,9 +576,9 @@ async def test_run_goal_loop_exhausts_attempts(tmp_path):
         ]
     )
 
-    with pytest.raises(GoalAttemptsExhausted, match="2 attempts") as exc_info:
-        await run_goal_loop(
-            task=TaskConfig(name="t1", prompt="x", goal="g", max_goal_attempts=2),
+    with pytest.raises(ValidationAttemptsExhausted, match="2 attempts") as exc_info:
+        await run_validation_loop(
+            task=TaskConfig(name="t1", prompt="x", goal="g", max_validation_attempts=2),
             goal_text="g",
             rendered_task_prompt="TASK",
             worker_process=worker_process,
@@ -439,7 +595,7 @@ async def test_run_goal_loop_exhausts_attempts(tmp_path):
     assert err.output_tokens == 3 + 5 + 4
 
 
-async def test_run_goal_loop_parse_retry_succeeds(tmp_path):
+async def test_run_validation_loop_parse_retry_succeeds(tmp_path):
     worker_process, _ = _make_worker_process([])
     initial_result = ReActResult(
         final_response=make_response("done"),
@@ -455,7 +611,7 @@ async def test_run_goal_loop_parse_retry_succeeds(tmp_path):
         ]
     )
 
-    outcome = await run_goal_loop(
+    outcome = await run_validation_loop(
         task=TaskConfig(name="t1", prompt="x", goal="g"),
         goal_text="g",
         rendered_task_prompt="TASK",
@@ -473,7 +629,7 @@ async def test_run_goal_loop_parse_retry_succeeds(tmp_path):
     assert outcome.total_output_tokens == 5 + 7
 
 
-async def test_run_goal_loop_parse_retry_fails_raises(tmp_path):
+async def test_run_validation_loop_parse_retry_fails_raises(tmp_path):
     worker_process, _ = _make_worker_process([])
     initial_result = ReActResult(
         final_response=make_response("done"),
@@ -489,8 +645,8 @@ async def test_run_goal_loop_parse_retry_fails_raises(tmp_path):
         ]
     )
 
-    with pytest.raises(GoalParseError) as exc_info:
-        await run_goal_loop(
+    with pytest.raises(ReviewerParseError) as exc_info:
+        await run_validation_loop(
             task=TaskConfig(name="t1", prompt="x", goal="g"),
             goal_text="g",
             rendered_task_prompt="TASK",
@@ -508,7 +664,7 @@ async def test_run_goal_loop_parse_retry_fails_raises(tmp_path):
     assert err.output_tokens == 3 + 4
 
 
-async def test_run_goal_loop_fires_callbacks(tmp_path):
+async def test_run_validation_loop_fires_callbacks(tmp_path):
     events: list = []
     cb_set = CallbackSet()
 
@@ -535,7 +691,7 @@ async def test_run_goal_loop_fires_callbacks(tmp_path):
         ]
     )
 
-    await run_goal_loop(
+    await run_validation_loop(
         task=TaskConfig(name="t1", prompt="x", goal="g"),
         goal_text="g",
         rendered_task_prompt="TASK",

--- a/ddev/tests/ai/phases/test_goal.py
+++ b/ddev/tests/ai/phases/test_goal.py
@@ -552,6 +552,29 @@ def test_run_deterministic_checks_rejects_duplicate_names_before_running_checks(
     assert calls == []
 
 
+@pytest.mark.parametrize(
+    "checks,match",
+    [
+        pytest.param(
+            (DeterministicCheck(name="  ", run=lambda: None),),
+            "must not be blank",
+            id="blank_name",
+        ),
+        pytest.param(
+            (DeterministicCheck(name="incomplete", run=lambda: ""),),
+            "blank failure reason",
+            id="blank_failure_reason",
+        ),
+    ],
+)
+def test_run_deterministic_checks_rejects_invalid_checks(
+    checks: tuple[DeterministicCheck, ...],
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        run_deterministic_checks(checks)
+
+
 def test_run_deterministic_checks_propagates_checker_exceptions() -> None:
     def broken_check() -> None:
         raise RuntimeError("catalog is unreadable")


### PR DESCRIPTION
> This is PR 1 of 3 in a stacked series: 
> 1. #24777 (reusable validation framework)  **<- you are here**
> 2. #24778 (OpenMetrics label-hygiene validation)
> 3. #24788 (Adds TUI feedback for deterministic checks)

### What does this PR do?

Adds composable deterministic validation to agentic tasks without requiring an LLM reviewer.

- Lets phase subclasses declare any number of named deterministic checks through `deterministic_checks()`.
- Runs all deterministic checks in declaration order and combines their failures into one actionable repair prompt.
- Supports deterministic-only validation, reviewer-only validation, and deterministic checks followed by an optional goal reviewer.
- Creates the reviewer lazily, only after deterministic checks pass and only when the task has a goal.
- Generalizes validation attempts and checkpoint records from goal-specific names to task-validation names.
- Renames `max_goal_attempts` to `max_validation_attempts` in the task model and existing flow configuration.

The OpenMetrics-specific check and the TUI updates are intentionally kept out of this PR (see the stack).

### Motivation

[AI-7081](https://datadoghq.atlassian.net/browse/AI-7081) describes a seven-minute review-and-retry round trip caused by a deterministic label-policy miss. The framework previously coupled validation to an LLM goal reviewer, which meant phases could not cheaply reject artifacts using local, repeatable checks.

This layer introduces the generic composition and retry lifecycle so future phases can add fast checks without forcing a reviewer agent or duplicating orchestration logic.

Scoped coverage includes validation composition, deterministic-only repair and exhaustion, lazy reviewer construction, combined deterministic-plus-reviewer validation, checkpoint recording, configuration validation, and existing orchestration behavior. The focused suite passed 230 tests; Ruff and mypy also pass.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7081]: https://datadoghq.atlassian.net/browse/AI-7081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ