### PR TITLE
Add Kafka Actions opt-out to Kafka Consumer

### DIFF
--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -49,6 +49,15 @@ files:
           - type: array
             items:
               type: string
+      - name: allow_kafka_actions
+        description: |
+          Set to `false` to prevent the Agent from running one-time Kafka actions against the cluster configured by
+          this instance. This does not disable Kafka consumer monitoring or other Remote Configuration features.
+        fleet_configurable: false
+        value:
+          type: boolean
+          example: true
+          display_default: true
       - name: kafka_client_api_version
         description: |
           Specify the highest client protocol version supported by all brokers in the cluster.

--- a/kafka_consumer/changelog.d/24858.added
+++ b/kafka_consumer/changelog.d/24858.added
@@ -1,0 +1,1 @@
+Add an option to prevent Kafka actions from running against a monitored cluster.

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
@@ -12,6 +12,10 @@ def shared_kafka_timeout():
     return 5
 
 
+def instance_allow_kafka_actions():
+    return True
+
+
 def instance_close_admin_client():
     return True
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
@@ -93,6 +93,7 @@ class InstanceConfig(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    allow_kafka_actions: Optional[bool] = None
     close_admin_client: Optional[bool] = None
     collect_consumer_group_state: Optional[bool] = None
     consumer_groups: Optional[MappingProxyType[str, Any]] = None

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -43,6 +43,12 @@ instances:
     #
   - kafka_connect_str: <KAFKA_CONNECT_STR>
 
+    ## @param allow_kafka_actions - boolean - optional - default: true
+    ## Set to `false` to prevent the Agent from running one-time Kafka actions against the cluster configured by
+    ## this instance. This does not disable Kafka consumer monitoring or other Remote Configuration features.
+    #
+    # allow_kafka_actions: true
+
     ## @param kafka_client_api_version - string - optional
     ## Specify the highest client protocol version supported by all brokers in the cluster.
     ##


### PR DESCRIPTION
### What does this PR do?

Adds the non-fleet-configurable `allow_kafka_actions` option to each `kafka_consumer` instance. It defaults to `true`; setting it to `false` prevents one-time Kafka actions against that instance while leaving Kafka monitoring and other Remote Configuration features enabled.

Agent-side enforcement is implemented in DataDog/datadog-agent#54867.

### Motivation

Kafka Actions uses a dedicated Remote Configuration provider, so the Agent generic integration block list does not disable it. Operators need a per-cluster safety control without turning off Remote Configuration globally.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged