### PR TITLE
[DBMON-6890] Avoid additional clickhouse version resolution query

### DIFF
--- a/clickhouse/changelog.d/24916.fixed
+++ b/clickhouse/changelog.d/24916.fixed
@@ -1,0 +1,1 @@
+Fixes a duplicate query for Clickhouse server version

--- a/clickhouse/changelog.d/24916.fixed
+++ b/clickhouse/changelog.d/24916.fixed
@@ -1,1 +1,1 @@
-Fixes a duplicate query for Clickhouse server version
+Fixes a duplicate query for Clickhouse server version.

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -230,14 +230,6 @@ class ClickhouseCheck(DatabaseCheck):
         """Send database instance metadata to the metadata intake."""
         current_time = time()
         if current_time - self._database_instance_last_emitted >= DATABASE_INSTANCE_COLLECTION_INTERVAL:
-            # Get the version for the metadata (and cache it)
-            try:
-                version_result = list(self.execute_query_raw('SELECT version()'))[0][0]
-                self._dbms_version = version_result
-            except Exception as e:
-                self.log.debug("Unable to fetch version for metadata: %s", e)
-                self._dbms_version = "unknown"
-
             # Get tags without db: prefix for metadata
             tags_no_db = [t for t in self.tags if not t.startswith('db:')]
 
@@ -251,7 +243,7 @@ class ClickhouseCheck(DatabaseCheck):
                 "dbms": self.dbms,
                 "kind": "database_instance",
                 "collection_interval": DATABASE_INSTANCE_COLLECTION_INTERVAL,
-                "dbms_version": self._dbms_version,
+                "dbms_version": self.dbms_version,
                 "integration_version": __version__,
                 "tags": tags_no_db,
                 "timestamp": current_time * 1000,
@@ -266,7 +258,7 @@ class ClickhouseCheck(DatabaseCheck):
 
     def check(self, _):
         self.connect()
-        self._server_version = self.select_version()
+        self._dbms_version = self.select_version()
 
         # Must run before the query manager is built and before the DBM jobs are handed
         # self.tags below, since both snapshot the tag list.
@@ -274,11 +266,11 @@ class ClickhouseCheck(DatabaseCheck):
             self.tag_manager.set_tag(CLUSTER_TAG, self.cluster_name, replace=True)
         self.tag_manager.set_tag(HOSTING_TYPE_TAG, self.hosting_type, replace=True)
 
-        if self._query_manager is None or self._query_manager_version != self._server_version:
+        if self._query_manager is None or self._query_manager_version != self.dbms_version:
             self._query_manager = self._build_query_manager()
-            self._query_manager_version = self._server_version
+            self._query_manager_version = self.dbms_version
         self._query_manager.execute()
-        self.set_version_metadata(self._server_version)
+        self.set_version_metadata(self.dbms_version)
 
         # Send database instance metadata
         self._send_database_instance_metadata()
@@ -670,7 +662,7 @@ class ClickhouseCheck(DatabaseCheck):
         if version == 'latest':
             return True
 
-        return utils.parse_version(self._server_version) < utils.parse_version(version)
+        return utils.parse_version(self.dbms_version) < utils.parse_version(version)
 
     def version_ge(self, version: str) -> bool:
         """
@@ -680,4 +672,4 @@ class ClickhouseCheck(DatabaseCheck):
         if version == 'latest':
             return False
 
-        return utils.parse_version(self._server_version) >= utils.parse_version(version)
+        return utils.parse_version(self.dbms_version) >= utils.parse_version(version)

--- a/clickhouse/tests/test_statement_samples.py
+++ b/clickhouse/tests/test_statement_samples.py
@@ -484,7 +484,7 @@ def test_buffer_collection_interval():
         'tags': ['test:clickhouse'],
     }
     check = ClickhouseCheck('clickhouse', {}, [instance])
-    check._server_version = '24.8'
+    check._dbms_version = '24.8'
     samples = check.statement_samples
     samples._tags = ['test:clickhouse']
 
@@ -529,7 +529,7 @@ def test_buffer_snapshot_skipped_below_min_version(server_version, expect_collec
         'tags': ['test:clickhouse'],
     }
     check = ClickhouseCheck('clickhouse', {}, [instance])
-    check._server_version = server_version
+    check._dbms_version = server_version
     samples = check.statement_samples
     samples._tags = ['test:clickhouse']
 
@@ -565,7 +565,7 @@ def test_buffer_snapshot_stops_collecting_when_table_missing():
         'tags': ['test:clickhouse'],
     }
     check = ClickhouseCheck('clickhouse', {}, [instance])
-    check._server_version = '24.8'
+    check._dbms_version = '24.8'
     samples = check.statement_samples
     samples._tags = ['test:clickhouse']
 

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -290,7 +290,7 @@ def test_connect_no_password_uses_empty_string():
 )
 def test_version_lt(instance, ch_version, comparable, expected):
     check = ClickhouseCheck('clickhouse', {}, [instance])
-    check._server_version = ch_version
+    check._dbms_version = ch_version
     assert check.version_lt(comparable) == expected
 
 
@@ -307,7 +307,7 @@ def test_version_lt(instance, ch_version, comparable, expected):
 )
 def test_version_ge(instance, ch_version, comparable, expected):
     check = ClickhouseCheck('clickhouse', {}, [instance])
-    check._server_version = ch_version
+    check._dbms_version = ch_version
     assert check.version_ge(comparable) == expected
 
 
@@ -439,7 +439,7 @@ def test_get_queries_tags_system_tables_per_node_in_single_endpoint_mode(instanc
         'use_legacy_queries': not use_advanced_queries,
     }
     check = ClickhouseCheck('clickhouse', {}, [instance])
-    check._server_version = '24.8'
+    check._dbms_version = '24.8'
 
     cluster_aware = [q for q in check.get_queries() if 'clusterAllReplicas' in q['query']]
 
@@ -463,7 +463,7 @@ def test_get_queries_uses_base_queries_for_direct_connection(instance, use_advan
         'use_legacy_queries': not use_advanced_queries,
     }
     check = ClickhouseCheck('clickhouse', {}, [instance])
-    check._server_version = '24.8'
+    check._dbms_version = '24.8'
 
     assert all('clusterAllReplicas' not in q['query'] for q in check.get_queries())
 

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -24,6 +24,16 @@ from .utils import ensure_csv_safe, parse_described_metrics, raise_error
 
 pytestmark = pytest.mark.unit
 
+MOCK_CLICKHOUSE_VERSION = '24.8.0'
+
+
+def mock_clickhouse_client():
+    """A client mock whose command() returns a version string, as select_version() expects."""
+    client = mock.MagicMock()
+    client.command.return_value = MOCK_CLICKHOUSE_VERSION
+    client.ping.return_value = True
+    return client
+
 
 def test_config(instance):
     check = ClickhouseCheck('clickhouse', {}, [instance])
@@ -135,7 +145,8 @@ def test_can_connect_submits_on_every_check_run(is_metadata_collection_enabled, 
     (It used to be submitted only once on check init, which led to customer seeing "no data" in the UI.)
     """
     check = ClickhouseCheck('clickhouse', {}, [instance])
-    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_connect"):
+    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_connect") as mock_connect:
+        mock_connect.get_client.return_value = mock_clickhouse_client()
         # Test for consecutive healthy clickhouse.can_connect statuses
         num_runs = 3
         for _ in range(num_runs):
@@ -148,7 +159,8 @@ def test_can_connect_recovers_after_failed_connection(is_metadata_collection_ena
     check = ClickhouseCheck('clickhouse', {}, [instance])
 
     # Test 1 healthy connection --> 2 Unhealthy service checks --> 1 healthy connection. Recovered
-    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_connect"):
+    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_connect") as mock_connect:
+        mock_connect.get_client.return_value = mock_clickhouse_client()
         check.check({})
     with mock.patch('clickhouse_connect.get_client', side_effect=OperationalError('Connection refused')):
         with mock.patch('datadog_checks.clickhouse.ClickhouseCheck.ping_clickhouse', return_value=False):
@@ -156,7 +168,8 @@ def test_can_connect_recovers_after_failed_connection(is_metadata_collection_ena
                 check.check({})
             with pytest.raises(Exception):
                 check.check({})
-    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_connect"):
+    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_connect") as mock_connect:
+        mock_connect.get_client.return_value = mock_clickhouse_client()
         check.check({})
     aggregator.assert_service_check("clickhouse.can_connect", count=2, status=check.CRITICAL)
     aggregator.assert_service_check("clickhouse.can_connect", count=2, status=check.OK)
@@ -166,7 +179,8 @@ def test_can_connect_recovers_after_failed_connection(is_metadata_collection_ena
 def test_can_connect_recovers_after_failed_ping(is_metadata_collection_enabled, aggregator, instance):
     check = ClickhouseCheck('clickhouse', {}, [instance])
     # Test Exception in ping_clickhouse(), but reestablishes connection.
-    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_connect"):
+    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_connect") as mock_connect:
+        mock_connect.get_client.return_value = mock_clickhouse_client()
         check.check({})
         with mock.patch('datadog_checks.clickhouse.ClickhouseCheck.ping_clickhouse', side_effect=Error()):
             # connect() should be able to handle an exception in ping_clickhouse() and attempt reconnection
@@ -555,7 +569,7 @@ def test_check_tags_with_cluster(instance):
     check = ClickhouseCheck('clickhouse', {}, [instance])
     with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
         cluster_name.return_value = 'prod_cluster'
-        with mock.patch('clickhouse_connect.get_client'):
+        with mock.patch('clickhouse_connect.get_client', return_value=mock_clickhouse_client()):
             check.check({})
 
     assert f'{CLUSTER_TAG}:prod_cluster' in check.tags
@@ -571,7 +585,7 @@ def test_can_connect_carries_cluster_tag_from_the_second_run(aggregator, instanc
     check = ClickhouseCheck('clickhouse', {}, [instance])
     with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
         cluster_name.return_value = 'prod_cluster'
-        with mock.patch('clickhouse_connect.get_client'):
+        with mock.patch('clickhouse_connect.get_client', return_value=mock_clickhouse_client()):
             check.check({})
             first_run_tags = list(check.tags)
             check.check({})
@@ -585,7 +599,7 @@ def test_check_omits_cluster_tag_when_unresolved(instance):
     check = ClickhouseCheck('clickhouse', {}, [instance])
     with mock.patch.object(ClickhouseCheck, 'cluster_name', new_callable=mock.PropertyMock) as cluster_name:
         cluster_name.return_value = None
-        with mock.patch('clickhouse_connect.get_client'):
+        with mock.patch('clickhouse_connect.get_client', return_value=mock_clickhouse_client()):
             check.check({})
 
     assert not any(tag.startswith(f'{CLUSTER_TAG}:') for tag in check.tags)
@@ -633,7 +647,7 @@ def test_check_tags_with_hosting_type(instance):
         cluster_name.return_value = None
         with mock.patch.object(ClickhouseCheck, 'hosting_type', new_callable=mock.PropertyMock) as hosting_type:
             hosting_type.return_value = HostingType.CLOUD
-            with mock.patch('clickhouse_connect.get_client'):
+            with mock.patch('clickhouse_connect.get_client', return_value=mock_clickhouse_client()):
                 check.check({})
 
     assert f'{HOSTING_TYPE_TAG}:{HostingType.CLOUD}' in check.tags
@@ -646,7 +660,7 @@ def test_check_always_emits_a_hosting_type_tag(instance):
         cluster_name.return_value = None
         with mock.patch.object(ClickhouseCheck, 'hosting_type', new_callable=mock.PropertyMock) as hosting_type:
             hosting_type.return_value = HostingType.UNKNOWN
-            with mock.patch('clickhouse_connect.get_client'):
+            with mock.patch('clickhouse_connect.get_client', return_value=mock_clickhouse_client()):
                 check.check({})
 
     assert f'{HOSTING_TYPE_TAG}:{HostingType.UNKNOWN}' in check.tags


### PR DESCRIPTION
### What does this PR do?
Currently there's two separate paths for resolving Clickhouse version. One get's called at the top of every check loop, the other got called whenever we emitted `database_instance` metadata events. This change aligns both these paths under the same `dbms_version` cached property which will be standardized name across DatabaseCheck class soon and avoids the extra query on the metadata events

### Motivation
Cleanup found while working towards pushing database_instance events in the DatabaseCheck base class

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
