### PR TITLE
Run Weaviate E2E with the Kubernetes Agent backend

### DIFF
--- a/weaviate/tests/conftest.py
+++ b/weaviate/tests/conftest.py
@@ -8,10 +8,8 @@ import pytest
 
 from datadog_checks.dev import get_here
 from datadog_checks.dev._env import get_state, save_state
-from datadog_checks.dev.conditions import WaitFor
 from datadog_checks.dev.kind import kind_run
 from datadog_checks.dev.subprocess import run_command
-from datadog_checks.weaviate.check import DEFAULT_LIVENESS_ENDPOINT
 
 from .common import BATCH_OBJECTS, USE_AUTH
 
@@ -42,8 +40,6 @@ def setup_weaviate():
     # is torn down, so the pod IP is cached here via `save_state`/`get_state` rather than looked up live.
     save_state(POD_IP_STATE, get_weaviate_pod_ip())
 
-    # Sometimes the API endpoint isn't ready when the cluster is ready. Wait for it before seeding data.
-    WaitFor(weaviate_ready, wait=2, attempts=150)()
     make_weaviate_request()
 
 
@@ -57,35 +53,6 @@ def get_weaviate_pod_ip() -> str:
     if len(pods) != 1 or not pods[0].get('status', {}).get('podIP'):
         raise RuntimeError(f'Expected one ready Weaviate pod, found {len(pods)}')
     return pods[0]['status']['podIP']
-
-
-def weaviate_ready() -> bool:
-    # The host cannot reach the cluster directly, so check readiness from a temporary pod.
-    endpoint = f'{WEAVIATE_API_ENDPOINT}{DEFAULT_LIVENESS_ENDPOINT}'
-    result = run_command(
-        [
-            'kubectl',
-            'run',
-            'weaviate-readiness',
-            '--namespace',
-            NAMESPACE,
-            '--image=busybox:1.36.1',
-            '--restart=Never',
-            '--attach',
-            '--rm',
-            '--quiet',
-            '--',
-            'wget',
-            '-q',
-            '-T',
-            '2',
-            '-O',
-            '/dev/null',
-            endpoint,
-        ],
-        capture='both',
-    )
-    return result.code == 0
 
 
 def make_weaviate_request():

--- a/weaviate/tests/conftest.py
+++ b/weaviate/tests/conftest.py
@@ -3,15 +3,13 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
 import os
-import time
-from contextlib import ExitStack
 
 import pytest
-import requests
 
 from datadog_checks.dev import get_here
+from datadog_checks.dev._env import get_state, save_state
+from datadog_checks.dev.conditions import WaitFor
 from datadog_checks.dev.kind import kind_run
-from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.subprocess import run_command
 from datadog_checks.weaviate.check import DEFAULT_LIVENESS_ENDPOINT
 
@@ -19,6 +17,12 @@ from .common import BATCH_OBJECTS, USE_AUTH
 
 HERE = get_here()
 opj = os.path.join
+
+NAMESPACE = 'weaviate'
+# No Service targets the StatefulSet's metrics port, only the API port (see weaviate_install.yaml /
+# weaviate_auth.yaml), so the API endpoint uses Service DNS while metrics fall back to the pod IP.
+WEAVIATE_API_ENDPOINT = f'http://weaviate.{NAMESPACE}.svc.cluster.local:80'
+POD_IP_STATE = 'weaviate_pod_ip'
 
 
 def setup_weaviate():
@@ -33,54 +37,101 @@ def setup_weaviate():
     run_command(['kubectl', 'rollout', 'status', 'statefulset/weaviate', '-n', 'weaviate'])
     run_command(['kubectl', 'wait', 'pods', '--all', '-n', 'weaviate', '--for=condition=Ready', '--timeout=600s'])
 
+    # `setup_weaviate` only runs once, on the initial `ddev env start`. Later invocations of the
+    # `dd_environment` fixture (e.g. during `ddev env stop`) run in a fresh process after the cluster
+    # is torn down, so the pod IP is cached here via `save_state`/`get_state` rather than looked up live.
+    save_state(POD_IP_STATE, get_weaviate_pod_ip())
+
+    # Sometimes the API endpoint isn't ready when the cluster is ready. Wait for it before seeding data.
+    WaitFor(weaviate_ready, wait=2, attempts=150)()
+    make_weaviate_request()
+
+
+def get_weaviate_pod_ip() -> str:
+    result = run_command(
+        ['kubectl', 'get', 'pods', '--namespace', NAMESPACE, '--selector', 'app=weaviate', '--output', 'json'],
+        capture='out',
+        check=True,
+    )
+    pods = json.loads(result.stdout)['items']
+    if len(pods) != 1 or not pods[0].get('status', {}).get('podIP'):
+        raise RuntimeError(f'Expected one ready Weaviate pod, found {len(pods)}')
+    return pods[0]['status']['podIP']
+
+
+def weaviate_ready() -> bool:
+    # The host cannot reach the cluster directly, so check readiness from a temporary pod.
+    endpoint = f'{WEAVIATE_API_ENDPOINT}{DEFAULT_LIVENESS_ENDPOINT}'
+    result = run_command(
+        [
+            'kubectl',
+            'run',
+            'weaviate-readiness',
+            '--namespace',
+            NAMESPACE,
+            '--image=busybox:1.36.1',
+            '--restart=Never',
+            '--attach',
+            '--rm',
+            '--quiet',
+            '--',
+            'wget',
+            '-q',
+            '-T',
+            '2',
+            '-O',
+            '/dev/null',
+            endpoint,
+        ],
+        capture='both',
+    )
+    return result.code == 0
+
+
+def make_weaviate_request():
+    # This helps seed some dummy data in to Weaviate to make some metrics available. Run from a
+    # temporary pod since the host cannot reach the cluster directly.
+    weaviate_batch_endpoint = f'{WEAVIATE_API_ENDPOINT}/v1/batch/objects'
+
+    command = [
+        'kubectl',
+        'run',
+        'weaviate-seed-data',
+        '--namespace',
+        NAMESPACE,
+        '--image=curlimages/curl',
+        '--restart=Never',
+        '--attach',
+        '--rm',
+        '--quiet',
+        '--',
+        'curl',
+        '-sf',
+        '-X',
+        'POST',
+        weaviate_batch_endpoint,
+        '-H',
+        'Content-Type: application/json',
+    ]
+    if USE_AUTH:
+        command.extend(['-H', 'Authorization: Bearer test123'])
+    command.extend(['-d', json.dumps(BATCH_OBJECTS)])
+
+    run_command(command, capture='both', check=True)
+
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    with kind_run(conditions=[setup_weaviate]) as kubeconfig, ExitStack() as stack:
-        weaviate_host, weaviate_port = stack.enter_context(
-            port_forward(kubeconfig, 'weaviate', 2112, 'statefulset', 'weaviate')
-        )
-        weaviate_host, weaviate_api_port = stack.enter_context(
-            port_forward(kubeconfig, 'weaviate', 8080, 'statefulset', 'weaviate')
-        )
+    with kind_run(conditions=[setup_weaviate]) as kubeconfig:
+        weaviate_metrics_port = 2112
 
         instance = {
-            'openmetrics_endpoint': f'http://{weaviate_host}:{weaviate_port}/metrics',
-            'weaviate_api_endpoint': f'http://{weaviate_host}:{weaviate_api_port}',
+            'openmetrics_endpoint': f'http://{get_state(POD_IP_STATE)}:{weaviate_metrics_port}/metrics',
+            'weaviate_api_endpoint': WEAVIATE_API_ENDPOINT,
         }
         if USE_AUTH:
             instance['headers'] = {'Authorization': 'Bearer test123'}
 
-        make_weaviate_request(instance)
-        yield instance
+        metadata = {'agent_type': 'kubernetes', 'kubernetes': {'kubeconfig': kubeconfig}}
 
-
-def make_weaviate_request(instance):
-    # This helps seed some dummy data in to Weaviate to make some metrics available
-    weaviate_api_endpoint = instance.get('weaviate_api_endpoint')
-    weaviate_batch_endpoint = f'{weaviate_api_endpoint}/v1/batch/objects'
-    headers = {'content-type': 'application/json'}
-
-    if instance.get('headers'):
-        headers.update(instance['headers'])
-
-    if ready_check(weaviate_api_endpoint, 300):
-        requests.post(weaviate_batch_endpoint, headers=headers, data=json.dumps(BATCH_OBJECTS))
-
-
-def ready_check(endpoint, timeout=300):
-    # Sometimes the API endpoint isn't ready when the cluster is ready. This will try to ensure the
-    # API is ready for requests before we seed some dummy data.
-    stop_time = time.time() + timeout
-    endpoint = f'{endpoint}{DEFAULT_LIVENESS_ENDPOINT}'
-    while time.time() < stop_time:
-        try:
-            response = requests.get(endpoint, timeout=5)
-            if response.ok:
-                return True
-        except requests.RequestException as e:
-            print(f'Request failed: {e}')
-
-        time.sleep(1)
-
-    return False
+        yield instance, metadata

--- a/weaviate/tests/conftest.py
+++ b/weaviate/tests/conftest.py
@@ -24,16 +24,21 @@ POD_IP_STATE = 'weaviate_pod_ip'
 
 
 def setup_weaviate():
-    run_command(['kubectl', 'create', 'ns', 'weaviate'])
+    run_command(['kubectl', 'create', 'ns', 'weaviate'], check=True)
 
     if USE_AUTH:
-        run_command(['kubectl', 'apply', '-f', opj(HERE, 'kind', 'weaviate_auth.yaml'), '-n', 'weaviate'])
+        run_command(['kubectl', 'apply', '-f', opj(HERE, 'kind', 'weaviate_auth.yaml'), '-n', 'weaviate'], check=True)
     else:
-        run_command(['kubectl', 'apply', '-f', opj(HERE, 'kind', 'weaviate_install.yaml'), '-n', 'weaviate'])
+        run_command(
+            ['kubectl', 'apply', '-f', opj(HERE, 'kind', 'weaviate_install.yaml'), '-n', 'weaviate'], check=True
+        )
 
     # Tries to ensure that the Kubernetes resources are deployed and ready before we do anything else
-    run_command(['kubectl', 'rollout', 'status', 'statefulset/weaviate', '-n', 'weaviate'])
-    run_command(['kubectl', 'wait', 'pods', '--all', '-n', 'weaviate', '--for=condition=Ready', '--timeout=600s'])
+    run_command(['kubectl', 'rollout', 'status', 'statefulset/weaviate', '-n', 'weaviate'], check=True)
+    run_command(
+        ['kubectl', 'wait', 'pods', '--all', '-n', 'weaviate', '--for=condition=Ready', '--timeout=600s'],
+        check=True,
+    )
 
     # `setup_weaviate` only runs once, on the initial `ddev env start`. Later invocations of the
     # `dd_environment` fixture (e.g. during `ddev env stop`) run in a fresh process after the cluster


### PR DESCRIPTION
### What does this PR do?
Runs the Weaviate Kind E2E with the Kubernetes Agent backend introduced by #24639.

- The `weaviate_api_endpoint` now uses the in-cluster Service DNS endpoint, `http://weaviate.weaviate.svc.cluster.local:80`, backed by the `weaviate` Service (`port: 80` -> `targetPort: 8080`).
- The `openmetrics_endpoint` (port 2112) has no matching Service, so it falls back to the pod IP of the single-replica `weaviate` StatefulSet, fetched via `kubectl get pods -l app=weaviate`.
- The data-seeding `POST` to `/v1/batch/objects` previously ran on the host via `requests`. It now runs from a disposable `curlimages/curl` pod inside the cluster instead.
- The host-side readiness poll that previously ran before seeding (`ready_check()`, hitting `/v1/.well-known/live` through a `kubectl port-forward` tunnel) has been removed rather than converted to an in-cluster equivalent.
  `/v1/.well-known/live` (`DEFAULT_LIVENESS_ENDPOINT`, what the removed check polled) is an unconditional 200 with [no real check behind it](https://github.com/weaviate/weaviate/blob/027977eb7edf76eeae3bdc9f22544192770d628c/adapters/handlers/rest/middlewares.go#L235-L262). The actual startup check lives behind `/v1/.well-known/ready`, which is exactly what the StatefulSet's `readinessProbe` hits (see `weaviate_install.yaml`), and the Kubernetes Pod `Ready` condition is driven by the readiness probe, not the liveness probe. So `kubectl wait pods --for=condition=Ready`, which `setup_weaviate()` already runs before seeding, provides a strictly stronger readiness guarantee than the removed poll ever did.
- `setup_weaviate()`'s `kubectl` calls (namespace/manifest creation, rollout status, readiness wait) now all pass `check=True`, so a cluster that never becomes ready fails loudly there instead of surfacing as a confusing seed-request error further down.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-659

This PR migrates Weaviate to the new backend, following the same pattern already applied to argo_rollouts (#24674) and calico (#24673), plus the pod-IP fallback pattern from velero (#24645) for the port with no Service.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

---
_This PR description was generated by Claude Code, on behalf of Vincent Whitchurch._
