### PR TITLE
[DBMON-6892] Report ClickHouse cluster topology in the database_instance payload

### DIFF
--- a/clickhouse/changelog.d/24889.added
+++ b/clickhouse/changelog.d/24889.added
@@ -1,0 +1,1 @@
+Add the hosting type, the connection mode and the cluster node inventory to the ``database_instance`` metadata payload.

--- a/clickhouse/changelog.d/24920.fixed
+++ b/clickhouse/changelog.d/24920.fixed
@@ -1,0 +1,1 @@
+Fan out over the cluster the instance actually belongs to in single endpoint mode, instead of assuming it is named ``default``, and read local system tables when no cluster can be resolved.

--- a/clickhouse/changelog.d/24920.fixed
+++ b/clickhouse/changelog.d/24920.fixed
@@ -1,1 +1,0 @@
-Fan out over the cluster the instance actually belongs to in single endpoint mode, instead of assuming it is named ``default``, and read local system tables when no cluster can be resolved.

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -28,12 +28,14 @@ from .utils import (
     CLUSTER_MACRO_QUERY,
     CLUSTER_NAME_QUERY,
     CLUSTER_TAG,
+    CONNECT_NODE_QUERY,
     HOSTING_TYPE_TAG,
     SHARED_MERGE_TREE_QUERY,
     ErrorSanitizer,
     HostingType,
     cluster_all_replicas,
     cluster_aware_query,
+    cluster_nodes_query,
 )
 
 try:
@@ -234,6 +236,14 @@ class ClickhouseCheck(DatabaseCheck):
             # Get tags without db: prefix for metadata
             tags_no_db = [t for t in self.tags if not t.startswith('db:')]
 
+            metadata = {
+                "dbm": self._config.dbm,
+                "connection_host": self._config.server,
+                "hosting_type": self.hosting_type,
+                "single_endpoint_mode": self.is_single_endpoint_mode,
+                **self._cluster_topology_metadata(),
+            }
+
             event = {
                 "host": self.reported_hostname,
                 "port": self._config.port,
@@ -248,10 +258,7 @@ class ClickhouseCheck(DatabaseCheck):
                 "integration_version": __version__,
                 "tags": tags_no_db,
                 "timestamp": current_time * 1000,
-                "metadata": {
-                    "dbm": self._config.dbm,
-                    "connection_host": self._config.server,
-                },
+                "metadata": metadata,
             }
 
             self._database_instance_last_emitted = current_time
@@ -419,6 +426,48 @@ class ClickhouseCheck(DatabaseCheck):
         if self.cluster_name:
             return self.cluster_name
         return None if self.hosting_type == HostingType.SELF_HOSTED else 'default'
+
+    def _cluster_topology_metadata(self) -> dict:
+        """The cluster node inventory, for the database_instance payload.
+
+        Keys are omitted rather than reported empty, so a failed query never claims a cluster has
+        no nodes.
+        """
+        metadata = {}
+        if self.cluster_name:
+            metadata["cluster_name"] = self.cluster_name
+        connect_node = self._resolve_connect_node()
+        if connect_node:
+            metadata["connect_node"] = connect_node
+        nodes = self._resolve_cluster_nodes(connect_node)
+        if nodes:
+            metadata["nodes"] = nodes
+        return metadata
+
+    def _resolve_connect_node(self) -> str | None:
+        """The name of the node serving this connection, or None when it cannot be read."""
+        try:
+            rows = self.execute_query_raw(CONNECT_NODE_QUERY)
+        except Exception as e:
+            self.log.debug('Unable to read the connected node name: %s', e)
+            return None
+        return str(rows[0][0]) if rows and rows[0] and rows[0][0] else None
+
+    def _resolve_cluster_nodes(self, connect_node: str | None) -> list[str]:
+        """Sorted, de-duplicated cluster node names, or an empty list when they cannot be determined.
+
+        A point-in-time observation rather than a steady-state count: replicas are replaced
+        make-before-break, so old and new both answer while the old one drains.
+        """
+        cluster = self.fanout_cluster_name
+        if not cluster:
+            return [connect_node] if connect_node else []
+        try:
+            rows = self.execute_query_raw(cluster_nodes_query(cluster))
+        except Exception as e:
+            self.log.debug('Unable to enumerate the nodes of cluster %r: %s', cluster, e)
+            return []
+        return sorted({str(row[0]) for row in rows if row and row[0]})
 
     @property
     def hosting_type(self) -> str:

--- a/clickhouse/datadog_checks/clickhouse/utils.py
+++ b/clickhouse/datadog_checks/clickhouse/utils.py
@@ -89,6 +89,19 @@ def cluster_all_replicas(cluster: str, table: str) -> str:
     return f"clusterAllReplicas({quote_string(cluster)}, system.{table})"
 
 
+# The node serving the current connection. Read per emission rather than cached, since behind a
+# single endpoint the connection can land on a different node after any reconnect.
+CONNECT_NODE_QUERY = "SELECT hostName()"
+
+
+def cluster_nodes_query(cluster: str) -> str:
+    """Query listing every replica of a cluster currently serving traffic, one row per node.
+
+    skip_unavailable_shards keeps one unreachable node from failing the whole fan-out.
+    """
+    return f"SELECT hostName() FROM {cluster_all_replicas(cluster, 'one')} SETTINGS skip_unavailable_shards=1"
+
+
 HOSTING_TYPE_TAG = 'hosting_type'
 
 

--- a/clickhouse/scripts/generate_metrics.py
+++ b/clickhouse/scripts/generate_metrics.py
@@ -75,12 +75,14 @@ KIND_SPECS = {
 # The async metrics and profile events tables are not always populated on a freshly started server.
 OPTIONAL_KINDS = frozenset({MetricKind.ASYNC_METRICS, MetricKind.EVENTS})
 
-# Metrics that don't come from the system tables above but may show up in a check run, so the tests
-# have to tolerate them. The JIT execution counter comes from the legacy query set, which stays
-# enabled next to the advanced queries, and only appears once a compiled function is actually run.
+# Metrics that don't come from the bulk system tables above but may show up in a check run, so the
+# tests have to tolerate them. The JIT execution counter comes from the legacy query set, which stays
+# enabled next to the advanced queries. The errors metric comes from a separate system.errors query.
+# Both are only emitted when the corresponding events occur.
 EXTRA_OPTIONAL_METRICS = [
     'clickhouse.compilation.function.execute.count',
     'clickhouse.compilation.function.execute.total',
+    'clickhouse.errors.raised',
 ]
 
 

--- a/clickhouse/tests/advanced_metrics.py
+++ b/clickhouse/tests/advanced_metrics.py
@@ -392,6 +392,7 @@ OPTIONAL_METRICS = [
     'clickhouse.asynchronous_metrics.jemalloc.epoch',
     'clickhouse.compilation.function.execute.count',
     'clickhouse.compilation.function.execute.total',
+    'clickhouse.errors.raised',
     'clickhouse.events.AIORead.count',
     'clickhouse.events.AIORead.total',
     'clickhouse.events.AIOReadBytes.count',

--- a/clickhouse/tests/metrics.py
+++ b/clickhouse/tests/metrics.py
@@ -250,6 +250,10 @@ OPTIONAL_METRICS = [
     'clickhouse.syscall.write.wait',
     'clickhouse.table.distributed.file.insert.broken',
     'clickhouse.table.distributed.file.insert.pending',
+    # Incremented by the check's own clusterAllReplicas node enumeration, so it only appears once
+    # that fan-out has run, and only on versions carrying the ProfileEvent.
+    'clickhouse.table.function.count',
+    'clickhouse.table.function.total',
     'clickhouse.table.insert.row.count',
     'clickhouse.table.insert.row.total',
     'clickhouse.table.insert.size.count',

--- a/clickhouse/tests/test_clickhouse.py
+++ b/clickhouse/tests/test_clickhouse.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import mock
 import pytest
 
 from datadog_checks.clickhouse import ClickhouseCheck
@@ -141,47 +140,3 @@ def test_database_instance_metadata(aggregator, instance, datadog_agent, dd_run_
     assert event['metadata']['connect_node']
     assert event['metadata']['nodes']
     assert event['metadata']['connect_node'] in event['metadata']['nodes']
-
-
-def _database_instance_event(aggregator):
-    dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
-    return next((e for e in dbm_metadata if e['kind'] == 'database_instance'), None)
-
-
-def test_database_instance_metadata_cluster_topology(aggregator, instance, dd_run_check):
-    """The payload carries the node inventory behind the endpoint."""
-    instance = {**instance, 'single_endpoint_mode': True}
-    check = ClickhouseCheck('clickhouse', {}, [instance])
-    check.check_id = 'test:457'
-
-    with mock.patch.object(ClickhouseCheck, '_resolve_cluster_nodes', return_value=['node-a', 'node-b', 'node-c']):
-        with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
-            cluster_name.return_value = 'default'
-            dd_run_check(check)
-
-    event = _database_instance_event(aggregator)
-
-    assert event is not None
-    assert event['metadata']['cluster_name'] == 'default'
-    assert event['metadata']['nodes'] == ['node-a', 'node-b', 'node-c']
-    assert event['metadata']['connect_node']
-    assert event['metadata']['single_endpoint_mode'] is True
-
-
-def test_database_instance_metadata_omits_cluster_topology_when_unresolved(aggregator, instance, dd_run_check):
-    """A cluster that cannot be enumerated is omitted, not reported empty."""
-    instance = {**instance, 'single_endpoint_mode': True}
-    check = ClickhouseCheck('clickhouse', {}, [instance])
-    check.check_id = 'test:458'
-
-    with mock.patch.object(ClickhouseCheck, '_resolve_cluster_nodes', return_value=[]):
-        with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
-            cluster_name.return_value = None
-            dd_run_check(check)
-
-    event = _database_instance_event(aggregator)
-
-    assert event is not None
-    assert 'nodes' not in event['metadata']
-    assert 'cluster_name' not in event['metadata']
-    assert event['metadata']['single_endpoint_mode'] is True

--- a/clickhouse/tests/test_clickhouse.py
+++ b/clickhouse/tests/test_clickhouse.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
 import pytest
 
 from datadog_checks.clickhouse import ClickhouseCheck
@@ -135,3 +136,52 @@ def test_database_instance_metadata(aggregator, instance, datadog_agent, dd_run_
     assert 'dbm' in event['metadata']
     assert 'connection_host' in event['metadata']
     assert event['metadata']['connection_host'] == instance['server']
+    assert event['metadata']['hosting_type'] == check.hosting_type
+    assert event['metadata']['single_endpoint_mode'] is False
+    assert event['metadata']['connect_node']
+    assert event['metadata']['nodes']
+    assert event['metadata']['connect_node'] in event['metadata']['nodes']
+
+
+def _database_instance_event(aggregator):
+    dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
+    return next((e for e in dbm_metadata if e['kind'] == 'database_instance'), None)
+
+
+def test_database_instance_metadata_cluster_topology(aggregator, instance, dd_run_check):
+    """The payload carries the node inventory behind the endpoint."""
+    instance = {**instance, 'single_endpoint_mode': True}
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    check.check_id = 'test:457'
+
+    with mock.patch.object(ClickhouseCheck, '_resolve_cluster_nodes', return_value=['node-a', 'node-b', 'node-c']):
+        with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
+            cluster_name.return_value = 'default'
+            dd_run_check(check)
+
+    event = _database_instance_event(aggregator)
+
+    assert event is not None
+    assert event['metadata']['cluster_name'] == 'default'
+    assert event['metadata']['nodes'] == ['node-a', 'node-b', 'node-c']
+    assert event['metadata']['connect_node']
+    assert event['metadata']['single_endpoint_mode'] is True
+
+
+def test_database_instance_metadata_omits_cluster_topology_when_unresolved(aggregator, instance, dd_run_check):
+    """A cluster that cannot be enumerated is omitted, not reported empty."""
+    instance = {**instance, 'single_endpoint_mode': True}
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    check.check_id = 'test:458'
+
+    with mock.patch.object(ClickhouseCheck, '_resolve_cluster_nodes', return_value=[]):
+        with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
+            cluster_name.return_value = None
+            dd_run_check(check)
+
+    event = _database_instance_event(aggregator)
+
+    assert event is not None
+    assert 'nodes' not in event['metadata']
+    assert 'cluster_name' not in event['metadata']
+    assert event['metadata']['single_endpoint_mode'] is True

--- a/clickhouse/tests/test_cluster_fanout_integration.py
+++ b/clickhouse/tests/test_cluster_fanout_integration.py
@@ -4,7 +4,7 @@
 import pytest
 
 from datadog_checks.clickhouse import ClickhouseCheck
-from datadog_checks.clickhouse.utils import CLUSTER_NODE_TAG
+from datadog_checks.clickhouse.utils import CLUSTER_NODE_TAG, CLUSTER_TAG, HOSTING_TYPE_TAG
 
 from .common import CLICKHOUSE_VERSION, is_legacy
 
@@ -46,6 +46,31 @@ def test_get_system_table_fans_out_over_the_resolved_cluster(instance, dd_run_ch
     # cluster on a self-hosted deployment) or silently read the stock local-only cluster instead.
     rows = check.execute_query_raw(f'SELECT count() FROM {table_ref}')
     assert rows[0][0] == 1
+
+
+def test_database_instance_payload_carries_real_cluster_topology(aggregator, instance, dd_run_check):
+    """The metadata payload reports topology read from the actual ClickHouse cluster."""
+    instance = {**instance, 'single_endpoint_mode': True}
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    dd_run_check(check)
+
+    connect_node = check.execute_query_raw('SELECT hostName()')[0][0]
+    node_rows = check.execute_query_raw(
+        f"SELECT hostName() FROM clusterAllReplicas('{TEST_CLUSTER_NAME}', system.one) "
+        "SETTINGS skip_unavailable_shards=1"
+    )
+    nodes = sorted({row[0] for row in node_rows})
+    events = aggregator.get_event_platform_events('dbm-metadata')
+    event = next(event for event in events if event['kind'] == 'database_instance')
+
+    assert event['metadata']['cluster_name'] == TEST_CLUSTER_NAME
+    assert event['metadata']['connect_node'] == connect_node
+    assert event['metadata']['nodes'] == nodes
+    assert event['metadata']['single_endpoint_mode'] is True
+    assert event['metadata']['hosting_type'] == check.hosting_type
+    assert connect_node in nodes
+    assert f'{CLUSTER_TAG}:{TEST_CLUSTER_NAME}' in event['tags']
+    assert f'{HOSTING_TYPE_TAG}:{check.hosting_type}' in event['tags']
 
 
 def test_single_endpoint_mode_metrics_carry_the_cluster_node_tag(aggregator, instance, dd_run_check):

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -14,10 +14,12 @@ from datadog_checks.clickhouse.utils import (
     CLUSTER_MACRO_QUERY,
     CLUSTER_NAME_QUERY,
     CLUSTER_TAG,
+    CONNECT_NODE_QUERY,
     HOSTING_TYPE_TAG,
     SHARED_MERGE_TREE_QUERY,
     HostingType,
     cluster_aware_query,
+    cluster_nodes_query,
 )
 
 from .utils import ensure_csv_safe, parse_described_metrics, raise_error
@@ -621,6 +623,17 @@ def test_cluster_name_is_cached_including_the_absent_case():
     assert check.execute_query_raw.call_count == 2  # one attempt per source, not per access
 
 
+def test_cluster_nodes_query_fans_out_without_failing_on_a_down_node():
+    query = cluster_nodes_query('default')
+
+    assert 'skip_unavailable_shards=1' in query
+    assert "clusterAllReplicas('default', system.one)" in query
+
+
+def test_cluster_nodes_query_fans_out_over_the_named_cluster():
+    assert "clusterAllReplicas('prod_cluster', system.one)" in cluster_nodes_query('prod_cluster')
+
+
 @pytest.mark.parametrize(
     ('cluster_name', 'hosting_type', 'expected'),
     [
@@ -639,6 +652,208 @@ def test_fanout_cluster_name(cluster_name, hosting_type, expected):
             hosting_type_prop.return_value = hosting_type
 
             assert check.fanout_cluster_name == expected
+
+
+def resolve_cluster_nodes(fanout_cluster, nodes_result, connect_node='node-a'):
+    """Run the node fan-out over a fixed cluster, replaying nodes_result."""
+    replayed = {cluster_nodes_query(fanout_cluster): nodes_result} if fanout_cluster else {}
+    check = make_query_replaying_check(replayed)
+    with mock.patch.object(ClickhouseCheck, 'fanout_cluster_name', new_callable=mock.PropertyMock) as fanout:
+        fanout.return_value = fanout_cluster
+        return check._resolve_cluster_nodes(connect_node)
+
+
+def test_resolve_cluster_nodes_deduplicates_and_sorts():
+    nodes = resolve_cluster_nodes('default', [['node-b'], ['node-a'], ['node-b']])
+
+    assert nodes == ['node-a', 'node-b']
+
+
+def test_resolve_cluster_nodes_uses_the_self_hosted_cluster_name():
+    nodes = resolve_cluster_nodes('prod_cluster', [['node-b'], ['node-a']])
+
+    assert nodes == ['node-a', 'node-b']
+
+
+def test_resolve_cluster_nodes_empty_when_the_fan_out_fails():
+    assert resolve_cluster_nodes('default', Error('Requested cluster not found')) == []
+
+
+def test_resolve_cluster_nodes_reports_the_single_node_when_there_is_no_cluster():
+    """An instance with no cluster reports the one node that answered."""
+    assert resolve_cluster_nodes(None, None) == ['node-a']
+
+
+def test_resolve_cluster_nodes_empty_when_there_is_neither_a_cluster_nor_a_known_node():
+    assert resolve_cluster_nodes(None, None, connect_node=None) == []
+
+
+def test_cluster_topology_metadata():
+    check = make_query_replaying_check(
+        {
+            CONNECT_NODE_QUERY: [['node-a']],
+            cluster_nodes_query('default'): [['node-a'], ['node-b'], ['node-c']],
+        }
+    )
+    with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
+        with mock.patch.object(ClickhouseCheck, 'fanout_cluster_name', new_callable=mock.PropertyMock) as fanout:
+            cluster_name.return_value = 'default'
+            fanout.return_value = 'default'
+            metadata = check._cluster_topology_metadata()
+
+    assert metadata == {
+        'cluster_name': 'default',
+        'connect_node': 'node-a',
+        'nodes': ['node-a', 'node-b', 'node-c'],
+    }
+
+
+@pytest.mark.parametrize(
+    ('cluster_name', 'node_result', 'nodes_result', 'expected'),
+    [
+        pytest.param('default', [], [['node-a']], {'cluster_name', 'nodes'}, id='no-connect-node'),
+        pytest.param('default', [['node-a']], Error('boom'), {'cluster_name', 'connect_node'}, id='fan-out-failed'),
+        pytest.param('default', [['node-a']], [], {'cluster_name', 'connect_node'}, id='no-rows'),
+    ],
+)
+def test_cluster_topology_metadata_omits_what_it_cannot_determine(cluster_name, node_result, nodes_result, expected):
+    """An absent key beats a wrong one: a failed probe must not report a cluster with no nodes."""
+    check = make_query_replaying_check(
+        {CONNECT_NODE_QUERY: node_result, cluster_nodes_query(cluster_name): nodes_result}
+    )
+    with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name_prop:
+        with mock.patch.object(ClickhouseCheck, 'fanout_cluster_name', new_callable=mock.PropertyMock) as fanout:
+            cluster_name_prop.return_value = cluster_name
+            fanout.return_value = cluster_name
+            metadata = check._cluster_topology_metadata()
+
+    assert set(metadata) == expected
+
+
+def test_cluster_topology_metadata_without_a_cluster_reports_the_connected_node():
+    """cluster_name stays absent, but the connected node is still known."""
+    check = make_query_replaying_check({CONNECT_NODE_QUERY: [['node-a']]})
+    with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
+        with mock.patch.object(ClickhouseCheck, 'fanout_cluster_name', new_callable=mock.PropertyMock) as fanout:
+            cluster_name.return_value = None
+            fanout.return_value = None
+            metadata = check._cluster_topology_metadata()
+
+    assert metadata == {'connect_node': 'node-a', 'nodes': ['node-a']}
+
+
+VERSION_QUERY = 'SELECT version()'
+
+
+def make_metadata_emitting_check(instance, nodes_result, fanout_cluster='default'):
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+
+    def execute(query):
+        if query == VERSION_QUERY:
+            return [['24.8.1.1']]
+        if query == CONNECT_NODE_QUERY:
+            return [['node-a']]
+        if query == cluster_nodes_query(fanout_cluster):
+            if isinstance(nodes_result, Exception):
+                raise nodes_result
+            return nodes_result
+        return []
+
+    check.execute_query_raw = mock.Mock(side_effect=execute)
+    return check
+
+
+def emitted_metadata(aggregator):
+    events = aggregator.get_event_platform_events('dbm-metadata')
+    return next(e for e in events if e['kind'] == 'database_instance')['metadata']
+
+
+@pytest.mark.parametrize('single_endpoint_mode', [True, False], ids=['single-endpoint-mode', 'direct-connection'])
+def test_database_instance_payload_carries_cluster_topology(aggregator, instance, single_endpoint_mode):
+    """Both connection modes report the inventory, so the node list means one thing rather than two."""
+    instance = {**instance, 'single_endpoint_mode': single_endpoint_mode}
+    check = make_metadata_emitting_check(instance, [['node-b'], ['node-a']])
+    with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
+        cluster_name.return_value = 'default'
+        check._send_database_instance_metadata()
+
+    metadata = emitted_metadata(aggregator)
+
+    assert metadata['cluster_name'] == 'default'
+    assert metadata['connect_node'] == 'node-a'
+    assert metadata['nodes'] == ['node-a', 'node-b']
+    assert set(metadata) == {
+        'dbm',
+        'connection_host',
+        'hosting_type',
+        'single_endpoint_mode',
+        'cluster_name',
+        'connect_node',
+        'nodes',
+    }
+
+
+def test_database_instance_payload_carries_a_self_hosted_cluster_topology(aggregator, instance):
+    """The fan-out follows the name a self-hosted cluster is given in remote_servers."""
+    instance = {**instance, 'single_endpoint_mode': True}
+    check = make_metadata_emitting_check(instance, [['node-b'], ['node-a']], fanout_cluster='prod_cluster')
+    with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
+        with mock.patch.object(ClickhouseCheck, 'hosting_type', new_callable=mock.PropertyMock) as hosting_type:
+            cluster_name.return_value = 'prod_cluster'
+            hosting_type.return_value = HostingType.SELF_HOSTED
+            check._send_database_instance_metadata()
+
+    metadata = emitted_metadata(aggregator)
+
+    assert metadata['cluster_name'] == 'prod_cluster'
+    assert metadata['nodes'] == ['node-a', 'node-b']
+
+
+def test_database_instance_payload_omits_the_topology_when_every_probe_fails(aggregator, instance):
+    """The payload is still emitted, carrying only what does not depend on a query."""
+    instance = {**instance, 'single_endpoint_mode': True}
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    check.execute_query_raw = mock.Mock(side_effect=Error('Not enough privileges'))
+    with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
+        cluster_name.return_value = 'default'
+        check._send_database_instance_metadata()
+
+    metadata = emitted_metadata(aggregator)
+
+    assert set(metadata) == {'dbm', 'connection_host', 'hosting_type', 'single_endpoint_mode', 'cluster_name'}
+    assert metadata['hosting_type'] == HostingType.UNKNOWN
+
+
+@pytest.mark.parametrize('single_endpoint_mode', [True, False], ids=['single-endpoint-mode', 'direct-connection'])
+def test_database_instance_payload_carries_the_hosting_type(aggregator, instance, single_endpoint_mode):
+    """The hosting type describes the deployment itself, so both connection modes report it."""
+    instance = {**instance, 'single_endpoint_mode': single_endpoint_mode}
+    check = make_metadata_emitting_check(instance, [['node-a']])
+    with mock.patch.object(ClickhouseCheck, 'hosting_type', new_callable=mock.PropertyMock) as hosting_type:
+        hosting_type.return_value = HostingType.CLOUD
+        check._send_database_instance_metadata()
+
+    assert emitted_metadata(aggregator)['hosting_type'] == HostingType.CLOUD
+
+
+@pytest.mark.parametrize('single_endpoint_mode', [True, False], ids=['single-endpoint-mode', 'direct-connection'])
+def test_database_instance_payload_carries_the_connection_mode(aggregator, instance, single_endpoint_mode):
+    """The backend needs to know whether the hostName() it sees is one node or a whole cluster."""
+    instance = {**instance, 'single_endpoint_mode': single_endpoint_mode}
+    check = make_metadata_emitting_check(instance, [['node-a']])
+
+    check._send_database_instance_metadata()
+
+    assert emitted_metadata(aggregator)['single_endpoint_mode'] is single_endpoint_mode
+
+
+def test_database_instance_payload_reports_the_connection_mode_when_unset(aggregator, instance):
+    """The option is optional, so the payload must still carry an explicit boolean."""
+    check = make_metadata_emitting_check(instance, [['node-a']])
+
+    check._send_database_instance_metadata()
+
+    assert emitted_metadata(aggregator)['single_endpoint_mode'] is False
 
 
 def test_check_tags_with_cluster(instance):


### PR DESCRIPTION
### What does this PR do?

Adds the hosting type, the connection mode and the cluster node inventory (the connected node plus the node list) to the ClickHouse `database_instance` metadata payload. Keys are omitted rather than reported empty, so a failed probe never claims a cluster has no nodes.

The `clusterAllReplicas` fan-out fix that used to live here is split out into #24920, keeping the two changelog entries separate (`fixed` there, `added` here). This PR is stacked on that branch and should be merged after it.

1. cloud with single_endpoint_mode
```json
[
    {
        "host": "bpzyyp5jlh.us-east-2.aws.clickhouse.cloud",
        "port": 8443,
        "database_instance": "bpzyyp5jlh.us-east-2.aws.clickhouse.cloud:8443:default",
        "database_hostname": "bpzyyp5jlh.us-east-2.aws.clickhouse.cloud",
        "agent_version": "7.77.2",
        "ddagenthostname": "dbm-orders-clickhouse-cloud-sangeeta.shivajirao",
        "dbms": "clickhouse",
        "kind": "database_instance",
        "collection_interval": 300,
        "dbms_version": "26.2.1.558",
        "integration_version": "7.2.0",
        "tags": [
            "env:local",
            "deployment:cloud",
            "user:sangeeta",
            "server:bpzyyp5jlh.us-east-2.aws.clickhouse.cloud",
            "port:8443",
            "database_hostname:bpzyyp5jlh.us-east-2.aws.clickhouse.cloud",
            "database_instance:bpzyyp5jlh.us-east-2.aws.clickhouse.cloud:8443:default",
            "clickhouse_cluster:default",
            "hosting_type:clickhouse-cloud"
        ],
        "timestamp": 1787147945024.457,
        "metadata": {
            "dbm": true,
            "connection_host": "bpzyyp5jlh.us-east-2.aws.clickhouse.cloud",
            "hosting_type": "clickhouse-cloud",
            "single_endpoint_mode": true,
            "cluster_name": "default",
            "connect_node": "c-mintaws-bz-27-server-rbdgg8n-0",
            "nodes": [
                "c-mintaws-bz-27-server-rbdgg8n-0",
                "c-mintaws-bz-27-server-t2d8t8j-0"
            ]
        }
    }
]
```
2. self-hosted using single-endpoint-mode with a cluster name that is not default
### The cluster name is not always `default`

```json
[
    {
        "host": "clickhouse-lb",
        "port": 8123,
        "database_instance": "clickhouse-lb:8123:default",
        "database_hostname": "clickhouse-lb",
        "agent_version": "7.77.2",
        "ddagenthostname": "dbm-orders-local-clickhouse-se-sangeeta.shivajirao",
        "dbms": "clickhouse",
        "kind": "database_instance",
        "collection_interval": 300,
        "dbms_version": "24.8.14.39",
        "integration_version": "7.2.0",
        "tags": [
            "env:local",
            "deployment:self-hosted",
            "endpoint:single",
            "user:sangeeta",
            "server:clickhouse-lb",
            "port:8123",
            "database_hostname:clickhouse-lb",
            "database_instance:clickhouse-lb:8123:default",
            "clickhouse_cluster:dbm_single_endpoint",
            "hosting_type:self-hosted"
        ],
        "timestamp": 1787153884466.4001,
        "metadata": {
            "dbm": true,
            "connection_host": "clickhouse-lb",
            "hosting_type": "self-hosted",
            "single_endpoint_mode": true,
            "cluster_name": "dbm_single_endpoint",
            "connect_node": "clickhouse-se-01",
            "nodes": [
                "clickhouse-se-01",
                "clickhouse-se-02",
                "clickhouse-se-03"
            ]
        }
    }
]
```

3. self-hosted with single_endpoint_mode false
```json
[
    {
        "host": "clickhouse-03",
        "port": 8123,
        "database_instance": "clickhouse-03:8123:default",
        "database_hostname": "clickhouse-03",
        "agent_version": "7.77.2",
        "ddagenthostname": "dbm-orders-local-clickhouse-sangeeta.shivajirao",
        "dbms": "clickhouse",
        "kind": "database_instance",
        "collection_interval": 300,
        "dbms_version": "24.8.14.39",
        "integration_version": "7.2.0",
        "tags": [
            "env:local",
            "node:clickhouse-03",
            "deployment:self-hosted",
            "server:clickhouse-03",
            "port:8123",
            "database_hostname:clickhouse-03",
            "database_instance:clickhouse-03:8123:default",
            "clickhouse_cluster:default",
            "hosting_type:self-hosted"
        ],
        "timestamp": 1787152211758.7336,
        "metadata": {
            "dbm": true,
            "connection_host": "clickhouse-03",
            "hosting_type": "self-hosted",
            "single_endpoint_mode": false,
            "cluster_name": "default",
            "connect_node": "clickhouse-03",
            "nodes": [
                "clickhouse-03"
            ]
        }
    }
]
```

## Motivation

The backend needs to know whether the `hostName()` it sees behind a single endpoint is one node or a whole cluster, and which nodes make up that cluster.

## Testing

Tested on staging.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add the `qa/skip-qa` label if the PR does not need to be tested during QA. If the PR needs to be tested during QA, you should add `qa/required` label.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
