### PR TITLE
Apply Renovate action rules to all composite actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,7 @@
   ],
   "packageRules": [
     {
-      "description": "Only consider full vX.Y.Z tags upstream so we never pin to a moving major-only tag (e.g. v3, v9). pinact's --check rewrites the trailing comment to the canonical full-semver tag of the SHA, so a v3 comment from Renovate would always fail validation.",
+      "description": "Only consider full vX.Y.Z tags upstream so we never pin to a moving major-only tag (e.g. v3, v9). pinact's --check rewrites the trailing comment to the canonical full-semver tag of the SHA, so a v3 comment from Renovate would always fail validation. matchFileNames must stay broad enough to cover every composite action: the manager discovers all action.yml files regardless of this rule, so any path it omits yields ungrouped, unlabelled PRs.",
       "matchManagers": [
         "github-actions"
       ],
@@ -49,7 +49,7 @@
       ],
       "matchFileNames": [
         ".github/workflows/**",
-        ".github/actions/tag-job/**"
+        ".github/actions/**"
       ],
       "matchPackageNames": [
         "!dtolnay/rust-toolchain"


### PR DESCRIPTION
### What does this PR do?

Widens `matchFileNames` on the Renovate `action` rule from `.github/actions/tag-job/**` to `.github/actions/**`.

### Motivation

Renovate opened #24209 (`Update actions/cache action to v6.1.0`) with no `renovate/actions` and no `qa/skip-qa` label, so `Run Validations / Validate` fails on it and it doesn't show up when we search for dependency bumps in rotation.

That PR touches `.github/actions/setup-ddev/action.yml`, which the rule's `matchFileNames` didn't cover, so no group, no labels, no schedule and no `minimumReleaseAge` were applied. Renovate still found the dep because discovery is driven by the manager's default `managerFilePatterns`, which include `/(^|/)action\.ya?ml$/`; `matchFileNames` only scopes which config applies.

The path list came from #23061, which transcribed the Dependabot config removed in #23037. Dependabot needed one entry per composite action directory because its `directory` controls discovery, and `tag-job` was the only composite action with a `uses:` pin at the time. The enumeration went stale when #23623 added `setup-ddev`. Using the directory instead of listing individual actions means it won't go stale again.

Two other pins were in the same gap and would have produced unlabelled PRs on their next bump:

- `.github/actions/setup-ddev/action.yml`: `actions/cache/{restore,save}`, `astral-sh/setup-uv`
- `.github/actions/setup-test-target-scripts/action.yml`: `actions/setup-node`

Renovate only sets labels at PR creation, so #24209 still needs its labels added by hand or a fresh run.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
