### PR TITLE
Run Argo Workflows E2E with the Kubernetes Agent backend

### DIFF
--- a/argo_workflows/tests/conftest.py
+++ b/argo_workflows/tests/conftest.py
@@ -7,10 +7,13 @@ import os
 import pytest
 
 from datadog_checks.dev import get_here
+from datadog_checks.dev._env import get_state, save_state
 from datadog_checks.dev.kind import kind_run
 from datadog_checks.dev.subprocess import run_command
 
 HERE = get_here()
+
+CONTROLLER_IP_STATE = 'argo_workflows_controller_ip'
 
 
 def setup_argo_wf():
@@ -20,6 +23,11 @@ def setup_argo_wf():
         ["kubectl", "wait", "deployments", "--all", "--for=condition=Available", "-n", "argo", "--timeout=300s"]
     )
     # run_command(["kubectl", "wait", "pods", "--all", "--for=condition=Ready", "--timeout=300s"])
+
+    # This only runs once, when the Kind cluster is created, so the resolved pod IP is cached here
+    # rather than re-resolved by `dd_environment` on every invocation (e.g. `ddev env stop`, which
+    # runs in a fresh process after the cluster has already been torn down).
+    save_state(CONTROLLER_IP_STATE, get_workflow_controller_pod_ip())
 
 
 def get_workflow_controller_pod_ip() -> str:
@@ -38,7 +46,7 @@ def get_workflow_controller_pod_ip() -> str:
 @pytest.fixture(scope='session')
 def dd_environment():
     with kind_run(conditions=[setup_argo_wf]) as kubeconfig:
-        controller_ip = get_workflow_controller_pod_ip()
+        controller_ip = get_state(CONTROLLER_IP_STATE)
         metadata = {'agent_type': 'kubernetes', 'kubernetes': {'kubeconfig': kubeconfig}}
 
         yield {'openmetrics_endpoint': f'http://{controller_ip}:9090/metrics'}, metadata

--- a/argo_workflows/tests/conftest.py
+++ b/argo_workflows/tests/conftest.py
@@ -25,8 +25,7 @@ def setup_argo_wf():
     # run_command(["kubectl", "wait", "pods", "--all", "--for=condition=Ready", "--timeout=300s"])
 
     # This only runs once, when the Kind cluster is created, so the resolved pod IP is cached here
-    # rather than re-resolved by `dd_environment` on every invocation (e.g. `ddev env stop`, which
-    # runs in a fresh process after the cluster has already been torn down).
+    # rather than re-resolved by `dd_environment` on every invocation.
     save_state(CONTROLLER_IP_STATE, get_workflow_controller_pod_ip())
 
 

--- a/argo_workflows/tests/conftest.py
+++ b/argo_workflows/tests/conftest.py
@@ -1,14 +1,13 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
 import os
-from contextlib import ExitStack
 
 import pytest
 
 from datadog_checks.dev import get_here
 from datadog_checks.dev.kind import kind_run
-from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.subprocess import run_command
 
 HERE = get_here()
@@ -23,18 +22,26 @@ def setup_argo_wf():
     # run_command(["kubectl", "wait", "pods", "--all", "--for=condition=Ready", "--timeout=300s"])
 
 
+def get_workflow_controller_pod_ip() -> str:
+    # There is no Service for workflow-controller, so the pod IP is fetched directly.
+    result = run_command(
+        ["kubectl", "get", "pods", "--namespace", "argo", "--selector", "app=workflow-controller", "--output", "json"],
+        capture='out',
+        check=True,
+    )
+    pods = json.loads(result.stdout)['items']
+    if len(pods) != 1 or not pods[0].get('status', {}).get('podIP'):
+        raise RuntimeError(f'Expected exactly one ready workflow-controller pod, found {len(pods)}')
+    return pods[0]['status']['podIP']
+
+
 @pytest.fixture(scope='session')
 def dd_environment():
     with kind_run(conditions=[setup_argo_wf]) as kubeconfig:
-        with ExitStack() as stack:
-            controller_host, controller_port = stack.enter_context(
-                # there is no service for workflow-controller
-                port_forward(kubeconfig, 'argo', 9090, 'deployment', 'workflow-controller')
-            )
-            # save this instance to use for openmetrics_v2 instance, since the endpoint is different each run
-            # dd_save_state("argocd_instance", instance)
+        controller_ip = get_workflow_controller_pod_ip()
+        metadata = {'agent_type': 'kubernetes', 'kubernetes': {'kubeconfig': kubeconfig}}
 
-            yield {'openmetrics_endpoint': f'http://{controller_host}:{controller_port}/metrics'}
+        yield {'openmetrics_endpoint': f'http://{controller_ip}:9090/metrics'}, metadata
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?
Runs the Argo Workflows Kind E2E with the Kubernetes Agent backend introduced by #24639. `workflow-controller` has no backing Service, so the Agent (now running inside the Kind cluster) reaches it directly via the pod's IP address, fetched with `kubectl get pods --namespace argo --selector app=workflow-controller --output json`. The check now scrapes `http://<pod-ip>:9090/metrics`, so the external Docker Agent and the `kubectl port-forward` to `workflow-controller` are no longer needed.

Validation:
- `ddev test -fs argo_workflows`
- `ddev --no-interactive test argo_workflows` (3 passed, 1 E2E skipped)
- `ddev env show argo_workflows` (`py3.13`)
- `ddev env start --dev argo_workflows py3.13`
- `ddev env test --dev argo_workflows py3.13` (1 passed, 3 deselected)
- `ddev env stop argo_workflows py3.13`

### Motivation
This PR follows the conversion pattern from #24674 (argo_rollouts), adapted for a target with no Service: the pod IP is fetched directly, mirroring the approach used for Velero's `node-agent` DaemonSet in #24645. Running the Agent inside the same Kind cluster removes the long-lived host-side port-forward without changing the E2E setup, waits, instance shape, or assertions.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

