### PR TITLE
Ensure check hasn't been dereferenced before we access check_id

### DIFF
--- a/datadog_checks_base/changelog.d/24903.fixed
+++ b/datadog_checks_base/changelog.d/24903.fixed
@@ -1,0 +1,1 @@
+Avoid an ``AttributeError`` when a check logs after the logging adapter's check reference has been released.

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -47,7 +47,9 @@ class CheckLoggingAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):
         # Cache for performance
         if not self.check_id:
-            self.check_id = self.check.check_id
+            # Ensure check hasn't been dereferenced before we access check_id
+            if self.check is not None:
+                self.check_id = self.check.check_id
             # Default to `unknown` for checks that log during
             # `__init__` and therefore have no `check_id` yet
             self.extra['_check_id'] = self.check_id or 'unknown'


### PR DESCRIPTION
### What does this PR do?
Puts a guard around `self.check` before accessing `check_id` to prevent a race condition where a check is cancelled before a `check_id` is set and the AgentCheck.log.check cyclical reference has already been broken.

### Motivation
Follow up finding from https://github.com/DataDog/integrations-core/pull/24844. We need to ensure cyclical references are broken on check cancellation and cleanup to prevent delayed garbage collection.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
