### PR TITLE
Add test writing guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,23 @@ ddev env test --dev --recreate <INTEGRATION> <ENV>
 
 For E2E tests, `--recreate` performs `docker compose down --volumes` followed by `docker compose up -d --force-recreate`.
 
+### Writing Tests
+
+These rules cover what to test. For how test code itself is organized in `ddev`, see `ddev/tests/AGENTS.md`.
+
+A test must be justified by the code as it stands now. Someone reading the test with no knowledge of how the code got there should be able to see why the assertion matters. This rules out two patterns that keep showing up:
+
+- Tests that only exist because of the development history, such as asserting the code no longer does what an earlier iteration did. There are infinitely many things the code does not do, so picking one is arbitrary. The exception is a regression test for a bug that actually shipped; it asserts the correct observable behavior and references the issue or PR.
+- Tests of language or framework mechanics: that a constructor assigned the attributes passed to it, that a dataclass compares equal, that an enum has the values it was declared with, that a property returns what was just set, that a mock returns what it was configured to return.
+
+What to do instead:
+
+- Test observable behavior at the unit's boundary: given this input or state, what does it return, produce, or change? A test that would still pass after a reimplementation with the same contract is testing behavior; one that breaks is usually testing implementation details.
+- Before adding a test, state in one sentence the bug it would catch and why that bug matters. If that sentence cannot be written, do not add the test.
+- Do not repeat coverage across layers. Edge cases belong at the lowest layer that owns the logic; layers above it cover wiring and integration, so they should have fewer tests, not more.
+- Parameterize variants of the same behavior with `pytest.mark.parametrize` instead of copying near-identical test functions.
+- Prefer a small number of meaningful tests over a high count. Do not pad a suite to look thorough.
+
 ### Linting and Formatting
 
 Always run linting and formatting through `ddev`; never invoke `ruff`, `black`, or `mypy` directly. CI runs them inside `ddev`'s pinned hatch lint environment, and a different locally installed version can report different results — passing locally while failing CI, or the other way around.
@@ -221,6 +238,7 @@ echo "Fix a bug where ``tempdb`` is wrongly excluded from database files metrics
 These guidelines apply to automated code review (the Codex review bot). They do not relax any requirement above for code you author.
 
 - Do not raise findings for a missing changelog entry. Changelog files are named `<INTEGRATION>/changelog.d/<PR_NUMBER>.<TYPE>`, so they can only be created after the PR number is assigned; their absence when a PR is first opened is expected rather than a defect. The requirement is already enforced by the `check_changelog` job in `.github/workflows/pr-quick-check.yml`.
+- Flag tests that violate [Writing Tests](#writing-tests). For each finding, say which behavior the test fails to verify rather than only naming the pattern.
 - When a PR changes the `metric_type` column in `metadata.csv`, verify that the new type uses the correct in-app (backend) type, not the submission type. The submission-to-backend mapping is defined in `datadog_checks_base/datadog_checks/base/stubs/aggregator.py` (`METRIC_TYPE_SUBMISSION_TO_BACKEND_MAP`). The valid in-app types for `metadata.csv` are `gauge`, `count`, and `rate`. The full mapping is: `gauge` → `gauge`, `rate` → `gauge`, `count` → `count`, `monotonic_count` → `count`, `counter` → `rate`, `histogram` → `rate`, `historate` → `rate`. For example, a metric submitted as a `rate` should appear as `gauge` in `metadata.csv`, and a metric submitted as a `monotonic_count` should appear as `count`.
 
 ## Pull Requests


### PR DESCRIPTION
### What does this PR do?

Adds a `Writing Tests` section to `AGENTS.md` covering what to test, and a matching bullet under `Review Guidelines` so the Codex review bot flags the same patterns.

The rules: a test has to be justified by the code as it stands now, no asserting that the code no longer does what an earlier iteration did, no testing language or framework mechanics, no duplicated edge-case coverage across layers, parameterize instead of copy-pasting.

### Motivation

Agents keep producing tests that assert nothing meaningful. The two recurring shapes are tests of language mechanics (a constructor assigned the attributes it was passed, a mock returned its configured value) and tests that only make sense as a record of the conversation that produced the code ("we no longer do X"), which read as arbitrary when the code is looked at as a snapshot. Neither would fail for a reason a user cares about. Nothing in the repo said not to do it, so this writes it down where both authors and the review bot will see it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged