### PR TITLE
Run cert-manager E2E with the Kubernetes Agent backend

### DIFF
--- a/cert_manager/tests/conftest.py
+++ b/cert_manager/tests/conftest.py
@@ -1,18 +1,13 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
 import os
 
 import pytest
 
 from datadog_checks.dev import run_command
 from datadog_checks.dev.kind import kind_run
-from datadog_checks.dev.kube_port_forward import port_forward
-
-try:
-    from contextlib import ExitStack
-except ImportError:
-    from contextlib2 import ExitStack
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -81,17 +76,39 @@ def setup_cert_manager():
 @pytest.fixture(scope='session')
 def dd_environment():
     with kind_run(conditions=[setup_cert_manager]) as kubeconfig:
-        with ExitStack() as stack:
-            ip_ports = [
-                stack.enter_context(port_forward(kubeconfig, 'cert-manager', PORT, 'deployment', 'cert-manager'))
-            ]
+        pods = []
+        for selector in ('app.kubernetes.io/component=controller', 'app=cert-manager'):
+            result = run_command(
+                [
+                    "kubectl",
+                    "get",
+                    "pods",
+                    "--namespace",
+                    "cert-manager",
+                    "--selector",
+                    selector,
+                    "--output",
+                    "json",
+                ],
+                capture='out',
+                check=True,
+            )
+            pods = json.loads(result.stdout)['items']
+            if pods:
+                break
+
+        if len(pods) != 1 or not pods[0].get('status', {}).get('podIP'):
+            raise RuntimeError(f'Expected exactly one ready cert-manager controller pod, found {len(pods)}')
+
+        controller_ip = pods[0]['status']['podIP']
         instances = {
             'instances': [
-                {'openmetrics_endpoint': 'http://{}:{}/metrics'.format(*ip_ports[0])},
+                {'openmetrics_endpoint': f'http://{controller_ip}:{PORT}/metrics'},
             ]
         }
+        metadata = {'agent_type': 'kubernetes', 'kubernetes': {'kubeconfig': kubeconfig}}
 
-        yield instances
+        yield instances, metadata
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?

Runs the cert-manager Kind E2E with the Kubernetes Agent backend introduced by #24639.

- The `openmetrics_endpoint` (port 9402) has no matching Service, so it falls back to the pod IP of the `cert-manager` deployment, fetched via `kubectl get pods -n cert-manager --selector app.kubernetes.io/component=controller` (falling back to `--selector app=cert-manager` if no pods match). The Agent now scrapes `http://{controller_ip}:9402/metrics` from inside the cluster instead of through a `kubectl port-forward` tunnel.
- Removes the `ExitStack`/`port_forward` setup; the Agent runs in a pod inside the kind cluster (`agent_type: kubernetes`), eliminating the port-forward startup race.

### Motivation

Reduces Kind E2E flakes caused by the Agent running outside the cluster with port forwarding, which introduces startup races (e.g. `Connection refused` to the forwarded endpoint). Running the Agent inside the cluster removes the port-forward dependency. See the cert-manager master flake on 2026-08-12 (`test_check_ok` — `Connection refused` to `http://10.1.0.253:36415/metrics`), which is exactly the class this conversion eliminates.

Follows the same pattern already applied to argo_workflows (#24827), fluxcd (#24829), and weaviate (#24830), plus the pod-IP fallback pattern from velero (#24645) for the port with no Service.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged