### PR TITLE
Map ocsf.src_endpoint.uid in DNS Activity [4003] pipelines

### DIFF
--- a/bluecat_integrity/assets/logs/bluecat-integrity.yaml
+++ b/bluecat_integrity/assets/logs/bluecat-integrity.yaml
@@ -644,6 +644,15 @@ pipeline:
               preserveSource: true
               overrideOnConflict: true
               type: schema-remapper
+            - name: Map `ocsf.src_endpoint.ip` to `ocsf.src_endpoint.uid`
+              sources:
+                - ocsf.src_endpoint.ip
+              sourceType: attribute
+              target: ocsf.src_endpoint.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
             - name: Map `sourcePort` to `ocsf.src_endpoint.port`
               sources:
                 - sourcePort

--- a/bluecat_integrity/assets/logs/bluecat-integrity_tests.yaml
+++ b/bluecat_integrity/assets/logs/bluecat-integrity_tests.yaml
@@ -98,6 +98,7 @@ tests:
         src_endpoint:
           ip: "10.10.10.10"
           port: 57895
+          uid: "10.10.10.10"
         time: 1772082904884
       payloadType: "dnstap"
       requestData:
@@ -283,6 +284,7 @@ tests:
         src_endpoint:
           ip: "10.10.10.10"
           port: 39927
+          uid: "10.10.10.10"
         time: 1771522140526
       payloadType: "dnstap"
       responseAddress: "10.1.1.1"
@@ -530,6 +532,7 @@ tests:
         src_endpoint:
           ip: "10.10.10.10"
           port: 18456
+          uid: "10.10.10.10"
         time: 1772001594423
       payloadType: "dnstap"
       queryZone: "google.local."
@@ -828,6 +831,7 @@ tests:
         src_endpoint:
           ip: "10.10.10.10"
           port: 39927
+          uid: "10.10.10.10"
         time: 1771522140526
       payloadType: "dnstap"
       requestData:

--- a/cisco_umbrella_dns/assets/logs/cisco-umbrella-dns.yaml
+++ b/cisco_umbrella_dns/assets/logs/cisco-umbrella-dns.yaml
@@ -752,6 +752,15 @@ pipeline:
       filter:
         query: service:dns
       processors:
+        - type: array-processor
+          name: Extract roaming computer `id` from `identities` array
+          enabled: true
+          operation:
+            source: identities
+            target: ocsf.src_endpoint.uid
+            filter: "type.type:roaming"
+            valueToExtract: id
+            type: select
         - type: schema-processor
           name: Apply OCSF schema for 4003
           enabled: true
@@ -873,14 +882,15 @@ pipeline:
               preserveSource: true
               overrideOnConflict: true
               type: schema-remapper
-            - name: Map `identities.0.id` to `ocsf.src_endpoint.uid`
+            - name: Map `ocsf.src_endpoint.uid`, `internalip` to `ocsf.src_endpoint.uid`
               sources:
-                - identities.0.id
+                - ocsf.src_endpoint.uid
+                - internalip
               sourceType: attribute
               target: ocsf.src_endpoint.uid
               targetFormat: string
               preserveSource: true
-              overrideOnConflict: true
+              overrideOnConflict: false
               type: schema-remapper
             - name: Map `externalip` to `ocsf.proxy_endpoint.ip`
               sources:

--- a/cisco_umbrella_dns/assets/logs/cisco-umbrella-dns.yaml
+++ b/cisco_umbrella_dns/assets/logs/cisco-umbrella-dns.yaml
@@ -873,6 +873,15 @@ pipeline:
               preserveSource: true
               overrideOnConflict: true
               type: schema-remapper
+            - name: Map `identities.0.id` to `ocsf.src_endpoint.uid`
+              sources:
+                - identities.0.id
+              sourceType: attribute
+              target: ocsf.src_endpoint.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
             - name: Map `externalip` to `ocsf.proxy_endpoint.ip`
               sources:
                 - externalip

--- a/cisco_umbrella_dns/assets/logs/cisco-umbrella-dns_tests.yaml
+++ b/cisco_umbrella_dns/assets/logs/cisco-umbrella-dns_tests.yaml
@@ -173,6 +173,7 @@ tests:
         severity_id: 1
         src_endpoint:
           ip: "185.64.148.0"
+          uid: "617808138"
         status: "Failure"
         status_id: 2
         time: 1702288020000
@@ -428,6 +429,7 @@ tests:
         severity_id: 1
         src_endpoint:
           ip: "185.64.148.0"
+          uid: "618368586"
         status: "Success"
         status_id: 1
         time: 1702990616000
@@ -668,6 +670,7 @@ tests:
         severity_id: 1
         src_endpoint:
           ip: "185.64.148.0"
+          uid: "618368586"
         time: 1702990616000
       policycategories:
        -

--- a/coredns/assets/logs/coredns.yaml
+++ b/coredns/assets/logs/coredns.yaml
@@ -452,6 +452,15 @@ pipeline:
               preserveSource: true
               overrideOnConflict: true
               type: schema-remapper
+            - name: Map `ocsf.src_endpoint.ip` to `ocsf.src_endpoint.uid`
+              sources:
+                - ocsf.src_endpoint.ip
+              sourceType: attribute
+              target: ocsf.src_endpoint.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+              type: schema-remapper
             - name: Map `network.client.port` to `ocsf.src_endpoint.port`
               sources:
                 - network.client.port

--- a/coredns/assets/logs/coredns_tests.yaml
+++ b/coredns/assets/logs/coredns_tests.yaml
@@ -59,6 +59,7 @@ tests:
         src_endpoint:
           ip: "10.145.105.176"
           port: 36008
+          uid: "10.145.105.176"
         status: "Failure"
         status_code: "NXDOMAIN"
         status_id: 2
@@ -127,6 +128,7 @@ tests:
         src_endpoint:
           ip: "127.0.0.1"
           port: 50759
+          uid: "127.0.0.1"
         status: "Success"
         status_code: "NOERROR"
         status_id: 1

--- a/zeek/assets/logs/zeek.yaml
+++ b/zeek/assets/logs/zeek.yaml
@@ -3506,6 +3506,14 @@ pipeline:
               preserveSource: true
               overrideOnConflict: true
             - type: schema-remapper
+              name: Map `ocsf.src_endpoint.ip` to `ocsf.src_endpoint.uid`
+              sources:
+                - ocsf.src_endpoint.ip
+              target: ocsf.src_endpoint.uid
+              preserveSource: true
+              overrideOnConflict: true
+              targetFormat: string
+            - type: schema-remapper
               name: Map `id.orig_p` to `ocsf.src_endpoint.port`
               sources:
                 - id.orig_p

--- a/zeek/assets/logs/zeek_tests.yaml
+++ b/zeek/assets/logs/zeek_tests.yaml
@@ -417,6 +417,7 @@ tests:
         src_endpoint:
           ip: 185.64.148.0
           port: 58013
+          uid: 185.64.148.0
         status: Success
         status_detail: NOERROR
         status_id: 1
@@ -565,6 +566,7 @@ tests:
         src_endpoint:
           ip: 10.10.10.10
           port: 123
+          uid: 10.10.10.10
         status: Unknown
         status_id: 0
         time: 1709786320085
@@ -1090,6 +1092,7 @@ tests:
         src_endpoint:
           ip: 185.64.148.0
           port: 58013
+          uid: 185.64.148.0
         status: Success
         status_detail: NOERROR
         status_id: 1


### PR DESCRIPTION
### What does this PR do?

Populates `ocsf.src_endpoint.uid` in every DNS Activity [4003] sub pipeline in this repo.

Where the source events carry a client device identifier, that field is mapped:

| Integration | Source field |
| --- | --- |
| `cisco_umbrella_dns` | `identities.0.id` — the Umbrella identity that issued the query |

Where no client device identifier exists in the DNS sample logs, `ocsf.src_endpoint.ip` is mapped instead:

| Integration | Why there is no device ID |
| --- | --- |
| `bluecat_integrity` | `sourceId` / `serverId` identify the BlueCat appliance and are already mapped to `ocsf.dst_endpoint.uid` |
| `coredns` | The grok-parsed log line carries only client IP and port |
| `zeek` | `uid` is a per-connection identifier, not a device identifier |

`dnsfilter` already maps `agentid` to `ocsf.src_endpoint.uid`, so it is unchanged.

Expected results in the `_tests.yaml` files were updated in alphabetical key order to match the repository's `deepSort` convention.

### Motivation

`ocsf.src_endpoint.uid` was unpopulated across most DNS Activity pipelines, so DNS events could not be correlated to a source device by ID. Filling it consistently — with a device ID where one exists and the source IP as a stable fallback where one does not — gives every 4003 event a source endpoint identifier.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
