### PR TITLE
[SEC-34456] Add Anomali ThreatStream account configuration

### DIFF
--- a/anomali_threatstream/assets/account_config.json
+++ b/anomali_threatstream/assets/account_config.json
@@ -1,0 +1,64 @@
+{
+  "supported_auth_methods": [],
+  "additional_config_fields": [
+    {
+      "key": "api_domain",
+      "label": "Domain",
+      "editable": true,
+      "required": true,
+      "domain": {
+        "pattern": "^(?:[a-zA-Z0-9-]+\\.)*threatstream\\.com$"
+      }
+    },
+    {
+      "key": "email",
+      "label": "Email",
+      "editable": true,
+      "required": true,
+      "text": {}
+    },
+    {
+      "key": "api_key",
+      "label": "API Key",
+      "editable": true,
+      "required": true,
+      "password": {}
+    },
+    {
+      "key": "domain",
+      "label": "Collect Domain Indicators (Threat Intel Feed)",
+      "help": "Enrich logs with Anomali ThreatStream domain indicators data",
+      "editable": true,
+      "required": false,
+      "checkbox": {
+        "default": true
+      }
+    },
+    {
+      "key": "ip_address",
+      "label": "Collect IP Address Indicators (Threat Intel Feed)",
+      "help": "Enrich logs with Anomali ThreatStream ip address indicators data",
+      "editable": true,
+      "required": false,
+      "checkbox": {
+        "default": true
+      }
+    },
+    {
+      "key": "sha256",
+      "label": "Collect hash SHA256 Indicators (Threat Intel Feed)",
+      "help": "Enrich logs with Anomali ThreatStream hash SHA256 indicators data",
+      "editable": true,
+      "required": false,
+      "checkbox": {
+        "default": true
+      }
+    }
+  ],
+  "dataflow_config": [
+    {
+      "dataflow_id": "anomali-threatstream-threat-intel-feed",
+      "additional_config_fields": []
+    }
+  ]
+}


### PR DESCRIPTION
### What does this PR do?

Adds the Anomali ThreatStream `account_config.json` asset used to generate the AMS account setup UI. The schema matches the crawler's configuration contract for the ThreatStream domain, email, API key, and domain/IP address/SHA256 collection toggles.

### Motivation

Prepare the account configuration asset for the Anomali ThreatStream threat intelligence integration under SEC-34456.

This PR depends on #23345, which adds the referenced `anomali-threatstream-threat-intel-feed` dataflow and the remaining integration assets. It should remain draft until #23345 merges.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged