### PR TITLE
Run Traefik Mesh E2E with the Kubernetes Agent backend

### DIFF
--- a/traefik_mesh/tests/conftest.py
+++ b/traefik_mesh/tests/conftest.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 import pytest
 
 from datadog_checks.dev import get_here
-from datadog_checks.dev._env import get_state, save_state
+from datadog_checks.dev._env import get_state, save_state, set_up_env
 from datadog_checks.dev.kind import kind_run
 from datadog_checks.dev.subprocess import run_command
 
@@ -102,6 +102,9 @@ def get_traefik_mesh_proxy_pod_ip() -> str:
 def dd_environment(dd_save_state):
     with kind_run(conditions=[setup_traefik_mesh]) as kubeconfig:
         proxy_pod_ip = get_state(PROXY_IP_STATE)
+        if set_up_env() and not proxy_pod_ip:
+            raise RuntimeError(f'No Traefik Mesh proxy pod IP found in the `{PROXY_IP_STATE}` state')
+
         traefik_proxy_endpoint = f'http://{proxy_pod_ip}:8080/metrics'
         traefik_controller_api_endpoint = 'http://traefik-mesh-controller.traefik-mesh.svc.cluster.local:9000'
 

--- a/traefik_mesh/tests/conftest.py
+++ b/traefik_mesh/tests/conftest.py
@@ -51,8 +51,10 @@ def setup_traefik_mesh():
         check=True,
     )
 
-    # This only runs once, when the Kind cluster is created, so the resolved pod IP is cached here
-    # rather than re-resolved by `dd_environment` on every invocation.
+    # `setup_traefik_mesh` only runs while the environment is being set up. Later invocations of the
+    # `dd_environment` fixture (e.g. during `ddev env stop`) run in a fresh process, and by then the
+    # cluster may already be gone, so the pod IP is cached here via `save_state`/`get_state` rather
+    # than looked up live.
     save_state(PROXY_IP_STATE, get_traefik_mesh_proxy_pod_ip())
 
 

--- a/traefik_mesh/tests/conftest.py
+++ b/traefik_mesh/tests/conftest.py
@@ -65,7 +65,9 @@ def setup_traefik_mesh():
 
 
 def get_traefik_mesh_proxy_pod_ip() -> str:
-    # There is no Service for the Traefik Mesh proxy, so the pod IP is fetched directly.
+    # There is no Service for the Traefik Mesh proxy, so the pod IP is fetched directly. The proxy is a
+    # DaemonSet, so exactly one pod is expected on the single-node cluster `kind_run` creates when no
+    # `kind_config` is passed. A multi-node cluster would need one instance per proxy pod.
     result = run_command(
         [
             "kubectl",
@@ -82,9 +84,18 @@ def get_traefik_mesh_proxy_pod_ip() -> str:
         check=True,
     )
     pods = json.loads(result.stdout)['items']
-    if len(pods) != 1 or not pods[0].get('status', {}).get('podIP'):
-        raise RuntimeError(f'Expected exactly one traefik-mesh-proxy pod with a pod IP, found {len(pods)}')
-    return pods[0]['status']['podIP']
+    if len(pods) != 1:
+        pod_names = [pod['metadata']['name'] for pod in pods]
+        raise RuntimeError(f'Expected exactly one traefik-mesh-proxy pod, found {len(pods)}: {pod_names}')
+
+    pod = pods[0]
+    pod_ip = pod.get('status', {}).get('podIP')
+    if not pod_ip:
+        pod_name = pod['metadata']['name']
+        pod_phase = pod.get('status', {}).get('phase')
+        raise RuntimeError(f'The traefik-mesh-proxy pod {pod_name} has no pod IP (phase: {pod_phase})')
+
+    return pod_ip
 
 
 @pytest.fixture(scope='session')

--- a/traefik_mesh/tests/conftest.py
+++ b/traefik_mesh/tests/conftest.py
@@ -1,19 +1,21 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
 import os
-from contextlib import ExitStack
 from copy import deepcopy
 
 import pytest
 
 from datadog_checks.dev import get_here
+from datadog_checks.dev._env import get_state, save_state
 from datadog_checks.dev.kind import kind_run
-from datadog_checks.dev.kube_port_forward import port_forward
 from datadog_checks.dev.subprocess import run_command
 
 HERE = get_here()
 opj = os.path.join
+
+PROXY_IP_STATE = 'traefik_mesh_proxy_ip'
 
 
 @pytest.fixture
@@ -44,28 +46,48 @@ def setup_traefik_mesh():
     )
     run_command(["kubectl", "wait", "pods", "--all", "--for=condition=Ready", "--timeout=90s"])
 
+    # This only runs once, when the Kind cluster is created, so the resolved pod IP is cached here
+    # rather than re-resolved by `dd_environment` on every invocation.
+    save_state(PROXY_IP_STATE, get_traefik_mesh_proxy_pod_ip())
+
+
+def get_traefik_mesh_proxy_pod_ip() -> str:
+    # There is no Service for the Traefik Mesh proxy, so the pod IP is fetched directly.
+    result = run_command(
+        [
+            "kubectl",
+            "get",
+            "pods",
+            "--namespace",
+            "traefik-mesh",
+            "--selector",
+            "app=maesh,component=maesh-mesh,release=traefik-mesh",
+            "--output",
+            "json",
+        ],
+        capture='out',
+        check=True,
+    )
+    pods = json.loads(result.stdout)['items']
+    if len(pods) != 1 or not pods[0].get('status', {}).get('podIP'):
+        raise RuntimeError(f'Expected exactly one traefik-mesh-proxy pod with a pod IP, found {len(pods)}')
+    return pods[0]['status']['podIP']
+
 
 @pytest.fixture(scope='session')
 def dd_environment(dd_save_state):
     with kind_run(conditions=[setup_traefik_mesh]) as kubeconfig:
-        with ExitStack() as stack:
-            traefik_controller_api_url, traefik_controller_api_port = stack.enter_context(
-                port_forward(kubeconfig, 'traefik-mesh', 9000, 'service', 'traefik-mesh-controller')
-            )
+        proxy_pod_ip = get_state(PROXY_IP_STATE)
+        traefik_proxy_endpoint = f'http://{proxy_pod_ip}:8080/metrics'
+        traefik_controller_api_endpoint = 'http://traefik-mesh-controller.traefik-mesh.svc.cluster.local:9000'
 
-            traefik_proxy_url, traefik_proxy_port = stack.enter_context(
-                port_forward(kubeconfig, 'traefik-mesh', 8080, 'daemonset', 'traefik-mesh-proxy')
-            )
+        instance = {
+            'openmetrics_endpoint': traefik_proxy_endpoint,
+            'traefik_proxy_api_endpoint': traefik_proxy_endpoint,
+            'traefik_controller_api_endpoint': traefik_controller_api_endpoint,
+        }
 
-            traefik_proxy_endpoint = f'http://{traefik_proxy_url}:{traefik_proxy_port}/metrics'
-            traefik_controller_api_endpoint = f'http://{traefik_controller_api_url}:{traefik_controller_api_port}'
+        dd_save_state("traefik_instance", instance)
+        metadata = {'agent_type': 'kubernetes', 'kubernetes': {'kubeconfig': kubeconfig}}
 
-            instance = {
-                'openmetrics_endpoint': traefik_proxy_endpoint,
-                'traefik_proxy_api_endpoint': traefik_proxy_endpoint,
-                'traefik_controller_api_endpoint': traefik_controller_api_endpoint,
-            }
-
-            dd_save_state("traefik_instance", instance)
-
-        yield instance
+        yield instance, metadata

--- a/traefik_mesh/tests/conftest.py
+++ b/traefik_mesh/tests/conftest.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
 import os
-from copy import deepcopy
 
 import pytest
 
@@ -16,13 +15,6 @@ HERE = get_here()
 opj = os.path.join
 
 PROXY_IP_STATE = 'traefik_mesh_proxy_ip'
-
-
-@pytest.fixture
-def instance_openmetrics_v2(dd_get_state):
-    openmetrics_v2 = deepcopy(dd_get_state('traefik_instance', default={}))
-    openmetrics_v2['use_openmetrics'] = 'true'
-    return openmetrics_v2
 
 
 def setup_traefik_mesh():
@@ -99,7 +91,7 @@ def get_traefik_mesh_proxy_pod_ip() -> str:
 
 
 @pytest.fixture(scope='session')
-def dd_environment(dd_save_state):
+def dd_environment():
     with kind_run(conditions=[setup_traefik_mesh]) as kubeconfig:
         proxy_pod_ip = get_state(PROXY_IP_STATE)
         if set_up_env() and not proxy_pod_ip:
@@ -115,7 +107,6 @@ def dd_environment(dd_save_state):
             'traefik_controller_api_endpoint': traefik_controller_api_endpoint,
         }
 
-        dd_save_state("traefik_instance", instance)
         metadata = {'agent_type': 'kubernetes', 'kubernetes': {'kubeconfig': kubeconfig}}
 
         yield instance, metadata

--- a/traefik_mesh/tests/conftest.py
+++ b/traefik_mesh/tests/conftest.py
@@ -44,7 +44,20 @@ def setup_traefik_mesh():
     run_command(
         ["kubectl", "wait", "deployments", "--all", "--for=condition=Available", "-n", "traefik-mesh", "--timeout=90s"]
     )
-    run_command(["kubectl", "wait", "pods", "--all", "--for=condition=Ready", "--timeout=90s"])
+    # The proxy DaemonSet is what the Agent scrapes, and its pod gets an IP as soon as it is scheduled,
+    # before Traefik listens on port 8080, so wait for the rollout to report the pod as ready.
+    run_command(
+        [
+            "kubectl",
+            "rollout",
+            "status",
+            "daemonset/traefik-mesh-proxy",
+            "--namespace",
+            "traefik-mesh",
+            "--timeout=90s",
+        ],
+        check=True,
+    )
 
     # This only runs once, when the Kind cluster is created, so the resolved pod IP is cached here
     # rather than re-resolved by `dd_environment` on every invocation.

--- a/traefik_mesh/tests/conftest.py
+++ b/traefik_mesh/tests/conftest.py
@@ -36,8 +36,6 @@ def setup_traefik_mesh():
     run_command(
         ["kubectl", "wait", "deployments", "--all", "--for=condition=Available", "-n", "traefik-mesh", "--timeout=90s"]
     )
-    # The proxy DaemonSet is what the Agent scrapes, and its pod gets an IP as soon as it is scheduled,
-    # before Traefik listens on port 8080, so wait for the rollout to report the pod as ready.
     run_command(
         [
             "kubectl",
@@ -59,9 +57,6 @@ def setup_traefik_mesh():
 
 
 def get_traefik_mesh_proxy_pod_ip() -> str:
-    # There is no Service for the Traefik Mesh proxy, so the pod IP is fetched directly. The proxy is a
-    # DaemonSet, so exactly one pod is expected on the single-node cluster `kind_run` creates when no
-    # `kind_config` is passed. A multi-node cluster would need one instance per proxy pod.
     result = run_command(
         [
             "kubectl",

--- a/traefik_mesh/tests/conftest.py
+++ b/traefik_mesh/tests/conftest.py
@@ -105,12 +105,13 @@ def dd_environment(dd_save_state):
         if set_up_env() and not proxy_pod_ip:
             raise RuntimeError(f'No Traefik Mesh proxy pod IP found in the `{PROXY_IP_STATE}` state')
 
-        traefik_proxy_endpoint = f'http://{proxy_pod_ip}:8080/metrics'
+        traefik_proxy_api_endpoint = f'http://{proxy_pod_ip}:8080'
+        traefik_proxy_metrics_endpoint = f'{traefik_proxy_api_endpoint}/metrics'
         traefik_controller_api_endpoint = 'http://traefik-mesh-controller.traefik-mesh.svc.cluster.local:9000'
 
         instance = {
-            'openmetrics_endpoint': traefik_proxy_endpoint,
-            'traefik_proxy_api_endpoint': traefik_proxy_endpoint,
+            'openmetrics_endpoint': traefik_proxy_metrics_endpoint,
+            'traefik_proxy_api_endpoint': traefik_proxy_api_endpoint,
             'traefik_controller_api_endpoint': traefik_controller_api_endpoint,
         }
 

--- a/traefik_mesh/tests/kind/traefik_mesh.yaml
+++ b/traefik_mesh/tests/kind/traefik_mesh.yaml
@@ -484,6 +484,7 @@ spec:
             - "--api.dashboard=false"
             - "--api.insecure"
             - "--ping"
+            - "--ping.entrypoint=readiness"
             - "--metrics.prometheus=true"
           ports:
             - name: readiness


### PR DESCRIPTION
### What does this PR do?

Runs the Traefik Mesh Kind E2E with the Kubernetes Agent backend introduced by #24639.

- The `traefik_controller_api_endpoint` (port 9000) uses the in-cluster Service DNS endpoint, `http://traefik-mesh-controller.traefik-mesh.svc.cluster.local:9000`, backed by the `traefik-mesh-controller` Service (`port: 9000` -> `targetPort: api`).
- The `openmetrics_endpoint` / `traefik_proxy_api_endpoint` (port 8080) has no matching Service (the proxy is a DaemonSet), so it falls back to the pod IP of the `traefik-mesh-proxy` DaemonSet, fetched via `kubectl get pods -n traefik-mesh --selector app=maesh,component=maesh-mesh,release=traefik-mesh`. The IP is cached via `save_state`/`get_state` since `dd_environment` re-runs in a fresh process after teardown.
- Removes the `ExitStack`/`port_forward` setup; the Agent runs in a pod inside the kind cluster (`agent_type: kubernetes`), eliminating the port-forward startup race.

### Motivation

Reduces Kind E2E flakes caused by the Agent running outside the cluster with port forwarding, which introduces startup races (e.g. `Connection refused` to the forwarded endpoint). Running the Agent inside the cluster removes the port-forward dependency.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged