### PR TITLE
Remove aiohttp<3.14 pin in ddev test dependencies

### DIFF
--- a/ddev/changelog.d/24930.fixed
+++ b/ddev/changelog.d/24930.fixed
@@ -1,1 +1,0 @@
-Remove aiohttp<3.14 pin now that vcrpy 8.2.0+ is compatible with aiohttp 3.14.

--- a/ddev/changelog.d/24930.fixed
+++ b/ddev/changelog.d/24930.fixed
@@ -1,0 +1,1 @@
+Remove aiohttp<3.14 pin now that vcrpy 8.2.0+ is compatible with aiohttp 3.14.

--- a/ddev/hatch.toml
+++ b/ddev/hatch.toml
@@ -9,7 +9,9 @@ python = "3.13"
 e2e-env = false
 dependencies = [
   "pyyaml",
-  "vcrpy",
+  # vcrpy 8.2.0 dropped the dependency on aiohttp.streams.AsyncStreamReaderMixin,
+  # removed in aiohttp 3.14
+  "vcrpy>=8.2.0",
 ]
 # TODO: remove this when the old CLI is gone
 pre-install-commands = [

--- a/ddev/hatch.toml
+++ b/ddev/hatch.toml
@@ -10,8 +10,6 @@ e2e-env = false
 dependencies = [
   "pyyaml",
   "vcrpy",
-  # vcrpy uses aiohttp.streams.AsyncStreamReaderMixin, removed in aiohttp 3.14
-  "aiohttp<3.14",
 ]
 # TODO: remove this when the old CLI is gone
 pre-install-commands = [


### PR DESCRIPTION
### What does this PR do?

Removes the `aiohttp<3.14` pin added to `ddev`'s test dependencies in #23909.

### Motivation

`vcrpy` 8.2.0 (released after #23909 was merged) stopped subclassing `aiohttp.streams.AsyncStreamReaderMixin` — the attribute aiohttp 3.14 removed — and instead provides the async-iteration helpers directly on top of `asyncio.StreamReader`. This makes `vcrpy` compatible with current aiohttp releases, so the pin that worked around the incompatibility is no longer needed.

Verified with an isolated smoke test reproducing a `network_replay`-style record/replay flow:
- `vcrpy==8.1.1` + `aiohttp==3.14.3` reproduces the original `AttributeError: module 'aiohttp.streams' has no attribute 'AsyncStreamReaderMixin'`.
- `vcrpy==8.2.0`/`8.2.1`/`8.3.0` + `aiohttp==3.14.3` complete a full record-then-replay HTTP request (including `resp.read()`, `resp.text()`, and `resp.content.iter_chunked()`) without error.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged