### PR TITLE
Select RESP2 explicitly in the redisdb client

### DIFF
--- a/redisdb/changelog.d/24833.fixed
+++ b/redisdb/changelog.d/24833.fixed
@@ -1,0 +1,1 @@
+Select the RESP2 protocol explicitly when connecting to Redis so the wire protocol stays the same when the ``redis`` client default flips to RESP3 in newer versions.

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -95,6 +95,10 @@ class Redis(AgentCheck):
                 # Set a default timeout (in seconds) if no timeout is specified in the instance config
                 instance_config['socket_timeout'] = instance_config.get('socket_timeout', 5)
                 connection_params = {k: instance_config[k] for k in list_params if k in instance_config}
+                # Select RESP2 explicitly instead of relying on the client default, which flipped to RESP3
+                # in redis-py 8. RESP3 sends `HELLO` on connect, unsupported before Redis 6.0, and changes
+                # the shape of some replies we parse.
+                connection_params['protocol'] = 2
                 # If caching is disabled, we overwrite the dictionary value so the old connection
                 # will be closed as soon as the corresponding Python object gets garbage collected
                 self.connections[key] = redis.Redis(**connection_params)

--- a/redisdb/tests/test_unit.py
+++ b/redisdb/tests/test_unit.py
@@ -134,7 +134,8 @@ def test_check_all_available_config_options(check, aggregator, redis_instance, d
     redis_check = check(redis_instance)
     with mock.patch('redis.Redis') as redis_conn:
         dd_run_check(redis_check)
-        assert redis_conn.call_args.kwargs == connection_args
+        # RESP2 is pinned by the check rather than taken from the client default
+        assert redis_conn.call_args.kwargs == connection_args | {'protocol': 2}
 
 
 def test_slowlog_quiet_failure(check, aggregator, redis_instance):


### PR DESCRIPTION
### What does this PR do?

Pass `protocol=2` explicitly when the redisdb check builds its `redis.Redis` client, instead of inheriting whatever the installed redis-py uses as its default.

### Motivation

redis-py 8 flipped `DEFAULT_RESP_VERSION` from 2 to 3 ([redis/redis-py#4031](https://github.com/redis/redis-py/pull/4031)). RESP3 sends `HELLO` during the connection handshake and there is no RESP2 fallback if the server rejects it ([redis/redis-py#4089](https://github.com/redis/redis-py/issues/4089)). `HELLO` doesn't exist before Redis 6.0, so picking up redis 8.x breaks every connection to a Redis 5.x server. That is what currently fails the dependency bump in #24817, where the redisdb `py3.13-5.0` env dies during fixture setup with `ResponseError: unknown command HELLO`.

With the pinned redis 7.3.0 the default is already 2, so this is a no-op today. It only means the bump to redis 8.x no longer changes the wire protocol as a side effect.

Adopting RESP3 where the server supports it is worth doing separately. It changes the shape of replies the check parses by hand (the custom `SLOWLOG GET` callback, `config_get`, `client_list`, `cluster('info')`), so it needs its own matrix run rather than riding along with a dependency bump.

Ran the full redisdb suite locally against real containers on 5.0, 6.0, 7.0 and 8.0: 33 passed, 1 skipped on each.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
