### PR TITLE
Cache worktree lookups in GitRepository

### DIFF
--- a/ddev/changelog.d/24809.fixed
+++ b/ddev/changelog.d/24809.fixed
@@ -1,0 +1,1 @@
+Read the repository worktrees once per lookup instead of once per checked path.

--- a/ddev/src/ddev/utils/git.py
+++ b/ddev/src/ddev/utils/git.py
@@ -25,6 +25,7 @@ class GitRepository:
         self.__repo_root = repo_root
 
         self.__filtered_tags: dict[str, list[str]] = {}
+        self.__worktree_paths: list[Path] | None = None
 
     @property
     def repo_root(self) -> Path:
@@ -36,9 +37,7 @@ class GitRepository:
         If `include_root` is True, the worktree representing the root of the repo is included.
         If `only_subpaths` is True, worktrees outside of the repo root are not included.
         """
-        worktree_output = self.capture('worktree', 'list', '--porcelain')
-
-        worktree_paths = [Path(line.split()[1]) for line in worktree_output.splitlines() if line.startswith('worktree')]
+        worktree_paths = self.__list_worktrees()
 
         # Use the resolved repo path because git will show the resolved path of the worktrees
         # in the porcelain output
@@ -51,6 +50,20 @@ class GitRepository:
 
         result = [worktree_path for worktree_path in worktree_paths if include_root or worktree_path != repo_root]
         return result
+
+    def __list_worktrees(self) -> list[Path]:
+        """Return every worktree path, asking git once per set of worktrees.
+
+        Callers such as `IntegrationRegistry` ask whether each of hundreds of directories is a
+        worktree, and the answer only changes when this repository adds or removes one.
+        """
+        if self.__worktree_paths is None:
+            output = self.capture('worktree', 'list', '--porcelain')
+            self.__worktree_paths = [
+                Path(line.split()[1]) for line in output.splitlines() if line.startswith('worktree')
+            ]
+
+        return self.__worktree_paths
 
     def is_worktree(self, path: Path, include_root=False, only_subpaths=True) -> bool:
         """
@@ -191,6 +204,7 @@ class GitRepository:
     def run(self, *args):
         import subprocess
 
+        self.__forget_worktrees(args)
         with self.repo_root.as_cwd():
             try:
                 subprocess.run(['git', *args], check=True)
@@ -200,6 +214,7 @@ class GitRepository:
     def capture(self, *args):
         import subprocess
 
+        self.__forget_worktrees(args)
         with self.repo_root.as_cwd():
             try:
                 process = subprocess.run(
@@ -209,6 +224,11 @@ class GitRepository:
                 raise OSError(f'{str(e)[:-1]}:\n{e.output}') from None
 
         return process.stdout
+
+    def __forget_worktrees(self, args: tuple[str, ...]) -> None:
+        """Drop the cached worktree paths when a command is about to change them."""
+        if args[:1] == ('worktree',) and args[1:2] != ('list',):
+            self.__worktree_paths = None
 
     def merge_base(self, ref_a: str, ref_b: str | None = "HEAD") -> str:
         return self.capture('merge-base', ref_a, ref_b).splitlines()[0]

--- a/ddev/tests/utils/test_git.py
+++ b/ddev/tests/utils/test_git.py
@@ -333,14 +333,23 @@ def test_worktrees_asks_git_once(repository, mocker):
     assert [call.args for call in capture.call_args_list] == [('worktree', 'list', '--porcelain')]
 
 
-def test_worktrees_are_looked_up_again_after_the_set_changes(repository):
+# Both entry points must invalidate: `capture` is what ddev reads through, `run` is what
+# `ddev release port-commit` adds and removes its worktree with.
+@pytest.mark.parametrize('entry_point', ['capture', 'run'])
+def test_worktrees_are_looked_up_again_after_the_set_changes(repository, entry_point):
     repo = Repository(repository.path.name, str(repository.path))
-    added = repo.path / 'wt3'
+    git = getattr(repo.git, entry_point)
+    added = repo.path / f'wt-{entry_point}'
 
     assert not repo.git.is_worktree(added)
 
     # Registering the worktree is enough, and checking out this repository exceeds the Windows
     # path length limit
-    repo.git.capture('worktree', 'add', '--no-checkout', str(added), 'HEAD')
+    git('worktree', 'add', '--no-checkout', str(added), 'HEAD')
+    try:
+        assert repo.git.is_worktree(added)
+    finally:
+        # `reset_branch` cannot undo this, so the session-scoped clone would keep the worktree
+        git('worktree', 'remove', '--force', str(added))
 
-    assert repo.git.is_worktree(added)
+    assert not repo.git.is_worktree(added)

--- a/ddev/tests/utils/test_git.py
+++ b/ddev/tests/utils/test_git.py
@@ -321,3 +321,26 @@ def test_is_worktree(
         repo.git.is_worktree(repo.path.parent / "wt2", include_root=include_root, only_subpaths=only_subpaths)
         is not only_subpaths
     )
+
+
+def test_worktrees_asks_git_once(repository, mocker):
+    repo = Repository(repository.path.name, str(repository.path))
+    capture = mocker.spy(repo.git, 'capture')
+
+    for path in repository.path.iterdir():
+        repo.git.is_worktree(path)
+
+    assert [call.args for call in capture.call_args_list] == [('worktree', 'list', '--porcelain')]
+
+
+def test_worktrees_are_looked_up_again_after_the_set_changes(repository):
+    repo = Repository(repository.path.name, str(repository.path))
+    added = repo.path / 'wt3'
+
+    assert not repo.git.is_worktree(added)
+
+    # Registering the worktree is enough, and checking out this repository exceeds the Windows
+    # path length limit
+    repo.git.capture('worktree', 'add', '--no-checkout', str(added), 'HEAD')
+
+    assert repo.git.is_worktree(added)


### PR DESCRIPTION
> **Stack** (bottom to top)
> 1. **Cache worktree lookups in `GitRepository`** :arrow_left: you are here
> 2. #24776 Return structured change records from `GitRepository.changed_files`
> 3. #24687 Build deterministic Dispatcher test batching plans

### What does this PR do?
Reads the repository's worktree paths once instead of once per question.

`is_worktree` shelled out to `git worktree list --porcelain` on every call, and `IntegrationRegistry.__iter_filtered` asks it about every top-level directory. On `integrations-core` that is 444 subprocesses for a single `iter_*()` call. The paths are now cached on the `GitRepository` instance and dropped whenever a `worktree` command other than `list` runs, so `ddev release port-commit` adding or removing a worktree cannot leave a stale answer.

Measured on `tests/repo/test_core.py`, `tests/utils/test_git.py` and `tests/cli/release/test_changelog.py`, same 103 tests passing both ways:

| | time |
| --- | --- |
| before | 468s |
| after | 90s |

Several test modules already patched `worktrees` with `return_value=[]` to sidestep the cost; those workarounds can go away later.

### Motivation
Repository-backed tests dominate the `ddev` suite runtime, and the cost was subprocess spawning rather than any real work. This is also groundwork for the two PRs above, which query changed files more than the current code does.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
