### PR TITLE
[DBMON-6881] Move postgres onto the DatabaseCheck cancellation lifecycle

### DIFF
--- a/postgres/changelog.d/24933.fixed
+++ b/postgres/changelog.d/24933.fixed
@@ -1,1 +1,1 @@
-Inherit the check cancellation lifecycle from ``DatabaseCheck`` instead of carrying a local copy.
+Inherit the check cancellation lifecycle from ``DatabaseCheck``.

--- a/postgres/changelog.d/24933.fixed
+++ b/postgres/changelog.d/24933.fixed
@@ -1,0 +1,1 @@
+Inherit the check cancellation lifecycle from ``DatabaseCheck`` instead of carrying a local copy.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -5,7 +5,6 @@ import contextlib
 import copy
 import functools
 import os
-import threading
 from time import time
 
 import psycopg
@@ -195,11 +194,6 @@ class PostgreSql(DatabaseCheck):
         )  # type: TTLCache
 
         self.diagnosis.register(functools.partial(run_diagnostics, self))
-
-        self._cancel_lock = threading.Lock()
-        self._is_running = False
-        self._cancelled = False
-        self._finalized = False
 
     def database_monitoring_column_statistics(self, raw_event: str):
         self.event_platform_event(raw_event, "dbm-column-statistics")
@@ -479,52 +473,6 @@ class PostgreSql(DatabaseCheck):
 
         return self._dynamic_queries
 
-    def run(self):
-        # TODO: move this lock into the base class
-        with self._cancel_lock:
-            if self._cancelled:
-                self.log.debug("run() skipped, check already cancelled")
-                return ''
-            self._is_running = True
-        try:
-            return super().run()
-        finally:
-            needs_finalize = False
-            with self._cancel_lock:
-                self._is_running = False
-                if self._cancelled:
-                    needs_finalize = True
-            if needs_finalize:
-                self.log.debug("Check cancel has been signaled, finalizing now that run() is complete")
-                self._finalize()
-
-    def cancel(self):
-        """Signal that the check is being unscheduled.
-
-        This method can be called while check() is running on another thread
-        (the GIL is released during psycopg I/O). It must not perform any
-        destructive operations — closing connections or nulling attributes that
-        check() depends on — because that causes a SIGSEGV in libpq when
-        check() resumes.
-
-        Destructive cleanup is deferred to _finalize(), which is called either
-        here (if the check is idle) or by run()'s finally block (if the check
-        is in-flight). The Agent guarantees it will not call run() again after
-        cancel().
-        """
-        self.log.debug("Marking check as cancelled")
-        self.cancel_async_jobs()
-        needs_finalize = False
-        with self._cancel_lock:
-            self._cancelled = True
-            if not self._is_running:
-                needs_finalize = True
-        if needs_finalize:
-            self.log.debug("cancel() finalizing immediately, check is idle")
-            self._finalize()
-        else:
-            self.log.debug("cancel() deferred finalize, check is still running")
-
     def _register_async_jobs(self):
         """Build and register the async jobs enabled by this check's configuration."""
         if self._config.dbm:
@@ -537,23 +485,13 @@ class PostgreSql(DatabaseCheck):
         if self._config.data_observability.enabled:
             self.data_observability = self.register_async_job(PostgresDataObservability(self, self._config))
 
-    def _finalize(self):
-        """Tear down check state. Runs at most once, and never while check() is executing."""
-        with self._cancel_lock:
-            if self._finalized:
-                return
-            self._finalized = True
-        self.log.debug("Finalizing check: closing connections and clearing state")
-        self.shutdown_async_jobs()
+    def shutdown(self) -> None:
+        """Release the resources this check holds for its whole lifetime."""
         self._clean_state()
-        self.check_initializations.clear()
-        # TODO: move diagnosis cleanup into AgentCheck.cancel() in the base class
-        self._diagnosis = None
         self._query_manager = None
         self.health = None
         self._close_db()
         self._close_db_pool()
-        self.log.debug("Check cleanup complete")
 
     def _clean_state(self):
         self.log.debug("Cleaning state")
@@ -1249,7 +1187,7 @@ class PostgreSql(DatabaseCheck):
 
             if not self._config.only_custom_queries:
                 self._collect_stats(tags)
-                if not self._cancelled:
+                if not self.is_cancelled:
                     self.run_async_jobs(tags)
                 if self._config.collect_wal_metrics is True:
                     # collect wal metrics for pg < 10 only when explicitly enabled

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=38.0.0",
+    "datadog-checks-base>=38.1.0",
 ]
 dynamic = [
     "version",

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -390,15 +390,20 @@ def test_close_db_noop_when_no_connection(integration_check, pg_instance):
     assert check._db is None
 
 
-def test_cancel_closes_main_db_connection(integration_check, pg_instance):
+def test_cancel_releases_check_resources(integration_check, pg_instance):
+    """cancel() runs shutdown(), which releases everything the check holds for its lifetime."""
     check = integration_check(pg_instance)
     conn = mock.MagicMock()
     check._db = conn
 
-    check.cancel()
+    with mock.patch.object(check.db_pool, 'close_all', wraps=check.db_pool.close_all) as close_all:
+        check.cancel()
 
     conn.close.assert_called_once()
+    close_all.assert_called_once()
     assert check._db is None
+    assert check._query_manager is None
+    assert check.health is None
 
 
 def test_check_gc_after_cancel(pg_instance):
@@ -410,8 +415,8 @@ def test_check_gc_after_cancel(pg_instance):
     1. Identify the referrer type in the failure message (e.g. ``QueryManager``).
     2. Find which attribute on that object points back to the check (usually
        ``self.check`` or ``self._check``).
-    3. Null that attribute in ``cancel()`` or add it to the relevant
-       ``shutdown()`` method.
+    3. Null that attribute in the check's ``shutdown()`` or in the relevant job's
+       ``shutdown()``.
     4. If the referrer is a closure or ``functools.partial``, find the
        registration site and null or clear the container that holds it.
     """
@@ -443,95 +448,6 @@ def test_check_gc_after_cancel(pg_instance):
             fail(f"Check still alive after cancel() + del -- pinned by: {referrers}")
     finally:
         gc.enable()
-
-
-def test_cancel_during_running_check_defers_finalize(pg_instance):
-    """Verify that cancel() during an in-flight check() does not close connections.
-
-    Destructive cleanup (_finalize) must be deferred until run() completes so
-    that check() never accesses a closed psycopg connection, which would cause
-    a SIGSEGV in libpq.
-    """
-    import threading
-
-    check = PostgreSql('postgres', {}, [pg_instance])
-    conn = mock.MagicMock()
-    check._db = conn
-
-    check_started = threading.Event()
-    cancel_done = threading.Event()
-
-    def slow_run(self_arg):
-        check_started.set()
-        cancel_done.wait(timeout=5)
-        return ''
-
-    run_result = [None]
-
-    def run_check():
-        with mock.patch.object(type(check).__mro__[1], 'run', slow_run):
-            run_result[0] = check.run()
-
-    run_thread = threading.Thread(target=run_check)
-    run_thread.start()
-
-    check_started.wait(timeout=5)
-
-    check.cancel()
-    # cancel() should have signaled but NOT finalized since run() is in-flight
-    assert not conn.close.called, "_close_db() ran while check() was still executing"
-    assert check._cancelled is True
-
-    cancel_done.set()
-    run_thread.join(timeout=5)
-
-    # After run() completes, _finalize() should have been called
-    conn.close.assert_called_once()
-    assert check._db is None
-    assert check._query_manager is None
-    assert check.health is None
-
-
-def test_cancel_on_idle_check_finalizes_immediately(pg_instance):
-    """Verify that cancel() on an idle check runs _finalize() inline."""
-    check = PostgreSql('postgres', {}, [pg_instance])
-    conn = mock.MagicMock()
-    check._db = conn
-
-    assert not check._is_running
-
-    check.cancel()
-
-    conn.close.assert_called_once()
-    assert check._db is None
-    assert check._query_manager is None
-    assert check.health is None
-
-
-def test_run_after_cancel_returns_immediately(pg_instance):
-    """Verify that run() returns '' without executing check() if already cancelled."""
-    check = PostgreSql('postgres', {}, [pg_instance])
-    check.cancel()
-
-    with mock.patch.object(check, 'check', side_effect=AssertionError("check() should not be called")):
-        result = check.run()
-
-    assert result == ''
-
-
-def test_finalize_runs_once_across_repeated_cancels(pg_instance):
-    """Verify that teardown is idempotent."""
-    check = PostgreSql('postgres', {}, [pg_instance])
-    conn = mock.MagicMock()
-    check._db = conn
-
-    with mock.patch.object(check.db_pool, 'close_all', wraps=check.db_pool.close_all) as close_all:
-        check.cancel()
-        check.cancel()
-        check._finalize()
-
-    conn.close.assert_called_once()
-    close_all.assert_called_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

Moves the Postgres integration to use the cancellation lifecycle from `DatabaseCheck` base class as the source of truth which was merged in `datadog_checks_base` in #24844

Two behavior changes come from the base implementation:

- Cancellation is recorded *before* the jobs are signaled. Postgres did the reverse, leaving a window where a concurrent `check()` could restart a loop that `cancel_async_jobs()` had just stopped.
- `shutdown_async_jobs()` and `shutdown()` are each wrapped in their own `try/except`, so a job that fails to stop no longer abandons the connection and pool cleanup that follows it.

### Motivation

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)