### PR TITLE
Fix query activity crash when statement instruments are untimed

### DIFF
--- a/mysql/changelog.d/24843.fixed
+++ b/mysql/changelog.d/24843.fixed
@@ -1,0 +1,1 @@
+Fix a crash in the query activity job when statement instruments have ``TIMED = NO`` and a thread has more than one ``events_statements_current`` row.

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -303,9 +303,10 @@ class MySQLActivity(ManagedAuthConnectionMixin, DBMAsyncJob):
         estimated_size = 0
         for row in rows:
             if row["thread_id"] in seen:
-                # `performance_schema.events_statements_current` can contain previous statements
-                # for the same thread. We only want the most recent one.
-                if row["event_timer_end"] < seen[row["thread_id"]]["event_timer_start"]:
+                # A thread appears more than once when `performance_schema.events_statements_current`
+                # holds a row per nesting level, and when it still holds a statement the thread has
+                # already finished. Only the finished ones are safe to drop.
+                if self._ended_before(row, seen[row["thread_id"]]["event_timer_start"]):
                     continue
                 else:
                     second_pass[row["thread_id"]] = {"event_timer_start": row["event_timer_start"]}
@@ -323,13 +324,31 @@ class MySQLActivity(ManagedAuthConnectionMixin, DBMAsyncJob):
         return normalized_rows
 
     @staticmethod
+    def _ended_before(row, event_timer_start):
+        # type: (Dict[str], int | None) -> bool
+        """
+        Whether the statement in `row` finished before `event_timer_start`, the start of the most
+        recent statement seen for the same thread. Such a row is a leftover that
+        `performance_schema.events_statements_current` still holds for a thread that has moved on.
+
+        Both timers are NULL when the instrument that produced the event has `TIMED = NO` in
+        `setup_instruments`, and when no `events_statements_current` row joins to the thread at all,
+        in which case the SQL text comes from `PROCESSLIST_info` instead. Ordering is undecidable
+        without both timers, so such a row is never dropped: reporting a possibly stale statement is
+        preferable to dropping an active one.
+        """
+        event_timer_end = row.get("event_timer_end")
+        if event_timer_end is None or event_timer_start is None:
+            return False
+        return event_timer_end < event_timer_start
+
+    @staticmethod
     def _eliminate_duplicate_rows(rows, second_pass):
         # type: (List[Dict[str]], Dict[str]) -> List[Dict[str]]
         filtered_rows = []
         for row in rows:
-            if (
-                row["thread_id"] in second_pass
-                and row["event_timer_end"] < second_pass[row["thread_id"]]["event_timer_start"]
+            if row["thread_id"] in second_pass and MySQLActivity._ended_before(
+                row, second_pass[row["thread_id"]]["event_timer_start"]
             ):
                 continue
             filtered_rows.append(row)

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -7,7 +7,7 @@ import decimal
 import time
 from contextlib import closing
 from enum import Enum
-from typing import Dict, List  # noqa: F401
+from typing import Any, Dict, List  # noqa: F401
 
 import pymysql
 
@@ -324,8 +324,7 @@ class MySQLActivity(ManagedAuthConnectionMixin, DBMAsyncJob):
         return normalized_rows
 
     @staticmethod
-    def _ended_before(row, event_timer_start):
-        # type: (Dict[str], int | None) -> bool
+    def _ended_before(row: dict[str, Any], event_timer_start: int | None) -> bool:
         """
         Whether the statement in `row` finished before `event_timer_start`, the start of the most
         recent statement seen for the same thread. Such a row is a leftover that

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -392,6 +392,170 @@ def test_truncate_on_max_size_bytes(dbm_instance, datadog_agent, rows, expected_
             assert result_rows[index]['processlist_user'] == user
 
 
+def _activity_row(thread_id, event_timer_start, event_timer_end, processlist_user):
+    return {
+        "current_schema": "dog",
+        "processlist_command": "Query",
+        "processlist_user": processlist_user,
+        "sql_text": "something",
+        "event_timer_start": event_timer_start,
+        "event_timer_end": event_timer_end,
+        "thread_id": thread_id,
+    }
+
+
+@pytest.mark.parametrize(
+    "rows,expected_users",
+    [
+        pytest.param(
+            [
+                _activity_row(1748, _older_time(), _old_time(), "older"),
+                _activity_row(1748, _new_time(), _new_time(), "current"),
+            ],
+            ["current"],
+            id="timed_rows_dedupe_to_most_recent",
+        ),
+        pytest.param(
+            [
+                _activity_row(1748, _older_time(), _old_time(), "timed"),
+                _activity_row(1748, None, None, "untimed"),
+            ],
+            ["timed", "untimed"],
+            id="untimed_row_alongside_timed_row",
+        ),
+        pytest.param(
+            [
+                _activity_row(1748, None, None, "bob"),
+                _activity_row(1748, None, None, "bob"),
+            ],
+            ["bob", "bob"],
+            id="all_rows_untimed",
+        ),
+    ],
+)
+def test_normalize_rows_with_null_event_timers(dbm_instance, datadog_agent, rows, expected_users):
+    """
+    Statement timers are NULL when the instrument has `TIMED = NO` in `setup_instruments`, and when
+    no `events_statements_current` row joins to the thread. Rows that cannot be ordered are kept.
+    """
+    check = MySql(CHECK_NAME, {}, [dbm_instance])
+    with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
+        mock_agent.side_effect = "something"
+        result_rows = check._query_activity._normalize_rows(rows)
+        assert [row['processlist_user'] for row in result_rows] == expected_users
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_activity_collection_with_untimed_statements(aggregator, dbm_instance, dd_run_check, root_conn):
+    '''
+    Instruments with `TIMED = NO` in `setup_instruments` produce statement events whose
+    `TIMER_START`, `TIMER_END` and `TIMER_WAIT` are all NULL.
+
+    `events_statements_current` holds a row per nesting level, so a session blocked inside a stored
+    procedure has a row for both the CALL and the statement the procedure is running. Collection has
+    to reconcile two rows for that thread with no timers to order them by.
+    '''
+    check = MySql(CHECK_NAME, {}, instances=[deepcopy(dbm_instance)])
+    procedure = 'testdb.dd_untimed_nested'
+
+    with closing(root_conn.cursor()) as cursor:
+        # Ensure the consumers are enabled — other tests in this session may disable them.
+        cursor.execute(
+            "UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name = 'events_waits_current'"
+        )
+        cursor.execute(
+            "UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%'"
+        )
+        cursor.execute('DROP PROCEDURE IF EXISTS {}'.format(procedure))
+        cursor.execute(
+            'CREATE PROCEDURE {}() SQL SECURITY DEFINER BEGIN SELECT id FROM testdb.users FOR UPDATE; END'.format(
+                procedure
+            )
+        )
+        cursor.execute("GRANT EXECUTE ON PROCEDURE {} TO 'fred'@'%'".format(procedure))
+        # Restoring a blanket TIMED='YES' would enable instruments that ship disabled, so record
+        # exactly which ones to turn back on. This container is shared with every other test.
+        cursor.execute(
+            "SELECT NAME FROM performance_schema.setup_instruments WHERE NAME LIKE 'statement/%' AND TIMED = 'YES'"
+        )
+        previously_timed = [row[0] for row in cursor.fetchall()]
+        cursor.execute("UPDATE performance_schema.setup_instruments SET TIMED='NO' WHERE NAME LIKE 'statement/%'")
+    root_conn.commit()
+
+    # A pymysql connection is not thread safe, so the main thread must not touch bob's connection
+    # until the worker holding it is done with it
+    lock_held = Event()
+
+    def _hold_row_lock(conn):
+        conn.begin()
+        conn.cursor().execute('SELECT id FROM testdb.users FOR UPDATE')
+        lock_held.set()
+
+    def _call_procedure(conn):
+        try:
+            conn.cursor().execute('CALL {}()'.format(procedure))
+        except Exception:
+            # The call is expected to still be blocked when the test tears down
+            pass
+
+    def _wait_for_nested_statements(timeout=20):
+        # Two rows: one for the CALL, one for the statement the procedure is blocked on
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with closing(root_conn.cursor()) as cursor:
+                cursor.execute(
+                    'SELECT COUNT(*) FROM performance_schema.events_statements_current AS statement '
+                    'JOIN performance_schema.threads AS thread ON thread.thread_id = statement.thread_id '
+                    "WHERE thread.processlist_user = 'fred' AND thread.processlist_command = 'Query'"
+                )
+                if cursor.fetchone()[0] >= 2:
+                    return True
+            time.sleep(0.1)
+        return False
+
+    bob_conn = _get_conn_for_user('bob')
+    fred_conn = _get_conn_for_user('fred')
+    executor = ThreadPoolExecutor(2)
+    try:
+        executor.submit(_hold_row_lock, bob_conn)
+        assert lock_held.wait(timeout=20), "bob should have acquired the row lock"
+
+        executor.submit(_call_procedure, fred_conn)
+        # Waiting on the rows the check is about to read keeps the payload deterministic; a plain
+        # sleep lets a loaded runner reach the check before the procedure is blocked
+        assert _wait_for_nested_statements(), "fred's procedure should be blocked on bob's row lock"
+
+        dd_run_check(check)
+
+        # A failure to order the two untimed rows aborts collection before anything is submitted
+        dbm_activity = aggregator.get_event_platform_events("dbm-activity")
+        assert dbm_activity, "should have collected at least one activity payload"
+        rows = [row for event in dbm_activity for row in event['mysql_activity']]
+        assert rows, "should have collected at least one activity row"
+        # `_sanitize_row` drops NULL values, so an untimed row carries no event timer keys at all
+        assert any('event_timer_start' not in row for row in rows), (
+            "expected at least one untimed row, got keys: {}".format([sorted(row) for row in rows])
+        )
+    finally:
+        # Only safe once the worker has finished with this connection; committing releases the row
+        # lock so the blocked procedure can return and the executor can drain
+        if lock_held.is_set():
+            bob_conn.commit()
+        executor.shutdown(wait=True)
+        bob_conn.close()
+        fred_conn.close()
+        with closing(root_conn.cursor()) as cursor:
+            if previously_timed:
+                cursor.execute(
+                    "UPDATE performance_schema.setup_instruments SET TIMED='YES' WHERE NAME IN ({})".format(
+                        ', '.join(['%s'] * len(previously_timed))
+                    ),
+                    previously_timed,
+                )
+            cursor.execute('DROP PROCEDURE IF EXISTS {}'.format(procedure))
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_activity_collection_rate_limit(aggregator, dd_run_check, dbm_instance):

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -516,15 +516,39 @@ def test_database_identifier(template, expected, tags):
     assert check.database_identifier == expected
 
 
-def test__eliminate_duplicate_rows():
-    rows = [
-        {'thread_id': 1, 'event_timer_start': 1000, 'event_timer_end': 2000, 'sql_text': 'SELECT 1'},
-        {'thread_id': 1, 'event_timer_start': 2001, 'event_timer_end': 3000, 'sql_text': 'SELECT 1'},
-    ]
-    second_pass = {1: {'event_timer_start': 2001}}
-    assert MySQLActivity._eliminate_duplicate_rows(rows, second_pass) == [
-        {'thread_id': 1, 'event_timer_start': 2001, 'event_timer_end': 3000, 'sql_text': 'SELECT 1'},
-    ]
+@pytest.mark.parametrize(
+    'rows,second_pass,expected',
+    [
+        pytest.param(
+            [
+                {'thread_id': 1, 'event_timer_start': 1000, 'event_timer_end': 2000, 'sql_text': 'SELECT 1'},
+                {'thread_id': 1, 'event_timer_start': 2001, 'event_timer_end': 3000, 'sql_text': 'SELECT 1'},
+            ],
+            {1: {'event_timer_start': 2001}},
+            [{'thread_id': 1, 'event_timer_start': 2001, 'event_timer_end': 3000, 'sql_text': 'SELECT 1'}],
+            id='drops_statement_that_ended_before_the_newest_one_started',
+        ),
+        pytest.param(
+            [
+                {'thread_id': 1, 'event_timer_start': 1000, 'event_timer_end': 2000, 'sql_text': 'SELECT 1'},
+                {'thread_id': 1, 'event_timer_start': 2001, 'sql_text': 'SELECT 1'},
+            ],
+            {1: {'event_timer_start': 2001}},
+            [{'thread_id': 1, 'event_timer_start': 2001, 'sql_text': 'SELECT 1'}],
+            id='keeps_row_missing_event_timer_end',
+        ),
+        pytest.param(
+            [{'thread_id': 2, 'sql_text': 'SELECT 2'}],
+            {2: {'event_timer_start': None}},
+            [{'thread_id': 2, 'sql_text': 'SELECT 2'}],
+            id='keeps_row_with_no_timers_at_all',
+        ),
+    ],
+)
+def test__eliminate_duplicate_rows(rows, second_pass, expected):
+    # `_sanitize_row` drops keys whose value is NULL before rows reach `_eliminate_duplicate_rows`,
+    # so rows produced by an instrument with `TIMED = NO` arrive without any event timer at all
+    assert MySQLActivity._eliminate_duplicate_rows(rows, second_pass) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

Guards the statement timer comparisons in the MySQL query-activity job against NULL timers.

`_normalize_rows` and `_eliminate_duplicate_rows` both compared `event_timer_end` against
`event_timer_start` to decide whether a row held a statement the thread had already moved on
from. Neither handled those timers being absent, which produced two distinct failures:

- `TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'` in
  `_normalize_rows`, where the keys are present but hold `None`.
- `KeyError: 'event_timer_end'` in `_eliminate_duplicate_rows`, which runs after `_sanitize_row`
  has stripped every key whose value is `None`, so the key is gone entirely.

Both comparisons now go through a single `_ended_before` helper. When either timer is missing the
ordering is undecidable, so the row is not treated as finished and is kept: reporting a possibly
stale statement is better than dropping an active one. Rows that carry both timers are unaffected
and still deduplicate exactly as before.

Also corrects the comment above the deduplication branch, which claimed a repeated `thread_id`
only comes from statements the thread has finished. The more common source is nesting --
`events_statements_current` holds a row per nesting level -- and those rows are both current.

Tests:

- Parametrized unit coverage for `_eliminate_duplicate_rows` spanning the normal dedupe case plus
  the two shapes an untimed instrument produces.
- Coverage of `_normalize_rows` for NULL timers, including a row that is untimed alongside a
  timed one.
- An integration test that reproduces the crash end to end: statement instruments set to
  `TIMED = NO`, and a session blocked inside a stored procedure so its thread has a row for both
  the `CALL` and the statement inside it. It synchronizes on observable server state rather than
  sleeps, and restores the exact set of instruments it changed.

### Motivation

Fixes #24697.

When statement instruments have `TIMED = NO` in `setup_instruments`, `TIMER_START`, `TIMER_END`
and `TIMER_WAIT` are all NULL. If a thread also has more than one `events_statements_current` row
-- which any session inside a stored procedure has, since the table holds a row per nesting level
-- the comparison raises. The exception propagates out of `_collect_activity` before anything is
submitted, so the run emits no activity payload at all and DBM Active Sessions goes blank for that
host. It is not a partial or degraded result.

Verified across the full test matrix. The crash reproduces without this change and is resolved
with it on MySQL 5.7, 8.0.18, 8.0.36 and 8.4.0; MariaDB 10.5, 10.6, 10.11 and 11.4; and Percona
8.0.42 and 8.4. Every supported flavor and version is affected, not only MySQL.

This supersedes #24698, which addressed only the `TypeError` and dropped untimed rows rather than
keeping them.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)