### PR TITLE
Default Istio integration to OpenMetrics V2

### DIFF
--- a/istio/assets/configuration/spec.yaml
+++ b/istio/assets/configuration/spec.yaml
@@ -16,7 +16,7 @@ files:
           fleet_configurable: true
           value:
             example: true
-            display_default: false
+            display_default: true
             type: boolean
           enabled: true
         - name: istio_mode
@@ -125,7 +125,7 @@ files:
           `istiod_endpoint` or `istio_mesh_endpoint`.
         value:
           example: true
-          display_default: false
+          display_default: true
           type: boolean
       - name: istio_mode
         description: |

--- a/istio/changelog.d/24808.changed
+++ b/istio/changelog.d/24808.changed
@@ -1,0 +1,1 @@
+Default to the OpenMetrics V2 implementation when ``use_openmetrics`` is unset, fixing a regression where it was never actually applied.

--- a/istio/datadog_checks/istio/config_models/defaults.py
+++ b/istio/datadog_checks/istio/config_models/defaults.py
@@ -169,7 +169,7 @@ def instance_use_legacy_auth_encoding():
 
 
 def instance_use_openmetrics():
-    return False
+    return True
 
 
 def instance_use_process_start_time():

--- a/istio/datadog_checks/istio/data/auto_conf.yaml
+++ b/istio/datadog_checks/istio/data/auto_conf.yaml
@@ -16,7 +16,7 @@ init_config:
 instances:
 
   -
-    ## @param use_openmetrics - boolean - optional - default: false
+    ## @param use_openmetrics - boolean - optional - default: true
     ## Use the OpenMetrics V2 implementation for more features and better performance.
     ## This implementation is only available for Istio >= 1.5, and should be used with
     ## `istiod_endpoint` or `istio_mesh_endpoint`.

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -45,7 +45,7 @@ init_config:
 #
 instances:
 
-    ## @param use_openmetrics - boolean - optional - default: false
+    ## @param use_openmetrics - boolean - optional - default: true
     ## Use the OpenMetrics V2 implementation for more features and better performance.
     ## This implementation is only available for Istio >= 1.5, and should be used with
     ## `istiod_endpoint` or `istio_mesh_endpoint`.

--- a/istio/datadog_checks/istio/istio.py
+++ b/istio/datadog_checks/istio/istio.py
@@ -44,7 +44,7 @@ class Istio(OpenMetricsBaseCheck):
     def __new__(cls, name, init_config, instances):
         instance = instances[0]
 
-        if is_affirmative(instance.get('use_openmetrics', False)):
+        if is_affirmative(instance.get('use_openmetrics', True)):
             return IstioCheckV2(name, init_config, instances)
         else:
             if instance.get('istiod_endpoint'):

--- a/istio/tests/test_unit_istio_v2.py
+++ b/istio/tests/test_unit_istio_v2.py
@@ -9,11 +9,27 @@ from datadog_checks.base import ConfigurationError
 from datadog_checks.dev import get_here
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.istio import Istio
+from datadog_checks.istio.check import IstioCheckV2
 
 from . import common
 from .utils import _assert_tags_excluded, get_fixture_path
 
 FIXTURE_DIR = '{}/fixtures'.format(get_here())
+
+
+def test_uses_openmetrics_v2_when_use_openmetrics_is_unset():
+    """
+    spec.yaml/conf.yaml.example show `use_openmetrics: true` uncommented and PR #10304's stated intent
+    was to make OpenMetrics V2 the default. Confirm that intent actually holds when the key is omitted
+    entirely from the config, as it is for any pre-existing install or anyone following docs/tutorials
+    that predate this option.
+    """
+    instance = {k: v for k, v in common.MOCK_LEGACY_ISTIOD_INSTANCE.items() if k != 'use_openmetrics'}
+    assert 'use_openmetrics' not in instance
+
+    check = Istio(common.CHECK_NAME, {}, [instance])
+
+    assert isinstance(check, IstioCheckV2)
 
 
 def test_istiod(aggregator, dd_run_check, mock_http_response):


### PR DESCRIPTION
### What does this PR do?
- Makes Istio use OpenMetrics V2 by default, as intended by [PR #10304](https://github.com/DataDog/integrations-core/pull/10304) but never actually took effect.
- Adds a regression test (`test_uses_openmetrics_v2_when_use_openmetrics_is_unset`) asserting V2 dispatch when the `use_openmetrics` is absent.

### Motivation

- [PR #10304](https://github.com/DataDog/integrations-core/pull/10304) (2021) intended to default Istio to OpenMetrics V2, but only changed the documentation/config-model layer — `validators.py`'s `instance_use_openmetrics()`, `spec.yaml`'s `display_default`, and the `conf.yaml.example` comment. It never touched `istio.py`'s `__new__`, which is the actual dispatch code and reads the raw instance dict directly, before any of that pydantic-model machinery ever runs. So the real default was `False` the whole time — the PR's title didn't match what it shipped.

- [PR #11953](https://github.com/DataDog/integrations-core/pull/11953) (2022) then changed those same docs/config-model values back to `false` — but since #10304 had never functionally changed anything, #11953 didn't revert working behavior. It just re-aligned the documentation with what the code had been doing continuously since 2021. Two PRs, three years apart, and the actual dispatch behavior never moved once.

This gap is the root cause of a recurring multi-year pattern of support escalations where customers on the undocumented "actual" default (V1) see metric-type mismatches against Prometheus/OpenMetrics — V1 submits `*.count` metrics as a gauge, V2 submits the same name as a monotonic count.
 - AGENT-14573
 - AGENT-14712
 - AGENT-14704
 - AGENT-14412
 - AGENT-16166
 - AGENT-16342
 - AGENT-16654 (current) 
 

**Note for reviewers:** 
- this changes default behavior for any existing instance that doesn't explicitly set `use_openmetrics`. Once this ships, `istio.mesh.request.count` (and other `*.count`/`*.sum` metrics) switch from gauge to monotonic_count submission for those users, and V2 also collects a different metric set than V1 (per #10304's description). This is intentionally the fix for the underlying regression, but the rollout/communication strategy (changelog messaging, deprecation notice, staged rollout, etc.) needs discussion before merging — opening as draft for that conversation. Do we need a breaking change message?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
