### PR TITLE
Collect SQL Server view schema metadata

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -1142,8 +1142,7 @@ files:
           fleet_configurable: false
         - name: collect_views
           description: |
-            Enable collection of SQL Server views. Set to false to continue collecting table schemas
-            without collecting views. Defaults to true.
+            Enable collection of SQL Server views when schema collection is enabled. Defaults to true.
           value:
             type: boolean
             example: true

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -1140,6 +1140,14 @@ files:
             type: boolean
             example: false
           fleet_configurable: false
+        - name: collect_views
+          description: |
+            Enable collection of SQL Server views. Set to false to continue collecting table schemas
+            without collecting views. Defaults to true.
+          value:
+            type: boolean
+            example: true
+          fleet_configurable: false
         - name: collection_interval
           description: |
             Set the database schema collection interval (in seconds). Defaults to 600 seconds.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -1154,6 +1154,13 @@ files:
             type: integer
             example: 300
           fleet_configurable: false
+        - name: max_views
+          description: |
+            Set the maximum number of views to collect. Defaults to 1000.
+          value:
+            type: integer
+            example: 1000
+          fleet_configurable: false
         - name: max_execution_time
           deprecation:
             Agent version: 7.74.0

--- a/sqlserver/changelog.d/24928.added
+++ b/sqlserver/changelog.d/24928.added
@@ -1,0 +1,1 @@
+Collect view definitions and column metadata during schema collection.

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -75,6 +75,7 @@ class CollectSchemas(BaseModel):
     enabled: Optional[bool] = None
     max_execution_time: Optional[float] = None
     max_tables: Optional[int] = None
+    max_views: Optional[int] = None
 
 
 class CollectSettings(BaseModel):

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -71,6 +71,7 @@ class CollectSchemas(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collect_views: Optional[bool] = None
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
     max_execution_time: Optional[float] = None

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -829,6 +829,12 @@ instances:
         #
         # enabled: false
 
+        ## @param collect_views - boolean - optional - default: true
+        ## Enable collection of SQL Server views. Set to false to continue collecting table schemas
+        ## without collecting views. Defaults to true.
+        #
+        # collect_views: true
+
         ## @param collection_interval - number - optional - default: 600
         ## Set the database schema collection interval (in seconds). Defaults to 600 seconds.
         #

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -839,6 +839,11 @@ instances:
         #
         # max_tables: 300
 
+        ## @param max_views - integer - optional - default: 1000
+        ## Set the maximum number of views to collect. Defaults to 1000.
+        #
+        # max_views: 1000
+
         ## @param max_execution_time - number - optional - default: 10
         ## Set the maximum time for schema collection (in seconds). Defaults to 10 seconds.
         ## Capped by `collect_schemas.collection_interval`

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -830,8 +830,7 @@ instances:
         # enabled: false
 
         ## @param collect_views - boolean - optional - default: true
-        ## Enable collection of SQL Server views. Set to false to continue collecting table schemas
-        ## without collecting views. Defaults to true.
+        ## Enable collection of SQL Server views when schema collection is enabled. Defaults to true.
         #
         # collect_views: true
 

--- a/sqlserver/datadog_checks/sqlserver/metadata.py
+++ b/sqlserver/datadog_checks/sqlserver/metadata.py
@@ -18,6 +18,7 @@ from datadog_checks.sqlserver.const import (
 )
 from datadog_checks.sqlserver.schemas import SQLServerSchemaCollector
 from datadog_checks.sqlserver.utils import raise_if_cancelled
+from datadog_checks.sqlserver.views import SQLServerViewCollector
 
 # default settings collection interval in seconds
 DEFAULT_SETTINGS_COLLECTION_INTERVAL = 600
@@ -82,6 +83,7 @@ class SqlserverMetadata(DBMAsyncJob):
         self._time_since_last_settings_query = 0
         self._max_query_metrics = self._config.statement_metrics_config.get("max_queries", 250)
         self._schema_collector = SQLServerSchemaCollector(check)
+        self._view_collector = SQLServerViewCollector(check)
         self._schema_config = self._config.schema_config
         self._schema_collection_interval = self._schema_config.get(
             'collection_interval', DEFAULT_SCHEMAS_COLLECTION_INTERVAL
@@ -172,3 +174,4 @@ class SqlserverMetadata(DBMAsyncJob):
         raise_if_cancelled(self._cancel_event)
         self._last_schemas_collection_time = time.time()
         self._schema_collector.collect_schemas()
+        self._view_collector.collect_schemas()

--- a/sqlserver/datadog_checks/sqlserver/metadata.py
+++ b/sqlserver/datadog_checks/sqlserver/metadata.py
@@ -174,4 +174,5 @@ class SqlserverMetadata(DBMAsyncJob):
         raise_if_cancelled(self._cancel_event)
         self._last_schemas_collection_time = time.time()
         self._schema_collector.collect_schemas()
-        self._view_collector.collect_schemas()
+        if self._schema_config.get('collect_views', True):
+            self._view_collector.collect_schemas()

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -29,6 +29,21 @@ FROM
     sys.tables
 """
 
+VIEWS_QUERY = """
+SELECT
+    v.object_id AS view_id,
+    v.name AS view_name,
+    v.schema_id,
+    CONVERT(varchar(33), v.create_date, 126) AS create_date,
+    CONVERT(varchar(33), v.modify_date, 126) AS modify_date,
+    m.definition
+FROM
+    sys.views v
+    LEFT JOIN sys.sql_modules m ON v.object_id = m.object_id
+WHERE
+    v.is_ms_shipped = 0
+"""
+
 COLUMN_QUERY = """
 SELECT
     c.name, t.name as data_type, coalesce(dc.definition, 'None') as "default", c.is_nullable AS nullable

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -54,6 +54,21 @@ FROM
 WHERE c.object_id = schema_tables.table_id
 """
 
+VIEW_COLUMN_QUERY = """
+SELECT
+    c.name,
+    t.name AS data_type,
+    coalesce(dc.definition, 'None') AS "default",
+    c.is_nullable AS nullable,
+    CONVERT(varchar(10), c.column_id) AS ordinal_position
+FROM
+    sys.columns c
+    INNER JOIN sys.types t ON c.user_type_id = t.user_type_id
+    LEFT JOIN sys.default_constraints dc ON c.default_object_id = dc.object_id
+WHERE c.object_id = schema_views.view_id
+ORDER BY c.column_id
+"""
+
 PARTITIONS_QUERY = """
 SELECT
     COUNT(*) AS partition_count

--- a/sqlserver/datadog_checks/sqlserver/schemas.py
+++ b/sqlserver/datadog_checks/sqlserver/schemas.py
@@ -29,6 +29,7 @@ from datadog_checks.sqlserver.queries import (
     PARTITIONS_QUERY,
     SCHEMA_QUERY,
     TABLES_QUERY,
+    VIEWS_QUERY,
 )
 
 KEY_PREFIX = "dbm-schemas-"
@@ -56,23 +57,50 @@ class DatabaseObject(TypedDict):
     owner: str
 
 
+class ColumnObjectBase(TypedDict):
+    data_type: str
+    name: str
+    nullable: bool
+
+
+class ColumnObject(ColumnObjectBase, total=False):
+    default: str | None
+    ordinal_position: str | None
+
+
 class TableObject(TypedDict):
     id: str
     name: str
-    columns: list
+    columns: list[ColumnObject]
     indexes: list
     foreign_keys: list
+
+
+class ViewObject(TypedDict):
+    id: str
+    name: str
+    create_date: str
+    modify_date: str
+    definition: str | None
+    columns: list[ColumnObject]
 
 
 class SchemaObject(TypedDict):
     name: str
     id: str
-    owner: str
+    owner_name: str
+
+
+class TableSchemaObject(SchemaObject):
     tables: list[TableObject]
 
 
+class ViewSchemaObject(SchemaObject):
+    views: list[ViewObject]
+
+
 class SQLServerDatabaseObject(DatabaseObject):
-    schemas: list[SchemaObject]
+    schemas: list[TableSchemaObject | ViewSchemaObject]
 
 
 class SQLServerSchemaCollector(SchemaCollector):
@@ -84,6 +112,7 @@ class SQLServerSchemaCollector(SchemaCollector):
             "collection_interval", DEFAULT_SCHEMAS_COLLECTION_INTERVAL
         )
         config.max_tables = check._config.schema_config.get('max_tables', 300)
+        config.max_views = check._config.schema_config.get('max_views', 1000)
         self._is_2016_or_earlier = None
         self._database_compatibility_levels: dict[str, int] = {}
         self._pre_2017_cursor = None
@@ -122,7 +151,7 @@ class SQLServerSchemaCollector(SchemaCollector):
                     )
                     self._pre_2017_cursor.execute(switch_db_statement)
 
-                query = self._get_tables_query()
+                query = self._get_schema_objects_query()
                 cursor.execute(query)
                 yield cursor
             finally:
@@ -165,11 +194,12 @@ class SQLServerSchemaCollector(SchemaCollector):
             return True
         return compatibility_level < MINIMUM_JSON_COMPATIBILITY_LEVEL
 
-    def _get_tables_query(self):
-        limit = int(self._config.max_tables or 1_000_000)
+    def _get_schema_objects_query(self):
+        table_limit = int(self._config.max_tables or 1_000_000)
+        view_limit = int(self._config.max_views or 1_000_000)
 
-        # Note that we INNER JOIN tables to omit schemas with no tables
-        # This is a simple way to omit the system tables like db_blah
+        # Limit tables and views independently, then combine them into one result stream.
+        # `_map_row` uses object_type to place each object in its corresponding schema list.
         query = f"""
             WITH
             schemas AS (
@@ -178,19 +208,43 @@ class SQLServerSchemaCollector(SchemaCollector):
             tables AS (
                 {TABLES_QUERY}
             ),
-            schema_tables AS (
-                SELECT TOP {limit} schemas.schema_name, schemas.schema_id, schemas.owner_name,
+            views AS (
+                {VIEWS_QUERY}
+            ),
+            limited_tables AS (
+                SELECT TOP {table_limit} schemas.schema_name, schemas.schema_id, schemas.owner_name,
                 tables.table_id, tables.table_name
                 FROM schemas
                 INNER JOIN tables ON schemas.schema_id = tables.schema_id
                 ORDER BY schemas.schema_name, tables.table_name
+            ),
+            limited_views AS (
+                SELECT TOP {view_limit} schemas.schema_name, schemas.schema_id, schemas.owner_name,
+                views.view_id, views.view_name, views.create_date, views.modify_date, views.definition
+                FROM schemas
+                INNER JOIN views ON schemas.schema_id = views.schema_id
+                ORDER BY schemas.schema_name, views.view_name
+            ),
+            schema_tables AS (
+                SELECT schema_name, schema_id, owner_name, table_id, table_name,
+                    'TABLE' AS object_type,
+                    CAST(NULL AS varchar(33)) AS create_date,
+                    CAST(NULL AS varchar(33)) AS modify_date,
+                    CAST(NULL AS nvarchar(max)) AS definition
+                FROM limited_tables
+                UNION ALL
+                SELECT schema_name, schema_id, owner_name, view_id AS table_id, view_name AS table_name,
+                    'VIEW' AS object_type, create_date, modify_date, definition
+                FROM limited_views
             )
         """
         if self._is_2016_or_earlier:
             query += """
             SELECT schema_tables.schema_id, schema_tables.schema_name, schema_tables.owner_name,
-                schema_tables.table_name, schema_tables.table_id
+                schema_tables.table_name, schema_tables.table_id, schema_tables.object_type,
+                schema_tables.create_date, schema_tables.modify_date, schema_tables.definition
             FROM schema_tables
+            ORDER BY schema_tables.schema_name, schema_tables.object_type, schema_tables.table_name
             ;
         """
             return query
@@ -198,12 +252,16 @@ class SQLServerSchemaCollector(SchemaCollector):
         # For 2017 and later we can get all the data in one query
         query += f"""
             SELECT schema_tables.schema_id, schema_tables.schema_name, schema_tables.owner_name,
-                schema_tables.table_name
+                schema_tables.table_name, schema_tables.table_id, schema_tables.object_type,
+                schema_tables.create_date, schema_tables.modify_date, schema_tables.definition
                 , json_query(({COLUMN_QUERY} FOR JSON PATH), '$') as columns
-                , json_query(({INDEX_QUERY} FOR JSON PATH), '$') as indexes
-                , json_query(({FOREIGN_KEY_QUERY} FOR JSON PATH), '$') as foreign_keys
-                , ({PARTITIONS_QUERY}) as partition_count
+                , CASE WHEN schema_tables.object_type = 'TABLE'
+                    THEN json_query(({INDEX_QUERY} FOR JSON PATH), '$') ELSE json_query('[]') END as indexes
+                , CASE WHEN schema_tables.object_type = 'TABLE'
+                    THEN json_query(({FOREIGN_KEY_QUERY} FOR JSON PATH), '$') ELSE json_query('[]') END as foreign_keys
+                , CASE WHEN schema_tables.object_type = 'TABLE' THEN ({PARTITIONS_QUERY}) END as partition_count
             FROM schema_tables
+            ORDER BY schema_tables.schema_name, schema_tables.object_type, schema_tables.table_name
             ;
         """
         return query
@@ -216,8 +274,9 @@ class SQLServerSchemaCollector(SchemaCollector):
 
     def _map_row(self, database: DatabaseInfo, cursor_row) -> DatabaseObject:
         object = super()._map_row(database, cursor_row)
+        is_view = cursor_row.get("object_type") == "VIEW"
         if self._is_2016_or_earlier:
-            # We need to fetch the related data for each table
+            # We need to fetch the related data for each table or view.
             # Use a separate connection to avoid conflicts with the main cursor while it streams table rows.
             cursor = self._pre_2017_cursor
             if cursor is None:
@@ -227,16 +286,21 @@ class SQLServerSchemaCollector(SchemaCollector):
             columns_query = COLUMN_QUERY.replace("schema_tables.table_id", table_id)
             cursor.execute(columns_query)
             columns = cursor.fetchall_dict()
-            indexes_query = INDEX_QUERY_PRE_2017.replace("schema_tables.table_id", table_id)
-            cursor.execute(indexes_query)
-            indexes = cursor.fetchall_dict()
-            foreign_keys_query = FOREIGN_KEY_QUERY_PRE_2017.replace("schema_tables.table_id", table_id)
-            cursor.execute(foreign_keys_query)
-            foreign_keys = cursor.fetchall_dict()
-            partitions_query = PARTITIONS_QUERY.replace("schema_tables.table_id", table_id)
-            cursor.execute(partitions_query)
-            partition_row = cursor.fetchone_dict()
-            partition_count = partition_row.get("partition_count") if partition_row else None
+            if is_view:
+                indexes = []
+                foreign_keys = []
+                partition_count = None
+            else:
+                indexes_query = INDEX_QUERY_PRE_2017.replace("schema_tables.table_id", table_id)
+                cursor.execute(indexes_query)
+                indexes = cursor.fetchall_dict()
+                foreign_keys_query = FOREIGN_KEY_QUERY_PRE_2017.replace("schema_tables.table_id", table_id)
+                cursor.execute(foreign_keys_query)
+                foreign_keys = cursor.fetchall_dict()
+                partitions_query = PARTITIONS_QUERY.replace("schema_tables.table_id", table_id)
+                cursor.execute(partitions_query)
+                partition_row = cursor.fetchone_dict()
+                partition_count = partition_row.get("partition_count") if partition_row else None
         else:
             columns = json.loads(cursor_row.get("columns") or "[]")
             indexes = json.loads(cursor_row.get("indexes") or "[]")
@@ -244,33 +308,40 @@ class SQLServerSchemaCollector(SchemaCollector):
             partition_count = cursor_row.get("partition_count")
 
         # Map the cursor row to the expected schema, and strip out None values
-        object["schemas"] = [
-            {
-                "name": cursor_row.get("schema_name"),
-                "id": str(cursor_row.get("schema_id")),  # Backend expects a string
-                "owner_name": cursor_row.get("owner_name"),
-                "tables": (
-                    [
-                        {
-                            k: v
-                            for k, v in {
-                                "id": str(cursor_row.get("table_id")),  # Backend expects a string
-                                "name": cursor_row.get("table_name"),
-                                "columns": [column for column in columns if column.get("name") is not None],
-                                "indexes": [index for index in indexes if index.get("name") is not None],
-                                "foreign_keys": [
-                                    foreign_key
-                                    for foreign_key in foreign_keys
-                                    if foreign_key.get("foreign_key_name") is not None
-                                ],
-                                "partitions": {"partition_count": partition_count},
-                            }.items()
-                            if v is not None
-                        }
-                    ]
-                    if cursor_row.get("table_name") is not None
-                    else []
-                ),
-            }
-        ]
+        schema = {
+            "name": cursor_row.get("schema_name"),
+            "id": str(cursor_row.get("schema_id")),  # Backend expects a string
+            "owner_name": cursor_row.get("owner_name"),
+        }
+        if is_view:
+            schema["views"] = [
+                {
+                    "id": str(cursor_row.get("table_id")),  # Backend expects a string
+                    "name": cursor_row.get("table_name"),
+                    "create_date": cursor_row.get("create_date"),
+                    "modify_date": cursor_row.get("modify_date"),
+                    "definition": cursor_row.get("definition"),
+                    "columns": [column for column in columns if column.get("name") is not None],
+                }
+            ]
+        else:
+            schema["tables"] = [
+                {
+                    k: v
+                    for k, v in {
+                        "id": str(cursor_row.get("table_id")),  # Backend expects a string
+                        "name": cursor_row.get("table_name"),
+                        "columns": [column for column in columns if column.get("name") is not None],
+                        "indexes": [index for index in indexes if index.get("name") is not None],
+                        "foreign_keys": [
+                            foreign_key
+                            for foreign_key in foreign_keys
+                            if foreign_key.get("foreign_key_name") is not None
+                        ],
+                        "partitions": {"partition_count": partition_count},
+                    }.items()
+                    if v is not None
+                }
+            ]
+        object["schemas"] = [schema]
         return object

--- a/sqlserver/datadog_checks/sqlserver/schemas.py
+++ b/sqlserver/datadog_checks/sqlserver/schemas.py
@@ -29,7 +29,6 @@ from datadog_checks.sqlserver.queries import (
     PARTITIONS_QUERY,
     SCHEMA_QUERY,
     TABLES_QUERY,
-    VIEWS_QUERY,
 )
 
 KEY_PREFIX = "dbm-schemas-"
@@ -76,35 +75,21 @@ class TableObject(TypedDict):
     foreign_keys: list
 
 
-class ViewObject(TypedDict):
-    id: str
-    name: str
-    create_date: str
-    modify_date: str
-    definition: str | None
-    columns: list[ColumnObject]
-
-
 class SchemaObject(TypedDict):
     name: str
     id: str
     owner_name: str
-
-
-class TableSchemaObject(SchemaObject):
     tables: list[TableObject]
 
 
-class ViewSchemaObject(SchemaObject):
-    views: list[ViewObject]
-
-
 class SQLServerDatabaseObject(DatabaseObject):
-    schemas: list[TableSchemaObject | ViewSchemaObject]
+    schemas: list[SchemaObject]
 
 
 class SQLServerSchemaCollector(SchemaCollector):
     _check: SQLServer
+    connection_key_prefix = KEY_PREFIX
+    legacy_connection_key_prefix = KEY_PREFIX_PRE_2017
 
     def __init__(self, check: SQLServer):
         config = SchemaCollectorConfig()
@@ -112,7 +97,6 @@ class SQLServerSchemaCollector(SchemaCollector):
             "collection_interval", DEFAULT_SCHEMAS_COLLECTION_INTERVAL
         )
         config.max_tables = check._config.schema_config.get('max_tables', 300)
-        config.max_views = check._config.schema_config.get('max_views', 1000)
         self._is_2016_or_earlier = None
         self._database_compatibility_levels: dict[str, int] = {}
         self._pre_2017_cursor = None
@@ -124,8 +108,8 @@ class SQLServerSchemaCollector(SchemaCollector):
 
     def _get_databases(self) -> list[DatabaseInfo]:
         database_names = self._check.get_databases()
-        with self._check.connection.open_managed_default_connection(KEY_PREFIX):
-            with self._check.connection.get_managed_cursor(KEY_PREFIX) as cursor:
+        with self._check.connection.open_managed_default_connection(self.connection_key_prefix):
+            with self._check.connection.get_managed_cursor(self.connection_key_prefix) as cursor:
                 if not database_names:
                     return []
                 placeholders = ",".join(["?"] * len(database_names))
@@ -138,20 +122,22 @@ class SQLServerSchemaCollector(SchemaCollector):
     def _get_cursor(self, database_name):
         with contextlib.ExitStack() as stack:
             try:
-                stack.enter_context(self._check.connection.open_managed_default_connection(KEY_PREFIX))
-                cursor = stack.enter_context(self._check.connection.get_managed_cursor(KEY_PREFIX))
+                stack.enter_context(self._check.connection.open_managed_default_connection(self.connection_key_prefix))
+                cursor = stack.enter_context(self._check.connection.get_managed_cursor(self.connection_key_prefix))
                 switch_db_statement = construct_use_statement(database_name)
                 cursor.execute(switch_db_statement)
                 self._is_2016_or_earlier = self._should_use_legacy_schema_query(database_name)
 
                 if self._is_2016_or_earlier:
-                    stack.enter_context(self._check.connection.open_managed_default_connection(KEY_PREFIX_PRE_2017))
+                    stack.enter_context(
+                        self._check.connection.open_managed_default_connection(self.legacy_connection_key_prefix)
+                    )
                     self._pre_2017_cursor = stack.enter_context(
-                        self._check.connection.get_managed_cursor(KEY_PREFIX_PRE_2017)
+                        self._check.connection.get_managed_cursor(self.legacy_connection_key_prefix)
                     )
                     self._pre_2017_cursor.execute(switch_db_statement)
 
-                query = self._get_schema_objects_query()
+                query = self._get_objects_query()
                 cursor.execute(query)
                 yield cursor
             finally:
@@ -194,12 +180,11 @@ class SQLServerSchemaCollector(SchemaCollector):
             return True
         return compatibility_level < MINIMUM_JSON_COMPATIBILITY_LEVEL
 
-    def _get_schema_objects_query(self):
-        table_limit = int(self._config.max_tables or 1_000_000)
-        view_limit = int(self._config.max_views or 1_000_000)
+    def _get_objects_query(self):
+        limit = int(self._config.max_tables or 1_000_000)
 
-        # Limit tables and views independently, then combine them into one result stream.
-        # `_map_row` uses object_type to place each object in its corresponding schema list.
+        # Note that we INNER JOIN tables to omit schemas with no tables
+        # This is a simple way to omit the system tables like db_blah
         query = f"""
             WITH
             schemas AS (
@@ -208,41 +193,18 @@ class SQLServerSchemaCollector(SchemaCollector):
             tables AS (
                 {TABLES_QUERY}
             ),
-            views AS (
-                {VIEWS_QUERY}
-            ),
-            limited_tables AS (
-                SELECT TOP {table_limit} schemas.schema_name, schemas.schema_id, schemas.owner_name,
+            schema_tables AS (
+                SELECT TOP {limit} schemas.schema_name, schemas.schema_id, schemas.owner_name,
                 tables.table_id, tables.table_name
                 FROM schemas
                 INNER JOIN tables ON schemas.schema_id = tables.schema_id
                 ORDER BY schemas.schema_name, tables.table_name
-            ),
-            limited_views AS (
-                SELECT TOP {view_limit} schemas.schema_name, schemas.schema_id, schemas.owner_name,
-                views.view_id, views.view_name, views.create_date, views.modify_date, views.definition
-                FROM schemas
-                INNER JOIN views ON schemas.schema_id = views.schema_id
-                ORDER BY schemas.schema_name, views.view_name
-            ),
-            schema_tables AS (
-                SELECT schema_name, schema_id, owner_name, table_id, table_name,
-                    'TABLE' AS object_type,
-                    CAST(NULL AS varchar(33)) AS create_date,
-                    CAST(NULL AS varchar(33)) AS modify_date,
-                    CAST(NULL AS nvarchar(max)) AS definition
-                FROM limited_tables
-                UNION ALL
-                SELECT schema_name, schema_id, owner_name, view_id AS table_id, view_name AS table_name,
-                    'VIEW' AS object_type, create_date, modify_date, definition
-                FROM limited_views
             )
         """
         if self._is_2016_or_earlier:
             query += """
             SELECT schema_tables.schema_id, schema_tables.schema_name, schema_tables.owner_name,
-                schema_tables.table_name, schema_tables.table_id, schema_tables.object_type,
-                schema_tables.create_date, schema_tables.modify_date, schema_tables.definition
+                schema_tables.table_name, schema_tables.table_id
             FROM schema_tables
             ;
         """
@@ -251,14 +213,11 @@ class SQLServerSchemaCollector(SchemaCollector):
         # For 2017 and later we can get all the data in one query
         query += f"""
             SELECT schema_tables.schema_id, schema_tables.schema_name, schema_tables.owner_name,
-                schema_tables.table_name, schema_tables.table_id, schema_tables.object_type,
-                schema_tables.create_date, schema_tables.modify_date, schema_tables.definition
+                schema_tables.table_name, schema_tables.table_id
                 , json_query(({COLUMN_QUERY} FOR JSON PATH), '$') as columns
-                , CASE WHEN schema_tables.object_type = 'TABLE'
-                    THEN json_query(({INDEX_QUERY} FOR JSON PATH), '$') ELSE json_query('[]') END as indexes
-                , CASE WHEN schema_tables.object_type = 'TABLE'
-                    THEN json_query(({FOREIGN_KEY_QUERY} FOR JSON PATH), '$') ELSE json_query('[]') END as foreign_keys
-                , CASE WHEN schema_tables.object_type = 'TABLE' THEN ({PARTITIONS_QUERY}) END as partition_count
+                , json_query(({INDEX_QUERY} FOR JSON PATH), '$') as indexes
+                , json_query(({FOREIGN_KEY_QUERY} FOR JSON PATH), '$') as foreign_keys
+                , ({PARTITIONS_QUERY}) as partition_count
             FROM schema_tables
             ;
         """
@@ -272,9 +231,8 @@ class SQLServerSchemaCollector(SchemaCollector):
 
     def _map_row(self, database: DatabaseInfo, cursor_row) -> DatabaseObject:
         object = super()._map_row(database, cursor_row)
-        is_view = cursor_row.get("object_type") == "VIEW"
         if self._is_2016_or_earlier:
-            # We need to fetch the related data for each table or view.
+            # We need to fetch the related data for each table
             # Use a separate connection to avoid conflicts with the main cursor while it streams table rows.
             cursor = self._pre_2017_cursor
             if cursor is None:
@@ -284,21 +242,16 @@ class SQLServerSchemaCollector(SchemaCollector):
             columns_query = COLUMN_QUERY.replace("schema_tables.table_id", table_id)
             cursor.execute(columns_query)
             columns = cursor.fetchall_dict()
-            if is_view:
-                indexes = []
-                foreign_keys = []
-                partition_count = None
-            else:
-                indexes_query = INDEX_QUERY_PRE_2017.replace("schema_tables.table_id", table_id)
-                cursor.execute(indexes_query)
-                indexes = cursor.fetchall_dict()
-                foreign_keys_query = FOREIGN_KEY_QUERY_PRE_2017.replace("schema_tables.table_id", table_id)
-                cursor.execute(foreign_keys_query)
-                foreign_keys = cursor.fetchall_dict()
-                partitions_query = PARTITIONS_QUERY.replace("schema_tables.table_id", table_id)
-                cursor.execute(partitions_query)
-                partition_row = cursor.fetchone_dict()
-                partition_count = partition_row.get("partition_count") if partition_row else None
+            indexes_query = INDEX_QUERY_PRE_2017.replace("schema_tables.table_id", table_id)
+            cursor.execute(indexes_query)
+            indexes = cursor.fetchall_dict()
+            foreign_keys_query = FOREIGN_KEY_QUERY_PRE_2017.replace("schema_tables.table_id", table_id)
+            cursor.execute(foreign_keys_query)
+            foreign_keys = cursor.fetchall_dict()
+            partitions_query = PARTITIONS_QUERY.replace("schema_tables.table_id", table_id)
+            cursor.execute(partitions_query)
+            partition_row = cursor.fetchone_dict()
+            partition_count = partition_row.get("partition_count") if partition_row else None
         else:
             columns = json.loads(cursor_row.get("columns") or "[]")
             indexes = json.loads(cursor_row.get("indexes") or "[]")
@@ -306,40 +259,29 @@ class SQLServerSchemaCollector(SchemaCollector):
             partition_count = cursor_row.get("partition_count")
 
         # Map the cursor row to the expected schema, and strip out None values
-        schema = {
-            "name": cursor_row.get("schema_name"),
-            "id": str(cursor_row.get("schema_id")),  # Backend expects a string
-            "owner_name": cursor_row.get("owner_name"),
-        }
-        if is_view:
-            schema["views"] = [
-                {
-                    "id": str(cursor_row.get("table_id")),  # Backend expects a string
-                    "name": cursor_row.get("table_name"),
-                    "create_date": cursor_row.get("create_date"),
-                    "modify_date": cursor_row.get("modify_date"),
-                    "definition": cursor_row.get("definition"),
-                    "columns": [column for column in columns if column.get("name") is not None],
-                }
-            ]
-        else:
-            schema["tables"] = [
-                {
-                    k: v
-                    for k, v in {
-                        "id": str(cursor_row.get("table_id")),  # Backend expects a string
-                        "name": cursor_row.get("table_name"),
-                        "columns": [column for column in columns if column.get("name") is not None],
-                        "indexes": [index for index in indexes if index.get("name") is not None],
-                        "foreign_keys": [
-                            foreign_key
-                            for foreign_key in foreign_keys
-                            if foreign_key.get("foreign_key_name") is not None
-                        ],
-                        "partitions": {"partition_count": partition_count},
-                    }.items()
-                    if v is not None
-                }
-            ]
-        object["schemas"] = [schema]
+        object["schemas"] = [
+            {
+                "name": cursor_row.get("schema_name"),
+                "id": str(cursor_row.get("schema_id")),  # Backend expects a string
+                "owner_name": cursor_row.get("owner_name"),
+                "tables": [
+                    {
+                        k: v
+                        for k, v in {
+                            "id": str(cursor_row.get("table_id")),  # Backend expects a string
+                            "name": cursor_row.get("table_name"),
+                            "columns": [column for column in columns if column.get("name") is not None],
+                            "indexes": [index for index in indexes if index.get("name") is not None],
+                            "foreign_keys": [
+                                foreign_key
+                                for foreign_key in foreign_keys
+                                if foreign_key.get("foreign_key_name") is not None
+                            ],
+                            "partitions": {"partition_count": partition_count},
+                        }.items()
+                        if v is not None
+                    }
+                ],
+            }
+        ]
         return object

--- a/sqlserver/datadog_checks/sqlserver/schemas.py
+++ b/sqlserver/datadog_checks/sqlserver/schemas.py
@@ -56,21 +56,10 @@ class DatabaseObject(TypedDict):
     owner: str
 
 
-class ColumnObjectBase(TypedDict):
-    data_type: str
-    name: str
-    nullable: bool
-
-
-class ColumnObject(ColumnObjectBase, total=False):
-    default: str | None
-    ordinal_position: str | None
-
-
 class TableObject(TypedDict):
     id: str
     name: str
-    columns: list[ColumnObject]
+    columns: list
     indexes: list
     foreign_keys: list
 
@@ -78,7 +67,7 @@ class TableObject(TypedDict):
 class SchemaObject(TypedDict):
     name: str
     id: str
-    owner_name: str
+    owner: str
     tables: list[TableObject]
 
 
@@ -88,8 +77,6 @@ class SQLServerDatabaseObject(DatabaseObject):
 
 class SQLServerSchemaCollector(SchemaCollector):
     _check: SQLServer
-    connection_key_prefix = KEY_PREFIX
-    legacy_connection_key_prefix = KEY_PREFIX_PRE_2017
 
     def __init__(self, check: SQLServer):
         config = SchemaCollectorConfig()
@@ -108,8 +95,8 @@ class SQLServerSchemaCollector(SchemaCollector):
 
     def _get_databases(self) -> list[DatabaseInfo]:
         database_names = self._check.get_databases()
-        with self._check.connection.open_managed_default_connection(self.connection_key_prefix):
-            with self._check.connection.get_managed_cursor(self.connection_key_prefix) as cursor:
+        with self._check.connection.open_managed_default_connection(KEY_PREFIX):
+            with self._check.connection.get_managed_cursor(KEY_PREFIX) as cursor:
                 if not database_names:
                     return []
                 placeholders = ",".join(["?"] * len(database_names))
@@ -122,22 +109,20 @@ class SQLServerSchemaCollector(SchemaCollector):
     def _get_cursor(self, database_name):
         with contextlib.ExitStack() as stack:
             try:
-                stack.enter_context(self._check.connection.open_managed_default_connection(self.connection_key_prefix))
-                cursor = stack.enter_context(self._check.connection.get_managed_cursor(self.connection_key_prefix))
+                stack.enter_context(self._check.connection.open_managed_default_connection(KEY_PREFIX))
+                cursor = stack.enter_context(self._check.connection.get_managed_cursor(KEY_PREFIX))
                 switch_db_statement = construct_use_statement(database_name)
                 cursor.execute(switch_db_statement)
                 self._is_2016_or_earlier = self._should_use_legacy_schema_query(database_name)
 
                 if self._is_2016_or_earlier:
-                    stack.enter_context(
-                        self._check.connection.open_managed_default_connection(self.legacy_connection_key_prefix)
-                    )
+                    stack.enter_context(self._check.connection.open_managed_default_connection(KEY_PREFIX_PRE_2017))
                     self._pre_2017_cursor = stack.enter_context(
-                        self._check.connection.get_managed_cursor(self.legacy_connection_key_prefix)
+                        self._check.connection.get_managed_cursor(KEY_PREFIX_PRE_2017)
                     )
                     self._pre_2017_cursor.execute(switch_db_statement)
 
-                query = self._get_objects_query()
+                query = self._get_tables_query()
                 cursor.execute(query)
                 yield cursor
             finally:
@@ -180,7 +165,7 @@ class SQLServerSchemaCollector(SchemaCollector):
             return True
         return compatibility_level < MINIMUM_JSON_COMPATIBILITY_LEVEL
 
-    def _get_objects_query(self):
+    def _get_tables_query(self):
         limit = int(self._config.max_tables or 1_000_000)
 
         # Note that we INNER JOIN tables to omit schemas with no tables
@@ -213,7 +198,7 @@ class SQLServerSchemaCollector(SchemaCollector):
         # For 2017 and later we can get all the data in one query
         query += f"""
             SELECT schema_tables.schema_id, schema_tables.schema_name, schema_tables.owner_name,
-                schema_tables.table_name, schema_tables.table_id
+                schema_tables.table_name
                 , json_query(({COLUMN_QUERY} FOR JSON PATH), '$') as columns
                 , json_query(({INDEX_QUERY} FOR JSON PATH), '$') as indexes
                 , json_query(({FOREIGN_KEY_QUERY} FOR JSON PATH), '$') as foreign_keys
@@ -264,24 +249,28 @@ class SQLServerSchemaCollector(SchemaCollector):
                 "name": cursor_row.get("schema_name"),
                 "id": str(cursor_row.get("schema_id")),  # Backend expects a string
                 "owner_name": cursor_row.get("owner_name"),
-                "tables": [
-                    {
-                        k: v
-                        for k, v in {
-                            "id": str(cursor_row.get("table_id")),  # Backend expects a string
-                            "name": cursor_row.get("table_name"),
-                            "columns": [column for column in columns if column.get("name") is not None],
-                            "indexes": [index for index in indexes if index.get("name") is not None],
-                            "foreign_keys": [
-                                foreign_key
-                                for foreign_key in foreign_keys
-                                if foreign_key.get("foreign_key_name") is not None
-                            ],
-                            "partitions": {"partition_count": partition_count},
-                        }.items()
-                        if v is not None
-                    }
-                ],
+                "tables": (
+                    [
+                        {
+                            k: v
+                            for k, v in {
+                                "id": str(cursor_row.get("table_id")),  # Backend expects a string
+                                "name": cursor_row.get("table_name"),
+                                "columns": [column for column in columns if column.get("name") is not None],
+                                "indexes": [index for index in indexes if index.get("name") is not None],
+                                "foreign_keys": [
+                                    foreign_key
+                                    for foreign_key in foreign_keys
+                                    if foreign_key.get("foreign_key_name") is not None
+                                ],
+                                "partitions": {"partition_count": partition_count},
+                            }.items()
+                            if v is not None
+                        }
+                    ]
+                    if cursor_row.get("table_name") is not None
+                    else []
+                ),
             }
         ]
         return object

--- a/sqlserver/datadog_checks/sqlserver/schemas.py
+++ b/sqlserver/datadog_checks/sqlserver/schemas.py
@@ -244,7 +244,6 @@ class SQLServerSchemaCollector(SchemaCollector):
                 schema_tables.table_name, schema_tables.table_id, schema_tables.object_type,
                 schema_tables.create_date, schema_tables.modify_date, schema_tables.definition
             FROM schema_tables
-            ORDER BY schema_tables.schema_name, schema_tables.object_type, schema_tables.table_name
             ;
         """
             return query
@@ -261,7 +260,6 @@ class SQLServerSchemaCollector(SchemaCollector):
                     THEN json_query(({FOREIGN_KEY_QUERY} FOR JSON PATH), '$') ELSE json_query('[]') END as foreign_keys
                 , CASE WHEN schema_tables.object_type = 'TABLE' THEN ({PARTITIONS_QUERY}) END as partition_count
             FROM schema_tables
-            ORDER BY schema_tables.schema_name, schema_tables.object_type, schema_tables.table_name
             ;
         """
         return query

--- a/sqlserver/datadog_checks/sqlserver/views.py
+++ b/sqlserver/datadog_checks/sqlserver/views.py
@@ -1,0 +1,121 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
+from datadog_checks.base.utils.db.schemas import SchemaCollector
+from datadog_checks.base.utils.serialization import json
+from datadog_checks.sqlserver.queries import SCHEMA_QUERY, VIEW_COLUMN_QUERY, VIEWS_QUERY
+from datadog_checks.sqlserver.schemas import ColumnObject, DatabaseInfo, DatabaseObject, SQLServerSchemaCollector
+
+if TYPE_CHECKING:
+    from datadog_checks.sqlserver import SQLServer
+
+
+KEY_PREFIX = "dbm-views-"
+KEY_PREFIX_PRE_2017 = "dbm-views-pre-2017"
+
+
+class ViewObject(TypedDict):
+    id: str
+    name: str
+    create_date: str
+    modify_date: str
+    definition: str | None
+    columns: list[ColumnObject]
+
+
+class ViewSchemaObject(TypedDict):
+    name: str
+    id: str
+    owner_name: str
+    tables: list
+    views: list[ViewObject]
+
+
+class SQLServerViewCollector(SQLServerSchemaCollector):
+    _check: SQLServer
+    connection_key_prefix = KEY_PREFIX
+    legacy_connection_key_prefix = KEY_PREFIX_PRE_2017
+
+    def __init__(self, check: SQLServer):
+        super().__init__(check)
+        self._config.max_views = check._config.schema_config.get('max_views', 1000)
+
+    @property
+    def kind(self) -> str:
+        return "sqlserver_views"
+
+    def _get_objects_query(self) -> str:
+        limit = int(self._config.max_views or 1_000_000)
+        query = f"""
+            WITH
+            schemas AS (
+                {SCHEMA_QUERY}
+            ),
+            views AS (
+                {VIEWS_QUERY}
+            ),
+            schema_views AS (
+                SELECT TOP {limit} schemas.schema_name, schemas.schema_id, schemas.owner_name,
+                    views.view_id, views.view_name, views.create_date, views.modify_date, views.definition
+                FROM schemas
+                INNER JOIN views ON schemas.schema_id = views.schema_id
+                ORDER BY schemas.schema_name, views.view_name
+            )
+        """
+        if self._is_2016_or_earlier:
+            query += """
+            SELECT schema_views.schema_id, schema_views.schema_name, schema_views.owner_name,
+                schema_views.view_name, schema_views.view_id,
+                schema_views.create_date, schema_views.modify_date, schema_views.definition
+            FROM schema_views
+            ;
+        """
+            return query
+
+        query += f"""
+            SELECT schema_views.schema_id, schema_views.schema_name, schema_views.owner_name,
+                schema_views.view_name, schema_views.view_id,
+                schema_views.create_date, schema_views.modify_date, schema_views.definition,
+                json_query(({VIEW_COLUMN_QUERY} FOR JSON PATH), '$') AS columns
+            FROM schema_views
+            ;
+        """
+        return query
+
+    def _map_row(self, database: DatabaseInfo, cursor_row) -> DatabaseObject:
+        object = SchemaCollector._map_row(self, database, cursor_row)
+        if self._is_2016_or_earlier:
+            cursor = self._pre_2017_cursor
+            if cursor is None:
+                raise RuntimeError("pre-2017 view cursor is not initialized")
+            view_id = str(cursor_row.get("view_id"))
+            columns_query = VIEW_COLUMN_QUERY.replace("schema_views.view_id", view_id)
+            cursor.execute(columns_query)
+            columns = cursor.fetchall_dict()
+        else:
+            columns = json.loads(cursor_row.get("columns") or "[]")
+
+        object["schemas"] = [
+            {
+                "name": cursor_row.get("schema_name"),
+                "id": str(cursor_row.get("schema_id")),
+                "owner_name": cursor_row.get("owner_name"),
+                "tables": [],
+                "views": [
+                    {
+                        "id": str(cursor_row.get("view_id")),
+                        "name": cursor_row.get("view_name"),
+                        "create_date": cursor_row.get("create_date"),
+                        "modify_date": cursor_row.get("modify_date"),
+                        "definition": cursor_row.get("definition"),
+                        "columns": [column for column in columns if column.get("name") is not None],
+                    }
+                ],
+            }
+        ]
+        return object

--- a/sqlserver/datadog_checks/sqlserver/views.py
+++ b/sqlserver/datadog_checks/sqlserver/views.py
@@ -9,14 +9,21 @@ from typing import TYPE_CHECKING, TypedDict
 from datadog_checks.base.utils.db.schemas import SchemaCollector
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.sqlserver.queries import SCHEMA_QUERY, VIEW_COLUMN_QUERY, VIEWS_QUERY
-from datadog_checks.sqlserver.schemas import ColumnObject, DatabaseInfo, DatabaseObject, SQLServerSchemaCollector
+from datadog_checks.sqlserver.schemas import DatabaseInfo, DatabaseObject, SQLServerSchemaCollector
 
 if TYPE_CHECKING:
     from datadog_checks.sqlserver import SQLServer
 
 
-KEY_PREFIX = "dbm-views-"
-KEY_PREFIX_PRE_2017 = "dbm-views-pre-2017"
+class ViewColumnObjectBase(TypedDict):
+    data_type: str
+    name: str
+    nullable: bool
+
+
+class ViewColumnObject(ViewColumnObjectBase, total=False):
+    default: str | None
+    ordinal_position: str | None
 
 
 class ViewObject(TypedDict):
@@ -25,7 +32,7 @@ class ViewObject(TypedDict):
     create_date: str
     modify_date: str
     definition: str | None
-    columns: list[ColumnObject]
+    columns: list[ViewColumnObject]
 
 
 class ViewSchemaObject(TypedDict):
@@ -38,8 +45,6 @@ class ViewSchemaObject(TypedDict):
 
 class SQLServerViewCollector(SQLServerSchemaCollector):
     _check: SQLServer
-    connection_key_prefix = KEY_PREFIX
-    legacy_connection_key_prefix = KEY_PREFIX_PRE_2017
 
     def __init__(self, check: SQLServer):
         super().__init__(check)
@@ -49,7 +54,7 @@ class SQLServerViewCollector(SQLServerSchemaCollector):
     def kind(self) -> str:
         return "sqlserver_views"
 
-    def _get_objects_query(self) -> str:
+    def _get_tables_query(self) -> str:
         limit = int(self._config.max_views or 1_000_000)
         query = f"""
             WITH

--- a/sqlserver/datadog_checks/sqlserver/views.py
+++ b/sqlserver/datadog_checks/sqlserver/views.py
@@ -54,6 +54,10 @@ class SQLServerViewCollector(SQLServerSchemaCollector):
     def kind(self) -> str:
         return "sqlserver_views"
 
+    @property
+    def object_count_metric_name(self) -> str:
+        return f"dd.{self._check.dbms}.schema.views_count"
+
     def _get_tables_query(self) -> str:
         limit = int(self._config.max_views or 1_000_000)
         query = f"""

--- a/sqlserver/tests/test_schemas.py
+++ b/sqlserver/tests/test_schemas.py
@@ -152,20 +152,29 @@ def test_collect_views(aggregator, dbm_instance, integration_check, sa_conn):
 
     try:
         check = integration_check(dbm_instance)
-        collector = SQLServerSchemaCollector(check)
-        collector.collect_schemas()
+        check.sql_metadata.collect_schemas()
 
         views = [
             view
             for event in aggregator.get_event_platform_events('dbm-metadata')
-            if event['kind'] == 'sqlserver_databases'
+            if event['kind'] == 'sqlserver_views'
             for database in event['metadata']
             if database['name'] == SCHEMA_DATABASE
             for schema in database['schemas']
             for view in schema.get('views', [])
         ]
         view = next(view for view in views if view['name'] == view_name)
+        schema = next(
+            schema
+            for event in aggregator.get_event_platform_events('dbm-metadata')
+            if event['kind'] == 'sqlserver_views'
+            for database in event['metadata']
+            if database['name'] == SCHEMA_DATABASE
+            for schema in database['schemas']
+            if any(candidate['name'] == view_name for candidate in schema['views'])
+        )
 
+        assert schema['tables'] == []
         assert view['id'].isdigit()
         datetime.fromisoformat(view['create_date'])
         datetime.fromisoformat(view['modify_date'])
@@ -173,8 +182,8 @@ def test_collect_views(aggregator, dbm_instance, integration_check, sa_conn):
         assert view_name in view['definition']
         assert {column['name'] for column in view['columns']} == {'id', 'name', 'population'}
         for column in view['columns']:
-            assert {'name', 'data_type', 'nullable'} <= set(column)
-            assert set(column) <= {'name', 'data_type', 'default', 'nullable', 'ordinal_position'}
+            assert set(column) == {'name', 'data_type', 'default', 'nullable', 'ordinal_position'}
+        assert [column['ordinal_position'] for column in view['columns']] == ['1', '2', '3']
     finally:
         with sa_conn.cursor() as cursor:
             cursor.execute('USE {}'.format(SCHEMA_DATABASE))

--- a/sqlserver/tests/test_schemas.py
+++ b/sqlserver/tests/test_schemas.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import json
+from datetime import datetime
 from typing import Callable, Optional
 
 import pytest
@@ -137,6 +138,47 @@ def test_collect_schemas(dbm_instance, integration_check):
     collector = SQLServerSchemaCollector(check)
 
     collector.collect_schemas()
+
+
+def test_collect_views(aggregator, dbm_instance, integration_check, sa_conn):
+    view_name = 'city_names'
+    with sa_conn.cursor() as cursor:
+        cursor.execute('USE {}'.format(SCHEMA_DATABASE))
+        cursor.execute(
+            'CREATE OR ALTER VIEW test_schema.{} AS SELECT id, name, population FROM test_schema.cities'.format(
+                view_name
+            )
+        )
+
+    try:
+        check = integration_check(dbm_instance)
+        collector = SQLServerSchemaCollector(check)
+        collector.collect_schemas()
+
+        views = [
+            view
+            for event in aggregator.get_event_platform_events('dbm-metadata')
+            if event['kind'] == 'sqlserver_databases'
+            for database in event['metadata']
+            if database['name'] == SCHEMA_DATABASE
+            for schema in database['schemas']
+            for view in schema.get('views', [])
+        ]
+        view = next(view for view in views if view['name'] == view_name)
+
+        assert view['id'].isdigit()
+        datetime.fromisoformat(view['create_date'])
+        datetime.fromisoformat(view['modify_date'])
+        assert 'CREATE' in view['definition'].upper()
+        assert view_name in view['definition']
+        assert {column['name'] for column in view['columns']} == {'id', 'name', 'population'}
+        for column in view['columns']:
+            assert {'name', 'data_type', 'nullable'} <= set(column)
+            assert set(column) <= {'name', 'data_type', 'default', 'nullable', 'ordinal_position'}
+    finally:
+        with sa_conn.cursor() as cursor:
+            cursor.execute('USE {}'.format(SCHEMA_DATABASE))
+            cursor.execute('DROP VIEW IF EXISTS test_schema.{}'.format(view_name))
 
 
 # Force pre-2017 behavior for testing that collections don't crash

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -33,6 +33,7 @@ from datadog_checks.sqlserver.const import (
     STATIC_INFO_VERSION,
 )
 from datadog_checks.sqlserver.database_metrics import SqlserverDatabaseStatsMetrics
+from datadog_checks.sqlserver.metadata import SqlserverMetadata
 from datadog_checks.sqlserver.metrics import DEFAULT_PERFORMANCE_TABLE, SqlFractionMetric, SqlSimpleMetric
 from datadog_checks.sqlserver.schemas import KEY_PREFIX, KEY_PREFIX_PRE_2017, SQLServerSchemaCollector
 from datadog_checks.sqlserver.sqlserver import SQLConnectionError
@@ -169,6 +170,28 @@ def test_schema_collectors_use_independent_queries_and_limits() -> None:
     assert "SELECT TOP 1000" in view_query
     assert "sys.views" in view_query
     assert "sys.tables" not in view_query
+
+
+@pytest.mark.parametrize(
+    ('schema_config', 'views_collected'),
+    [
+        ({'enabled': True}, True),
+        ({'enabled': True, 'collect_views': True}, True),
+        ({'enabled': True, 'collect_views': False}, False),
+    ],
+)
+def test_schema_collection_can_disable_views(schema_config: dict, views_collected: bool) -> None:
+    metadata = object.__new__(SqlserverMetadata)
+    metadata._schema_config = schema_config
+    metadata._schema_collection_interval = 0
+    metadata._last_schemas_collection_time = 0
+    metadata._schema_collector = mock.Mock()
+    metadata._view_collector = mock.Mock()
+
+    metadata.collect_schemas()
+
+    metadata._schema_collector.collect_schemas.assert_called_once_with()
+    assert metadata._view_collector.collect_schemas.called is views_collected
 
 
 def test_schema_collector_records_database_compatibility_levels() -> None:

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -158,8 +158,8 @@ def test_schema_collectors_use_independent_queries_and_limits() -> None:
     table_collector._is_2016_or_earlier = False
     view_collector._is_2016_or_earlier = False
 
-    table_query = table_collector._get_objects_query()
-    view_query = view_collector._get_objects_query()
+    table_query = table_collector._get_tables_query()
+    view_query = view_collector._get_tables_query()
 
     assert table_collector._config.max_tables == 25
     assert view_collector._config.max_views == 1000

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -218,6 +218,8 @@ def test_schema_collection_can_disable_views(schema_config: dict, views_collecte
     metadata._schema_config = schema_config
     metadata._schema_collection_interval = 0
     metadata._last_schemas_collection_time = 0
+    metadata._cancel_event = mock.Mock()
+    metadata._cancel_event.is_set.return_value = False
     metadata._schema_collector = mock.Mock()
     metadata._view_collector = mock.Mock()
 

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -162,14 +162,47 @@ def test_schema_collectors_use_independent_queries_and_limits() -> None:
     table_query = table_collector._get_tables_query()
     view_query = view_collector._get_tables_query()
 
-    assert table_collector._config.max_tables == 25
-    assert view_collector._config.max_views == 1000
     assert "SELECT TOP 25" in table_query
     assert "sys.tables" in table_query
     assert "sys.views" not in table_query
     assert "SELECT TOP 1000" in view_query
     assert "sys.views" in view_query
     assert "sys.tables" not in view_query
+
+
+@pytest.mark.parametrize(
+    ('collector_class', 'expected_metric', 'unexpected_metric'),
+    [
+        (
+            SQLServerSchemaCollector,
+            'dd.sqlserver.schema.tables_count',
+            'dd.sqlserver.schema.views_count',
+        ),
+        (
+            SQLServerViewCollector,
+            'dd.sqlserver.schema.views_count',
+            'dd.sqlserver.schema.tables_count',
+        ),
+    ],
+)
+def test_schema_collectors_report_separate_object_counts(
+    collector_class: type[SQLServerSchemaCollector], expected_metric: str, unexpected_metric: str
+) -> None:
+    check = mock.Mock()
+    check._config.schema_config = {}
+    check.log = mock.Mock()
+    check.static_info_cache = {}
+    check.dbms = 'sqlserver'
+    check.tags = []
+    check.reported_hostname = 'test-host'
+    collector = collector_class(check)
+    collector._get_databases = mock.Mock(return_value=[])
+
+    collector.collect_schemas()
+
+    submitted_metrics = {call.args[0] for call in check.gauge.call_args_list}
+    assert expected_metric in submitted_metrics
+    assert unexpected_metric not in submitted_metrics
 
 
 @pytest.mark.parametrize(

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -47,6 +47,7 @@ from datadog_checks.sqlserver.utils import (
     parse_sqlserver_year,
     set_default_driver_conf,
 )
+from datadog_checks.sqlserver.views import SQLServerViewCollector
 
 from .common import CHECK_NAME, DOCKER_SERVER, assert_metrics
 from .utils import not_windows_ci, windows_ci
@@ -151,18 +152,23 @@ def create_schema_collector(
     return SQLServerSchemaCollector(check)
 
 
-def test_schema_collector_configures_independent_table_and_view_limits() -> None:
-    collector = create_schema_collector(schema_config={'max_tables': 25})
-    collector._is_2016_or_earlier = False
+def test_schema_collectors_use_independent_queries_and_limits() -> None:
+    table_collector = create_schema_collector(schema_config={'max_tables': 25, 'max_views': 1000})
+    view_collector = SQLServerViewCollector(table_collector._check)
+    table_collector._is_2016_or_earlier = False
+    view_collector._is_2016_or_earlier = False
 
-    query = collector._get_schema_objects_query()
+    table_query = table_collector._get_objects_query()
+    view_query = view_collector._get_objects_query()
 
-    assert collector._config.max_tables == 25
-    assert collector._config.max_views == 1000
-    assert "SELECT TOP 25" in query
-    assert "SELECT TOP 1000" in query
-    assert "sys.tables" in query
-    assert "sys.views" in query
+    assert table_collector._config.max_tables == 25
+    assert view_collector._config.max_views == 1000
+    assert "SELECT TOP 25" in table_query
+    assert "sys.tables" in table_query
+    assert "sys.views" not in table_query
+    assert "SELECT TOP 1000" in view_query
+    assert "sys.views" in view_query
+    assert "sys.tables" not in view_query
 
 
 def test_schema_collector_records_database_compatibility_levels() -> None:
@@ -468,28 +474,25 @@ def test_schema_collector_does_not_open_pre_2017_connection_for_modern_query() -
 
 
 def test_schema_collector_maps_view_metadata() -> None:
-    collector = create_schema_collector()
+    check = create_schema_collector()._check
+    collector = SQLServerViewCollector(check)
     collector._is_2016_or_earlier = False
     database = {"name": "datadog_test", "id": "1", "collation": "SQL_Latin1_General_CP1_CI_AS", "owner": "dbo"}
     row = {
         "schema_name": "test_schema",
         "schema_id": 1,
         "owner_name": "dbo",
-        "table_name": "city_names",
-        "table_id": 201,
-        "object_type": "VIEW",
+        "view_name": "city_names",
+        "view_id": 201,
         "create_date": "2026-08-19T10:15:00",
         "modify_date": "2026-08-19T11:30:00",
         "definition": "CREATE VIEW test_schema.city_names AS SELECT id, name FROM test_schema.cities",
-        "columns": '[{"name":"id","data_type":"int","default":"None","nullable":false}]',
-        "indexes": "[]",
-        "foreign_keys": "[]",
-        "partition_count": None,
+        "columns": ('[{"name":"id","data_type":"int","default":"None","nullable":false,"ordinal_position":"1"}]'),
     }
 
     mapped_row = collector._map_row(database, row)
 
-    assert "tables" not in mapped_row["schemas"][0]
+    assert mapped_row["schemas"][0]["tables"] == []
     assert mapped_row["schemas"][0]["views"] == [
         {
             "id": "201",
@@ -497,17 +500,32 @@ def test_schema_collector_maps_view_metadata() -> None:
             "create_date": "2026-08-19T10:15:00",
             "modify_date": "2026-08-19T11:30:00",
             "definition": "CREATE VIEW test_schema.city_names AS SELECT id, name FROM test_schema.cities",
-            "columns": [{"name": "id", "data_type": "int", "default": "None", "nullable": False}],
+            "columns": [
+                {
+                    "name": "id",
+                    "data_type": "int",
+                    "default": "None",
+                    "nullable": False,
+                    "ordinal_position": "1",
+                }
+            ],
         }
     ]
 
 
 def test_schema_collector_legacy_view_fetches_only_columns() -> None:
-    collector = create_schema_collector()
+    check = create_schema_collector()._check
+    collector = SQLServerViewCollector(check)
     collector._is_2016_or_earlier = True
     detail_cursor = mock.Mock()
     detail_cursor.fetchall_dict.return_value = [
-        {"name": "id", "data_type": "int", "default": "None", "nullable": False}
+        {
+            "name": "id",
+            "data_type": "int",
+            "default": "None",
+            "nullable": False,
+            "ordinal_position": "1",
+        }
     ]
     collector._pre_2017_cursor = detail_cursor
     database = {"name": "datadog_test", "id": "1", "collation": "SQL_Latin1_General_CP1_CI_AS", "owner": "dbo"}
@@ -515,9 +533,8 @@ def test_schema_collector_legacy_view_fetches_only_columns() -> None:
         "schema_name": "test_schema",
         "schema_id": 1,
         "owner_name": "dbo",
-        "table_name": "city_names",
-        "table_id": 201,
-        "object_type": "VIEW",
+        "view_name": "city_names",
+        "view_id": 201,
         "create_date": "2026-08-19T10:15:00",
         "modify_date": "2026-08-19T11:30:00",
         "definition": None,
@@ -529,7 +546,13 @@ def test_schema_collector_legacy_view_fetches_only_columns() -> None:
     assert "201" in detail_cursor.execute.call_args.args[0]
     assert mapped_row["schemas"][0]["views"][0]["definition"] is None
     assert mapped_row["schemas"][0]["views"][0]["columns"] == [
-        {"name": "id", "data_type": "int", "default": "None", "nullable": False}
+        {
+            "name": "id",
+            "data_type": "int",
+            "default": "None",
+            "nullable": False,
+            "ordinal_position": "1",
+        }
     ]
 
 

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -141,12 +141,28 @@ def test_execute_query_raw_collects_multiple_result_sets(instance_docker):
     assert cursor.fetchall.call_count == 2
 
 
-def create_schema_collector(static_info_cache: dict | None = None) -> SQLServerSchemaCollector:
+def create_schema_collector(
+    static_info_cache: dict | None = None, schema_config: dict | None = None
+) -> SQLServerSchemaCollector:
     check = mock.Mock()
-    check._config.schema_config = {}
+    check._config.schema_config = schema_config or {}
     check.log = mock.Mock()
     check.static_info_cache = static_info_cache or {}
     return SQLServerSchemaCollector(check)
+
+
+def test_schema_collector_configures_independent_table_and_view_limits() -> None:
+    collector = create_schema_collector(schema_config={'max_tables': 25})
+    collector._is_2016_or_earlier = False
+
+    query = collector._get_schema_objects_query()
+
+    assert collector._config.max_tables == 25
+    assert collector._config.max_views == 1000
+    assert "SELECT TOP 25" in query
+    assert "SELECT TOP 1000" in query
+    assert "sys.tables" in query
+    assert "sys.views" in query
 
 
 def test_schema_collector_records_database_compatibility_levels() -> None:
@@ -449,6 +465,72 @@ def test_schema_collector_does_not_open_pre_2017_connection_for_modern_query() -
     assert collector._check.connection.get_managed_cursor.call_args_list == [mock.call(KEY_PREFIX)]
     assert collector._pre_2017_cursor is None
     assert mapped_row["schemas"][0]["tables"][0]["columns"] == [{"name": "id"}]
+
+
+def test_schema_collector_maps_view_metadata() -> None:
+    collector = create_schema_collector()
+    collector._is_2016_or_earlier = False
+    database = {"name": "datadog_test", "id": "1", "collation": "SQL_Latin1_General_CP1_CI_AS", "owner": "dbo"}
+    row = {
+        "schema_name": "test_schema",
+        "schema_id": 1,
+        "owner_name": "dbo",
+        "table_name": "city_names",
+        "table_id": 201,
+        "object_type": "VIEW",
+        "create_date": "2026-08-19T10:15:00",
+        "modify_date": "2026-08-19T11:30:00",
+        "definition": "CREATE VIEW test_schema.city_names AS SELECT id, name FROM test_schema.cities",
+        "columns": '[{"name":"id","data_type":"int","default":"None","nullable":false}]',
+        "indexes": "[]",
+        "foreign_keys": "[]",
+        "partition_count": None,
+    }
+
+    mapped_row = collector._map_row(database, row)
+
+    assert "tables" not in mapped_row["schemas"][0]
+    assert mapped_row["schemas"][0]["views"] == [
+        {
+            "id": "201",
+            "name": "city_names",
+            "create_date": "2026-08-19T10:15:00",
+            "modify_date": "2026-08-19T11:30:00",
+            "definition": "CREATE VIEW test_schema.city_names AS SELECT id, name FROM test_schema.cities",
+            "columns": [{"name": "id", "data_type": "int", "default": "None", "nullable": False}],
+        }
+    ]
+
+
+def test_schema_collector_legacy_view_fetches_only_columns() -> None:
+    collector = create_schema_collector()
+    collector._is_2016_or_earlier = True
+    detail_cursor = mock.Mock()
+    detail_cursor.fetchall_dict.return_value = [
+        {"name": "id", "data_type": "int", "default": "None", "nullable": False}
+    ]
+    collector._pre_2017_cursor = detail_cursor
+    database = {"name": "datadog_test", "id": "1", "collation": "SQL_Latin1_General_CP1_CI_AS", "owner": "dbo"}
+    row = {
+        "schema_name": "test_schema",
+        "schema_id": 1,
+        "owner_name": "dbo",
+        "table_name": "city_names",
+        "table_id": 201,
+        "object_type": "VIEW",
+        "create_date": "2026-08-19T10:15:00",
+        "modify_date": "2026-08-19T11:30:00",
+        "definition": None,
+    }
+
+    mapped_row = collector._map_row(database, row)
+
+    detail_cursor.execute.assert_called_once()
+    assert "201" in detail_cursor.execute.call_args.args[0]
+    assert mapped_row["schemas"][0]["views"][0]["definition"] is None
+    assert mapped_row["schemas"][0]["views"][0]["columns"] == [
+        {"name": "id", "data_type": "int", "default": "None", "nullable": False}
+    ]
 
 
 def test_get_cursor(instance_docker):


### PR DESCRIPTION
### What does this PR do?

Adds a dedicated SQL Server view collector that runs alongside table schema collection and emits a separate `sqlserver_views` DBM metadata payload. Each schema contains an empty `tables` array and a populated `views` array. Views include ID, name, creation and modification dates, nullable definition, and table-compatible column metadata.

Adds an independent `max_views` configuration option with a default of 1000. The existing `sqlserver_databases` payload and `max_tables` limit remain unchanged.

Shared telemetry dependency: https://github.com/DataDog/integrations-core/pull/24947

Companion backend change: https://github.com/ddoghq/dd-go/pull/11536

### Motivation

DBM schema collection currently discovers only SQL Server tables. UGP needs view definitions and projected column metadata to represent SQL Server views without treating them as physical tables.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged