### PR TITLE
Pin kubernetes

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -219,6 +219,8 @@ exclude = [
     'pymysql',      # Pinned to below 1.2.0 as requested by DBM while they work on supporting 1.2+
     'foundationdb', # 7+ has a breaking changes
     'ddtrace', # 4.5.1 does not support MacOS 11, which is used by the Agent
+    'kubernetes',   # Excluded on size: 36 bundles the aio client and aiohttp, +24M on disk.
+                    # Unpin once https://github.com/kubernetes-client/python/issues/2677 is resolved.
 
 ]
 


### PR DESCRIPTION
### What does this PR do?

Adds `kubernetes` to the dependency update exclude list, so the automated dependency PRs stop proposing 36.x and we stay on 35.0.0.

### Motivation

`kubernetes` 36 folded the `kubernetes_asyncio` project into the package as `kubernetes.aio` and made `aiohttp` a hard requirement. Measured against the Agent's static quality gates, the bump costs **+24.5 MiB on disk** (wheel contents, with ELF stripping accounted for):

| package | old -> new | disk |
|---|---|---|
| kubernetes | 35.0.0 -> 36.0.3 | +21.76 M |
| aiohttp + yarl + multidict + propcache + frozenlist + aiosignal + aiohappyeyeballs | new | +2.47 M |
| rest of the bump PR (cryptography, redis, clickhouse-connect, ...) | | +0.26 M |

Of that, `kubernetes/aio/` alone is 18.77 MiB across 855 files, since the async client is a full duplicate of the generated sync client.

That broke 16 static quality gates in https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1944467427, triggered from #24817:

```
Agent DEB (AMD64)           FAIL  784.0/764.5 MB   -19.5 MB
Agent RPM (ARM64)           FAIL  761.0/736.5 MB   -24.4 MB
Docker Agent (JMX) (AMD64)  FAIL 1033.5/1010.8 MB  -22.7 MB
...
```

Every gate that embeds Python failed on the on-disk dimension. The Agent ratchets those limits down to current+1 MiB on each main commit, so there is no room to absorb a bump of this size without an approved size exception.

Nothing in this repo imports `kubernetes.aio`. The three consumers (`datadog_checks_base`'s kube leader election, `kubevirt_api`, `kueue`) all use the sync client, and upstream's own changelog marks the asyncio package as experimental. Holding at 35.0.0 also does not freeze the security-relevant transitive dependencies: 35 and 36 constrain `urllib3`, `requests` and `certifi` identically and loosely, and we pin those ourselves in `agent_requirements.in`.

This is a hold, not a resolution. Taking 36 eventually needs either pruning `kubernetes/aio` at build time (which brings the bump down to about +3 M) or an approved quality gate exception, and that is tracked separately.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
