### PR TITLE
Add opt-in incremental query metrics collector for MySQL

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -569,6 +569,17 @@ files:
                   type: boolean
                   example: true
                   display_default: true
+              - name: incremental_query_metrics
+                hidden: true
+                description: |
+                  When enabled query metrics collection uses a lightweight multi-pass pipeline.
+                  The check determines which statements had a change in execution counts since the last collection,
+                  then fetches query text from `events_statements_summary_by_digest` and runs obfuscation for those
+                  statements only.
+                value:
+                  type: boolean
+                  display_default: false
+                  example: false
 
           - name: query_samples
             display_priority: 0

--- a/mysql/changelog.d/24790.added
+++ b/mysql/changelog.d/24790.added
@@ -1,0 +1,1 @@
+Add an opt-in incremental query metrics collector that only obfuscates statements whose execution counters changed since the previous collection.

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -175,6 +175,7 @@ class QueryMetrics(BaseModel):
     collect_prepared_statements: Optional[bool] = None
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
+    incremental_query_metrics: Optional[bool] = None
     only_query_recent_statements: Optional[bool] = None
 
 

--- a/mysql/datadog_checks/mysql/delta_detector.py
+++ b/mysql/datadog_checks/mysql/delta_detector.py
@@ -1,0 +1,147 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Hashable
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+DeltaKey = Hashable
+"""Identifies the cumulative counter series a row belongs to, as returned by the key callable."""
+
+
+@dataclass
+class DeltaResult:
+    derivative_rows: list[dict]
+    """Rows whose counters advanced since the previous snapshot, with metric columns replaced by their deltas."""
+    changed_keys: set[DeltaKey]
+    """Keys of the rows in ``derivative_rows``."""
+    vanished_keys: set[DeltaKey]
+    """Keys present in the previous snapshot but absent from this one."""
+
+
+class DeltaDetector:
+    """Diffs consecutive snapshots of cumulative counters to produce per-key derivative rows.
+
+    Rows are identified by the ``key`` callable, which must return the same value for every row
+    belonging to one cumulative counter series. Rows sharing a key within a single snapshot are
+    summed before diffing.
+
+    Only keys whose counters advanced are reported, so callers can restrict expensive per-row work
+    (query text resolution, obfuscation) to statements that actually ran during the interval.
+    """
+
+    def __init__(
+        self,
+        metric_columns: frozenset[str] | set[str],
+        key: Callable[[dict], DeltaKey],
+        execution_indicators: frozenset[str] | set[str] | None = None,
+    ):
+        self._metric_columns = frozenset(metric_columns)
+        self._key = key
+        # Counters that only advance when a statement executes. When set, a key whose indicators are
+        # all flat is skipped without diffing the remaining columns.
+        self._execution_indicators = frozenset(execution_indicators or ())
+        self._previous: dict[DeltaKey, dict] = {}
+
+    def reset(self):
+        self._previous.clear()
+
+    def compute(self, rows: list[dict]) -> DeltaResult:
+        """Diff *rows* against the previous snapshot and remember them for the next call."""
+        current = self._collapse(rows)
+
+        derivative_rows: list[dict] = []
+        changed_keys: set[DeltaKey] = set()
+
+        available_metrics: frozenset[str] | None = None
+        indicator_cols: frozenset[str] | None = None
+
+        for key, row in current.items():
+            prev = self._previous.get(key)
+            if prev is None:
+                # First time we've seen this key; there is no baseline to subtract yet.
+                continue
+
+            if available_metrics is None:
+                available_metrics = self._metric_columns & row.keys() & prev.keys()
+                indicator_cols = self._execution_indicators & available_metrics
+
+            if indicator_cols and not any(row[col] - prev[col] > 0 for col in indicator_cols):
+                continue
+
+            has_negative = False
+            has_change = False
+            for col in available_metrics:
+                diff = row[col] - prev[col]
+                if diff < 0:
+                    # A counter went backwards, so the series was reset (e.g. FLUSH STATUS) and the
+                    # diff is meaningless. Drop the row; the next cycle re-baselines against it.
+                    has_negative = True
+                    break
+                if diff != 0:
+                    has_change = True
+
+            if has_negative or not has_change:
+                continue
+
+            derivative = {}
+            for col in row:
+                if col in available_metrics:
+                    derivative[col] = row[col] - prev[col]
+                else:
+                    derivative[col] = row[col]
+            derivative_rows.append(derivative)
+            changed_keys.add(key)
+
+        vanished_keys = self._previous.keys() - current.keys()
+
+        logger.debug(
+            "delta: snapshot=%d prev=%d derivative=%d changed=%d vanished=%d",
+            len(current),
+            len(self._previous),
+            len(derivative_rows),
+            len(changed_keys),
+            len(vanished_keys),
+        )
+
+        self._update_cache(current)
+
+        return DeltaResult(
+            derivative_rows=derivative_rows,
+            changed_keys=changed_keys,
+            vanished_keys=vanished_keys,
+        )
+
+    def _collapse(self, rows: list[dict]) -> dict[DeltaKey, dict]:
+        """Group rows by key, summing metric columns across rows that share one."""
+        collapsed: dict[DeltaKey, dict] = {}
+        for row in rows:
+            key = self._key(row)
+            existing = collapsed.get(key)
+            if existing is None:
+                collapsed[key] = dict(row)
+                continue
+            for col in self._metric_columns:
+                if col in row:
+                    existing[col] = existing.get(col, 0) + row[col]
+        return collapsed
+
+    def _update_cache(self, current: dict[DeltaKey, dict]):
+        for key in self._previous.keys() - current.keys():
+            del self._previous[key]
+
+        for key, row in current.items():
+            prev = self._previous.get(key)
+            if prev is None:
+                self._previous[key] = {col: row[col] for col in self._metric_columns if col in row}
+                continue
+            # Only the metric columns are retained; everything else is re-read each cycle.
+            for col in self._metric_columns:
+                if col in row:
+                    prev[col] = row[col]
+                elif col in prev:
+                    del prev[col]

--- a/mysql/datadog_checks/mysql/global_variables.py
+++ b/mysql/datadog_checks/mysql/global_variables.py
@@ -61,6 +61,22 @@ class GlobalVariables:
         value = self._get_variable(variable_name)
         return is_affirmative(value.lower().strip() if value is not None else value)
 
+    def _get_int_variable(self, variable_name: str) -> Optional[int]:
+        """
+        Get a global variable coerced to an int.
+
+        Args:
+            variable_name: The name of the variable to retrieve
+
+        Returns:
+            The variable value as an int, or None if it is absent or not an integer
+        """
+        value = self._get_variable(variable_name)
+        try:
+            return int(value) if value is not None else None
+        except (ValueError, TypeError):
+            return None
+
     @property
     def version(self) -> Optional[str]:
         return self._get_variable('version')
@@ -99,19 +115,15 @@ class GlobalVariables:
 
     @property
     def key_buffer_size(self) -> Optional[int]:
-        value = self._get_variable('key_buffer_size')
-        try:
-            return int(value) if value is not None else None
-        except (ValueError, TypeError):
-            return None
+        return self._get_int_variable('key_buffer_size')
 
     @property
     def key_cache_block_size(self) -> Optional[int]:
-        value = self._get_variable('key_cache_block_size')
-        try:
-            return int(value) if value is not None else None
-        except (ValueError, TypeError):
-            return None
+        return self._get_int_variable('key_cache_block_size')
+
+    @property
+    def performance_schema_digests_size(self) -> Optional[int]:
+        return self._get_int_variable('performance_schema_digests_size')
 
     @property
     def all_variables(self) -> Dict[str, Any]:

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -85,6 +85,7 @@ from .queries import (
 )
 from .statement_samples import MySQLStatementSamples
 from .statements import MySQLStatementMetrics
+from .statements_v2 import MySQLStatementMetricsV2
 from .util import DatabaseConfigurationError, connect_with_session_variables  # noqa: F401
 from .version_utils import parse_version
 
@@ -150,9 +151,7 @@ class MySql(DatabaseCheck):
         )
 
         # Pass function reference and managed auth flag to async jobs
-        self._statement_metrics = MySQLStatementMetrics(
-            self, self._config, self._get_connection_args, self._uses_aws_managed_auth
-        )
+        self._initialize_statement_metrics()
         self._statement_samples = MySQLStatementSamples(
             self, self._config, self._get_connection_args, self._uses_aws_managed_auth
         )
@@ -170,6 +169,16 @@ class MySql(DatabaseCheck):
         self._is_innodb_engine_enabled_cached = None
 
         self._submit_initialization_health_event()
+
+    def _initialize_statement_metrics(self):
+        if is_affirmative(self._config.statement_metrics_config.get('incremental_query_metrics', False)):
+            self.log.info("Using incremental query metrics collector")
+            collector_class = MySQLStatementMetricsV2
+        else:
+            collector_class = MySQLStatementMetrics
+        self._statement_metrics = collector_class(
+            self, self._config, self._get_connection_args, self._uses_aws_managed_auth
+        )
 
     def _submit_initialization_health_event(self):
         try:

--- a/mysql/datadog_checks/mysql/obfuscation_lookup.py
+++ b/mysql/datadog_checks/mysql/obfuscation_lookup.py
@@ -1,0 +1,251 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from dataclasses import dataclass
+
+from datadog_checks.base.utils.db.sql import compute_sql_signature
+from datadog_checks.base.utils.db.utils import obfuscate_sql_with_metadata
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class ObfuscationResult:
+    obfuscated_statement: str
+    query_signature: str
+    tables: list[str] | None
+    commands: list[str] | None
+    comments: list[str] | None
+
+
+def obfuscate_statement(
+    raw_text: str, obfuscate_options: str, log_unobfuscated_queries: bool = False
+) -> ObfuscationResult | None:
+    """Obfuscate one statement via the FFI, returning None if it cannot be obfuscated.
+
+    Exposed separately from :class:`ObfuscationLookup` for statement sources whose identity does not
+    determine their text, which therefore cannot be cached.
+    """
+    try:
+        statement = obfuscate_sql_with_metadata(raw_text, obfuscate_options)
+    except Exception as e:
+        if log_unobfuscated_queries:
+            logger.warning("Failed to obfuscate query=[%s] | err=[%s]", raw_text, e)
+        else:
+            logger.debug("Failed to obfuscate query | err=[%s]", e)
+        return None
+
+    obfuscated_statement = statement['query']
+    metadata = statement['metadata']
+    return ObfuscationResult(
+        obfuscated_statement=obfuscated_statement,
+        query_signature=compute_sql_signature(obfuscated_statement),
+        tables=metadata.get('tables', None),
+        commands=metadata.get('commands', None),
+        comments=metadata.get('comments', None),
+    )
+
+
+class ObfuscationLookup:
+    """LRU cache mapping statement digests to obfuscated query results.
+
+    MySQL derives a digest by hashing the normalized statement text, so ``digest_text`` is a pure
+    function of the digest: the same statement seen under several schemas needs one cache entry, and
+    a digest's text never changes. That makes the digest a sufficient cache key and makes any
+    outcome for a digest — including a failure — permanently valid.
+
+    A lookup resolves a digest to one of three outcomes:
+
+    - hit: the obfuscated result is cached, avoiding both the text fetch and FFI obfuscation.
+      Stored as two tiers, digest -> query_signature -> result, so the several digests that
+      normalize to one signature share a single result.
+    - miss: nothing is cached for the digest; the caller must fetch its text and pass it to
+      :meth:`populate` to obfuscate, store, and discard the raw text.
+    - ignored: the digest is known to resolve to nothing usable, either because the caller
+      rejected its text (e.g. an ``EXPLAIN`` statement) or because obfuscation failed. These are
+      neither hit nor miss; lookup skips them so they are never fetched again.
+
+    The caller decides what is non-cacheable (via :meth:`mark_ignored`); the cache only owns
+    storage and lifecycle. All three tiers are LRU-bounded by :attr:`maxsize` and cleared for a
+    digest by :meth:`evict` when it leaves the digest table.
+    """
+
+    def __init__(self, maxsize: int, obfuscate_options: str, log_unobfuscated_queries: bool = False):
+        self._maxsize = maxsize
+        self._obfuscate_options = obfuscate_options
+        self._log_unobfuscated_queries = log_unobfuscated_queries
+
+        self._digest_to_sig: OrderedDict[str, str] = OrderedDict()
+        self._sig_to_result: OrderedDict[str, ObfuscationResult] = OrderedDict()
+        # Negative cache: digests we have learned resolve to nothing cacheable.
+        self._ignored_digests: OrderedDict[str, None] = OrderedDict()
+
+        self._hits = 0
+        self._misses = 0
+
+    @property
+    def maxsize(self) -> int:
+        return self._maxsize
+
+    @maxsize.setter
+    def maxsize(self, value: int):
+        self._maxsize = value
+        self._trim()
+
+    @property
+    def digest_map_size(self) -> int:
+        return len(self._digest_to_sig)
+
+    @property
+    def signature_map_size(self) -> int:
+        return len(self._sig_to_result)
+
+    @property
+    def ignored_map_size(self) -> int:
+        return len(self._ignored_digests)
+
+    @property
+    def hits(self) -> int:
+        return self._hits
+
+    @property
+    def misses(self) -> int:
+        return self._misses
+
+    def reset_stats(self):
+        self._hits = 0
+        self._misses = 0
+
+    def lookup(self, digests: set[str]) -> tuple[dict[str, ObfuscationResult], set[str]]:
+        """Return (hits, misses) for the given digests.
+
+        Digests in the negative cache are excluded from both: they are neither a hit (no result to
+        return) nor a miss (must not be re-fetched).
+        """
+        hits: dict[str, ObfuscationResult] = {}
+        misses: set[str] = set()
+        ignored = 0
+
+        for digest in digests:
+            if digest in self._ignored_digests:
+                self._ignored_digests.move_to_end(digest)
+                ignored += 1
+                continue
+            sig = self._digest_to_sig.get(digest)
+            if sig is not None:
+                self._digest_to_sig.move_to_end(digest)
+                result = self._sig_to_result.get(sig)
+                if result is not None:
+                    self._sig_to_result.move_to_end(sig)
+                    self._hits += 1
+                    hits[digest] = result
+                    continue
+            self._misses += 1
+            misses.add(digest)
+
+        logger.debug(
+            "lookup: requested=%d hits=%d misses=%d ignored=%d digest_map=%d sig_map=%d ignored_map=%d",
+            len(digests),
+            len(hits),
+            len(misses),
+            ignored,
+            len(self._digest_to_sig),
+            len(self._sig_to_result),
+            len(self._ignored_digests),
+        )
+        return hits, misses
+
+    def mark_ignored(self, digests: set[str]) -> None:
+        """Record digests that resolve to nothing usable so future lookups skip them.
+
+        Because a digest's text never changes, both caller-side rejection and obfuscation failure
+        are permanent outcomes, so caching them costs one fetch per digest ever rather than one per
+        collection. Entries are forgotten via :meth:`evict` when the digest disappears from the
+        digest table.
+        """
+        if not digests:
+            return
+        for digest in digests:
+            # Drop any stale positive mapping so an ignored digest can never resurface as a hit
+            # (e.g. if its signature is later repopulated by another digest after this negative
+            # entry is LRU-trimmed).
+            self._digest_to_sig.pop(digest, None)
+            self._ignored_digests[digest] = None
+            self._ignored_digests.move_to_end(digest)
+        self._trim_ignored()
+        logger.debug("mark_ignored: added=%d ignored_map=%d", len(digests), len(self._ignored_digests))
+
+    def populate(self, raw_texts: dict[str, str]) -> tuple[dict[str, ObfuscationResult], set[str]]:
+        """Obfuscate raw texts and store the results.
+
+        Returns (results, failures), where failures are the digests whose text could not be
+        obfuscated. The caller should pass those to :meth:`mark_ignored`, since retrying them is
+        guaranteed to fail again.
+        """
+        results: dict[str, ObfuscationResult] = {}
+        failures: set[str] = set()
+
+        for digest, raw_text in raw_texts.items():
+            result = self._obfuscate_single(raw_text)
+            if result is None:
+                failures.add(digest)
+                continue
+
+            self._digest_to_sig[digest] = result.query_signature
+            self._trim_digests()
+
+            if result.query_signature not in self._sig_to_result:
+                self._sig_to_result[result.query_signature] = result
+                self._trim_sig()
+            else:
+                self._sig_to_result.move_to_end(result.query_signature)
+
+            results[digest] = result
+
+        logger.debug(
+            "populate: input=%d obfuscated=%d failed=%d digest_map=%d sig_map=%d",
+            len(raw_texts),
+            len(results),
+            len(failures),
+            len(self._digest_to_sig),
+            len(self._sig_to_result),
+        )
+        return results, failures
+
+    def evict(self, digests: set[str]) -> None:
+        """Forget all state (positive and negative) for digests that left the digest table."""
+        if not digests:
+            return
+        for digest in digests:
+            self._digest_to_sig.pop(digest, None)
+            self._ignored_digests.pop(digest, None)
+        logger.debug(
+            "evict: removed=%d digest_map=%d ignored_map=%d",
+            len(digests),
+            len(self._digest_to_sig),
+            len(self._ignored_digests),
+        )
+
+    def _obfuscate_single(self, raw_text: str) -> ObfuscationResult | None:
+        return obfuscate_statement(raw_text, self._obfuscate_options, self._log_unobfuscated_queries)
+
+    def _trim(self):
+        self._trim_digests()
+        self._trim_sig()
+        self._trim_ignored()
+
+    def _trim_digests(self):
+        while len(self._digest_to_sig) > self._maxsize:
+            self._digest_to_sig.popitem(last=False)
+
+    def _trim_sig(self):
+        while len(self._sig_to_result) > self._maxsize:
+            self._sig_to_result.popitem(last=False)
+
+    def _trim_ignored(self):
+        while len(self._ignored_digests) > self._maxsize:
+            self._ignored_digests.popitem(last=False)

--- a/mysql/datadog_checks/mysql/statements_v2.py
+++ b/mysql/datadog_checks/mysql/statements_v2.py
@@ -1,0 +1,538 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from __future__ import annotations
+
+import time
+from contextlib import closing
+from operator import attrgetter
+from typing import Any
+
+import pymysql
+from cachetools import TTLCache
+
+from datadog_checks.base import is_affirmative
+from datadog_checks.base.log import get_check_logger
+from datadog_checks.base.utils.common import to_native_string
+from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding
+from datadog_checks.base.utils.serialization import json
+from datadog_checks.base.utils.tracking import tracked_method
+from datadog_checks.mysql.cursor import CommenterDictCursor
+
+from .delta_detector import DeltaDetector, DeltaKey
+from .obfuscation_lookup import ObfuscationLookup, ObfuscationResult, obfuscate_statement
+from .statements import INTERNAL_COLUMNS, METRICS_COLUMNS, PREPARED_STATEMENT_SOURCE
+from .util import DatabaseConfigurationError, ManagedAuthConnectionMixin, get_list_chunks, warning_with_tags
+
+try:
+    import datadog_agent
+except ImportError:
+    from datadog_checks.base.stubs import datadog_agent
+
+Row = dict[str, Any]
+
+# Ordered projection of the cumulative counters, derived from METRICS_COLUMNS so the snapshot and
+# the delta computation can never drift apart.
+SNAPSHOT_METRIC_COLUMNS = tuple(sorted(METRICS_COLUMNS))
+
+# The digest table is bounded by performance_schema_digests_size, so a plain scan is cheap. Rows
+# with a NULL digest are the single overflow bucket, which aggregates every statement that did not
+# fit in the table and therefore has no resolvable text.
+DIGEST_SNAPSHOT_QUERY = """\
+    SELECT `schema_name`,
+           `digest`,
+           {metric_columns},
+           `last_seen`
+    FROM performance_schema.events_statements_summary_by_digest
+    WHERE `digest` IS NOT NULL
+    ORDER BY `count_star` DESC
+    LIMIT 10000
+    """.format(metric_columns=',\n           '.join('`{}`'.format(col) for col in SNAPSHOT_METRIC_COLUMNS))
+
+# The table is indexed on (SCHEMA_NAME, DIGEST), so filtering on the digest alone cannot use the
+# index and scans instead. Acceptable because this only runs for digests missing from the
+# obfuscation cache, which is empty once at startup and then only sees genuinely new statements.
+DIGEST_TEXT_QUERY = """\
+    SELECT `digest`,
+           MIN(`digest_text`) AS `digest_text`
+    FROM performance_schema.events_statements_summary_by_digest
+    WHERE `digest` IN ({placeholders})
+    GROUP BY `digest`
+    """
+
+# Every prepared statement object has a row in `performance_schema.prepared_statements_instances`.
+# MySQL documents `object_instance_begin` as the table's primary key:
+# https://dev.mysql.com/doc/refman/8.4/en/performance-schema-prepared-statements-instances-table.html
+PREPARED_STATEMENTS_QUERY = """\
+    SELECT  `object_instance_begin` AS `_dd_statement_id`,
+            `owner_object_schema` AS `schema_name`,
+            NULL AS `digest`,
+            `sql_text` AS `digest_text`,
+            `count_execute` AS `count_star`,
+            `sum_timer_execute` AS `sum_timer_wait`,
+            `sum_lock_time` AS `sum_lock_time`,
+            `sum_errors` AS `sum_errors`,
+            `sum_rows_affected` AS `sum_rows_affected`,
+            `sum_rows_sent` AS `sum_rows_sent`,
+            `sum_rows_examined` AS `sum_rows_examined`,
+            `sum_select_scan` AS `sum_select_scan`,
+            `sum_select_full_join` AS `sum_select_full_join`,
+            `sum_no_index_used` AS `sum_no_index_used`,
+            `sum_no_good_index_used` AS `sum_no_good_index_used`,
+            `sum_sort_rows` AS `sum_sort_rows`,
+            `sum_sort_merge_passes` AS `sum_sort_merge_passes`,
+            `sum_sort_range` AS `sum_sort_range`,
+            `sum_sort_scan` AS `sum_sort_scan`,
+            `sum_created_tmp_tables` AS `sum_created_tmp_tables`,
+            `sum_created_tmp_disk_tables` AS `sum_created_tmp_disk_tables`,
+            `sum_select_full_range_join` AS `sum_select_full_range_join`,
+            `sum_select_range` AS `sum_select_range`,
+            `sum_select_range_check` AS `sum_select_range_check`,
+            NOW() AS `last_seen`
+    FROM performance_schema.prepared_statements_instances
+    WHERE (`sql_text` NOT LIKE 'EXPLAIN %' OR `sql_text` IS NULL)
+    """
+
+STATEMENT_COUNT_QUERY = "SELECT count(*) AS count from performance_schema.events_statements_summary_by_digest"
+
+# Fallback when performance_schema_digests_size is unreadable. Matches the size MySQL autosizes to.
+DEFAULT_DIGESTS_SIZE = 10000
+
+# Digests per IN list. Bounded to keep the statement short enough to stay well inside
+# max_allowed_packet and to avoid a pathological parse on the first collection after startup.
+DIGEST_TEXT_BATCH_SIZE = 500
+
+
+def _digest_delta_key(row: Row) -> DeltaKey:
+    """Key the cumulative counters of a digest row.
+
+    `events_statements_summary_by_digest` aggregates per (schema, digest), so both are needed even
+    though the query text depends on the digest alone.
+    """
+    return row['schema_name'], row['digest']
+
+
+def _prepared_delta_key(row: Row) -> DeltaKey:
+    """Key the cumulative counters of a prepared statement row.
+
+    `object_instance_begin` is a reusable address, so a recycled instance can carry unrelated text.
+    Including the signature keeps a counter series tied to one statement.
+    """
+    return PREPARED_STATEMENT_SOURCE, row['schema_name'], row['_dd_statement_id'], row['query_signature']
+
+
+def _output_row_key(row: Row):
+    return row['schema_name'], row['query_signature']
+
+
+def _strip_internal_columns(row: Row) -> Row:
+    return {k: v for k, v in row.items() if k not in INTERNAL_COLUMNS}
+
+
+def _merge_rows_by_query_signature(rows: list[Row]) -> list[Row]:
+    """Merge rows sharing (schema_name, query_signature) by summing their metric columns."""
+    merged_rows: dict[tuple, Row] = {}
+    for row in rows:
+        query_key = _output_row_key(row)
+        if query_key in merged_rows:
+            for metric in METRICS_COLUMNS:
+                if metric in row:
+                    merged_rows[query_key][metric] = merged_rows[query_key].get(metric, 0) + row[metric]
+        else:
+            merged_rows[query_key] = _strip_internal_columns(row)
+
+    return list(merged_rows.values())
+
+
+class MySQLStatementMetricsV2(ManagedAuthConnectionMixin, DBMAsyncJob):
+    """Collects per-statement metrics using change detection and cached obfuscation.
+
+    The v1 collector transfers and obfuscates `digest_text` for every row in
+    `events_statements_summary_by_digest` on every collection, even though most of those statements
+    did not run during the interval. Each cycle here instead:
+
+      1. Reads a counters-only snapshot of the digest table (no query text).
+      2. Diffs it against the previous snapshot to find the statements that actually executed.
+      3. Resolves those digests against an obfuscation cache; on a miss, fetches the text, obfuscates
+         it via the FFI, caches the result, and discards the raw text.
+      4. Merges the derivative rows by (schema_name, query_signature) and emits.
+
+    Prepared statements stay on the eager path: `prepared_statements_instances` exposes no stable
+    identity for its `sql_text`, so their text is fetched and obfuscated every cycle. That table is
+    small, and its rows are merged into the output alongside the digest rows.
+    """
+
+    def __init__(self, check, config, connection_args_provider, uses_managed_auth=False):
+        collection_interval = float(config.statement_metrics_config.get('collection_interval', 10))
+        if collection_interval <= 0:
+            collection_interval = 10
+        super().__init__(
+            check,
+            rate_limit=1 / float(collection_interval),
+            run_sync=is_affirmative(config.statement_metrics_config.get('run_sync', False)),
+            enabled=is_affirmative(config.statement_metrics_config.get('enabled', True)),
+            expected_db_exceptions=(pymysql.err.DatabaseError,),
+            min_collection_interval=config.min_collection_interval,
+            dbms=check.dbms,
+            job_name="statement-metrics",
+            shutdown_callback=self._close_db_conn,
+        )
+        self._check = check
+        self._collect_prepared_statements = None
+        self._metric_collection_interval = collection_interval
+        self._connection_args_provider = connection_args_provider
+        self._uses_managed_auth = uses_managed_auth
+        self._db_created_at = 0
+        self._db = None
+        self._config = config
+        self.log = get_check_logger()
+
+        if is_affirmative(config.statement_metrics_config.get('only_query_recent_statements', False)):
+            self.log.warning(
+                "only_query_recent_statements has no effect when incremental_query_metrics is enabled, "
+                "because the counters-only snapshot already restricts collection to statements that ran."
+            )
+
+        self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
+        self._obfuscation_lookup = ObfuscationLookup(
+            maxsize=DEFAULT_DIGESTS_SIZE,
+            obfuscate_options=self._obfuscate_options,
+            log_unobfuscated_queries=self._config.log_unobfuscated_queries,
+        )
+
+        # Separate detectors: the two sources are read by separate queries, so feeding both through
+        # one detector would make each source's keys look vanished to the other.
+        self._digest_delta = DeltaDetector(
+            metric_columns=METRICS_COLUMNS,
+            key=_digest_delta_key,
+            execution_indicators=frozenset({'count_star'}),
+        )
+        self._prepared_delta = DeltaDetector(
+            metric_columns=METRICS_COLUMNS,
+            key=_prepared_delta_key,
+            execution_indicators=frozenset({'count_star'}),
+        )
+
+        # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature
+        self._full_statement_text_cache = TTLCache(
+            maxsize=self._config.full_statement_text_cache_max_size,
+            ttl=60 * 60 / self._config.full_statement_text_samples_per_hour_per_query,
+        )
+
+    def _close_db_conn(self):
+        if self._db:
+            try:
+                self._db.close()
+            except Exception:
+                self._log.debug("Failed to close db connection", exc_info=1)
+            finally:
+                self._db = None
+
+    # -- Main collection pipeline -----------------------------------------
+
+    def run_job(self):
+        start = time.time()
+        self.collect_per_statement_metrics()
+        self._check.gauge(
+            "dd.mysql.statement_metrics.collect_metrics.elapsed_ms",
+            (time.time() - start) * 1000,
+            tags=self._check.tag_manager.get_tags() + self._check._get_debug_tags(),
+            hostname=self._check.resolved_hostname,
+        )
+
+    @tracked_method(agent_check_getter=attrgetter('_check'))
+    def collect_per_statement_metrics(self):
+        # Detect a database misconfiguration by checking if the performance schema is enabled since mysql
+        # just returns no rows without errors if the performance schema is disabled
+        if self._check.global_variables.performance_schema_enabled is False:
+            self._check.record_warning(
+                DatabaseConfigurationError.performance_schema_not_enabled,
+                warning_with_tags(
+                    'Unable to collect statement metrics because the performance schema is disabled. '
+                    'See https://docs.datadoghq.com/database_monitoring/setup_mysql/'
+                    'troubleshooting#%s for more details',
+                    DatabaseConfigurationError.performance_schema_not_enabled.value,
+                    code=DatabaseConfigurationError.performance_schema_not_enabled.value,
+                    host=self._check.reported_hostname,
+                ),
+            )
+            return
+
+        # Omit internal tags for dbm payloads since those are only relevant to metrics processed directly
+        # by the agent
+        tags = [t for t in self._tags if not t.startswith('dd.internal')]
+
+        rows = self._collect_per_statement_metrics(tags)
+        if not rows:
+            # No rows to process, can skip the rest of the payload generation and avoid an empty payload
+            return
+        for event in self._rows_to_fqt_events(rows, tags):
+            self._check.database_monitoring_query_sample(json.dumps(event, default=default_json_event_encoding))
+        payload = {
+            'host': self._check.resolved_hostname,
+            'timestamp': time.time() * 1000,
+            'mysql_version': self._check.version.version + '+' + self._check.version.build,
+            'mysql_flavor': self._check.version.flavor,
+            'ddagentversion': datadog_agent.get_version(),
+            'min_collection_interval': self._metric_collection_interval,
+            'tags': tags,
+            'cloud_metadata': self._config.cloud_metadata,
+            'service': self._config.service,
+            'mysql_rows': rows,
+        }
+        self._check.database_monitoring_query_metrics(json.dumps(payload, default=default_json_event_encoding))
+        self._check.gauge(
+            "dd.mysql.collect_per_statement_metrics.rows",
+            len(rows),
+            tags=tags + self._check._get_debug_tags(),
+            hostname=self._check.reported_hostname,
+        )
+
+    @tracked_method(agent_check_getter=attrgetter('_check'), track_result_length=True)
+    def _collect_per_statement_metrics(self, tags: list[str]) -> list[Row]:
+        self._get_statement_count(tags)
+        self._sync_cache_sizes()
+
+        snapshot_rows = self._query_digest_snapshot()
+        self._check.gauge(
+            "dd.mysql.statement_metrics.query_rows",
+            len(snapshot_rows),
+            tags=tags + self._check._get_debug_tags(),
+            hostname=self._check.resolved_hostname,
+        )
+
+        delta = self._digest_delta.compute(snapshot_rows)
+
+        changed_digests = {digest for _schema_name, digest in delta.changed_keys}
+        # A digest is only forgotten once no schema references it any more, since the cached text is
+        # shared across every schema that ran the same statement.
+        live_digests = {row['digest'] for row in snapshot_rows}
+        vanished_digests = {digest for _schema_name, digest in delta.vanished_keys} - live_digests
+
+        self._check.gauge(
+            "dd.mysql.statement_metrics.delta.derivative_rows",
+            len(delta.derivative_rows),
+            tags=tags + self._check._get_debug_tags(),
+            hostname=self._check.reported_hostname,
+        )
+        self._check.gauge(
+            "dd.mysql.statement_metrics.delta.changed_digests",
+            len(changed_digests),
+            tags=tags + self._check._get_debug_tags(),
+            hostname=self._check.reported_hostname,
+        )
+
+        obfuscations = self._resolve_obfuscations(changed_digests, vanished_digests, tags)
+        rows = self._assemble_digest_rows(delta.derivative_rows, obfuscations)
+        rows.extend(self._collect_prepared_statement_rows())
+
+        self._log.debug(
+            "collect: snapshot=%d derivative=%d changed_digests=%d obfuscated=%d rows=%d",
+            len(snapshot_rows),
+            len(delta.derivative_rows),
+            len(changed_digests),
+            len(obfuscations),
+            len(rows),
+        )
+
+        return _merge_rows_by_query_signature(rows)
+
+    # -- Cache size management --------------------------------------------
+
+    def _sync_cache_sizes(self):
+        """Size the obfuscation cache to the digest table it mirrors.
+
+        The cache is keyed on the digest while `performance_schema_digests_size` bounds
+        (schema, digest) rows, so the table's size is a safe upper bound on the distinct digests
+        that can be live at once.
+        """
+        digests_size = self._check.global_variables.performance_schema_digests_size
+        maxsize = digests_size if digests_size and digests_size > 0 else DEFAULT_DIGESTS_SIZE
+        if self._obfuscation_lookup.maxsize != maxsize:
+            self._obfuscation_lookup.maxsize = maxsize
+
+    # -- Database reads ---------------------------------------------------
+
+    def _get_statement_count(self, tags: list[str]):
+        with closing(self._get_db_connection().cursor(CommenterDictCursor)) as cursor:
+            cursor.execute(STATEMENT_COUNT_QUERY)
+
+            rows = cursor.fetchall() or []
+            if rows:
+                self._check.gauge(
+                    "dd.mysql.statement_metrics.events_statements_summary_by_digest.total_rows",
+                    rows[0]['count'],
+                    tags=tags + self._check._get_debug_tags(),
+                    hostname=self._check.resolved_hostname,
+                )
+
+    @tracked_method(agent_check_getter=attrgetter('_check'), track_result_length=True)
+    def _query_digest_snapshot(self) -> list[Row]:
+        """Read the cumulative counters for every digest, without any query text."""
+        with closing(self._get_db_connection().cursor(CommenterDictCursor)) as cursor:
+            cursor.execute(DIGEST_SNAPSHOT_QUERY)
+            return cursor.fetchall() or []
+
+    @tracked_method(agent_check_getter=attrgetter('_check'), track_result_length=True)
+    def _fetch_digest_texts(self, digests: set[str]) -> dict[str, str]:
+        """Fetch `digest_text` for the given digests, in batches."""
+        texts: dict[str, str] = {}
+        if not digests:
+            return texts
+        try:
+            with closing(self._get_db_connection().cursor(CommenterDictCursor)) as cursor:
+                for chunk in get_list_chunks(sorted(digests), DIGEST_TEXT_BATCH_SIZE):
+                    query = DIGEST_TEXT_QUERY.format(placeholders=', '.join(['%s'] * len(chunk)))
+                    cursor.execute(query, chunk)
+                    for row in cursor.fetchall() or []:
+                        texts[row['digest']] = row['digest_text']
+        except pymysql.err.DatabaseError as e:
+            # Digests left unresolved stay misses and are retried on the next collection.
+            self._log.warning("Failed to fetch digest text for %d digests: %s", len(digests), e)
+        return texts
+
+    @tracked_method(agent_check_getter=attrgetter('_check'), track_result_length=True)
+    def _query_prepared_statements(self) -> list[Row]:
+        with closing(self._get_db_connection().cursor(CommenterDictCursor)) as cursor:
+            cursor.execute(PREPARED_STATEMENTS_QUERY)
+            return cursor.fetchall() or []
+
+    # -- Obfuscation resolution -------------------------------------------
+
+    @tracked_method(agent_check_getter=attrgetter('_check'), track_result_length=True)
+    def _resolve_obfuscations(
+        self, changed_digests: set[str], vanished_digests: set[str], tags: list[str]
+    ) -> dict[str, ObfuscationResult]:
+        self._obfuscation_lookup.evict(vanished_digests)
+
+        if not changed_digests:
+            return {}
+
+        hits, misses = self._obfuscation_lookup.lookup(changed_digests)
+
+        self._check.gauge(
+            "dd.mysql.statement_metrics.lookup.hits",
+            len(hits),
+            tags=tags + self._check._get_debug_tags(),
+            hostname=self._check.reported_hostname,
+        )
+        self._check.gauge(
+            "dd.mysql.statement_metrics.lookup.misses",
+            len(misses),
+            tags=tags + self._check._get_debug_tags(),
+            hostname=self._check.reported_hostname,
+        )
+
+        if misses:
+            raw_texts = self._fetch_digest_texts(misses)
+            cacheable: dict[str, str] = {}
+            ignorable: set[str] = set()
+            for digest, text in raw_texts.items():
+                if not text:
+                    continue
+                if text.lower().startswith('explain'):
+                    # EXPLAIN statements are an artifact of plan collection rather than application
+                    # traffic. v1 filters them out of the snapshot; here the snapshot has no text to
+                    # filter on, so they are recognized after resolution and negative-cached to keep
+                    # the filtering to one fetch per digest.
+                    ignorable.add(digest)
+                    continue
+                cacheable[digest] = text
+            populated, failures = self._obfuscation_lookup.populate(cacheable)
+            self._obfuscation_lookup.mark_ignored(ignorable | failures)
+            hits.update(populated)
+
+        return hits
+
+    # -- Row assembly -----------------------------------------------------
+
+    def _assemble_digest_rows(
+        self, derivative_rows: list[Row], obfuscations: dict[str, ObfuscationResult]
+    ) -> list[Row]:
+        assembled: list[Row] = []
+        for row in derivative_rows:
+            obf = obfuscations.get(row['digest'])
+            if obf is None:
+                continue
+            out = dict(row)
+            out['digest_text'] = obf.obfuscated_statement
+            out['query_signature'] = obf.query_signature
+            out['dd_tables'] = obf.tables
+            out['dd_commands'] = obf.commands
+            out['dd_comments'] = obf.comments
+            assembled.append(out)
+        return assembled
+
+    def _collect_prepared_statement_rows(self) -> list[Row]:
+        if not self.collect_prepared_statements:
+            return []
+        rows = self._normalize_prepared_statements(self._query_prepared_statements())
+        return self._prepared_delta.compute(rows).derivative_rows
+
+    def _normalize_prepared_statements(self, rows: list[Row]) -> list[Row]:
+        """Obfuscate prepared statement text, which must happen before the delta is computed.
+
+        Unlike a digest, `object_instance_begin` does not determine the statement text, so the
+        signature is part of the counter key and has to be resolved for every row every cycle.
+        """
+        normalized_rows: list[Row] = []
+        for row in rows:
+            text = row['digest_text']
+            if text is None or text.lower().startswith('explain'):
+                continue
+            result = obfuscate_statement(text, self._obfuscate_options, self._config.log_unobfuscated_queries)
+            if result is None:
+                continue
+            normalized_row = dict(row)
+            normalized_row['digest_text'] = result.obfuscated_statement
+            normalized_row['query_signature'] = result.query_signature
+            normalized_row['dd_tables'] = result.tables
+            normalized_row['dd_commands'] = result.commands
+            normalized_row['dd_comments'] = result.comments
+            normalized_rows.append(normalized_row)
+        return normalized_rows
+
+    # -- Output formatting ------------------------------------------------
+
+    def _rows_to_fqt_events(self, rows: list[Row], tags: list[str]):
+        for row in rows:
+            query_cache_key = _output_row_key(row)
+            if query_cache_key in self._full_statement_text_cache:
+                continue
+            self._full_statement_text_cache[query_cache_key] = True
+            row_tags = tags + ["schema:{}".format(row['schema_name'])] if row['schema_name'] else tags
+            yield {
+                "timestamp": time.time() * 1000,
+                "host": self._check.reported_hostname,
+                "ddagentversion": datadog_agent.get_version(),
+                "ddsource": "mysql",
+                "ddtags": ",".join(row_tags),
+                "dbm_type": "fqt",
+                'service': self._config.service,
+                "db": {
+                    "instance": row['schema_name'],
+                    "query_signature": row['query_signature'],
+                    "statement": row['digest_text'],
+                    "metadata": {
+                        "tables": row['dd_tables'],
+                        "commands": row['dd_commands'],
+                        "comments": row['dd_comments'],
+                    },
+                },
+                "mysql": {"schema": row["schema_name"]},
+            }
+
+    @property
+    def collect_prepared_statements(self):
+        if self._collect_prepared_statements is None:
+            # prepared_statements_instances table was added to MariaDB 10.5.2
+            if self._check.is_mariadb and self._check.version.version_compatible((10, 5, 2)) is False:
+                self._collect_prepared_statements = False
+            # prepared_statements_instances table was added to MySQL 5.7.4
+            elif self._check.version.version_compatible((5, 7, 4)) is False:
+                self._collect_prepared_statements = False
+            else:
+                self._collect_prepared_statements = self._config.statement_metrics_config.get(
+                    'collect_prepared_statements', True
+                )
+        return self._collect_prepared_statements

--- a/mysql/tests/test_statements_v2.py
+++ b/mysql/tests/test_statements_v2.py
@@ -1,0 +1,760 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Unit tests for the V2 statement metrics layers (DeltaDetector, ObfuscationLookup, MySQLStatementMetricsV2)."""
+
+import logging
+import time
+from concurrent.futures.thread import ThreadPoolExecutor
+
+import mock
+import pymysql
+import pytest
+
+from datadog_checks.base.utils.db.sql import compute_sql_signature
+from datadog_checks.base.utils.db.utils import DBMAsyncJob
+from datadog_checks.base.utils.serialization import json
+from datadog_checks.mysql import MySql
+from datadog_checks.mysql.delta_detector import DeltaDetector
+from datadog_checks.mysql.obfuscation_lookup import ObfuscationLookup
+from datadog_checks.mysql.statements import METRICS_COLUMNS, MySQLStatementMetrics
+from datadog_checks.mysql.statements_v2 import (
+    DEFAULT_DIGESTS_SIZE,
+    MySQLStatementMetricsV2,
+    _digest_delta_key,
+    _prepared_delta_key,
+)
+
+from . import common
+
+pytestmark = pytest.mark.unit
+
+CLOSE_TO_ZERO_INTERVAL = 0.0000001
+
+METRIC_COLS = frozenset({'count_star', 'sum_timer_wait', 'sum_rows_sent'})
+
+
+@pytest.fixture
+def dbm_instance(instance_complex):
+    instance_complex['dbm'] = True
+    instance_complex['disable_generic_tags'] = False
+    instance_complex['query_samples'] = {'enabled': False}
+    instance_complex['query_metrics'] = {
+        'enabled': True,
+        'run_sync': True,
+        'collection_interval': CLOSE_TO_ZERO_INTERVAL,
+        'incremental_query_metrics': True,
+    }
+    instance_complex['query_activity'] = {'enabled': False}
+    instance_complex['collect_settings'] = {'enabled': False}
+    return instance_complex
+
+
+@pytest.fixture(autouse=True)
+def stop_orphaned_threads():
+    # make sure we shut down any orphaned threads and create a new Executor for each test
+    DBMAsyncJob.executor.shutdown(wait=True)
+    DBMAsyncJob.executor = ThreadPoolExecutor()
+
+
+# ---------------------------------------------------------------------------
+# DeltaDetector
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaDetector:
+    def _make(self, key=_digest_delta_key, execution_indicators=frozenset({'count_star'})):
+        return DeltaDetector(metric_columns=METRIC_COLS, key=key, execution_indicators=execution_indicators)
+
+    def _row(self, digest, schema_name='testdb', **counters):
+        row = {
+            'schema_name': schema_name,
+            'digest': digest,
+            'count_star': 0,
+            'sum_timer_wait': 0,
+            'sum_rows_sent': 0,
+            'last_seen': '2026-01-01 00:00:00',
+        }
+        row.update(counters)
+        return row
+
+    def test_first_cycle_returns_no_derivatives(self):
+        dd = self._make()
+        result = dd.compute([self._row('d1', count_star=10, sum_rows_sent=100)])
+        assert result.derivative_rows == []
+        assert result.changed_keys == set()
+
+    def test_second_cycle_returns_derivatives_for_changed_rows(self):
+        dd = self._make()
+        dd.compute([self._row('d1', count_star=10, sum_rows_sent=100)])
+        result = dd.compute([self._row('d1', count_star=15, sum_rows_sent=150)])
+
+        assert len(result.derivative_rows) == 1
+        derivative = result.derivative_rows[0]
+        assert derivative['count_star'] == 5
+        assert derivative['sum_rows_sent'] == 50
+        # Non-metric columns are passed through untouched.
+        assert derivative['digest'] == 'd1'
+        assert derivative['schema_name'] == 'testdb'
+        assert result.changed_keys == {('testdb', 'd1')}
+
+    def test_unchanged_rows_are_not_emitted(self):
+        dd = self._make()
+        dd.compute([self._row('d1', count_star=10), self._row('d2', count_star=20)])
+        result = dd.compute([self._row('d1', count_star=10), self._row('d2', count_star=25)])
+        assert [row['digest'] for row in result.derivative_rows] == ['d2']
+
+    def test_negative_diff_discards_row(self):
+        dd = self._make()
+        dd.compute([self._row('d1', count_star=10, sum_rows_sent=100)])
+        result = dd.compute([self._row('d1', count_star=5, sum_rows_sent=50)])
+        assert result.derivative_rows == []
+
+    def test_execution_indicator_required(self):
+        """A row whose count_star is flat did not execute, whatever the other counters say."""
+        dd = self._make()
+        dd.compute([self._row('d1', count_star=10, sum_timer_wait=100)])
+        result = dd.compute([self._row('d1', count_star=10, sum_timer_wait=200)])
+        assert result.derivative_rows == []
+
+    def test_new_key_is_baselined_not_emitted(self):
+        dd = self._make()
+        dd.compute([self._row('d1', count_star=10)])
+        result = dd.compute([self._row('d1', count_star=15), self._row('d2', count_star=5000)])
+        assert result.changed_keys == {('testdb', 'd1')}
+
+    def test_vanished_keys_detected(self):
+        dd = self._make()
+        dd.compute([self._row('d1', count_star=10), self._row('d2', count_star=20)])
+        result = dd.compute([self._row('d1', count_star=15)])
+        assert result.vanished_keys == {('testdb', 'd2')}
+
+    def test_same_digest_in_different_schemas_are_separate_series(self):
+        """The digest table aggregates per (schema, digest), so each pair keeps its own baseline."""
+        dd = self._make()
+        dd.compute([self._row('d1', schema_name='a', count_star=10), self._row('d1', schema_name='b', count_star=10)])
+        result = dd.compute(
+            [self._row('d1', schema_name='a', count_star=15), self._row('d1', schema_name='b', count_star=10)]
+        )
+        assert result.changed_keys == {('a', 'd1')}
+        assert result.derivative_rows[0]['count_star'] == 5
+
+    def test_rows_sharing_a_key_are_summed(self):
+        dd = self._make()
+        dd.compute([self._row('d1', count_star=10, sum_rows_sent=100)])
+        result = dd.compute(
+            [self._row('d1', count_star=8, sum_rows_sent=60), self._row('d1', count_star=7, sum_rows_sent=55)]
+        )
+        assert len(result.derivative_rows) == 1
+        assert result.derivative_rows[0]['count_star'] == 5
+        assert result.derivative_rows[0]['sum_rows_sent'] == 15
+
+    def test_collapse_does_not_mutate_input_rows(self):
+        dd = self._make()
+        rows = [self._row('d1', count_star=8), self._row('d1', count_star=7)]
+        dd.compute(rows)
+        assert [row['count_star'] for row in rows] == [8, 7]
+
+    def test_reset_clears_state(self):
+        dd = self._make()
+        dd.compute([self._row('d1', count_star=10)])
+        dd.reset()
+        assert dd.compute([self._row('d1', count_star=15)]).derivative_rows == []
+
+    def test_prepared_key_includes_signature(self):
+        """A recycled object_instance_begin carrying different text must not diff against the old series."""
+        dd = self._make(key=_prepared_delta_key)
+
+        def row(instance_id, signature, count_star):
+            return {
+                'schema_name': 'testdb',
+                'digest': None,
+                '_dd_statement_id': instance_id,
+                'query_signature': signature,
+                'count_star': count_star,
+                'sum_timer_wait': 0,
+                'sum_rows_sent': 0,
+            }
+
+        dd.compute([row(1001, 'sig-a', 100)])
+        result = dd.compute([row(1001, 'sig-b', 5000)])
+        assert result.derivative_rows == []
+
+
+# ---------------------------------------------------------------------------
+# ObfuscationLookup
+# ---------------------------------------------------------------------------
+
+
+class TestObfuscationLookup:
+    def _make(self, maxsize=100):
+        return ObfuscationLookup(maxsize=maxsize, obfuscate_options='{}')
+
+    def test_empty_lookup_all_misses(self):
+        lk = self._make()
+        hits, misses = lk.lookup({'d1', 'd2', 'd3'})
+        assert hits == {}
+        assert misses == {'d1', 'd2', 'd3'}
+
+    def test_populate_then_lookup(self):
+        lk = self._make()
+        results, failures = lk.populate({'d1': 'SELECT 1', 'd2': 'SELECT 2'})
+        assert failures == set()
+        assert set(results) == {'d1', 'd2'}
+
+        hits, misses = lk.lookup({'d1', 'd2', 'd3'})
+        assert set(hits) == {'d1', 'd2'}
+        assert misses == {'d3'}
+        assert hits['d1'].obfuscated_statement is not None
+        assert hits['d1'].query_signature is not None
+
+    def test_hit_and_miss_counters(self):
+        lk = self._make()
+        lk.populate({'d1': 'SELECT 1'})
+        lk.reset_stats()
+        lk.lookup({'d1', 'd2'})
+        assert lk.hits == 1
+        assert lk.misses == 1
+
+    def test_evict_removes_digest(self):
+        lk = self._make()
+        lk.populate({'d1': 'SELECT 1', 'd2': 'SELECT 2'})
+        lk.evict({'d1'})
+        hits, misses = lk.lookup({'d1', 'd2'})
+        assert misses == {'d1'}
+        assert 'd2' in hits
+
+    def test_multiple_digests_share_signature(self):
+        """Digests that normalize to one statement share a single cached result."""
+        lk = self._make()
+        lk.populate({'d1': 'SELECT 1', 'd2': 'SELECT 1'})
+        hits, _ = lk.lookup({'d1', 'd2'})
+        assert hits['d1'].query_signature == hits['d2'].query_signature
+        assert lk.digest_map_size == 2
+        assert lk.signature_map_size == 1
+
+    def test_evict_does_not_remove_shared_signature(self):
+        lk = self._make()
+        lk.populate({'d1': 'SELECT 1', 'd2': 'SELECT 1'})
+        lk.evict({'d1'})
+        hits, _ = lk.lookup({'d2'})
+        assert 'd2' in hits
+
+    def test_lru_eviction_on_max_size(self):
+        lk = self._make(maxsize=2)
+        lk.populate({'d1': 'SELECT 1', 'd2': 'SELECT 2', 'd3': 'SELECT 3'})
+        assert lk.digest_map_size == 2
+        _, misses = lk.lookup({'d1'})
+        assert misses == {'d1'}
+
+    def test_lookup_updates_lru_order(self):
+        lk = self._make(maxsize=2)
+        lk.populate({'d1': 'SELECT 1', 'd2': 'SELECT 2'})
+        lk.lookup({'d1'})
+        lk.populate({'d3': 'SELECT 3'})
+        hits, _ = lk.lookup({'d1'})
+        assert 'd1' in hits
+        _, misses = lk.lookup({'d2'})
+        assert misses == {'d2'}
+
+    def test_maxsize_setter_trims_immediately(self):
+        lk = self._make(maxsize=10)
+        lk.populate({'d1': 'SELECT 1', 'd2': 'SELECT 2', 'd3': 'SELECT 3'})
+        lk.mark_ignored({'i1', 'i2', 'i3'})
+        lk.maxsize = 1
+        assert lk.maxsize == 1
+        assert lk.digest_map_size == 1
+        assert lk.signature_map_size == 1
+        assert lk.ignored_map_size == 1
+
+    def test_maxsize_setter_growing_does_not_evict(self):
+        lk = self._make(maxsize=2)
+        lk.populate({'d1': 'SELECT 1', 'd2': 'SELECT 2'})
+        lk.maxsize = 100
+        assert lk.digest_map_size == 2
+
+    # --- negative cache (ignored digests) ---
+
+    def test_mark_ignored_excludes_from_hits_and_misses(self):
+        lk = self._make()
+        lk.mark_ignored({'d1'})
+        hits, misses = lk.lookup({'d1', 'd2'})
+        assert 'd1' not in hits
+        assert misses == {'d2'}
+        assert lk.ignored_map_size == 1
+
+    def test_ignored_digests_do_not_move_counters(self):
+        lk = self._make()
+        lk.mark_ignored({'d1'})
+        lk.reset_stats()
+        lk.lookup({'d1'})
+        assert lk.hits == 0
+        assert lk.misses == 0
+
+    def test_evict_forgets_ignored_digest(self):
+        lk = self._make()
+        lk.mark_ignored({'d1'})
+        lk.evict({'d1'})
+        assert lk.ignored_map_size == 0
+        _, misses = lk.lookup({'d1'})
+        assert misses == {'d1'}
+
+    def test_ignored_digests_lru_trimmed_to_maxsize(self):
+        lk = self._make(maxsize=2)
+        lk.mark_ignored({'d1', 'd2', 'd3'})
+        assert lk.ignored_map_size == 2
+
+    def test_mark_ignored_drops_stale_positive_mapping(self):
+        """An ignored digest must not resurface as a hit via a stale tier-1 mapping."""
+        lk = self._make()
+        lk.populate({'d1': 'SELECT 1', 'd2': 'SELECT 1'})
+        lk.mark_ignored({'d1'})
+        hits, misses = lk.lookup({'d1'})
+        assert 'd1' not in hits
+        assert 'd1' not in misses
+
+    def test_populate_reports_obfuscation_failures(self, datadog_agent):
+        """A digest whose text cannot be obfuscated is reported so the caller can negative-cache it."""
+        lk = self._make()
+        with mock.patch.object(datadog_agent, 'obfuscate_sql', side_effect=Exception('boom')):
+            results, failures = lk.populate({'d1': 'SELECT 1'})
+        assert results == {}
+        assert failures == {'d1'}
+
+
+# ---------------------------------------------------------------------------
+# MySQLStatementMetricsV2
+# ---------------------------------------------------------------------------
+
+
+NORMALIZED_QUERY = 'SELECT * FROM `employees` WHERE `id` = ?'
+QUERY_SIGNATURE = compute_sql_signature(NORMALIZED_QUERY)
+
+
+def _snapshot_row(digest, count_star, schema_name='testdb'):
+    row = {
+        'schema_name': schema_name,
+        'digest': digest,
+        'last_seen': '2026-01-01 00:00:00',
+    }
+    row.update(dict.fromkeys(METRICS_COLUMNS, 0))
+    row['count_star'] = count_star
+    return row
+
+
+def _prepared_row(instance_id, count_star, sql_text='SELECT * FROM employees WHERE id = ?', schema_name='testdb'):
+    row = {
+        '_dd_statement_id': instance_id,
+        'schema_name': schema_name,
+        'digest': None,
+        'digest_text': sql_text,
+        'last_seen': '2026-01-01 00:00:00',
+    }
+    row.update(dict.fromkeys(METRICS_COLUMNS, 0))
+    row['count_star'] = count_star
+    return row
+
+
+class TestMySQLStatementMetricsV2:
+    @pytest.fixture(autouse=True)
+    def _obfuscate(self, datadog_agent):
+        """Route the obfuscator FFI to a stub and expose the call count to tests."""
+        with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
+            mock_agent.side_effect = lambda query, options=None: json.dumps({'query': NORMALIZED_QUERY, 'metadata': {}})
+            self.obfuscate_sql = mock_agent
+            yield mock_agent
+
+    def _make(self, dbm_instance):
+        check = MySql(common.CHECK_NAME, {}, [dbm_instance])
+        job = check._statement_metrics
+        job._collect_prepared_statements = False
+        return check, job
+
+    def test_check_selects_v2_when_flag_enabled(self, dbm_instance):
+        check = MySql(common.CHECK_NAME, {}, [dbm_instance])
+        assert isinstance(check._statement_metrics, MySQLStatementMetricsV2)
+
+    def test_check_selects_v1_by_default(self, dbm_instance):
+        del dbm_instance['query_metrics']['incremental_query_metrics']
+        check = MySql(common.CHECK_NAME, {}, [dbm_instance])
+        assert isinstance(check._statement_metrics, MySQLStatementMetrics)
+        assert not isinstance(check._statement_metrics, MySQLStatementMetricsV2)
+
+    def test_first_cycle_baselines_and_emits_nothing(self, dbm_instance):
+        _, job = self._make(dbm_instance)
+        with (
+            mock.patch.object(job, '_get_statement_count'),
+            mock.patch.object(job, '_query_digest_snapshot', return_value=[_snapshot_row('d1', 100)]),
+            mock.patch.object(job, '_fetch_digest_texts', return_value={}) as fetch,
+        ):
+            assert job._collect_per_statement_metrics([]) == []
+        # Nothing executed during the interval, so no text is fetched at all.
+        fetch.assert_not_called()
+
+    def test_second_cycle_emits_only_changed_digests(self, dbm_instance):
+        _, job = self._make(dbm_instance)
+        snapshots = iter(
+            [
+                [_snapshot_row('d1', 100), _snapshot_row('d2', 200)],
+                [_snapshot_row('d1', 110), _snapshot_row('d2', 200)],
+            ]
+        )
+        with (
+            mock.patch.object(job, '_get_statement_count'),
+            mock.patch.object(job, '_query_digest_snapshot', side_effect=snapshots),
+            mock.patch.object(job, '_fetch_digest_texts', return_value={'d1': 'SELECT 1'}) as fetch,
+        ):
+            assert job._collect_per_statement_metrics([]) == []
+            rows = job._collect_per_statement_metrics([])
+
+        # d2 was flat, so its text is never requested or obfuscated.
+        assert fetch.call_args[0][0] == {'d1'}
+        assert len(rows) == 1
+        assert rows[0]['count_star'] == 10
+        assert rows[0]['query_signature'] == QUERY_SIGNATURE
+        assert rows[0]['digest_text'] == NORMALIZED_QUERY
+
+    def test_cached_digest_is_not_refetched_or_reobfuscated(self, dbm_instance):
+        _, job = self._make(dbm_instance)
+        snapshots = iter(
+            [
+                [_snapshot_row('d1', 100)],
+                [_snapshot_row('d1', 110)],
+                [_snapshot_row('d1', 120)],
+            ]
+        )
+        with (
+            mock.patch.object(job, '_get_statement_count'),
+            mock.patch.object(job, '_query_digest_snapshot', side_effect=snapshots),
+            mock.patch.object(job, '_fetch_digest_texts', return_value={'d1': 'SELECT 1'}) as fetch,
+        ):
+            job._collect_per_statement_metrics([])
+            job._collect_per_statement_metrics([])
+            obfuscate_calls_after_first_resolve = self.obfuscate_sql.call_count
+            rows = job._collect_per_statement_metrics([])
+
+        assert fetch.call_count == 1
+        assert self.obfuscate_sql.call_count == obfuscate_calls_after_first_resolve
+        assert rows[0]['count_star'] == 10
+
+    def test_one_digest_across_schemas_is_obfuscated_once(self, dbm_instance):
+        """digest_text is a function of the digest, so schemas sharing a digest share a cache entry."""
+        _, job = self._make(dbm_instance)
+        schemas = ('a', 'b', 'c')
+        snapshots = iter(
+            [
+                [_snapshot_row('d1', 100, schema_name=s) for s in schemas],
+                [_snapshot_row('d1', 110, schema_name=s) for s in schemas],
+            ]
+        )
+        with (
+            mock.patch.object(job, '_get_statement_count'),
+            mock.patch.object(job, '_query_digest_snapshot', side_effect=snapshots),
+            mock.patch.object(job, '_fetch_digest_texts', return_value={'d1': 'SELECT 1'}) as fetch,
+        ):
+            job._collect_per_statement_metrics([])
+            self.obfuscate_sql.reset_mock()
+            rows = job._collect_per_statement_metrics([])
+
+        assert fetch.call_args[0][0] == {'d1'}
+        assert self.obfuscate_sql.call_count == 1
+        # Each schema still reports its own row.
+        assert len(rows) == 3
+        assert {row['schema_name'] for row in rows} == set(schemas)
+
+    def test_explain_digests_are_fetched_once_then_skipped(self, dbm_instance):
+        """EXPLAIN text can only be recognized after resolution, so it is negative-cached."""
+        _, job = self._make(dbm_instance)
+        snapshots = iter(
+            [
+                [_snapshot_row('d1', 100)],
+                [_snapshot_row('d1', 110)],
+                [_snapshot_row('d1', 120)],
+            ]
+        )
+        with (
+            mock.patch.object(job, '_get_statement_count'),
+            mock.patch.object(job, '_query_digest_snapshot', side_effect=snapshots),
+            mock.patch.object(job, '_fetch_digest_texts', return_value={'d1': 'EXPLAIN SELECT 1'}) as fetch,
+        ):
+            job._collect_per_statement_metrics([])
+            assert job._collect_per_statement_metrics([]) == []
+            assert job._collect_per_statement_metrics([]) == []
+
+        assert fetch.call_count == 1
+        assert 'd1' in job._obfuscation_lookup._ignored_digests
+
+    def test_obfuscation_failures_are_negative_cached(self, dbm_instance):
+        """A digest's text never changes, so a failed obfuscation is never retried."""
+        _, job = self._make(dbm_instance)
+        snapshots = iter(
+            [
+                [_snapshot_row('d1', 100)],
+                [_snapshot_row('d1', 110)],
+                [_snapshot_row('d1', 120)],
+            ]
+        )
+        self.obfuscate_sql.side_effect = Exception('boom')
+        with (
+            mock.patch.object(job, '_get_statement_count'),
+            mock.patch.object(job, '_query_digest_snapshot', side_effect=snapshots),
+            mock.patch.object(job, '_fetch_digest_texts', return_value={'d1': 'SELECT 1'}) as fetch,
+        ):
+            job._collect_per_statement_metrics([])
+            assert job._collect_per_statement_metrics([]) == []
+            assert job._collect_per_statement_metrics([]) == []
+
+        assert fetch.call_count == 1
+        assert 'd1' in job._obfuscation_lookup._ignored_digests
+
+    def test_digest_is_kept_while_live_in_another_schema(self, dbm_instance):
+        _, job = self._make(dbm_instance)
+        snapshots = iter(
+            [
+                [_snapshot_row('d1', 100, schema_name='a'), _snapshot_row('d1', 100, schema_name='b')],
+                [_snapshot_row('d1', 110, schema_name='b')],
+            ]
+        )
+        with (
+            mock.patch.object(job, '_get_statement_count'),
+            mock.patch.object(job, '_query_digest_snapshot', side_effect=snapshots),
+            mock.patch.object(job, '_fetch_digest_texts', return_value={'d1': 'SELECT 1'}),
+        ):
+            job._collect_per_statement_metrics([])
+            job._collect_per_statement_metrics([])
+
+        # Schema 'a' vanished but 'b' still runs the digest, so the cached text survives.
+        assert 'd1' in job._obfuscation_lookup._digest_to_sig
+
+    def test_fully_vanished_digest_is_evicted(self, dbm_instance):
+        _, job = self._make(dbm_instance)
+        snapshots = iter(
+            [
+                [_snapshot_row('d1', 100), _snapshot_row('d2', 100)],
+                [_snapshot_row('d1', 110), _snapshot_row('d2', 110)],
+                [_snapshot_row('d1', 120)],
+            ]
+        )
+        with (
+            mock.patch.object(job, '_get_statement_count'),
+            mock.patch.object(job, '_query_digest_snapshot', side_effect=snapshots),
+            mock.patch.object(job, '_fetch_digest_texts', return_value={'d1': 'SELECT 1', 'd2': 'SELECT 2'}),
+        ):
+            job._collect_per_statement_metrics([])
+            job._collect_per_statement_metrics([])
+            assert 'd2' in job._obfuscation_lookup._digest_to_sig
+            job._collect_per_statement_metrics([])
+
+        assert 'd2' not in job._obfuscation_lookup._digest_to_sig
+
+    def test_lookup_gauges_report_hit_rate(self, dbm_instance):
+        check, job = self._make(dbm_instance)
+        snapshots = iter(
+            [
+                [_snapshot_row('d1', 100)],
+                [_snapshot_row('d1', 110)],
+                [_snapshot_row('d1', 120)],
+            ]
+        )
+        with (
+            mock.patch.object(job, '_get_statement_count'),
+            mock.patch.object(job, '_query_digest_snapshot', side_effect=snapshots),
+            mock.patch.object(job, '_fetch_digest_texts', return_value={'d1': 'SELECT 1'}),
+            mock.patch.object(check, 'gauge') as gauge,
+        ):
+            job._collect_per_statement_metrics([])
+            job._collect_per_statement_metrics([])
+            job._collect_per_statement_metrics([])
+
+        def values(name):
+            return [call[0][1] for call in gauge.call_args_list if call[0][0] == name]
+
+        # Cycle 1 resolves nothing; cycle 2 misses on the cold cache; cycle 3 hits.
+        assert values('dd.mysql.statement_metrics.lookup.misses') == [1, 0]
+        assert values('dd.mysql.statement_metrics.lookup.hits') == [0, 1]
+        assert values('dd.mysql.statement_metrics.delta.changed_digests') == [0, 1, 1]
+        assert values('dd.mysql.statement_metrics.delta.derivative_rows') == [0, 1, 1]
+
+    def test_prepared_statements_merge_with_digest_rows(self, dbm_instance):
+        _, job = self._make(dbm_instance)
+        job._collect_prepared_statements = True
+        snapshots = iter([[_snapshot_row('d1', 100)], [_snapshot_row('d1', 110)]])
+        prepared = iter([[_prepared_row(1001, 100)], [_prepared_row(1001, 105)]])
+
+        with (
+            mock.patch.object(job, '_get_statement_count'),
+            mock.patch.object(job, '_query_digest_snapshot', side_effect=snapshots),
+            mock.patch.object(job, '_query_prepared_statements', side_effect=prepared),
+            mock.patch.object(job, '_fetch_digest_texts', return_value={'d1': 'SELECT 1'}),
+        ):
+            assert job._collect_per_statement_metrics([]) == []
+            rows = job._collect_per_statement_metrics([])
+
+        # Both sources normalize to the same signature and schema, so they merge into one row.
+        assert len(rows) == 1
+        assert rows[0]['query_signature'] == QUERY_SIGNATURE
+        assert rows[0]['count_star'] == 15
+        assert '_dd_statement_id' not in rows[0]
+
+    def test_prepared_statements_skipped_when_disabled(self, dbm_instance):
+        _, job = self._make(dbm_instance)
+        snapshots = iter([[_snapshot_row('d1', 100)], [_snapshot_row('d1', 110)]])
+        with (
+            mock.patch.object(job, '_get_statement_count'),
+            mock.patch.object(job, '_query_digest_snapshot', side_effect=snapshots),
+            mock.patch.object(job, '_query_prepared_statements') as prepared,
+            mock.patch.object(job, '_fetch_digest_texts', return_value={'d1': 'SELECT 1'}),
+        ):
+            job._collect_per_statement_metrics([])
+            job._collect_per_statement_metrics([])
+        prepared.assert_not_called()
+
+    def test_unresolvable_digest_is_dropped_from_output(self, dbm_instance):
+        """A digest whose text cannot be fetched produces no row rather than an unlabeled one."""
+        _, job = self._make(dbm_instance)
+        snapshots = iter([[_snapshot_row('d1', 100)], [_snapshot_row('d1', 110)]])
+        with (
+            mock.patch.object(job, '_get_statement_count'),
+            mock.patch.object(job, '_query_digest_snapshot', side_effect=snapshots),
+            mock.patch.object(job, '_fetch_digest_texts', return_value={}),
+        ):
+            job._collect_per_statement_metrics([])
+            assert job._collect_per_statement_metrics([]) == []
+
+    @pytest.mark.parametrize(
+        "digests_size, expected_maxsize",
+        [
+            pytest.param('20000', 20000, id='uses_reported_size'),
+            pytest.param('-1', DEFAULT_DIGESTS_SIZE, id='falls_back_when_autosized'),
+            pytest.param(None, DEFAULT_DIGESTS_SIZE, id='falls_back_when_absent'),
+            pytest.param('not-a-number', DEFAULT_DIGESTS_SIZE, id='falls_back_when_unparseable'),
+        ],
+    )
+    def test_sync_cache_sizes(self, dbm_instance, digests_size, expected_maxsize):
+        check, job = self._make(dbm_instance)
+        check.global_variables._variables = (
+            {'performance_schema_digests_size': digests_size} if digests_size is not None else {}
+        )
+        job._sync_cache_sizes()
+        assert job._obfuscation_lookup.maxsize == expected_maxsize
+
+    def test_fqt_events_emitted_once_per_signature(self, dbm_instance):
+        _, job = self._make(dbm_instance)
+        rows = [
+            {
+                'schema_name': 'testdb',
+                'query_signature': QUERY_SIGNATURE,
+                'digest_text': NORMALIZED_QUERY,
+                'dd_tables': ['employees'],
+                'dd_commands': ['SELECT'],
+                'dd_comments': None,
+            }
+        ]
+        assert len(list(job._rows_to_fqt_events(rows, []))) == 1
+        assert list(job._rows_to_fqt_events(rows, [])) == []
+
+    def test_only_query_recent_statements_warns(self, dbm_instance, caplog):
+        dbm_instance['query_metrics']['only_query_recent_statements'] = True
+        caplog.set_level(logging.WARNING, logger="datadog_checks")
+        MySql(common.CHECK_NAME, {}, [dbm_instance])
+        assert 'only_query_recent_statements has no effect' in caplog.text
+
+    def test_digest_text_fetch_is_batched(self, dbm_instance):
+        _, job = self._make(dbm_instance)
+        digests = {'d{}'.format(i) for i in range(1200)}
+        cursor = mock.MagicMock()
+        cursor.fetchall.return_value = []
+        connection = mock.MagicMock()
+        connection.cursor.return_value = cursor
+
+        with mock.patch.object(job, '_get_db_connection', return_value=connection):
+            job._fetch_digest_texts(digests)
+
+        batch_sizes = [len(call[0][1]) for call in cursor.execute.call_args_list]
+        assert batch_sizes == [500, 500, 200]
+        # Every statement binds exactly as many placeholders as it passes parameters.
+        for call in cursor.execute.call_args_list:
+            statement, params = call[0]
+            assert statement.count('%s') == len(params)
+
+    def test_digest_text_fetch_returns_partial_result_on_error(self, dbm_instance):
+        """A failed batch leaves its digests unresolved instead of losing the whole cycle."""
+        _, job = self._make(dbm_instance)
+        cursor = mock.MagicMock()
+        cursor.execute.side_effect = [None, pymysql.err.OperationalError('gone')]
+        cursor.fetchall.return_value = [{'digest': 'd1', 'digest_text': 'SELECT 1'}]
+        connection = mock.MagicMock()
+        connection.cursor.return_value = cursor
+
+        with mock.patch.object(job, '_get_db_connection', return_value=connection):
+            texts = job._fetch_digest_texts({'d{}'.format(i) for i in range(600)})
+
+        assert texts == {'d1': 'SELECT 1'}
+
+    def test_performance_schema_disabled_records_warning(self, dbm_instance):
+        check, job = self._make(dbm_instance)
+        check.global_variables._variables = {'performance_schema': 'OFF'}
+        with mock.patch.object(job, '_collect_per_statement_metrics') as collect:
+            job.collect_per_statement_metrics()
+        collect.assert_not_called()
+        assert check._warnings_by_code
+
+
+# ---------------------------------------------------------------------------
+# Payload parity between v1 and v2
+# ---------------------------------------------------------------------------
+
+
+def test_v2_row_shape_matches_v1(dbm_instance, datadog_agent):
+    """The rows the two collectors hand to the payload carry the same keys."""
+    v1_instance = dict(dbm_instance)
+    v1_instance['query_metrics'] = dict(dbm_instance['query_metrics'])
+    del v1_instance['query_metrics']['incremental_query_metrics']
+
+    v1_check = MySql(common.CHECK_NAME, {}, [v1_instance])
+    v2_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
+
+    def v1_row(count_star):
+        row = {
+            '_dd_statement_id': None,
+            'schema_name': 'testdb',
+            'digest': 'd1',
+            'digest_text': 'SELECT * FROM employees WHERE id = ?',
+            'last_seen': time.time(),
+        }
+        row.update(dict.fromkeys(METRICS_COLUMNS, 0))
+        row['count_star'] = count_star
+        return row
+
+    with (
+        mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent,
+        mock.patch.object(v1_check._statement_metrics, '_get_statement_count'),
+        mock.patch.object(
+            v1_check._statement_metrics,
+            '_query_summary_per_statement',
+            side_effect=iter([[v1_row(100)], [v1_row(110)]]),
+        ),
+        mock.patch.object(v2_check._statement_metrics, '_get_statement_count'),
+        mock.patch.object(
+            v2_check._statement_metrics,
+            '_query_digest_snapshot',
+            side_effect=iter([[_snapshot_row('d1', 100)], [_snapshot_row('d1', 110)]]),
+        ),
+        mock.patch.object(
+            v2_check._statement_metrics,
+            '_fetch_digest_texts',
+            return_value={'d1': 'SELECT * FROM employees WHERE id = ?'},
+        ),
+    ):
+        mock_agent.side_effect = lambda query, options=None: json.dumps({'query': NORMALIZED_QUERY, 'metadata': {}})
+        v2_check._statement_metrics._collect_prepared_statements = False
+
+        v1_check._statement_metrics._collect_per_statement_metrics([])
+        v1_rows = v1_check._statement_metrics._collect_per_statement_metrics([])
+        v2_check._statement_metrics._collect_per_statement_metrics([])
+        v2_rows = v2_check._statement_metrics._collect_per_statement_metrics([])
+
+    assert len(v1_rows) == len(v2_rows) == 1
+    assert set(v1_rows[0]) == set(v2_rows[0])
+    assert v1_rows[0]['query_signature'] == v2_rows[0]['query_signature']
+    assert v1_rows[0]['count_star'] == v2_rows[0]['count_star'] == 10


### PR DESCRIPTION
### What does this PR do?

Adds an alternative query metrics collector for MySQL behind a new hidden, default-off `incremental_query_metrics` flag.

The existing collector obfuscates every row returned from `events_statements_summary_by_digest` on every collection, including statements that have not executed since the previous one. The new collector snapshots the cumulative counters, diffs them against the previous snapshot to determine which statements actually executed, and resolves and obfuscates query text only for those. Obfuscation results are memoized in a digest-keyed cache sized from `performance_schema_digests_size`.

Three new modules are added — `delta_detector.py`, `obfuscation_lookup.py`, and `statements_v2.py` — mirroring the structure of the equivalent Postgres implementation. Collector selection happens once at check initialization in `_initialize_statement_metrics`. A `performance_schema_digests_size` accessor is added to `GlobalVariables`, and the existing integer-coercing property bodies there are folded into a shared `_get_int_variable` helper.

The emitted payload is unchanged. Existing users are unaffected until they explicitly opt in.

### Motivation

Obfuscation is a cgo call and is the dominant cost of query metrics collection on instances with large digest tables, since it is repeated every collection for statements whose counters have not moved.

Benchmarked end to end against a live Agent container with both collectors running side by side over four workload shapes (cold, warm, hot-light, hot-churn), comparing intercepted payloads:

- Obfuscation calls fall by up to 3572x on steady-state workloads.
- Wall clock improves by 1.01x to 1.54x depending on workload shape, and never regresses.
- Emitted metric payloads are identical to the existing collector in every scenario.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)