### PR TITLE
[DOIO-253] Collect MySQL views in schema metadata

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -472,7 +472,8 @@ files:
             display_priority: 0
             description: |
               Configure collection of schemas (databases).
-              Only tables and schemas for which the user has been granted SELECT privileges are collected.
+              Only tables, views, and schemas for which the user has been granted SELECT privileges are collected.
+              Collecting view definitions also requires the SHOW VIEW privilege.
             options:
               - name: enabled
                 description: |
@@ -504,7 +505,8 @@ files:
             description: |
               DEPRECATED: Use `collect_schemas` instead.
               Configure collection of schemas (databases).
-              Only tables and schemas for which the user has been granted SELECT privileges are collected.
+              Only tables, views, and schemas for which the user has been granted SELECT privileges are collected.
+              Collecting view definitions also requires the SHOW VIEW privilege.
             options:
               - name: enabled
                 description: |

--- a/mysql/changelog.d/24932.added
+++ b/mysql/changelog.d/24932.added
@@ -1,0 +1,1 @@
+Collect MySQL view definitions and projected columns in schema metadata.

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -334,7 +334,8 @@ instances:
         # collection_interval: 600
 
     ## Configure collection of schemas (databases).
-    ## Only tables and schemas for which the user has been granted SELECT privileges are collected.
+    ## Only tables, views, and schemas for which the user has been granted SELECT privileges are collected.
+    ## Collecting view definitions also requires the SHOW VIEW privilege.
     #
     # collect_schemas:
 
@@ -356,7 +357,8 @@ instances:
 
     ## DEPRECATED: Use `collect_schemas` instead.
     ## Configure collection of schemas (databases).
-    ## Only tables and schemas for which the user has been granted SELECT privileges are collected.
+    ## Only tables, views, and schemas for which the user has been granted SELECT privileges are collected.
+    ## Collecting view definitions also requires the SHOW VIEW privilege.
     ##
     ##
     ## <<< DEPRECATED >>>

--- a/mysql/datadog_checks/mysql/databases_data.py
+++ b/mysql/datadog_checks/mysql/databases_data.py
@@ -10,6 +10,7 @@ import json
 import time
 from collections import defaultdict
 from contextlib import closing
+from typing import Any
 
 import pymysql
 
@@ -22,6 +23,7 @@ from datadog_checks.mysql.queries import (
     SQL_FOREIGN_KEYS,
     SQL_PARTITION,
     SQL_TABLES,
+    SQL_VIEWS,
     get_indexes_query,
 )
 
@@ -38,7 +40,8 @@ class SubmitData:
 
         self._columns_count = 0
         self._total_columns_sent = 0
-        self.db_to_tables = {}  # dbname : {"tables" : []}
+        self.db_to_tables = {}  # dbname: list of tables
+        self.db_to_views = {}  # dbname: list of views
         self.db_info = {}  # name to info
         self.any_tables_found = False  # Flag to track for permission issues
 
@@ -55,6 +58,7 @@ class SubmitData:
         self._columns_count = 0
         self.db_info.clear()
         self.db_to_tables.clear()
+        self.db_to_views.clear()
         self.any_tables_found = False
 
     def store_db_infos(self, db_infos):
@@ -67,6 +71,11 @@ class SubmitData:
         known_tables.extend(tables)
         if tables:
             self.any_tables_found = True
+
+    def store_views(self, db_name: str, views: list[dict], columns_count: int) -> None:
+        self._columns_count += columns_count
+        known_views = self.db_to_views.setdefault(db_name, [])
+        known_views.extend(views)
 
     def columns_since_last_submit(self):
         return self._columns_count
@@ -97,18 +106,25 @@ class SubmitData:
         self._submit_to_agent_queue(json_event)
 
     def submit(self):
-        if not self.db_to_tables:
+        if not self.db_to_tables and not self.db_to_views:
             return
         self._total_columns_sent += self._columns_count
         self._columns_count = 0
         event = {**self._base_event, "metadata": [], "timestamp": time.time() * 1000}
-        for db, tables in self.db_to_tables.items():
+        db_names = list(dict.fromkeys([*self.db_to_tables, *self.db_to_views]))
+        for db in db_names:
             db_info = self.db_info[db]
-            event["metadata"] = event["metadata"] + [{**(db_info), "tables": tables}]
+            metadata = {**db_info}
+            if db in self.db_to_tables:
+                metadata["tables"] = self.db_to_tables[db]
+            if db in self.db_to_views:
+                metadata["views"] = self.db_to_views[db]
+            event["metadata"].append(metadata)
         json_event = json.dumps(event, default=default_json_event_encoding)
         self._log.debug("Reporting the following payload for schema collection: {}".format(self.truncate(json_event)))
         self._submit_to_agent_queue(json_event)
         self.db_to_tables.clear()
+        self.db_to_views.clear()
 
 
 def agent_check_getter(self):
@@ -166,21 +182,50 @@ class DatabasesData:
     def _fetch_database_data(self, cursor, start_time, db_name):
         tables = self._get_tables(db_name, cursor)
         for tables_chunk in get_list_chunks(tables, self.TABLES_CHUNK_SIZE):
-            schema_collection_elapsed_time = time.time() - start_time
-            if schema_collection_elapsed_time > self._max_execution_time:
-                self._data_submitter.submit()
-                self._data_submitter.send_truncated_msg(db_name, schema_collection_elapsed_time)
-                raise StopIteration(
-                    """Schema collection took {}s which is longer than allowed limit of {}s,
-                    stopped while collecting for db - {}""".format(
-                        schema_collection_elapsed_time, self._max_execution_time, db_name
-                    )
-                )
+            self._check_execution_time(start_time, db_name)
             columns_count, tables_info = self._get_tables_data(tables_chunk, db_name, cursor)
             self._data_submitter.store(db_name, tables_info, columns_count)
             if self._data_submitter.columns_since_last_submit() > self.MAX_COLUMNS_PER_EVENT:
                 self._data_submitter.submit()
         self._data_submitter.submit()
+
+        self._check_execution_time(start_time, db_name)
+        try:
+            views = self._get_views(db_name, cursor)
+        except pymysql.DatabaseError as e:
+            error_code = e.args[0] if e.args else None
+            if error_code in (
+                pymysql.constants.ER.TABLEACCESS_DENIED_ERROR,
+                pymysql.constants.ER.SPECIFIC_ACCESS_DENIED_ERROR,
+            ):
+                self._log.warning(
+                    "Unable to collect views for database {} because the user lacks the SHOW VIEW privilege. "
+                    "Table metadata was collected normally.".format(db_name)
+                )
+                return
+            raise
+        self._check_execution_time(start_time, db_name)
+
+        for views_chunk in get_list_chunks(views, self.TABLES_CHUNK_SIZE):
+            self._check_execution_time(start_time, db_name)
+            columns_count, views_info = self._get_views_data(views_chunk, db_name, cursor)
+            self._data_submitter.store_views(db_name, views_info, columns_count)
+            if self._data_submitter.columns_since_last_submit() > self.MAX_COLUMNS_PER_EVENT:
+                self._data_submitter.submit()
+        if views:
+            self._data_submitter.submit()
+
+    def _check_execution_time(self, start_time: float, db_name: str) -> None:
+        schema_collection_elapsed_time = time.time() - start_time
+        if schema_collection_elapsed_time > self._max_execution_time:
+            self._data_submitter.submit()
+            self._data_submitter.send_truncated_msg(db_name, schema_collection_elapsed_time)
+            raise StopIteration(
+                """Schema collection took {}s which is longer than allowed limit of {}s,
+                stopped while collecting for db - {}""".format(
+                    schema_collection_elapsed_time, self._max_execution_time, db_name
+                )
+            )
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def collect_databases_data(self, tags):
@@ -246,6 +291,11 @@ class DatabasesData:
                                                 this is the sum of all subpartitions table_rows.
                             - data_length (int): The data length of the partition in bytes. If partition has
                                                  subpartitions, this is the sum of all subpartitions data_length.
+            - views (list): A list of view dictionaries.
+                - view (dict): A dictionary representing a view.
+                    - name (str): The name of the view.
+                    - definition (str or None): The view definition, when available.
+                    - columns (list): Projected columns using the table column shape.
         """
         self._data_submitter.reset()  # Ensure we start fresh
         self._tags = tags
@@ -311,6 +361,25 @@ class DatabasesData:
         self._cursor_run(cursor, query=SQL_TABLES, params=db_name)
         tables_info = cursor.fetchall()
         return tables_info
+
+    @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
+    def _get_views(self, db_name: str, cursor: Any) -> list[dict]:
+        """Return views and their definitions for a database."""
+        self._cursor_run(cursor, query=SQL_VIEWS, params=db_name)
+        return cursor.fetchall()
+
+    @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
+    def _get_views_data(self, view_list: list[dict], db_name: str, cursor: Any) -> tuple[int, list[dict]]:
+        if not view_list:
+            return 0, []
+
+        view_name_to_view_index = {view["name"]: i for i, view in enumerate(view_list)}
+        view_name_list = [str(view["name"]) for view in view_list]
+        placeholders = ','.join(['%s'] * len(view_name_list))
+        total_columns_number = self._populate_with_columns_data(
+            view_name_to_view_index, view_list, view_name_list, placeholders, db_name, cursor
+        )
+        return total_columns_number, view_list
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _get_tables_data(self, table_list, db_name, cursor):

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -106,6 +106,13 @@ SELECT table_name as `name`,
        WHERE TABLE_SCHEMA = %s AND TABLE_TYPE='BASE TABLE'
 """
 
+SQL_VIEWS = """\
+SELECT table_name as `name`,
+       view_definition as `definition`
+       FROM information_schema.VIEWS
+       WHERE TABLE_SCHEMA = %s
+"""
+
 SQL_COLUMNS = """\
 SELECT table_name as `table_name`,
        column_name as `name`,

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -611,6 +611,7 @@ def add_schema_test_databases(cursor):
     cursor.execute("CREATE DATABASE IF NOT EXISTS datadog_test_schemas;")
     cursor.execute("USE datadog_test_schemas;")
     cursor.execute("GRANT SELECT ON datadog_test_schemas.* TO 'dog'@'%';")
+    cursor.execute("GRANT SHOW VIEW ON datadog_test_schemas.* TO 'dog'@'%';")
     # needed to query INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS in mariadb 10.5 and above
     cursor.execute("GRANT REFERENCES ON datadog_test_schemas.* TO 'dog'@'%';")
     cursor.execute(
@@ -669,6 +670,11 @@ def add_schema_test_databases(cursor):
             Review TEXT,
             CONSTRAINT FK_RestaurantNameDistrict FOREIGN KEY (RestaurantName, District)
             REFERENCES Restaurants(RestaurantName, District) ON DELETE CASCADE ON UPDATE NO ACTION);
+        """
+    )
+    cursor.execute(
+        """CREATE VIEW restaurant_names AS
+           SELECT RestaurantName, District FROM Restaurants;
         """
     )
     # Second DB

--- a/mysql/tests/test_metadata.py
+++ b/mysql/tests/test_metadata.py
@@ -2,12 +2,17 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import json
 import re
+import time
+from unittest import mock
 
+import pymysql
 import pytest
 from packaging.version import parse as parse_version
 
 from datadog_checks.mysql import MySql
+from datadog_checks.mysql.databases_data import DatabasesData, SubmitData
 
 from . import common
 from .common import MYSQL_FLAVOR, MYSQL_REPLICATION, MYSQL_VERSION_PARSED
@@ -60,6 +65,15 @@ def normalize_values(actual_payload):
                             subpartition["subpartition_expression"] = (
                                 subpartition["subpartition_expression"].replace("`", "").lower().strip()
                             )
+    if 'views' in actual_payload:
+        actual_payload['views'].sort(key=lambda x: x['name'])
+        for view in actual_payload['views']:
+            if view['definition'] is not None:
+                view['definition'] = "normalized_value"
+            view['columns'].sort(key=lambda x: x['name'])
+            for column in view['columns']:
+                if column['column_type'] == 'int':
+                    column['column_type'] = 'int(11)'
 
 
 @pytest.mark.integration
@@ -485,6 +499,32 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
                 ],
             },
         ],
+        "views": [
+            {
+                "name": "restaurant_names",
+                "definition": "normalized_value",
+                "columns": [
+                    {
+                        "name": "RestaurantName",
+                        "column_type": "varchar(255)",
+                        "default": "NULL" if is_maria_db else None,
+                        "nullable": True,
+                        "ordinal_position": 1,
+                        "column_key": "",
+                        "extra": "",
+                    },
+                    {
+                        "name": "District",
+                        "column_type": "varchar(100)",
+                        "default": "NULL" if is_maria_db else None,
+                        "nullable": True,
+                        "ordinal_position": 2,
+                        "column_key": "",
+                        "extra": "",
+                    },
+                ],
+            }
+        ],
     }
     exp_datadog_test_schemas_second = {
         "name": "datadog_test_schemas_second",
@@ -656,6 +696,8 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
 
     actual_payloads = {}
+    table_fragment_found = False
+    view_fragment_found = False
 
     expected_tags = (
         'database_hostname:stubbed.hostname',
@@ -686,12 +728,24 @@ def test_collect_schemas(aggregator, dd_run_check, dbm_instance):
         if db_name not in databases_to_find:
             continue
 
-        if db_name in actual_payloads:
-            actual_payloads[db_name]['schemas'] = actual_payloads[db_name]['schemas'] + database_metadata[0]['schemas']
-        else:
-            actual_payloads[db_name] = database_metadata[0]
+        database_fragment = database_metadata[0]
+        database_payload = actual_payloads.setdefault(
+            db_name, {key: value for key, value in database_fragment.items() if key not in ('tables', 'views')}
+        )
+        for object_type in ('tables', 'views'):
+            if object_type in database_fragment:
+                database_payload.setdefault(object_type, []).extend(database_fragment[object_type])
+
+        if db_name == 'datadog_test_schemas' and 'tables' in database_fragment:
+            assert 'views' not in database_fragment
+            table_fragment_found = True
+        if db_name == 'datadog_test_schemas' and 'views' in database_fragment:
+            assert 'tables' not in database_fragment
+            view_fragment_found = True
 
     assert len(actual_payloads) == len(expected_data_for_db)
+    assert table_fragment_found
+    assert view_fragment_found
 
     for db_name, actual_payload in actual_payloads.items():
         normalize_values(actual_payload)
@@ -729,3 +783,111 @@ def test_schemas_collection_config(dbm_instance):
     dbm_instance['collect_schemas'] = {"enabled": True, "max_execution_time": 0}
     check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
     assert check._config.schemas_config == {"enabled": True, "max_execution_time": 0}
+
+
+@pytest.mark.unit
+def test_submit_data_counts_table_and_view_columns_together():
+    submitted_data = []
+    submitter = SubmitData(submitted_data.append, {"kind": "mysql_databases"}, mock.MagicMock())
+    submitter.store_db_infos([{"name": "test_db"}])
+
+    submitter.store("test_db", [{"name": "table"}], 2)
+    submitter.store_views("test_db", [{"name": "view", "definition": None, "columns": []}], 3)
+
+    assert submitter.columns_since_last_submit() == 5
+
+    submitter.submit()
+    metadata = json.loads(submitted_data[0])["metadata"][0]
+    assert metadata["tables"] == [{"name": "table"}]
+    assert metadata["views"] == [{"name": "view", "definition": None, "columns": []}]
+
+
+@pytest.mark.unit
+def test_submit_data_sends_table_and_view_fragments_independently():
+    submitted_data = []
+    submitter = SubmitData(submitted_data.append, {"kind": "mysql_databases"}, mock.MagicMock())
+    submitter.store_db_infos([{"name": "test_db"}])
+    column = {
+        "name": "id",
+        "column_type": "int",
+        "default": None,
+        "nullable": False,
+        "ordinal_position": 1,
+        "column_key": "",
+        "extra": "",
+    }
+
+    submitter.store("test_db", [{"name": "table"}], 1)
+    submitter.submit()
+    submitter.store_views("test_db", [{"name": "view", "definition": None, "columns": [column]}], 1)
+    submitter.submit()
+
+    table_metadata = json.loads(submitted_data[0])["metadata"][0]
+    view_metadata = json.loads(submitted_data[1])["metadata"][0]
+    assert table_metadata == {"name": "test_db", "tables": [{"name": "table"}]}
+    assert view_metadata == {
+        "name": "test_db",
+        "views": [{"name": "view", "definition": None, "columns": [column]}],
+    }
+    assert set(view_metadata["views"][0]["columns"][0]) == {
+        "name",
+        "column_type",
+        "default",
+        "nullable",
+        "ordinal_position",
+        "column_key",
+        "extra",
+    }
+
+
+@pytest.mark.unit
+def test_view_columns_split_payloads_at_the_column_limit():
+    check = MySql(common.CHECK_NAME, {}, instances=[{'server': 'localhost', 'user': 'datadog'}])
+    databases_data = DatabasesData({}, check, check._config)
+    submitted_data = []
+    databases_data.TABLES_CHUNK_SIZE = 1
+    databases_data.MAX_COLUMNS_PER_EVENT = 1
+    databases_data._data_submitter = SubmitData(submitted_data.append, {"kind": "mysql_databases"}, mock.MagicMock())
+    databases_data._data_submitter.store_db_infos([{"name": "test_db"}])
+    views = [{"name": "view_{}".format(i), "definition": None, "columns": []} for i in range(3)]
+
+    with (
+        mock.patch.object(databases_data, '_get_tables', return_value=[]),
+        mock.patch.object(databases_data, '_get_views', return_value=views),
+        mock.patch.object(databases_data, '_get_views_data', side_effect=lambda chunk, *_: (1, chunk)),
+    ):
+        databases_data._fetch_database_data(mock.MagicMock(), time.time(), "test_db")
+
+    payloads = [json.loads(event)["metadata"][0] for event in submitted_data]
+    assert [[view["name"] for view in payload["views"]] for payload in payloads] == [
+        ["view_0", "view_1"],
+        ["view_2"],
+    ]
+
+
+@pytest.mark.unit
+def test_view_permission_failure_preserves_table_metadata():
+    check = MySql(common.CHECK_NAME, {}, instances=[{'server': 'localhost', 'user': 'datadog'}])
+    databases_data = DatabasesData({}, check, check._config)
+    submitted_data = []
+    databases_data._log = mock.MagicMock()
+    databases_data._data_submitter = SubmitData(submitted_data.append, {"kind": "mysql_databases"}, databases_data._log)
+    databases_data._data_submitter.store_db_infos([{"name": "test_db"}])
+
+    with (
+        mock.patch.object(databases_data, '_get_tables', return_value=[{"name": "table"}]),
+        mock.patch.object(databases_data, '_get_tables_data', return_value=(1, [{"name": "table", "columns": []}])),
+        mock.patch.object(
+            databases_data,
+            '_get_views',
+            side_effect=pymysql.DatabaseError(
+                pymysql.constants.ER.TABLEACCESS_DENIED_ERROR, "SHOW VIEW command denied"
+            ),
+        ),
+    ):
+        databases_data._fetch_database_data(mock.MagicMock(), time.time(), "test_db")
+
+    metadata = json.loads(submitted_data[0])["metadata"][0]
+    assert metadata == {"name": "test_db", "tables": [{"name": "table", "columns": []}]}
+    databases_data._log.warning.assert_called_once()
+    assert "SHOW VIEW privilege" in databases_data._log.warning.call_args.args[0]

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -422,9 +422,10 @@ def test_submit_is_called_if_too_many_columns():
     check = MySql(common.CHECK_NAME, {}, instances=[{'server': 'localhost', 'user': 'datadog'}])
     databases_data = DatabasesData({}, check, check._config)
     with (
-        mock.patch('time.time', side_effect=[0, 0]),
+        mock.patch('time.time', return_value=0),
         mock.patch('datadog_checks.mysql.databases_data.DatabasesData._get_tables', return_value=[1, 2]),
         mock.patch('datadog_checks.mysql.databases_data.SubmitData.submit') as mocked_submit,
+        mock.patch('datadog_checks.mysql.databases_data.DatabasesData._get_views', return_value=[]),
         mock.patch(
             'datadog_checks.mysql.databases_data.DatabasesData._get_tables_data',
             return_value=(1000_000, {"name": "my_table"}),


### PR DESCRIPTION
MySQL schema collection now emits view definitions and projected columns in separate `views` database fragments while leaving table fragments unchanged. View and table collection share the existing execution-time and column-count limits. Missing `SHOW VIEW` access omits views without discarding table metadata.

Closes https://linear.app/datadog/issue/DOIO-253