### PR TITLE
Rename 'Kafka Monitoring' to 'Kafka Console' in Kafka integration README

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -2,7 +2,7 @@
 
 ![Kafka Dashboard][1]
 
-**New:** [Kafka Monitoring][24] tracks consumer lag, throughput, schemas, and adds message reading capabilities.
+**New:** [Kafka Console][24] tracks consumer lag, throughput, schemas, and adds message reading capabilities.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Renames the "Kafka Monitoring" callout introduced by PR #23710 to the official product name **Kafka Console**.

## Context

Per [this Slack thread](https://dd.slack.com/archives/C02TRJWDHQS/p1786470112140809), the Kafka monitoring product is officially called **Kafka Console**. PR #23710 introduced a callout at the top of the Kafka integration README using the name "Kafka Monitoring". This PR updates that callout to use the correct name.

## Files changed

| File | Change |
|------|--------|
| `kafka/README.md` | Callout text: "Kafka Monitoring" → "Kafka Console" (line 5) |

## Related PRs

- documentation: https://github.com/DataDog/documentation/pull/39148
- corp-hugo: pending (repo not cloned locally)