### PR TITLE
Push check_id into the logging adapter instead of holding a check reference

### DIFF
--- a/datadog_checks_base/changelog.d/24914.fixed
+++ b/datadog_checks_base/changelog.d/24914.fixed
@@ -1,0 +1,1 @@
+Stop the check logging adapter from holding a reference to the check, so a cancelled check is reclaimed without waiting for a garbage collection pass.

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -284,9 +284,14 @@ class AgentCheck(object):
         # everywhere just yet. It's complicated... See: https://github.com/DataDog/integrations-core/pull/5573
         instance = instances[0] if instances else None
 
-        self.check_id = ''
         self.provider = ''
         self.name = name  # type: str
+
+        # Built before `check_id` is assigned below, because its setter forwards the value here.
+        logger = logging.getLogger('{}.{}'.format(__name__, self.name))
+        self.log = CheckLoggingAdapter(logger)
+
+        self.check_id = ''
         self.init_config = init_config  # type: InitConfigType
         self.agentConfig = agentConfig  # type: AgentConfigType
         self.instance = instance  # type: InstanceType
@@ -306,9 +311,6 @@ class AgentCheck(object):
 
         # `self.hostname` is deprecated, use `datadog_agent.get_hostname()` instead
         self.hostname = datadog_agent.get_hostname()  # type: str
-
-        logger = logging.getLogger('{}.{}'.format(__name__, self.name))
-        self.log = CheckLoggingAdapter(logger, self)
 
         metric_patterns = self.instance.get('metric_patterns', {}) if instance else {}
         if not isinstance(metric_patterns, dict):
@@ -466,6 +468,21 @@ class AgentCheck(object):
             return self.DEFAULT_METRIC_LIMIT
 
         return limit
+
+    @property
+    def check_id(self) -> str:
+        """
+        The Agent's identifier for this check instance, in the form ``<name>:<instance hash>``.
+
+        Empty until the Agent assigns it, which happens after construction and before the first run.
+        """
+        return self._check_id
+
+    @check_id.setter
+    def check_id(self, value: str) -> None:
+        self._check_id = value
+        # The adapter tags every log record with the id, so it needs the value as soon as we have it.
+        self.log.set_check_id(value)
 
     @property
     def http(self) -> RequestsWrapper:

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -288,8 +288,11 @@ class AgentCheck(object):
         self.name = name  # type: str
 
         # Built before `check_id` is assigned below, because its setter forwards the value here.
+        # Held separately from `self.log` because subclasses are free to replace that with a logger
+        # of their own, as `PrometheusScraperMixin` does.
         logger = logging.getLogger('{}.{}'.format(__name__, self.name))
-        self.log = CheckLoggingAdapter(logger)
+        self._log_adapter = CheckLoggingAdapter(logger)
+        self.log = self._log_adapter
 
         self.check_id = ''
         self.init_config = init_config  # type: InitConfigType
@@ -482,7 +485,7 @@ class AgentCheck(object):
     def check_id(self, value: str) -> None:
         self._check_id = value
         # The adapter tags every log record with the id, so it needs the value as soon as we have it.
-        self.log.set_check_id(value)
+        self._log_adapter.set_check_id(value)
 
     @property
     def http(self) -> RequestsWrapper:

--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -34,10 +34,19 @@ class AgentLogger(logging.getLoggerClass()):
 
 
 class CheckLoggingAdapter(logging.LoggerAdapter):
-    def __init__(self, logger, check):
+    def __init__(self, logger, check_id=''):
         super(CheckLoggingAdapter, self).__init__(logger, {})
-        self.check = check
-        self.check_id = self.check.check_id
+        self.set_check_id(check_id)
+
+    def set_check_id(self, check_id: str) -> None:
+        """
+        Stamp ``check_id`` onto every record this adapter processes from now on.
+
+        An empty ``check_id`` is recorded as ``unknown``, which is what records logged before the
+        Agent assigns an id carry.
+        """
+        self.check_id = check_id
+        self.extra['_check_id'] = check_id or 'unknown'
 
     def setup_sanitization(self, sanitize: Callable[[str], str]) -> None:
         for handler in self.logger.handlers:
@@ -45,16 +54,6 @@ class CheckLoggingAdapter(logging.LoggerAdapter):
                 handler.setFormatter(SanitizationFormatter(handler.formatter, sanitize=sanitize))
 
     def process(self, msg, kwargs):
-        # Cache for performance
-        if not self.check_id:
-            self.check_id = self.check.check_id
-            # Default to `unknown` for checks that log during
-            # `__init__` and therefore have no `check_id` yet
-            self.extra['_check_id'] = self.check_id or 'unknown'
-            if self.check_id:
-                # Break the reference cycle, once we resolved check_id we don't need the check anymore
-                self.check = None
-
         kwargs.setdefault('extra', self.extra)
         return msg, kwargs
 

--- a/datadog_checks_base/tests/test_log.py
+++ b/datadog_checks_base/tests/test_log.py
@@ -107,6 +107,18 @@ def test_check_id_is_stamped_on_records_once_the_agent_assigns_it(caplog):
     assert stamped == ['unknown', 'test:abc123']
 
 
+def test_check_id_can_be_assigned_when_a_subclass_replaces_the_logger():
+    """`PrometheusScraperMixin` swaps `self.log` for a plain logger once `AgentCheck.__init__` has
+    run, so assigning the id must not depend on `self.log` still being the adapter."""
+    from datadog_checks.base.checks.prometheus import PrometheusCheck
+
+    check = PrometheusCheck('test_replaced_logger', {}, {}, [{}])
+
+    check.check_id = 'test:abc123'
+
+    assert check.check_id == 'test:abc123'
+
+
 @pytest.mark.parametrize('integration_tracing_enabled', [False, True])
 def test_log_trace_context_injection(integration_tracing_enabled):
     def _tracing_enabled():

--- a/datadog_checks_base/tests/test_log.py
+++ b/datadog_checks_base/tests/test_log.py
@@ -93,6 +93,20 @@ class MockAgentLogHandler(logging.Handler):
         self.records.append(self.format(record))
 
 
+def test_check_id_is_stamped_on_records_once_the_agent_assigns_it(caplog):
+    """The Agent assigns `check_id` after constructing the check, so records logged before that
+    carry `unknown` and every record after it carries the real id."""
+    caplog.set_level(logging.INFO)
+    check = AgentCheck('test_check_id_stamping', {}, [{}])
+
+    check.log.info("before the id is assigned")
+    check.check_id = 'test:abc123'
+    check.log.info("after the id is assigned")
+
+    stamped = [record._check_id for record in caplog.records if 'the id is assigned' in record.getMessage()]
+    assert stamped == ['unknown', 'test:abc123']
+
+
 @pytest.mark.parametrize('integration_tracing_enabled', [False, True])
 def test_log_trace_context_injection(integration_tracing_enabled):
     def _tracing_enabled():

--- a/postgres/changelog.d/24914.fixed
+++ b/postgres/changelog.d/24914.fixed
@@ -1,0 +1,1 @@
+Remove the logging adapter cleanup from check teardown, which the base class no longer needs.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -554,9 +554,6 @@ class PostgreSql(DatabaseCheck):
         self._close_db()
         self._close_db_pool()
         self.log.debug("Check cleanup complete")
-        # Must come last: the logging adapter reads back through this attribute for checks whose
-        # check_id was never resolved, so anything logged after this would fail.
-        self.log.check = None
 
     def _clean_state(self):
         self.log.debug("Cleaning state")


### PR DESCRIPTION
### What does this PR do?

Makes `AgentCheck.check_id` a property backed by `_check_id`, and has its setter forward the
value into the logging adapter. The adapter no longer holds a reference to the check.

- `CheckLoggingAdapter` takes a `check_id` string instead of a check, and gains
  `set_check_id()` to record it. An empty id is stamped as `unknown`, same as before.
- `process()` reduces to injecting `extra`, since there is no longer anything to resolve lazily.
- The adapter is built earlier in `AgentCheck.__init__`, before `check_id` is assigned, because
  the setter now forwards into it.
- Postgres drops `self.log.check = None` from `_finalize()`; there is no longer an attribute
  there to clear.

### Motivation

The adapter held the check purely so it could late-read `check_id`, which the Agent assigns
after the check is constructed. That is a pull where a push does the job, and it created a
`check -> adapter -> check` cycle that every check then had to break by hand during teardown.
The cycle is collectable, but only by the cyclic collector, so a cancelled check lingered until
a GC pass instead of being reclaimed by refcount as soon as the Agent let go of it.

Removing the reference means there is no cycle to break, so the teardown line goes away rather
than needing to be ordered correctly. Comparing referrers on a plain `AgentCheck` with the
collector disabled:

- before: `dict`, `CheckLoggingAdapter`, `method`, `method`
- after: `dict`, `method`, `method`

The remaining entries are unrelated and pre-existing (bound methods in `check_initializations`,
diagnosis); `DatabaseCheck._finalize()` is what clears those.

Both assignment paths go through the setter: the Agent sets the attribute through the CPython
API, which honours descriptors, and the e2e replay path assigns it directly in
`utils/replay/redirect.py`. `datadog_checks_base` was the only place constructing the adapter.

Follow-ups this makes possible, both owned elsewhere: #24903 becomes unnecessary, since there
is no reference left to guard against, and #24844 can drop the same teardown line from the
`DatabaseCheck` version of `_finalize()`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
