### PR TITLE
Add Category::SIEM classifier tag to Trellix, Cofense Triage, Anthropic Compliance Logs, IDE Shepherd, CrowdStrike FDR

### DIFF
--- a/anthropic_compliance_logs/manifest.json
+++ b/anthropic_compliance_logs/manifest.json
@@ -46,6 +46,7 @@
     "classifier_tags": [
       "Category::AI/ML",
       "Category::Log Collection",
+      "Category::SIEM",
       "Category::Security",
       "Submitted Data Type::Logs",
       "Offering::Integration"

--- a/cofense_triage/manifest.json
+++ b/cofense_triage/manifest.json
@@ -26,6 +26,7 @@
     "classifier_tags": [
       "Category::Cloud",
       "Category::Log Collection",
+      "Category::SIEM",
       "Category::Security",
       "Offering::Integration",
       "Submitted Data Type::Logs"

--- a/crowdstrike_fdr/manifest.json
+++ b/crowdstrike_fdr/manifest.json
@@ -47,6 +47,7 @@
       "Category::AWS",
       "Category::Cloud",
       "Category::Log Collection",
+      "Category::SIEM",
       "Category::Security",
       "Offering::Integration",
       "Submitted Data Type::Logs"

--- a/ide_shepherd/manifest.json
+++ b/ide_shepherd/manifest.json
@@ -23,6 +23,7 @@
       "Supported OS::Windows",
       "Supported OS::macOS",
       "Category::Log Collection",
+      "Category::SIEM",
       "Category::Security",
       "Category::Developer Tools",
       "Offering::Integration",

--- a/trellix_endpoint_security/manifest.json
+++ b/trellix_endpoint_security/manifest.json
@@ -20,6 +20,7 @@
     ],
     "classifier_tags": [
       "Category::Log Collection",
+      "Category::SIEM",
       "Category::Security",
       "Offering::Integration",
       "Submitted Data Type::Logs"


### PR DESCRIPTION
### What does this PR do?
Adds the `Category::SIEM` classifier tag to the `manifest.json` of five integrations: Trellix Endpoint Security (ENS), Cofense Triage, Claude Compliance (Anthropic Compliance Logs), IDE Shepherd, and CrowdStrike FDR.

### Motivation
These integrations are relevant to Cloud SIEM (log collection/security data used in detection content) but were missing the `Category::SIEM` classifier tag, so they don't surface correctly in SIEM-focused integration listings.

SEC-35935

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged