### PR TITLE
Add dd-octo-sts staging trust policy for agent_integrations_review_bot

### DIFF
--- a/.github/chainguard/agent-integrations-review-bot-staging.sts.yaml
+++ b/.github/chainguard/agent-integrations-review-bot-staging.sts.yaml
@@ -19,11 +19,10 @@
 # end-to-end.
 
 issuer: https://ticino.identity.local-cluster.local-dc.fabric.dog:8443/v1/issuer/sycamore
-subject: "rapid-agent-integrations.agent-integrations-review-bot@kubernetes.us1.staging.dog"
+subject_pattern: "rapid-agent-integrations\\.agent-integrations-review-bot@kubernetes\\.us1\\.staging\\.dog"
 
 claim_pattern:
   email: "rapid-agent-integrations\\.agent-integrations-review-bot@kubernetes\\.us1\\.staging\\.dog"
-  name: "rapid-agent-integrations-agent-integrations-review-bot"
 
 permissions:
   contents: read

--- a/.github/chainguard/agent-integrations-review-bot-staging.sts.yaml
+++ b/.github/chainguard/agent-integrations-review-bot-staging.sts.yaml
@@ -1,0 +1,31 @@
+# Trust policy for the agent_integrations_review_bot Rapid Slack review bot (staging)
+#
+# Grants a scoped, ephemeral token to the review bot's Kubernetes pod so it can
+# (1) shallow-clone this repo for the review skill, and (2) post PR review comments
+# via `gh api repos/.../pulls/<n>/reviews`. The bot never posts an APPROVE review --
+# that is enforced in application code (publisher.py::clamp_review_type in dd-source),
+# not by this policy's permission scope.
+#
+# Naming convention:
+#   Repo-local policy (per octo-sts): only DataDog/integrations-core can grant this
+#   identity access, and it's implicitly scoped to this repo -- no `repositories:`
+#   list needed.
+#
+# Identity: rapid-agent-integrations/agent-integrations-review-bot k8s service
+# account, staging datacenter (us1.staging.dog). Authenticates via the sycamore
+# (Ticino) OIDC issuer, not GitHub Actions.
+#
+# Staging only for now; a follow-up policy will add prod once staging is verified
+# end-to-end.
+
+issuer: https://ticino.identity.local-cluster.local-dc.fabric.dog:8443/v1/issuer/sycamore
+subject: "rapid-agent-integrations.agent-integrations-review-bot@kubernetes.us1.staging.dog"
+
+claim_pattern:
+  email: "rapid-agent-integrations\\.agent-integrations-review-bot@kubernetes\\.us1\\.staging\\.dog"
+  name: "rapid-agent-integrations-agent-integrations-review-bot"
+
+permissions:
+  contents: read
+  metadata: read
+  pull_requests: write


### PR DESCRIPTION
## Summary

Adds a repo-local dd-octo-sts trust policy so the Rapid Slack review bot
(`agent_integrations_review_bot`, team agent-integrations) can authenticate
to GitHub against this repo in **staging**.

Needed for Posting PR review comments via `gh api repos/.../pulls/<n>/reviews`.

## Scope

- Repo-local policy — implicitly scoped to `DataDog/integrations-core`, no
  `repositories:` list needed.
- **Permissions**: `contents: read`, `metadata: read`, `pull_requests: write`.
  No `issues` write, no admin/org-level scopes.
- The bot has a code-level invariant that it will never post an `APPROVE`
  review (see `publisher.py::clamp_review_type` in dd-source) — that's
  enforced in application code, not by this policy's permission scope, since
  GitHub doesn't have a finer-grained "review but never approve" permission.

## Not included

This PR is **staging only**. A follow-up will add the prod policy once the
staging integration is verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)