### PR TITLE
Add dd-octo-sts files for the agentrelease-worker

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -835,6 +835,7 @@ plaid/assets/logs/                                                  @DataDog/saa
 docs/developer/process/integration-release.md                         @DataDog/agent-integrations
 # As well as the pipelines.
 /.github/chainguard/                                                  @DataDog/agent-integrations
+/.github/chainguard/agentrelease-worker.*                             @DataDog/agent-delivery
 /.github/workflows/                                                   @DataDog/agent-integrations
 /.github/workflows/resolve-build-deps.yml                             @DataDog/agent-integrations @DataDog/agent-build
 /.gitlab-ci.yml                                                       @DataDog/agent-integrations

--- a/.github/chainguard/agentrelease-worker.dispatch-integrations-core-prod.sts.yaml
+++ b/.github/chainguard/agentrelease-worker.dispatch-integrations-core-prod.sts.yaml
@@ -1,0 +1,13 @@
+# Trust policy for agentrelease-worker on us1.ddbuild.io (prod): dispatch the
+# "Test Agent release" workflow (test-agent.yml) via dd-octo-sts.
+issuer: https://vault.us1.ddbuild.io/v1/identity/oidc
+
+# ddtool auth whois --datacenter us1.ddbuild.io agent-delivery-agentrelease-worker --format json | jq -r .id
+subject_pattern: "4f726413-caa9-061a-f03a-715a80d4850b"
+
+claim_pattern:
+  name: "agent-delivery-agentrelease-worker"
+
+permissions:
+  actions: write
+  metadata: read

--- a/.github/chainguard/agentrelease-worker.dispatch-integrations-core-staging.sts.yaml
+++ b/.github/chainguard/agentrelease-worker.dispatch-integrations-core-staging.sts.yaml
@@ -1,0 +1,13 @@
+# Trust policy for agentrelease-worker on us1.staging.dog (staging): dispatch the
+# "Test Agent release" workflow (test-agent.yml) via dd-octo-sts.
+issuer: https://vault.us1.staging.dog/v1/identity/oidc
+
+# ddtool auth whois --datacenter us1.staging.dog agent-delivery-agentrelease-worker --format json | jq -r .id
+subject_pattern: "20398f5e-272c-2812-8f22-f084f07f951c"
+
+claim_pattern:
+  name: "agent-delivery-agentrelease-worker"
+
+permissions:
+  actions: write
+  metadata: read


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add dd-octo-sts files for the agentrelease-worker to trigger GitHub Actions workflow from our automation

### Motivation
<!-- What inspired you to submit this pull request? -->

We want to trigger the Test Agent Release workflows automatically from the release workflow in https://github.com/ddoghq/dd-source/pull/63514

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
