### PR TITLE
Co-own base DBM database modules with agent-integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -156,6 +156,13 @@ datadog_checks_base/tests/**/test_db_sql.py         @DataDog/database-monitoring
 datadog_checks_base/tests/**/test_db_statements.py  @DataDog/database-monitoring-agent @DataDog/agent-integrations
 **/base/utils/db/query_metrics/                     @DataDog/database-monitoring-agent @DataDog/agent-integrations
 datadog_checks_base/tests/**/query_metrics/         @DataDog/database-monitoring-agent @DataDog/agent-integrations
+**/base/checks/db.py                                @DataDog/database-monitoring-agent @DataDog/agent-integrations
+datadog_checks_base/tests/**/test_database_check.py @DataDog/database-monitoring-agent @DataDog/agent-integrations
+**/base/utils/db/health.py                          @DataDog/database-monitoring-agent @DataDog/agent-integrations
+**/base/utils/db/schemas.py                         @DataDog/database-monitoring-agent @DataDog/agent-integrations
+datadog_checks_base/tests/**/db/test_schemas.py     @DataDog/database-monitoring-agent @DataDog/agent-integrations
+**/base/utils/db/sql_commenter.py                   @DataDog/database-monitoring-agent @DataDog/agent-integrations
+datadog_checks_base/tests/**/test_sql_commenter.py  @DataDog/database-monitoring-agent @DataDog/agent-integrations
 /postgres/                                          @DataDog/database-monitoring-agent @DataDog/agent-integrations
 /postgres/*.md                                      @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation
 /postgres/manifest.json                             @DataDog/database-monitoring @DataDog/agent-integrations @DataDog/documentation


### PR DESCRIPTION
### What does this PR do?

Adds `@DataDog/database-monitoring-agent` as a co-owner of the `datadog_checks_base` modules that only the DBM integrations consume, alongside the existing `@DataDog/agent-integrations` ownership:

| Module | Consumers |
| --- | --- |
| `base/checks/db.py` (`DatabaseCheck`) | clickhouse, postgres, sqlserver |
| `base/utils/db/health.py` | clickhouse, mysql, postgres, sqlserver |
| `base/utils/db/schemas.py` | clickhouse, postgres, sqlserver, sap_hana |
| `base/utils/db/sql_commenter.py` | mysql, postgres, sqlserver, do_query_actions |

Their tests are covered too: `tests/base/checks/test_database_check.py`, `tests/base/utils/db/test_schemas.py`, and `tests/base/utils/db/test_sql_commenter.py`. `health.py` needs no new test entry because its tests live in `tests/base/utils/db/test_util.py`, which the existing line already covers.

### Motivation

The Database monitoring block already co-owns `base/utils/db/utils.py`, `base/utils/db/sql.py`, `base/utils/db/statement_metrics.py`, and `base/utils/db/query_metrics/`, but four equally DBM-specific modules were missed and still route reviews solely to `@DataDog/agent-integrations`. An AST-based import scan across the repo confirms no non-DBM integration imports them, other than `sap_hana` reusing schema collection and `do_query_actions` reusing the SQL commenter, and `git log` shows every one of them was authored and maintained exclusively by DBM engineers.

Deliberately left out of scope:

- `base/utils/aws.py`, `base/utils/diagnose.py`, and `base/utils/tracking.py` are also DBM-only consumers today, but are general-purpose enough that claiming them isn't clearly right.
- `base/utils/db/timed_cache.py` is DBM-authored and db-related but entirely unused — `TimedCache` has no importer anywhere except its own test — so it's a deletion candidate rather than an ownership question.

The generic `QueryManager` plumbing (`base/utils/db/core.py`, `query.py`, `transform.py`, `types.py`) is intentionally untouched, since `duckdb`, `ibm_i`, `proxysql`, `rethinkdb`, `singlestore`, `teradata`, `vertica`, and `voltdb` all depend on it.

`ddev validate codeowners` passes. No agent-shipped files change, so no changelog entry is needed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)