### PR TITLE
[FA] Tag voltdb password_hashed option as secret

### DIFF
--- a/voltdb/assets/configuration/spec.yaml
+++ b/voltdb/assets/configuration/spec.yaml
@@ -173,6 +173,7 @@ files:
               password instead of the cleartext. The native binary client does
               not support pre-hashed passwords.
             display_priority: 1
+            secret: true
             value:
               type: boolean
               example: false

--- a/voltdb/changelog.d/24929.security
+++ b/voltdb/changelog.d/24929.security
@@ -1,0 +1,1 @@
+Tag the `password_hashed` option as a secret in the configuration spec.

--- a/voltdb/changelog.d/24929.security
+++ b/voltdb/changelog.d/24929.security
@@ -1,1 +1,0 @@
-Tag the `password_hashed` option as a secret in the configuration spec.


### PR DESCRIPTION
### What does this PR do?
Tag the `password_hashed` option in the voltdb configuration spec as `secret`, matching the existing `password` option.

### Motivation
The `password_hashed` option is a boolean flag that controls how the `password` value is interpreted. It is related to the password credential and should be marked as secret.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged