### PR TITLE
postgres: add deterministic Remote Queries COPY relay proofs

### DIFF
--- a/postgres/datadog_checks/postgres/remote_query.py
+++ b/postgres/datadog_checks/postgres/remote_query.py
@@ -182,13 +182,14 @@ class RemoteQueryCopyRequest(BaseModel):
         return self
 
     @model_validator(mode='after')
-    def validate_part_within_limits(self) -> 'RemoteQueryCopyRequest':
-        # The upload caps must not widen the caller/backend COPY safety caps. Fail closed so a
+    def validate_max_within_limits(self) -> 'RemoteQueryCopyRequest':
+        # The upload byte cap must not widen the caller/backend COPY safety cap. Fail closed so a
         # backend-injected resultDelivery cannot raise the integration's configured byte ceiling;
-        # equal or smaller upload caps are accepted.
+        # an equal or smaller upload maxBytes is accepted. ``partBytes`` (the multipart part size)
+        # and ``limits.chunkBytes`` (the COPY streaming chunk size) are distinct concepts, so
+        # partBytes may exceed chunkBytes: the COPY stream emits chunkBytes-sized events that the
+        # upload client aggregates into partBytes-sized parts.
         if self.result_delivery is not None:
-            if self.result_delivery.part_bytes > self.limits.chunk_bytes:
-                raise ValueError('resultDelivery.partBytes must not exceed limits.chunkBytes')
             if self.result_delivery.max_bytes > self.limits.max_bytes:
                 raise ValueError('resultDelivery.maxBytes must not exceed limits.maxBytes')
         return self
@@ -343,13 +344,12 @@ def _dbname_from_check(check: 'PostgreSql') -> str | None:
 
 def _started_metadata(request: RemoteQueryCopyRequest) -> dict[str, Any]:
     result_delivery = request.result_delivery
-    chunk_bytes = result_delivery.part_bytes if result_delivery is not None else request.limits.chunk_bytes
     max_bytes = result_delivery.max_bytes if result_delivery is not None else request.limits.max_bytes
     metadata: dict[str, Any] = {
         'status': 'STARTED',
         'format': request.format,
         'operation': request.operation,
-        'chunkBytes': chunk_bytes,
+        'chunkBytes': request.limits.chunk_bytes,
         'maxBytes': max_bytes,
         'maxRowBytes': request.limits.max_row_bytes,
     }
@@ -378,7 +378,7 @@ def _succeeded_metadata(state: _CopyStreamState, started_at: float, request: Rem
             'mode': result_delivery.mode,
             'uploadId': result_delivery.upload_id,
             'totalBytes': state.bytes_emitted,
-            'partCount': state.chunks_emitted,
+            'partCount': _multipart_part_count(state.bytes_emitted, result_delivery.part_bytes),
         }
     return metadata
 
@@ -442,7 +442,7 @@ def _copy_stream_data_events(
 ) -> Iterator[tuple[CopyStreamEvent, _CopyStreamState]]:
     limits = request.limits
     result_delivery = request.result_delivery
-    chunk_bytes = result_delivery.part_bytes if result_delivery is not None else limits.chunk_bytes
+    chunk_bytes = limits.chunk_bytes
     max_bytes = result_delivery.max_bytes if result_delivery is not None else limits.max_bytes
     max_row_bytes = limits.max_row_bytes
     timeout_ms = limits.timeout_ms
@@ -758,6 +758,14 @@ def _count_newlines(payload: bytes) -> int:
     return payload.count(b'\n')
 
 
+def _multipart_part_count(total_bytes: int, part_bytes: int) -> int:
+    # Number of multipart parts for ``total_bytes`` aggregated at ``part_bytes``: full parts of
+    # exactly partBytes plus a final short part, or zero parts for an empty result.
+    if total_bytes <= 0:
+        return 0
+    return (total_bytes + part_bytes - 1) // part_bytes
+
+
 def _intake_receipt_to_camel(resp: Mapping[str, Any]) -> dict[str, Any]:
     return {
         'mode': resp.get('mode', 'POC_PUBLIC_MULTIPART_UPLOAD'),
@@ -780,12 +788,52 @@ def _safe_abort(client: _UploadClient, creds: _UploadCredentials) -> None:
         LOGGER.debug('Remote query upload abort failed (best-effort)', exc_info=True)
 
 
-def _upload_one_part(client: _UploadClient, creds: _UploadCredentials, event: CopyStreamEvent) -> None:
-    metadata = event.metadata
-    # Part numbers are contiguous and 1-based to match provider multipart conventions; the
-    # iterator's 0-based sequence maps directly to a 1-based part number.
-    part_number = metadata['sequence'] + 1
-    client.put_part(creds, part_number, event.payload, metadata['sha256'], _count_newlines(event.payload))
+@dataclass(frozen=True)
+class _MultipartPart:
+    part_number: int
+    payload: bytes
+
+
+class _MultipartBuffer:
+    """Aggregate COPY chunk bytes into server-clamped multipart parts.
+
+    The COPY stream emits ``limits.chunkBytes``-sized chunks; this buffer accumulates them into
+    ``partBytes``-sized parts (the multipart part size), which may exceed the COPY chunk size.
+    At most one part is buffered at a time. Part numbers are contiguous and 1-based to match
+    provider multipart conventions.
+    """
+
+    def __init__(self, part_bytes: int) -> None:
+        self._part_bytes = part_bytes
+        self._pending = bytearray()
+        self._next_part_number = 1
+
+    def extend(self, data: bytes) -> None:
+        self._pending.extend(data)
+
+    def _take(self) -> _MultipartPart:
+        payload = bytes(self._pending[: self._part_bytes])
+        del self._pending[: self._part_bytes]
+        part = _MultipartPart(self._next_part_number, payload)
+        self._next_part_number += 1
+        return part
+
+    def full_parts(self) -> Iterator[_MultipartPart]:
+        while len(self._pending) >= self._part_bytes:
+            yield self._take()
+
+    def flush_final(self) -> _MultipartPart | None:
+        if not self._pending:
+            return None
+        return self._take()
+
+
+def _upload_one_part(client: _UploadClient, creds: _UploadCredentials, part: _MultipartPart) -> None:
+    # The part SHA-256 is over the aggregated part body (all chunks combined), not the
+    # individual COPY chunks, so the intake can verify the part it receives.
+    client.put_part(
+        creds, part.part_number, part.payload, hashlib.sha256(part.payload).hexdigest(), _count_newlines(part.payload)
+    )
 
 
 def _finalize_upload(
@@ -819,11 +867,25 @@ def _execute_upload_stream(
         return
     client = http_client if http_client is not None else _default_upload_client()
     events = iter_agent_rpc_stream_copy_events(request, StaticPostgresCheckRegistry([check]))
+    buffer: _MultipartBuffer | None = None
     try:
         for event in events:
-            if event.event_type == 'data':
-                _upload_one_part(client, creds, event)
+            if event.event_type == 'metadata':
+                # The STARTED metadata carries the backend-validated partBytes; the COPY stream
+                # emits chunkBytes-sized events that this client aggregates into partBytes parts.
+                delivery_meta = event.metadata.get('resultDelivery') or {}
+                buffer = _MultipartBuffer(int(delivery_meta.get('partBytes') or 0))
+                _emit_copy_event(emit, event)
+            elif event.event_type == 'data':
+                if buffer is not None:
+                    buffer.extend(event.payload)
+                    for part in buffer.full_parts():
+                        _upload_one_part(client, creds, part)
             elif event.event_type == 'final':
+                if buffer is not None:
+                    final_part = buffer.flush_final()
+                    if final_part is not None:
+                        _upload_one_part(client, creds, final_part)
                 _finalize_upload(client, creds, event, emit)
             elif event.event_type == 'error':
                 _safe_abort(client, creds)

--- a/postgres/datadog_checks/postgres/remote_query.py
+++ b/postgres/datadog_checks/postgres/remote_query.py
@@ -46,7 +46,7 @@ REMOTE_QUERY_COPY_SQL_ALLOWLIST = frozenset(
 )
 
 CopyStreamFormat = Literal['csv', 'binary']
-ResultDeliveryMode = Literal['POC_PUBLIC_CHUNKED_UPLOAD']
+ResultDeliveryMode = Literal['POC_PUBLIC_MULTIPART_UPLOAD']
 ResultDeliveryFormat = Literal['csv']
 ResultDeliveryCompression = Literal['none']
 CopyStreamEmit = Callable[[str, str, bytes], None]
@@ -138,7 +138,7 @@ class RemoteQueryResultDelivery(BaseModel):
     HTTP. The Agent forwards the intake base URL and scoped upload token here; the integration
     reads the org API key and POC application key from Agent config via ``datadog_agent.get_config``
     and attaches them to its own HTTP upload requests. The integration performs the HTTP upload
-    itself; bulk chunk bytes never traverse the native emit bridge, AgentSecure, PAR, or AP action
+    itself; bulk part bytes never traverse the native emit bridge, AgentSecure, PAR, or AP action
     output. Omitting ``resultDelivery`` keeps the existing inline streaming behavior unchanged.
     """
 
@@ -148,15 +148,15 @@ class RemoteQueryResultDelivery(BaseModel):
     upload_id: StrictStr = Field(alias='uploadId', min_length=1)
     base_url: StrictStr = Field(alias='baseUrl', min_length=1)
     token: StrictStr = Field(alias='token', min_length=1)
-    chunk_bytes: StrictInt = Field(alias='chunkBytes', ge=1)
+    part_bytes: StrictInt = Field(alias='partBytes', ge=1)
     max_bytes: StrictInt = Field(alias='maxBytes', ge=1)
     format: ResultDeliveryFormat = 'csv'
     compression: ResultDeliveryCompression = 'none'
 
     @model_validator(mode='after')
-    def validate_chunk_within_max(self) -> 'RemoteQueryResultDelivery':
-        if self.chunk_bytes > self.max_bytes:
-            raise ValueError('chunkBytes must not exceed maxBytes')
+    def validate_part_within_max(self) -> 'RemoteQueryResultDelivery':
+        if self.part_bytes > self.max_bytes:
+            raise ValueError('partBytes must not exceed maxBytes')
         return self
 
 
@@ -175,20 +175,20 @@ class RemoteQueryCopyRequest(BaseModel):
     @model_validator(mode='after')
     def validate_format_consistency(self) -> 'RemoteQueryCopyRequest':
         # When resultDelivery is present, the COPY stream format must match the upload format so the
-        # emitted bytes and the manifest agree. The current contract allows only ``csv`` for upload,
-        # so upload mode is CSV-only; a ``binary`` COPY stream with a ``csv`` upload is rejected.
+        # emitted bytes and the finalized object agree. The current contract allows only ``csv`` for
+        # upload, so upload mode is CSV-only; a ``binary`` COPY stream with a ``csv`` upload is rejected.
         if self.result_delivery is not None and self.format != self.result_delivery.format:
             raise ValueError('format must match resultDelivery.format when resultDelivery is present')
         return self
 
     @model_validator(mode='after')
-    def validate_chunk_within_limits(self) -> 'RemoteQueryCopyRequest':
+    def validate_part_within_limits(self) -> 'RemoteQueryCopyRequest':
         # The upload caps must not widen the caller/backend COPY safety caps. Fail closed so a
         # backend-injected resultDelivery cannot raise the integration's configured byte ceiling;
         # equal or smaller upload caps are accepted.
         if self.result_delivery is not None:
-            if self.result_delivery.chunk_bytes > self.limits.chunk_bytes:
-                raise ValueError('resultDelivery.chunkBytes must not exceed limits.chunkBytes')
+            if self.result_delivery.part_bytes > self.limits.chunk_bytes:
+                raise ValueError('resultDelivery.partBytes must not exceed limits.chunkBytes')
             if self.result_delivery.max_bytes > self.limits.max_bytes:
                 raise ValueError('resultDelivery.maxBytes must not exceed limits.maxBytes')
         return self
@@ -343,7 +343,7 @@ def _dbname_from_check(check: 'PostgreSql') -> str | None:
 
 def _started_metadata(request: RemoteQueryCopyRequest) -> dict[str, Any]:
     result_delivery = request.result_delivery
-    chunk_bytes = result_delivery.chunk_bytes if result_delivery is not None else request.limits.chunk_bytes
+    chunk_bytes = result_delivery.part_bytes if result_delivery is not None else request.limits.chunk_bytes
     max_bytes = result_delivery.max_bytes if result_delivery is not None else request.limits.max_bytes
     metadata: dict[str, Any] = {
         'status': 'STARTED',
@@ -357,7 +357,7 @@ def _started_metadata(request: RemoteQueryCopyRequest) -> dict[str, Any]:
         metadata['resultDelivery'] = {
             'mode': result_delivery.mode,
             'uploadId': result_delivery.upload_id,
-            'chunkBytes': result_delivery.chunk_bytes,
+            'partBytes': result_delivery.part_bytes,
             'maxBytes': result_delivery.max_bytes,
             'format': result_delivery.format,
             'compression': result_delivery.compression,
@@ -370,15 +370,15 @@ def _succeeded_metadata(state: _CopyStreamState, started_at: float, request: Rem
     result_delivery = request.result_delivery
     if result_delivery is not None:
         # Provisional receipt aligned to the Agent-owned uploadReceipt shape
-        # {mode, uploadId, bucketName, manifestPath, totalBytes, totalRows, chunkCount, sha256}.
+        # {mode, uploadId, bucketName, objectPath, totalBytes, totalRows, partCount, sha256}.
         # Python owns only the fields it can compute from the byte stream; the Agent Go side
-        # enriches it with bucketName, manifestPath, totalRows, and the aggregate sha256 after
+        # enriches it with bucketName, objectPath, totalRows, and the aggregate sha256 after
         # it finalizes the upload session.
         metadata['uploadReceipt'] = {
             'mode': result_delivery.mode,
             'uploadId': result_delivery.upload_id,
             'totalBytes': state.bytes_emitted,
-            'chunkCount': state.chunks_emitted,
+            'partCount': state.chunks_emitted,
         }
     return metadata
 
@@ -442,7 +442,7 @@ def _copy_stream_data_events(
 ) -> Iterator[tuple[CopyStreamEvent, _CopyStreamState]]:
     limits = request.limits
     result_delivery = request.result_delivery
-    chunk_bytes = result_delivery.chunk_bytes if result_delivery is not None else limits.chunk_bytes
+    chunk_bytes = result_delivery.part_bytes if result_delivery is not None else limits.chunk_bytes
     max_bytes = result_delivery.max_bytes if result_delivery is not None else limits.max_bytes
     max_row_bytes = limits.max_row_bytes
     timeout_ms = limits.timeout_ms
@@ -608,13 +608,13 @@ def _validation_location(location: tuple[Any, ...]) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Direct chunked upload to its-agent-intake (POC_PUBLIC_CHUNKED_UPLOAD)
+# Direct multipart upload to its-agent-intake (POC_PUBLIC_MULTIPART_UPLOAD)
 #
-# When resultDelivery is present, the integration uploads bounded COPY chunks
+# When resultDelivery is present, the integration uploads bounded COPY parts
 # directly to its-agent-intake over HTTP. The Agent forwards the intake base
 # URL and scoped upload token in resultDelivery, and the integration reads the
 # org API key and POC application key from Agent config via datadog_agent.get_config.
-# Bulk chunk bytes never traverse the native emit bridge, AgentSecure, PAR, or
+# Bulk part bytes never traverse the native emit bridge, AgentSecure, PAR, or
 # AP action output; only the compact final receipt is emitted back.
 
 REMOTE_QUERY_UPLOAD_HTTP_TIMEOUT_SECONDS = 60
@@ -636,7 +636,9 @@ class _UploadCredentials:
 
 
 class _UploadClient(Protocol):
-    def put_chunk(self, creds: _UploadCredentials, index: int, payload: bytes, sha256_hex: str, rows: int) -> None: ...
+    def put_part(
+        self, creds: _UploadCredentials, part_number: int, payload: bytes, sha256_hex: str, rows: int
+    ) -> None: ...
 
     def finalize(self, creds: _UploadCredentials) -> Mapping[str, Any]: ...
 
@@ -661,12 +663,12 @@ class _RequestsUploadClient:
             headers[REMOTE_QUERY_UPLOAD_TEST_DRIVE_HEADER] = creds.test_drive_selector
         return headers
 
-    def put_chunk(self, creds: _UploadCredentials, index: int, payload: bytes, sha256_hex: str, rows: int) -> None:
+    def put_part(self, creds: _UploadCredentials, part_number: int, payload: bytes, sha256_hex: str, rows: int) -> None:
         headers = self._headers(creds, 'application/octet-stream')
-        headers['X-DD-Chunk-SHA256'] = sha256_hex
-        headers['X-DD-Chunk-Bytes'] = str(len(payload))
-        headers['X-DD-Chunk-Rows'] = str(rows)
-        url = '{}/uploads/{}/chunks/{}'.format(creds.base_url.rstrip('/'), creds.upload_id, index)
+        headers['X-DD-Part-SHA256'] = sha256_hex
+        headers['X-DD-Part-Bytes'] = str(len(payload))
+        headers['X-DD-Part-Rows'] = str(rows)
+        url = '{}/uploads/{}/parts/{}'.format(creds.base_url.rstrip('/'), creds.upload_id, part_number)
         _upload_with_retry('PUT', url, headers, payload)
 
     def finalize(self, creds: _UploadCredentials) -> Mapping[str, Any]:
@@ -721,7 +723,7 @@ def _upload_with_retry(method: str, url: str, headers: Mapping[str, str], body: 
 
 def _is_upload_request(request: Mapping[str, Any]) -> bool:
     delivery = request.get('resultDelivery')
-    return isinstance(delivery, Mapping) and delivery.get('mode') == 'POC_PUBLIC_CHUNKED_UPLOAD'
+    return isinstance(delivery, Mapping) and delivery.get('mode') == 'POC_PUBLIC_MULTIPART_UPLOAD'
 
 
 def _get_agent_config(key: str) -> str:
@@ -758,13 +760,13 @@ def _count_newlines(payload: bytes) -> int:
 
 def _intake_receipt_to_camel(resp: Mapping[str, Any]) -> dict[str, Any]:
     return {
-        'mode': resp.get('mode', 'POC_PUBLIC_CHUNKED_UPLOAD'),
+        'mode': resp.get('mode', 'POC_PUBLIC_MULTIPART_UPLOAD'),
         'uploadId': resp.get('upload_id', ''),
         'bucketName': resp.get('bucket_name', ''),
-        'manifestPath': resp.get('manifest_key', ''),
+        'objectPath': resp.get('object_key', ''),
         'totalBytes': resp.get('total_bytes', 0),
         'totalRows': resp.get('total_rows', 0),
-        'chunkCount': resp.get('chunk_count', 0),
+        'partCount': resp.get('part_count', 0),
         'sha256': resp.get('sha256', ''),
     }
 
@@ -778,9 +780,12 @@ def _safe_abort(client: _UploadClient, creds: _UploadCredentials) -> None:
         LOGGER.debug('Remote query upload abort failed (best-effort)', exc_info=True)
 
 
-def _upload_one_chunk(client: _UploadClient, creds: _UploadCredentials, event: CopyStreamEvent) -> None:
+def _upload_one_part(client: _UploadClient, creds: _UploadCredentials, event: CopyStreamEvent) -> None:
     metadata = event.metadata
-    client.put_chunk(creds, metadata['sequence'], event.payload, metadata['sha256'], _count_newlines(event.payload))
+    # Part numbers are contiguous and 1-based to match provider multipart conventions; the
+    # iterator's 0-based sequence maps directly to a 1-based part number.
+    part_number = metadata['sequence'] + 1
+    client.put_part(creds, part_number, event.payload, metadata['sha256'], _count_newlines(event.payload))
 
 
 def _finalize_upload(
@@ -801,7 +806,7 @@ def _execute_upload_stream(
     emit: CopyStreamEmit,
     http_client: _UploadClient | None = None,
 ) -> None:
-    """Upload COPY chunks directly to its-agent-intake; emit only metadata/final/error events."""
+    """Upload COPY parts directly to its-agent-intake; emit only metadata/final/error events."""
     creds = _resolve_upload_credentials(request)
     if not creds.api_key or not creds.app_key:
         _emit_copy_event(
@@ -817,7 +822,7 @@ def _execute_upload_stream(
     try:
         for event in events:
             if event.event_type == 'data':
-                _upload_one_chunk(client, creds, event)
+                _upload_one_part(client, creds, event)
             elif event.event_type == 'final':
                 _finalize_upload(client, creds, event, emit)
             elif event.event_type == 'error':

--- a/postgres/datadog_checks/postgres/remote_query.py
+++ b/postgres/datadog_checks/postgres/remote_query.py
@@ -45,6 +45,13 @@ REMOTE_QUERY_COPY_SQL_ALLOWLIST = frozenset(
     )
 )
 
+# Server-owned maximums for the POC multipart upload path. The backend selects/clamps these,
+# not the caller. The multipart part size is independent of the COPY read chunk size
+# (limits.chunkBytes); it may be up to 128 MiB. maxBytes must not exceed the caller/backend COPY
+# safety cap (limits.maxBytes).
+REMOTE_QUERY_UPLOAD_MAX_PART_BYTES = 128 * 1024 * 1024
+REMOTE_QUERY_UPLOAD_MAX_TOTAL_BYTES = 10 * 1024 * 1024 * 1024
+
 CopyStreamFormat = Literal['csv', 'binary']
 ResultDeliveryMode = Literal['POC_PUBLIC_MULTIPART_UPLOAD']
 ResultDeliveryFormat = Literal['csv']
@@ -148,8 +155,8 @@ class RemoteQueryResultDelivery(BaseModel):
     upload_id: StrictStr = Field(alias='uploadId', min_length=1)
     base_url: StrictStr = Field(alias='baseUrl', min_length=1)
     token: StrictStr = Field(alias='token', min_length=1)
-    part_bytes: StrictInt = Field(alias='partBytes', ge=1)
-    max_bytes: StrictInt = Field(alias='maxBytes', ge=1)
+    part_bytes: StrictInt = Field(alias='partBytes', ge=1, le=REMOTE_QUERY_UPLOAD_MAX_PART_BYTES)
+    max_bytes: StrictInt = Field(alias='maxBytes', ge=1, le=REMOTE_QUERY_UPLOAD_MAX_TOTAL_BYTES)
     format: ResultDeliveryFormat = 'csv'
     compression: ResultDeliveryCompression = 'none'
 
@@ -617,12 +624,20 @@ def _validation_location(location: tuple[Any, ...]) -> str:
 # Bulk part bytes never traverse the native emit bridge, AgentSecure, PAR, or
 # AP action output; only the compact final receipt is emitted back.
 
-REMOTE_QUERY_UPLOAD_HTTP_TIMEOUT_SECONDS = 60
 REMOTE_QUERY_UPLOAD_TEST_DRIVE_HEADER = 'test-drive-its-agent-intake-poc'
 REMOTE_QUERY_UPLOAD_TEST_DRIVE_CONFIG_KEY = 'remote_queries.execute.intake_test_drive_selector'
 REMOTE_QUERY_UPLOAD_MAX_RETRIES = 4
 REMOTE_QUERY_UPLOAD_INITIAL_BACKOFF_SECONDS = 0.1
 REMOTE_QUERY_UPLOAD_MAX_BACKOFF_SECONDS = 5.0
+# Per-upload HTTP timeout as an explicit (connect, read) tuple: a short connect timeout and a
+# 5-minute read timeout so a slow part upload (e.g. a large part over a constrained link) is
+# not cut short, while a stuck connect fails fast. Retry count and backoff stay bounded above.
+REMOTE_QUERY_UPLOAD_HTTP_CONNECT_TIMEOUT_SECONDS = 10
+REMOTE_QUERY_UPLOAD_HTTP_READ_TIMEOUT_SECONDS = 300
+REMOTE_QUERY_UPLOAD_HTTP_TIMEOUT = (
+    REMOTE_QUERY_UPLOAD_HTTP_CONNECT_TIMEOUT_SECONDS,
+    REMOTE_QUERY_UPLOAD_HTTP_READ_TIMEOUT_SECONDS,
+)
 
 
 @dataclass(frozen=True)
@@ -648,8 +663,8 @@ class _UploadClient(Protocol):
 class _RequestsUploadClient:
     """HTTP upload client for its-agent-intake. Imports requests lazily."""
 
-    def __init__(self, timeout_seconds: int = REMOTE_QUERY_UPLOAD_HTTP_TIMEOUT_SECONDS) -> None:
-        self._timeout = timeout_seconds
+    def __init__(self, timeout: tuple[int, int] = REMOTE_QUERY_UPLOAD_HTTP_TIMEOUT) -> None:
+        self._timeout = timeout
 
     def _headers(self, creds: _UploadCredentials, content_type: str | None = None) -> dict[str, str]:
         headers = {
@@ -669,19 +684,19 @@ class _RequestsUploadClient:
         headers['X-DD-Part-Bytes'] = str(len(payload))
         headers['X-DD-Part-Rows'] = str(rows)
         url = '{}/uploads/{}/parts/{}'.format(creds.base_url.rstrip('/'), creds.upload_id, part_number)
-        _upload_with_retry('PUT', url, headers, payload)
+        _upload_with_retry('PUT', url, headers, payload, self._timeout)
 
     def finalize(self, creds: _UploadCredentials) -> Mapping[str, Any]:
         headers = self._headers(creds, 'application/json')
         url = '{}/uploads/{}/finalize'.format(creds.base_url.rstrip('/'), creds.upload_id)
-        _status, body = _upload_with_retry('POST', url, headers, b'{}')
+        _status, body = _upload_with_retry('POST', url, headers, b'{}', self._timeout)
         return json.loads(body.decode('utf-8'))
 
     def abort(self, creds: _UploadCredentials) -> None:
         headers = self._headers(creds, 'application/json')
         url = '{}/uploads/{}/abort'.format(creds.base_url.rstrip('/'), creds.upload_id)
         try:
-            _upload_with_retry('POST', url, headers, b'{}')
+            _upload_with_retry('POST', url, headers, b'{}', self._timeout)
         except _CopyStreamFailure:
             LOGGER.debug('Remote query upload abort failed (best-effort)', exc_info=True)
 
@@ -690,16 +705,20 @@ def _is_transient_upload_status(status: int) -> bool:
     return status == 408 or status == 429 or status >= 500
 
 
-def _upload_with_retry(method: str, url: str, headers: Mapping[str, str], body: bytes) -> tuple[int, bytes]:
+def _upload_with_retry(
+    method: str,
+    url: str,
+    headers: Mapping[str, str],
+    body: bytes,
+    timeout: tuple[int, int] = REMOTE_QUERY_UPLOAD_HTTP_TIMEOUT,
+) -> tuple[int, bytes]:
     import requests  # lazy: only the POC upload path needs it
 
     backoff = REMOTE_QUERY_UPLOAD_INITIAL_BACKOFF_SECONDS
     last_err: Any = None
     for attempt in range(REMOTE_QUERY_UPLOAD_MAX_RETRIES + 1):
         try:
-            resp = requests.request(
-                method, url, headers=dict(headers), data=body, timeout=REMOTE_QUERY_UPLOAD_HTTP_TIMEOUT_SECONDS
-            )
+            resp = requests.request(method, url, headers=dict(headers), data=body, timeout=timeout)
         except requests.exceptions.RequestException as e:
             last_err = e
         else:

--- a/postgres/datadog_checks/postgres/remote_query.py
+++ b/postgres/datadog_checks/postgres/remote_query.py
@@ -790,7 +790,7 @@ def _intake_receipt_to_camel(resp: Mapping[str, Any]) -> dict[str, Any]:
         'mode': resp.get('mode', 'POC_PUBLIC_MULTIPART_UPLOAD'),
         'uploadId': resp.get('upload_id', ''),
         'bucketName': resp.get('bucket_name', ''),
-        'objectPath': resp.get('object_key', ''),
+        'objectPath': resp.get('object_path', ''),
         'totalBytes': resp.get('total_bytes', 0),
         'totalRows': resp.get('total_rows', 0),
         'partCount': resp.get('part_count', 0),

--- a/postgres/tests/test_remote_query.py
+++ b/postgres/tests/test_remote_query.py
@@ -13,6 +13,7 @@ from datadog_checks.postgres import remote_query
 from datadog_checks.postgres.remote_query import (
     StaticPostgresCheckRegistry,
     _execute_upload_stream,
+    _intake_receipt_to_camel,
     execute_agent_rpc_stream_copy,
     iter_agent_rpc_stream_copy_events,
     normalize_target,
@@ -161,7 +162,7 @@ class FakeUploadClient:
             'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
             'upload_id': 'upload-01k',
             'bucket_name': 'rq-bucket',
-            'object_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
+            'object_path': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
             'total_bytes': 0,
             'total_rows': 0,
             'part_count': 0,
@@ -995,7 +996,7 @@ def test_agent_rpc_stream_copy_upload_mode_uploads_parts_directly(monkeypatch):
             'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
             'upload_id': 'upload-01k',
             'bucket_name': 'rq-bucket',
-            'object_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
+            'object_path': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
             'total_bytes': 18,
             'total_rows': 0,
             'part_count': 3,
@@ -1293,7 +1294,7 @@ def test_copy_stream_upload_mode_uploads_exact_mib_directly_to_intake(total_mib,
             'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
             'upload_id': 'upload-01k',
             'bucket_name': 'rq-bucket',
-            'object_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
+            'object_path': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
             'total_bytes': total_bytes,
             'total_rows': 0,
             'part_count': total_bytes // PROOF_MIB,
@@ -1360,7 +1361,7 @@ def test_copy_stream_upload_mode_backpressure_fences_copy_reads_during_http_uplo
             'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
             'upload_id': 'upload-01k',
             'bucket_name': 'rq-bucket',
-            'object_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
+            'object_path': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
             'total_bytes': total_bytes,
             'total_rows': 0,
             'part_count': total_blocks,
@@ -1586,7 +1587,7 @@ def test_copy_stream_upload_mode_finalizes_empty_result_with_zero_parts(monkeypa
             'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
             'upload_id': 'upload-01k',
             'bucket_name': 'rq-bucket',
-            'object_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
+            'object_path': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
             'total_bytes': 0,
             'total_rows': 0,
             'part_count': 0,
@@ -1747,7 +1748,7 @@ def test_copy_stream_upload_mode_aggregates_many_copy_reads_into_64_mib_parts(mo
                 'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
                 'upload_id': 'upload-01k',
                 'bucket_name': 'rq-bucket',
-                'object_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
+                'object_path': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
                 'total_bytes': total_bytes,
                 'total_rows': 0,
                 'part_count': 2,
@@ -1773,3 +1774,46 @@ def test_copy_stream_upload_mode_aggregates_many_copy_reads_into_64_mib_parts(mo
     assert fake.finalize_calls == 1
     assert fake.abort_calls == 0
     assert pool.closed_copies == 1
+
+
+@pytest.mark.parametrize(
+    'resp, expected_object_path',
+    [
+        (
+            {
+                'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
+                'upload_id': 'upload-01k',
+                'bucket_name': 'rq-bucket',
+                'object_path': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
+                'total_bytes': 18,
+                'total_rows': 3,
+                'part_count': 1,
+                'sha256': 'aggregate-sha',
+            },
+            'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
+        ),
+        ({'object_path': 'solo/path/result.csv'}, 'solo/path/result.csv'),
+    ],
+)
+def test_intake_receipt_to_camel_maps_object_path_to_objectPath(resp, expected_object_path):
+    # The intake finalize route serializes the canonical final path as the snake-case
+    # ``object_path`` field; the AP receipt must carry it as the camelCase ``objectPath``.
+    receipt = _intake_receipt_to_camel(resp)
+    assert receipt['objectPath'] == expected_object_path
+    assert receipt['objectPath'] != ''
+
+
+def test_intake_receipt_to_camel_does_not_preserve_obsolete_object_key():
+    # Remote Queries is greenfield: the obsolete ``object_key`` alias is not preserved, so an
+    # intake response that only carries ``object_key`` yields an empty ``objectPath``.
+    resp = {
+        'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
+        'upload_id': 'upload-01k',
+        'bucket_name': 'rq-bucket',
+        'object_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
+        'total_bytes': 18,
+        'total_rows': 3,
+        'part_count': 1,
+        'sha256': 'aggregate-sha',
+    }
+    assert _intake_receipt_to_camel(resp)['objectPath'] == ''

--- a/postgres/tests/test_remote_query.py
+++ b/postgres/tests/test_remote_query.py
@@ -131,11 +131,11 @@ def valid_database_instance_copy_request(database_instance='postgres-dbi', **ext
 
 def valid_result_delivery(**extra):
     result_delivery = {
-        'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+        'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
         'uploadId': 'upload-01k',
         'baseUrl': 'https://dd.datad0g.com/api/unstable/its-agent-intake',
         'token': 'scoped-upload-token',
-        'chunkBytes': 8,
+        'partBytes': 8,
         'maxBytes': 24,
         'format': 'csv',
         'compression': 'none',
@@ -158,21 +158,21 @@ class FakeUploadClient:
         self.put_status = put_status
         self.raise_on_put = raise_on_put
         self.finalize_resp = finalize_resp or {
-            'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+            'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
             'upload_id': 'upload-01k',
             'bucket_name': 'rq-bucket',
-            'manifest_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/manifest.json',
+            'object_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
             'total_bytes': 0,
             'total_rows': 0,
-            'chunk_count': 0,
+            'part_count': 0,
             'sha256': 'aggregate',
             'format': 'csv',
             'compression': 'none',
-            'finalized_at': '2026-08-20T00:00:00Z',
+            'completed_at': '2026-08-20T00:00:00Z',
         }
 
-    def put_chunk(self, creds, index, payload, sha256_hex, rows):
-        self.put_calls.append((index, payload, sha256_hex, rows))
+    def put_part(self, creds, part_number, payload, sha256_hex, rows):
+        self.put_calls.append((part_number, payload, sha256_hex, rows))
         if self.raise_on_put is not None:
             raise self.raise_on_put
 
@@ -820,9 +820,9 @@ def test_copy_stream_upload_mode_emits_started_result_delivery_data_sha256_and_r
     assert events[0].event_type == 'metadata'
     started = event_metadata(events[0])
     assert started['status'] == 'STARTED'
-    assert started['resultDelivery']['mode'] == 'POC_PUBLIC_CHUNKED_UPLOAD'
+    assert started['resultDelivery']['mode'] == 'POC_PUBLIC_MULTIPART_UPLOAD'
     assert started['resultDelivery']['uploadId'] == 'upload-01k'
-    assert started['resultDelivery']['chunkBytes'] == 8
+    assert started['resultDelivery']['partBytes'] == 8
     assert started['resultDelivery']['maxBytes'] == 24
     assert 'baseUrl' not in started['resultDelivery']
     assert 'token' not in started['resultDelivery']
@@ -839,10 +839,10 @@ def test_copy_stream_upload_mode_emits_started_result_delivery_data_sha256_and_r
         assert len(payload) <= 8
     assert events[-1].event_type == 'final'
     assert event_metadata(events[-1])['uploadReceipt'] == {
-        'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+        'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
         'uploadId': 'upload-01k',
         'totalBytes': 18,
-        'chunkCount': 3,
+        'partCount': 3,
     }
     assert event_metadata(events[-1])['stats']['bytesEmitted'] == 18
     assert event_metadata(events[-1])['stats']['chunksEmitted'] == 3
@@ -902,7 +902,7 @@ def test_copy_stream_upload_mode_rejects_binary_format_mismatch_with_result_deli
     request = valid_upload_copy_request()
     request['format'] = 'binary'
     request['query'] = "SELECT decode('00ff80', 'hex') AS payload"
-    request['resultDelivery']['chunkBytes'] = 1024
+    request['resultDelivery']['partBytes'] = 1024
     request['resultDelivery']['maxBytes'] = 4096
     request['limits'] = {'chunkBytes': 1024, 'maxBytes': 4096, 'maxRowBytes': 4096, 'timeoutMs': 5000}
 
@@ -929,7 +929,7 @@ def test_copy_stream_upload_mode_never_buffers_more_than_one_chunk(monkeypatch):
     patch_upload_credentials(monkeypatch)
     pool = FakePool(copy_blocks=[b'aaaa', b'bbbb', b'cccc', b'dddd', b'eeee', b'ffff'])
     request = valid_upload_copy_request()
-    request['resultDelivery']['chunkBytes'] = 4
+    request['resultDelivery']['partBytes'] = 4
     request['resultDelivery']['maxBytes'] = 28
     request['limits'] = {'chunkBytes': 4, 'maxBytes': 28, 'maxRowBytes': 32, 'timeoutMs': 5000}
     fake = FakeUploadClient()
@@ -987,22 +987,22 @@ def test_copy_stream_upload_mode_accepts_baseurl_and_token():
     assert pool.requested_dbnames != []
 
 
-def test_agent_rpc_stream_copy_upload_mode_uploads_chunks_directly(monkeypatch):
+def test_agent_rpc_stream_copy_upload_mode_uploads_parts_directly(monkeypatch):
     patch_upload_credentials(monkeypatch)
     pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop', b'qr'])
     fake = FakeUploadClient(
         finalize_resp={
-            'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+            'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
             'upload_id': 'upload-01k',
             'bucket_name': 'rq-bucket',
-            'manifest_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/manifest.json',
+            'object_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
             'total_bytes': 18,
             'total_rows': 0,
-            'chunk_count': 3,
+            'part_count': 3,
             'sha256': 'aggregate-sha',
             'format': 'csv',
             'compression': 'none',
-            'finalized_at': '2026-08-20T00:00:00Z',
+            'completed_at': '2026-08-20T00:00:00Z',
         }
     )
     events = []
@@ -1018,10 +1018,11 @@ def test_agent_rpc_stream_copy_upload_mode_uploads_chunks_directly(monkeypatch):
     assert 'baseUrl' not in started['resultDelivery']
     assert 'token' not in started['resultDelivery']
 
-    # Three chunks uploaded directly, each with its sha256 and byte count.
+    # Three parts uploaded directly with contiguous 1-based part numbers, each carrying its
+    # sha256 and byte count.
     assert len(fake.put_calls) == 3
-    assert [call[0] for call in fake.put_calls] == [0, 1, 2]
-    for _index, payload, sha256_hex, _rows in fake.put_calls:
+    assert [call[0] for call in fake.put_calls] == [1, 2, 3]
+    for _part_number, payload, sha256_hex, _rows in fake.put_calls:
         assert sha256_hex == hashlib.sha256(payload).hexdigest()
     assert fake.finalize_calls == 1
     assert fake.abort_calls == 0
@@ -1030,13 +1031,13 @@ def test_agent_rpc_stream_copy_upload_mode_uploads_chunks_directly(monkeypatch):
     # server-expected snake_case outer key.
     receipt = json.loads(events[-1][1])['upload_receipt']
     assert receipt == {
-        'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+        'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
         'uploadId': 'upload-01k',
         'bucketName': 'rq-bucket',
-        'manifestPath': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/manifest.json',
+        'objectPath': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
         'totalBytes': 18,
         'totalRows': 0,
-        'chunkCount': 3,
+        'partCount': 3,
         'sha256': 'aggregate-sha',
     }
 
@@ -1071,10 +1072,10 @@ def test_copy_stream_upload_mode_stops_on_http_failure_and_aborts(monkeypatch):
         ({'mode': 'PRESIGNED_URL'}, 'mode'),
         ({'format': 'json'}, 'format'),
         ({'compression': 'gzip'}, 'compression'),
-        ({'chunkBytes': 0}, 'chunkBytes'),
+        ({'partBytes': 0}, 'partBytes'),
         ({'maxBytes': 0}, 'maxBytes'),
-        ({'chunkBytes': '8'}, 'chunkBytes'),
-        ({'chunkBytes': 64, 'maxBytes': 32}, 'chunkBytes must not exceed maxBytes'),
+        ({'partBytes': '8'}, 'partBytes'),
+        ({'partBytes': 64, 'maxBytes': 32}, 'partBytes must not exceed maxBytes'),
     ],
 )
 def test_copy_stream_upload_mode_rejects_invalid_result_delivery(mutation, expected):
@@ -1097,9 +1098,9 @@ def test_copy_stream_upload_mode_rejects_missing_upload_id():
     'delivery, limits, expected',
     [
         (
-            {'chunkBytes': 16},
+            {'partBytes': 16},
             {'chunkBytes': 8, 'maxBytes': 64},
-            'resultDelivery.chunkBytes must not exceed limits.chunkBytes',
+            'resultDelivery.partBytes must not exceed limits.chunkBytes',
         ),
         (
             {'maxBytes': 128},
@@ -1119,7 +1120,7 @@ def test_copy_stream_upload_mode_rejects_upload_cap_widening(delivery, limits, e
 def test_copy_stream_upload_mode_accepts_equal_upload_caps():
     pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop', b'qr'])
     request = valid_upload_copy_request()
-    request['resultDelivery']['chunkBytes'] = 8
+    request['resultDelivery']['partBytes'] = 8
     request['resultDelivery']['maxBytes'] = 64
     request['limits'] = {'chunkBytes': 8, 'maxBytes': 64, 'maxRowBytes': 32, 'timeoutMs': 5000}
 
@@ -1160,7 +1161,7 @@ def test_copy_stream_upload_mode_enforces_smaller_upload_cap_over_wider_limit():
 # those byte counts (the CSV ``\n`` terminator is elided); this is documented
 # here and asserted by the total-bytes assertions.
 #
-# Unlike the prior emit-bridge proof, bulk chunk bytes go directly to
+# Unlike the prior emit-bridge proof, bulk part bytes go directly to
 # its-agent-intake over HTTP via an injectable ``_UploadClient`` (a fake here),
 # NOT through the native emit callback. Only metadata/final/error events cross
 # the callback. This proves the integration owns the upload and the Agent is
@@ -1193,18 +1194,18 @@ def incremental_reference_sha256(total_bytes, block_size=PROOF_MIB):
     return hasher.hexdigest()
 
 
-def mib_upload_request(query, total_bytes, chunk_bytes=PROOF_MIB, upload_max_bytes=None, copy_max_bytes=None):
-    """Build a valid ``resultDelivery`` upload request sized for MiB-scale proof."""
+def mib_upload_request(query, total_bytes, part_bytes=PROOF_MIB, upload_max_bytes=None, copy_max_bytes=None):
+    """Build a valid ``resultDelivery`` multipart upload request sized for MiB-scale proof."""
     upload_cap = upload_max_bytes if upload_max_bytes is not None else total_bytes
     copy_cap = copy_max_bytes if copy_max_bytes is not None else total_bytes
     request = valid_upload_copy_request()
     request['query'] = query
     request['format'] = 'csv'
     request['resultDelivery']['format'] = 'csv'
-    request['resultDelivery']['chunkBytes'] = chunk_bytes
+    request['resultDelivery']['partBytes'] = part_bytes
     request['resultDelivery']['maxBytes'] = upload_cap
     request['limits'] = {
-        'chunkBytes': chunk_bytes,
+        'chunkBytes': part_bytes,
         'maxBytes': copy_cap,
         'maxRowBytes': PROOF_MIB,
         'timeoutMs': 30000,
@@ -1215,11 +1216,11 @@ def mib_upload_request(query, total_bytes, chunk_bytes=PROOF_MIB, upload_max_byt
 def run_direct_upload_stream(request, pool, fake, monkeypatch=None):
     """Drive the real direct-HTTP upload path and collect proof metrics.
 
-    Bulk chunk bytes are hashed and discarded as the fake intake accepts them, so the
+    Bulk part bytes are hashed and discarded as the fake intake accepts them, so the
     full multi-MiB payload is never accumulated in memory. Returns the STARTED/FINAL
     metadata emitted on the callback, plus the fake intake's recorded put/finalize/abort
-    calls, the total uploaded bytes, chunk count, max chunk size, and the incremental
-    SHA-256 of the uploaded chunk bodies.
+    calls, the total uploaded bytes, part count, max part size, and the incremental
+    SHA-256 of the uploaded part bodies.
     """
     if monkeypatch is not None:
         patch_upload_credentials(monkeypatch)
@@ -1236,7 +1237,7 @@ def run_direct_upload_stream(request, pool, fake, monkeypatch=None):
 
     _execute_upload_stream(request, make_check(pool=pool), emit, http_client=fake)
 
-    for _index, payload, _sha256_hex, _rows in fake.put_calls:
+    for _part_number, payload, _sha256_hex, _rows in fake.put_calls:
         hasher.update(payload)
         total_bytes += len(payload)
 
@@ -1247,8 +1248,8 @@ def run_direct_upload_stream(request, pool, fake, monkeypatch=None):
         finalize_calls=fake.finalize_calls,
         abort_calls=fake.abort_calls,
         total_bytes=total_bytes,
-        chunk_count=len(fake.put_calls),
-        max_chunk=max((len(c[1]) for c in fake.put_calls), default=0),
+        part_count=len(fake.put_calls),
+        max_part=max((len(c[1]) for c in fake.put_calls), default=0),
         digest=hasher.hexdigest(),
     )
 
@@ -1266,31 +1267,31 @@ def test_copy_stream_upload_mode_uploads_exact_mib_directly_to_intake(total_mib,
     pool = FakePool(copy_blocks=incremental_copy_blocks(total_bytes))
     fake = FakeUploadClient(
         finalize_resp={
-            'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+            'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
             'upload_id': 'upload-01k',
             'bucket_name': 'rq-bucket',
-            'manifest_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/manifest.json',
+            'object_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
             'total_bytes': total_bytes,
             'total_rows': 0,
-            'chunk_count': total_bytes // PROOF_MIB,
+            'part_count': total_bytes // PROOF_MIB,
             'sha256': incremental_reference_sha256(total_bytes),
             'format': 'csv',
             'compression': 'none',
-            'finalized_at': '2026-08-20T00:00:00Z',
+            'completed_at': '2026-08-20T00:00:00Z',
         }
     )
 
     proof = run_direct_upload_stream(request, pool, fake, monkeypatch)
 
     # Bulk bytes go directly to the intake over HTTP, not through the emit callback.
-    assert proof.chunk_count == total_bytes // PROOF_MIB
+    assert proof.part_count == total_bytes // PROOF_MIB
     assert proof.total_bytes == total_bytes
-    assert proof.max_chunk == PROOF_MIB
-    # Each uploaded chunk carries its per-chunk SHA-256 over the raw body.
-    for _index, payload, _sha256_hex, _rows in proof.put_calls:
+    assert proof.max_part == PROOF_MIB
+    # Each uploaded part carries its per-part SHA-256 over the raw body.
+    for _part_number, payload, _sha256_hex, _rows in proof.put_calls:
         assert _sha256_hex == hashlib.sha256(payload).hexdigest()
         assert len(payload) == PROOF_MIB
-    # The aggregate SHA-256 of uploaded chunk bodies matches the incremental reference.
+    # The aggregate SHA-256 of uploaded part bodies matches the incremental reference.
     assert proof.digest == incremental_reference_sha256(total_bytes)
     # Finalize is called exactly once; no abort on the happy path.
     assert proof.finalize_calls == 1
@@ -1298,7 +1299,7 @@ def test_copy_stream_upload_mode_uploads_exact_mib_directly_to_intake(total_mib,
 
     # Only metadata and final reach the emit callback; no bulk data events cross it.
     assert proof.started['status'] == 'STARTED'
-    assert proof.started['resultDelivery']['mode'] == 'POC_PUBLIC_CHUNKED_UPLOAD'
+    assert proof.started['resultDelivery']['mode'] == 'POC_PUBLIC_MULTIPART_UPLOAD'
     assert proof.started['resultDelivery']['uploadId'] == 'upload-01k'
     assert 'baseUrl' not in proof.started['resultDelivery']
     assert 'token' not in proof.started['resultDelivery']
@@ -1306,7 +1307,7 @@ def test_copy_stream_upload_mode_uploads_exact_mib_directly_to_intake(total_mib,
     # The final receipt is the Agent-shaped camelCase receipt under the snake_case outer key.
     assert proof.final['upload_receipt']['uploadId'] == 'upload-01k'
     assert proof.final['upload_receipt']['totalBytes'] == total_bytes
-    assert proof.final['upload_receipt']['chunkCount'] == total_bytes // PROOF_MIB
+    assert proof.final['upload_receipt']['partCount'] == total_bytes // PROOF_MIB
     assert proof.final['upload_receipt']['sha256'] == incremental_reference_sha256(total_bytes)
     assert pool.closed_copies == 1
 
@@ -1323,38 +1324,38 @@ def test_copy_stream_upload_mode_backpressure_fences_copy_reads_during_http_uplo
 
     request = mib_upload_request(M3_PROOF_QUERY, total_bytes)
     pool = FakePool(copy_blocks=counting_block_stream())
-    # Record how many COPY blocks have been read at the moment each chunk is uploaded.
+    # Record how many COPY blocks have been read at the moment each part is uploaded.
     reads_at_put = []
 
     class LockstepFakeClient(FakeUploadClient):
-        def put_chunk(self, creds, index, payload, sha256_hex, rows):
+        def put_part(self, creds, part_number, payload, sha256_hex, rows):
             reads_at_put.append(read_state['count'])
-            super().put_chunk(creds, index, payload, sha256_hex, rows)
+            super().put_part(creds, part_number, payload, sha256_hex, rows)
 
     fake = LockstepFakeClient(
         finalize_resp={
-            'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+            'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
             'upload_id': 'upload-01k',
             'bucket_name': 'rq-bucket',
-            'manifest_key': 'manifest.json',
+            'object_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
             'total_bytes': total_bytes,
             'total_rows': 0,
-            'chunk_count': total_blocks,
+            'part_count': total_blocks,
             'sha256': incremental_reference_sha256(total_bytes),
             'format': 'csv',
             'compression': 'none',
-            'finalized_at': '2026-08-20T00:00:00Z',
+            'completed_at': '2026-08-20T00:00:00Z',
         }
     )
 
     proof = run_direct_upload_stream(request, pool, fake, monkeypatch)
 
-    # Lockstep backpressure: when chunk i (1-indexed) is uploaded, exactly i blocks have
-    # been read and block i+1 is fenced (not yet read). The full 8 MiB is never buffered
-    # ahead of the HTTP upload.
+    # Lockstep backpressure: when part i is uploaded, exactly i blocks have been read and
+    # block i+1 is fenced (not yet read). The full 8 MiB is never buffered ahead of the
+    # HTTP upload.
     assert reads_at_put == list(range(1, total_blocks + 1))
     assert read_state['count'] == total_blocks
-    assert proof.chunk_count == total_blocks
+    assert proof.part_count == total_blocks
     assert pool.closed_copies == 1
 
 
@@ -1368,7 +1369,7 @@ def test_copy_stream_upload_mode_aborts_on_http_failure_at_mib_scale(monkeypatch
 
     proof = run_direct_upload_stream(request, pool, fake, monkeypatch)
 
-    # The first chunk upload fails; the session is aborted and an error event is emitted.
+    # The first part upload fails; the session is aborted and an error event is emitted.
     assert len(proof.put_calls) == 1
     assert proof.abort_calls == 1
     assert proof.final['status'] == 'FAILED'
@@ -1388,10 +1389,199 @@ def test_copy_stream_upload_mode_enforces_max_bytes_at_mib_scale(monkeypatch):
 
     # maxBytes enforced: exactly the upload cap is uploaded, then the stream fails.
     assert proof.total_bytes == upload_cap
-    assert proof.chunk_count == upload_cap // PROOF_MIB
-    assert proof.max_chunk == PROOF_MIB
+    assert proof.part_count == upload_cap // PROOF_MIB
+    assert proof.max_part == PROOF_MIB
     assert proof.final['status'] == 'FAILED'
     assert proof.final['error']['code'] == 'max_bytes_exceeded'
     # No receipt is emitted when the upload cap is exceeded.
     assert 'upload_receipt' not in proof.final
+    assert pool.closed_copies == 1
+
+
+# ---------------------------------------------------------------------------
+# Multipart HTTP contract, retry, sizing, and empty-result behavior
+#
+# These tests pin the exact POC_PUBLIC_MULTIPART_UPLOAD data-plane contract
+# (routes, 1-based part numbers, X-DD-Part-* headers) against the real
+# ``_RequestsUploadClient`` by stubbing ``requests.request``, plus the
+# integration-level multipart sizing and zero-row finalization behavior.
+# ---------------------------------------------------------------------------
+
+
+def _upload_creds(**overrides):
+    defaults = {
+        'base_url': 'https://dd.datad0g.com/api/unstable/its-agent-intake',
+        'upload_id': 'upload-01k',
+        'api_key': 'TEST_API_KEY',
+        'app_key': 'TEST_APP_KEY',
+        'token': 'scoped-upload-token',
+        'test_drive_selector': 'its-agent-intake-poc',
+    }
+    defaults.update(overrides)
+    return remote_query._UploadCredentials(**defaults)
+
+
+def test_requests_upload_client_uses_exact_multipart_http_contract(monkeypatch):
+    import requests
+
+    captured = []
+
+    def fake_request(method, url, headers=None, data=None, timeout=None):
+        captured.append(
+            SimpleNamespace(method=method, url=url, headers=dict(headers or {}), data=data, timeout=timeout)
+        )
+        return SimpleNamespace(status_code=200, content=b'{}')
+
+    monkeypatch.setattr(requests, 'request', fake_request)
+    monkeypatch.setattr(remote_query.time, 'sleep', lambda _seconds: None)
+
+    creds = _upload_creds()
+    client = remote_query._RequestsUploadClient()
+    payload = b'abcdefgh'
+    client.put_part(creds, 2, payload, hashlib.sha256(payload).hexdigest(), 1)
+
+    # PUT to the 1-based part route with the exact multipart headers and auth.
+    put = captured[0]
+    assert put.method == 'PUT'
+    assert put.url == 'https://dd.datad0g.com/api/unstable/its-agent-intake/uploads/upload-01k/parts/2'
+    assert put.headers['Content-Type'] == 'application/octet-stream'
+    assert put.headers['X-DD-Part-SHA256'] == hashlib.sha256(payload).hexdigest()
+    assert put.headers['X-DD-Part-Bytes'] == '8'
+    assert put.headers['X-DD-Part-Rows'] == '1'
+    assert put.headers['dd-api-key'] == 'TEST_API_KEY'
+    assert put.headers['dd-application-key'] == 'TEST_APP_KEY'
+    assert put.headers['Authorization'] == 'Bearer scoped-upload-token'
+    assert put.headers[remote_query.REMOTE_QUERY_UPLOAD_TEST_DRIVE_HEADER] == 'its-agent-intake-poc'
+    assert put.data == payload
+    assert put.timeout == remote_query.REMOTE_QUERY_UPLOAD_HTTP_TIMEOUT_SECONDS
+
+    # finalize -> POST .../finalize with an empty JSON body.
+    client.finalize(creds)
+    finalize = captured[1]
+    assert finalize.method == 'POST'
+    assert finalize.url == 'https://dd.datad0g.com/api/unstable/its-agent-intake/uploads/upload-01k/finalize'
+    assert finalize.headers['Content-Type'] == 'application/json'
+    assert finalize.data == b'{}'
+
+    # abort -> POST .../abort with an empty JSON body (best-effort).
+    client.abort(creds)
+    abort = captured[2]
+    assert abort.method == 'POST'
+    assert abort.url == 'https://dd.datad0g.com/api/unstable/its-agent-intake/uploads/upload-01k/abort'
+    assert abort.data == b'{}'
+
+
+@pytest.mark.parametrize('trigger', ['transient_status', 'connection_error'])
+def test_requests_upload_client_retries_part_idempotently(monkeypatch, trigger):
+    import requests
+
+    calls = []
+
+    def fake_request(method, url, headers=None, data=None, timeout=None):
+        calls.append(SimpleNamespace(url=url, headers=dict(headers or {}), data=data))
+        if len(calls) == 1 and trigger == 'transient_status':
+            return SimpleNamespace(status_code=503, content=b'')
+        if len(calls) == 1 and trigger == 'connection_error':
+            raise requests.exceptions.RequestException('boom')
+        return SimpleNamespace(status_code=200, content=b'{}')
+
+    monkeypatch.setattr(requests, 'request', fake_request)
+    monkeypatch.setattr(remote_query.time, 'sleep', lambda _seconds: None)
+
+    creds = _upload_creds(test_drive_selector=None)
+    client = remote_query._RequestsUploadClient()
+    payload = b'ijklmnop'
+    client.put_part(creds, 1, payload, hashlib.sha256(payload).hexdigest(), 0)
+
+    # The same part request (same 1-based part URL, same checksum header, same body) is
+    # retried verbatim after a transient failure, so a server-side idempotent replay by
+    # (part_number, sha256) cannot double-count bytes.
+    assert len(calls) == 2
+    assert calls[0].url == calls[1].url
+    assert calls[0].url == 'https://dd.datad0g.com/api/unstable/its-agent-intake/uploads/upload-01k/parts/1'
+    assert calls[0].headers['X-DD-Part-SHA256'] == calls[1].headers['X-DD-Part-SHA256']
+    assert calls[0].data == calls[1].data == payload
+
+
+def test_requests_upload_client_fails_closed_on_non_transient_status(monkeypatch):
+    import requests
+
+    calls = []
+
+    def fake_request(method, url, headers=None, data=None, timeout=None):
+        calls.append(url)
+        return SimpleNamespace(status_code=400, content=b'')
+
+    monkeypatch.setattr(requests, 'request', fake_request)
+    monkeypatch.setattr(remote_query.time, 'sleep', lambda _seconds: None)
+
+    creds = _upload_creds(test_drive_selector=None)
+    client = remote_query._RequestsUploadClient()
+
+    with pytest.raises(remote_query._CopyStreamFailure) as excinfo:
+        client.put_part(creds, 1, b'x', 'deadbeef', 0)
+    assert excinfo.value.code == 'upload_failed'
+    assert excinfo.value.retryable is False
+    # A non-transient rejection is not retried.
+    assert len(calls) == 1
+
+
+def test_copy_stream_upload_mode_sizes_multipart_parts_with_final_short_part(monkeypatch):
+    patch_upload_credentials(monkeypatch)
+    # 20 bytes total with 8-byte parts -> two full parts and one final short part.
+    pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop', b'mnop'])
+    request = valid_upload_copy_request()
+    request['resultDelivery']['partBytes'] = 8
+    request['resultDelivery']['maxBytes'] = 24
+    request['limits'] = {'chunkBytes': 8, 'maxBytes': 24, 'maxRowBytes': 32, 'timeoutMs': 5000}
+    fake = FakeUploadClient()
+
+    _execute_upload_stream(request, make_check(pool=pool), lambda *event: None, http_client=fake)
+
+    # Contiguous 1-based part numbers; non-final parts are exactly partBytes and the
+    # final part is allowed to be shorter.
+    assert [call[0] for call in fake.put_calls] == [1, 2, 3]
+    assert [len(call[1]) for call in fake.put_calls] == [8, 8, 4]
+    assert sum(len(call[1]) for call in fake.put_calls) == 20
+    assert fake.finalize_calls == 1
+    assert fake.abort_calls == 0
+    assert pool.closed_copies == 1
+
+
+def test_copy_stream_upload_mode_finalizes_empty_result_with_zero_parts(monkeypatch):
+    patch_upload_credentials(monkeypatch)
+    pool = FakePool(copy_blocks=[])
+    request = valid_upload_copy_request()
+    fake = FakeUploadClient(
+        finalize_resp={
+            'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
+            'upload_id': 'upload-01k',
+            'bucket_name': 'rq-bucket',
+            'object_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
+            'total_bytes': 0,
+            'total_rows': 0,
+            'part_count': 0,
+            'sha256': hashlib.sha256(b'').hexdigest(),
+            'format': 'csv',
+            'compression': 'none',
+            'completed_at': '2026-08-20T00:00:00Z',
+        }
+    )
+    events = []
+
+    _execute_upload_stream(request, make_check(pool=pool), lambda *event: events.append(event), http_client=fake)
+
+    # Zero-row result: no parts are uploaded, but finalize is called once so the intake
+    # takes the explicit empty-object finalization path. Only metadata and final cross
+    # the callback; the receipt reports partCount 0 and a result.csv object path.
+    assert fake.put_calls == []
+    assert fake.finalize_calls == 1
+    assert fake.abort_calls == 0
+    assert [event[0] for event in events] == ['metadata', 'final']
+    receipt = json.loads(events[-1][1])['upload_receipt']
+    assert receipt['mode'] == 'POC_PUBLIC_MULTIPART_UPLOAD'
+    assert receipt['partCount'] == 0
+    assert receipt['totalBytes'] == 0
+    assert receipt['totalRows'] == 0
+    assert receipt['objectPath'].endswith('result.csv')
     assert pool.closed_copies == 1

--- a/postgres/tests/test_remote_query.py
+++ b/postgres/tests/test_remote_query.py
@@ -1212,10 +1212,15 @@ def incremental_reference_sha256(total_bytes, block_size=PROOF_MIB):
     return hasher.hexdigest()
 
 
-def mib_upload_request(query, total_bytes, part_bytes=PROOF_MIB, upload_max_bytes=None, copy_max_bytes=None):
+def mib_upload_request(
+    query, total_bytes, part_bytes=PROOF_MIB, upload_max_bytes=None, copy_max_bytes=None, copy_chunk_bytes=None
+):
     """Build a valid ``resultDelivery`` multipart upload request sized for MiB-scale proof."""
     upload_cap = upload_max_bytes if upload_max_bytes is not None else total_bytes
     copy_cap = copy_max_bytes if copy_max_bytes is not None else total_bytes
+    # The COPY read chunk size is independent of the multipart part size; default it to the part
+    # size to preserve prior proof behavior, but allow a smaller chunk to prove aggregation.
+    chunk_bytes = copy_chunk_bytes if copy_chunk_bytes is not None else part_bytes
     request = valid_upload_copy_request()
     request['query'] = query
     request['format'] = 'csv'
@@ -1223,7 +1228,7 @@ def mib_upload_request(query, total_bytes, part_bytes=PROOF_MIB, upload_max_byte
     request['resultDelivery']['partBytes'] = part_bytes
     request['resultDelivery']['maxBytes'] = upload_cap
     request['limits'] = {
-        'chunkBytes': part_bytes,
+        'chunkBytes': chunk_bytes,
         'maxBytes': copy_cap,
         'maxRowBytes': PROOF_MIB,
         'timeoutMs': 30000,
@@ -1471,7 +1476,13 @@ def test_requests_upload_client_uses_exact_multipart_http_contract(monkeypatch):
     assert put.headers['Authorization'] == 'Bearer scoped-upload-token'
     assert put.headers[remote_query.REMOTE_QUERY_UPLOAD_TEST_DRIVE_HEADER] == 'its-agent-intake-poc'
     assert put.data == payload
-    assert put.timeout == remote_query.REMOTE_QUERY_UPLOAD_HTTP_TIMEOUT_SECONDS
+    # The HTTP timeout is an explicit (connect, read) tuple with a 5-minute read timeout.
+    assert put.timeout == remote_query.REMOTE_QUERY_UPLOAD_HTTP_TIMEOUT
+    assert put.timeout == (
+        remote_query.REMOTE_QUERY_UPLOAD_HTTP_CONNECT_TIMEOUT_SECONDS,
+        remote_query.REMOTE_QUERY_UPLOAD_HTTP_READ_TIMEOUT_SECONDS,
+    )
+    assert remote_query.REMOTE_QUERY_UPLOAD_HTTP_READ_TIMEOUT_SECONDS == 300
 
     # finalize -> POST .../finalize with an empty JSON body.
     client.finalize(creds)
@@ -1627,6 +1638,138 @@ def test_copy_stream_upload_mode_aggregates_copy_chunks_into_partbytes_parts(mon
     # Each part carries the SHA-256 of its aggregated body, not of the individual COPY chunks.
     for _part_number, payload, sha256_hex, _rows in fake.put_calls:
         assert sha256_hex == hashlib.sha256(payload).hexdigest()
+    assert fake.finalize_calls == 1
+    assert fake.abort_calls == 0
+    assert pool.closed_copies == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: 10 GiB capacity, 128 MiB part ceiling, and 5-minute HTTP timeout
+#
+# These tests prove the server-owned maximums (10 GiB total, 128 MiB per part) are accepted
+# up to the boundary and rejected one byte past it, that partBytes stays independent of the
+# 1 MiB COPY read chunk, that many 1 MiB COPY reads aggregate into 64 MiB parts without
+# materializing the full result, and that the per-upload HTTP timeout is a 5-minute
+# (connect, read) tuple. No test allocates 10 GiB; the boundary tests are pure validation,
+# and the aggregation test uses a generated 1 MiB-block stream with a discarding client.
+# ---------------------------------------------------------------------------
+
+GIB = 1024 * 1024 * 1024
+TEN_GIB = 10 * GIB
+MAX_PART_BYTES = 128 * 1024 * 1024
+
+
+def test_copy_stream_upload_mode_accepts_ten_gib_max_bytes_when_extraction_cap_matches():
+    # A large int64 maxBytes (10 GiB) is accepted when the COPY extraction cap matches. No data is
+    # allocated: an empty result finalizes with zero bytes, proving the caps validate without
+    # materializing 10 GiB.
+    pool = FakePool(copy_blocks=[])
+    request = valid_upload_copy_request()
+    request['resultDelivery']['partBytes'] = MAX_PART_BYTES
+    request['resultDelivery']['maxBytes'] = TEN_GIB
+    request['limits'] = {'chunkBytes': PROOF_MIB, 'maxBytes': TEN_GIB, 'maxRowBytes': PROOF_MIB, 'timeoutMs': 30000}
+
+    events = collect_copy_events(request, make_check(pool=pool))
+
+    started = event_metadata(events[0])
+    assert started['status'] == 'STARTED'
+    assert started['resultDelivery']['partBytes'] == MAX_PART_BYTES
+    assert started['resultDelivery']['maxBytes'] == TEN_GIB
+    assert started['maxBytes'] == TEN_GIB
+    assert event_metadata(events[-1])['status'] == 'SUCCEEDED'
+    assert event_metadata(events[-1])['uploadReceipt']['totalBytes'] == 0
+    assert event_metadata(events[-1])['uploadReceipt']['partCount'] == 0
+    assert pool.closed_copies == 1
+
+
+def test_copy_stream_upload_mode_rejects_max_bytes_above_ten_gib():
+    # Plus-one safety: one byte past the 10 GiB server-owned maximum is rejected before any pool
+    # access. No allocation.
+    request = valid_upload_copy_request()
+    request['resultDelivery']['partBytes'] = MAX_PART_BYTES
+    request['resultDelivery']['maxBytes'] = TEN_GIB + 1
+    request['limits'] = {'chunkBytes': PROOF_MIB, 'maxBytes': TEN_GIB + 1, 'maxRowBytes': PROOF_MIB, 'timeoutMs': 30000}
+
+    events = list(iter_agent_rpc_stream_copy_events(request, ExplodingRegistry()))
+
+    assert_failed_event(events, 'invalid_request', 'maxBytes')
+
+
+@pytest.mark.parametrize('part_bytes', [MAX_PART_BYTES, MAX_PART_BYTES + 1])
+def test_copy_stream_upload_mode_part_bytes_boundary(part_bytes):
+    request = valid_upload_copy_request()
+    request['resultDelivery']['partBytes'] = part_bytes
+    request['resultDelivery']['maxBytes'] = TEN_GIB
+    request['limits'] = {'chunkBytes': PROOF_MIB, 'maxBytes': TEN_GIB, 'maxRowBytes': PROOF_MIB, 'timeoutMs': 30000}
+    # An empty registry separates validation from resolution: a valid request reaches target
+    # resolution (target_not_found), while an invalid one fails at validation (invalid_request)
+    # before the registry is touched. No data is allocated in either case.
+    events = list(iter_agent_rpc_stream_copy_events(request, StaticPostgresCheckRegistry([])))
+    if part_bytes <= MAX_PART_BYTES:
+        assert_failed_event(events, 'target_not_found')
+    else:
+        assert_failed_event(events, 'invalid_request', 'partBytes')
+
+
+def test_copy_stream_upload_mode_aggregates_many_copy_reads_into_64_mib_parts(monkeypatch):
+    patch_upload_credentials(monkeypatch)
+    # 128 MiB total, 1 MiB COPY reads, 64 MiB parts: 128 reads form 2 parts of 64 MiB each. The
+    # full 128 MiB is never materialized; at most one 64 MiB part is buffered at a time.
+    total_bytes = 128 * PROOF_MIB
+    part_bytes = 64 * PROOF_MIB
+    read_state = {'count': 0}
+
+    def counting_block_stream():
+        for _ in range(total_bytes // PROOF_MIB):
+            read_state['count'] += 1
+            yield b'x' * PROOF_MIB
+
+    request = mib_upload_request(M4_PROOF_QUERY, total_bytes, part_bytes=part_bytes, copy_chunk_bytes=PROOF_MIB)
+    pool = FakePool(copy_blocks=counting_block_stream())
+    reads_at_put = []
+
+    # Discard part bodies immediately so the fake never accumulates the full 128 MiB; record only
+    # the part number, size, checksum, and how many COPY blocks had been read when it uploaded.
+    class DiscardingCountingClient:
+        def __init__(self):
+            self.put_calls = []
+            self.finalize_calls = 0
+            self.abort_calls = 0
+
+        def put_part(self, creds, part_number, payload, sha256_hex, rows):
+            reads_at_put.append(read_state['count'])
+            self.put_calls.append((part_number, len(payload), sha256_hex, rows))
+            assert sha256_hex == hashlib.sha256(payload).hexdigest()
+
+        def finalize(self, creds):
+            self.finalize_calls += 1
+            return {
+                'mode': 'POC_PUBLIC_MULTIPART_UPLOAD',
+                'upload_id': 'upload-01k',
+                'bucket_name': 'rq-bucket',
+                'object_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/result.csv',
+                'total_bytes': total_bytes,
+                'total_rows': 0,
+                'part_count': 2,
+                'sha256': incremental_reference_sha256(total_bytes),
+                'format': 'csv',
+                'compression': 'none',
+                'completed_at': '2026-08-21T00:00:00Z',
+            }
+
+        def abort(self, creds):
+            self.abort_calls += 1
+
+    fake = DiscardingCountingClient()
+    _execute_upload_stream(request, make_check(pool=pool), lambda *event: None, http_client=fake)
+
+    # Two 64 MiB parts aggregated from 128 one-MiB COPY reads; each part is exactly partBytes.
+    assert [call[0] for call in fake.put_calls] == [1, 2]
+    assert [call[1] for call in fake.put_calls] == [part_bytes, part_bytes]
+    # Lockstep bounding: part 1 uploads after exactly 64 reads (the next 64 not yet read), and
+    # part 2 uploads at finalize after all 128 reads. The full 128 MiB is never held at once.
+    assert reads_at_put == [64, 128]
+    assert read_state['count'] == 128
     assert fake.finalize_calls == 1
     assert fake.abort_calls == 0
     assert pool.closed_copies == 1

--- a/postgres/tests/test_remote_query.py
+++ b/postgres/tests/test_remote_query.py
@@ -1141,3 +1141,257 @@ def test_copy_stream_upload_mode_enforces_smaller_upload_cap_over_wider_limit():
     assert sum(event_metadata(event)['bytes'] for event in data_events) == 16
     assert_failed_event(events, 'max_bytes_exceeded')
     assert event_metadata(events[-1])['stats']['bytesEmitted'] == 16
+
+
+# ---------------------------------------------------------------------------
+# M3/M4 deterministic direct-HTTP upload proof (test-only tooling)
+#
+# These tests drive the real Postgres direct-HTTP upload path
+# (``_execute_upload_stream``) in optional ``resultDelivery`` upload mode with
+# the allowlisted 8 MiB and 32 MiB proof queries. The COPY byte stream is
+# generated incrementally (1 MiB blocks) so no multi-MiB static fixture or full
+# duplicate payload is ever materialized: the bridge pulls one block at a time,
+# matching real psycopg COPY row/block streaming.
+#
+# Real Postgres appends a CSV row terminator (``\n``) to a single-column text
+# row, so ``repeat('x', 8388608)`` would emit 8388609 bytes and miss the exact
+# 8 MiB boundary. To hit exactly 8 MiB (8388608) and 32 MiB (33554432), the
+# fake COPY stream below yields a deterministic RAW byte stream of exactly
+# those byte counts (the CSV ``\n`` terminator is elided); this is documented
+# here and asserted by the total-bytes assertions.
+#
+# Unlike the prior emit-bridge proof, bulk chunk bytes go directly to
+# its-agent-intake over HTTP via an injectable ``_UploadClient`` (a fake here),
+# NOT through the native emit callback. Only metadata/final/error events cross
+# the callback. This proves the integration owns the upload and the Agent is
+# out of the data path.
+# ---------------------------------------------------------------------------
+
+PROOF_MIB = 1024 * 1024
+M3_PROOF_QUERY = "SELECT repeat('x', 8388608) AS payload"  # 8 MiB allowlisted proof query
+M4_PROOF_QUERY = "SELECT repeat('x', 33554432) AS payload"  # 32 MiB allowlisted proof query
+
+
+def incremental_copy_blocks(total_bytes, block_size=PROOF_MIB):
+    """Yield ``block_size`` blocks of ``b'x'`` until ``total_bytes`` are produced.
+
+    Blocks are generated on demand (a generator, not a static list) so the full
+    payload is never materialized as a single fixture; the consumer pulls one
+    block at a time, matching real psycopg COPY row/block streaming.
+    """
+    if total_bytes % block_size != 0:
+        raise ValueError('total_bytes must be a multiple of block_size for an exact raw byte count')
+    for _ in range(total_bytes // block_size):
+        yield b'x' * block_size
+
+
+def incremental_reference_sha256(total_bytes, block_size=PROOF_MIB):
+    """Compute the reference SHA-256 of the raw byte stream one block at a time."""
+    hasher = hashlib.sha256()
+    for _ in range(total_bytes // block_size):
+        hasher.update(b'x' * block_size)
+    return hasher.hexdigest()
+
+
+def mib_upload_request(query, total_bytes, chunk_bytes=PROOF_MIB, upload_max_bytes=None, copy_max_bytes=None):
+    """Build a valid ``resultDelivery`` upload request sized for MiB-scale proof."""
+    upload_cap = upload_max_bytes if upload_max_bytes is not None else total_bytes
+    copy_cap = copy_max_bytes if copy_max_bytes is not None else total_bytes
+    request = valid_upload_copy_request()
+    request['query'] = query
+    request['format'] = 'csv'
+    request['resultDelivery']['format'] = 'csv'
+    request['resultDelivery']['chunkBytes'] = chunk_bytes
+    request['resultDelivery']['maxBytes'] = upload_cap
+    request['limits'] = {
+        'chunkBytes': chunk_bytes,
+        'maxBytes': copy_cap,
+        'maxRowBytes': PROOF_MIB,
+        'timeoutMs': 30000,
+    }
+    return request
+
+
+def run_direct_upload_stream(request, pool, fake, monkeypatch=None):
+    """Drive the real direct-HTTP upload path and collect proof metrics.
+
+    Bulk chunk bytes are hashed and discarded as the fake intake accepts them, so the
+    full multi-MiB payload is never accumulated in memory. Returns the STARTED/FINAL
+    metadata emitted on the callback, plus the fake intake's recorded put/finalize/abort
+    calls, the total uploaded bytes, chunk count, max chunk size, and the incremental
+    SHA-256 of the uploaded chunk bodies.
+    """
+    if monkeypatch is not None:
+        patch_upload_credentials(monkeypatch)
+    started = final = None
+    hasher = hashlib.sha256()
+    total_bytes = 0
+
+    def emit(event_type, metadata_json, payload):
+        nonlocal started, final, total_bytes
+        if event_type == 'metadata':
+            started = json.loads(metadata_json)
+        elif event_type in ('final', 'error'):
+            final = json.loads(metadata_json)
+
+    _execute_upload_stream(request, make_check(pool=pool), emit, http_client=fake)
+
+    for _index, payload, _sha256_hex, _rows in fake.put_calls:
+        hasher.update(payload)
+        total_bytes += len(payload)
+
+    return SimpleNamespace(
+        started=started,
+        final=final,
+        put_calls=fake.put_calls,
+        finalize_calls=fake.finalize_calls,
+        abort_calls=fake.abort_calls,
+        total_bytes=total_bytes,
+        chunk_count=len(fake.put_calls),
+        max_chunk=max((len(c[1]) for c in fake.put_calls), default=0),
+        digest=hasher.hexdigest(),
+    )
+
+
+@pytest.mark.parametrize(
+    'total_mib, query',
+    [
+        (8, M3_PROOF_QUERY),
+        (32, M4_PROOF_QUERY),
+    ],
+)
+def test_copy_stream_upload_mode_uploads_exact_mib_directly_to_intake(total_mib, query, monkeypatch):
+    total_bytes = total_mib * PROOF_MIB
+    request = mib_upload_request(query, total_bytes)
+    pool = FakePool(copy_blocks=incremental_copy_blocks(total_bytes))
+    fake = FakeUploadClient(
+        finalize_resp={
+            'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+            'upload_id': 'upload-01k',
+            'bucket_name': 'rq-bucket',
+            'manifest_key': 'its-agent-intake/poc/org-1/task-t/run-r/upload-upload-01k/manifest.json',
+            'total_bytes': total_bytes,
+            'total_rows': 0,
+            'chunk_count': total_bytes // PROOF_MIB,
+            'sha256': incremental_reference_sha256(total_bytes),
+            'format': 'csv',
+            'compression': 'none',
+            'finalized_at': '2026-08-20T00:00:00Z',
+        }
+    )
+
+    proof = run_direct_upload_stream(request, pool, fake, monkeypatch)
+
+    # Bulk bytes go directly to the intake over HTTP, not through the emit callback.
+    assert proof.chunk_count == total_bytes // PROOF_MIB
+    assert proof.total_bytes == total_bytes
+    assert proof.max_chunk == PROOF_MIB
+    # Each uploaded chunk carries its per-chunk SHA-256 over the raw body.
+    for _index, payload, _sha256_hex, _rows in proof.put_calls:
+        assert _sha256_hex == hashlib.sha256(payload).hexdigest()
+        assert len(payload) == PROOF_MIB
+    # The aggregate SHA-256 of uploaded chunk bodies matches the incremental reference.
+    assert proof.digest == incremental_reference_sha256(total_bytes)
+    # Finalize is called exactly once; no abort on the happy path.
+    assert proof.finalize_calls == 1
+    assert proof.abort_calls == 0
+
+    # Only metadata and final reach the emit callback; no bulk data events cross it.
+    assert proof.started['status'] == 'STARTED'
+    assert proof.started['resultDelivery']['mode'] == 'POC_PUBLIC_CHUNKED_UPLOAD'
+    assert proof.started['resultDelivery']['uploadId'] == 'upload-01k'
+    assert 'baseUrl' not in proof.started['resultDelivery']
+    assert 'token' not in proof.started['resultDelivery']
+    assert proof.final['status'] == 'SUCCEEDED'
+    # The final receipt is the Agent-shaped camelCase receipt under the snake_case outer key.
+    assert proof.final['upload_receipt']['uploadId'] == 'upload-01k'
+    assert proof.final['upload_receipt']['totalBytes'] == total_bytes
+    assert proof.final['upload_receipt']['chunkCount'] == total_bytes // PROOF_MIB
+    assert proof.final['upload_receipt']['sha256'] == incremental_reference_sha256(total_bytes)
+    assert pool.closed_copies == 1
+
+
+def test_copy_stream_upload_mode_backpressure_fences_copy_reads_during_http_upload(monkeypatch):
+    total_bytes = 8 * PROOF_MIB
+    total_blocks = total_bytes // PROOF_MIB
+    read_state = {'count': 0}
+
+    def counting_block_stream():
+        for _ in range(total_blocks):
+            read_state['count'] += 1
+            yield b'x' * PROOF_MIB
+
+    request = mib_upload_request(M3_PROOF_QUERY, total_bytes)
+    pool = FakePool(copy_blocks=counting_block_stream())
+    # Record how many COPY blocks have been read at the moment each chunk is uploaded.
+    reads_at_put = []
+
+    class LockstepFakeClient(FakeUploadClient):
+        def put_chunk(self, creds, index, payload, sha256_hex, rows):
+            reads_at_put.append(read_state['count'])
+            super().put_chunk(creds, index, payload, sha256_hex, rows)
+
+    fake = LockstepFakeClient(
+        finalize_resp={
+            'mode': 'POC_PUBLIC_CHUNKED_UPLOAD',
+            'upload_id': 'upload-01k',
+            'bucket_name': 'rq-bucket',
+            'manifest_key': 'manifest.json',
+            'total_bytes': total_bytes,
+            'total_rows': 0,
+            'chunk_count': total_blocks,
+            'sha256': incremental_reference_sha256(total_bytes),
+            'format': 'csv',
+            'compression': 'none',
+            'finalized_at': '2026-08-20T00:00:00Z',
+        }
+    )
+
+    proof = run_direct_upload_stream(request, pool, fake, monkeypatch)
+
+    # Lockstep backpressure: when chunk i (1-indexed) is uploaded, exactly i blocks have
+    # been read and block i+1 is fenced (not yet read). The full 8 MiB is never buffered
+    # ahead of the HTTP upload.
+    assert reads_at_put == list(range(1, total_blocks + 1))
+    assert read_state['count'] == total_blocks
+    assert proof.chunk_count == total_blocks
+    assert pool.closed_copies == 1
+
+
+def test_copy_stream_upload_mode_aborts_on_http_failure_at_mib_scale(monkeypatch):
+    total_bytes = 8 * PROOF_MIB
+    request = mib_upload_request(M3_PROOF_QUERY, total_bytes)
+    pool = FakePool(copy_blocks=incremental_copy_blocks(total_bytes))
+    fake = FakeUploadClient(
+        raise_on_put=remote_query._CopyStreamFailure('upload_failed', 'transient exhausted', retryable=True)
+    )
+
+    proof = run_direct_upload_stream(request, pool, fake, monkeypatch)
+
+    # The first chunk upload fails; the session is aborted and an error event is emitted.
+    assert len(proof.put_calls) == 1
+    assert proof.abort_calls == 1
+    assert proof.final['status'] == 'FAILED'
+    assert proof.final['error']['code'] == 'upload_failed'
+    assert pool.closed_copies == 1
+
+
+def test_copy_stream_upload_mode_enforces_max_bytes_at_mib_scale(monkeypatch):
+    total_bytes = 8 * PROOF_MIB
+    upload_cap = 4 * PROOF_MIB
+    # The copy limit is wider than the upload cap; the tighter upload cap must win.
+    request = mib_upload_request(M3_PROOF_QUERY, total_bytes, upload_max_bytes=upload_cap, copy_max_bytes=total_bytes)
+    pool = FakePool(copy_blocks=incremental_copy_blocks(total_bytes))
+    fake = FakeUploadClient()
+
+    proof = run_direct_upload_stream(request, pool, fake, monkeypatch)
+
+    # maxBytes enforced: exactly the upload cap is uploaded, then the stream fails.
+    assert proof.total_bytes == upload_cap
+    assert proof.chunk_count == upload_cap // PROOF_MIB
+    assert proof.max_chunk == PROOF_MIB
+    assert proof.final['status'] == 'FAILED'
+    assert proof.final['error']['code'] == 'max_bytes_exceeded'
+    # No receipt is emitted when the upload cap is exceeded.
+    assert 'upload_receipt' not in proof.final
+    assert pool.closed_copies == 1

--- a/postgres/tests/test_remote_query.py
+++ b/postgres/tests/test_remote_query.py
@@ -1098,11 +1098,6 @@ def test_copy_stream_upload_mode_rejects_missing_upload_id():
     'delivery, limits, expected',
     [
         (
-            {'partBytes': 16},
-            {'chunkBytes': 8, 'maxBytes': 64},
-            'resultDelivery.partBytes must not exceed limits.chunkBytes',
-        ),
-        (
             {'maxBytes': 128},
             {'chunkBytes': 8, 'maxBytes': 64},
             'resultDelivery.maxBytes must not exceed limits.maxBytes',
@@ -1115,6 +1110,29 @@ def test_copy_stream_upload_mode_rejects_upload_cap_widening(delivery, limits, e
     request['limits'].update(limits)
     events = list(iter_agent_rpc_stream_copy_events(request, ExplodingRegistry()))
     assert_failed_event(events, 'invalid_request', expected)
+
+
+def test_copy_stream_upload_mode_part_bytes_may_exceed_copy_chunk_bytes():
+    # partBytes (the multipart part size) and limits.chunkBytes (the COPY streaming chunk size)
+    # are distinct concepts: partBytes may exceed chunkBytes. The request validates without
+    # widening the COPY maxBytes cap and the stream proceeds to SUCCEEDED.
+    pool = FakePool(copy_blocks=[b'abcdefgh', b'ijklmnop', b'qr'])  # 18 bytes
+    request = valid_upload_copy_request()
+    request['resultDelivery']['partBytes'] = 16
+    request['resultDelivery']['maxBytes'] = 64
+    request['limits'] = {'chunkBytes': 8, 'maxBytes': 64, 'maxRowBytes': 32, 'timeoutMs': 5000}
+
+    events = collect_copy_events(request, make_check(pool=pool))
+
+    started = event_metadata(events[0])
+    assert started['status'] == 'STARTED'
+    assert started['chunkBytes'] == 8  # COPY streaming chunk size
+    assert started['resultDelivery']['partBytes'] == 16  # multipart part size, exceeds chunkBytes
+    assert event_metadata(events[-1])['status'] == 'SUCCEEDED'
+    # The COPY stream emits 3 chunkBytes-sized chunks, but the upload aggregates them into
+    # ceil(18/16) = 2 parts: the provisional receipt reports the part count, not the chunk count.
+    assert event_metadata(events[-1])['stats']['chunksEmitted'] == 3
+    assert event_metadata(events[-1])['uploadReceipt']['partCount'] == 2
 
 
 def test_copy_stream_upload_mode_accepts_equal_upload_caps():
@@ -1584,4 +1602,31 @@ def test_copy_stream_upload_mode_finalizes_empty_result_with_zero_parts(monkeypa
     assert receipt['totalBytes'] == 0
     assert receipt['totalRows'] == 0
     assert receipt['objectPath'].endswith('result.csv')
+    assert pool.closed_copies == 1
+
+
+def test_copy_stream_upload_mode_aggregates_copy_chunks_into_partbytes_parts(monkeypatch):
+    patch_upload_credentials(monkeypatch)
+    # partBytes (8) exceeds limits.chunkBytes (4): the COPY stream emits 4-byte chunks and the
+    # upload client aggregates them into 8-byte parts. Two full parts plus a final short part.
+    pool = FakePool(copy_blocks=[b'aaaa', b'bbbb', b'cccc', b'dddd', b'ee'])
+    request = valid_upload_copy_request()
+    request['resultDelivery']['partBytes'] = 8
+    request['resultDelivery']['maxBytes'] = 24
+    request['limits'] = {'chunkBytes': 4, 'maxBytes': 64, 'maxRowBytes': 32, 'timeoutMs': 5000}
+    fake = FakeUploadClient()
+
+    _execute_upload_stream(request, make_check(pool=pool), lambda *event: None, http_client=fake)
+
+    # Contiguous 1-based part numbers; each non-final part is exactly partBytes (8) and aggregates
+    # two 4-byte COPY chunks; the final part is the short remainder.
+    assert [call[0] for call in fake.put_calls] == [1, 2, 3]
+    assert [call[1] for call in fake.put_calls] == [b'aaaabbbb', b'ccccdddd', b'ee']
+    assert [len(call[1]) for call in fake.put_calls] == [8, 8, 2]
+    assert sum(len(call[1]) for call in fake.put_calls) == 18
+    # Each part carries the SHA-256 of its aggregated body, not of the individual COPY chunks.
+    for _part_number, payload, sha256_hex, _rows in fake.put_calls:
+        assert sha256_hex == hashlib.sha256(payload).hexdigest()
+    assert fake.finalize_calls == 1
+    assert fake.abort_calls == 0
     assert pool.closed_copies == 1


### PR DESCRIPTION
## Stack

- Base: #24925 (`nubtron/remote-queries-intake-poc`)
- This draft: test-only deterministic COPY bridge proof

## Summary

- exercise the actual Python COPY-to-Agent emit bridge at exact 8 MiB and 32 MiB
- verify backpressure and read fencing
- verify incremental checksums and maximum-byte failures
- keep production `remote_query.py` unchanged in this tooling layer

## Validation

- 133 focused tests passed
- lint passed
- independently reviewed

## Deployment

Test-only local proof tooling; no shared deployment.