### PR TITLE
Update PyPI publish action

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -908,7 +908,7 @@ jobs:
     # workflow file name, environment and repository the request is comming from to
     # provide the valid JWT token.
     - name: Push Python artifacts to PyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         skip-existing: true
 

--- a/.github/workflows/claim-pypi-name.yaml
+++ b/.github/workflows/claim-pypi-name.yaml
@@ -40,7 +40,7 @@ jobs:
         bash .github/workflows/scripts/build_placeholders.sh
 
     - name: Push Python artifacts to PyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         # We don't mind invalid metadata, we only want to claim the package name.
         verify-metadata: false

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -46,7 +46,7 @@ jobs:
     # validates the workflow file name, environment and repository the request is
     # comming from to provide the valid JWT token.
     - name: Release base package to PyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         skip-existing: true
         packages-dir: datadog_checks_base/dist

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -46,7 +46,7 @@ jobs:
     # validates the workflow file name, environment and repository the request is
     # comming from to provide the valid JWT token.
     - name: Release dev package to PyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         skip-existing: true
         packages-dir: datadog_checks_dev/dist


### PR DESCRIPTION
### What does this PR do?
Updates all `pypa/gh-action-pypi-publish` usages from v1.13.0 to v1.14.2, pinned to commit `dc37677b2e1c63e2034f94d8a5b11f265b73ba33`.

### Motivation
Split this action update out of the [grouped Renovate actions PR](https://github.com/DataDog/integrations-core/pull/23481) so it can be reviewed and merged independently without changing the dependency-resolution workflow input hash.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
