### PR TITLE
Include target branch in backport PR titles

### DIFF
--- a/ddev/changelog.d/24868.added
+++ b/ddev/changelog.d/24868.added
@@ -1,0 +1,1 @@
+Include the target branch in backport PR titles (`[Backport <branch>] <subject>`).

--- a/ddev/src/ddev/cli/release/port_commit_workflow.py
+++ b/ddev/src/ddev/cli/release/port_commit_workflow.py
@@ -740,7 +740,7 @@ def build_port_plan(
         target_branch=target_branch,
         new_branch=new_branch,
         worktree_path=_worktree_path_for(app, new_branch),
-        pr_title=f'[Backport] {clean_subject}',
+        pr_title=f'[Backport {target_branch}] {clean_subject}',
         pr_body=build_pr_body(
             app,
             sha=full_sha,

--- a/ddev/tests/cli/release/test_port_commit.py
+++ b/ddev/tests/cli/release/test_port_commit.py
@@ -464,7 +464,7 @@ def test_command_happy_path(ddev: CliRunner, mocker: MockerFixture, fake_async_g
     pr_call = fake_async_github.last_call('create_pull_request')
     assert pr_call.kwargs['owner'] == 'DataDog'
     assert pr_call.kwargs['repo'] == 'integrations-core'
-    assert pr_call.kwargs['title'] == '[Backport] Fix bug'
+    assert pr_call.kwargs['title'] == '[Backport master] Fix bug'
     assert pr_call.kwargs['head'] == 'alice/port-1234567890-to-master'
     assert pr_call.kwargs['base'] == 'master'
     assert pr_call.kwargs['draft'] is False
@@ -792,7 +792,7 @@ def test_command_fetches_commit_when_not_local(
         'create_pull_request',
         owner='DataDog',
         repo='integrations-core',
-        title='[Backport] Fix bug',
+        title='[Backport master] Fix bug',
         head=f'alice/port-{commit_sha[:10]}-to-master',
         base='master',
         body=mocker.ANY,
@@ -1086,6 +1086,8 @@ def test_command_from_pr_ports_every_backport_label(
     assert bases == ['7.62.x', '7.61.x']
     heads = [c.kwargs['head'] for c in fake_async_github.calls_to('create_pull_request')]
     assert heads == ['alice/port-1234567890-to-7.62.x', 'alice/port-1234567890-to-7.61.x']
+    titles = [c.kwargs['title'] for c in fake_async_github.calls_to('create_pull_request')]
+    assert titles == ['[Backport 7.62.x] Fix bug', '[Backport 7.61.x] Fix bug']
 
 
 def test_command_from_pr_explicit_target_restricts_to_one_base(


### PR DESCRIPTION
### What does this PR do?

Backport PRs opened by `ddev release port-commit` now title as `[Backport <branch>] <subject>` instead of `[Backport] <subject>`.

### Motivation

Follow-up to #24470. With one merged PR fanning out to multiple release branches, `[Backport]` alone made the PRs indistinguishable in the PR list and notifications; the target branch is now visible without opening each one.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged