### PR TITLE
Allow schema collectors to customize count metric name

### DIFF
--- a/datadog_checks_base/changelog.d/24947.fixed
+++ b/datadog_checks_base/changelog.d/24947.fixed
@@ -1,0 +1,1 @@
+Allow schema collectors to report object-specific count telemetry.

--- a/datadog_checks_base/datadog_checks/base/utils/db/schemas.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/schemas.py
@@ -116,7 +116,7 @@ class SchemaCollector(ABC):
                 raw=True,
             )
             self._check.gauge(
-                f"dd.{self._check.dbms}.schema.tables_count",
+                self.object_count_metric_name,
                 self._total_rows_count,
                 tags=self._check.tags + ["status:" + status],
                 hostname=self._check.reported_hostname,
@@ -131,6 +131,10 @@ class SchemaCollector(ABC):
             )
             self._reset()
         return True
+
+    @property
+    def object_count_metric_name(self) -> str:
+        return f"dd.{self._check.dbms}.schema.tables_count"
 
     @property
     def base_event(self):


### PR DESCRIPTION
### What does this PR do?

Adds an overridable `object_count_metric_name` property to the shared schema collector. Existing collectors retain `dd.<dbms>.schema.tables_count` by default, while specialized collectors can report a distinct object-count metric.

### Motivation

The SQL Server view collector reuses the shared schema collection lifecycle but must report `views_count` without submitting view rows to the existing table-count metric.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged