### PR TITLE
Release SNMP (backport to master)

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -210,7 +210,7 @@ datadog-silk==4.5.0
 datadog-silverstripe-cms==1.9.0
 datadog-singlestore==4.6.0
 datadog-slurm==2.5.1; sys_platform == 'linux2'
-datadog-snmp==13.2.0
+datadog-snmp==13.3.0
 datadog-solr==2.4.0
 datadog-sonarqube==5.6.1
 datadog-sonatype-nexus==2.3.0; sys_platform != 'darwin'

--- a/snmp/CHANGELOG.md
+++ b/snmp/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 13.3.0 / 2026-08-21
+
+***Security***:
+
+* Bump pyasn1 from 0.6.3 to 0.6.4 to remediate CVE-2026-59884, CVE-2026-59885, CVE-2026-59886, and PYSEC-2026-3455 (denial-of-service in BER/CER/DER decoding). ([#24727](https://github.com/DataDog/integrations-core/pull/24727))
+
 ## 13.2.0 / 2026-08-05
 
 ***Added***:

--- a/snmp/changelog.d/24727.security
+++ b/snmp/changelog.d/24727.security
@@ -1,1 +1,0 @@
-Bump pyasn1 from 0.6.3 to 0.6.4 to remediate CVE-2026-59884, CVE-2026-59885, CVE-2026-59886, and PYSEC-2026-3455 (denial-of-service in BER/CER/DER decoding).

--- a/snmp/datadog_checks/snmp/__about__.py
+++ b/snmp/datadog_checks/snmp/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '13.2.0'
+__version__ = '13.3.0'


### PR DESCRIPTION
### What does this PR do?
Backports #24943 ([Release] Bumped snmp version to 13.3.0) to `master`.

### Motivation
Backport of the 7.83 SNMP release commit to keep `master` in sync.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged