### PR TITLE
Add Aurora role tag to PostgreSQL metrics

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -164,7 +164,9 @@ files:
       display_priority: 0
       fleet_configurable: true
       hidden: true
-      description: Tag metrics and checks with `replication_role:<master|standby>`.
+      description: |
+        Tag metrics and checks with `replication_role:<master|standby>`. Aurora instances are also tagged with
+        `aurora_role:<writer|reader>`.
       value:
         type: boolean
         example: true

--- a/postgres/changelog.d/24901.added
+++ b/postgres/changelog.d/24901.added
@@ -1,0 +1,1 @@
+Add an `aurora_role` tag with writer and reader values to PostgreSQL metrics emitted from Aurora instances.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -574,6 +574,12 @@ class PostgreSql(DatabaseCheck):
                 # value fetched for role is of <type 'bool'>
                 return "standby" if role else "master"
 
+    def _update_replication_role_tags(self, replication_role: str) -> None:
+        self.tag_manager.set_tag('replication_role', replication_role, replace=True)
+        if self.is_aurora:
+            aurora_role = 'reader' if replication_role == 'standby' else 'writer'
+            self.tag_manager.set_tag('aurora_role', aurora_role, replace=True)
+
     def _collect_wal_metrics(self):
         if self.version >= V10:
             # _collect_stats will gather wal file metrics
@@ -1236,7 +1242,8 @@ class PostgreSql(DatabaseCheck):
                 self.tag_manager.set_tag('postgresql_cluster_name', self.cluster_name, replace=True)
 
             if self._config.tag_replication_role:
-                self.tag_manager.set_tag('replication_role', self._get_replication_role(), replace=True)
+                replication_role = self._get_replication_role()
+                self._update_replication_role_tags(replication_role)
 
             tags = self.tag_manager.get_tags()
             self._send_database_instance_metadata()

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -792,7 +792,6 @@ class PostgreSql(DatabaseCheck):
             # This happens for example when trying to get replication metrics from readers in Aurora. Let's ignore it.
             log_func(e)
             self.log.debug("Disabling replication metrics")
-            self.is_aurora = False
             self.metrics_cache.replication_metrics = {}
         except psycopg.errors.UndefinedFunction as e:
             log_func(e)

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -173,6 +173,8 @@ def _get_expected_tags(
     )
     if role:
         base_tags.append(f'replication_role:{role}')
+        if check.is_aurora:
+            base_tags.append(f'aurora_role:{"reader" if role == "standby" else "writer"}')
     if with_db:
         base_tags.append(f'db:{pg_instance["dbname"]}')
     if with_host:

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -350,30 +350,69 @@ def test_session_idle_in_transaction_time(aggregator, integration_check, pg_inst
     postgres_conn.close()
 
 
-def test_unsupported_replication(aggregator, integration_check, pg_instance):
+def test_feature_not_supported_preserves_aurora_role_after_promotion(aggregator, integration_check, pg_instance):
+    pg_instance['tag_replication_role'] = True
+    pg_instance['database_instance_collection_interval'] = 0
     check = integration_check(pg_instance)
+    check.is_aurora = True
+    check._get_replication_role = mock.MagicMock(side_effect=['standby', 'master'])
     unpatched_fmt = PartialFormatter()
 
     called = []
 
-    def format_with_error(value, **kwargs):
-        if 'pg_is_in_recovery' in value:
+    def format_with_error(value: str, **kwargs: str) -> str:
+        if 'pg_stat_bgwriter' in value and not called:
             called.append(True)
             raise psycopg.errors.FeatureNotSupported("Not available")
         return unpatched_fmt.format(value, **kwargs)
 
-    # This simulate an error in the fmt function, as it's a bit hard to mock psycopg
+    # Simulate an Aurora reader rejecting a metrics query.
     with mock.patch.object(fmt, 'format', passthrough=True) as mock_fmt:
         mock_fmt.side_effect = format_with_error
         check.run()
 
-    # Verify our mocking was called
+        reader_role_tags = {'replication_role:standby', 'aurora_role:reader'}
+        db_count = aggregator.metrics('postgresql.db.count')
+        assert len(db_count) == 1
+        assert {tag for tag in db_count[0].tags if tag.startswith(('replication_role:', 'aurora_role:'))} == (
+            reader_role_tags
+        )
+
+        service_checks = aggregator.service_checks(check.SERVICE_CHECK_NAME)
+        assert len(service_checks) == 1
+        assert {
+            tag for tag in service_checks[0].tags if tag.startswith(('replication_role:', 'aurora_role:'))
+        } == reader_role_tags
+
+        dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
+        database_instance = next(event for event in dbm_metadata if event['kind'] == 'database_instance')
+        assert {
+            tag for tag in database_instance['tags'] if tag.startswith(('replication_role:', 'aurora_role:'))
+        } == reader_role_tags
+
+        aggregator.reset()
+        check.run()
+
     assert called == [True]
 
-    expected_tags = _get_expected_tags(check, pg_instance)
-    check_bgw_metrics(aggregator, expected_tags)
+    writer_role_tags = {'replication_role:master', 'aurora_role:writer'}
+    db_count = aggregator.metrics('postgresql.db.count')
+    assert len(db_count) == 1
+    assert {
+        tag for tag in db_count[0].tags if tag.startswith(('replication_role:', 'aurora_role:'))
+    } == writer_role_tags
 
-    check_common_metrics(aggregator, expected_tags=expected_tags)
+    service_checks = aggregator.service_checks(check.SERVICE_CHECK_NAME)
+    assert len(service_checks) == 1
+    assert {
+        tag for tag in service_checks[0].tags if tag.startswith(('replication_role:', 'aurora_role:'))
+    } == writer_role_tags
+
+    dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
+    database_instance = next(event for event in dbm_metadata if event['kind'] == 'database_instance')
+    assert {
+        tag for tag in database_instance['tags'] if tag.startswith(('replication_role:', 'aurora_role:'))
+    } == writer_role_tags
 
 
 def test_can_connect_service_check(aggregator, integration_check, pg_instance):

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -125,43 +125,6 @@ def test_resolved_hostname_metadata(check, test_case):
         m.assert_any_call('test:123', 'resolved_hostname', test_case)
 
 
-@pytest.mark.parametrize(
-    'is_aurora, replication_role, expected_role_tags',
-    [
-        (False, 'master', {'replication_role:master'}),
-        (True, 'master', {'replication_role:master', 'aurora_role:writer'}),
-        (True, 'standby', {'replication_role:standby', 'aurora_role:reader'}),
-    ],
-)
-def test_update_replication_role_tags(integration_check, pg_instance, is_aurora, replication_role, expected_role_tags):
-    check = integration_check(pg_instance)
-    check.is_aurora = is_aurora
-
-    check._update_replication_role_tags(replication_role)
-
-    role_tags = {
-        tag
-        for tag in check.tag_manager.get_tags()
-        if tag.startswith('replication_role:') or tag.startswith('aurora_role:')
-    }
-    assert role_tags == expected_role_tags
-
-
-def test_update_replication_role_tags_after_aurora_failover(integration_check, pg_instance):
-    check = integration_check(pg_instance)
-    check.is_aurora = True
-
-    check._update_replication_role_tags('master')
-    check._update_replication_role_tags('standby')
-
-    role_tags = {
-        tag
-        for tag in check.tag_manager.get_tags()
-        if tag.startswith('replication_role:') or tag.startswith('aurora_role:')
-    }
-    assert role_tags == {'replication_role:standby', 'aurora_role:reader'}
-
-
 def test_query_timeout_connection_string(aggregator, integration_check, pg_instance):
     pg_instance['password'] = ''
     pg_instance['query_timeout'] = 1000

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -125,6 +125,43 @@ def test_resolved_hostname_metadata(check, test_case):
         m.assert_any_call('test:123', 'resolved_hostname', test_case)
 
 
+@pytest.mark.parametrize(
+    'is_aurora, replication_role, expected_role_tags',
+    [
+        (False, 'master', {'replication_role:master'}),
+        (True, 'master', {'replication_role:master', 'aurora_role:writer'}),
+        (True, 'standby', {'replication_role:standby', 'aurora_role:reader'}),
+    ],
+)
+def test_update_replication_role_tags(integration_check, pg_instance, is_aurora, replication_role, expected_role_tags):
+    check = integration_check(pg_instance)
+    check.is_aurora = is_aurora
+
+    check._update_replication_role_tags(replication_role)
+
+    role_tags = {
+        tag
+        for tag in check.tag_manager.get_tags()
+        if tag.startswith('replication_role:') or tag.startswith('aurora_role:')
+    }
+    assert role_tags == expected_role_tags
+
+
+def test_update_replication_role_tags_after_aurora_failover(integration_check, pg_instance):
+    check = integration_check(pg_instance)
+    check.is_aurora = True
+
+    check._update_replication_role_tags('master')
+    check._update_replication_role_tags('standby')
+
+    role_tags = {
+        tag
+        for tag in check.tag_manager.get_tags()
+        if tag.startswith('replication_role:') or tag.startswith('aurora_role:')
+    }
+    assert role_tags == {'replication_role:standby', 'aurora_role:reader'}
+
+
 def test_query_timeout_connection_string(aggregator, integration_check, pg_instance):
     pg_instance['password'] = ''
     pg_instance['query_timeout'] = 1000


### PR DESCRIPTION
### What does this PR do?

Adds `aurora_role:writer|reader` to metrics, checks, and DBM metadata emitted by the PostgreSQL integration when the database is Aurora.

The check derives the Aurora role from the existing `replication_role` query, preserves `replication_role:master|standby`, and replaces both dynamic tags after a failover. No additional database query is introduced.

Validation:

- `ddev validate config -s postgres`
- `ddev validate models -s postgres`
- Focused role-tag unit tests across the configured PostgreSQL test matrix
- `ddev test --lint postgres`

The Docker-backed replication tests could not run locally because an existing SSH tunnel owns `127.0.0.1:5432`.

### Motivation

[SDBM-2870](https://datadoghq.atlassian.net/browse/SDBM-2870) requests Aurora's writer/reader terminology. Changing the existing PostgreSQL `replication_role:master|standby` values would break existing queries and dashboards, so this adds a separate Aurora-specific tag.

This tag applies to PostgreSQL integration telemetry. It does not add the tag to independently collected `aws.rds.*` metrics.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

[SDBM-2870]: https://datadoghq.atlassian.net/browse/SDBM-2870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ