### PR TITLE
Own the whole base/utils/db tree and DatabaseCheck in database monitoring

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -148,12 +148,9 @@ manifest.json         @DataDog/documentation @DataDog/agent-integrations
 /otel/manifest.json                       @DataDog/opentelemetry @DataDog/agent-integrations @DataDog/documentation
 
 # Database monitoring
-**/base/utils/db/utils.py                           @DataDog/agent-integrations @DataDog/database-monitoring-agent
-datadog_checks_base/tests/**/test_util.py           @DataDog/agent-integrations @DataDog/database-monitoring-agent
-**/base/utils/db/sql.py                             @DataDog/database-monitoring-agent @DataDog/agent-integrations
-datadog_checks_base/tests/**/test_db_sql.py         @DataDog/database-monitoring-agent @DataDog/agent-integrations
-**/base/utils/db/statement_metrics.py               @DataDog/database-monitoring-agent @DataDog/agent-integrations
-datadog_checks_base/tests/**/test_db_statements.py  @DataDog/database-monitoring-agent @DataDog/agent-integrations
+**/base/checks/db.py                                @DataDog/database-monitoring-agent @DataDog/agent-integrations
+datadog_checks_base/tests/**/test_database_check.py @DataDog/database-monitoring-agent @DataDog/agent-integrations
+**/base/utils/db/                                   @DataDog/database-monitoring-agent @DataDog/agent-integrations
 /postgres/                                          @DataDog/database-monitoring-agent @DataDog/agent-integrations
 /postgres/*.md                                      @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
 /postgres/manifest.json                             @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation


### PR DESCRIPTION
### What does this PR do?

Replaces DBM's file-by-file ownership of the base package's database modules with a single directory rule, and adds ownership of the `DatabaseCheck` base class.

| Rule | Covers |
| --- | --- |
| `**/base/checks/db.py` | `DatabaseCheck`, the base class every DBM integration extends |
| `datadog_checks_base/tests/**/test_database_check.py` | its test |
| `**/base/utils/db/` | the whole `base/utils/db` tree, source and tests |

The directory rule subsumes all six lines it replaces. Because `**/` matches at any depth, one line covers both `datadog_checks/base/utils/db/` and `tests/base/utils/db/`, so the three source rules and the three test rules are no longer needed. Confirmed against gitignore-style matching, which is what CODEOWNERS uses: `**/base/utils/db/` matches `utils.py`, `sql.py` and `statement_metrics.py` under the source package, and `test_util.py`, `test_db_sql.py` and `test_db_statements.py` under the test directory.

Nothing loses coverage. Those six files are the only paths in the repo that matched the six patterns being removed.

### Motivation

Enumerating individual files means every new module added under `base/utils/db` silently loses DBM review. The incremental query metrics package in #24791 is the current example: it matches no DBM rule, so it falls through to `/datadog_checks_base/ @DataDog/agent-integrations` and has no DBM owner.

`checks/db.py` was never owned by DBM at all, despite defining the base class every DBM integration extends.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
