### PR TITLE
Run Flux CD E2E with the Kubernetes Agent backend

### DIFF
--- a/fluxcd/tests/conftest.py
+++ b/fluxcd/tests/conftest.py
@@ -48,7 +48,7 @@ def setup_fluxcd():
         save_state(POD_IP_STATE_PREFIX + controller, get_controller_pod_ip(controller))
 
 
-def get_controller_pod_ip(controller):
+def get_controller_pod_ip(controller: str) -> str:
     result = run_command(
         [
             "kubectl",

--- a/fluxcd/tests/conftest.py
+++ b/fluxcd/tests/conftest.py
@@ -1,20 +1,30 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
 import os
-from contextlib import ExitStack
 from unittest import mock
 
 import pytest
 
 from datadog_checks.dev import get_here
+from datadog_checks.dev._env import get_state, save_state
 from datadog_checks.dev.kind import kind_run
-from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.subprocess import run_command
 from datadog_checks.fluxcd import FluxcdCheck
 
 HERE = get_here()
 opj = os.path.join
+
+# The Services in flux-system (source-controller, notification-controller) only expose the
+# controllers' API port (9090) as port 80, not the Prometheus metrics port (8080), so Service DNS
+# cannot reach /metrics for any controller. All four controllers are single-replica Deployments, so
+# their pod IP is fetched directly and used to reach the metrics port. The `allow-scraping`
+# NetworkPolicy shipped in install.yaml explicitly permits cross-namespace ingress on port 8080,
+# confirming this is the intended scrape path.
+CONTROLLERS = ('source-controller', 'helm-controller', 'kustomize-controller', 'notification-controller')
+METRICS_PORT = 8080
+POD_IP_STATE_PREFIX = 'fluxcd_pod_ip_'
 
 
 def setup_fluxcd():
@@ -31,29 +41,48 @@ def setup_fluxcd():
             "--timeout=300s",
         ]
     )
+    # Save each controller's pod IP now, while the cluster is guaranteed to be up. `dd_environment`
+    # runs again (without `conditions`, so without this function) on every `ddev env` invocation,
+    # including `stop`, when the cluster may already be gone.
+    for controller in CONTROLLERS:
+        save_state(POD_IP_STATE_PREFIX + controller, get_controller_pod_ip(controller))
+
+
+def get_controller_pod_ip(controller):
+    result = run_command(
+        [
+            "kubectl",
+            "get",
+            "pods",
+            "--namespace",
+            "flux-system",
+            "--selector",
+            f"app={controller}",
+            "--output",
+            "json",
+        ],
+        capture='out',
+        check=True,
+    )
+    pods = json.loads(result.stdout)['items']
+    if len(pods) != 1 or not pods[0].get('status', {}).get('podIP'):
+        raise RuntimeError(f'Expected exactly one ready {controller} pod, found {len(pods)}')
+    return pods[0]['status']['podIP']
 
 
 @pytest.fixture(scope='session')
 def dd_environment():
     with kind_run(conditions=[setup_fluxcd]) as kubeconfig:
-        instances = []
-        with ExitStack() as stack:
-            for controller in (
-                'source-controller',
-                'helm-controller',
-                'kustomize-controller',
-                'notification-controller',
-            ):
-                host, port = stack.enter_context(
-                    port_forward(kubeconfig, 'flux-system', 8080, 'deployment', controller)
-                )
-                instances.append(
-                    {
-                        'openmetrics_endpoint': 'http://{}:{}/metrics'.format(host, port),
-                    }
-                )
+        instances = [
+            {
+                'openmetrics_endpoint': f'http://{get_state(POD_IP_STATE_PREFIX + controller)}:{METRICS_PORT}/metrics',
+            }
+            for controller in CONTROLLERS
+        ]
 
-            yield {'instances': instances}
+        metadata = {'agent_type': 'kubernetes', 'kubernetes': {'kubeconfig': kubeconfig}}
+
+        yield {'instances': instances}, metadata
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?
Runs the Flux CD Kind E2E with the Kubernetes Agent backend introduced by #24639, following the pattern established for Argo Rollouts in #24674.

The `dd_environment` fixture no longer port-forwards from the host; instead it builds endpoints that are reachable from inside the Kind cluster:

- `source-controller` and `notification-controller` do have a Kubernetes `Service`, but that Service only forwards its port `80` to the controller's API port (`9090`), not to the Prometheus metrics port (`8080`) — confirmed by inspecting the `Endpoints` object and by a manual in-cluster `wget` against the Service DNS name, which times out on `:8080`. Service DNS therefore cannot be used to reach `/metrics` for these two controllers.
- `helm-controller` and `kustomize-controller` have no Service at all.

Because none of the four controllers' metrics ports are reachable via a Service, all four use their pod's IP directly on port `8080` (the port the shipped `allow-scraping` NetworkPolicy explicitly opens to cross-namespace ingress, confirming it's the intended scrape path). Each controller is a single-replica Deployment, so the pod IP is unambiguous. The pod IP is looked up once inside `setup_fluxcd()` — while the Kind cluster is guaranteed to still be up — and cached with `datadog_checks.dev._env.save_state`/`get_state` (mirroring `get_node_agent()` in #24645 for Velero), so `ddev env test` and `ddev env stop`, which re-invoke `dd_environment` in a fresh process, don't need to re-run `kubectl` against a cluster that may already be gone.

Validation:
- `ddev test -fs fluxcd`
- `ddev --no-interactive test fluxcd` (4 passed, 1 E2E skipped)
- `ddev env show fluxcd` (`py3.13`)
- `ddev env start --dev fluxcd py3.13`
- `ddev env test --dev fluxcd py3.13` (1 passed, 4 deselected)
- `ddev env stop fluxcd py3.13`

### Motivation
This PR migrates Flux CD to the new backend. Running the Agent inside the same Kind cluster removes the long-lived host-side `kubectl port-forward` processes without changing the E2E setup, waits, instance shape, assertions, or timeout behavior.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

