### PR TITLE
[DBMON-6882] Make Postgres check teardown idempotent

### DIFF
--- a/postgres/changelog.d/24852.fixed
+++ b/postgres/changelog.d/24852.fixed
@@ -1,0 +1,1 @@
+Only tear the check down once when it is cancelled, and keep logging usable through the end of teardown.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -199,6 +199,7 @@ class PostgreSql(DatabaseCheck):
         self._cancel_lock = threading.Lock()
         self._is_running = False
         self._cancelled = False
+        self._finalized = False
 
     def database_monitoring_column_statistics(self, raw_event: str):
         self.event_platform_event(raw_event, "dbm-column-statistics")
@@ -537,19 +538,26 @@ class PostgreSql(DatabaseCheck):
             self.data_observability = self.register_async_job(PostgresDataObservability(self, self._config))
 
     def _finalize(self):
-        """Tear down check state. Must not run while check() is executing."""
+        """Tear down check state. Runs at most once, and never while check() is executing."""
+        with self._cancel_lock:
+            if self._finalized:
+                self.log.debug("Check already finalized, nothing to tear down")
+                return
+            self._finalized = True
         self.log.debug("Finalizing check: closing connections and clearing state")
         self.shutdown_async_jobs()
         self._clean_state()
         self.check_initializations.clear()
         # TODO: move diagnosis cleanup into AgentCheck.cancel() in the base class
         self._diagnosis = None
-        self.log.check = None
         self._query_manager = None
         self.health = None
         self._close_db()
         self._close_db_pool()
         self.log.debug("Check cleanup complete")
+        # Must come last: the logging adapter reads back through this attribute for checks whose
+        # check_id was never resolved, so anything logged after this would fail.
+        self.log.check = None
 
     def _clean_state(self):
         self.log.debug("Cleaning state")

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -541,7 +541,6 @@ class PostgreSql(DatabaseCheck):
         """Tear down check state. Runs at most once, and never while check() is executing."""
         with self._cancel_lock:
             if self._finalized:
-                self.log.debug("Check already finalized, nothing to tear down")
                 return
             self._finalized = True
         self.log.debug("Finalizing check: closing connections and clearing state")

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import copy
 import gc
+import logging
 import weakref
 
 import mock
@@ -517,6 +518,42 @@ def test_run_after_cancel_returns_immediately(pg_instance):
         result = check.run()
 
     assert result == ''
+
+
+def test_finalize_runs_once_across_repeated_cancels(pg_instance):
+    """Verify that teardown is idempotent.
+
+    The check is cancelled more than once in practice: run_one_check() cancels, and the
+    integration_check fixture cancels again on teardown. Re-running teardown re-closes
+    connections and re-tears down the async jobs for no benefit.
+    """
+    check = PostgreSql('postgres', {}, [pg_instance])
+    conn = mock.MagicMock()
+    check._db = conn
+
+    with mock.patch.object(check.db_pool, 'close_all', wraps=check.db_pool.close_all) as close_all:
+        check.cancel()
+        check.cancel()
+        check._finalize()
+
+    conn.close.assert_called_once()
+    close_all.assert_called_once()
+
+
+def test_finalize_logs_after_dropping_the_check_reference(pg_instance, caplog):
+    """Verify that _finalize() can log after nulling log.check.
+
+    CheckLoggingAdapter.process reads back through log.check on every call for checks whose
+    check_id was never resolved, so nulling it before the last log line raises AttributeError
+    once debug logging is enabled.
+    """
+    caplog.set_level(logging.DEBUG)
+    check = PostgreSql('postgres', {}, [pg_instance])
+    assert not check.check_id, "test only exercises the hazard while check_id is unresolved"
+
+    check._finalize()
+
+    assert check.log.check is None
 
 
 @pytest.mark.parametrize(

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -3,7 +3,6 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import copy
 import gc
-import logging
 import weakref
 
 import mock
@@ -521,12 +520,7 @@ def test_run_after_cancel_returns_immediately(pg_instance):
 
 
 def test_finalize_runs_once_across_repeated_cancels(pg_instance):
-    """Verify that teardown is idempotent.
-
-    The check is cancelled more than once in practice: run_one_check() cancels, and the
-    integration_check fixture cancels again on teardown. Re-running teardown re-closes
-    connections and re-tears down the async jobs for no benefit.
-    """
+    """Verify that teardown is idempotent."""
     check = PostgreSql('postgres', {}, [pg_instance])
     conn = mock.MagicMock()
     check._db = conn
@@ -538,22 +532,6 @@ def test_finalize_runs_once_across_repeated_cancels(pg_instance):
 
     conn.close.assert_called_once()
     close_all.assert_called_once()
-
-
-def test_finalize_logs_after_dropping_the_check_reference(pg_instance, caplog):
-    """Verify that _finalize() can log after nulling log.check.
-
-    CheckLoggingAdapter.process reads back through log.check on every call for checks whose
-    check_id was never resolved, so nulling it before the last log line raises AttributeError
-    once debug logging is enabled.
-    """
-    caplog.set_level(logging.DEBUG)
-    check = PostgreSql('postgres', {}, [pg_instance])
-    assert not check.check_id, "test only exercises the hazard while check_id is unresolved"
-
-    check._finalize()
-
-    assert check.log.check is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

Makes `PostgreSql._finalize()` run at most once, guarded by a `_finalized` flag under the
existing `_cancel_lock`, and moves `self.log.check = None` after the final log statement.

### Motivation

Two independent problems on the teardown path, both surfaced while preparing #24844 (lifting
this protocol into `DatabaseCheck`).

Teardown is not idempotent, and the check is already finalized more than once in practice:
`run_one_check()` calls `cancel()` and the `integration_check` fixture calls it again on
teardown, so every integration test closes the main connection, calls `db_pool.close_all()`
and re-runs async job shutdown twice. It only survives today because each individual step
happens to tolerate a second call.

Nulling `log.check` before the trailing debug line is a latent crash.
`CheckLoggingAdapter.process` re-reads `self.check.check_id` on every call for checks whose
`check_id` was never resolved, so `_finalize()` raises `AttributeError: 'NoneType' object has
no attribute 'check_id'` as soon as debug logging is enabled. Verified locally against an
unmodified check.

This also unblocks #24844 from carrying transitional logic. When the base class gains the same
protocol, `PostgreSql.run()` reaches it through `super().run()`, so the inner and outer wrappers
would both finalize on an in-flight cancel. With teardown idempotent here, the base wrapper
needs no special case for integrations that have not yet migrated, and this guard moves into the
base once Postgres adopts it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged