### PR TITLE
Bump pinact-action to v3.0.0

### DIFF
--- a/.github/workflows/validate-pinned-actions.yml
+++ b/.github/workflows/validate-pinned-actions.yml
@@ -25,9 +25,11 @@ jobs:
         # suzuki-shunsuke/commit-action@9faad521ea6a1e768439ffbe6b25b6cb3fc1b181
         # suzuki-shunsuke/github-token-action@350d7506222e3a0016491abe85b5c4dd475b67d1
         # tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        uses: suzuki-shunsuke/pinact-action@1081f5ad49ac904b7d977784f338145150a32112 # v1.4.0
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
         with:
           skip_push: true
+          # Required for check-only mode as of v3.0.0.
+          fix: false
 
       - name: Output pin actions failure message
         if: failure() && steps.pin-actions.outcome == 'failure'


### PR DESCRIPTION
### What does this PR do?

Bumps `suzuki-shunsuke/pinact-action` from v1.4.0 to v3.0.0 in `.github/workflows/validate-pinned-actions.yml`, and adds `fix: false` to keep the step in check-only mode.

The `fix: false` is not cosmetic. v3.0.0 changes what `skip_push: true` means:

- **v1.4.0** — `skip_push: true` was check-only. pinact validated the workflows and failed the job on any violation.
- **v3.0.0** — `skip_push: true` only skips the commit. `fix` defaults to `true`, so pinact rewrites the workflow files in the runner workspace, exits 0, and those edits are then thrown away with the runner.

The net effect of bumping alone would be a check that goes green while the offending action stays unpinned on `master`. Verified locally with pinact 4.0.0 against this repository, with a single tag-pinned reference introduced as the only violation:

| invocation | exit code | outcome |
| --- | --- | --- |
| `pinact run --fix=false` (`fix: false`) | 1 | violation reported, check fails |
| `pinact run --fix` (v3.0.0 default) | 0 | file rewritten in place, check passes |

Upstream documents this under [v3.0.0's breaking changes](https://github.com/suzuki-shunsuke/pinact-action/releases/tag/v3.0.0): "With `skip_push: true, fix: false`, validation is performed just like the previous `skip_push: true` behavior."

Also worth noting about the intermediate major: v2.0.0 requires Node.js 24 (v3.0.0's `action.yaml` declares `using: node24`). This job runs on `ubuntu-24.04`, a GitHub-hosted runner, so the runtime is available.

### Motivation

This bump was deliberately held back from #24837 (`Update actions (major)`) and reverted there so it could land on its own.

pinact-action v3.0.0 pulls in pinact v4.0.0, which adds a new rule: every SHA-pinned action must also carry a version comment. That rule flagged eight pre-existing lines in this repository, so bumping the action and fixing those lines in the same Renovate PR would have mixed an unrelated repo-wide cleanup into a dependency update.

Those eight version-comment fixes are already on #24837 and are not repeated here, which makes this PR dependent on that one:

- **Until #24837 merges**, the `Validate Pinned Actions` check on this PR fails, reporting those eight lines. That failure is expected and is not caused by anything in this diff.
- **Once #24837 merges**, the check passes with no action needed here. `pull_request` checks run against the merge ref, so the fixes are picked up from `master` automatically without a rebase.

Confirmed locally: pinact 4.0.0 with `--fix=false` exits 0 against a tree combining this bump with #24837's version-comment fixes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
