### PR TITLE
[DBMON-6881] Move clickhouse onto the DatabaseCheck job registry and cancellation lifecycle

### DIFF
--- a/clickhouse/changelog.d/24934.fixed
+++ b/clickhouse/changelog.d/24934.fixed
@@ -1,1 +1,2 @@
 Manage the DBM async jobs through the ``DatabaseCheck`` registry.
+Stop the query samples, table metrics, and parts and merges jobs from starting another query once cancelled, so the Agent no longer waits out a client read timeout per remaining query when unscheduling the check.

--- a/clickhouse/changelog.d/24934.fixed
+++ b/clickhouse/changelog.d/24934.fixed
@@ -1,2 +1,1 @@
 Manage the DBM async jobs through the ``DatabaseCheck`` registry.
-Stop the query samples, table metrics, and parts and merges jobs from starting another query once cancelled, so the Agent no longer waits out a client read timeout per remaining query when unscheduling the check.

--- a/clickhouse/changelog.d/24934.fixed
+++ b/clickhouse/changelog.d/24934.fixed
@@ -1,0 +1,1 @@
+Manage the DBM async jobs through the ``DatabaseCheck`` registry.

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -110,10 +110,12 @@ class ClickhouseCheck(DatabaseCheck):
         self._init_dbm_components()
 
     def _init_dbm_components(self):
-        """Initialize DBM components based on typed configuration."""
+        """Build and register the DBM async jobs enabled by the typed configuration."""
         # Initialize query metrics (from system.query_log - analogous to pg_stat_statements)
         if self._config.dbm and self._config.query_metrics.enabled:
-            self.statement_metrics = ClickhouseStatementMetrics(self, self._config.query_metrics)
+            self.statement_metrics = self.register_async_job(
+                ClickhouseStatementMetrics(self, self._config.query_metrics)
+            )
         else:
             self.statement_metrics = None
 
@@ -124,8 +126,8 @@ class ClickhouseCheck(DatabaseCheck):
         if self._config.dbm and (
             self._config.query_samples.enabled or self._config.collect_pending_async_inserts.enabled
         ):
-            self.statement_samples = ClickhouseStatementSamples(
-                self, self._config.query_samples, self._config.collect_pending_async_inserts
+            self.statement_samples = self.register_async_job(
+                ClickhouseStatementSamples(self, self._config.query_samples, self._config.collect_pending_async_inserts)
             )
         else:
             self.statement_samples = None
@@ -135,33 +137,35 @@ class ClickhouseCheck(DatabaseCheck):
         # so its config is passed in here rather than run as its own DBMAsyncJob, which would add another
         # concurrent connection to the check's capped DBM connection pool.
         if self._config.dbm and (self._config.query_completions.enabled or self._config.collect_async_inserts.enabled):
-            self.query_completions = ClickhouseQueryCompletions(
-                self, self._config.query_completions, self._config.collect_async_inserts
+            self.query_completions = self.register_async_job(
+                ClickhouseQueryCompletions(self, self._config.query_completions, self._config.collect_async_inserts)
             )
         else:
             self.query_completions = None
 
         # Initialize query errors (from system.query_log - failed queries)
         if self._config.dbm and self._config.query_errors.enabled:
-            self.query_errors = ClickhouseQueryErrors(self, self._config.query_errors)
+            self.query_errors = self.register_async_job(ClickhouseQueryErrors(self, self._config.query_errors))
         else:
             self.query_errors = None
 
         # Initialize schema metrics (per-table size and per-view refresh gauges)
         if self._config.dbm and self._config.schema_metrics.enabled:
-            self.table_metrics = ClickhouseTableMetrics(self, self._config.schema_metrics)
+            self.table_metrics = self.register_async_job(ClickhouseTableMetrics(self, self._config.schema_metrics))
         else:
             self.table_metrics = None
 
         # Initialize schema collection (catalog metadata for Schema Explorer)
         if self._config.dbm and self._config.collect_schemas.enabled:
-            self.metadata = ClickhouseMetadata(self)
+            self.metadata = self.register_async_job(ClickhouseMetadata(self))
         else:
             self.metadata = None
 
         # Initialize parts and merges monitoring (from system.parts, merges, mutations, replication_queue)
         if self._config.dbm and self._config.parts_and_merges.enabled:
-            self.parts_and_merges = ClickhousePartsAndMerges(self, self._config.parts_and_merges)
+            self.parts_and_merges = self.register_async_job(
+                ClickhousePartsAndMerges(self, self._config.parts_and_merges)
+            )
         else:
             self.parts_and_merges = None
 
@@ -275,33 +279,7 @@ class ClickhouseCheck(DatabaseCheck):
         # Send database instance metadata
         self._send_database_instance_metadata()
 
-        # Run query metrics collection if DBM is enabled (from system.query_log)
-        if self.statement_metrics:
-            self.statement_metrics.run_job_loop(self.tags)
-
-        # Run query samples collection if DBM is enabled (from system.processes)
-        if self.statement_samples:
-            self.statement_samples.run_job_loop(self.tags)
-
-        # Run query completions if DBM is enabled (from system.query_log)
-        if self.query_completions:
-            self.query_completions.run_job_loop(self.tags)
-
-        # Run query errors if DBM is enabled (from system.query_log - failed queries)
-        if self.query_errors:
-            self.query_errors.run_job_loop(self.tags)
-
-        # Run schema metrics (per-table size and per-view refresh gauges) if enabled
-        if self.table_metrics:
-            self.table_metrics.run_job_loop(self.tags)
-
-        # Run schema collection if enabled
-        if self.metadata:
-            self.metadata.run_job_loop(self.tags)
-
-        # Run parts and merges monitoring if enabled
-        if self.parts_and_merges:
-            self.parts_and_merges.run_job_loop(self.tags)
+        self.run_async_jobs(self.tags)
 
     def get_queries(self) -> list[dict]:
         query_list = []
@@ -603,46 +581,8 @@ class ClickhouseCheck(DatabaseCheck):
             self.log.warning(error)
             raise
 
-    def cancel(self):
-        """
-        Cancel DBM async jobs and clean up connections.
-        This is called when the check is being shut down.
-        """
-        self.log.debug("Cancelling ClickHouse check and cleaning up connections")
-
-        # Cancel DBM async jobs
-        if self.statement_metrics:
-            self.statement_metrics.cancel()
-        if self.statement_samples:
-            self.statement_samples.cancel()
-        if self.query_completions:
-            self.query_completions.cancel()
-        if self.query_errors:
-            self.query_errors.cancel()
-        if self.table_metrics:
-            self.table_metrics.cancel()
-        if self.metadata:
-            self.metadata.cancel()
-        if self.parts_and_merges:
-            self.parts_and_merges.cancel()
-
-        # Wait for job loops to finish
-        if self.statement_metrics and self.statement_metrics._job_loop_future:
-            self.statement_metrics._job_loop_future.result()
-        if self.statement_samples and self.statement_samples._job_loop_future:
-            self.statement_samples._job_loop_future.result()
-        if self.query_completions and self.query_completions._job_loop_future:
-            self.query_completions._job_loop_future.result()
-        if self.query_errors and self.query_errors._job_loop_future:
-            self.query_errors._job_loop_future.result()
-        if self.table_metrics and self.table_metrics._job_loop_future:
-            self.table_metrics._job_loop_future.result()
-        if self.metadata and self.metadata._job_loop_future:
-            self.metadata._job_loop_future.result()
-        if self.parts_and_merges and self.parts_and_merges._job_loop_future:
-            self.parts_and_merges._job_loop_future.result()
-
-        # Close main client
+    def shutdown(self) -> None:
+        """Close the main client and release the shared connection pool."""
         if self._client:
             try:
                 self._client.close()
@@ -650,8 +590,8 @@ class ClickhouseCheck(DatabaseCheck):
                 self.log.debug("Error closing main client: %s", e)
             self._client = None
 
-        # Clear the shared pool manager
-        # Note: urllib3 pool connections are automatically closed when idle
+        # urllib3 pool connections are closed automatically once idle, so dropping the manager is
+        # enough. The jobs' dedicated clients share it, and they are shut down before this runs.
         self._pool_manager = None
 
     def version_lt(self, version: str) -> bool:

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -106,68 +106,63 @@ class ClickhouseCheck(DatabaseCheck):
             ca_cert=self._config.tls_ca_cert,
         )
 
-        # Initialize DBM components if enabled
-        self._init_dbm_components()
+        # DBM async jobs, left as None by _register_async_jobs() when the configuration disables them
+        self.statement_metrics: ClickhouseStatementMetrics | None = None
+        self.statement_samples: ClickhouseStatementSamples | None = None
+        self.query_completions: ClickhouseQueryCompletions | None = None
+        self.query_errors: ClickhouseQueryErrors | None = None
+        self.table_metrics: ClickhouseTableMetrics | None = None
+        self.metadata: ClickhouseMetadata | None = None
+        self.parts_and_merges: ClickhousePartsAndMerges | None = None
+        self._register_async_jobs()
 
-    def _init_dbm_components(self):
-        """Build and register the DBM async jobs enabled by the typed configuration."""
-        # Initialize query metrics (from system.query_log - analogous to pg_stat_statements)
-        if self._config.dbm and self._config.query_metrics.enabled:
+    def _register_async_jobs(self):
+        """Build and register the async jobs enabled by this check's configuration."""
+        # Every job requires DBM, so it is checked once here rather than repeated per job.
+        if not self._config.dbm:
+            return
+
+        # Query metrics (from system.query_log - analogous to pg_stat_statements)
+        if self._config.query_metrics.enabled:
             self.statement_metrics = self.register_async_job(
                 ClickhouseStatementMetrics(self, self._config.query_metrics)
             )
-        else:
-            self.statement_metrics = None
 
-        # Initialize query samples (from system.processes - analogous to pg_stat_activity).
+        # Query samples (from system.processes - analogous to pg_stat_activity).
         # The async insert buffer snapshot collapses into this job (sharing its connection and
         # loop) instead of running as its own DBMAsyncJob, which would open another concurrent
         # connection against the check's capped DBM connection pool.
-        if self._config.dbm and (
-            self._config.query_samples.enabled or self._config.collect_pending_async_inserts.enabled
-        ):
+        if self._config.query_samples.enabled or self._config.collect_pending_async_inserts.enabled:
             self.statement_samples = self.register_async_job(
                 ClickhouseStatementSamples(self, self._config.query_samples, self._config.collect_pending_async_inserts)
             )
-        else:
-            self.statement_samples = None
 
-        # Initialize query completions (from system.query_log - completed queries).
+        # Query completions (from system.query_log - completed queries).
         # The async insert flush log collection collapses into this job (shares its connection and loop),
         # so its config is passed in here rather than run as its own DBMAsyncJob, which would add another
         # concurrent connection to the check's capped DBM connection pool.
-        if self._config.dbm and (self._config.query_completions.enabled or self._config.collect_async_inserts.enabled):
+        if self._config.query_completions.enabled or self._config.collect_async_inserts.enabled:
             self.query_completions = self.register_async_job(
                 ClickhouseQueryCompletions(self, self._config.query_completions, self._config.collect_async_inserts)
             )
-        else:
-            self.query_completions = None
 
-        # Initialize query errors (from system.query_log - failed queries)
-        if self._config.dbm and self._config.query_errors.enabled:
+        # Query errors (from system.query_log - failed queries)
+        if self._config.query_errors.enabled:
             self.query_errors = self.register_async_job(ClickhouseQueryErrors(self, self._config.query_errors))
-        else:
-            self.query_errors = None
 
-        # Initialize schema metrics (per-table size and per-view refresh gauges)
-        if self._config.dbm and self._config.schema_metrics.enabled:
+        # Schema metrics (per-table size and per-view refresh gauges)
+        if self._config.schema_metrics.enabled:
             self.table_metrics = self.register_async_job(ClickhouseTableMetrics(self, self._config.schema_metrics))
-        else:
-            self.table_metrics = None
 
-        # Initialize schema collection (catalog metadata for Schema Explorer)
-        if self._config.dbm and self._config.collect_schemas.enabled:
+        # Schema collection (catalog metadata for Schema Explorer)
+        if self._config.collect_schemas.enabled:
             self.metadata = self.register_async_job(ClickhouseMetadata(self))
-        else:
-            self.metadata = None
 
-        # Initialize parts and merges monitoring (from system.parts, merges, mutations, replication_queue)
-        if self._config.dbm and self._config.parts_and_merges.enabled:
+        # Parts and merges monitoring (from system.parts, merges, mutations, replication_queue)
+        if self._config.parts_and_merges.enabled:
             self.parts_and_merges = self.register_async_job(
                 ClickhousePartsAndMerges(self, self._config.parts_and_merges)
             )
-        else:
-            self.parts_and_merges = None
 
     def _add_core_tags(self):
         """

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -251,22 +251,11 @@ class ClickhouseCheck(DatabaseCheck):
         self.connect()
         self._dbms_version = self.select_version()
 
-        # The Agent cancels from another thread, and teardown is deferred until this returns so it
-        # cannot close the client from under us. Each remaining stage queries, so gate them on the
-        # cancellation rather than working through them all against a check that is going away.
-        if self.is_cancelled:
-            self.log.debug("Check cancelled, skipping the rest of the run")
-            return
-
         # Must run before the query manager is built and before the DBM jobs are handed
         # self.tags below, since both snapshot the tag list.
         if self.cluster_name:
             self.tag_manager.set_tag(CLUSTER_TAG, self.cluster_name, replace=True)
         self.tag_manager.set_tag(HOSTING_TYPE_TAG, self.hosting_type, replace=True)
-
-        if self.is_cancelled:
-            self.log.debug("Check cancelled, skipping the rest of the run")
-            return
 
         if self._query_manager is None or self._query_manager_version != self.dbms_version:
             self._query_manager = self._build_query_manager()

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -251,11 +251,22 @@ class ClickhouseCheck(DatabaseCheck):
         self.connect()
         self._dbms_version = self.select_version()
 
+        # The Agent cancels from another thread, and teardown is deferred until this returns so it
+        # cannot close the client from under us. Each remaining stage queries, so gate them on the
+        # cancellation rather than working through them all against a check that is going away.
+        if self.is_cancelled:
+            self.log.debug("Check cancelled, skipping the rest of the run")
+            return
+
         # Must run before the query manager is built and before the DBM jobs are handed
         # self.tags below, since both snapshot the tag list.
         if self.cluster_name:
             self.tag_manager.set_tag(CLUSTER_TAG, self.cluster_name, replace=True)
         self.tag_manager.set_tag(HOSTING_TYPE_TAG, self.hosting_type, replace=True)
+
+        if self.is_cancelled:
+            self.log.debug("Check cancelled, skipping the rest of the run")
+            return
 
         if self._query_manager is None or self._query_manager_version != self.dbms_version:
             self._query_manager = self._build_query_manager()

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -106,7 +106,6 @@ class ClickhouseCheck(DatabaseCheck):
             ca_cert=self._config.tls_ca_cert,
         )
 
-        # DBM async jobs, left as None by _register_async_jobs() when the configuration disables them
         self.statement_metrics: ClickhouseStatementMetrics | None = None
         self.statement_samples: ClickhouseStatementSamples | None = None
         self.query_completions: ClickhouseQueryCompletions | None = None
@@ -118,47 +117,40 @@ class ClickhouseCheck(DatabaseCheck):
 
     def _register_async_jobs(self):
         """Build and register the async jobs enabled by this check's configuration."""
-        # Every job requires DBM, so it is checked once here rather than repeated per job.
         if not self._config.dbm:
             return
 
-        # Query metrics (from system.query_log - analogous to pg_stat_statements)
+        # Query metrics (from system.query_log)
         if self._config.query_metrics.enabled:
             self.statement_metrics = self.register_async_job(
                 ClickhouseStatementMetrics(self, self._config.query_metrics)
             )
 
-        # Query samples (from system.processes - analogous to pg_stat_activity).
-        # The async insert buffer snapshot collapses into this job (sharing its connection and
-        # loop) instead of running as its own DBMAsyncJob, which would open another concurrent
-        # connection against the check's capped DBM connection pool.
+        # Query samples (from system.processes) and pending async inserts (system.asynchronous_inserts)
         if self._config.query_samples.enabled or self._config.collect_pending_async_inserts.enabled:
             self.statement_samples = self.register_async_job(
                 ClickhouseStatementSamples(self, self._config.query_samples, self._config.collect_pending_async_inserts)
             )
 
-        # Query completions (from system.query_log - completed queries).
-        # The async insert flush log collection collapses into this job (shares its connection and loop),
-        # so its config is passed in here rather than run as its own DBMAsyncJob, which would add another
-        # concurrent connection to the check's capped DBM connection pool.
+        # Completed queries and async insert flushes (from system.query_log and system.asynchronous_insert_log)
         if self._config.query_completions.enabled or self._config.collect_async_inserts.enabled:
             self.query_completions = self.register_async_job(
                 ClickhouseQueryCompletions(self, self._config.query_completions, self._config.collect_async_inserts)
             )
 
-        # Query errors (from system.query_log - failed queries)
+        # Failed queries (from system.query_log)
         if self._config.query_errors.enabled:
             self.query_errors = self.register_async_job(ClickhouseQueryErrors(self, self._config.query_errors))
 
-        # Schema metrics (per-table size and per-view refresh gauges)
+        # Schema metrics (from system.tables and system.view_refreshes)
         if self._config.schema_metrics.enabled:
             self.table_metrics = self.register_async_job(ClickhouseTableMetrics(self, self._config.schema_metrics))
 
-        # Schema collection (catalog metadata for Schema Explorer)
+        # Schema collection (from system.tables and system.columns)
         if self._config.collect_schemas.enabled:
             self.metadata = self.register_async_job(ClickhouseMetadata(self))
 
-        # Parts and merges monitoring (from system.parts, merges, mutations, replication_queue)
+        # Parts and merges (from system.parts, merges, mutations, replication_queue)
         if self._config.parts_and_merges.enabled:
             self.parts_and_merges = self.register_async_job(
                 ClickhousePartsAndMerges(self, self._config.parts_and_merges)

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -583,6 +583,8 @@ class ClickhouseCheck(DatabaseCheck):
 
     def shutdown(self) -> None:
         """Close the main client and release the shared connection pool."""
+        self._query_manager = None
+        self.health = None
         if self._client:
             try:
                 self._client.close()

--- a/clickhouse/datadog_checks/clickhouse/metadata.py
+++ b/clickhouse/datadog_checks/clickhouse/metadata.py
@@ -41,7 +41,8 @@ class ClickhouseMetadata(DBMAsyncJob):
         self._schema_collector._cancel_event = self._cancel_event
 
     def shutdown(self) -> None:
-        self._schema_collector.close()
+        if self._schema_collector is not None:
+            self._schema_collector.close()
         # The collector holds the check too, so dropping it here releases both.
         self._schema_collector = None
         self._check = None

--- a/clickhouse/datadog_checks/clickhouse/metadata.py
+++ b/clickhouse/datadog_checks/clickhouse/metadata.py
@@ -40,8 +40,7 @@ class ClickhouseMetadata(DBMAsyncJob):
         self._schema_collector = ClickhouseSchemaCollector(check)
         self._schema_collector._cancel_event = self._cancel_event
 
-    def cancel(self):
-        super(ClickhouseMetadata, self).cancel()
+    def shutdown(self) -> None:
         self._schema_collector.close()
 
     @tracked_method(agent_check_getter=agent_check_getter)

--- a/clickhouse/datadog_checks/clickhouse/metadata.py
+++ b/clickhouse/datadog_checks/clickhouse/metadata.py
@@ -42,6 +42,9 @@ class ClickhouseMetadata(DBMAsyncJob):
 
     def shutdown(self) -> None:
         self._schema_collector.close()
+        # The collector holds the check too, so dropping it here releases both.
+        self._schema_collector = None
+        self._check = None
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def run_job(self):

--- a/clickhouse/datadog_checks/clickhouse/parts_and_merges.py
+++ b/clickhouse/datadog_checks/clickhouse/parts_and_merges.py
@@ -268,6 +268,7 @@ class ClickhousePartsAndMerges(DBMAsyncJob):
 
     def shutdown(self) -> None:
         self._close_db_client()
+        self._check = None
 
     def _close_db_client(self):
         if self._db_client:

--- a/clickhouse/datadog_checks/clickhouse/parts_and_merges.py
+++ b/clickhouse/datadog_checks/clickhouse/parts_and_merges.py
@@ -282,6 +282,8 @@ class ClickhousePartsAndMerges(DBMAsyncJob):
         return list(self._tags_no_db) if self._tags_no_db else []
 
     def _execute_query(self, query: str) -> list:
+        if self._cancel_event.is_set():
+            raise Exception("Job loop cancelled. Aborting query.")
         if self._db_client is None:
             self._db_client = self._check.create_dbm_client()
         try:

--- a/clickhouse/datadog_checks/clickhouse/parts_and_merges.py
+++ b/clickhouse/datadog_checks/clickhouse/parts_and_merges.py
@@ -266,8 +266,7 @@ class ClickhousePartsAndMerges(DBMAsyncJob):
         }
         self._obfuscate_options = to_native_string(json.dumps(obfuscate_options))
 
-    def cancel(self):
-        super(ClickhousePartsAndMerges, self).cancel()
+    def shutdown(self) -> None:
         self._close_db_client()
 
     def _close_db_client(self):

--- a/clickhouse/datadog_checks/clickhouse/query_completions.py
+++ b/clickhouse/datadog_checks/clickhouse/query_completions.py
@@ -148,6 +148,11 @@ class ClickhouseQueryCompletions(ClickhouseQueryLogJob):
         self._flush_checkpoint = NodeCheckpoint(self, FLUSH_CHECKPOINT_CACHE_KEY, self._flush_collection_interval)
         self._last_flush_collection_time = 0.0
 
+    def shutdown(self) -> None:
+        super().shutdown()
+        # Holds the check and a bound method of this job, so dropping it releases both.
+        self._explain_plans = None
+
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_and_submit(self):
         """

--- a/clickhouse/datadog_checks/clickhouse/query_log_job.py
+++ b/clickhouse/datadog_checks/clickhouse/query_log_job.py
@@ -380,6 +380,7 @@ class ClickhouseQueryLogJob(DBMAsyncJob):
     def shutdown(self) -> None:
         """Close the dedicated client, once the job loop has stopped."""
         self._close_db_client()
+        self._check = None
 
     def _close_db_client(self):
         """Close the dedicated database client if it exists."""

--- a/clickhouse/datadog_checks/clickhouse/query_log_job.py
+++ b/clickhouse/datadog_checks/clickhouse/query_log_job.py
@@ -377,9 +377,8 @@ class ClickhouseQueryLogJob(DBMAsyncJob):
         }
         self._obfuscate_options = to_native_string(json.dumps(obfuscate_options))
 
-    def cancel(self):
-        """Cancel the job and clean up the dedicated client."""
-        super().cancel()
+    def shutdown(self) -> None:
+        """Close the dedicated client, once the job loop has stopped."""
         self._close_db_client()
 
     def _close_db_client(self):

--- a/clickhouse/datadog_checks/clickhouse/statement_samples.py
+++ b/clickhouse/datadog_checks/clickhouse/statement_samples.py
@@ -223,6 +223,9 @@ class ClickhouseStatementSamples(DBMAsyncJob):
         all nodes in the cluster.
         For self-hosted: Queries only the local node's system.processes.
         """
+        if self._cancel_event.is_set():
+            raise Exception("Job loop cancelled. Aborting query.")
+
         start_time = time.time()
 
         try:
@@ -383,6 +386,9 @@ class ClickhouseStatementSamples(DBMAsyncJob):
         For ClickHouse Cloud: Uses clusterAllReplicas to aggregate across all nodes.
         For self-hosted: Aggregates only the local node's connections.
         """
+        if self._cancel_event.is_set():
+            raise Exception("Job loop cancelled. Aborting query.")
+
         try:
             start_time = time.time()
 
@@ -534,6 +540,10 @@ class ClickhouseStatementSamples(DBMAsyncJob):
             asynchronous_inserts_table=buffer_table,
             max_samples_per_collection=self._buffer_max_samples_per_collection,
         )
+
+        if self._cancel_event.is_set():
+            raise Exception("Job loop cancelled. Aborting query.")
+
         try:
             if self._db_client is None:
                 self._db_client = self._check.create_dbm_client()

--- a/clickhouse/datadog_checks/clickhouse/statement_samples.py
+++ b/clickhouse/datadog_checks/clickhouse/statement_samples.py
@@ -193,9 +193,8 @@ class ClickhouseStatementSamples(DBMAsyncJob):
         # Set once system.asynchronous_inserts is found to be missing, so we skip collection
         self._buffer_unavailable = False
 
-    def cancel(self):
-        """Cancel the job and clean up the dedicated client."""
-        super(ClickhouseStatementSamples, self).cancel()
+    def shutdown(self) -> None:
+        """Close the dedicated client, once the job loop has stopped."""
         self._close_db_client()
 
     def _close_db_client(self):

--- a/clickhouse/datadog_checks/clickhouse/statement_samples.py
+++ b/clickhouse/datadog_checks/clickhouse/statement_samples.py
@@ -196,6 +196,7 @@ class ClickhouseStatementSamples(DBMAsyncJob):
     def shutdown(self) -> None:
         """Close the dedicated client, once the job loop has stopped."""
         self._close_db_client()
+        self._check = None
 
     def _close_db_client(self):
         """Close the dedicated database client if it exists."""

--- a/clickhouse/datadog_checks/clickhouse/table_metrics.py
+++ b/clickhouse/datadog_checks/clickhouse/table_metrics.py
@@ -110,6 +110,10 @@ class ClickhouseTableMetrics(DBMAsyncJob):
     @tracked_method(agent_check_getter=agent_check_getter)
     def run_job(self):
         self._emit_table_size_gauges()
+        # _emit_table_size_gauges() swallows the cancellation raised by _execute_query, and the
+        # view refresh collection queries the check's client directly, so it needs its own check.
+        if self._cancel_event.is_set():
+            return
         self._collect_view_refresh_metrics()
 
     def _emit_table_size_gauges(self) -> None:

--- a/clickhouse/datadog_checks/clickhouse/table_metrics.py
+++ b/clickhouse/datadog_checks/clickhouse/table_metrics.py
@@ -82,8 +82,7 @@ class ClickhouseTableMetrics(DBMAsyncJob):
         self._view_refreshes_permission_logged = False
         self._view_refreshes_skip = False
 
-    def cancel(self):
-        super(ClickhouseTableMetrics, self).cancel()
+    def shutdown(self) -> None:
         self._close_db_client()
 
     def _close_db_client(self):

--- a/clickhouse/datadog_checks/clickhouse/table_metrics.py
+++ b/clickhouse/datadog_checks/clickhouse/table_metrics.py
@@ -84,6 +84,7 @@ class ClickhouseTableMetrics(DBMAsyncJob):
 
     def shutdown(self) -> None:
         self._close_db_client()
+        self._check = None
 
     def _close_db_client(self):
         if self._db_client:

--- a/clickhouse/datadog_checks/clickhouse/table_metrics.py
+++ b/clickhouse/datadog_checks/clickhouse/table_metrics.py
@@ -95,6 +95,8 @@ class ClickhouseTableMetrics(DBMAsyncJob):
             self._db_client = None
 
     def _execute_query(self, query: str) -> list:
+        if self._cancel_event.is_set():
+            raise Exception("Job loop cancelled. Aborting query.")
         if self._db_client is None:
             self._db_client = self._check.create_dbm_client()
             self._db_client.set_client_setting('max_execution_time', self._collection_interval)

--- a/clickhouse/pyproject.toml
+++ b/clickhouse/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.42.0",
+    "datadog-checks-base>=38.1.0",
 ]
 dynamic = [
     "version",

--- a/clickhouse/tests/test_metadata.py
+++ b/clickhouse/tests/test_metadata.py
@@ -410,6 +410,16 @@ def test_shutdown_closes_db_client(check):
     fake_client.close.assert_called_once()
 
 
+def test_shutdown_is_idempotent(check):
+    """DBMAsyncJob.shutdown() overrides must tolerate a second call.
+
+    shutdown_async_jobs() does not isolate teardown failures per job, so a job that raises here
+    would stop the jobs after it from releasing their own clients.
+    """
+    check.metadata.shutdown()
+    check.metadata.shutdown()
+
+
 def test_combined_query_dedupes_replicas_before_limit(check):
     _capture_payloads(check)
     with _capture_all_queries(check.metadata._schema_collector) as seen_queries:

--- a/clickhouse/tests/test_metadata.py
+++ b/clickhouse/tests/test_metadata.py
@@ -400,12 +400,13 @@ def test_collect_all_chunks_share_collection_started_at(check):
 
 
 def test_shutdown_closes_db_client(check):
+    collector = check.metadata._schema_collector
     fake_client = mock.MagicMock()
-    check.metadata._schema_collector._db_client = fake_client
+    collector._db_client = fake_client
 
     check.metadata.shutdown()
 
-    assert check.metadata._schema_collector._db_client is None
+    assert collector._db_client is None
     fake_client.close.assert_called_once()
 
 

--- a/clickhouse/tests/test_metadata.py
+++ b/clickhouse/tests/test_metadata.py
@@ -399,11 +399,11 @@ def test_collect_all_chunks_share_collection_started_at(check):
     assert len(started_ats) == 1
 
 
-def test_cancel_closes_db_client(check):
+def test_shutdown_closes_db_client(check):
     fake_client = mock.MagicMock()
     check.metadata._schema_collector._db_client = fake_client
 
-    check.metadata.cancel()
+    check.metadata.shutdown()
 
     assert check.metadata._schema_collector._db_client is None
     fake_client.close.assert_called_once()

--- a/clickhouse/tests/test_table_metrics.py
+++ b/clickhouse/tests/test_table_metrics.py
@@ -151,12 +151,12 @@ def test_run_job_table_sizes_query_dedupes_via_limit_by(check):
     assert 'LIMIT 1 BY database, name' in captured[0]
 
 
-def test_cancel_closes_db_client(check):
+def test_shutdown_closes_db_client(check):
     job = check.table_metrics
     fake_client = mock.MagicMock()
     job._db_client = fake_client
 
-    job.cancel()
+    job.shutdown()
 
     assert job._db_client is None
     fake_client.close.assert_called_once()

--- a/clickhouse/tests/test_table_metrics.py
+++ b/clickhouse/tests/test_table_metrics.py
@@ -252,6 +252,25 @@ def test_collect_view_refresh_skips_when_flag_set(check):
     mock_query.assert_not_called()
 
 
+def test_run_job_skips_view_refresh_once_cancelled(check):
+    """A cancel landing mid-tick must not start the view refresh query.
+
+    The table size collection swallows the cancellation raised by _execute_query, so without the
+    check in run_job() unscheduling would issue this query and wait out the client read timeout.
+    """
+    job = check.table_metrics
+    job.cancel()
+
+    with (
+        mock.patch.object(check, 'create_dbm_client') as mock_client,
+        mock.patch.object(check, 'execute_query_raw') as mock_query,
+    ):
+        job.run_job()
+
+    mock_query.assert_not_called()
+    mock_client.assert_not_called()
+
+
 def test_handle_view_refreshes_unknown_table_sets_skip_and_logs_once(check):
     job = check.table_metrics
     with mock.patch.object(job._log, 'info') as mock_log:

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -707,31 +707,6 @@ def test_configured_jobs_are_the_jobs_that_run(instance, dbm_enabled, expected):
     assert sorted(started) == expected
 
 
-def test_cancel_mid_run_stops_core_collection(instance):
-    """A cancel arriving mid-run must stop the check from issuing further queries.
-
-    Teardown is deferred until check() returns, so the main client stays open and nothing else
-    interrupts the run. Without the cancellation checks the check works through cluster resolution
-    and every configured core query, each bounded only by the client read timeout.
-    """
-    check = ClickhouseCheck('clickhouse', {}, [instance])
-    client = mock_clickhouse_client()
-
-    def cancel_then_report_version(*_args, **_kwargs):
-        check.cancel()
-        # Only queries issued after the cancel are of interest.
-        client.query.reset_mock()
-        return MOCK_CLICKHOUSE_VERSION
-
-    client.command.side_effect = cancel_then_report_version
-    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_connect") as mock_connect:
-        mock_connect.get_client.return_value = client
-        error_report = check.run()
-
-    assert error_report == '', error_report
-    client.query.assert_not_called()
-
-
 def test_cancel_closes_main_client_and_releases_pool(instance):
     """cancel() runs shutdown(), which releases what the check holds for its whole lifetime."""
     check = ClickhouseCheck('clickhouse', {}, [instance])

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -733,6 +733,35 @@ def test_cancel_shuts_down_registered_jobs(instance):
     assert check.query_errors._db_client is None
 
 
+CANCEL_POLLED_QUERY_METHODS = [
+    ('statement_samples', '_get_active_queries', ()),
+    ('statement_samples', '_get_active_connections', ()),
+    ('statement_samples', '_query_buffer_snapshot', ()),
+    ('table_metrics', '_execute_query', ('SELECT 1',)),
+    ('parts_and_merges', '_execute_query', ('SELECT 1',)),
+]
+
+
+@pytest.mark.parametrize('job_attr, method_name, args', CANCEL_POLLED_QUERY_METHODS)
+def test_query_methods_abort_once_cancelled(instance, job_attr, method_name, args):
+    """A cancel that lands mid-tick must not start another query.
+
+    Without the check, a job already inside run_job issues its remaining queries and
+    each one blocks until the client read_timeout elapses, stalling the Agent's
+    unschedule for as many timeouts as the tick has queries left.
+    """
+    instance = {**instance, 'dbm': True, **{option: {'enabled': True} for option in ALL_DBM_JOBS}}
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    check.create_dbm_client = mock.MagicMock()
+    job = getattr(check, job_attr)
+    job.cancel()
+
+    with pytest.raises(Exception, match='cancelled'):
+        getattr(job, method_name)(*args)
+
+    check.create_dbm_client.assert_not_called()
+
+
 def test_check_gc_after_cancel(instance):
     """Verify cancel() breaks all reference cycles so refcount alone reclaims the check.
 

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -707,6 +707,31 @@ def test_configured_jobs_are_the_jobs_that_run(instance, dbm_enabled, expected):
     assert sorted(started) == expected
 
 
+def test_cancel_mid_run_stops_core_collection(instance):
+    """A cancel arriving mid-run must stop the check from issuing further queries.
+
+    Teardown is deferred until check() returns, so the main client stays open and nothing else
+    interrupts the run. Without the cancellation checks the check works through cluster resolution
+    and every configured core query, each bounded only by the client read timeout.
+    """
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    client = mock_clickhouse_client()
+
+    def cancel_then_report_version(*_args, **_kwargs):
+        check.cancel()
+        # Only queries issued after the cancel are of interest.
+        client.query.reset_mock()
+        return MOCK_CLICKHOUSE_VERSION
+
+    client.command.side_effect = cancel_then_report_version
+    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_connect") as mock_connect:
+        mock_connect.get_client.return_value = client
+        error_report = check.run()
+
+    assert error_report == '', error_report
+    client.query.assert_not_called()
+
+
 def test_cancel_closes_main_client_and_releases_pool(instance):
     """cancel() runs shutdown(), which releases what the check holds for its whole lifetime."""
     check = ClickhouseCheck('clickhouse', {}, [instance])

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -10,6 +10,7 @@ import pytest
 from clickhouse_connect.driver.exceptions import Error, OperationalError
 
 from datadog_checks.base import ConfigurationError
+from datadog_checks.base.utils.db.utils import DBMAsyncJob
 from datadog_checks.clickhouse import ClickhouseCheck, advanced_queries, queries
 from datadog_checks.clickhouse.utils import (
     BUILTIN_SAMPLE_CLUSTERS,
@@ -681,30 +682,29 @@ ALL_DBM_JOBS = {
 }
 
 
-def test_async_job_registry_holds_every_enabled_job(instance):
-    """Each enabled job is registered under its job name, and the attribute holds it."""
-    instance = {**instance, 'dbm': True, **{option: {'enabled': True} for option in ALL_DBM_JOBS}}
+@pytest.mark.parametrize(
+    'dbm_enabled, expected',
+    [
+        pytest.param(True, sorted(ALL_DBM_JOBS.values()), id='dbm-on'),
+        pytest.param(False, [], id='dbm-off'),
+    ],
+)
+def test_configured_jobs_are_the_jobs_that_run(instance, dbm_enabled, expected):
+    """Every job this configuration enables is the set that the check actually starts.
 
+    Catches a job that stops being wired up: it would keep its config option and its attribute
+    while silently never collecting. Every job is gated on dbm, so nothing runs when it is off.
+    """
+    instance = {**instance, 'dbm': dbm_enabled, **{option: {'enabled': True} for option in ALL_DBM_JOBS}}
     check = ClickhouseCheck('clickhouse', {}, [instance])
 
-    registered = check._async_job_registry
-    assert sorted(registered) == sorted(ALL_DBM_JOBS.values())
-    assert check.statement_metrics is registered['query-metrics']
-    assert check.statement_samples is registered['query-samples']
-    assert check.query_completions is registered['query-completions']
-    assert check.query_errors is registered['query-errors']
-    assert check.table_metrics is registered['clickhouse-table-metrics']
-    assert check.metadata is registered['clickhouse-metadata']
-    assert check.parts_and_merges is registered['parts-and-merges']
+    started = []
+    with mock.patch.object(
+        DBMAsyncJob, 'run_job_loop', autospec=True, side_effect=lambda self, tags: started.append(self._job_name)
+    ):
+        check.run_async_jobs(check.tags)
 
-
-def test_async_job_registry_empty_without_dbm(instance):
-    """Every job is gated on dbm, so nothing is registered when it is off."""
-    instance = {**instance, 'dbm': False, **{option: {'enabled': True} for option in ALL_DBM_JOBS}}
-
-    check = ClickhouseCheck('clickhouse', {}, [instance])
-
-    assert check._async_job_registry == {}
+    assert sorted(started) == expected
 
 
 def test_cancel_closes_main_client_and_releases_pool(instance):

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -1,6 +1,10 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import gc
+import inspect
+import weakref
+
 import mock
 import pytest
 from clickhouse_connect.driver.exceptions import Error, OperationalError
@@ -727,3 +731,40 @@ def test_cancel_shuts_down_registered_jobs(instance):
 
     job_client.close.assert_called_once()
     assert check.query_errors._db_client is None
+
+
+def test_check_gc_after_cancel(instance):
+    """Verify cancel() breaks all reference cycles so refcount alone reclaims the check.
+
+    If this test fails, the assertion message lists the types still holding a
+    reference to the check. To fix it:
+
+    1. Identify the referrer type in the failure message (e.g. ``QueryManager``).
+    2. Find which attribute on that object points back to the check (usually
+       ``self.check`` or ``self._check``).
+    3. Null that attribute in the check's ``shutdown()`` or in the relevant job's
+       ``shutdown()``.
+    4. If the referrer is a closure or ``functools.partial``, find the
+       registration site and null or clear the container that holds it.
+    """
+    instance = {**instance, 'dbm': True, **{option: {'enabled': True} for option in ALL_DBM_JOBS}}
+
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    ref = weakref.ref(check)
+
+    check.cancel()
+
+    gc.collect()
+    gc.disable()
+    try:
+        del check
+        obj = ref()
+        if obj is not None:
+            referrers = [
+                f"bound method {r.__qualname__}" if inspect.ismethod(r) else type(r).__name__
+                for r in gc.get_referrers(obj)
+            ]
+            del obj
+            pytest.fail(f"Check still alive after cancel() + del -- pinned by: {referrers}")
+    finally:
+        gc.enable()

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -664,3 +664,66 @@ def test_check_always_emits_a_hosting_type_tag(instance):
                 check.check({})
 
     assert f'{HOSTING_TYPE_TAG}:{HostingType.UNKNOWN}' in check.tags
+
+
+ALL_DBM_JOBS = {
+    'query_metrics': 'query-metrics',
+    'query_samples': 'query-samples',
+    'query_completions': 'query-completions',
+    'query_errors': 'query-errors',
+    'schema_metrics': 'clickhouse-table-metrics',
+    'collect_schemas': 'clickhouse-metadata',
+    'parts_and_merges': 'parts-and-merges',
+}
+
+
+def test_async_job_registry_holds_every_enabled_job(instance):
+    """Each enabled job is registered under its job name, and the attribute holds it."""
+    instance = {**instance, 'dbm': True, **{option: {'enabled': True} for option in ALL_DBM_JOBS}}
+
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+
+    registered = check._async_job_registry
+    assert sorted(registered) == sorted(ALL_DBM_JOBS.values())
+    assert check.statement_metrics is registered['query-metrics']
+    assert check.statement_samples is registered['query-samples']
+    assert check.query_completions is registered['query-completions']
+    assert check.query_errors is registered['query-errors']
+    assert check.table_metrics is registered['clickhouse-table-metrics']
+    assert check.metadata is registered['clickhouse-metadata']
+    assert check.parts_and_merges is registered['parts-and-merges']
+
+
+def test_async_job_registry_empty_without_dbm(instance):
+    """Every job is gated on dbm, so nothing is registered when it is off."""
+    instance = {**instance, 'dbm': False, **{option: {'enabled': True} for option in ALL_DBM_JOBS}}
+
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+
+    assert check._async_job_registry == {}
+
+
+def test_cancel_closes_main_client_and_releases_pool(instance):
+    """cancel() runs shutdown(), which releases what the check holds for its whole lifetime."""
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    client = mock.MagicMock()
+    check._client = client
+
+    check.cancel()
+
+    client.close.assert_called_once()
+    assert check._client is None
+    assert check._pool_manager is None
+
+
+def test_cancel_shuts_down_registered_jobs(instance):
+    """The registry drives teardown, so each job's shutdown() releases its dedicated client."""
+    instance = {**instance, 'dbm': True, 'query_errors': {'enabled': True}}
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    job_client = mock.MagicMock()
+    check.query_errors._db_client = job_client
+
+    check.cancel()
+
+    job_client.close.assert_called_once()
+    assert check.query_errors._db_client is None


### PR DESCRIPTION
### What does this PR do?

Moves clickhouse's seven `DBMAsyncJob`s onto the `DatabaseCheck` registry and cancellation lifecycle.

- `_register_async_jobs()` builds and registers the jobs the config enables, following the postgres and mysql pattern: the attributes default to `None` in `__init__`, and the shared `dbm` gate is a single early return.
- `check()` ends in `self.run_async_jobs(self.tags)` instead of a per-job fan-out, and no-ops once the check is cancelled.
- The `cancel()` override is gone. Closing the main client and dropping the shared pool manager moved to `shutdown()`, which the base calls once, after the loops stop and never while `check()` is running.
- Each job's `cancel()` override became `shutdown()`, which closes its client and drops `_check`. The check's `shutdown()` releases the query manager and health reporter; `ClickhouseMetadata` also drops the schema collector and `ClickhouseQueryCompletions` the explain plans helper, both of which hold the check.
- Query samples, table metrics, and parts and merges now check `_cancel_event` before issuing each query, matching the query log job and postgres.

### Motivation

The old `cancel()` signalled all seven jobs and then called `.result()` on all seven futures, blocking the Agent's unschedule thread inside `cancel()` — which `AgentCheck.cancel()` explicitly warns against. Inheriting the base protocol moves that wait after `check()` returns, so `cancel()` signals and gets out of the way.

One behavior change: a job's `cancel()` used to close its dedicated client immediately, which is what aborted an in-flight query. Teardown now waits for the loop to finish its current iteration, so a query already issued is bounded by the client `read_timeout` (10s) rather than cut short. The new cancel-event checks keep a cancelled job from starting further queries, so that wait is one query rather than one per query left in the tick.

Tests follow the postgres migration (#24933): the base suite owns the state machine, so per-job tests target `shutdown()`, and this adds wiring tests for registry contents (DBM on and off), resource release on cancel, and the cancel-event checks. `test_check_gc_after_cancel` is ported from postgres and is what found the reference cycles above — with the cycle collector disabled it asserts refcounting alone reclaims the check.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)
