### PR TITLE
[DBMON-6888] Fix potential connection leak in stored procedure metrics

### DIFF
--- a/sqlserver/changelog.d/24904.fixed
+++ b/sqlserver/changelog.d/24904.fixed
@@ -1,0 +1,1 @@
+Fix a connection leak in ``stored_procedure`` metric collection when the procedure call raises an exception.

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -218,8 +218,8 @@ class Connection(object):
         self.log.debug('Connection initialized.')
 
     @contextmanager
-    def get_managed_cursor(self, key_prefix):
-        cursor = self.get_cursor(self.DEFAULT_DB_KEY, key_prefix=key_prefix)
+    def get_managed_cursor(self, key_prefix, db_key=None):
+        cursor = self.get_cursor(db_key or self.DEFAULT_DB_KEY, key_prefix=key_prefix)
         try:
             yield cursor
         finally:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -1076,39 +1076,38 @@ class SQLServer(DatabaseCheck):
         guardSql = self.instance.get("proc_only_if")
 
         if (guardSql and self.proc_check_guard(guardSql)) or not guardSql:
-            self.connection.open_db_connections(self.connection.DEFAULT_DB_KEY)
-            cursor = self.connection.get_cursor(self.connection.DEFAULT_DB_KEY)
+            with self.connection.open_managed_default_connection(KEY_PREFIX):
+                with self.connection.get_managed_cursor(KEY_PREFIX) as cursor:
+                    try:
+                        self.log.debug("Calling Stored Procedure : %s", proc)
+                        if self.connection.connector == "adodbapi":
+                            cursor.callproc(proc)
+                        else:
+                            # pyodbc does not support callproc; use execute instead.
+                            # Reference: https://github.com/mkleehammer/pyodbc/wiki/Calling-Stored-Procedures
+                            call_proc = "{{CALL {}}}".format(proc)
+                            cursor.execute(call_proc)
 
-            try:
-                self.log.debug("Calling Stored Procedure : %s", proc)
-                if self.connection.connector == "adodbapi":
-                    cursor.callproc(proc)
-                else:
-                    # pyodbc does not support callproc; use execute instead.
-                    # Reference: https://github.com/mkleehammer/pyodbc/wiki/Calling-Stored-Procedures
-                    call_proc = "{{CALL {}}}".format(proc)
-                    cursor.execute(call_proc)
+                        rows = cursor.fetchall()
+                        self.log.debug("Row count (%s) : %s", proc, cursor.rowcount)
 
-                rows = cursor.fetchall()
-                self.log.debug("Row count (%s) : %s", proc, cursor.rowcount)
+                        for row in rows:
+                            tags = [] if row.tags is None or row.tags == "" else row.tags.split(",")
+                            tags.extend(self.tag_manager.get_tags())
 
-                for row in rows:
-                    tags = [] if row.tags is None or row.tags == "" else row.tags.split(",")
-                    tags.extend(self.tag_manager.get_tags())
+                            if row.type.lower() in self.proc_type_mapping:
+                                self.proc_type_mapping[row.type](row.metric, row.value, tags, raw=True)
+                            else:
+                                self.log.warning(
+                                    "%s is not a recognised type from procedure %s, metric %s",
+                                    row.type,
+                                    proc,
+                                    row.metric,
+                                )
 
-                    if row.type.lower() in self.proc_type_mapping:
-                        self.proc_type_mapping[row.type](row.metric, row.value, tags, raw=True)
-                    else:
-                        self.log.warning(
-                            "%s is not a recognised type from procedure %s, metric %s", row.type, proc, row.metric
-                        )
-
-            except Exception as e:
-                self.log.warning("Could not call procedure %s: %s", proc, e)
-                raise e
-
-            self.connection.close_cursor(cursor)
-            self.connection.close_db_connections(self.connection.DEFAULT_DB_KEY)
+                    except Exception as e:
+                        self.log.warning("Could not call procedure %s: %s", proc, e)
+                        raise
         else:
             self.log.info("Skipping call to %s due to only_if", proc)
 
@@ -1117,19 +1116,17 @@ class SQLServer(DatabaseCheck):
         check to see if the guard SQL returns a single column containing 0 or 1
         We return true if 1, else False
         """
-        self.connection.open_db_connections(self.connection.PROC_GUARD_DB_KEY)
-        cursor = self.connection.get_cursor(self.connection.PROC_GUARD_DB_KEY)
-
         should_run = False
-        try:
-            cursor.execute(sql, ())
-            result = cursor.fetchone()
-            should_run = result[0] == 1
-        except Exception as e:
-            self.log.error("Failed to run proc_only_if sql %s : %s", sql, e)
-
-        self.connection.close_cursor(cursor)
-        self.connection.close_db_connections(self.connection.PROC_GUARD_DB_KEY)
+        with self.connection._open_managed_db_connections(self.connection.PROC_GUARD_DB_KEY):
+            with self.connection.get_managed_cursor(
+                key_prefix=None, db_key=self.connection.PROC_GUARD_DB_KEY
+            ) as cursor:
+                try:
+                    cursor.execute(sql, ())
+                    result = cursor.fetchone()
+                    should_run = result[0] == 1
+                except Exception as e:
+                    self.log.error("Failed to run proc_only_if sql %s : %s", sql, e)
         return should_run
 
     def _send_database_instance_metadata(self):

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -392,6 +392,30 @@ def test_get_cursor(instance_docker):
         check.connection.get_cursor('foo')
 
 
+def test_stored_procedure_check_closes_connection_on_error(instance_docker):
+    instance = copy.copy(instance_docker)
+    instance['stored_procedure'] = 'fake_proc'
+    check = SQLServer(CHECK_NAME, {}, [instance])
+    check.initialize_connection()
+
+    mock_cursor = mock.MagicMock()
+    mock_cursor.execute.side_effect = Exception("proc failed")
+    mock_cursor.callproc.side_effect = Exception("proc failed")
+
+    with (
+        mock.patch.object(check.connection, 'open_db_connections') as open_db,
+        mock.patch.object(check.connection, 'close_db_connections') as close_db,
+        mock.patch.object(check.connection, 'get_cursor', return_value=mock_cursor),
+        mock.patch.object(check.connection, 'close_cursor') as close_cursor,
+    ):
+        with pytest.raises(Exception, match="proc failed"):
+            check.do_stored_procedure_check()
+
+    open_db.assert_called_once()
+    close_db.assert_called_once()
+    close_cursor.assert_called_once_with(mock_cursor)
+
+
 def test_missing_db(instance_docker, dd_run_check):
     instance = copy.copy(instance_docker)
     instance['ignore_missing_database'] = False


### PR DESCRIPTION
### What does this PR do?
Switches out manual connection/cursor handling in stored procedure metric collection with context managers to avoid potential resource leaking when exceptions are raised from within these functions.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-6888

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
