### PR TITLE
Add TUI feedback for validations

### DIFF
--- a/ddev/src/ddev/ai/callbacks/callbacks.py
+++ b/ddev/src/ddev/ai/callbacks/callbacks.py
@@ -6,6 +6,7 @@ from typing import Any, Protocol
 
 from ddev.ai.agent.scope import AgentScope
 from ddev.ai.agent.types import AgentResponse, ToolCall
+from ddev.ai.phases.messages import TaskValidationStatus
 from ddev.ai.react.types import ReActResult
 from ddev.ai.tools.core.types import ToolResult
 
@@ -107,9 +108,16 @@ class OnBeforeTaskValidationCallback(Protocol):
 
 
 class OnAfterTaskValidationCallback(Protocol):
-    """Called after each validation attempt, with its verdict."""
+    """Called after each validation attempt, with its status."""
 
-    async def __call__(self, phase_id: str, task_name: str, attempt: int, valid: bool, reason: str) -> None: ...
+    async def __call__(
+        self,
+        phase_id: str,
+        task_name: str,
+        attempt: int,
+        status: TaskValidationStatus,
+        reason: str,
+    ) -> None: ...
 
 
 # ---------------------------------------------------------------------------
@@ -260,9 +268,14 @@ class CallbackSet:
         return func
 
     async def fire_after_task_validation(
-        self, phase_id: str, task_name: str, attempt: int, valid: bool, reason: str
+        self,
+        phase_id: str,
+        task_name: str,
+        attempt: int,
+        status: TaskValidationStatus,
+        reason: str,
     ) -> None:
-        await self._fire(self._on_after_task_validation, phase_id, task_name, attempt, valid, reason)
+        await self._fire(self._on_after_task_validation, phase_id, task_name, attempt, status, reason)
 
 
 class Callbacks:
@@ -332,7 +345,12 @@ class Callbacks:
             await s.fire_before_task_validation(phase_id, task_name, attempt)
 
     async def fire_after_task_validation(
-        self, phase_id: str, task_name: str, attempt: int, valid: bool, reason: str
+        self,
+        phase_id: str,
+        task_name: str,
+        attempt: int,
+        status: TaskValidationStatus,
+        reason: str,
     ) -> None:
         for s in self._sets:
-            await s.fire_after_task_validation(phase_id, task_name, attempt, valid, reason)
+            await s.fire_after_task_validation(phase_id, task_name, attempt, status, reason)

--- a/ddev/src/ddev/ai/callbacks/callbacks.py
+++ b/ddev/src/ddev/ai/callbacks/callbacks.py
@@ -100,14 +100,14 @@ class OnRunErrorCallback(Protocol):
     async def __call__(self) -> None: ...
 
 
-class OnBeforeGoalCheckCallback(Protocol):
-    """Called immediately before each reviewer agent run for a task with a goal."""
+class OnBeforeTaskValidationCallback(Protocol):
+    """Called immediately before each validation attempt for a task."""
 
     async def __call__(self, phase_id: str, task_name: str, attempt: int) -> None: ...
 
 
-class OnAfterGoalCheckCallback(Protocol):
-    """Called after each reviewer agent run, with the parsed verdict."""
+class OnAfterTaskValidationCallback(Protocol):
+    """Called after each validation attempt, with its verdict."""
 
     async def __call__(self, phase_id: str, task_name: str, attempt: int, valid: bool, reason: str) -> None: ...
 
@@ -147,8 +147,8 @@ class CallbackSet:
         self._on_phase_finish: list[OnPhaseFinishCallback] = []
         self._on_phase_error: list[OnPhaseErrorCallback] = []
         self._on_run_error: list[OnRunErrorCallback] = []
-        self._on_before_goal_check: list[OnBeforeGoalCheckCallback] = []
-        self._on_after_goal_check: list[OnAfterGoalCheckCallback] = []
+        self._on_before_task_validation: list[OnBeforeTaskValidationCallback] = []
+        self._on_after_task_validation: list[OnAfterTaskValidationCallback] = []
 
     async def _fire(self, handlers: list[Any], *args: Any) -> None:
         for handler in handlers:
@@ -248,21 +248,21 @@ class CallbackSet:
     async def fire_run_error(self) -> None:
         await self._fire(self._on_run_error)
 
-    def on_before_goal_check(self, func: OnBeforeGoalCheckCallback) -> OnBeforeGoalCheckCallback:
-        self._on_before_goal_check.append(func)
+    def on_before_task_validation(self, func: OnBeforeTaskValidationCallback) -> OnBeforeTaskValidationCallback:
+        self._on_before_task_validation.append(func)
         return func
 
-    async def fire_before_goal_check(self, phase_id: str, task_name: str, attempt: int) -> None:
-        await self._fire(self._on_before_goal_check, phase_id, task_name, attempt)
+    async def fire_before_task_validation(self, phase_id: str, task_name: str, attempt: int) -> None:
+        await self._fire(self._on_before_task_validation, phase_id, task_name, attempt)
 
-    def on_after_goal_check(self, func: OnAfterGoalCheckCallback) -> OnAfterGoalCheckCallback:
-        self._on_after_goal_check.append(func)
+    def on_after_task_validation(self, func: OnAfterTaskValidationCallback) -> OnAfterTaskValidationCallback:
+        self._on_after_task_validation.append(func)
         return func
 
-    async def fire_after_goal_check(
+    async def fire_after_task_validation(
         self, phase_id: str, task_name: str, attempt: int, valid: bool, reason: str
     ) -> None:
-        await self._fire(self._on_after_goal_check, phase_id, task_name, attempt, valid, reason)
+        await self._fire(self._on_after_task_validation, phase_id, task_name, attempt, valid, reason)
 
 
 class Callbacks:
@@ -327,12 +327,12 @@ class Callbacks:
         for s in self._sets:
             await s.fire_run_error()
 
-    async def fire_before_goal_check(self, phase_id: str, task_name: str, attempt: int) -> None:
+    async def fire_before_task_validation(self, phase_id: str, task_name: str, attempt: int) -> None:
         for s in self._sets:
-            await s.fire_before_goal_check(phase_id, task_name, attempt)
+            await s.fire_before_task_validation(phase_id, task_name, attempt)
 
-    async def fire_after_goal_check(
+    async def fire_after_task_validation(
         self, phase_id: str, task_name: str, attempt: int, valid: bool, reason: str
     ) -> None:
         for s in self._sets:
-            await s.fire_after_goal_check(phase_id, task_name, attempt, valid, reason)
+            await s.fire_after_task_validation(phase_id, task_name, attempt, valid, reason)

--- a/ddev/src/ddev/ai/phases/goal.py
+++ b/ddev/src/ddev/ai/phases/goal.py
@@ -454,11 +454,13 @@ async def run_validation_loop(
     try:
         while True:
             attempts += 1
+            await callbacks.fire_before_task_validation(phase_id, task.name, attempts)
             failure_reason = run_deterministic_checks(deterministic_checks).failure_reason()
             reviewer_feedback: tuple[str, str] | None = None
 
             if failure_reason is None:
                 if goal_text is None:
+                    await callbacks.fire_after_task_validation(phase_id, task.name, attempts, True, "")
                     return ValidationLoopOutcome(
                         final_result=worker_result,
                         attempts=attempts,
@@ -483,19 +485,12 @@ async def run_validation_loop(
                 if needs_reset:
                     await reviewer_process.reset()
 
-                await callbacks.fire_before_goal_check(phase_id, task.name, attempts)
                 reviewer_result = await _run_reviewer_once(reviewer_process, user_message)
                 previous_check = reviewer_result
                 total_in += reviewer_result.input_tokens
                 total_out += reviewer_result.output_tokens
-                await callbacks.fire_after_goal_check(
-                    phase_id,
-                    task.name,
-                    attempts,
-                    reviewer_result.valid,
-                    reviewer_result.reason,
-                )
                 if reviewer_result.valid:
+                    await callbacks.fire_after_task_validation(phase_id, task.name, attempts, True, "")
                     return ValidationLoopOutcome(
                         final_result=worker_result,
                         attempts=attempts,
@@ -505,6 +500,7 @@ async def run_validation_loop(
                 failure_reason = reviewer_result.reason
                 reviewer_feedback = (goal_text, reviewer_result.verdict_json)
 
+            await callbacks.fire_after_task_validation(phase_id, task.name, attempts, False, failure_reason)
             if attempts >= task.max_validation_attempts:
                 raise ValidationAttemptsExhausted(
                     f"Task {task.name!r} failed validation after "

--- a/ddev/src/ddev/ai/phases/goal.py
+++ b/ddev/src/ddev/ai/phases/goal.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.config.models import AgentConfig, TaskConfig
+from ddev.ai.phases.messages import TaskValidationStatus
 from ddev.ai.react.factory import ReActProcessFactory
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.react.types import ReActResult
@@ -451,6 +452,21 @@ async def run_validation_loop(
     reviewer_process: ReActProcess | None = None
     previous_check: ReviewerCheckResult | None = None
 
+    async def _succeed() -> ValidationLoopOutcome:
+        await callbacks.fire_after_task_validation(
+            phase_id,
+            task.name,
+            attempts,
+            TaskValidationStatus.PASSED,
+            "",
+        )
+        return ValidationLoopOutcome(
+            final_result=worker_result,
+            attempts=attempts,
+            total_input_tokens=total_in,
+            total_output_tokens=total_out,
+        )
+
     try:
         while True:
             attempts += 1
@@ -460,13 +476,7 @@ async def run_validation_loop(
 
             if failure_reason is None:
                 if goal_text is None:
-                    await callbacks.fire_after_task_validation(phase_id, task.name, attempts, True, "")
-                    return ValidationLoopOutcome(
-                        final_result=worker_result,
-                        attempts=attempts,
-                        total_input_tokens=total_in,
-                        total_output_tokens=total_out,
-                    )
+                    return await _succeed()
                 if reviewer_process is None:
                     reviewer_process = build_reviewer_process(
                         task=task,
@@ -490,18 +500,23 @@ async def run_validation_loop(
                 total_in += reviewer_result.input_tokens
                 total_out += reviewer_result.output_tokens
                 if reviewer_result.valid:
-                    await callbacks.fire_after_task_validation(phase_id, task.name, attempts, True, "")
-                    return ValidationLoopOutcome(
-                        final_result=worker_result,
-                        attempts=attempts,
-                        total_input_tokens=total_in,
-                        total_output_tokens=total_out,
-                    )
+                    return await _succeed()
                 failure_reason = reviewer_result.reason
                 reviewer_feedback = (goal_text, reviewer_result.verdict_json)
 
-            await callbacks.fire_after_task_validation(phase_id, task.name, attempts, False, failure_reason)
-            if attempts >= task.max_validation_attempts:
+            validation_status = (
+                TaskValidationStatus.RETRYING
+                if attempts < task.max_validation_attempts
+                else TaskValidationStatus.FAILED
+            )
+            await callbacks.fire_after_task_validation(
+                phase_id,
+                task.name,
+                attempts,
+                validation_status,
+                failure_reason,
+            )
+            if validation_status is TaskValidationStatus.FAILED:
                 raise ValidationAttemptsExhausted(
                     f"Task {task.name!r} failed validation after "
                     f"{attempts} attempts. Last validation reason: {failure_reason}"

--- a/ddev/src/ddev/ai/phases/messages.py
+++ b/ddev/src/ddev/ai/phases/messages.py
@@ -3,8 +3,18 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 from dataclasses import dataclass
+from enum import Enum, auto
 
 from ddev.event_bus.orchestrator import BaseMessage
+
+
+class TaskValidationStatus(Enum):
+    """Status of a task validation attempt."""
+
+    VALIDATING = auto()
+    PASSED = auto()
+    RETRYING = auto()
+    FAILED = auto()
 
 
 @dataclass

--- a/ddev/src/ddev/cli/meta/ai/rendering.py
+++ b/ddev/src/ddev/cli/meta/ai/rendering.py
@@ -312,7 +312,8 @@ def render_task_validation_line(
     line.append(label, style=f"bold {color}")
     line.append(f" · {task_name} · attempt {attempt}", style="dim")
     if reason:
-        line.append(f"\n    {reason}", style="dim")
+        indented_reason = textwrap.indent(reason, "    ")
+        line.append(f"\n{indented_reason}", style="dim")
     return line
 
 

--- a/ddev/src/ddev/cli/meta/ai/rendering.py
+++ b/ddev/src/ddev/cli/meta/ai/rendering.py
@@ -29,6 +29,7 @@ from ddev.cli.meta.ai.palette import (
     STATUS_RUNNING,
     TOOL_CALL,
     TOOL_SEARCH,
+    WARNING,
 )
 
 if TYPE_CHECKING:
@@ -280,6 +281,27 @@ def render_compact_notice() -> Text:
 def render_context_cleared_notice() -> Text:
     """Build the context-cleared notice line."""
     return Text("  ↻ context cleared", style="dim")
+
+
+def render_task_validation_line(task_name: str, attempt: int, valid: bool | None, reason: str = "") -> Text:
+    """Build a validation progress line without presenting retries as terminal failures."""
+    if valid is None:
+        line = Text("  ◆ ", style=STATUS_RUNNING)
+        label = "validating"
+        color = STATUS_RUNNING
+    elif valid:
+        line = Text("  ✓ ", style=STATUS_DONE)
+        label = "validation passed"
+        color = STATUS_DONE
+    else:
+        line = Text("  ↻ ", style=WARNING)
+        label = "repair requested"
+        color = WARNING
+    line.append(label, style=f"bold {color}")
+    line.append(f" · {task_name} · attempt {attempt}", style="dim")
+    if reason:
+        line.append(f"\n    {reason}", style="dim")
+    return line
 
 
 def render_agent_finish_line(scope: AgentScope, result: ReActResult) -> Text:

--- a/ddev/src/ddev/cli/meta/ai/rendering.py
+++ b/ddev/src/ddev/cli/meta/ai/rendering.py
@@ -12,7 +12,7 @@ visual output across phase logs.
 from __future__ import annotations
 
 import textwrap
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, assert_never
 
 from rich.markdown import Markdown, TableElement
 from rich.panel import Panel
@@ -20,6 +20,7 @@ from rich.text import Text
 
 from ddev.ai.agent.exceptions import describe_agent_error
 from ddev.ai.agent.scope import AgentRole
+from ddev.ai.phases.messages import TaskValidationStatus
 from ddev.cli.meta.ai.palette import (
     ERROR,
     ROLE_GOAL_REVIEWER,
@@ -283,20 +284,31 @@ def render_context_cleared_notice() -> Text:
     return Text("  ↻ context cleared", style="dim")
 
 
-def render_task_validation_line(task_name: str, attempt: int, valid: bool | None, reason: str = "") -> Text:
-    """Build a validation progress line without presenting retries as terminal failures."""
-    if valid is None:
+def render_task_validation_line(
+    task_name: str,
+    attempt: int,
+    status: TaskValidationStatus,
+    reason: str = "",
+) -> Text:
+    """Build a ``◆/✓/↻/✗ <status> · <task> · attempt N`` validation line."""
+    if status is TaskValidationStatus.VALIDATING:
         line = Text("  ◆ ", style=STATUS_RUNNING)
         label = "validating"
         color = STATUS_RUNNING
-    elif valid:
+    elif status is TaskValidationStatus.PASSED:
         line = Text("  ✓ ", style=STATUS_DONE)
         label = "validation passed"
         color = STATUS_DONE
-    else:
+    elif status is TaskValidationStatus.RETRYING:
         line = Text("  ↻ ", style=WARNING)
         label = "repair requested"
         color = WARNING
+    elif status is TaskValidationStatus.FAILED:
+        line = Text("  ✗ ", style=ERROR)
+        label = "validation failed"
+        color = ERROR
+    else:
+        assert_never(status)
     line.append(label, style=f"bold {color}")
     line.append(f" · {task_name} · attempt {attempt}", style="dim")
     if reason:

--- a/ddev/src/ddev/cli/meta/ai/tui/app.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/app.py
@@ -22,7 +22,7 @@ from ddev.ai.phases.registry import PhaseRegistry
 from ddev.cli.meta.ai.palette import STATUS_DONE, STATUS_FAILED, STATUS_PENDING, STATUS_RUNNING
 from ddev.cli.meta.ai.tui.messages import (
     AfterCompact,
-    AfterGoalCheck,
+    AfterTaskValidation,
     AgentBeforeSend,
     AgentErrored,
     AgentFinished,
@@ -30,7 +30,7 @@ from ddev.cli.meta.ai.tui.messages import (
     AgentStarted,
     AgentToolCalled,
     BeforeCompact,
-    BeforeGoalCheck,
+    BeforeTaskValidation,
     ContextCleared,
     PhaseErrored,
     PhaseFinished,
@@ -185,8 +185,8 @@ class TogoApp(App):
     async def on_context_cleared(self, msg: ContextCleared) -> None:
         self._record(msg)
 
-    async def on_before_goal_check(self, msg: BeforeGoalCheck) -> None:
+    async def on_before_task_validation(self, msg: BeforeTaskValidation) -> None:
         self._record(msg)
 
-    async def on_after_goal_check(self, msg: AfterGoalCheck) -> None:
+    async def on_after_task_validation(self, msg: AfterTaskValidation) -> None:
         self._record(msg)

--- a/ddev/src/ddev/cli/meta/ai/tui/bridge.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/bridge.py
@@ -16,6 +16,7 @@ from textual.message_pump import MessagePump
 from ddev.ai.agent.scope import AgentScope
 from ddev.ai.agent.types import AgentResponse, ToolCall
 from ddev.ai.callbacks.callbacks import CallbackSet
+from ddev.ai.phases.messages import TaskValidationStatus
 from ddev.ai.react.types import ReActResult
 from ddev.ai.tools.core.types import ToolResult
 from ddev.cli.meta.ai.tui.messages import (
@@ -118,7 +119,13 @@ def build_app_callback_set(app: BridgeApp) -> CallbackSet:
         _target().post_message(BeforeTaskValidation(phase_id, task_name, attempt))
 
     @cb.on_after_task_validation
-    async def _(phase_id: str, task_name: str, attempt: int, valid: bool, reason: str) -> None:
-        _target().post_message(AfterTaskValidation(phase_id, task_name, attempt, valid, reason))
+    async def _(
+        phase_id: str,
+        task_name: str,
+        attempt: int,
+        status: TaskValidationStatus,
+        reason: str,
+    ) -> None:
+        _target().post_message(AfterTaskValidation(phase_id, task_name, attempt, status, reason))
 
     return cb

--- a/ddev/src/ddev/cli/meta/ai/tui/bridge.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/bridge.py
@@ -20,7 +20,7 @@ from ddev.ai.react.types import ReActResult
 from ddev.ai.tools.core.types import ToolResult
 from ddev.cli.meta.ai.tui.messages import (
     AfterCompact,
-    AfterGoalCheck,
+    AfterTaskValidation,
     AgentBeforeSend,
     AgentErrored,
     AgentFinished,
@@ -28,7 +28,7 @@ from ddev.cli.meta.ai.tui.messages import (
     AgentStarted,
     AgentToolCalled,
     BeforeCompact,
-    BeforeGoalCheck,
+    BeforeTaskValidation,
     ContextCleared,
     PhaseErrored,
     PhaseFinished,
@@ -113,12 +113,12 @@ def build_app_callback_set(app: BridgeApp) -> CallbackSet:
     async def _(scope: AgentScope, error: BaseException) -> None:
         _target().post_message(AgentErrored(scope, error))
 
-    @cb.on_before_goal_check
+    @cb.on_before_task_validation
     async def _(phase_id: str, task_name: str, attempt: int) -> None:
-        _target().post_message(BeforeGoalCheck(phase_id, task_name, attempt))
+        _target().post_message(BeforeTaskValidation(phase_id, task_name, attempt))
 
-    @cb.on_after_goal_check
+    @cb.on_after_task_validation
     async def _(phase_id: str, task_name: str, attempt: int, valid: bool, reason: str) -> None:
-        _target().post_message(AfterGoalCheck(phase_id, task_name, attempt, valid, reason))
+        _target().post_message(AfterTaskValidation(phase_id, task_name, attempt, valid, reason))
 
     return cb

--- a/ddev/src/ddev/cli/meta/ai/tui/messages.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/messages.py
@@ -12,6 +12,7 @@ from textual.message import Message
 
 from ddev.ai.agent.scope import AgentScope
 from ddev.ai.agent.types import AgentResponse, ToolCall
+from ddev.ai.phases.messages import TaskValidationStatus
 from ddev.ai.react.types import ReActResult
 from ddev.ai.tools.core.types import ToolResult
 
@@ -147,19 +148,19 @@ class BeforeTaskValidation(Message):
 
 
 class AfterTaskValidation(Message):
-    """Fired after each validation attempt, with its verdict."""
+    """Fired after each validation attempt, with its status."""
 
     def __init__(
         self,
         phase_id: str,
         task_name: str,
         attempt: int,
-        valid: bool,
+        status: TaskValidationStatus,
         reason: str,
     ) -> None:
         super().__init__()
         self.phase_id = phase_id
         self.task_name = task_name
         self.attempt = attempt
-        self.valid = valid
+        self.status = status
         self.reason = reason

--- a/ddev/src/ddev/cli/meta/ai/tui/messages.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/messages.py
@@ -136,8 +136,8 @@ class AgentBeforeSend(Message):
         self.iteration = iteration
 
 
-class BeforeGoalCheck(Message):
-    """Fired immediately before each reviewer agent run for a task with a goal."""
+class BeforeTaskValidation(Message):
+    """Fired immediately before each validation attempt for a task."""
 
     def __init__(self, phase_id: str, task_name: str, attempt: int) -> None:
         super().__init__()
@@ -146,8 +146,8 @@ class BeforeGoalCheck(Message):
         self.attempt = attempt
 
 
-class AfterGoalCheck(Message):
-    """Fired after each reviewer agent run, with the parsed verdict."""
+class AfterTaskValidation(Message):
+    """Fired after each validation attempt, with its verdict."""
 
     def __init__(
         self,

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -32,6 +32,7 @@ from ddev.cli.meta.ai.rendering import (
     render_prompt_panel,
     render_response_header,
     render_response_text,
+    render_task_validation_line,
     render_tool_call_line,
     render_tool_result_line,
     render_web_fetch_line,
@@ -39,7 +40,7 @@ from ddev.cli.meta.ai.rendering import (
 )
 from ddev.cli.meta.ai.tui.app import OrchestratorLike
 from ddev.cli.meta.ai.tui.messages import (
-    AfterGoalCheck,
+    AfterTaskValidation,
     AgentBeforeSend,
     AgentErrored,
     AgentFinished,
@@ -47,7 +48,7 @@ from ddev.cli.meta.ai.tui.messages import (
     AgentStarted,
     AgentToolCalled,
     BeforeCompact,
-    BeforeGoalCheck,
+    BeforeTaskValidation,
     ContextCleared,
     ExecutionFailed,
     PhaseErrored,
@@ -426,14 +427,19 @@ class ExecutionScreen(TogoScreen):
             self._mark_phase_failed(phase_id)
         self._update_display()
 
-    def on_before_goal_check(self, msg: BeforeGoalCheck) -> None:
+    def on_before_task_validation(self, msg: BeforeTaskValidation) -> None:
         key = (msg.phase_id, msg.task_name)
         if key in self._task_statuses:
             self._task_statuses[key] = RunStatus.RUNNING
             self._update_display()
+        self._write_output(render_task_validation_line(msg.task_name, msg.attempt, None), phase_id=msg.phase_id)
 
-    def on_after_goal_check(self, msg: AfterGoalCheck) -> None:
+    def on_after_task_validation(self, msg: AfterTaskValidation) -> None:
         key = (msg.phase_id, msg.task_name)
         if key in self._task_statuses:
-            self._task_statuses[key] = RunStatus.DONE if msg.valid else RunStatus.FAILED
+            self._task_statuses[key] = RunStatus.DONE if msg.valid else RunStatus.RUNNING
             self._update_display()
+        self._write_output(
+            render_task_validation_line(msg.task_name, msg.attempt, msg.valid, msg.reason),
+            phase_id=msg.phase_id,
+        )

--- a/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
+++ b/ddev/src/ddev/cli/meta/ai/tui/screens/execution.py
@@ -20,6 +20,7 @@ from textual.worker import Worker
 
 from ddev.ai.callbacks.callbacks import Callbacks
 from ddev.ai.config.models import ResolvedFlow, RuntimeVariables
+from ddev.ai.phases.messages import TaskValidationStatus
 from ddev.ai.react.process import TOOL_RESULTS_SENTINEL
 from ddev.cli.meta.ai.rendering import (
     render_agent_error_line,
@@ -432,14 +433,22 @@ class ExecutionScreen(TogoScreen):
         if key in self._task_statuses:
             self._task_statuses[key] = RunStatus.RUNNING
             self._update_display()
-        self._write_output(render_task_validation_line(msg.task_name, msg.attempt, None), phase_id=msg.phase_id)
+        self._write_output(
+            render_task_validation_line(msg.task_name, msg.attempt, TaskValidationStatus.VALIDATING),
+            phase_id=msg.phase_id,
+        )
 
     def on_after_task_validation(self, msg: AfterTaskValidation) -> None:
         key = (msg.phase_id, msg.task_name)
         if key in self._task_statuses:
-            self._task_statuses[key] = RunStatus.DONE if msg.valid else RunStatus.RUNNING
+            if msg.status is TaskValidationStatus.PASSED:
+                self._task_statuses[key] = RunStatus.DONE
+            elif msg.status is TaskValidationStatus.FAILED:
+                self._task_statuses[key] = RunStatus.FAILED
+            else:
+                self._task_statuses[key] = RunStatus.RUNNING
             self._update_display()
         self._write_output(
-            render_task_validation_line(msg.task_name, msg.attempt, msg.valid, msg.reason),
+            render_task_validation_line(msg.task_name, msg.attempt, msg.status, msg.reason),
             phase_id=msg.phase_id,
         )

--- a/ddev/tests/ai/callbacks/test_callbacks.py
+++ b/ddev/tests/ai/callbacks/test_callbacks.py
@@ -561,16 +561,16 @@ async def test_before_agent_send_exception_is_swallowed(scope: AgentScope) -> No
 
 
 # ---------------------------------------------------------------------------
-# on_before_goal_check and on_after_goal_check
+# on_before_task_validation and on_after_task_validation
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("event", ["before", "after"], ids=["before", "after"])
-async def test_goal_check_callbacks_register_fire_and_swallow_exceptions(event):
+async def test_task_validation_callbacks_register_fire_and_swallow_exceptions(event):
     cb = CallbackSet()
     fired: list = []
 
-    decorator = cb.on_before_goal_check if event == "before" else cb.on_after_goal_check
+    decorator = cb.on_before_task_validation if event == "before" else cb.on_after_task_validation
 
     @decorator
     async def bad(*args):
@@ -581,45 +581,45 @@ async def test_goal_check_callbacks_register_fire_and_swallow_exceptions(event):
         fired.append(args)
 
     if event == "before":
-        await cb.fire_before_goal_check("phase-a", "task-x", 3)
+        await cb.fire_before_task_validation("phase-a", "task-x", 3)
         assert fired == [("phase-a", "task-x", 3)]
     else:
-        await cb.fire_after_goal_check("phase-a", "task-x", 3, False, "missing y")
+        await cb.fire_after_task_validation("phase-a", "task-x", 3, False, "missing y")
         assert fired == [("phase-a", "task-x", 3, False, "missing y")]
 
 
-async def test_callbacks_dispatches_goal_check_to_all_sets():
+async def test_callbacks_dispatches_task_validation_to_all_sets():
     s1, s2 = CallbackSet(), CallbackSet()
     fired: list = []
 
-    @s1.on_before_goal_check
+    @s1.on_before_task_validation
     async def h1(phase_id, name, attempt):
         fired.append(("s1", phase_id, name, attempt))
 
-    @s2.on_after_goal_check
+    @s2.on_after_task_validation
     async def h2(phase_id, name, attempt, valid, reason):
         fired.append(("s2", phase_id, name, attempt, valid, reason))
 
     cb = Callbacks([s1, s2])
-    await cb.fire_before_goal_check("phase-a", "t", 1)
-    await cb.fire_after_goal_check("phase-a", "t", 1, True, "")
+    await cb.fire_before_task_validation("phase-a", "t", 1)
+    await cb.fire_after_task_validation("phase-a", "t", 1, True, "")
     assert fired == [
         ("s1", "phase-a", "t", 1),
         ("s2", "phase-a", "t", 1, True, ""),
     ]
 
 
-async def test_goal_callbacks_distinguish_duplicate_task_names_across_phases():
+async def test_validation_callbacks_distinguish_duplicate_task_names_across_phases():
     callback_set = CallbackSet()
     fired: list[tuple[str, str]] = []
 
-    @callback_set.on_before_goal_check
+    @callback_set.on_before_task_validation
     async def record(phase_id: str, task_name: str, attempt: int) -> None:
         fired.append((phase_id, task_name))
 
     callbacks = Callbacks([callback_set])
-    await callbacks.fire_before_goal_check("phase-a", "review", 1)
-    await callbacks.fire_before_goal_check("phase-b", "review", 1)
+    await callbacks.fire_before_task_validation("phase-a", "review", 1)
+    await callbacks.fire_before_task_validation("phase-b", "review", 1)
 
     assert fired == [("phase-a", "review"), ("phase-b", "review")]
 
@@ -646,8 +646,8 @@ async def test_callbacks_empty_is_noop(
     await callbacks.fire_phase_finish("p")
     await callbacks.fire_phase_error("p", RuntimeError("boom"))
     await callbacks.fire_run_error()
-    await callbacks.fire_before_goal_check("p", "t", 1)
-    await callbacks.fire_after_goal_check("p", "t", 1, True, "")
+    await callbacks.fire_before_task_validation("p", "t", 1)
+    await callbacks.fire_after_task_validation("p", "t", 1, True, "")
 
 
 async def test_callbacks_dispatches_to_all_sets(scope: AgentScope, response: AgentResponse) -> None:

--- a/ddev/tests/ai/callbacks/test_callbacks.py
+++ b/ddev/tests/ai/callbacks/test_callbacks.py
@@ -7,6 +7,7 @@ import pytest
 from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.agent.types import AgentResponse, StopReason, TokenUsage, ToolCall
 from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
+from ddev.ai.phases.messages import TaskValidationStatus
 from ddev.ai.react.types import ReActResult
 from ddev.ai.tools.core.types import ToolResult
 
@@ -584,8 +585,8 @@ async def test_task_validation_callbacks_register_fire_and_swallow_exceptions(ev
         await cb.fire_before_task_validation("phase-a", "task-x", 3)
         assert fired == [("phase-a", "task-x", 3)]
     else:
-        await cb.fire_after_task_validation("phase-a", "task-x", 3, False, "missing y")
-        assert fired == [("phase-a", "task-x", 3, False, "missing y")]
+        await cb.fire_after_task_validation("phase-a", "task-x", 3, TaskValidationStatus.RETRYING, "missing y")
+        assert fired == [("phase-a", "task-x", 3, TaskValidationStatus.RETRYING, "missing y")]
 
 
 async def test_callbacks_dispatches_task_validation_to_all_sets():
@@ -597,15 +598,15 @@ async def test_callbacks_dispatches_task_validation_to_all_sets():
         fired.append(("s1", phase_id, name, attempt))
 
     @s2.on_after_task_validation
-    async def h2(phase_id, name, attempt, valid, reason):
-        fired.append(("s2", phase_id, name, attempt, valid, reason))
+    async def h2(phase_id, name, attempt, status, reason):
+        fired.append(("s2", phase_id, name, attempt, status, reason))
 
     cb = Callbacks([s1, s2])
     await cb.fire_before_task_validation("phase-a", "t", 1)
-    await cb.fire_after_task_validation("phase-a", "t", 1, True, "")
+    await cb.fire_after_task_validation("phase-a", "t", 1, TaskValidationStatus.PASSED, "")
     assert fired == [
         ("s1", "phase-a", "t", 1),
-        ("s2", "phase-a", "t", 1, True, ""),
+        ("s2", "phase-a", "t", 1, TaskValidationStatus.PASSED, ""),
     ]
 
 
@@ -647,7 +648,7 @@ async def test_callbacks_empty_is_noop(
     await callbacks.fire_phase_error("p", RuntimeError("boom"))
     await callbacks.fire_run_error()
     await callbacks.fire_before_task_validation("p", "t", 1)
-    await callbacks.fire_after_task_validation("p", "t", 1, True, "")
+    await callbacks.fire_after_task_validation("p", "t", 1, TaskValidationStatus.PASSED, "")
 
 
 async def test_callbacks_dispatches_to_all_sets(scope: AgentScope, response: AgentResponse) -> None:

--- a/ddev/tests/ai/phases/test_goal.py
+++ b/ddev/tests/ai/phases/test_goal.py
@@ -24,6 +24,7 @@ from ddev.ai.phases.goal import (
     run_deterministic_checks,
     run_validation_loop,
 )
+from ddev.ai.phases.messages import TaskValidationStatus
 from ddev.ai.react.process import ReActProcess
 from ddev.ai.react.types import ReActResult
 from ddev.ai.runtime.agent_log import AgentLogger
@@ -483,7 +484,7 @@ async def test_run_validation_loop_deterministic_exhaustion_never_creates_review
         context_usage=None,
     )
     factory, builder_calls, reviewer_agent = _reviewer_factory([])
-    events: list[tuple[str, bool | None]] = []
+    events: list[tuple[str, TaskValidationStatus | None]] = []
     callback_set = CallbackSet()
 
     @callback_set.on_before_task_validation
@@ -491,8 +492,14 @@ async def test_run_validation_loop_deterministic_exhaustion_never_creates_review
         events.append(("before", None))
 
     @callback_set.on_after_task_validation
-    async def _after(_phase_id: str, _task_name: str, _attempt: int, valid: bool, _reason: str) -> None:
-        events.append(("after", valid))
+    async def _after(
+        _phase_id: str,
+        _task_name: str,
+        _attempt: int,
+        status: TaskValidationStatus,
+        _reason: str,
+    ) -> None:
+        events.append(("after", status))
 
     with pytest.raises(ValidationAttemptsExhausted, match=r"(?s)Last validation reason.*required_field") as exc_info:
         await run_validation_loop(
@@ -515,7 +522,7 @@ async def test_run_validation_loop_deterministic_exhaustion_never_creates_review
     assert worker_agent.send_calls == []
     assert reviewer_agent.send_calls == []
     assert builder_calls == []
-    assert events == [("before", None), ("after", False)]
+    assert events == [("before", None), ("after", TaskValidationStatus.FAILED)]
 
 
 async def test_run_validation_loop_accepts_passing_deterministic_checks_without_goal() -> None:
@@ -528,6 +535,18 @@ async def test_run_validation_loop_accepts_passing_deterministic_checks_without_
         context_usage=None,
     )
     factory, builder_calls, reviewer_agent = _reviewer_factory([])
+    statuses: list[TaskValidationStatus] = []
+    callback_set = CallbackSet()
+
+    @callback_set.on_after_task_validation
+    async def _after(
+        _phase_id: str,
+        _task_name: str,
+        _attempt: int,
+        status: TaskValidationStatus,
+        _reason: str,
+    ) -> None:
+        statuses.append(status)
 
     outcome = await run_validation_loop(
         task=TaskConfig(name="t1", prompt="x"),
@@ -537,7 +556,7 @@ async def test_run_validation_loop_accepts_passing_deterministic_checks_without_
         initial_result=initial_result,
         parent_agent_config=make_agent_config(tools=[]),
         process_factory=factory,
-        callbacks=Callbacks(),
+        callbacks=Callbacks([callback_set]),
         phase_id="p1",
         compact_if_needed=_noop_compact,
         deterministic_checks=(DeterministicCheck(name="artifact schema", run=lambda: None),),
@@ -548,6 +567,7 @@ async def test_run_validation_loop_accepts_passing_deterministic_checks_without_
     assert worker_agent.send_calls == []
     assert reviewer_agent.send_calls == []
     assert builder_calls == []
+    assert statuses == [TaskValidationStatus.PASSED]
 
 
 def test_run_deterministic_checks_rejects_duplicate_names_before_running_checks() -> None:
@@ -707,8 +727,14 @@ async def test_run_validation_loop_fires_callbacks(tmp_path):
         events.append(("before", phase_id, task_name, attempt))
 
     @cb_set.on_after_task_validation
-    async def _after(phase_id: str, task_name: str, attempt: int, valid: bool, reason: str) -> None:
-        events.append(("after", phase_id, task_name, attempt, valid, reason))
+    async def _after(
+        phase_id: str,
+        task_name: str,
+        attempt: int,
+        status: TaskValidationStatus,
+        reason: str,
+    ) -> None:
+        events.append(("after", phase_id, task_name, attempt, status, reason))
 
     worker_process, _ = _make_worker_process([make_response("attempt 2", 0, 0)])
     initial_result = ReActResult(
@@ -739,7 +765,7 @@ async def test_run_validation_loop_fires_callbacks(tmp_path):
     )
     assert events == [
         ("before", "p1", "t1", 1),
-        ("after", "p1", "t1", 1, False, "fix X"),
+        ("after", "p1", "t1", 1, TaskValidationStatus.RETRYING, "fix X"),
         ("before", "p1", "t1", 2),
-        ("after", "p1", "t1", 2, True, ""),
+        ("after", "p1", "t1", 2, TaskValidationStatus.PASSED, ""),
     ]

--- a/ddev/tests/ai/phases/test_goal.py
+++ b/ddev/tests/ai/phases/test_goal.py
@@ -483,6 +483,16 @@ async def test_run_validation_loop_deterministic_exhaustion_never_creates_review
         context_usage=None,
     )
     factory, builder_calls, reviewer_agent = _reviewer_factory([])
+    events: list[tuple[str, bool | None]] = []
+    callback_set = CallbackSet()
+
+    @callback_set.on_before_task_validation
+    async def _before(_phase_id: str, _task_name: str, _attempt: int) -> None:
+        events.append(("before", None))
+
+    @callback_set.on_after_task_validation
+    async def _after(_phase_id: str, _task_name: str, _attempt: int, valid: bool, _reason: str) -> None:
+        events.append(("after", valid))
 
     with pytest.raises(ValidationAttemptsExhausted, match=r"(?s)Last validation reason.*required_field") as exc_info:
         await run_validation_loop(
@@ -493,7 +503,7 @@ async def test_run_validation_loop_deterministic_exhaustion_never_creates_review
             initial_result=initial_result,
             parent_agent_config=make_agent_config(tools=[]),
             process_factory=factory,
-            callbacks=Callbacks(),
+            callbacks=Callbacks([callback_set]),
             phase_id="p1",
             compact_if_needed=_noop_compact,
             deterministic_checks=(
@@ -505,6 +515,7 @@ async def test_run_validation_loop_deterministic_exhaustion_never_creates_review
     assert worker_agent.send_calls == []
     assert reviewer_agent.send_calls == []
     assert builder_calls == []
+    assert events == [("before", None), ("after", False)]
 
 
 async def test_run_validation_loop_accepts_passing_deterministic_checks_without_goal() -> None:
@@ -691,11 +702,11 @@ async def test_run_validation_loop_fires_callbacks(tmp_path):
     events: list = []
     cb_set = CallbackSet()
 
-    @cb_set.on_before_goal_check
+    @cb_set.on_before_task_validation
     async def _before(phase_id: str, task_name: str, attempt: int) -> None:
         events.append(("before", phase_id, task_name, attempt))
 
-    @cb_set.on_after_goal_check
+    @cb_set.on_after_task_validation
     async def _after(phase_id: str, task_name: str, attempt: int, valid: bool, reason: str) -> None:
         events.append(("after", phase_id, task_name, attempt, valid, reason))
 

--- a/ddev/tests/cli/meta/ai/test_rendering.py
+++ b/ddev/tests/cli/meta/ai/test_rendering.py
@@ -42,6 +42,7 @@ from ddev.cli.meta.ai.rendering import (
     render_prompt_panel,
     render_response_header,
     render_response_text,
+    render_task_validation_line,
     render_tool_call_line,
     render_tool_result_line,
     render_web_fetch_line,
@@ -446,6 +447,16 @@ def test_render_context_cleared_notice_returns_text():
     result = render_context_cleared_notice()
     assert isinstance(result, Text)
     assert "context cleared" in result.plain.lower()
+
+
+def test_render_task_validation_line_distinguishes_progress_repair_and_success():
+    started = render_task_validation_line("write_code", 1, None)
+    repair = render_task_validation_line("write_code", 1, False, "rename `version`")
+    passed = render_task_validation_line("write_code", 2, True)
+
+    assert started.plain == "  ◆ validating · write_code · attempt 1"
+    assert repair.plain == "  ↻ repair requested · write_code · attempt 1\n    rename `version`"
+    assert passed.plain == "  ✓ validation passed · write_code · attempt 2"
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/cli/meta/ai/test_rendering.py
+++ b/ddev/tests/cli/meta/ai/test_rendering.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
@@ -20,6 +21,7 @@ from ddev.ai.agent.types import (
     WebFetchCall,
     WebSearchCall,
 )
+from ddev.ai.phases.messages import TaskValidationStatus
 from ddev.ai.react.types import ReActResult
 from ddev.ai.tools.core.types import ToolResult
 from ddev.cli.meta.ai.palette import ROLE_GOAL_REVIEWER, ROLE_PHASE, ROLE_SUBAGENT
@@ -449,14 +451,46 @@ def test_render_context_cleared_notice_returns_text():
     assert "context cleared" in result.plain.lower()
 
 
-def test_render_task_validation_line_distinguishes_progress_repair_and_success():
-    started = render_task_validation_line("write_code", 1, None)
-    repair = render_task_validation_line("write_code", 1, False, "rename `version`")
-    passed = render_task_validation_line("write_code", 2, True)
-
-    assert started.plain == "  ◆ validating · write_code · attempt 1"
-    assert repair.plain == "  ↻ repair requested · write_code · attempt 1\n    rename `version`"
-    assert passed.plain == "  ✓ validation passed · write_code · attempt 2"
+@pytest.mark.parametrize(
+    ("status", "attempt", "reason", "expected"),
+    [
+        pytest.param(
+            TaskValidationStatus.VALIDATING,
+            1,
+            "",
+            "  ◆ validating · write_code · attempt 1",
+            id="validating",
+        ),
+        pytest.param(
+            TaskValidationStatus.RETRYING,
+            1,
+            "rename `version`",
+            "  ↻ repair requested · write_code · attempt 1\n    rename `version`",
+            id="retrying",
+        ),
+        pytest.param(
+            TaskValidationStatus.PASSED,
+            2,
+            "",
+            "  ✓ validation passed · write_code · attempt 2",
+            id="passed",
+        ),
+        pytest.param(
+            TaskValidationStatus.FAILED,
+            2,
+            "rename `version`",
+            "  ✗ validation failed · write_code · attempt 2\n    rename `version`",
+            id="failed",
+        ),
+    ],
+)
+def test_render_task_validation_line(
+    status: TaskValidationStatus,
+    attempt: int,
+    reason: str,
+    expected: str,
+) -> None:
+    assert render_task_validation_line("write_code", attempt, status, reason).plain == expected
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/cli/meta/ai/tui/test_bridge.py
+++ b/ddev/tests/cli/meta/ai/tui/test_bridge.py
@@ -11,6 +11,7 @@ from ddev.ai.agent.scope import AgentRole, AgentScope
 from ddev.ai.agent.types import AgentResponse as AgentResponsePayload
 from ddev.ai.agent.types import StopReason, TokenUsage, ToolCall
 from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
+from ddev.ai.phases.messages import TaskValidationStatus
 from ddev.ai.react.types import ReActResult
 from ddev.ai.tools.core.types import ToolResult
 from ddev.cli.meta.ai.tui.bridge import build_app_callback_set
@@ -87,7 +88,7 @@ class StubOrchestrator:
         await self.cb_set.fire_agent_finish(SCOPE, _make_react_result())
         await self.cb_set.fire_agent_error(SCOPE, ValueError("boom"))
         await self.cb_set.fire_before_task_validation("phase1", "task1", 1)
-        await self.cb_set.fire_after_task_validation("phase1", "task1", 1, True, "looks good")
+        await self.cb_set.fire_after_task_validation("phase1", "task1", 1, TaskValidationStatus.PASSED, "looks good")
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +228,7 @@ async def test_after_task_validation_payload(received_from_stub):
     assert msgs[0].phase_id == "phase1"
     assert msgs[0].task_name == "task1"
     assert msgs[0].attempt == 1
-    assert msgs[0].valid is True
+    assert msgs[0].status is TaskValidationStatus.PASSED
     assert msgs[0].reason == "looks good"
 
 

--- a/ddev/tests/cli/meta/ai/tui/test_bridge.py
+++ b/ddev/tests/cli/meta/ai/tui/test_bridge.py
@@ -16,7 +16,7 @@ from ddev.ai.tools.core.types import ToolResult
 from ddev.cli.meta.ai.tui.bridge import build_app_callback_set
 from ddev.cli.meta.ai.tui.messages import (
     AfterCompact,
-    AfterGoalCheck,
+    AfterTaskValidation,
     AgentBeforeSend,
     AgentErrored,
     AgentFinished,
@@ -24,7 +24,7 @@ from ddev.cli.meta.ai.tui.messages import (
     AgentStarted,
     AgentToolCalled,
     BeforeCompact,
-    BeforeGoalCheck,
+    BeforeTaskValidation,
     ContextCleared,
     PhaseErrored,
     PhaseFinished,
@@ -86,8 +86,8 @@ class StubOrchestrator:
         await self.cb_set.fire_context_cleared(SCOPE)
         await self.cb_set.fire_agent_finish(SCOPE, _make_react_result())
         await self.cb_set.fire_agent_error(SCOPE, ValueError("boom"))
-        await self.cb_set.fire_before_goal_check("phase1", "task1", 1)
-        await self.cb_set.fire_after_goal_check("phase1", "task1", 1, True, "looks good")
+        await self.cb_set.fire_before_task_validation("phase1", "task1", 1)
+        await self.cb_set.fire_after_task_validation("phase1", "task1", 1, True, "looks good")
 
 
 # ---------------------------------------------------------------------------
@@ -213,16 +213,16 @@ async def test_agent_errored_payload(received_from_stub):
     assert str(msgs[0].error) == "boom"
 
 
-async def test_before_goal_check_payload(received_from_stub):
-    msgs = [m for m in received_from_stub if isinstance(m, BeforeGoalCheck)]
+async def test_before_task_validation_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, BeforeTaskValidation)]
     assert len(msgs) == 1
     assert msgs[0].phase_id == "phase1"
     assert msgs[0].task_name == "task1"
     assert msgs[0].attempt == 1
 
 
-async def test_after_goal_check_payload(received_from_stub):
-    msgs = [m for m in received_from_stub if isinstance(m, AfterGoalCheck)]
+async def test_after_task_validation_payload(received_from_stub):
+    msgs = [m for m in received_from_stub if isinstance(m, AfterTaskValidation)]
     assert len(msgs) == 1
     assert msgs[0].phase_id == "phase1"
     assert msgs[0].task_name == "task1"

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -199,8 +199,8 @@ class _FakeOrchestrator:
 
         # Goal validation for each task
         for task_name in task_names:
-            await self._callbacks.fire_before_goal_check(phase_id, task_name, 1)
-            await self._callbacks.fire_after_goal_check(phase_id, task_name, 1, True, "Goal achieved.")
+            await self._callbacks.fire_before_task_validation(phase_id, task_name, 1)
+            await self._callbacks.fire_after_task_validation(phase_id, task_name, 1, True, "")
 
         react_result = _make_react_result(resp2)
         await self._callbacks.fire_agent_finish(scope, react_result)
@@ -338,21 +338,21 @@ async def test_fake_orchestrator_fires_sentinel_prompt():
     assert TOOL_RESULTS_SENTINEL in all_prompts
 
 
-async def test_fake_orchestrator_fires_goal_check_events():
-    """_FakeOrchestrator fires before/after_goal_check for each task."""
+async def test_fake_orchestrator_fires_task_validation_events():
+    """_FakeOrchestrator fires before/after validation for each task."""
     from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
 
-    goal_results: list[tuple[str, str, bool]] = []
+    validation_results: list[tuple[str, str, bool]] = []
     cb_set = CallbackSet()
 
-    @cb_set.on_after_goal_check
+    @cb_set.on_after_task_validation
     async def _(phase_id: str, task_name: str, attempt: int, valid: bool, reason: str) -> None:
-        goal_results.append((phase_id, task_name, valid))
+        validation_results.append((phase_id, task_name, valid))
 
     demo = _FakeOrchestrator(Callbacks([cb_set]), DEMO_PHASES)
     await demo.run_async()
-    assert ("phase_1", "task_one", True) in goal_results
-    assert ("phase_2", "task_two", True) in goal_results
+    assert ("phase_1", "task_one", True) in validation_results
+    assert ("phase_2", "task_two", True) in validation_results
 
 
 async def test_fake_orchestrator_failure_raises():
@@ -643,9 +643,9 @@ def test_phase_error_is_written_in_full_to_failed_phase_log() -> None:
     assert "https://errors.example.test/noise" in rendered
 
 
-def test_scoped_goal_event_only_mutates_identified_phase() -> None:
-    """A goal verdict for phase A cannot update the same-named task in phase B."""
-    from ddev.cli.meta.ai.tui.messages import AfterGoalCheck, BeforeGoalCheck, PhaseStarted
+def test_scoped_validation_event_only_mutates_identified_phase() -> None:
+    """A validation verdict for phase A cannot update the same-named task in phase B."""
+    from ddev.cli.meta.ai.tui.messages import AfterTaskValidation, BeforeTaskValidation, PhaseStarted
     from ddev.cli.meta.ai.tui.screens.execution import ExecutionScreen
 
     flow = _make_flow(phases=[("phase_1", ["shared_task"]), ("phase_2", ["shared_task"])])
@@ -653,17 +653,18 @@ def test_scoped_goal_event_only_mutates_identified_phase() -> None:
     screen.on_phase_started(PhaseStarted("phase_1"))
     screen.on_phase_started(PhaseStarted("phase_2"))
 
-    screen.on_before_goal_check(BeforeGoalCheck("phase_1", "shared_task", 1))
-    screen.on_before_goal_check(BeforeGoalCheck("phase_2", "shared_task", 1))
-    screen.on_after_goal_check(AfterGoalCheck("phase_1", "shared_task", 1, True, "done"))
+    screen.on_before_task_validation(BeforeTaskValidation("phase_1", "shared_task", 1))
+    screen.on_before_task_validation(BeforeTaskValidation("phase_2", "shared_task", 1))
+    screen.on_after_task_validation(AfterTaskValidation("phase_1", "shared_task", 1, True, ""))
 
     assert screen._task_statuses[("phase_1", "shared_task")] is RunStatus.DONE
     assert screen._task_statuses[("phase_2", "shared_task")] is RunStatus.RUNNING
 
-    screen.on_after_goal_check(AfterGoalCheck("phase_2", "shared_task", 1, False, "failed"))
+    screen.on_after_task_validation(AfterTaskValidation("phase_2", "shared_task", 1, False, "needs repair"))
 
     assert screen._task_statuses[("phase_1", "shared_task")] is RunStatus.DONE
-    assert screen._task_statuses[("phase_2", "shared_task")] is RunStatus.FAILED
+    assert screen._task_statuses[("phase_2", "shared_task")] is RunStatus.RUNNING
+    assert "needs repair" in str(screen._phase_logs["phase_2"][-1])
 
 
 def test_context_cleared_notice_is_written_to_scoped_phase_log() -> None:

--- a/ddev/tests/cli/meta/ai/tui/test_execution.py
+++ b/ddev/tests/cli/meta/ai/tui/test_execution.py
@@ -17,6 +17,7 @@ from textual.widgets import Input
 
 from ddev.ai.agent.registry import AgentProviderRegistry
 from ddev.ai.config.models import AgentConfig, FlowConfig, FlowEntry, PhaseConfig, ResolvedFlow, TaskConfig
+from ddev.ai.phases.messages import TaskValidationStatus
 from ddev.ai.phases.registry import PhaseRegistry
 from ddev.cli.meta.ai.tui.app import TogoApp
 from ddev.cli.meta.ai.tui.status import RunStatus
@@ -200,7 +201,13 @@ class _FakeOrchestrator:
         # Goal validation for each task
         for task_name in task_names:
             await self._callbacks.fire_before_task_validation(phase_id, task_name, 1)
-            await self._callbacks.fire_after_task_validation(phase_id, task_name, 1, True, "")
+            await self._callbacks.fire_after_task_validation(
+                phase_id,
+                task_name,
+                1,
+                TaskValidationStatus.PASSED,
+                "",
+            )
 
         react_result = _make_react_result(resp2)
         await self._callbacks.fire_agent_finish(scope, react_result)
@@ -342,17 +349,23 @@ async def test_fake_orchestrator_fires_task_validation_events():
     """_FakeOrchestrator fires before/after validation for each task."""
     from ddev.ai.callbacks.callbacks import Callbacks, CallbackSet
 
-    validation_results: list[tuple[str, str, bool]] = []
+    validation_results: list[tuple[str, str, TaskValidationStatus]] = []
     cb_set = CallbackSet()
 
     @cb_set.on_after_task_validation
-    async def _(phase_id: str, task_name: str, attempt: int, valid: bool, reason: str) -> None:
-        validation_results.append((phase_id, task_name, valid))
+    async def _(
+        phase_id: str,
+        task_name: str,
+        attempt: int,
+        status: TaskValidationStatus,
+        reason: str,
+    ) -> None:
+        validation_results.append((phase_id, task_name, status))
 
     demo = _FakeOrchestrator(Callbacks([cb_set]), DEMO_PHASES)
     await demo.run_async()
-    assert ("phase_1", "task_one", True) in validation_results
-    assert ("phase_2", "task_two", True) in validation_results
+    assert ("phase_1", "task_one", TaskValidationStatus.PASSED) in validation_results
+    assert ("phase_2", "task_two", TaskValidationStatus.PASSED) in validation_results
 
 
 async def test_fake_orchestrator_failure_raises():
@@ -654,17 +667,29 @@ def test_scoped_validation_event_only_mutates_identified_phase() -> None:
     screen.on_phase_started(PhaseStarted("phase_2"))
 
     screen.on_before_task_validation(BeforeTaskValidation("phase_1", "shared_task", 1))
+    assert "validating" in str(screen._phase_logs["phase_1"][-1])
+    assert screen._phase_logs["phase_2"] == []
+
     screen.on_before_task_validation(BeforeTaskValidation("phase_2", "shared_task", 1))
-    screen.on_after_task_validation(AfterTaskValidation("phase_1", "shared_task", 1, True, ""))
+    screen.on_after_task_validation(AfterTaskValidation("phase_1", "shared_task", 1, TaskValidationStatus.PASSED, ""))
 
     assert screen._task_statuses[("phase_1", "shared_task")] is RunStatus.DONE
     assert screen._task_statuses[("phase_2", "shared_task")] is RunStatus.RUNNING
 
-    screen.on_after_task_validation(AfterTaskValidation("phase_2", "shared_task", 1, False, "needs repair"))
+    screen.on_after_task_validation(
+        AfterTaskValidation("phase_2", "shared_task", 1, TaskValidationStatus.RETRYING, "needs repair")
+    )
 
     assert screen._task_statuses[("phase_1", "shared_task")] is RunStatus.DONE
     assert screen._task_statuses[("phase_2", "shared_task")] is RunStatus.RUNNING
     assert "needs repair" in str(screen._phase_logs["phase_2"][-1])
+
+    screen.on_after_task_validation(
+        AfterTaskValidation("phase_2", "shared_task", 2, TaskValidationStatus.FAILED, "still invalid")
+    )
+
+    assert screen._task_statuses[("phase_2", "shared_task")] is RunStatus.FAILED
+    assert "validation failed" in str(screen._phase_logs["phase_2"][-1])
 
 
 def test_context_cleared_notice_is_written_to_scoped_phase_log() -> None:


### PR DESCRIPTION
> This is PR 3 of 3 in a stacked series: 
> 1. #24777 (reusable validation framework)
> 2. #24778 (OpenMetrics label-hygiene validation)  
> 3. #24788 (Adds TUI feedback for deterministic checks) **<- you are here**

### What does this PR do?

Shows validation progress and repair requests in the Togo TUI for both deterministic checks and LLM goal reviews.

### Motivation

Make fast validation and repair loops visible without presenting a retryable check failure as a failed phase. This supports [AI-7081](https://datadoghq.atlassian.net/browse/AI-7081).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7081]: https://datadoghq.atlassian.net/browse/AI-7081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ