### PR TITLE
Discard negative broker offsets instead of reporting them

### DIFF
--- a/kafka_consumer/changelog.d/24814.fixed
+++ b/kafka_consumer/changelog.d/24814.fixed
@@ -1,0 +1,1 @@
+Discard broker and log-start offsets that come back negative, instead of reporting a negative ``kafka.broker_offset`` and firing a spurious negative consumer lag event for every partition on every run.

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -172,11 +172,26 @@ class KafkaClient:
         )
 
         results = []
+        negative = []
         for tp, future in futures.items():
             try:
-                results.append((tp.topic, tp.partition, future.result().offset))
+                partition_offset = future.result().offset
             except Exception as e:
                 self.log.debug("Skipping offsets for %s/%s: %s", tp.topic, tp.partition, e)
+                continue
+            if partition_offset < 0:
+                negative.append((tp.topic, tp.partition, partition_offset))
+                continue
+            results.append((tp.topic, tp.partition, partition_offset))
+        if negative:
+            # A Kafka offset is never negative, so the client library mangled this one: it narrows
+            # ListOffsets results through a C long, which is 32 bits wide on Windows x64.
+            # https://github.com/confluentinc/confluent-kafka-python/issues/1696
+            self.log.warning(
+                "Discarding %s negative offset(s), so broker offset and lag will be missing for those partitions: %s",
+                len(negative),
+                negative[:5],
+            )
         return results
 
     def _list_topics(self):

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -184,12 +184,14 @@ class KafkaClient:
                 continue
             results.append((tp.topic, tp.partition, partition_offset))
         if negative:
-            # A Kafka offset is never negative, so the client library mangled this one: it narrows
+            # A Kafka offset is never negative, so the client library mangled these: it narrows
             # ListOffsets results through a C long, which is 32 bits wide on Windows x64.
             # https://github.com/confluentinc/confluent-kafka-python/issues/1696
             self.log.warning(
-                "Discarding %s negative offset(s), so broker offset and lag will be missing for those partitions: %s",
+                "Discarding %d/%d negative offset(s): broker_offset and consumer_lag will be "
+                "missing for those partitions (up to 5 shown): %s",
                 len(negative),
+                len(request),
                 negative[:5],
             )
         return results

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -488,6 +488,7 @@ class ClusterMetadataCollector:
 
         result = {}
         errors = 0
+        negative = []
         try:
             futures = self.client.kafka_client.list_offsets(
                 requests,
@@ -507,17 +508,8 @@ class ClusterMetadataCollector:
                             e,
                         )
                     continue
-                # A Kafka offset is never negative, so the client library mangled this one.
-                # https://github.com/confluentinc/confluent-kafka-python/issues/1696
                 if offset < 0:
-                    errors += 1
-                    if errors <= 3:
-                        self.log.debug(
-                            "Discarding negative earliest offset %s for %s:%s",
-                            offset,
-                            tp.topic,
-                            tp.partition,
-                        )
+                    negative.append((tp.topic, tp.partition, offset))
                     continue
                 result[(tp.topic, tp.partition)] = offset
         except Exception as e:
@@ -533,6 +525,18 @@ class ClusterMetadataCollector:
                 "earliest-dependent metrics will be skipped for those partitions",
                 errors,
                 len(requests),
+            )
+        if negative:
+            # A Kafka offset is never negative, so the client library mangled these: it narrows
+            # ListOffsets results through a C long, which is 32 bits wide on Windows x64.
+            # https://github.com/confluentinc/confluent-kafka-python/issues/1696
+            self.log.warning(
+                "Discarding %d/%d negative earliest offset(s): partition.beginning_offset and "
+                "partition.size will be missing for those partitions, and topic.size for their "
+                "entire topic (up to 5 shown): %s",
+                len(negative),
+                len(requests),
+                negative[:5],
             )
         return result
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -496,8 +496,7 @@ class ClusterMetadataCollector:
             )
             for tp, future in futures.items():
                 try:
-                    info = future.result()
-                    result[(tp.topic, tp.partition)] = info.offset
+                    offset = future.result().offset
                 except Exception as e:
                     errors += 1
                     if errors <= 3:
@@ -507,6 +506,20 @@ class ClusterMetadataCollector:
                             tp.partition,
                             e,
                         )
+                    continue
+                # A Kafka offset is never negative, so the client library mangled this one.
+                # https://github.com/confluentinc/confluent-kafka-python/issues/1696
+                if offset < 0:
+                    errors += 1
+                    if errors <= 3:
+                        self.log.debug(
+                            "Discarding negative earliest offset %s for %s:%s",
+                            offset,
+                            tp.topic,
+                            tp.partition,
+                        )
+                    continue
+                result[(tp.topic, tp.partition)] = offset
         except Exception as e:
             self.log.warning(
                 "Failed to issue list_offsets request; partition.beginning_offset, "

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -5,6 +5,7 @@
 
 import hashlib
 import json
+import logging
 import time
 from unittest import mock
 
@@ -1190,8 +1191,9 @@ def test_fetch_earliest_offsets_refetches_when_cache_missing_partitions(check):
     assert saved['expire_at'] == expire_at
 
 
-def test_fetch_earliest_offsets_drops_negative_offsets(check):
+def test_fetch_earliest_offsets_drops_negative_offsets(check, caplog):
     """A negative earliest offset is discarded instead of being reported as a log-start offset."""
+    caplog.set_level(logging.WARNING)
     instance = {
         'kafka_connect_str': 'localhost:9092',
         'enable_cluster_monitoring': True,
@@ -1216,6 +1218,10 @@ def test_fetch_earliest_offsets_drops_negative_offsets(check):
     result = kafka_consumer_check.metadata_collector.fetch_earliest_offsets({'test-topic': [0, 1]})
 
     assert result == {('test-topic', 0): 10}
+    # A mangled offset is not a failed fetch, so it must not be reported as one: that would send
+    # an operator after broker connectivity instead of the client library's 32-bit narrowing.
+    assert "Failed to fetch earliest offset" not in caplog.text
+    assert "Discarding 1/2 negative earliest offset(s)" in caplog.text
 
 
 def test_schema_registry_oauth_oidc_token(check, dd_run_check, aggregator):

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -1190,6 +1190,34 @@ def test_fetch_earliest_offsets_refetches_when_cache_missing_partitions(check):
     assert saved['expire_at'] == expire_at
 
 
+def test_fetch_earliest_offsets_drops_negative_offsets(check):
+    """A negative earliest offset is discarded instead of being reported as a log-start offset."""
+    instance = {
+        'kafka_connect_str': 'localhost:9092',
+        'enable_cluster_monitoring': True,
+    }
+    kafka_consumer_check = check(instance)
+    mock_kafka_client = seed_mock_kafka_client()
+
+    def negative_offset_for_partition_1(requests, **_kwargs):
+        futures = {}
+        for tp in requests:
+            future = mock.MagicMock()
+            future.result.return_value = mock.MagicMock(offset=10 if tp.partition == 0 else -1533701557)
+            futures[tp] = future
+        return futures
+
+    mock_kafka_client.kafka_client.list_offsets.side_effect = negative_offset_for_partition_1
+    kafka_consumer_check.client = mock_kafka_client
+    kafka_consumer_check.metadata_collector.client = mock_kafka_client
+
+    _wire_cache(kafka_consumer_check)
+
+    result = kafka_consumer_check.metadata_collector.fetch_earliest_offsets({'test-topic': [0, 1]})
+
+    assert result == {('test-topic', 0): 10}
+
+
 def test_schema_registry_oauth_oidc_token(check, dd_run_check, aggregator):
     """Test that OIDC OAuth token is fetched and passed as Bearer header for Schema Registry."""
     instance = {

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -1201,3 +1201,24 @@ def test_get_partition_offsets_returns_all_healthy_partitions():
     # READ_UNCOMMITTED is load-bearing: READ_COMMITTED would return the LSO, not the true high watermark.
     assert client._kafka_client.list_offsets.call_args.kwargs["isolation_level"] == IsolationLevel.READ_UNCOMMITTED
     assert client._kafka_client.list_offsets.call_args.kwargs["request_timeout"] == 5
+
+
+def test_get_partition_offsets_drops_negative_offsets():
+    """A Kafka offset is never negative, so such a value is dropped instead of becoming a metric."""
+    from confluent_kafka import TopicPartition
+
+    config = mock.MagicMock()
+    config._request_timeout = 5
+
+    client = KafkaClient(config, logging.getLogger(__name__))
+
+    futures = {
+        TopicPartition(topic="healthy_topic", partition=0): _offset_future(100),
+        TopicPartition(topic="wrapped_topic", partition=0): _offset_future(-1533701557),
+    }
+    client._kafka_client = mock.MagicMock()
+    client._kafka_client.list_offsets.return_value = futures
+
+    results = client.get_partition_offsets([("healthy_topic", 0), ("wrapped_topic", 0)])
+
+    assert results == [("healthy_topic", 0, 100)]


### PR DESCRIPTION
### What does this PR do?

Skips broker and log-start offsets that come back negative instead of reporting them.

A Kafka offset is never negative, so such a value means the client library mangled it: `confluent-kafka` narrows ListOffsets results through a C `long`, which is 32 bits on Windows x64 ([`Admin.c:4951`](https://github.com/confluentinc/confluent-kafka-python/blob/v2.13.2/src/confluent_kafka/src/Admin.c#L4951)). The guard sits where offsets enter the check, so a rejected offset is also absent from the lag computation and the partition is skipped rather than emitting a lag derived from a wrong high watermark.

This bounds the damage. It does not recover the metric. A Windows host past 2^31 loses `kafka.broker_offset` and `kafka.consumer_lag` for the affected partitions, plus one warning per run naming them, until the accessor changes or the client library is fixed upstream.

### Motivation

[AGENT-16736](https://datadoghq.atlassian.net/browse/AGENT-16736): a Windows Server 2025 host reported `kafka.broker_offset = -1533701557` where the true high watermark was 2761265739, exactly `true - 2^32`. That clamped `kafka.consumer_lag` to 0 and fired a "Negative consumer lag" event for all 6 partitions on every run. `kafka.consumer_offset` was correct in the same run, which localizes the defect to the one accessor the two paths do not share.

The behavior that caused the issue was introduced in this commit: [`d23a7d9`](https://github.com/DataDog/integrations-core/commit/d23a7d9a5041e583c5ea268a26aecd6d5311b22d) (#24263), which switched highwater collection from `Consumer.offsets_for_times()` to `AdminClient.list_offsets()` so that one unresolvable partition would stop aborting the whole run. The new accessor narrows offsets where the old one did not, which was not considered at the time. kafka_consumer 8.1.0 and Agent 7.82.0 are therefore the first releases that can exhibit this, and 9.0.0 still ships a byte-identical `client.py`. Agent version 7.81.x and older read the 64-bit-clean `TopicPartition.offset` instead.

The upstream issue in `confluent-kafka-python` is also documented in this issue report: https://github.com/confluentinc/confluent-kafka-python/issues/1696. 

### Verification

One unit test per guarded path, both confirmed failing without the guard. 166 passed on this branch against 164 on the merge base, same 39 deselected. `ddev test -fs kafka_consumer` is clean.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

[AGENT-16736]: https://datadoghq.atlassian.net/browse/AGENT-16736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
