### PR TITLE
Retry release approval notifications

### DIFF
--- a/.github/workflows/scripts/notify_release.py
+++ b/.github/workflows/scripts/notify_release.py
@@ -7,6 +7,7 @@ import http.client
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.request
 
@@ -56,6 +57,10 @@ def report_config_error(error: str) -> None:
             summary.write(f"### \u274c Release notification failed\n\n{message}\n")
 
 
+RETRY_DELAYS = (2, 4, 8, 16)
+TRANSIENT_HTTP_STATUSES = frozenset({408, 429})
+
+
 def post(api_url: str, api_key: str, app_key: str, text: str) -> bool:
     """Trigger the workflow; return False only on a persistent misconfiguration."""
     data = json.dumps({"meta": {"payload": {"text": text}}}).encode()
@@ -68,18 +73,33 @@ def post(api_url: str, api_key: str, app_key: str, text: str) -> bool:
             "DD-APPLICATION-KEY": app_key,
         },
     )
-    try:
-        urllib.request.urlopen(request, timeout=15).close()
-    except urllib.error.HTTPError as e:
-        if e.code == 429 or e.code >= 500:
-            print(f"::warning::Release notification failed (transient): HTTP {e.code}")
+    for attempt in range(len(RETRY_DELAYS) + 1):
+        try:
+            urllib.request.urlopen(request, timeout=15).close()
+        except urllib.error.HTTPError as e:
+            is_transient = e.code in TRANSIENT_HTTP_STATUSES or e.code >= 500
+            # dd-sts registers new application keys with the Actions API before
+            # returning them, but authorization reads can briefly lag that write.
+            if (e.code == 403 or is_transient) and attempt < len(RETRY_DELAYS):
+                delay = RETRY_DELAYS[attempt]
+                print(f"::warning::Release notification received HTTP {e.code}; retrying in {delay} seconds")
+                time.sleep(delay)
+                continue
+            if is_transient:
+                print(f"::warning::Release notification failed (transient): HTTP {e.code}")
+                return True
+            report_config_error(f"HTTP {e.code}")
+            return False
+        except (OSError, http.client.HTTPException, ValueError) as e:
+            if attempt < len(RETRY_DELAYS):
+                delay = RETRY_DELAYS[attempt]
+                print(f"::warning::Release notification request failed: {e}; retrying in {delay} seconds")
+                time.sleep(delay)
+                continue
+            print(f"::warning::Release notification request failed (transient): {e}")
             return True
-        report_config_error(f"HTTP {e.code}")
-        return False
-    except (OSError, http.client.HTTPException, ValueError) as e:
-        print(f"::warning::Release notification request failed (transient): {e}")
         return True
-    return True
+    raise AssertionError("unreachable")
 
 
 def main() -> None:

--- a/.github/workflows/scripts/tests/test_notify_release.py
+++ b/.github/workflows/scripts/tests/test_notify_release.py
@@ -2,7 +2,7 @@
 import http.client
 import json
 import urllib.error
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -99,27 +99,91 @@ def test_post_returns_true_on_success():
     "error",
     [urllib.error.URLError("boom"), http.client.RemoteDisconnected("disconnected")],
 )
-def test_post_warns_on_transient_network_error(error, capsys):
-    with patch("urllib.request.urlopen", side_effect=error):
+def test_post_retries_transient_network_error(error, capsys):
+    with (
+        patch("urllib.request.urlopen", side_effect=[error, MagicMock()]) as urlopen,
+        patch("notify_release.time.sleep") as sleep,
+    ):
         result = notify_release.post(WEBHOOK, "api", "app", "hi")
     assert result is True
+    assert urlopen.call_count == 2
+    sleep.assert_called_once_with(2)
+    assert "retrying" in capsys.readouterr().out
+
+
+def test_post_warns_after_transient_network_retries(capsys):
+    with (
+        patch("urllib.request.urlopen", side_effect=urllib.error.URLError("boom")) as urlopen,
+        patch("notify_release.time.sleep") as sleep,
+    ):
+        result = notify_release.post(WEBHOOK, "api", "app", "hi")
+    assert result is True
+    assert urlopen.call_count == 5
+    assert sleep.call_args_list == [call(2), call(4), call(8), call(16)]
     out = capsys.readouterr().out
     assert "transient" in out
     assert "::error::" not in out
 
 
-@pytest.mark.parametrize("code", [500, 502, 503, 429])
-def test_post_warns_on_transient_http_error(code, capsys):
+@pytest.mark.parametrize("code", [408, 429, 500, 502, 503])
+def test_post_retries_transient_http_error(code, capsys):
     error = urllib.error.HTTPError(WEBHOOK, code, "err", {}, None)
-    with patch("urllib.request.urlopen", side_effect=error):
+    with (
+        patch("urllib.request.urlopen", side_effect=[error, MagicMock()]) as urlopen,
+        patch("notify_release.time.sleep") as sleep,
+    ):
         result = notify_release.post(WEBHOOK, "api", "app", "hi")
     assert result is True
+    assert urlopen.call_count == 2
+    sleep.assert_called_once_with(2)
+    assert "retrying" in capsys.readouterr().out
+
+
+def test_post_warns_after_transient_http_retries(capsys):
+    error = urllib.error.HTTPError(WEBHOOK, 503, "err", {}, None)
+    with (
+        patch("urllib.request.urlopen", side_effect=error) as urlopen,
+        patch("notify_release.time.sleep") as sleep,
+    ):
+        result = notify_release.post(WEBHOOK, "api", "app", "hi")
+    assert result is True
+    assert urlopen.call_count == 5
+    assert sleep.call_args_list == [call(2), call(4), call(8), call(16)]
     out = capsys.readouterr().out
     assert "transient" in out
     assert "::error::" not in out
 
 
-@pytest.mark.parametrize("code", [400, 401, 403, 404])
+def test_post_retries_forbidden_response(capsys):
+    error = urllib.error.HTTPError(WEBHOOK, 403, "err", {}, None)
+    with (
+        patch("urllib.request.urlopen", side_effect=[error, MagicMock()]) as urlopen,
+        patch("notify_release.time.sleep") as sleep,
+    ):
+        result = notify_release.post(WEBHOOK, "api", "app", "hi")
+    assert result is True
+    assert urlopen.call_count == 2
+    sleep.assert_called_once_with(2)
+    assert "retrying" in capsys.readouterr().out
+
+
+def test_post_fails_after_forbidden_retries(capsys, tmp_path, monkeypatch):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    error = urllib.error.HTTPError(WEBHOOK, 403, "err", {}, None)
+    with (
+        patch("urllib.request.urlopen", side_effect=error) as urlopen,
+        patch("notify_release.time.sleep") as sleep,
+    ):
+        result = notify_release.post(WEBHOOK, "api", "app", "hi")
+    assert result is False
+    assert urlopen.call_count == 5
+    assert sleep.call_args_list == [call(2), call(4), call(8), call(16)]
+    assert "::error::" in capsys.readouterr().out
+    assert "HTTP 403" in summary.read_text()
+
+
+@pytest.mark.parametrize("code", [400, 401, 404])
 def test_post_fails_on_config_http_error(code, capsys, tmp_path, monkeypatch):
     summary = tmp_path / "summary.md"
     monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))


### PR DESCRIPTION
### What does this PR do?

Retries release-notification trigger failures with bounded backoff at 2, 4, 8, and 16 seconds. This covers temporary 403 authorization responses, HTTP 408/429/5xx responses, and transport failures.

Persistent configuration errors, including an exhausted 403, still fail the notification job. Exhausted transient failures retain the existing warning-only behavior so they do not block the release.

### Motivation

The notification in https://github.com/DataDog/integrations-core/actions/runs/32404693005/job/96540924408 failed immediately after dd-sts minted and registered a new application key. A later dry-run dispatch using the cached registered key succeeded, confirming registration propagation lag between the primary write and replica-backed authorization read.

The Datadog workflow can retry delivery actions only after its API trigger creates an instance. The caller previously classified 408/429/5xx and transport failures as transient but did not retry the trigger request, so those notifications were dropped.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
