### PR TITLE
Add cached agent_version to DatabaseCheck

### DIFF
--- a/datadog_checks_base/changelog.d/24905.added
+++ b/datadog_checks_base/changelog.d/24905.added
@@ -1,0 +1,1 @@
+Implement the ``agent_version`` property on the ``DatabaseCheck`` base class.

--- a/datadog_checks_base/datadog_checks/base/checks/db.py
+++ b/datadog_checks_base/datadog_checks/base/checks/db.py
@@ -28,6 +28,7 @@ class DatabaseCheck(AgentCheck):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._agent_hostname = None
+        self._agent_version = None
         self._database_identifier = None
         self._dbms_fallback_warning_logged = False
         self.tag_manager = TagManager()
@@ -164,6 +165,12 @@ class DatabaseCheck(AgentCheck):
         if self._agent_hostname is None:
             self._agent_hostname = datadog_agent.get_hostname()
         return self._agent_hostname
+
+    @property
+    def agent_version(self) -> str:
+        if self._agent_version is None:
+            self._agent_version = datadog_agent.get_version()
+        return self._agent_version
 
     @property
     def dbms(self) -> str:

--- a/datadog_checks_base/tests/base/checks/test_database_check.py
+++ b/datadog_checks_base/tests/base/checks/test_database_check.py
@@ -71,6 +71,15 @@ def test_agent_hostname_resolves_once_and_caches():
         assert get_hostname.call_count == 1
 
 
+def test_agent_version_resolves_once_and_caches():
+    check = FakeDatabaseCheck("test", {}, [{}])
+    # The version comes from an FFI call, so it should only be resolved once and cached.
+    with mock.patch.object(datadog_agent, "get_version", return_value="7.70.0") as get_version:
+        assert check.agent_version == "7.70.0"
+        assert check.agent_version == "7.70.0"
+        assert get_version.call_count == 1
+
+
 @pytest.mark.parametrize(
     ("tags", "template", "connection_params", "expected"),
     [


### PR DESCRIPTION
### What does this PR do?
Add an `agent_version` property on `DatabaseCheck` that calls `datadog_agent.get_version()` once and caches the result, matching the existing `agent_hostname` pattern.

### Motivation
`datadog_agent.get_version()` is an FFI call. DBM payloads include the Agent version in many places; caching it avoids repeating that call.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)