### PR TITLE
Fix release approval notifications

### DIFF
--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -83,7 +83,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
         with:
-          policy: integrations-core
+          policy: integrations-core-release-notifications
       - name: Notify pending release via Datadog workflow
         env:
           DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}


### PR DESCRIPTION
### What does this PR do?

Uses the dedicated `integrations-core-release-notifications` dd-sts policy when sending pending release approval notifications. The policy is introduced by https://github.com/ddoghq/dd-source/pull/59600 and grants the short-lived application key the required `workflows_run` permission.

### Motivation

Release notification jobs are failing with HTTP 403 when triggering the Datadog notification workflow, including https://github.com/DataDog/integrations-core/actions/runs/31813285530. The generic `integrations-core` policy has no Workflow Automation RBAC permissions.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
