### PR TITLE
Add OpenMetrics label hygiene validation

### DIFF
--- a/ddev/src/ddev/ai/flows/openmetrics/phases.yaml
+++ b/ddev/src/ddev/ai/flows/openmetrics/phases.yaml
@@ -35,7 +35,7 @@
     name: build_integration
     description: >-
       Copy the test environment and captured fixtures, then implement the OpenMetrics check and its configuration specification.
-    class: AgenticPhase
+    class: OpenMetricsBuildPhase
     agent: integration_coder
     variables:
       - name: integration

--- a/ddev/src/ddev/ai/flows/openmetrics/prompts/metrics_renamer.md
+++ b/ddev/src/ddev/ai/flows/openmetrics/prompts/metrics_renamer.md
@@ -32,14 +32,16 @@ the exact artifact to produce, its paths, delegation strategy, format, and accep
 ## Integration identity
 
 Derive the integration name and metric prefix from the supplied display name with one rule:
-lowercase it and replace every run of non-alphanumeric characters with one underscore. The
-integration name and metric prefix are identical, except the scaffolding command receives the
-prefix with a trailing dot.
+lowercase it, replace every run of non-alphanumeric characters with one underscore, and remove
+leading or trailing underscores. The result must be a valid Python identifier starting with a
+letter. The integration name and metric prefix are identical, except the scaffolding command
+receives the prefix with a trailing dot.
 
 Examples:
 
 - `MyIntegration` -> `myintegration`
 - `HPE Aruba Edge` -> `hpe_aruba_edge`
+- `Iris DB!` -> `iris_db`
 - `Kuma` -> `kuma`
 
 Use this identity consistently in package paths, emitted metric names, metadata, and summaries.

--- a/ddev/src/ddev/ai/flows/openmetrics/prompts/phase1_metadata_goal.md
+++ b/ddev/src/ddev/ai/flows/openmetrics/prompts/phase1_metadata_goal.md
@@ -12,8 +12,8 @@ ${inspect_endpoint_memory}
 ## What must be true
 
 `<integration_name>` is `${integration}` lowercased with each run of non-alphanumeric
-characters replaced by `_`; the metric prefix is `<integration_name>`. The worker summary
-lists the exact file paths; use them.
+characters replaced by `_` and leading and trailing underscores removed; the metric prefix is
+`<integration_name>`. The worker summary lists the exact file paths; use them.
 
 1. Read every rename mapping: `metrics.yaml` for a single endpoint, or every
    `metrics/<endpoint_name>.yaml` for multiple endpoints. Collect the deduplicated union of

--- a/ddev/src/ddev/ai/flows/openmetrics/prompts/phase1_rename_goal.md
+++ b/ddev/src/ddev/ai/flows/openmetrics/prompts/phase1_rename_goal.md
@@ -17,8 +17,8 @@ ${inspect_endpoint_memory}
    `<integration_name>/datadog_checks/<integration_name>/metrics.yaml`; multiple endpoints
    use one `<integration_name>/datadog_checks/<integration_name>/metrics/<endpoint_name>.yaml`
    per normalized endpoint, where `<integration_name>` is `${integration}` lowercased with
-   each run of non-alphanumeric characters replaced by `_`. The mapping-file count must equal
-   the endpoint count.
+   each run of non-alphanumeric characters replaced by `_`, with leading and trailing
+   underscores removed. The mapping-file count must equal the endpoint count.
 3. For each endpoint, that mapping's YAML **keys** must match that endpoint's catalog names:
    - every catalog family appears as a key in the correct endpoint file (no source metric dropped), and
    - no key exists that is neither a catalog family nor a metric the worker added from an

--- a/ddev/src/ddev/ai/flows/openmetrics/prompts/phase2_materialize.md
+++ b/ddev/src/ddev/ai/flows/openmetrics/prompts/phase2_materialize.md
@@ -10,7 +10,8 @@ here — you do not author, read, or modify their contents.
 
 The integration lives in the scaffolded directory named after `${integration}` in
 snake_case (lowercase, each run of non-alphanumeric characters replaced by a single
-underscore). List the working tree if you need to confirm the exact directory name.
+underscore, with leading and trailing underscores removed). List the working tree if you need
+to confirm the exact directory name.
 
 **Use the `copy_path` tool for every copy below.** Do not read a file and re-create it —
 these inputs are large, and copying them through your response is impossible and

--- a/ddev/src/ddev/ai/phases/openmetrics/build_integration.py
+++ b/ddev/src/ddev/ai/phases/openmetrics/build_integration.py
@@ -1,0 +1,137 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from ddev.ai.config.errors import ConfigError
+from ddev.ai.config.models import AgentConfig, PhaseConfig, TaskConfig
+from ddev.ai.phases.agentic_phase import AgenticPhase
+from ddev.ai.phases.base import FlowContext
+from ddev.ai.phases.goal import DeterministicCheck
+from ddev.ai.phases.openmetrics.inspect_endpoint import normalize_endpoint_name
+from ddev.ai.phases.openmetrics.label_hygiene import LabelHygieneError, lint_label_hygiene
+from ddev.ai.runtime.checkpoints import CheckpointManager, SuccessCheckpoint
+
+if TYPE_CHECKING:
+    from ddev.ai.phases.resources import PhaseResources
+    from ddev.ai.react.factory import ReActProcessFactory
+
+INSPECTION_PHASE_ID = "inspect_endpoint"
+CODE_TASK_NAME = "write_code"
+
+
+class OpenMetricsBuildPhase(AgenticPhase):
+    """Build an OpenMetrics integration with deterministic checks before task acceptance."""
+
+    def __init__(
+        self,
+        phase_id: str,
+        dependencies: list[str],
+        config: PhaseConfig,
+        checkpoint_manager: CheckpointManager,
+        context: FlowContext,
+        agent_config: AgentConfig,
+        process_factory: ReActProcessFactory,
+        write_root: Path,
+    ) -> None:
+        super().__init__(
+            phase_id=phase_id,
+            dependencies=dependencies,
+            config=config,
+            checkpoint_manager=checkpoint_manager,
+            context=context,
+            agent_config=agent_config,
+            process_factory=process_factory,
+        )
+        self._write_root = write_root
+
+    @classmethod
+    def validate_config(cls, phase_id: str, config: PhaseConfig) -> None:
+        super().validate_config(phase_id, config)
+        code_tasks = [task for task in config.tasks if task.name == CODE_TASK_NAME]
+        if len(code_tasks) != 1:
+            raise ConfigError(
+                f"Phase {phase_id!r} (OpenMetricsBuildPhase) requires exactly one task named {CODE_TASK_NAME!r}"
+            )
+
+    @classmethod
+    def build(
+        cls,
+        phase_id: str,
+        config: PhaseConfig,
+        deps: list[str],
+        resources: PhaseResources,
+        checkpoint_manager: CheckpointManager,
+        context: FlowContext,
+    ) -> OpenMetricsBuildPhase:
+        agent_name = cast(str, config.agent)
+        return cls(
+            phase_id=phase_id,
+            dependencies=deps,
+            config=config,
+            checkpoint_manager=checkpoint_manager,
+            context=context,
+            agent_config=resources.agent_config(agent_name),
+            process_factory=resources.process_factory,
+            write_root=resources.write_root,
+        )
+
+    def deterministic_checks(self, task: TaskConfig, context: dict[str, Any]) -> tuple[DeterministicCheck, ...]:
+        checks = super().deterministic_checks(task, context)
+        if task.name != CODE_TASK_NAME:
+            return checks
+        return (*checks, DeterministicCheck(name="label hygiene", run=lambda: self._check_label_hygiene(context)))
+
+    def _check_label_hygiene(self, context: dict[str, Any]) -> str | None:
+        """Validate captured label catalogs against the generated check configuration."""
+        integration = context.get("integration")
+        if not isinstance(integration, str):
+            raise ConfigError("'integration' runtime variable must be a string")
+        try:
+            integration_name = normalize_endpoint_name(integration)
+        except ValueError as e:
+            raise ConfigError(f"invalid 'integration' runtime variable: {e}") from e
+
+        catalog_paths = self._catalog_paths(context)
+        check_path = (self._write_root / integration_name / "datadog_checks" / integration_name / "check.py").resolve()
+        if not check_path.is_file() and (misplaced_check := self._find_misplaced_check(integration_name)) is not None:
+            raise LabelHygieneError(
+                f"Expected generated check at {check_path}, but found it at {misplaced_check}; "
+                "the scaffolded integration name does not match the normalized runtime name"
+            )
+        result = lint_label_hygiene(catalog_paths, check_path)
+        return result.failure_reason(check_path)
+
+    def _find_misplaced_check(self, integration_name: str) -> Path | None:
+        """Find a generated check whose package normalizes to the expected name."""
+        for path in self._write_root.glob("*/datadog_checks/*/check.py"):
+            try:
+                if normalize_endpoint_name(path.parent.name) == integration_name:
+                    return path.resolve()
+            except ValueError:
+                continue
+        return None
+
+    @staticmethod
+    def _catalog_paths(context: dict[str, Any]) -> list[Path]:
+        """Read authoritative catalog paths from the successful inspection checkpoint."""
+        checkpoints = context.get("checkpoints")
+        if not isinstance(checkpoints, dict):
+            raise LabelHygieneError("Phase context does not contain checkpoints")
+        checkpoint = checkpoints.get(INSPECTION_PHASE_ID)
+        if not isinstance(checkpoint, SuccessCheckpoint):
+            raise LabelHygieneError(f"Successful {INSPECTION_PHASE_ID!r} checkpoint is required")
+        endpoints = checkpoint.phase_data.get("endpoints")
+        if not isinstance(endpoints, list) or not endpoints:
+            raise LabelHygieneError("Inspection checkpoint contains no endpoint catalogs")
+
+        paths: list[Path] = []
+        for endpoint in endpoints:
+            if not isinstance(endpoint, dict) or not isinstance(endpoint.get("metrics_jsonl_path"), str):
+                raise LabelHygieneError("Inspection checkpoint contains an invalid endpoint catalog entry")
+            paths.append(Path(endpoint["metrics_jsonl_path"]))
+        return paths

--- a/ddev/src/ddev/ai/phases/openmetrics/label_hygiene.py
+++ b/ddev/src/ddev/ai/phases/openmetrics/label_hygiene.py
@@ -1,0 +1,298 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from __future__ import annotations
+
+import ast
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+
+LabelCategory = Literal["reserved", "generic", "unbounded"]
+RESERVED_LABELS = frozenset({"device", "env", "host", "service", "source", "team", "version"})
+GENERIC_LABELS = frozenset({"component", "id", "name", "role", "state", "status", "type"})
+UNBOUNDED_LABELS = frozenset({"request_id", "trace_id"})
+LABEL_CATEGORIES: dict[str, LabelCategory] = {
+    **dict.fromkeys(RESERVED_LABELS, "reserved"),
+    **dict.fromkeys(GENERIC_LABELS, "generic"),
+    **dict.fromkeys(UNBOUNDED_LABELS, "unbounded"),
+}
+UNRESOLVED = object()
+
+
+class LabelHygieneError(Exception):
+    """Raised when authoritative inputs cannot be read or interpreted."""
+
+
+@dataclass(frozen=True)
+class LabelHygieneIssue:
+    """A protected source label that is not safely renamed or excluded."""
+
+    label: str
+    category: LabelCategory
+    metric_families: tuple[str, ...]
+    invalid_target: str | None = None
+
+
+@dataclass(frozen=True)
+class LabelHygieneResult:
+    """The complete label-hygiene verdict for one generated check."""
+
+    issues: tuple[LabelHygieneIssue, ...]
+    config_error: str | None = None
+
+    @property
+    def valid(self) -> bool:
+        return not self.issues and self.config_error is None
+
+    def failure_reason(self, check_path: Path) -> str | None:
+        """Render an actionable worker diagnostic, or ``None`` when validation passed."""
+        if self.valid:
+            return None
+
+        lines = ["OpenMetrics label hygiene validation failed."]
+        if self.config_error is not None:
+            lines.append(f"- Could not verify `{check_path}`: {self.config_error}")
+        for issue in self.issues:
+            families = ", ".join(f"`{name}`" for name in issue.metric_families)
+            if self.config_error is not None:
+                problem = "requires verifiable handling"
+            elif issue.invalid_target is None:
+                problem = "is not renamed or excluded"
+            else:
+                problem = f"is renamed to `{issue.invalid_target}`, which is also a protected label"
+            lines.append(f"- `{issue.label}` ({issue.category}) {problem}; exposed by metric families: {families}.")
+        lines.append(
+            "Handle every listed source label in `get_default_config()` using a product-specific "
+            "`rename_labels` target or `exclude_labels`."
+        )
+        return "\n".join(lines)
+
+
+def lint_label_hygiene(catalog_paths: Sequence[Path], check_path: Path) -> LabelHygieneResult:
+    """Compare protected catalog labels with the generated check's declarative handling."""
+    occurrences = _load_protected_label_occurrences(catalog_paths)
+    if not occurrences:
+        return LabelHygieneResult(issues=())
+
+    try:
+        rename_labels, exclude_labels = _extract_label_handling(check_path)
+    except LabelHygieneError as e:
+        return LabelHygieneResult(issues=_unhandled_issues(occurrences), config_error=str(e))
+
+    issues: list[LabelHygieneIssue] = []
+    for label, metric_families in sorted(occurrences.items()):
+        if label in exclude_labels:
+            continue
+        target = rename_labels.get(label)
+        if target is not None and target not in LABEL_CATEGORIES:
+            continue
+        issues.append(
+            LabelHygieneIssue(
+                label=label,
+                category=LABEL_CATEGORIES[label],
+                metric_families=tuple(sorted(metric_families)),
+                invalid_target=target,
+            )
+        )
+    return LabelHygieneResult(issues=tuple(issues))
+
+
+def _unhandled_issues(occurrences: dict[str, set[str]]) -> tuple[LabelHygieneIssue, ...]:
+    """Convert catalog occurrences into stable issues when config handling is unknown."""
+    return tuple(
+        LabelHygieneIssue(
+            label=label,
+            category=LABEL_CATEGORIES[label],
+            metric_families=tuple(sorted(metric_families)),
+        )
+        for label, metric_families in sorted(occurrences.items())
+    )
+
+
+def _load_protected_label_occurrences(catalog_paths: Sequence[Path]) -> dict[str, set[str]]:
+    """Collect protected labels and every metric family exposing them across all catalogs.
+
+    The first JSONL row is provenance rather than a metric and is skipped when both
+    ``name`` and ``label_keys`` are absent. Metric rows are validated strictly because
+    incomplete catalog data would make a passing hygiene verdict unreliable.
+    """
+    occurrences: dict[str, set[str]] = {}
+    for path in catalog_paths:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError as e:
+            raise LabelHygieneError(f"Failed to read metrics catalog {path}: {e}") from e
+
+        for line_number, line in enumerate(lines, start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as e:
+                raise LabelHygieneError(f"Invalid JSON in metrics catalog {path}:{line_number}: {e}") from e
+            if not isinstance(row, dict):
+                raise LabelHygieneError(f"Expected an object in metrics catalog {path}:{line_number}")
+
+            metric_name = row.get("name")
+            label_keys = row.get("label_keys")
+            if metric_name is None and label_keys is None:
+                continue
+            if (
+                not isinstance(metric_name, str)
+                or not isinstance(label_keys, list)
+                or not all(isinstance(label, str) for label in label_keys)
+            ):
+                raise LabelHygieneError(f"Invalid metric row in metrics catalog {path}:{line_number}")
+            for label in label_keys:
+                if label in LABEL_CATEGORIES:
+                    occurrences.setdefault(label, set()).add(metric_name)
+    return occurrences
+
+
+def _extract_label_handling(check_path: Path) -> tuple[dict[str, str], set[str]]:
+    """Statically read ``rename_labels`` and ``exclude_labels`` from the generated check.
+
+    Generated integration code is deliberately never imported or executed. Instead, the
+    method evaluates the limited declarative Python shapes supported by
+    ``_evaluate_static_value`` and rejects code whose effective configuration cannot be
+    proven from its syntax. It returns the source-to-target ``rename_labels`` mapping and
+    the set of source labels named by ``exclude_labels``, in that order.
+    """
+    try:
+        source = check_path.read_text(encoding="utf-8")
+    except FileNotFoundError as e:
+        raise LabelHygieneError(f"Generated check does not exist at the expected path: {check_path}") from e
+    except OSError as e:
+        raise LabelHygieneError(f"Failed to read generated check: {e}") from e
+    try:
+        module = ast.parse(source, filename=str(check_path))
+    except SyntaxError as e:
+        raise LabelHygieneError(f"Generated check is not valid Python: {e.msg} (line {e.lineno})") from e
+
+    function = next(
+        (node for node in ast.walk(module) if isinstance(node, ast.FunctionDef) and node.name == "get_default_config"),
+        None,
+    )
+    if function is None:
+        raise LabelHygieneError("`get_default_config()` is missing")
+
+    values = _collect_assignments(module.body)
+    return_index = -1
+    return_node: ast.Return | None = None
+    for index, statement in enumerate(function.body):
+        if isinstance(statement, ast.Return):
+            return_index = index
+            return_node = statement
+            break
+    if return_node is None or return_node.value is None:
+        raise LabelHygieneError("`get_default_config()` does not return a configuration dictionary")
+    values.update(_collect_assignments(function.body[:return_index]))
+
+    config = _evaluate_static_value(return_node.value, values, set())
+    if not isinstance(config, dict):
+        raise LabelHygieneError("`get_default_config()` must return a statically readable dictionary")
+
+    rename_labels = _string_mapping(config.get("rename_labels", {}), "rename_labels")
+    exclude_labels = _string_set(config.get("exclude_labels", ()), "exclude_labels")
+    return rename_labels, exclude_labels
+
+
+def _collect_assignments(statements: Sequence[ast.stmt]) -> dict[str, ast.expr]:
+    """Index simple name assignments for later static expression resolution."""
+    values: dict[str, ast.expr] = {}
+    for statement in statements:
+        if (
+            isinstance(statement, ast.Assign)
+            and len(statement.targets) == 1
+            and isinstance(statement.targets[0], ast.Name)
+        ):
+            values[statement.targets[0].id] = statement.value
+        elif (
+            isinstance(statement, ast.AnnAssign)
+            and isinstance(statement.target, ast.Name)
+            and statement.value is not None
+        ):
+            values[statement.target.id] = statement.value
+    return values
+
+
+def _evaluate_static_value(node: ast.expr, values: dict[str, ast.expr], resolving: set[str]) -> object:
+    """Evaluate safe declarative AST expressions without running generated code.
+
+    Supported forms cover literals, named constants, containers, dictionary unpacking
+    and union, ``dict(...)`` keyword construction, and dictionary ``copy()``. Unknown
+    expressions return ``UNRESOLVED``; ``resolving`` prevents cycles between names.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        if node.id in resolving or node.id not in values:
+            return UNRESOLVED
+        return _evaluate_static_value(values[node.id], values, {*resolving, node.id})
+    if isinstance(node, ast.Dict):
+        result: dict[object, object] = {}
+        for key_node, value_node in zip(node.keys, node.values, strict=True):
+            if key_node is None:
+                unpacked = _evaluate_static_value(value_node, values, resolving)
+                if not isinstance(unpacked, dict):
+                    return UNRESOLVED
+                result.update(unpacked)
+                continue
+            key = _evaluate_static_value(key_node, values, resolving)
+            if key is UNRESOLVED:
+                return UNRESOLVED
+            try:
+                result[key] = _evaluate_static_value(value_node, values, resolving)
+            except TypeError:
+                return UNRESOLVED
+        return result
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        items = [_evaluate_static_value(element, values, resolving) for element in node.elts]
+        if isinstance(node, ast.List):
+            return items
+        if isinstance(node, ast.Tuple):
+            return tuple(items)
+        try:
+            return set(items)
+        except TypeError:
+            return UNRESOLVED
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        left = _evaluate_static_value(node.left, values, resolving)
+        right = _evaluate_static_value(node.right, values, resolving)
+        if isinstance(left, dict) and isinstance(right, dict):
+            return left | right
+        return UNRESOLVED
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "dict" and not node.args:
+        if any(keyword.arg is None for keyword in node.keywords):
+            return UNRESOLVED
+        return {keyword.arg: _evaluate_static_value(keyword.value, values, resolving) for keyword in node.keywords}
+    if (
+        isinstance(node, ast.Call)
+        and not node.args
+        and not node.keywords
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "copy"
+    ):
+        copied = _evaluate_static_value(node.func.value, values, resolving)
+        return copied.copy() if isinstance(copied, dict) else UNRESOLVED
+    return UNRESOLVED
+
+
+def _string_mapping(value: object, name: str) -> dict[str, str]:
+    """Require a statically resolved string-to-string configuration mapping."""
+    if not isinstance(value, dict) or not all(
+        isinstance(key, str) and isinstance(item, str) for key, item in value.items()
+    ):
+        raise LabelHygieneError(f"`{name}` must be a statically readable string-to-string dictionary")
+    return cast(dict[str, str], value)
+
+
+def _string_set(value: object, name: str) -> set[str]:
+    """Require a statically resolved collection of string label names."""
+    if not isinstance(value, (list, tuple, set)) or not all(isinstance(item, str) for item in value):
+        raise LabelHygieneError(f"`{name}` must be a statically readable collection of strings")
+    return set(value)

--- a/ddev/src/ddev/ai/phases/resources.py
+++ b/ddev/src/ddev/ai/phases/resources.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from ddev.ai.config.models import AgentConfig
     from ddev.ai.react.factory import ReActProcessFactory
 
@@ -22,3 +24,6 @@ class PhaseResources(Protocol):
 
     @property
     def process_factory(self) -> ReActProcessFactory: ...
+
+    @property
+    def write_root(self) -> Path: ...

--- a/ddev/src/ddev/ai/runtime/resources.py
+++ b/ddev/src/ddev/ai/runtime/resources.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from functools import cached_property
+from pathlib import Path
 
 from ddev.ai.agent.build import AgentRuntimeFactory, AgentRuntimeFactoryProtocol
 from ddev.ai.agent.registry import AgentProviderRegistry
@@ -40,6 +41,11 @@ class RunResources:
             return self._agents[name]
         except KeyError as e:
             raise ResourceUnavailableError(f"No agent definition named {name!r}. Known: {sorted(self._agents)}") from e
+
+    @property
+    def write_root(self) -> Path:
+        """Return the root where phases and their agents may create integration artifacts."""
+        return self._file_access_policy.write_root
 
     @cached_property
     def agent_runtime_factory(self) -> AgentRuntimeFactoryProtocol:

--- a/ddev/tests/ai/phases/helpers.py
+++ b/ddev/tests/ai/phases/helpers.py
@@ -144,6 +144,7 @@ def make_agent_phase(
     agent_config: AgentConfig | None = None,
     resume_frontier: frozenset[str] = frozenset(),
     phase_cls: type[AgenticPhase] = AgenticPhase,
+    phase_kwargs: dict[str, Any] | None = None,
 ) -> tuple[AgenticPhase, CheckpointManager]:
     """Build an AgenticPhase ready for process_message-driven tests."""
     effective_agent_config = agent_config or make_agent_config(tools=[])
@@ -178,6 +179,7 @@ def make_agent_phase(
         context=context,
         agent_config=effective_agent_config,
         process_factory=process_factory,
+        **(phase_kwargs or {}),
     )
     phase.queue = message_queue
     return phase, checkpoint_manager

--- a/ddev/tests/ai/phases/openmetrics/test_build_integration.py
+++ b/ddev/tests/ai/phases/openmetrics/test_build_integration.py
@@ -1,0 +1,250 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import asyncio
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from ddev.ai.agent.build import AgentRuntime
+from ddev.ai.agent.types import AgentResponse, ToolResultMessage
+from ddev.ai.config.errors import ConfigError
+from ddev.ai.config.models import PhaseConfig, TaskConfig
+from ddev.ai.phases.messages import PhaseTrigger
+from ddev.ai.phases.openmetrics.build_integration import OpenMetricsBuildPhase
+from ddev.ai.phases.openmetrics.label_hygiene import LabelHygieneError
+from ddev.ai.runtime.checkpoints import (
+    CheckpointTokenInfo,
+    SuccessCheckpoint,
+    TaskValidationRecord,
+)
+from ddev.ai.tools.registry import ToolRegistry
+from tests.ai.phases.helpers import MockAgent, make_agent_phase, make_goal_verdict, make_response
+
+
+def make_config() -> PhaseConfig:
+    return PhaseConfig(
+        name="build_integration",
+        agent="writer",
+        tasks=[TaskConfig(name="write_code", prompt="Write code.", goal="Verify code.", max_validation_attempts=3)],
+    )
+
+
+@pytest.mark.parametrize(
+    ("task_names", "match"),
+    [([], "at least one task"), (["other"], "task named 'write_code'"), (["write_code", "write_code"], "exactly one")],
+)
+def test_requires_exactly_one_write_code_task(task_names: list[str], match: str) -> None:
+    config = PhaseConfig(
+        name="build_integration",
+        agent="writer",
+        tasks=[TaskConfig(name=name, prompt="x") for name in task_names],
+    )
+
+    with pytest.raises(ConfigError, match=match):
+        OpenMetricsBuildPhase.validate_config("build_integration", config)
+
+
+async def test_repairs_label_hygiene_before_single_model_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    message_queue: asyncio.Queue,
+) -> None:
+    catalog = tmp_path / "inspect_endpoint_api_metrics.jsonl"
+    catalog.write_text(
+        json.dumps({"endpoint_name": "api"})
+        + "\n"
+        + json.dumps({"name": "iris_system_info", "label_keys": ["host", "version"]})
+        + "\n",
+        encoding="utf-8",
+    )
+    check_path = tmp_path / "iris" / "datadog_checks" / "iris" / "check.py"
+    check_path.parent.mkdir(parents=True)
+    check_path.write_text(
+        "class IrisCheck:\n"
+        "    def get_default_config(self):\n"
+        "        return {'rename_labels': {'host': 'iris_host'}}\n",
+        encoding="utf-8",
+    )
+
+    class RepairingAgent(MockAgent):
+        async def send(
+            self,
+            content: str | list[ToolResultMessage],
+            allowed_tools: list[str] | None = None,
+        ) -> AgentResponse:
+            if len(self.send_calls) == 1:
+                check_path.write_text(
+                    "class IrisCheck:\n"
+                    "    def get_default_config(self):\n"
+                    "        return {'rename_labels': {'host': 'iris_host', 'version': 'iris_version'}}\n",
+                    encoding="utf-8",
+                )
+            return await super().send(content, allowed_tools)
+
+    worker = RepairingAgent(
+        [
+            make_response("initial implementation", 10, 5),
+            make_response("fixed version", 8, 4),
+            make_response("phase memory", 2, 1),
+        ]
+    )
+    reviewer = MockAgent([make_response(make_goal_verdict(True), 6, 3)])
+
+    def goal_runtime_builder(_owner_id: str) -> AgentRuntime:
+        return AgentRuntime(agent=reviewer, tool_registry=ToolRegistry([]))
+
+    phase, checkpoint_manager = make_agent_phase(
+        tmp_path,
+        worker,
+        monkeypatch,
+        message_queue,
+        phase_id="build_integration",
+        dependencies=["inspect_endpoint"],
+        tasks=make_config().tasks,
+        runtime_variables={"integration": "Iris"},
+        goal_runtime_builder=goal_runtime_builder,
+        phase_cls=OpenMetricsBuildPhase,
+        phase_kwargs={"write_root": tmp_path},
+    )
+    checkpoint_manager.write_phase_checkpoint(
+        "inspect_endpoint",
+        success_checkpoint(tmp_path, [{"metrics_jsonl_path": str(catalog)}]),
+    )
+
+    checks = phase.deterministic_checks(make_config().tasks[0], {"integration": "Iris"})
+    assert [check.name for check in checks] == ["label hygiene"]
+
+    await phase.process_message(PhaseTrigger(id="inspect-finished", phase_id="inspect_endpoint"))
+
+    checkpoint = checkpoint_manager.read()["build_integration"]
+    assert checkpoint.task_validations == [TaskValidationRecord(task="write_code", attempts=2, final_valid=True)]
+    assert len(reviewer.send_calls) == 1
+    repair_prompt = worker.send_calls[1]
+    assert isinstance(repair_prompt, str)
+    assert "Deterministic checks failed" in repair_prompt
+    assert "## label hygiene" in repair_prompt
+    assert "`version` (reserved) is not renamed or excluded" in repair_prompt
+    assert "`iris_system_info`" in repair_prompt
+
+
+def success_checkpoint(tmp_path: Path, endpoints: object) -> SuccessCheckpoint:
+    return SuccessCheckpoint(
+        started_at="2026-08-05T00:00:00+00:00",
+        finished_at="2026-08-05T00:00:01+00:00",
+        tokens=CheckpointTokenInfo(total_input=0, total_output=0),
+        memory_path=str(tmp_path / "inspect_endpoint_memory.md"),
+        phase_data={"endpoints": endpoints},
+    )
+
+
+def make_build_phase(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    message_queue: asyncio.Queue,
+) -> OpenMetricsBuildPhase:
+    phase, _ = make_agent_phase(
+        tmp_path,
+        MockAgent([]),
+        monkeypatch,
+        message_queue,
+        phase_id="build_integration",
+        tasks=make_config().tasks,
+        runtime_variables={"integration": "Iris"},
+        phase_cls=OpenMetricsBuildPhase,
+        phase_kwargs={"write_root": tmp_path},
+    )
+    return cast(OpenMetricsBuildPhase, phase)
+
+
+@pytest.mark.parametrize("integration", [None, 123, "!!!"])
+def test_invalid_integration_aborts_label_hygiene_check(
+    integration: object,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    message_queue: asyncio.Queue,
+) -> None:
+    phase = make_build_phase(tmp_path, monkeypatch, message_queue)
+
+    with pytest.raises(ConfigError, match="integration"):
+        phase._check_label_hygiene({"integration": integration})
+
+
+@pytest.mark.parametrize(
+    ("context", "match"),
+    [
+        ({}, "does not contain checkpoints"),
+        ({"checkpoints": {}}, "Successful 'inspect_endpoint' checkpoint is required"),
+    ],
+)
+def test_invalid_checkpoint_context_aborts_label_hygiene_check(
+    context: dict[str, object],
+    match: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    message_queue: asyncio.Queue,
+) -> None:
+    phase = make_build_phase(tmp_path, monkeypatch, message_queue)
+
+    with pytest.raises(LabelHygieneError, match=match):
+        phase._catalog_paths(context)
+
+
+@pytest.mark.parametrize(
+    ("endpoints", "match"),
+    [([], "no endpoint catalogs"), ([{}], "invalid endpoint catalog entry")],
+)
+def test_invalid_endpoint_catalogs_abort_label_hygiene_check(
+    endpoints: object,
+    match: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    message_queue: asyncio.Queue,
+) -> None:
+    phase = make_build_phase(tmp_path, monkeypatch, message_queue)
+    context = {"checkpoints": {"inspect_endpoint": success_checkpoint(tmp_path, endpoints)}}
+
+    with pytest.raises(LabelHygieneError, match=match):
+        phase._catalog_paths(context)
+
+
+def test_misnamed_generated_check_aborts_instead_of_retrying(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    message_queue: asyncio.Queue,
+) -> None:
+    catalog = tmp_path / "metrics.jsonl"
+    catalog.write_text(json.dumps({"name": "metric", "label_keys": ["host"]}), encoding="utf-8")
+    misplaced = tmp_path / "iris_db_" / "datadog_checks" / "iris_db_" / "check.py"
+    misplaced.parent.mkdir(parents=True)
+    misplaced.write_text("", encoding="utf-8")
+    phase = make_build_phase(tmp_path, monkeypatch, message_queue)
+    context = {
+        "integration": "Iris DB!",
+        "checkpoints": {"inspect_endpoint": success_checkpoint(tmp_path, [{"metrics_jsonl_path": str(catalog)}])},
+    }
+
+    with pytest.raises(LabelHygieneError, match="scaffolded integration name does not match"):
+        phase._check_label_hygiene(context)
+
+
+def test_missing_generated_check_is_repairable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    message_queue: asyncio.Queue,
+) -> None:
+    catalog = tmp_path / "metrics.jsonl"
+    catalog.write_text(json.dumps({"name": "metric", "label_keys": ["host"]}), encoding="utf-8")
+    phase = make_build_phase(tmp_path, monkeypatch, message_queue)
+    context = {
+        "integration": "Iris",
+        "checkpoints": {"inspect_endpoint": success_checkpoint(tmp_path, [{"metrics_jsonl_path": str(catalog)}])},
+    }
+
+    reason = phase._check_label_hygiene(context)
+
+    assert reason is not None
+    assert "does not exist at the expected path" in reason

--- a/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
+++ b/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
@@ -738,6 +738,7 @@ def test_normalize_endpoint_name_variants():
     assert normalize_endpoint_name("App Controller") == "app_controller"
     assert normalize_endpoint_name("api-server") == "api_server"
     assert normalize_endpoint_name("  Mixed_Case  ") == "mixed_case"
+    assert normalize_endpoint_name("Iris DB!") == "iris_db"
     assert normalize_endpoint_name("foo123") == "foo123"
 
 

--- a/ddev/tests/ai/phases/openmetrics/test_label_hygiene.py
+++ b/ddev/tests/ai/phases/openmetrics/test_label_hygiene.py
@@ -1,0 +1,154 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ddev.ai.phases.openmetrics.label_hygiene import LabelHygieneError, lint_label_hygiene
+
+
+def write_catalog(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text(
+        "\n".join(
+            json.dumps(row)
+            for row in [
+                {"endpoint_name": "api", "endpoint_url": "http://example.test", "exposition_format": "prometheus"},
+                *rows,
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_check(path: Path, default_config: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        f"class ExampleCheck:\n    def get_default_config(self):\n        return {default_config!r}\n",
+        encoding="utf-8",
+    )
+
+
+def test_reports_reserved_generic_and_unbounded_labels_with_metric_provenance(tmp_path: Path) -> None:
+    catalog = tmp_path / "inspect_endpoint_api_metrics.jsonl"
+    check = tmp_path / "example" / "check.py"
+    write_catalog(
+        catalog,
+        [
+            {"name": "iris_system_info", "label_keys": ["version", "host"]},
+            {"name": "request_state", "label_keys": ["status", "request_id"]},
+            {"name": "another_info", "label_keys": ["version"]},
+        ],
+    )
+    write_check(check, {"rename_labels": {"host": "iris_host"}})
+
+    result = lint_label_hygiene([catalog], check)
+    reason = result.failure_reason(check)
+
+    assert not result.valid
+    assert reason is not None
+    assert "`version` (reserved) is not renamed or excluded" in reason
+    assert "`iris_system_info`, `another_info`" not in reason
+    assert "`another_info`, `iris_system_info`" in reason
+    assert "`status` (generic)" in reason
+    assert "`request_id` (unbounded)" in reason
+    assert "`host`" not in reason
+
+
+def test_accepts_product_specific_renames_and_exclusions(tmp_path: Path) -> None:
+    catalog = tmp_path / "inspect_endpoint_api_metrics.jsonl"
+    check = tmp_path / "example" / "check.py"
+    write_catalog(
+        catalog,
+        [{"name": "iris_system_info", "label_keys": ["version", "host", "status", "trace_id"]}],
+    )
+    check.parent.mkdir(parents=True)
+    check.write_text(
+        "RENAMES = {'version': 'iris_version'}\n"
+        "BASE = {'host': 'iris_host'}\n"
+        "class ExampleCheck:\n"
+        "    def get_default_config(self):\n"
+        "        rename_labels = BASE | RENAMES\n"
+        "        return dict(rename_labels=rename_labels, exclude_labels=['status', 'trace_id'])\n",
+        encoding="utf-8",
+    )
+
+    result = lint_label_hygiene([catalog], check)
+
+    assert result.valid
+    assert result.failure_reason(check) is None
+
+
+def test_rejects_rename_to_another_protected_label(tmp_path: Path) -> None:
+    catalog = tmp_path / "inspect_endpoint_api_metrics.jsonl"
+    check = tmp_path / "example" / "check.py"
+    write_catalog(catalog, [{"name": "iris_system_info", "label_keys": ["version"]}])
+    write_check(check, {"rename_labels": {"version": "status"}})
+
+    result = lint_label_hygiene([catalog], check)
+
+    assert not result.valid
+    assert result.issues[0].invalid_target == "status"
+    assert "also a protected label" in result.failure_reason(check)
+
+
+def test_passes_without_reading_check_when_catalog_has_no_protected_labels(tmp_path: Path) -> None:
+    catalog = tmp_path / "inspect_endpoint_api_metrics.jsonl"
+    missing_check = tmp_path / "missing.py"
+    write_catalog(catalog, [{"name": "requests", "label_keys": ["method", "route"]}])
+
+    result = lint_label_hygiene([catalog], missing_check)
+
+    assert result.valid
+
+
+def test_reports_configuration_that_cannot_be_statically_verified(tmp_path: Path) -> None:
+    catalog = tmp_path / "inspect_endpoint_api_metrics.jsonl"
+    check = tmp_path / "example" / "check.py"
+    write_catalog(catalog, [{"name": "iris_system_info", "label_keys": ["version"]}])
+    check.parent.mkdir(parents=True)
+    check.write_text(
+        "class ExampleCheck:\n    def get_default_config(self):\n        return build_config()\n",
+        encoding="utf-8",
+    )
+
+    result = lint_label_hygiene([catalog], check)
+
+    assert not result.valid
+    assert result.config_error is not None
+    assert "statically readable dictionary" in result.config_error
+    reason = result.failure_reason(check)
+    assert reason is not None
+    assert "`version` (reserved) requires verifiable handling" in reason
+    assert "`iris_system_info`" in reason
+
+
+@pytest.mark.parametrize(
+    "config_expression",
+    ["{['unhashable']: 1}", "{'rename_labels': {{'host': 'iris_host'}}}"],
+)
+def test_unhashable_static_values_are_unverifiable_instead_of_crashing(
+    config_expression: str,
+    tmp_path: Path,
+) -> None:
+    catalog = tmp_path / "metrics.jsonl"
+    check = tmp_path / "check.py"
+    write_catalog(catalog, [{"name": "metric", "label_keys": ["host"]}])
+    check.write_text(f"def get_default_config():\n    return {config_expression}\n", encoding="utf-8")
+
+    result = lint_label_hygiene([catalog], check)
+
+    assert not result.valid
+    assert result.config_error is not None
+    assert "statically readable" in result.config_error
+
+
+def test_rejects_malformed_catalog(tmp_path: Path) -> None:
+    catalog = tmp_path / "inspect_endpoint_api_metrics.jsonl"
+    catalog.write_text('{"name": "broken"\n', encoding="utf-8")
+
+    with pytest.raises(LabelHygieneError, match="Invalid JSON"):
+        lint_label_hygiene([catalog], tmp_path / "check.py")

--- a/ddev/tests/ai/phases/test_registry.py
+++ b/ddev/tests/ai/phases/test_registry.py
@@ -114,6 +114,7 @@ def test_register_from_discovers_subpackage_phases():
     names = registry.known_names()
     assert "AgenticPhase" in names
     assert "InspectEndpointPhase" in names
+    assert "OpenMetricsBuildPhase" in names
     assert registry.import_errors == {}
 
 


### PR DESCRIPTION
> This is PR 2 of 3 in a stacked series: 
> 1. #24777 (reusable validation framework)
> 2. #24778 (OpenMetrics label-hygiene validation)  **<- you are here**
> 3. #24788 (Adds TUI feedback for deterministic checks)

### What does this PR do?

Adds the OpenMetrics-specific deterministic validation built on #24777.

- Introduces `OpenMetricsBuildPhase`, which composes a label-hygiene check into the `write_code` task.
- Reads label names from the metric catalogs produced by `inspect_endpoint`.
- Statically inspects the generated check's `get_default_config()` without importing or executing generated code.
- Requires reserved, generic, and unbounded source labels to be renamed to product-specific labels or explicitly excluded.
- Reports every violation together with the metric families that expose it, so the worker can repair all findings in one attempt.
- Keeps `phase2_code_goal` in place: deterministic validation runs first, and the existing LLM reviewer runs only after it passes.
- Wires the phase to the configured artifact write root and selects it only for `build_integration`.
- Tweaks the prompt of the agents to specify that the integration name must be trimmed.

### Motivation

[AI-7081](https://datadoghq.atlassian.net/browse/AI-7081) records a seven-minute round trip after `build_integration` renamed `host` and `status` but missed the reserved `version` label exposed by `iris_system_info`. The metric catalog already contained enough information to detect the miss immediately.

This PR turns that known policy into a local deterministic check, preserving model review for semantic validation while avoiding a costly reviewer call for mechanically detectable label violations.

Scoped tests cover reserved, generic, and unbounded labels; valid renames and exclusions; protected rename targets; malformed catalogs; statically unverifiable configuration; composed repair before model review; phase discovery; and core-flow configuration. The focused suite passed 21 tests, the mocked demo repairs the issue in two attempts with zero reviewer calls, and Ruff plus mypy pass.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7081]: https://datadoghq.atlassian.net/browse/AI-7081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ