### PR TITLE
kuma: preload Docker Hub images in E2E and cache them in CI

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -2392,6 +2392,8 @@ jobs:
       target: kuma
       platform: linux
       runner: '["ubuntu-22.04"]'
+      e2e-image-cache-key: kuma-2.10.6
+      e2e-image-cache-images: "kumahq/kuma-cp:2.10.6 kumahq/kumactl:2.10.6"
       repo: "${{ inputs.repo }}"
       context: ${{ inputs.context }}
       python-version: "${{ inputs.python-version }}"

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -89,6 +89,16 @@ on:
         required: false
         default: 60
         type: number
+      e2e-image-cache-key:
+        description: "When set, cache these Docker images between runs (key suffix, e.g. kuma-2.10.6)"
+        required: false
+        default: ""
+        type: string
+      e2e-image-cache-images:
+        description: "Space-separated Docker images to cache (used with e2e-image-cache-key)"
+        required: false
+        default: ""
+        type: string
 
 defaults:
   run:
@@ -314,6 +324,21 @@ jobs:
     - name: Ensure Docker is running
       run: bash .github/workflows/scripts/ensure-docker.sh
 
+    - name: Restore cached E2E images
+      if: runner.os == 'Linux' && inputs.e2e-image-cache-key != '' && inputs.latest != true
+      id: restore-e2e-images
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.temp }}/e2e-images
+        key: e2e-images-${{ inputs.e2e-image-cache-key }}
+
+    - name: Load cached E2E images into Docker
+      if: runner.os == 'Linux' && inputs.e2e-image-cache-key != '' && inputs.latest != true
+      run: |
+        for f in "${RUNNER_TEMP}/e2e-images"/*.tar; do
+          [ -e "$f" ] && docker load -i "$f"
+        done
+
     - name: Run Unit & Integration tests
       if: inputs.latest != true
       timeout-minutes: ${{ inputs.step-timeout-minutes }}
@@ -325,6 +350,25 @@ jobs:
       run: bash .github/workflows/scripts/run-e2e-tests.sh
       env:
         INPUT_SESSION_NAME: "e2e-tests"
+
+    - name: Save E2E images for cache
+      if: >-
+        runner.os == 'Linux' && inputs.e2e-image-cache-key != '' && inputs.latest != true
+        && steps.restore-e2e-images.outputs.cache-hit != 'true'
+        && ((inputs.repo == 'core' && !inputs.minimum-base-package) || inputs.repo != 'core')
+      run: |
+        mkdir -p "${RUNNER_TEMP}/e2e-images"
+        docker save ${{ inputs.e2e-image-cache-images }} -o "${RUNNER_TEMP}/e2e-images/images.tar"
+
+    - name: Cache E2E images
+      if: >-
+        runner.os == 'Linux' && inputs.e2e-image-cache-key != '' && inputs.latest != true
+        && steps.restore-e2e-images.outputs.cache-hit != 'true'
+        && ((inputs.repo == 'core' && !inputs.minimum-base-package) || inputs.repo != 'core')
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ runner.temp }}/e2e-images
+        key: e2e-images-${{ inputs.e2e-image-cache-key }}
 
     - name: Run benchmarks
       if: inputs.benchmark

--- a/kuma/tests/conftest.py
+++ b/kuma/tests/conftest.py
@@ -2,11 +2,13 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+import platform
+import tempfile
 
 import pytest
 
 from datadog_checks.dev import get_here
-from datadog_checks.dev.kind import kind_run
+from datadog_checks.dev.kind import ClusterConfig, kind_run
 from datadog_checks.dev.subprocess import run_command
 
 HERE = get_here()
@@ -16,10 +18,29 @@ KUMA_NAMESPACE = 'kuma-system'
 KUMA_SERVICE = 'kuma-control-plane'
 KUMA_STARTUP_TIMEOUT = 600
 KUMA_METRICS_ENDPOINT = f'http://{KUMA_SERVICE}.{KUMA_NAMESPACE}.svc.cluster.local:5680/metrics'
+KUMA_VERSION = os.environ.get('KUMA_VERSION', '2.10.6')
+KUMA_IMAGES = [f'kumahq/kuma-cp:{KUMA_VERSION}', f'kumahq/kumactl:{KUMA_VERSION}']
+
+
+class PreloadImages:
+    """Side-load the chart's images into kind so the nodes don't pull them from Docker Hub."""
+
+    def add_cluster_info(self, cluster_config: ClusterConfig):
+        self.cluster_name = cluster_config.cluster_name
+
+    def __call__(self):
+        # The archive must be single-platform: `kind load docker-image` fails on
+        # multi-arch images when Docker uses the containerd image store.
+        spec = f'{platform.system().lower()}/{platform.machine()}'
+        for image in KUMA_IMAGES:
+            run_command(['docker', 'pull', image], check=True)
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                archive = os.path.join(tmp_dir, 'image.tar')
+                run_command(['docker', 'save', '--platform', spec, image, '-o', archive], check=True)
+                run_command(['kind', 'load', 'image-archive', archive, '--name', self.cluster_name], check=True)
 
 
 def setup_kuma():
-    kuma_version = os.environ.get('KUMA_VERSION', '2.10.6')
     run_command(['kubectl', 'create', 'namespace', KUMA_NAMESPACE], check=True)
     run_command(['helm', 'repo', 'add', 'kuma', 'https://kumahq.github.io/charts'], check=True)
     run_command(['helm', 'repo', 'update'], check=True)
@@ -31,7 +52,7 @@ def setup_kuma():
             'kuma',
             'kuma/kuma',
             '--version',
-            kuma_version,
+            KUMA_VERSION,
             '--create-namespace',
             '-n',
             KUMA_NAMESPACE,
@@ -55,7 +76,7 @@ def setup_kuma():
 
 @pytest.fixture(scope='session')
 def dd_environment(dd_save_state):
-    with kind_run(conditions=[setup_kuma]) as kubeconfig:
+    with kind_run(conditions=[PreloadImages(), setup_kuma]) as kubeconfig:
         instance = {'openmetrics_endpoint': KUMA_METRICS_ENDPOINT}
         metadata = {
             'agent_type': 'kubernetes',


### PR DESCRIPTION
## What does this PR do?

Speeds up the kuma E2E test by downloading the chart's Docker Hub images **once per machine** instead of once per run (the kind cluster is recreated every run, so today every run re-pulls them):

- **Locally**: the host Docker cache persists across the disposable clusters, so `docker pull` is a cache hit from the second run on.
- **In CI**: the images are cached between runs with `actions/cache`.

## Changes

- `kuma/tests/conftest.py`: a `PreloadImages` condition runs before `setup_kuma`. It pulls `kumahq/kuma-cp` / `kumahq/kumactl` and side-loads them into the kind nodes via `docker save --platform <os/arch>` + `kind load image-archive`. A single-platform archive is required: `kind load docker-image` fails on multi-arch images with the containerd image store (`ctr: content digest ...: not found`). No `imagePullPolicy` change needed — the chart defaults to `IfNotPresent`.
- `.github/workflows/test-target.yml`: new opt-in inputs (`e2e-image-cache-key`, `e2e-image-cache-images`). When the key is set: `actions/cache/restore` + `docker load` before the tests, `docker save` + `actions/cache/save` after (skipped on cache hit). No other job is affected unless it opts in.
- `.github/workflows/test-all.yml`: the Kuma job opts in with key `kuma-2.10.6`. **The key must be bumped together with the `kuma_version` hatch matrix.**
- The `kubectl` hook image is not preloaded (digest-pinned, from the fast `registry.k8s.io`).

## Measured (fresh cluster + helm install + rollout)

| Scenario | vs master (58.1s) |
|---|---|
| Repeated local runs | **52.4s** — ~10% faster (preload ~9s replaces ~15s of node pulls) |
| First run on a machine | ~90s — pays the initial download once, then warm forever |
| CI with cache hit | ≈ par — cache restore + load replaces the same pulls, and the kumahq images no longer touch Docker Hub (rate-limit immunity) |
| CI on cache miss (version bump / eviction) | first-run cost once, then the cache reseeds |

## Testing

- `ddev test kuma -- -m "not e2e"` → 27 passed.
- E2E verified locally: both images land in the node, `ddev env start kuma` brings the control plane up Running 1/1, metrics endpoint serves the asserted gauges.
- Test-only change; labeled `changelog/no-changelog`.
