### PR TITLE
Handle non-numeric version suffixes in ClickHouse version parsing

### DIFF
--- a/clickhouse/changelog.d/24805.fixed
+++ b/clickhouse/changelog.d/24805.fixed
@@ -1,0 +1,1 @@
+Fix a crash on Altinity FIPS builds whose version string includes a non-numeric suffix (e.g. ``25.3.8.30001.altinityfips``).

--- a/clickhouse/datadog_checks/clickhouse/utils.py
+++ b/clickhouse/datadog_checks/clickhouse/utils.py
@@ -108,5 +108,18 @@ def cluster_aware_query(base: dict) -> dict:
     }
 
 
+LEADING_DIGITS = re.compile(r'\d+')
+
+
 def parse_version(version: str) -> list[int]:
-    return [int(v) for v in version.split('.')]
+    # Parse the leading numeric parts of a dot-separated version, stopping at the
+    # first segment that doesn't start with a digit. Some distributions append a
+    # non-numeric qualifier (e.g. Altinity FIPS builds report
+    # `25.3.8.30001.altinityfips`), which would otherwise break ``int()``.
+    parts = []
+    for segment in version.split('.'):
+        match = LEADING_DIGITS.match(segment)
+        if match is None:
+            break
+        parts.append(int(match.group()))
+    return parts

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -286,6 +286,9 @@ def test_connect_no_password_uses_empty_string():
         ('25.1.2.3', '25.1.2.10', True),
         ('25.1', '25.3', True),
         ('23.1', '25.1', True),
+        # Altinity FIPS builds carry a non-numeric qualifier that must not break comparison.
+        ('25.3.8.30001.altinityfips', '25.3.8.30002', True),
+        ('25.3.8.30001.altinityfips', '21.3', False),
     ],
 )
 def test_version_lt(instance, ch_version, comparable, expected):
@@ -303,6 +306,9 @@ def test_version_lt(instance, ch_version, comparable, expected):
         ('25.1.2.3', '25.1.2.3', True),
         ('25.1', '25.3', False),
         ('23.1', '25.1', False),
+        # Altinity FIPS builds carry a non-numeric qualifier that must not break comparison.
+        ('25.3.8.30001.altinityfips', '21.3', True),
+        ('25.3.8.30001.altinityfips', '25.3.8.30002', False),
     ],
 )
 def test_version_ge(instance, ch_version, comparable, expected):

--- a/clickhouse/tests/test_utils.py
+++ b/clickhouse/tests/test_utils.py
@@ -30,7 +30,10 @@ class TestErrorSanitizer:
         ('25.1', [25, 1]),
         ('25.1.2', [25, 1, 2]),
         ('25.1.2.3', [25, 1, 2, 3]),
+        # Altinity FIPS builds append a non-numeric qualifier to the version string.
+        ('25.3.8.30001.altinityfips', [25, 3, 8, 30001]),
+        ('25.3.8.30001.altinityfips-alpine', [25, 3, 8, 30001]),
     ],
 )
 def test_parse_version(version: str, expected: list[int]):
-    expected == utils.parse_version(version)
+    assert utils.parse_version(version) == expected


### PR DESCRIPTION
### What does this PR do?
Makes the ClickHouse integration's version parsing tolerant of a non-numeric qualifier appended to the server version string. `parse_version` now parses the leading numeric parts of each dot-separated segment and stops at the first segment that doesn't start with a digit, instead of calling `int()` on every segment.

### Motivation
Altinity FIPS-compatible builds report a version like `25.3.8.30001.altinityfips`. The previous `parse_version` did `[int(v) for v in version.split('.')]`, so `int('altinityfips')` raised `ValueError: invalid literal for int() with base 10: 'altinityfips'`. This is hit on every check run via `get_queries()` → `version_ge('21.3')`, so the check crashed continuously on Altinity FIPS deployments and never reported.

Reproduced end-to-end against `altinity/clickhouse-server:25.3.8.30001.altinityfips`: before the fix the full `check()` crashes with the `ValueError` above; after the fix it completes cleanly and `version_ge`/`version_lt` return correct results. The regression was introduced in #21294 (check 6.7.0), which added `parse_version` — consistent with the reporter seeing 5.3.0 work and 7.0.0 fail.

Internal ref: SDBM-2866.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
