### PR TITLE
postgres: stream Remote Queries COPY output to the Agent relay

### DIFF
--- a/postgres/datadog_checks/postgres/remote_query.py
+++ b/postgres/datadog_checks/postgres/remote_query.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import time
@@ -45,6 +46,9 @@ REMOTE_QUERY_COPY_SQL_ALLOWLIST = frozenset(
 )
 
 CopyStreamFormat = Literal['csv', 'binary']
+ResultDeliveryMode = Literal['POC_PUBLIC_CHUNKED_UPLOAD']
+ResultDeliveryFormat = Literal['csv']
+ResultDeliveryCompression = Literal['none']
 CopyStreamEmit = Callable[[str, str, bytes], None]
 
 if TYPE_CHECKING:
@@ -127,6 +131,34 @@ class RemoteQueryCopyLimits(BaseModel):
     timeout_ms: StrictInt = Field(default=30_000, alias='timeoutMs', ge=1)
 
 
+class RemoteQueryResultDelivery(BaseModel):
+    """Validate optional result-delivery upload instructions for the Agent-owned upload transport.
+
+    When present, the integration feeds bounded COPY bytes through the native emit callback to the
+    Agent-owned upload transport. The Python side receives only the sanitized, non-secret session
+    handle: it never receives the upload ``baseUrl``, the scoped upload ``token``, or the Agent
+    API/app keys, and it performs no HTTP upload. The Agent Go side retains those secrets, attaches
+    the API key, and owns endpoint validation, retries, and finalization. Any ``baseUrl``/``token``
+    (or other unknown field) in the request is rejected before pool access. Omitting
+    ``resultDelivery`` keeps the existing inline streaming behavior unchanged.
+    """
+
+    model_config = ConfigDict(extra='forbid', frozen=True)
+
+    mode: ResultDeliveryMode
+    upload_id: StrictStr = Field(alias='uploadId', min_length=1)
+    chunk_bytes: StrictInt = Field(alias='chunkBytes', ge=1)
+    max_bytes: StrictInt = Field(alias='maxBytes', ge=1)
+    format: ResultDeliveryFormat = 'csv'
+    compression: ResultDeliveryCompression = 'none'
+
+    @model_validator(mode='after')
+    def validate_chunk_within_max(self) -> 'RemoteQueryResultDelivery':
+        if self.chunk_bytes > self.max_bytes:
+            raise ValueError('chunkBytes must not exceed maxBytes')
+        return self
+
+
 class RemoteQueryCopyRequest(BaseModel):
     """Accept only explicit COPY byte-stream export requests."""
 
@@ -137,6 +169,28 @@ class RemoteQueryCopyRequest(BaseModel):
     query: StrictStr = Field(min_length=1)
     format: CopyStreamFormat = 'csv'
     limits: RemoteQueryCopyLimits = Field(default_factory=RemoteQueryCopyLimits)
+    result_delivery: RemoteQueryResultDelivery | None = Field(default=None, alias='resultDelivery')
+
+    @model_validator(mode='after')
+    def validate_format_consistency(self) -> 'RemoteQueryCopyRequest':
+        # When resultDelivery is present, the COPY stream format must match the upload format so the
+        # emitted bytes and the manifest agree. The current contract allows only ``csv`` for upload,
+        # so upload mode is CSV-only; a ``binary`` COPY stream with a ``csv`` upload is rejected.
+        if self.result_delivery is not None and self.format != self.result_delivery.format:
+            raise ValueError('format must match resultDelivery.format when resultDelivery is present')
+        return self
+
+    @model_validator(mode='after')
+    def validate_chunk_within_limits(self) -> 'RemoteQueryCopyRequest':
+        # The upload caps must not widen the caller/backend COPY safety caps. Fail closed so a
+        # backend-injected resultDelivery cannot raise the integration's configured byte ceiling;
+        # equal or smaller upload caps are accepted.
+        if self.result_delivery is not None:
+            if self.result_delivery.chunk_bytes > self.limits.chunk_bytes:
+                raise ValueError('resultDelivery.chunkBytes must not exceed limits.chunkBytes')
+            if self.result_delivery.max_bytes > self.limits.max_bytes:
+                raise ValueError('resultDelivery.maxBytes must not exceed limits.maxBytes')
+        return self
 
 
 @dataclass(frozen=True)
@@ -282,6 +336,48 @@ def _dbname_from_check(check: 'PostgreSql') -> str | None:
     return getattr(config, 'dbname', None)
 
 
+def _started_metadata(request: RemoteQueryCopyRequest) -> dict[str, Any]:
+    result_delivery = request.result_delivery
+    chunk_bytes = result_delivery.chunk_bytes if result_delivery is not None else request.limits.chunk_bytes
+    max_bytes = result_delivery.max_bytes if result_delivery is not None else request.limits.max_bytes
+    metadata: dict[str, Any] = {
+        'status': 'STARTED',
+        'format': request.format,
+        'operation': request.operation,
+        'chunkBytes': chunk_bytes,
+        'maxBytes': max_bytes,
+        'maxRowBytes': request.limits.max_row_bytes,
+    }
+    if result_delivery is not None:
+        metadata['resultDelivery'] = {
+            'mode': result_delivery.mode,
+            'uploadId': result_delivery.upload_id,
+            'chunkBytes': result_delivery.chunk_bytes,
+            'maxBytes': result_delivery.max_bytes,
+            'format': result_delivery.format,
+            'compression': result_delivery.compression,
+        }
+    return metadata
+
+
+def _succeeded_metadata(state: _CopyStreamState, started_at: float, request: RemoteQueryCopyRequest) -> dict[str, Any]:
+    metadata: dict[str, Any] = {'status': 'SUCCEEDED', 'stats': _copy_stream_stats(state, started_at, request.format)}
+    result_delivery = request.result_delivery
+    if result_delivery is not None:
+        # Provisional receipt aligned to the Agent-owned uploadReceipt shape
+        # {mode, uploadId, bucketName, manifestPath, totalBytes, totalRows, chunkCount, sha256}.
+        # Python owns only the fields it can compute from the byte stream; the Agent Go side
+        # enriches it with bucketName, manifestPath, totalRows, and the aggregate sha256 after
+        # it finalizes the upload session.
+        metadata['uploadReceipt'] = {
+            'mode': result_delivery.mode,
+            'uploadId': result_delivery.upload_id,
+            'totalBytes': state.bytes_emitted,
+            'chunkCount': state.chunks_emitted,
+        }
+    return metadata
+
+
 def _iter_copy_stream_events(
     check: 'PostgreSql', request: RemoteQueryCopyRequest, execution_dbname: str, started_at: float
 ) -> Iterator[CopyStreamEvent]:
@@ -302,17 +398,7 @@ def _iter_copy_stream_events(
         )
         return
 
-    yield CopyStreamEvent(
-        'metadata',
-        {
-            'status': 'STARTED',
-            'format': request.format,
-            'operation': request.operation,
-            'chunkBytes': request.limits.chunk_bytes,
-            'maxBytes': request.limits.max_bytes,
-            'maxRowBytes': request.limits.max_row_bytes,
-        },
-    )
+    yield CopyStreamEvent('metadata', _started_metadata(request))
 
     state = _CopyStreamState()
     error: _CopyStreamFailure | None = None
@@ -339,10 +425,7 @@ def _iter_copy_stream_events(
         )
         return
 
-    yield CopyStreamEvent(
-        'final',
-        {'status': 'SUCCEEDED', 'stats': _copy_stream_stats(state, started_at, request.format)},
-    )
+    yield CopyStreamEvent('final', _succeeded_metadata(state, started_at, request))
 
 
 def _copy_stream_data_events(
@@ -353,7 +436,12 @@ def _copy_stream_data_events(
     started_at: float,
 ) -> Iterator[tuple[CopyStreamEvent, _CopyStreamState]]:
     limits = request.limits
-    deadline = started_at + (limits.timeout_ms / 1000)
+    result_delivery = request.result_delivery
+    chunk_bytes = result_delivery.chunk_bytes if result_delivery is not None else limits.chunk_bytes
+    max_bytes = result_delivery.max_bytes if result_delivery is not None else limits.max_bytes
+    max_row_bytes = limits.max_row_bytes
+    timeout_ms = limits.timeout_ms
+    deadline = started_at + (timeout_ms / 1000)
     copy_sql = _copy_stdout_sql(request.query, request.format)
     pending = bytearray()
 
@@ -363,12 +451,12 @@ def _copy_stream_data_events(
             try:
                 cursor.execute('BEGIN READ ONLY')
                 in_transaction = True
-                cursor.execute('SET LOCAL statement_timeout = %s', (limits.timeout_ms,))
+                cursor.execute('SET LOCAL statement_timeout = %s', (timeout_ms,))
                 with cursor.copy(copy_sql) as copy:
                     for block in copy:
                         _raise_if_timed_out(deadline)
                         block_view = memoryview(block)
-                        if len(block_view) > limits.max_row_bytes:
+                        if len(block_view) > max_row_bytes:
                             raise _CopyStreamFailure(
                                 'max_row_bytes_exceeded',
                                 'COPY stream row exceeded maxRowBytes; psycopg exposes COPY data at row granularity.',
@@ -377,29 +465,29 @@ def _copy_stream_data_events(
                         offset = 0
                         while offset < len(block_view):
                             _raise_if_timed_out(deadline)
-                            remaining_allowed = limits.max_bytes - state.bytes_emitted - len(pending)
+                            remaining_allowed = max_bytes - state.bytes_emitted - len(pending)
                             if remaining_allowed <= 0:
                                 raise _CopyStreamFailure('max_bytes_exceeded', 'COPY stream exceeded maxBytes.')
 
-                            remaining_chunk = limits.chunk_bytes - len(pending)
+                            remaining_chunk = chunk_bytes - len(pending)
                             take = min(remaining_chunk, remaining_allowed, len(block_view) - offset)
                             pending.extend(block_view[offset : offset + take])
                             offset += take
 
-                            if len(pending) >= limits.chunk_bytes:
-                                event, state = _copy_data_event(pending, state)
+                            if len(pending) >= chunk_bytes:
+                                event, state = _copy_data_event(pending, state, result_delivery)
                                 pending.clear()
                                 yield event, state
 
-                            if offset < len(block_view) and state.bytes_emitted + len(pending) >= limits.max_bytes:
+                            if offset < len(block_view) and state.bytes_emitted + len(pending) >= max_bytes:
                                 if pending:
-                                    event, state = _copy_data_event(pending, state)
+                                    event, state = _copy_data_event(pending, state, result_delivery)
                                     pending.clear()
                                     yield event, state
                                 raise _CopyStreamFailure('max_bytes_exceeded', 'COPY stream exceeded maxBytes.')
 
                     if pending:
-                        event, state = _copy_data_event(pending, state)
+                        event, state = _copy_data_event(pending, state, result_delivery)
                         pending.clear()
                         yield event, state
             finally:
@@ -443,17 +531,18 @@ def _raise_if_timed_out(deadline: float) -> None:
         raise _CopyStreamFailure('timeout', 'COPY stream exceeded timeoutMs.', retryable=True)
 
 
-def _copy_data_event(data: bytearray, state: _CopyStreamState) -> tuple[CopyStreamEvent, _CopyStreamState]:
+def _copy_data_event(
+    data: bytearray, state: _CopyStreamState, result_delivery: RemoteQueryResultDelivery | None = None
+) -> tuple[CopyStreamEvent, _CopyStreamState]:
     payload = bytes(data)
-    event = CopyStreamEvent(
-        'data',
-        {
-            'sequence': state.sequence,
-            'offset': state.bytes_emitted,
-            'bytes': len(payload),
-        },
-        payload,
-    )
+    metadata: dict[str, Any] = {
+        'sequence': state.sequence,
+        'offset': state.bytes_emitted,
+        'bytes': len(payload),
+    }
+    if result_delivery is not None:
+        metadata['sha256'] = hashlib.sha256(payload).hexdigest()
+    event = CopyStreamEvent('data', metadata, payload)
     next_state = _CopyStreamState(
         sequence=state.sequence + 1,
         chunks_emitted=state.chunks_emitted + 1,

--- a/postgres/datadog_checks/postgres/remote_query.py
+++ b/postgres/datadog_checks/postgres/remote_query.py
@@ -132,21 +132,22 @@ class RemoteQueryCopyLimits(BaseModel):
 
 
 class RemoteQueryResultDelivery(BaseModel):
-    """Validate optional result-delivery upload instructions for the Agent-owned upload transport.
+    """Validate optional result-delivery upload instructions for direct upload to its-agent-intake.
 
-    When present, the integration feeds bounded COPY bytes through the native emit callback to the
-    Agent-owned upload transport. The Python side receives only the sanitized, non-secret session
-    handle: it never receives the upload ``baseUrl``, the scoped upload ``token``, or the Agent
-    API/app keys, and it performs no HTTP upload. The Agent Go side retains those secrets, attaches
-    the API key, and owns endpoint validation, retries, and finalization. Any ``baseUrl``/``token``
-    (or other unknown field) in the request is rejected before pool access. Omitting
-    ``resultDelivery`` keeps the existing inline streaming behavior unchanged.
+    When present, the integration uploads bounded COPY bytes directly to its-agent-intake over
+    HTTP. The Agent forwards the intake base URL and scoped upload token here; the integration
+    reads the org API key and POC application key from Agent config via ``datadog_agent.get_config``
+    and attaches them to its own HTTP upload requests. The integration performs the HTTP upload
+    itself; bulk chunk bytes never traverse the native emit bridge, AgentSecure, PAR, or AP action
+    output. Omitting ``resultDelivery`` keeps the existing inline streaming behavior unchanged.
     """
 
     model_config = ConfigDict(extra='forbid', frozen=True)
 
     mode: ResultDeliveryMode
     upload_id: StrictStr = Field(alias='uploadId', min_length=1)
+    base_url: StrictStr = Field(alias='baseUrl', min_length=1)
+    token: StrictStr = Field(alias='token', min_length=1)
     chunk_bytes: StrictInt = Field(alias='chunkBytes', ge=1)
     max_bytes: StrictInt = Field(alias='maxBytes', ge=1)
     format: ResultDeliveryFormat = 'csv'
@@ -249,6 +250,10 @@ def execute_agent_rpc_stream_copy(
                 'invalid_request', 'Invalid remote query request: request_json must be a JSON object.'
             ),
         )
+        return
+
+    if _is_upload_request(request):
+        _execute_upload_stream(request, check, emit)
         return
 
     events = iter_agent_rpc_stream_copy_events(request, StaticPostgresCheckRegistry([check]))
@@ -600,3 +605,231 @@ def _validation_message(error: ValidationError) -> str:
 
 def _validation_location(location: tuple[Any, ...]) -> str:
     return '.'.join(str(part) for part in location)
+
+
+# ---------------------------------------------------------------------------
+# Direct chunked upload to its-agent-intake (POC_PUBLIC_CHUNKED_UPLOAD)
+#
+# When resultDelivery is present, the integration uploads bounded COPY chunks
+# directly to its-agent-intake over HTTP. The Agent forwards the intake base
+# URL and scoped upload token in resultDelivery, and the integration reads the
+# org API key and POC application key from Agent config via datadog_agent.get_config.
+# Bulk chunk bytes never traverse the native emit bridge, AgentSecure, PAR, or
+# AP action output; only the compact final receipt is emitted back.
+
+REMOTE_QUERY_UPLOAD_HTTP_TIMEOUT_SECONDS = 60
+REMOTE_QUERY_UPLOAD_TEST_DRIVE_HEADER = 'test-drive-its-agent-intake-poc'
+REMOTE_QUERY_UPLOAD_TEST_DRIVE_CONFIG_KEY = 'remote_queries.execute.intake_test_drive_selector'
+REMOTE_QUERY_UPLOAD_MAX_RETRIES = 4
+REMOTE_QUERY_UPLOAD_INITIAL_BACKOFF_SECONDS = 0.1
+REMOTE_QUERY_UPLOAD_MAX_BACKOFF_SECONDS = 5.0
+
+
+@dataclass(frozen=True)
+class _UploadCredentials:
+    base_url: str
+    upload_id: str
+    api_key: str
+    app_key: str
+    token: str
+    test_drive_selector: str | None
+
+
+class _UploadClient(Protocol):
+    def put_chunk(self, creds: _UploadCredentials, index: int, payload: bytes, sha256_hex: str, rows: int) -> None: ...
+
+    def finalize(self, creds: _UploadCredentials) -> Mapping[str, Any]: ...
+
+    def abort(self, creds: _UploadCredentials) -> None: ...
+
+
+class _RequestsUploadClient:
+    """HTTP upload client for its-agent-intake. Imports requests lazily."""
+
+    def __init__(self, timeout_seconds: int = REMOTE_QUERY_UPLOAD_HTTP_TIMEOUT_SECONDS) -> None:
+        self._timeout = timeout_seconds
+
+    def _headers(self, creds: _UploadCredentials, content_type: str | None = None) -> dict[str, str]:
+        headers = {
+            'dd-api-key': creds.api_key,
+            'dd-application-key': creds.app_key,
+            'Authorization': 'Bearer ' + creds.token,
+        }
+        if content_type is not None:
+            headers['Content-Type'] = content_type
+        if creds.test_drive_selector:
+            headers[REMOTE_QUERY_UPLOAD_TEST_DRIVE_HEADER] = creds.test_drive_selector
+        return headers
+
+    def put_chunk(self, creds: _UploadCredentials, index: int, payload: bytes, sha256_hex: str, rows: int) -> None:
+        headers = self._headers(creds, 'application/octet-stream')
+        headers['X-DD-Chunk-SHA256'] = sha256_hex
+        headers['X-DD-Chunk-Bytes'] = str(len(payload))
+        headers['X-DD-Chunk-Rows'] = str(rows)
+        url = '{}/uploads/{}/chunks/{}'.format(creds.base_url.rstrip('/'), creds.upload_id, index)
+        _upload_with_retry('PUT', url, headers, payload)
+
+    def finalize(self, creds: _UploadCredentials) -> Mapping[str, Any]:
+        headers = self._headers(creds, 'application/json')
+        url = '{}/uploads/{}/finalize'.format(creds.base_url.rstrip('/'), creds.upload_id)
+        _status, body = _upload_with_retry('POST', url, headers, b'{}')
+        return json.loads(body.decode('utf-8'))
+
+    def abort(self, creds: _UploadCredentials) -> None:
+        headers = self._headers(creds, 'application/json')
+        url = '{}/uploads/{}/abort'.format(creds.base_url.rstrip('/'), creds.upload_id)
+        try:
+            _upload_with_retry('POST', url, headers, b'{}')
+        except _CopyStreamFailure:
+            LOGGER.debug('Remote query upload abort failed (best-effort)', exc_info=True)
+
+
+def _is_transient_upload_status(status: int) -> bool:
+    return status == 408 or status == 429 or status >= 500
+
+
+def _upload_with_retry(method: str, url: str, headers: Mapping[str, str], body: bytes) -> tuple[int, bytes]:
+    import requests  # lazy: only the POC upload path needs it
+
+    backoff = REMOTE_QUERY_UPLOAD_INITIAL_BACKOFF_SECONDS
+    last_err: Any = None
+    for attempt in range(REMOTE_QUERY_UPLOAD_MAX_RETRIES + 1):
+        try:
+            resp = requests.request(
+                method, url, headers=dict(headers), data=body, timeout=REMOTE_QUERY_UPLOAD_HTTP_TIMEOUT_SECONDS
+            )
+        except requests.exceptions.RequestException as e:
+            last_err = e
+        else:
+            if 200 <= resp.status_code < 300:
+                return resp.status_code, resp.content
+            if not _is_transient_upload_status(resp.status_code):
+                raise _CopyStreamFailure(
+                    'upload_failed', 'upload to its-agent-intake rejected with status {}'.format(resp.status_code)
+                )
+            last_err = 'status {}'.format(resp.status_code)
+        if attempt == REMOTE_QUERY_UPLOAD_MAX_RETRIES:
+            break
+        time.sleep(backoff)
+        backoff = min(backoff * 2, REMOTE_QUERY_UPLOAD_MAX_BACKOFF_SECONDS)
+    raise _CopyStreamFailure(
+        'upload_failed',
+        'upload to its-agent-intake failed after {} attempts: {}'.format(REMOTE_QUERY_UPLOAD_MAX_RETRIES + 1, last_err),
+        retryable=True,
+    )
+
+
+def _is_upload_request(request: Mapping[str, Any]) -> bool:
+    delivery = request.get('resultDelivery')
+    return isinstance(delivery, Mapping) and delivery.get('mode') == 'POC_PUBLIC_CHUNKED_UPLOAD'
+
+
+def _get_agent_config(key: str) -> str:
+    try:
+        value = datadog_agent.get_config(key)
+    except Exception:
+        LOGGER.debug('Unable to read agent config %s', key, exc_info=True)
+        return ''
+    if value is None:
+        return ''
+    return str(value)
+
+
+def _resolve_upload_credentials(request: Mapping[str, Any]) -> _UploadCredentials:
+    delivery = request.get('resultDelivery') or {}
+    selector = _get_agent_config(REMOTE_QUERY_UPLOAD_TEST_DRIVE_CONFIG_KEY)
+    return _UploadCredentials(
+        base_url=str(delivery.get('baseUrl') or ''),
+        upload_id=str(delivery.get('uploadId') or ''),
+        api_key=_get_agent_config('api_key'),
+        app_key=_get_agent_config('app_key'),
+        token=str(delivery.get('token') or ''),
+        test_drive_selector=selector or None,
+    )
+
+
+def _default_upload_client() -> _UploadClient:
+    return _RequestsUploadClient()
+
+
+def _count_newlines(payload: bytes) -> int:
+    return payload.count(b'\n')
+
+
+def _intake_receipt_to_camel(resp: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        'mode': resp.get('mode', 'POC_PUBLIC_CHUNKED_UPLOAD'),
+        'uploadId': resp.get('upload_id', ''),
+        'bucketName': resp.get('bucket_name', ''),
+        'manifestPath': resp.get('manifest_key', ''),
+        'totalBytes': resp.get('total_bytes', 0),
+        'totalRows': resp.get('total_rows', 0),
+        'chunkCount': resp.get('chunk_count', 0),
+        'sha256': resp.get('sha256', ''),
+    }
+
+
+def _safe_abort(client: _UploadClient, creds: _UploadCredentials) -> None:
+    if not creds.base_url or not creds.upload_id or not creds.token:
+        return
+    try:
+        client.abort(creds)
+    except Exception:
+        LOGGER.debug('Remote query upload abort failed (best-effort)', exc_info=True)
+
+
+def _upload_one_chunk(client: _UploadClient, creds: _UploadCredentials, event: CopyStreamEvent) -> None:
+    metadata = event.metadata
+    client.put_chunk(creds, metadata['sequence'], event.payload, metadata['sha256'], _count_newlines(event.payload))
+
+
+def _finalize_upload(
+    client: _UploadClient, creds: _UploadCredentials, event: CopyStreamEvent, emit: CopyStreamEmit
+) -> None:
+    receipt = _intake_receipt_to_camel(client.finalize(creds))
+    metadata = dict(event.metadata)
+    # The iterator's provisional receipt uses the camelCase key; replace it with the
+    # server-expected snake_case outer key carrying the Agent-shaped camelCase receipt.
+    metadata.pop('uploadReceipt', None)
+    metadata['upload_receipt'] = receipt
+    _emit_copy_event(emit, CopyStreamEvent('final', metadata))
+
+
+def _execute_upload_stream(
+    request: Mapping[str, Any],
+    check: 'PostgreSql',
+    emit: CopyStreamEmit,
+    http_client: _UploadClient | None = None,
+) -> None:
+    """Upload COPY chunks directly to its-agent-intake; emit only metadata/final/error events."""
+    creds = _resolve_upload_credentials(request)
+    if not creds.api_key or not creds.app_key:
+        _emit_copy_event(
+            emit,
+            _stream_failed_event(
+                'credentials_unavailable',
+                'Remote query upload requires api_key and app_key to be configured on the Agent.',
+            ),
+        )
+        return
+    client = http_client if http_client is not None else _default_upload_client()
+    events = iter_agent_rpc_stream_copy_events(request, StaticPostgresCheckRegistry([check]))
+    try:
+        for event in events:
+            if event.event_type == 'data':
+                _upload_one_chunk(client, creds, event)
+            elif event.event_type == 'final':
+                _finalize_upload(client, creds, event, emit)
+            elif event.event_type == 'error':
+                _safe_abort(client, creds)
+                _emit_copy_event(emit, event)
+            else:
+                _emit_copy_event(emit, event)
+    except _CopyStreamFailure as e:
+        _safe_abort(client, creds)
+        _emit_copy_event(emit, _stream_failed_event(e.code, e.message, retryable=e.retryable))
+        events.close()
+    except BaseException:
+        _safe_abort(client, creds)
+        events.close()
+        raise

--- a/postgres/tests/test_remote_query.py
+++ b/postgres/tests/test_remote_query.py
@@ -12,6 +12,7 @@ import pytest
 from datadog_checks.postgres import remote_query
 from datadog_checks.postgres.remote_query import (
     StaticPostgresCheckRegistry,
+    _execute_upload_stream,
     execute_agent_rpc_stream_copy,
     iter_agent_rpc_stream_copy_events,
     normalize_target,
@@ -132,6 +133,8 @@ def valid_result_delivery(**extra):
     result_delivery = {
         'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
         'uploadId': 'upload-01k',
+        'baseUrl': 'https://dd.datad0g.com/api/unstable/its-agent-intake',
+        'token': 'scoped-upload-token',
         'chunkBytes': 8,
         'maxBytes': 24,
         'format': 'csv',
@@ -145,6 +148,51 @@ def valid_upload_copy_request(**extra):
     request = valid_copy_request(**extra)
     request['resultDelivery'] = valid_result_delivery()
     return request
+
+
+class FakeUploadClient:
+    def __init__(self, put_status=200, finalize_resp=None, raise_on_put=None):
+        self.put_calls = []
+        self.finalize_calls = 0
+        self.abort_calls = 0
+        self.put_status = put_status
+        self.raise_on_put = raise_on_put
+        self.finalize_resp = finalize_resp or {
+            'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+            'upload_id': 'upload-01k',
+            'bucket_name': 'rq-bucket',
+            'manifest_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/manifest.json',
+            'total_bytes': 0,
+            'total_rows': 0,
+            'chunk_count': 0,
+            'sha256': 'aggregate',
+            'format': 'csv',
+            'compression': 'none',
+            'finalized_at': '2026-08-20T00:00:00Z',
+        }
+
+    def put_chunk(self, creds, index, payload, sha256_hex, rows):
+        self.put_calls.append((index, payload, sha256_hex, rows))
+        if self.raise_on_put is not None:
+            raise self.raise_on_put
+
+    def finalize(self, creds):
+        self.finalize_calls += 1
+        return self.finalize_resp
+
+    def abort(self, creds):
+        self.abort_calls += 1
+
+
+def patch_upload_credentials(monkeypatch):
+    def get_config(key):
+        if key == 'api_key':
+            return 'TEST_API_KEY'
+        if key == 'app_key':
+            return 'TEST_APP_KEY'
+        return None
+
+    monkeypatch.setattr(remote_query.datadog_agent, 'get_config', get_config)
 
 
 class ExplodingRegistry:
@@ -877,26 +925,24 @@ def test_copy_stream_upload_mode_accepts_csv_format_matching_result_delivery():
     assert event_metadata(events[-1])['status'] == 'SUCCEEDED'
 
 
-def test_copy_stream_upload_mode_never_buffers_more_than_one_chunk():
+def test_copy_stream_upload_mode_never_buffers_more_than_one_chunk(monkeypatch):
+    patch_upload_credentials(monkeypatch)
     pool = FakePool(copy_blocks=[b'aaaa', b'bbbb', b'cccc', b'dddd', b'eeee', b'ffff'])
     request = valid_upload_copy_request()
     request['resultDelivery']['chunkBytes'] = 4
     request['resultDelivery']['maxBytes'] = 28
     request['limits'] = {'chunkBytes': 4, 'maxBytes': 28, 'maxRowBytes': 32, 'timeoutMs': 5000}
-    max_payload = 0
-    in_flight = 0
+    fake = FakeUploadClient()
+    events = []
 
-    def emit(event_type, metadata_json, payload):
-        nonlocal max_payload, in_flight
-        if event_type == 'data':
-            in_flight += 1
-            assert in_flight == 1
-            max_payload = max(max_payload, len(payload))
-            in_flight -= 1
+    _execute_upload_stream(request, make_check(pool=pool), lambda *event: events.append(event), http_client=fake)
 
-    execute_agent_rpc_stream_copy(json.dumps(request), make_check(pool=pool), emit)
-
-    assert max_payload <= 4
+    # Bulk data goes directly to the intake via HTTP, not through the emit callback.
+    assert [event[0] for event in events] == ['metadata', 'final']
+    assert all(len(call[1]) <= 4 for call in fake.put_calls)
+    assert sum(len(call[1]) for call in fake.put_calls) == 24
+    assert len(fake.put_calls) == 6
+    assert fake.finalize_calls == 1
 
 
 def test_copy_stream_upload_mode_emits_stable_sequence_and_sha256_for_idempotent_retry():
@@ -925,52 +971,93 @@ def test_copy_stream_upload_mode_emits_query_failed_and_no_receipt_on_copy_failu
     assert pool.closed_copies == 1
 
 
-def test_copy_stream_upload_mode_rejects_secret_fields_before_pool_access():
+def test_copy_stream_upload_mode_accepts_baseurl_and_token():
     pool = FakePool(copy_blocks=[b'abcdefgh'])
     request = valid_upload_copy_request()
-    request['resultDelivery']['baseUrl'] = 'https://dd.datad0g.com/api/intake/its-agent-intake/uploads/upload-01k'
+    request['resultDelivery']['baseUrl'] = 'https://dd.datad0g.com/api/unstable/its-agent-intake'
     request['resultDelivery']['token'] = 'scoped-upload-token'
 
     events = collect_copy_events(request, make_check(pool=pool))
 
-    assert_failed_event(events, 'invalid_request', 'baseUrl')
-    assert 'scoped-upload-token' not in str(events)
-    assert pool.requested_dbnames == []
+    # baseUrl/token are accepted model fields now; the request proceeds to pool access
+    # and the STARTED metadata does not echo them back.
+    assert event_metadata(events[0])['status'] == 'STARTED'
+    assert 'baseUrl' not in event_metadata(events[0])['resultDelivery']
+    assert 'token' not in event_metadata(events[0])['resultDelivery']
+    assert pool.requested_dbnames != []
 
 
-def test_agent_rpc_stream_copy_upload_mode_adapts_to_binary_safe_callback():
+def test_agent_rpc_stream_copy_upload_mode_uploads_chunks_directly(monkeypatch):
+    patch_upload_credentials(monkeypatch)
     pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop', b'qr'])
+    fake = FakeUploadClient(
+        finalize_resp={
+            'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+            'upload_id': 'upload-01k',
+            'bucket_name': 'rq-bucket',
+            'manifest_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/manifest.json',
+            'total_bytes': 18,
+            'total_rows': 0,
+            'chunk_count': 3,
+            'sha256': 'aggregate-sha',
+            'format': 'csv',
+            'compression': 'none',
+            'finalized_at': '2026-08-20T00:00:00Z',
+        }
+    )
     events = []
 
-    execute_agent_rpc_stream_copy(
-        json.dumps(valid_upload_copy_request()), make_check(pool=pool), lambda *event: events.append(event)
+    _execute_upload_stream(
+        valid_upload_copy_request(), make_check(pool=pool), lambda *event: events.append(event), http_client=fake
     )
 
-    assert [event[0] for event in events] == ['metadata', 'data', 'data', 'data', 'final']
+    # Only metadata and final reach the emit callback; bulk data goes directly via HTTP.
+    assert [event[0] for event in events] == ['metadata', 'final']
     started = json.loads(events[0][1])
+    assert started['status'] == 'STARTED'
     assert 'baseUrl' not in started['resultDelivery']
     assert 'token' not in started['resultDelivery']
-    assert json.loads(events[1][1])['sha256'] == hashlib.sha256(events[1][2]).hexdigest()
-    assert events[1][2] == b'abcdefgh'
-    receipt = json.loads(events[-1][1])['uploadReceipt']
-    assert receipt['chunkCount'] == 3
-    assert receipt['totalBytes'] == 18
+
+    # Three chunks uploaded directly, each with its sha256 and byte count.
+    assert len(fake.put_calls) == 3
+    assert [call[0] for call in fake.put_calls] == [0, 1, 2]
+    for _index, payload, sha256_hex, _rows in fake.put_calls:
+        assert sha256_hex == hashlib.sha256(payload).hexdigest()
+    assert fake.finalize_calls == 1
+    assert fake.abort_calls == 0
+
+    # The final receipt is the Agent-shaped camelCase receipt carried under the
+    # server-expected snake_case outer key.
+    receipt = json.loads(events[-1][1])['upload_receipt']
+    assert receipt == {
+        'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+        'uploadId': 'upload-01k',
+        'bucketName': 'rq-bucket',
+        'manifestPath': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/manifest.json',
+        'totalBytes': 18,
+        'totalRows': 0,
+        'chunkCount': 3,
+        'sha256': 'aggregate-sha',
+    }
 
 
-def test_agent_rpc_stream_copy_upload_mode_stops_on_callback_failure_without_retry():
+def test_copy_stream_upload_mode_stops_on_http_failure_and_aborts(monkeypatch):
+    patch_upload_credentials(monkeypatch)
     pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop', b'qrstuvwx'])
-    attempted = []
+    fake = FakeUploadClient(
+        raise_on_put=remote_query._CopyStreamFailure('upload_failed', 'transient exhausted', retryable=True)
+    )
+    events = []
 
-    def emit(event_type, metadata_json, payload):
-        attempted.append((event_type, metadata_json, payload))
-        if event_type == 'data' and json.loads(metadata_json)['sequence'] == 1:
-            raise RuntimeError('upload chunk failed')
+    _execute_upload_stream(
+        valid_upload_copy_request(), make_check(pool=pool), lambda *event: events.append(event), http_client=fake
+    )
 
-    with pytest.raises(RuntimeError, match='upload chunk failed'):
-        execute_agent_rpc_stream_copy(json.dumps(valid_upload_copy_request()), make_check(pool=pool), emit)
-
-    data_attempted = [event for event in attempted if event[0] == 'data']
-    assert [json.loads(event[1])['sequence'] for event in data_attempted] == [0, 1]
+    # The first chunk upload fails; an error event is emitted and the session is aborted.
+    assert len(fake.put_calls) == 1
+    assert fake.abort_calls == 1
+    assert events[-1][0] == 'error'
+    assert json.loads(events[-1][1])['error']['code'] == 'upload_failed'
     assert pool.closed_copies == 1
     assert pool.cursors[0].executed[-1] == ('ROLLBACK', None)
 
@@ -979,8 +1066,8 @@ def test_agent_rpc_stream_copy_upload_mode_stops_on_callback_failure_without_ret
     'mutation, expected',
     [
         ({'apiKey': 'SECRET_API_KEY'}, 'apiKey'),
-        ({'baseUrl': 'https://dd.datad0g.com/'}, 'baseUrl'),
-        ({'token': 'scoped-upload-token'}, 'token'),
+        ({'baseUrl': ''}, 'baseUrl'),
+        ({'token': ''}, 'token'),
         ({'mode': 'PRESIGNED_URL'}, 'mode'),
         ({'format': 'json'}, 'format'),
         ({'compression': 'gzip'}, 'compression'),

--- a/postgres/tests/test_remote_query.py
+++ b/postgres/tests/test_remote_query.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import hashlib
 import json
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -18,11 +19,12 @@ from datadog_checks.postgres.remote_query import (
 
 
 class FakePool:
-    def __init__(self, rows=None, description=None, closed=False, copy_blocks=None):
+    def __init__(self, rows=None, description=None, closed=False, copy_blocks=None, copy_error=None):
         self.rows = rows or [(1,)]
         self.description = description or [SimpleNamespace(name='value')]
         self.closed = closed
         self.copy_blocks = copy_blocks or []
+        self.copy_error = copy_error
         self.requested_dbnames = []
         self.closed_copies = 0
         self.cursors = []
@@ -33,28 +35,30 @@ class FakePool:
     @contextmanager
     def get_connection(self, dbname):
         self.requested_dbnames.append(dbname)
-        yield FakeConnection(self.rows, self.description, self.copy_blocks, self)
+        yield FakeConnection(self.rows, self.description, self.copy_blocks, self, self.copy_error)
 
 
 class FakeConnection:
-    def __init__(self, rows, description, copy_blocks, pool):
+    def __init__(self, rows, description, copy_blocks, pool, copy_error=None):
         self.rows = rows
         self.description = description
         self.copy_blocks = copy_blocks
+        self.copy_error = copy_error
         self.pool = pool
 
     @contextmanager
     def cursor(self):
-        cursor = FakeCursor(self.rows, self.description, self.copy_blocks, self.pool)
+        cursor = FakeCursor(self.rows, self.description, self.copy_blocks, self.pool, self.copy_error)
         self.pool.cursors.append(cursor)
         yield cursor
 
 
 class FakeCursor:
-    def __init__(self, rows, description, copy_blocks, pool):
+    def __init__(self, rows, description, copy_blocks, pool, copy_error=None):
         self.rows = rows
         self.description = description
         self.copy_blocks = copy_blocks
+        self.copy_error = copy_error
         self.pool = pool
         self.executed = []
 
@@ -66,13 +70,14 @@ class FakeCursor:
 
     def copy(self, query):
         self.executed.append((query, None))
-        return FakeCopy(self.copy_blocks, self.pool)
+        return FakeCopy(self.copy_blocks, self.pool, self.copy_error)
 
 
 class FakeCopy:
-    def __init__(self, blocks, pool):
+    def __init__(self, blocks, pool, copy_error=None):
         self.blocks = blocks
         self.pool = pool
+        self.copy_error = copy_error
 
     def __enter__(self):
         return self
@@ -81,6 +86,8 @@ class FakeCopy:
         self.pool.closed_copies += 1
 
     def __iter__(self):
+        if self.copy_error is not None:
+            raise self.copy_error
         return iter(self.blocks)
 
 
@@ -118,6 +125,25 @@ def valid_copy_request(host='LOCALHOST.', port=5432, dbname='datadog_test', **ex
 def valid_database_instance_copy_request(database_instance='postgres-dbi', **extra):
     request = valid_copy_request(**extra)
     request['target'] = {'database_instance': database_instance}
+    return request
+
+
+def valid_result_delivery(**extra):
+    result_delivery = {
+        'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+        'uploadId': 'upload-01k',
+        'chunkBytes': 8,
+        'maxBytes': 24,
+        'format': 'csv',
+        'compression': 'none',
+    }
+    result_delivery.update(extra)
+    return result_delivery
+
+
+def valid_upload_copy_request(**extra):
+    request = valid_copy_request(**extra)
+    request['resultDelivery'] = valid_result_delivery()
     return request
 
 
@@ -734,3 +760,297 @@ def test_agent_rpc_stream_copy_closes_copy_when_callback_raises():
     assert [event[0] for event in events] == ['metadata', 'data']
     assert pool.closed_copies == 1
     assert pool.cursors[0].executed[-1] == ('ROLLBACK', None)
+
+
+def test_copy_stream_upload_mode_emits_started_result_delivery_data_sha256_and_receipt():
+    pool = FakePool(copy_blocks=[b'abc', b'defgh', b'ijklmnop', b'qr'])
+    check = block_existing_query_helpers(make_check(pool=pool))
+    request = valid_upload_copy_request()
+
+    events = collect_copy_events(request, check)
+
+    assert events[0].event_type == 'metadata'
+    started = event_metadata(events[0])
+    assert started['status'] == 'STARTED'
+    assert started['resultDelivery']['mode'] == 'POC_PUBLIC_CHUNKED_UPLOAD'
+    assert started['resultDelivery']['uploadId'] == 'upload-01k'
+    assert started['resultDelivery']['chunkBytes'] == 8
+    assert started['resultDelivery']['maxBytes'] == 24
+    assert 'baseUrl' not in started['resultDelivery']
+    assert 'token' not in started['resultDelivery']
+    assert started['chunkBytes'] == 8
+    assert started['maxBytes'] == 24
+    assert started['maxRowBytes'] == 32
+
+    data_events = [event for event in events if event.event_type == 'data']
+    assert [event_metadata(event)['sequence'] for event in data_events] == [0, 1, 2]
+    assert [event_metadata(event)['bytes'] for event in data_events] == [8, 8, 2]
+    for event in data_events:
+        payload = event_payload(event)
+        assert event_metadata(event)['sha256'] == hashlib.sha256(payload).hexdigest()
+        assert len(payload) <= 8
+    assert events[-1].event_type == 'final'
+    assert event_metadata(events[-1])['uploadReceipt'] == {
+        'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+        'uploadId': 'upload-01k',
+        'totalBytes': 18,
+        'chunkCount': 3,
+    }
+    assert event_metadata(events[-1])['stats']['bytesEmitted'] == 18
+    assert event_metadata(events[-1])['stats']['chunksEmitted'] == 3
+    assert pool.closed_copies == 1
+
+
+def test_copy_stream_omitted_result_delivery_keeps_inline_streaming_behavior():
+    pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop', b'qr'])
+    request = valid_copy_request()
+
+    events = collect_copy_events(request, make_check(pool=pool))
+
+    assert 'resultDelivery' not in event_metadata(events[0])
+    data_events = [event for event in events if event.event_type == 'data']
+    for event in data_events:
+        assert 'sha256' not in event_metadata(event)
+    assert 'uploadReceipt' not in event_metadata(events[-1])
+    assert event_metadata(events[-1])['status'] == 'SUCCEEDED'
+
+
+def test_copy_stream_upload_mode_enforces_result_delivery_max_bytes():
+    pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop'])
+    request = valid_upload_copy_request()
+    request['resultDelivery']['maxBytes'] = 10
+
+    events = collect_copy_events(request, make_check(pool=pool))
+
+    data_events = [event for event in events if event.event_type == 'data']
+    assert [event_payload(event) for event in data_events] == [b'abcdefgh', b'ij']
+    assert sum(event_metadata(event)['bytes'] for event in data_events) == 10
+    assert_failed_event(events, 'max_bytes_exceeded')
+    assert event_metadata(events[-1])['stats']['bytesEmitted'] == 10
+    assert 'uploadReceipt' not in event_metadata(events[-1])
+    assert pool.closed_copies == 1
+
+
+def test_copy_stream_upload_mode_enforces_timeout(monkeypatch):
+    pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop'])
+    request = valid_upload_copy_request()
+    request['limits']['timeoutMs'] = 1000
+    values = iter([0.0, 0.0, 0.0] + [10.0] * 50)
+    monkeypatch.setattr(remote_query.time, 'monotonic', lambda: next(values))
+
+    events = collect_copy_events(request, make_check(pool=pool))
+
+    data_events = [event for event in events if event.event_type == 'data']
+    assert [event_payload(event) for event in data_events] == [b'abcdefgh']
+    assert_failed_event(events, 'timeout')
+    assert event_metadata(events[-1])['error']['retryable'] is True
+    assert 'uploadReceipt' not in event_metadata(events[-1])
+    assert pool.closed_copies == 1
+
+
+def test_copy_stream_upload_mode_rejects_binary_format_mismatch_with_result_delivery():
+    arbitrary_bytes = b'PGCOPY\n\xff\r\n\x00\x00\xff\x80abc\n'
+    pool = FakePool(copy_blocks=[arbitrary_bytes])
+    request = valid_upload_copy_request()
+    request['format'] = 'binary'
+    request['query'] = "SELECT decode('00ff80', 'hex') AS payload"
+    request['resultDelivery']['chunkBytes'] = 1024
+    request['resultDelivery']['maxBytes'] = 4096
+    request['limits'] = {'chunkBytes': 1024, 'maxBytes': 4096, 'maxRowBytes': 4096, 'timeoutMs': 5000}
+
+    events = list(iter_agent_rpc_stream_copy_events(request, ExplodingRegistry()))
+
+    assert_failed_event(events, 'invalid_request', 'format must match resultDelivery.format')
+    assert pool.requested_dbnames == []
+
+
+def test_copy_stream_upload_mode_accepts_csv_format_matching_result_delivery():
+    pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop', b'qr'])
+    request = valid_upload_copy_request()
+    request['format'] = 'csv'
+    request['resultDelivery']['format'] = 'csv'
+
+    events = collect_copy_events(request, make_check(pool=pool))
+
+    assert event_metadata(events[0])['format'] == 'csv'
+    assert event_metadata(events[0])['resultDelivery']['format'] == 'csv'
+    assert event_metadata(events[-1])['status'] == 'SUCCEEDED'
+
+
+def test_copy_stream_upload_mode_never_buffers_more_than_one_chunk():
+    pool = FakePool(copy_blocks=[b'aaaa', b'bbbb', b'cccc', b'dddd', b'eeee', b'ffff'])
+    request = valid_upload_copy_request()
+    request['resultDelivery']['chunkBytes'] = 4
+    request['resultDelivery']['maxBytes'] = 28
+    request['limits'] = {'chunkBytes': 4, 'maxBytes': 28, 'maxRowBytes': 32, 'timeoutMs': 5000}
+    max_payload = 0
+    in_flight = 0
+
+    def emit(event_type, metadata_json, payload):
+        nonlocal max_payload, in_flight
+        if event_type == 'data':
+            in_flight += 1
+            assert in_flight == 1
+            max_payload = max(max_payload, len(payload))
+            in_flight -= 1
+
+    execute_agent_rpc_stream_copy(json.dumps(request), make_check(pool=pool), emit)
+
+    assert max_payload <= 4
+
+
+def test_copy_stream_upload_mode_emits_stable_sequence_and_sha256_for_idempotent_retry():
+    blocks = [b'abcdefgh', b'ijklmnop', b'qr']
+    request = valid_upload_copy_request()
+    events = collect_copy_events(request, make_check(pool=FakePool(copy_blocks=blocks)))
+    data_events = [event for event in events if event.event_type == 'data']
+    sequences = [event_metadata(event)['sequence'] for event in data_events]
+    assert sequences == list(range(len(data_events)))
+    checksums = [event_metadata(event)['sha256'] for event in data_events]
+
+    replayed = collect_copy_events(request, make_check(pool=FakePool(copy_blocks=blocks)))
+    replayed_data = [event for event in replayed if event.event_type == 'data']
+    assert [event_metadata(event)['sequence'] for event in replayed_data] == sequences
+    assert [event_metadata(event)['sha256'] for event in replayed_data] == checksums
+
+
+def test_copy_stream_upload_mode_emits_query_failed_and_no_receipt_on_copy_failure():
+    pool = FakePool(copy_blocks=[], copy_error=Exception('copy stream broke'))
+    request = valid_upload_copy_request()
+
+    events = collect_copy_events(request, make_check(pool=pool))
+
+    assert_failed_event(events, 'query_failed')
+    assert 'uploadReceipt' not in event_metadata(events[-1])
+    assert pool.closed_copies == 1
+
+
+def test_copy_stream_upload_mode_rejects_secret_fields_before_pool_access():
+    pool = FakePool(copy_blocks=[b'abcdefgh'])
+    request = valid_upload_copy_request()
+    request['resultDelivery']['baseUrl'] = 'https://dd.datad0g.com/api/intake/its-agent-intake/uploads/upload-01k'
+    request['resultDelivery']['token'] = 'scoped-upload-token'
+
+    events = collect_copy_events(request, make_check(pool=pool))
+
+    assert_failed_event(events, 'invalid_request', 'baseUrl')
+    assert 'scoped-upload-token' not in str(events)
+    assert pool.requested_dbnames == []
+
+
+def test_agent_rpc_stream_copy_upload_mode_adapts_to_binary_safe_callback():
+    pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop', b'qr'])
+    events = []
+
+    execute_agent_rpc_stream_copy(
+        json.dumps(valid_upload_copy_request()), make_check(pool=pool), lambda *event: events.append(event)
+    )
+
+    assert [event[0] for event in events] == ['metadata', 'data', 'data', 'data', 'final']
+    started = json.loads(events[0][1])
+    assert 'baseUrl' not in started['resultDelivery']
+    assert 'token' not in started['resultDelivery']
+    assert json.loads(events[1][1])['sha256'] == hashlib.sha256(events[1][2]).hexdigest()
+    assert events[1][2] == b'abcdefgh'
+    receipt = json.loads(events[-1][1])['uploadReceipt']
+    assert receipt['chunkCount'] == 3
+    assert receipt['totalBytes'] == 18
+
+
+def test_agent_rpc_stream_copy_upload_mode_stops_on_callback_failure_without_retry():
+    pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop', b'qrstuvwx'])
+    attempted = []
+
+    def emit(event_type, metadata_json, payload):
+        attempted.append((event_type, metadata_json, payload))
+        if event_type == 'data' and json.loads(metadata_json)['sequence'] == 1:
+            raise RuntimeError('upload chunk failed')
+
+    with pytest.raises(RuntimeError, match='upload chunk failed'):
+        execute_agent_rpc_stream_copy(json.dumps(valid_upload_copy_request()), make_check(pool=pool), emit)
+
+    data_attempted = [event for event in attempted if event[0] == 'data']
+    assert [json.loads(event[1])['sequence'] for event in data_attempted] == [0, 1]
+    assert pool.closed_copies == 1
+    assert pool.cursors[0].executed[-1] == ('ROLLBACK', None)
+
+
+@pytest.mark.parametrize(
+    'mutation, expected',
+    [
+        ({'apiKey': 'SECRET_API_KEY'}, 'apiKey'),
+        ({'baseUrl': 'https://dd.datad0g.com/'}, 'baseUrl'),
+        ({'token': 'scoped-upload-token'}, 'token'),
+        ({'mode': 'PRESIGNED_URL'}, 'mode'),
+        ({'format': 'json'}, 'format'),
+        ({'compression': 'gzip'}, 'compression'),
+        ({'chunkBytes': 0}, 'chunkBytes'),
+        ({'maxBytes': 0}, 'maxBytes'),
+        ({'chunkBytes': '8'}, 'chunkBytes'),
+        ({'chunkBytes': 64, 'maxBytes': 32}, 'chunkBytes must not exceed maxBytes'),
+    ],
+)
+def test_copy_stream_upload_mode_rejects_invalid_result_delivery(mutation, expected):
+    request = valid_upload_copy_request()
+    request['resultDelivery'].update(mutation)
+    events = list(iter_agent_rpc_stream_copy_events(request, ExplodingRegistry()))
+    assert_failed_event(events, 'invalid_request', expected)
+    assert 'SECRET_API_KEY' not in str(events)
+    assert 'scoped-upload-token' not in str(events)
+
+
+def test_copy_stream_upload_mode_rejects_missing_upload_id():
+    request = valid_upload_copy_request()
+    del request['resultDelivery']['uploadId']
+    events = list(iter_agent_rpc_stream_copy_events(request, ExplodingRegistry()))
+    assert_failed_event(events, 'invalid_request', 'uploadId')
+
+
+@pytest.mark.parametrize(
+    'delivery, limits, expected',
+    [
+        (
+            {'chunkBytes': 16},
+            {'chunkBytes': 8, 'maxBytes': 64},
+            'resultDelivery.chunkBytes must not exceed limits.chunkBytes',
+        ),
+        (
+            {'maxBytes': 128},
+            {'chunkBytes': 8, 'maxBytes': 64},
+            'resultDelivery.maxBytes must not exceed limits.maxBytes',
+        ),
+    ],
+)
+def test_copy_stream_upload_mode_rejects_upload_cap_widening(delivery, limits, expected):
+    request = valid_upload_copy_request()
+    request['resultDelivery'].update(delivery)
+    request['limits'].update(limits)
+    events = list(iter_agent_rpc_stream_copy_events(request, ExplodingRegistry()))
+    assert_failed_event(events, 'invalid_request', expected)
+
+
+def test_copy_stream_upload_mode_accepts_equal_upload_caps():
+    pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop', b'qr'])
+    request = valid_upload_copy_request()
+    request['resultDelivery']['chunkBytes'] = 8
+    request['resultDelivery']['maxBytes'] = 64
+    request['limits'] = {'chunkBytes': 8, 'maxBytes': 64, 'maxRowBytes': 32, 'timeoutMs': 5000}
+
+    events = collect_copy_events(request, make_check(pool=pool))
+
+    assert event_metadata(events[-1])['status'] == 'SUCCEEDED'
+    assert event_metadata(events[-1])['uploadReceipt']['totalBytes'] == 18
+
+
+def test_copy_stream_upload_mode_enforces_smaller_upload_cap_over_wider_limit():
+    pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop', b'qrstuvwx'])
+    request = valid_upload_copy_request()
+    request['resultDelivery']['maxBytes'] = 16
+    request['limits'] = {'chunkBytes': 8, 'maxBytes': 64, 'maxRowBytes': 32, 'timeoutMs': 5000}
+
+    events = collect_copy_events(request, make_check(pool=pool))
+
+    data_events = [event for event in events if event.event_type == 'data']
+    assert sum(event_metadata(event)['bytes'] for event in data_events) == 16
+    assert_failed_event(events, 'max_bytes_exceeded')
+    assert event_metadata(events[-1])['stats']['bytesEmitted'] == 16


### PR DESCRIPTION
## Stack

- Base: `nubtron/remote-queries-poc`
- This draft: production Postgres COPY-to-Agent relay bridge

## Summary

- stream CSV COPY chunks synchronously through the native Agent callback
- enforce bounded backpressure and result-delivery caps
- return receipt-only metadata in upload mode
- keep Agent-owned credentials and intake routing out of Python
- preserve the ordinary small-result behavior when upload mode is omitted

## Validation

- 129 focused tests passed
- lint passed
- independently reviewed

## Deployment

Used only by the local Remote Queries intake proof setup; no shared deployment.