### PR TITLE
[SEC-36059] Add Anomali ThreatStream Account Config to Assets

### DIFF
--- a/anomali_threatstream/assets/account_config.json
+++ b/anomali_threatstream/assets/account_config.json
@@ -1,0 +1,64 @@
+{
+  "supported_auth_methods": [],
+  "additional_config_fields": [
+    {
+      "key": "api_domain",
+      "label": "Domain",
+      "editable": true,
+      "required": true,
+      "domain": {
+        "pattern": "^(?:[a-zA-Z0-9-]+\\.)*threatstream\\.com$"
+      }
+    },
+    {
+      "key": "email",
+      "label": "Email",
+      "editable": true,
+      "required": true,
+      "text": {}
+    },
+    {
+      "key": "api_key",
+      "label": "API Key",
+      "editable": true,
+      "required": true,
+      "password": {}
+    },
+    {
+      "key": "domain_risk_enabled",
+      "label": "Collect Domain Indicators (Threat Intel Feed)",
+      "help": "Enrich logs with Anomali ThreatStream domain indicators data",
+      "editable": true,
+      "required": false,
+      "checkbox": {
+        "default": true
+      }
+    },
+    {
+      "key": "ip_risk_enabled",
+      "label": "Collect IP Address Indicators (Threat Intel Feed)",
+      "help": "Enrich logs with Anomali ThreatStream ip address indicators data",
+      "editable": true,
+      "required": false,
+      "checkbox": {
+        "default": true
+      }
+    },
+    {
+      "key": "hash_risk_enabled",
+      "label": "Collect hash SHA256 Indicators (Threat Intel Feed)",
+      "help": "Enrich logs with Anomali ThreatStream hash SHA256 indicators data",
+      "editable": true,
+      "required": false,
+      "checkbox": {
+        "default": true
+      }
+    }
+  ],
+  "dataflow_config": [
+    {
+      "dataflow_id": "anomali-threatstream-threat-intel-feed",
+      "additional_config_fields": []
+    }
+  ]
+}


### PR DESCRIPTION
### What does this PR do?

Adds the Anomali ThreatStream `account_config.json` asset used to generate the AMS account setup UI.

The schema defines the ThreatStream domain, email, API key, and default-enabled domain, IP address, and SHA256 indicator collection options. Its keys, labels, validation, defaults, and dataflow ID match the crawler-sdk configuration contract.

### Motivation

Completes the AMS account configuration schema for the Anomali ThreatStream threat intelligence integration under SEC-36059.

This PR depends on:

- DataDog/crawler-sdk#1402, which declares these fields and the dataflow as in-development crawler dependencies.
- #23345, which adds the referenced `anomali-threatstream-threat-intel-feed` dataflow and the remaining integration assets.

This PR should remain draft until both dependencies are ready.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required. (`qa/skip-qa`: this asset does not ship with the Datadog Agent.)
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
