### PR TITLE
Use workflow trigger instead of slack app in `notify-new-integration`

### DIFF
--- a/.github/workflows/notify-new-integration.yml
+++ b/.github/workflows/notify-new-integration.yml
@@ -14,6 +14,7 @@ jobs:
   notify:
     name: Notify Slack on new integration check
     runs-on: ubuntu-latest
+    environment: publish-pypi
     permissions:
       contents: read
     steps:
@@ -42,11 +43,11 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.NEW_INTEGRATION_SLACK_WEBHOOK_URL }}
           NAME: ${{ steps.detect.outputs.name }}
-          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          COMMIT: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
         run: |
           curl -sf -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
             -d "$(jq -n \
               --arg name "$NAME" \
-              --arg commit_url "$COMMIT_URL" \
-              '{name: $name, commit_url: $commit_url}')"
+              --arg commit "$COMMIT" \
+              '{name: $name, commit: $commit}')"

--- a/.github/workflows/notify-new-integration.yml
+++ b/.github/workflows/notify-new-integration.yml
@@ -44,21 +44,9 @@ jobs:
           NAME: ${{ steps.detect.outputs.name }}
           COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
         run: |
-          message=$(cat <<MSGEOF
-          New integration merged to master: ${NAME}
-          Commit: ${COMMIT_URL}
-
-          A PyPI admin must fill the pending publisher form at https://pypi.org/manage/account/publishing/:
-          - PyPI Project Name: ${NAME}
-          - Owner: DataDog
-          - Repository name: integrations-core
-          - Workflow name: claim-pypi-name.yaml
-          - Environment name: publish-pypi
-
-          Please react to this message once completed.
-          Ask #agent-integrations if you have any questions.
-          MSGEOF
-          )
           curl -sf -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text "$message" '{text: $text}')"
+            -d "$(jq -n \
+              --arg name "$NAME" \
+              --arg commit_url "$COMMIT_URL" \
+              '{name: $name, commit_url: $commit_url}')"


### PR DESCRIPTION
### What does this PR do?
Use workflow trigger instead of slack app

### Motivation
Easier to set up and modify in slack

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
