### PR TITLE
Add metrics_prefix to discovery block

### DIFF
--- a/gearmand/assets/configuration/spec.yaml
+++ b/gearmand/assets/configuration/spec.yaml
@@ -55,3 +55,6 @@ files:
       value.example:
       - gearmand
   - template: auto_conf/discovery
+    overrides:
+      discovery.example:
+        metrics_prefix: gearman

--- a/gearmand/changelog.d/24861.added
+++ b/gearmand/changelog.d/24861.added
@@ -1,0 +1,1 @@
+Add ``metrics_prefix`` to the ``discovery`` block of ``auto_conf.yaml``.

--- a/gearmand/datadog_checks/gearmand/data/auto_conf.yaml
+++ b/gearmand/datadog_checks/gearmand/data/auto_conf.yaml
@@ -8,7 +8,8 @@ ad_identifiers:
 
 ## Enables configuration discovery
 #
-discovery: {}
+discovery:
+  metrics_prefix: gearman
 
 ## Unused init configuration
 #

--- a/krakend/assets/configuration/spec.yaml
+++ b/krakend/assets/configuration/spec.yaml
@@ -86,3 +86,6 @@ files:
         processes:
           - "process.name == 'krakend'"
   - template: auto_conf/discovery
+    overrides:
+      discovery.example:
+        metrics_prefix: krakend.api

--- a/krakend/changelog.d/24861.added
+++ b/krakend/changelog.d/24861.added
@@ -1,0 +1,1 @@
+Add ``metrics_prefix`` to the ``discovery`` block of ``auto_conf.yaml``.

--- a/krakend/datadog_checks/krakend/data/auto_conf.yaml
+++ b/krakend/datadog_checks/krakend/data/auto_conf.yaml
@@ -14,7 +14,8 @@ cel_selector:
 
 ## Enables configuration discovery
 #
-discovery: {}
+discovery:
+  metrics_prefix: krakend.api
 
 ## Unused init configuration
 #

--- a/prefect/assets/configuration/spec.yaml
+++ b/prefect/assets/configuration/spec.yaml
@@ -160,4 +160,7 @@ files:
       value.example:
       - prefect
   - template: auto_conf/discovery
+    overrides:
+      discovery.example:
+        metrics_prefix: prefect.server
 

--- a/prefect/changelog.d/24861.added
+++ b/prefect/changelog.d/24861.added
@@ -1,0 +1,1 @@
+Add ``metrics_prefix`` to the ``discovery`` block of ``auto_conf.yaml``.

--- a/prefect/datadog_checks/prefect/data/auto_conf.yaml
+++ b/prefect/datadog_checks/prefect/data/auto_conf.yaml
@@ -8,7 +8,8 @@ ad_identifiers:
 
 ## Enables configuration discovery
 #
-discovery: {}
+discovery:
+  metrics_prefix: prefect.server
 
 ## Unused init configuration
 #


### PR DESCRIPTION
### What does this PR do?

Adds a `metrics_prefix` field to the `discovery` block of `auto_conf.yaml` for `gearmand`, `krakend`, and `prefect` — the three integrations whose metric prefix diverges from their check name and that currently ship a `discovery` block.

This allows the core agent to detect conflicts with a generic `openmetrics`/`prometheus` config. See https://datadoghq.atlassian.net/wiki/spaces/DSCVR/pages/7031522288/ for more information.

This is an alternative to #24738 which computed the `metrics_prefix` value automatically at `ddev validate config` time, by reading each integration's `manifest.json` or, for integrations without one, the repo's `.ddev/config.toml` `[overrides.metrics-prefix]` table (the same source `ddev validate metadata` already consults). Code owners objected to that approach since it made `.ddev/config.toml` — a file intended as developer/tooling configuration — production-critical.

This PR instead hand-authors the value directly in each affected integration's `spec.yaml`, so it's an explicit, reviewable part of the integration's own spec rather than a side effect of unrelated dev tooling. `auto_conf.yaml` remains a generated file (regenerated here via `ddev validate config`).

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-640

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged