### PR TITLE
Stop retaining deobfuscated SQL through sqlserver statement collection

### DIFF
--- a/sqlserver/changelog.d/24871.fixed
+++ b/sqlserver/changelog.d/24871.fixed
@@ -1,0 +1,1 @@
+Stop retaining deobfuscated SQL text on query metrics rows after obfuscation, which held a second copy of every collected statement through metrics, full query text, and plan collection.

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -487,6 +487,11 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             row['dd_tables'] = metadata.get('tables', None)
             row['dd_commands'] = metadata.get('commands', None)
 
+            # Drop the deobfuscated text now that it has been obfuscated into `text`. Nothing downstream
+            # reads it, and keeping it would hold a second copy of every statement alive through
+            # derivative metrics, FQT, and plan collection.
+            del row['statement_text']
+
             normalized_rows.append(row)
         return normalized_rows
 

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -1236,6 +1236,44 @@ def test_normalize_queries_procedure_name_fallback(
         assert not result_row.get('procedure_text')
 
 
+@pytest.mark.unit
+def test_normalize_queries_drops_deobfuscated_text(instance_docker, datadog_agent):
+    """Normalized rows expose only the obfuscated statement. Retaining `statement_text` would keep a
+    second copy of every statement alive through derivative metrics, FQT, and plan collection, and
+    would expose deobfuscated SQL to any consumer that does not route through the metrics payload."""
+    instance_docker['dbm'] = True
+    check = SQLServer(CHECK_NAME, {}, [instance_docker])
+
+    deobfuscated_text = "SELECT * FROM ϑings WHERE id = 42"
+    obfuscated_text = "SELECT * FROM ϑings WHERE id = ?"
+
+    def _obfuscate_sql(sql_query, options=None):
+        return json.dumps(
+            {
+                'query': obfuscated_text,
+                'metadata': {'tables_csv': 'ϑings', 'commands': ['SELECT'], 'comments': []},
+            }
+        )
+
+    row = {
+        'statement_text': deobfuscated_text,
+        'text': None,
+        'query_hash': b'\x01\x02\x03\x04',
+        'query_plan_hash': b'\x05\x06\x07\x08',
+        'plan_handle': b'\x09\x0a\x0b\x0c',
+        'execution_count': 1,
+        'total_worker_time': 100,
+    }
+
+    with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
+        mock_agent.side_effect = _obfuscate_sql
+        result = check.statement_metrics._normalize_queries([row])
+
+    assert len(result) == 1
+    assert 'statement_text' not in result[0]
+    assert result[0]['text'] == obfuscated_text
+
+
 @pytest.mark.flaky
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')


### PR DESCRIPTION
### What does this PR do?

Deletes `statement_text` from each row at the end of `_normalize_queries` in `sqlserver/datadog_checks/sqlserver/statements.py`, once the statement has been obfuscated into `text`.

Previously the deobfuscated text was removed only in `_to_metrics_payload_row`, which runs on the top `max_queries` rows (250 by default). Every one of the up-to-`dm_exec_query_stats_row_limit` collected rows (10,000 by default) therefore carried two copies of its SQL — raw and obfuscated — through derivative metrics, FQT emission, and plan collection.

Adds a unit test asserting that normalized rows expose only the obfuscated statement. The test was verified to fail without the source change.

### Motivation

Found during a memory audit of the SQL Server integration.

`query_metrics` is enabled by default whenever `dbm: true`, so this path runs on every DBM-enabled instance. It combines a 10,000-row default limit with `statement_text` that has no character cap, which makes it the largest memory multiplier in the integration. Holding a second copy of every statement for the duration of the collection roughly doubles that cost for no benefit.

Nothing downstream reads `statement_text`. FQT events use `row['text']`, and plan events use `row.get(text_key)` where `text_key` is `'text'` or `'procedure_text'`, all obfuscated. The only other references are the obfuscation call itself and a log statement in its error branch, both of which run before the new deletion.

The defensive `if 'statement_text' in row` guard in `_to_metrics_payload_row` is intentionally left in place, so the payload stays protected if a future change reintroduces the field.

This is a memory-retention fix with no change to emitted data.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)