### PR TITLE
Add mysql.uptime metric

### DIFF
--- a/mysql/changelog.d/24802.added
+++ b/mysql/changelog.d/24802.added
@@ -1,0 +1,1 @@
+Add the ``mysql.uptime`` metric, reporting the number of seconds the server has been up.

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -16,6 +16,8 @@ AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPE = {
 
 # Vars found in "SHOW STATUS;"
 STATUS_VARS = {
+    # Server Metrics
+    'Uptime': ('mysql.uptime', GAUGE),
     # Command Metrics
     'Prepared_stmt_count': ('mysql.performance.prepared_stmt_count', GAUGE),
     'Slow_queries': ('mysql.performance.slow_queries', RATE),

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -697,7 +697,7 @@ class MySql(DatabaseCheck):
                 status_metric = status_dict["metric_name"]
                 if status_name in metrics.keys():
                     collected_metric = metrics.get(status_name)[0]
-                    self.log.debug(
+                    self.warning(
                         "Skipping status variable %s for metric %s as it is already collected by %s",
                         status_name,
                         status_metric,

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -253,3 +253,4 @@ mysql.replication.seconds_behind_master,gauge,,second,,The lag in seconds betwee
 mysql.replication.seconds_behind_source,gauge,,second,,The lag in seconds between the source and the replica.,-1,mysql,replication lag,
 mysql.replication.slave_running,gauge,,,,Deprecated. Use service check mysql.replication.replica_running instead. A boolean showing if this server is a replication slave / master that is running.,0,mysql,slave running,
 mysql.replication.slaves_connected,gauge,,,,Deprecated. Use `mysql.replication.replicas_connected` instead. Number of slaves connected to a replication master.,0,mysql,slaves connected,
+mysql.uptime,gauge,,second,,The number of seconds that the server has been up.,0,mysql,uptime,

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -798,7 +798,7 @@ def test_additional_variable_unknown(aggregator, dd_run_check, instance_invalid_
 @pytest.mark.usefixtures('dd_environment')
 def test_additional_status_already_queried(aggregator, dd_run_check, instance_status_already_queried, caplog):
     caplog.clear()
-    caplog.set_level(logging.DEBUG)
+    caplog.set_level(logging.WARNING)
     mysql_check = MySql(common.CHECK_NAME, {}, [instance_status_already_queried])
     dd_run_check(mysql_check)
 

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 STATUS_VARS = [
+    # Server Metrics
+    'mysql.uptime',
     # Command Metrics
     'mysql.performance.prepared_stmt_count',
     'mysql.performance.slow_queries',


### PR DESCRIPTION
### What does this PR do?

Adds `mysql.uptime`, a gauge reporting the number of seconds the MySQL server has been up.

The `Uptime` status variable was already returned by the `SHOW GLOBAL STATUS` query the check runs on every collection, but it was never mapped to a metric name. This maps it in `STATUS_VARS`, so there is no new query and no additional collection cost.

The name matches our other database integrations (`postgresql.uptime`, `mongodb.uptime`) and the OpenTelemetry `mysqlreceiver` metric of the same name.

### Motivation

Server uptime is an important signal to surface. This brings us inline with our other DBMS's

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged