### PR TITLE
Add multiple Kubernetes port forwarding

### DIFF
--- a/datadog_checks_dev/changelog.d/24786.added
+++ b/datadog_checks_dev/changelog.d/24786.added
@@ -1,0 +1,1 @@
+Add support for starting multiple Kubernetes port forwards with distinct local ports.

--- a/datadog_checks_dev/datadog_checks/dev/kube_port_forward.py
+++ b/datadog_checks_dev/datadog_checks/dev/kube_port_forward.py
@@ -4,15 +4,26 @@
 from __future__ import absolute_import
 
 import os
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
+from typing import Iterator
 
+from .conditions import WaitForPortListening
 from .env import environment_run
 from .fs import chdir
 from .ssh_tunnel import KillProcess, run_background_command
 from .structures import LazyFunction, TempDir
-from .utils import find_free_port, get_ip
+from .utils import find_free_port, find_free_ports, get_ip
 
 PID_FILE = 'kubectl.pid'
+
+
+@dataclass(frozen=True)
+class PortForwardConfig:
+    namespace: str
+    remote_port: int
+    resource: str
+    resource_name: str
 
 
 def _build_temp_key(namespace, deployment, remote_port):
@@ -20,9 +31,16 @@ def _build_temp_key(namespace, deployment, remote_port):
 
 
 @contextmanager
-def port_forward(kubeconfig, namespace, remote_port, resource, resource_name):
+def port_forward(
+    kubeconfig: str,
+    namespace: str,
+    remote_port: int,
+    resource: str,
+    resource_name: str,
+    local_port: int | None = None,
+) -> Iterator[tuple[str, int]]:
     """Use `kubectl` to forward a remote port locally."""
-    set_up = PortForwardUp(kubeconfig, namespace, remote_port, resource, resource_name)
+    set_up = PortForwardUp(kubeconfig, namespace, remote_port, resource, resource_name, local_port)
     key = _build_temp_key(namespace, resource_name, remote_port)
     tear_down = KillProcess(key, PID_FILE)
 
@@ -30,15 +48,47 @@ def port_forward(kubeconfig, namespace, remote_port, resource, resource_name):
         yield result
 
 
+@contextmanager
+def multiple_port_forward(kubeconfig: str, configs: list[PortForwardConfig]) -> Iterator[list[tuple[str, int]]]:
+    """Forward multiple remote ports to distinct local ports."""
+    ip = get_ip()
+    local_ports = find_free_ports(ip, len(configs))
+
+    with ExitStack() as stack:
+        forwards = [
+            stack.enter_context(
+                port_forward(
+                    kubeconfig,
+                    config.namespace,
+                    config.remote_port,
+                    config.resource,
+                    config.resource_name,
+                    local_port,
+                )
+            )
+            for config, local_port in zip(configs, local_ports, strict=True)
+        ]
+        yield forwards
+
+
 class PortForwardUp(LazyFunction):
     """Setup `kubectl port-forward`."""
 
-    def __init__(self, kubeconfig, namespace, remote_port, resource, resource_name):
+    def __init__(
+        self,
+        kubeconfig: str,
+        namespace: str,
+        remote_port: int,
+        resource: str,
+        resource_name: str,
+        local_port: int | None = None,
+    ) -> None:
         self.kubeconfig = kubeconfig
         self.namespace = namespace
         self.remote_port = remote_port
         self.resource = resource
         self.resource_name = resource_name
+        self.local_port = local_port
 
     def __call__(self):
         key = _build_temp_key(self.namespace, self.resource_name, self.remote_port)
@@ -46,7 +96,7 @@ class PortForwardUp(LazyFunction):
             # Run in the temp dir to put kube cache files there
             with chdir(temp_dir):
                 ip = get_ip()
-                local_port = find_free_port(ip)
+                local_port = self.local_port if self.local_port is not None else find_free_port(ip)
                 command = [
                     'kubectl',
                     'port-forward',
@@ -61,4 +111,5 @@ class PortForwardUp(LazyFunction):
                 env = os.environ.copy()
                 env['KUBECONFIG'] = self.kubeconfig
                 run_background_command(command, os.path.join(temp_dir, PID_FILE), env=env)
+                WaitForPortListening(ip, local_port)()
                 return ip, local_port

--- a/datadog_checks_dev/tests/test_kube_port_forward.py
+++ b/datadog_checks_dev/tests/test_kube_port_forward.py
@@ -1,0 +1,77 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+from contextlib import contextmanager
+
+import pytest
+
+from datadog_checks.dev import kube_port_forward
+from datadog_checks.dev.kube_port_forward import PortForwardConfig, PortForwardUp, multiple_port_forward
+
+
+@pytest.mark.parametrize('local_port', [None, 49152], ids=['allocated', 'provided'])
+def test_port_forward_up(mocker, local_port):
+    ip = '192.0.2.1'
+    allocated_port = 49153
+    expected_port = allocated_port if local_port is None else local_port
+    mocker.patch.object(kube_port_forward, 'get_ip', return_value=ip)
+    find_free_port = mocker.patch.object(kube_port_forward, 'find_free_port', return_value=allocated_port)
+    run_background_command = mocker.patch.object(kube_port_forward, 'run_background_command')
+    wait = mocker.patch.object(kube_port_forward, 'WaitForPortListening')
+
+    result = PortForwardUp('kubeconfig', 'namespace', 8080, 'service', 'api', local_port)()
+
+    assert result == (ip, expected_port)
+    if local_port is None:
+        find_free_port.assert_called_once_with(ip)
+    else:
+        find_free_port.assert_not_called()
+
+    command, pid_file = run_background_command.call_args.args
+    assert command == [
+        'kubectl',
+        'port-forward',
+        '--address',
+        f'localhost,{ip}',
+        '--namespace',
+        'namespace',
+        'service/api',
+        f'{expected_port}:8080',
+    ]
+    assert os.path.basename(pid_file) == kube_port_forward.PID_FILE
+    assert run_background_command.call_args.kwargs['env']['KUBECONFIG'] == 'kubeconfig'
+    wait.assert_called_once_with(ip, expected_port)
+    wait.return_value.assert_called_once_with()
+
+
+def test_multiple_port_forward(mocker):
+    ip = '192.0.2.1'
+    local_ports = [49152, 49153]
+    configs = [
+        PortForwardConfig('namespace', 2112, 'statefulset', 'weaviate'),
+        PortForwardConfig('namespace', 8080, 'statefulset', 'weaviate'),
+    ]
+    stopped = []
+
+    mocker.patch.object(kube_port_forward, 'get_ip', return_value=ip)
+    find_free_ports = mocker.patch.object(kube_port_forward, 'find_free_ports', return_value=local_ports)
+
+    @contextmanager
+    def port_forward(kubeconfig, namespace, remote_port, resource, resource_name, local_port):
+        assert kubeconfig == 'kubeconfig'
+        yield ip, local_port
+        stopped.append(local_port)
+
+    mocker.patch.object(kube_port_forward, 'port_forward', side_effect=port_forward)
+
+    with multiple_port_forward('kubeconfig', configs) as forwards:
+        assert forwards == [(ip, 49152), (ip, 49153)]
+        assert stopped == []
+
+    find_free_ports.assert_called_once_with(ip, 2)
+    assert kube_port_forward.port_forward.call_args_list == [
+        mocker.call('kubeconfig', 'namespace', 2112, 'statefulset', 'weaviate', 49152),
+        mocker.call('kubeconfig', 'namespace', 8080, 'statefulset', 'weaviate', 49153),
+    ]
+    assert stopped == [49153, 49152]


### PR DESCRIPTION
### What does this PR do?
Adds a `PortForwardConfig` model and a `multiple_port_forward` context manager to `datadog-checks-dev`. The helper allocates distinct local ports in one call, starts each forward, waits until every local listener is ready, and cleans them up together.

The existing `port_forward` helper now accepts an optional local port and waits for `kubectl` to bind it before yielding. #24787 uses the new API for the Weaviate test environment.

### Motivation
Back-to-back `port_forward` calls can select the same local port before the first `kubectl` process binds it. This caused the Weaviate metrics and API forwards to collide in [this CI run](https://github.com/DataDog/integrations-core/actions/runs/31006723258/job/92308512887).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label, and it will automatically open a backport PR once this one is merged
