### PR TITLE
[AI-7087] Stabilize modal layout tests

### DIFF
--- a/ddev/tests/cli/meta/ai/tui/test_launch_modal.py
+++ b/ddev/tests/cli/meta/ai/tui/test_launch_modal.py
@@ -49,6 +49,8 @@ async def test_launch_modal_occupies_at_least_half_viewport(make_launch_modal_ap
 
     async with app.run_test(size=viewport) as pilot:
         await pilot.pause()
+        app.screen.refresh(layout=True)
+        await app.screen.wait_for_refresh()
         dialog = app.screen.query_one("#dialog")
         actions = app.screen.query_one(".modal-actions")
         launch_button = app.screen.query_one("#btn-launch")

--- a/ddev/tests/cli/meta/ai/tui/test_main_screen.py
+++ b/ddev/tests/cli/meta/ai/tui/test_main_screen.py
@@ -153,6 +153,8 @@ async def test_diagnostics_modal_occupies_at_least_half_viewport(make_togo_app):
         await pilot.pause()
         app.screen.query_one("FlowCard").on_click()
         await pilot.pause()
+        app.screen.refresh(layout=True)
+        await app.screen.wait_for_refresh()
         dialog = app.screen.query_one("#dialog")
         actions = app.screen.query_one(".modal-actions")
         close_button = app.screen.query_one("#btn-close")


### PR DESCRIPTION
### What does this PR do?

Waits for an explicit Textual layout refresh before asserting modal geometry in the diagnostics and launch modal tests. This keeps both tests synchronized with the layout state they inspect instead of relying on a single event-loop pause.

### Motivation

The diagnostics modal test (CI test "ddev on Windows") intermittently observed a zero-sized dialog on Windows because the modal was mounted before its layout pass completed ([example](https://github.com/DataDog/integrations-core/actions/runs/31090700027/job/92580725353?pr=24701)). The launch modal test used the same timing-sensitive pattern, so it is hardened at the same time.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged