### PR TITLE
Stop Renovate holding docker image updates on a check that can never pass

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
   "enabledManagers": [
     "github-actions",
     "custom.regex"
@@ -160,6 +161,7 @@
       "minimumReleaseAge": "7 days"
     },
     {
+      "description": "Neither ghcr.io nor registry.ddbuild.io return release timestamps, and Renovate treats a missing timestamp as never having aged. Without timestamp-optional these updates sit with a permanently pending renovate/stability-days check.",
       "matchManagers": [
         "custom.regex"
       ],
@@ -174,7 +176,8 @@
         "renovate/docker-images",
         "qa/skip-qa"
       ],
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "7 days",
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?

- Scopes `minimumReleaseAgeBehaviour: "timestamp-optional"` to the docker-images Renovate group.
- Enables the dependency dashboard.

### Motivation

The 7-day `minimumReleaseAge` on the docker-images group can never be satisfied. Renovate's `docker` datasource only reads release timestamps from Docker Hub, and the two images tracked in `.gitlab/tagger/Dockerfile` come from `ghcr.io` ([renovate#39064](https://github.com/renovatebot/renovate/issues/39064)) and `registry.ddbuild.io`. Since Renovate 42, `minimumReleaseAgeBehaviour` defaults to `timestamp-required`, so a release with no timestamp is treated as not yet aged, and `renovate/stability-days` stays pending indefinitely rather than for 7 days. #24835 is an example.

`timestamp-optional` rather than dropping `minimumReleaseAge`, so the age check still applies if an image from a registry that does publish timestamps is added to the group later.

The dependency dashboard makes updates held back by the age check visible. Without it there is no way to tell "held back" from "nothing to update" short of reading the job log.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
