### PR TITLE
Add Supported OS::AIX tag to the apache check

### DIFF
--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -18,6 +18,7 @@
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS",
+      "Supported OS::AIX",
       "Offering::Integration"
     ],
     "resources": [


### PR DESCRIPTION
### What does this PR do?

Adds the `Supported OS::AIX` classifier tag to the Apache integration manifest, marking the check as supporting AIX.

### Motivation

The Apache check is being bundled in the AIX datadog-agent package. Following the same pattern as the process check (#24665) and the other AIX-bundled integrations (#23484), this PR adds the `Supported OS::AIX` tag to the Apache manifest so the integration is correctly classified as AIX-supported.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged