### PR TITLE
Strip libddwaf from Agent macOS ddtrace wheels

### DIFF
--- a/.builders/scripts/repair_wheels.py
+++ b/.builders/scripts/repair_wheels.py
@@ -1,16 +1,22 @@
 from __future__ import annotations
 
 import argparse
+import csv
+import io
 import os
 import re
 import shutil
 import sys
+import tempfile
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import NamedTuple
 from zipfile import ZipFile
 
 from utils import iter_wheels
+
+
+MACOS_DDTRACE_LIBDDWAF_PATTERN = 'ddtrace/appsec/_ddwaf/libddwaf/*/lib/libddwaf.dylib'
 
 
 def find_patterns_in_wheel(wheel: Path, patterns: list[str]) -> list[str]:
@@ -41,6 +47,55 @@ class WheelName(NamedTuple):
 
     def __str__(self):
         return '-'.join([self.name, self.version, self.python_tag, self.abi_tag, self.platform_tag]) + '.whl'
+
+
+def _strip_macos_ddtrace_libddwaf(wheel: Path) -> list[str]:
+    if WheelName.parse(wheel.name).name != 'ddtrace':
+        return []
+
+    removed = find_patterns_in_wheel(wheel, [MACOS_DDTRACE_LIBDDWAF_PATTERN])
+
+    if not removed:
+        return []
+
+    removed_set = set(removed)
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=wheel.parent, suffix='.whl', delete=False) as temp_file:
+            temp_path = Path(temp_file.name)
+
+        with ZipFile(wheel) as source, ZipFile(temp_path, 'w') as destination:
+            for info in source.infolist():
+                if info.filename in removed_set:
+                    continue
+
+                contents = source.read(info)
+                if info.filename.endswith('.dist-info/RECORD'):
+                    record = io.StringIO(contents.decode('utf-8'), newline='')
+                    updated_record = io.StringIO(newline='')
+                    writer = csv.writer(updated_record, lineterminator='\n')
+                    writer.writerows(row for row in csv.reader(record) if not row or row[0] not in removed_set)
+                    contents = updated_record.getvalue().encode('utf-8')
+
+                destination.writestr(info, contents)
+
+        shutil.copymode(wheel, temp_path)
+        os.replace(temp_path, wheel)
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+
+    return removed
+
+
+def _find_record_references(wheel: Path, pattern: str) -> list[str]:
+    with ZipFile(wheel) as archive:
+        references: list[str] = []
+        for record_path in (name for name in archive.namelist() if name.endswith('.dist-info/RECORD')):
+            with archive.open(record_path) as record_file:
+                record = io.TextIOWrapper(record_file, encoding='utf-8')
+                references.extend(row[0] for row in csv.reader(record) if row and fnmatch(row[0], pattern))
+    return references
 
 
 def check_unacceptable_files(
@@ -214,6 +269,10 @@ def repair_darwin(source_built_dir: str, source_external_dir: str, built_dir: st
 
     for wheel in iter_wheels(source_external_dir):
         print(f'--> {wheel.name}')
+        wheel_name = WheelName.parse(wheel.name)
+        if wheel_name.name == 'ddtrace' and find_patterns_in_wheel(wheel, [MACOS_DDTRACE_LIBDDWAF_PATTERN]):
+            shutil.move(wheel, Path(source_built_dir) / wheel.name)
+            continue
         print('Using existing wheel')
         shutil.move(wheel, external_dir)
 
@@ -231,13 +290,23 @@ def repair_darwin(source_built_dir: str, source_external_dir: str, built_dir: st
             continue
 
         # Platform dependent wheels: prune excluded files, verify target architecture & macOS version
+        removed_libddwaf = _strip_macos_ddtrace_libddwaf(wheel)
+        if removed_libddwaf:
+            print('Removed bundled libddwaf from Agent ddtrace wheel:')
+            print('\n'.join(removed_libddwaf))
+
+        output_wheel = Path(built_dir) / wheel.name
         copied_libs = delocate_wheel(
             str(wheel),
-            os.path.join(built_dir, wheel.name),
+            str(output_wheel),
             copy_filt_func=copy_filt_func,
             require_archs=[os.uname().machine],
             require_target_macos_version=min_macos_version,
         )
+        remaining_libddwaf = find_patterns_in_wheel(output_wheel, [MACOS_DDTRACE_LIBDDWAF_PATTERN])
+        stale_record_entries = _find_record_references(output_wheel, MACOS_DDTRACE_LIBDDWAF_PATTERN)
+        if remaining_libddwaf or stale_record_entries:
+            raise RuntimeError(f'Failed to remove bundled libddwaf from {wheel.name}')
         print('Repaired wheel')
         if copied_libs:
             print('Libraries copied into the wheel:')

--- a/.builders/tests/test_repair_wheels.py
+++ b/.builders/tests/test_repair_wheels.py
@@ -1,0 +1,144 @@
+import csv
+import importlib
+import io
+import shutil
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from zipfile import ZIP_DEFLATED
+from zipfile import ZipFile
+from zipfile import ZipInfo
+
+import pytest
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / 'scripts'))
+repair_wheels = importlib.import_module('repair_wheels')
+
+
+LIBDDWAF_PATH = 'ddtrace/appsec/_ddwaf/libddwaf/x86_64/lib/libddwaf.dylib'
+MODULE_PATH = 'ddtrace/__init__.py'
+
+
+def write_wheel(path: Path) -> None:
+    record_path = f'{path.name.split("-")[0]}-1.0.0.dist-info/RECORD'
+    entries = [(MODULE_PATH, b'package contents')]
+    entries.append((LIBDDWAF_PATH, b'incompatible dylib'))
+
+    record = io.StringIO(newline='')
+    writer = csv.writer(record, lineterminator='\n')
+    for name, contents in entries:
+        writer.writerow((name, 'sha256=placeholder', str(len(contents))))
+    writer.writerow((record_path, '', ''))
+
+    with ZipFile(path, 'w') as wheel:
+        for name, contents in entries:
+            info = ZipInfo(name, date_time=(2024, 1, 2, 3, 4, 6))
+            info.compress_type = ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            wheel.writestr(info, contents)
+        wheel.writestr(record_path, record.getvalue())
+
+
+def test_strip_macos_ddtrace_libddwaf_removes_only_dylib_and_record_entry(tmp_path: Path) -> None:
+    wheel_path = tmp_path / 'ddtrace-1.0.0-cp313-cp313-macosx_12_0_arm64.whl'
+    write_wheel(wheel_path)
+
+    with ZipFile(wheel_path) as wheel:
+        original_module_info = wheel.getinfo(MODULE_PATH)
+
+    removed = repair_wheels._strip_macos_ddtrace_libddwaf(wheel_path)
+
+    assert removed == [LIBDDWAF_PATH]
+    with ZipFile(wheel_path) as wheel:
+        assert LIBDDWAF_PATH not in wheel.namelist()
+        assert wheel.read(MODULE_PATH) == b'package contents'
+        assert wheel.getinfo(MODULE_PATH).date_time == original_module_info.date_time
+        assert wheel.getinfo(MODULE_PATH).external_attr == original_module_info.external_attr
+        record_path = next(name for name in wheel.namelist() if name.endswith('.dist-info/RECORD'))
+        record_rows = list(csv.reader(io.TextIOWrapper(wheel.open(record_path), encoding='utf-8')))
+        assert all(row[0] != LIBDDWAF_PATH for row in record_rows)
+
+
+def test_strip_macos_ddtrace_libddwaf_leaves_other_projects_unchanged(tmp_path: Path) -> None:
+    wheel_path = tmp_path / 'other-1.0.0-cp313-cp313-macosx_12_0_arm64.whl'
+    write_wheel(wheel_path)
+    original_contents = wheel_path.read_bytes()
+
+    removed = repair_wheels._strip_macos_ddtrace_libddwaf(wheel_path)
+
+    assert removed == []
+    assert wheel_path.read_bytes() == original_contents
+
+
+def test_repair_darwin_strips_libddwaf_before_delocate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_built_dir = tmp_path / 'source-built'
+    source_external_dir = tmp_path / 'source-external'
+    built_dir = tmp_path / 'built'
+    external_dir = tmp_path / 'external'
+    for directory in (source_built_dir, source_external_dir, built_dir, external_dir):
+        directory.mkdir()
+
+    wheel_path = source_built_dir / 'ddtrace-1.0.0-cp313-cp313-macosx_12_0_arm64.whl'
+    write_wheel(wheel_path)
+    delocate_saw_members = []
+
+    def fake_delocate_wheel(source: str, destination: str, **_kwargs) -> set[str]:
+        with ZipFile(source) as wheel:
+            delocate_saw_members.extend(wheel.namelist())
+        shutil.copyfile(source, destination)
+        return set()
+
+    monkeypatch.setitem(sys.modules, 'delocate', SimpleNamespace(delocate_wheel=fake_delocate_wheel))
+    monkeypatch.setenv('MACOSX_DEPLOYMENT_TARGET', '12.0')
+
+    repair_wheels.repair_darwin(
+        str(source_built_dir), str(source_external_dir), str(built_dir), str(external_dir)
+    )
+
+    assert LIBDDWAF_PATH not in delocate_saw_members
+    with ZipFile(built_dir / wheel_path.name) as wheel:
+        assert LIBDDWAF_PATH not in wheel.namelist()
+
+
+def test_repair_darwin_repairs_external_ddtrace_and_preserves_other_external_wheels(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_built_dir = tmp_path / 'source-built'
+    source_external_dir = tmp_path / 'source-external'
+    built_dir = tmp_path / 'built'
+    external_dir = tmp_path / 'external'
+    for directory in (source_built_dir, source_external_dir, built_dir, external_dir):
+        directory.mkdir()
+
+    ddtrace_wheel = source_external_dir / 'ddtrace-1.0.0-cp313-cp313-macosx_12_0_arm64.whl'
+    other_wheel = source_external_dir / 'other-1.0.0-cp313-cp313-macosx_12_0_arm64.whl'
+    write_wheel(ddtrace_wheel)
+    write_wheel(other_wheel)
+    original_other_contents = other_wheel.read_bytes()
+    repaired_wheels = []
+
+    def fake_delocate_wheel(source: str, destination: str, **_kwargs) -> set[str]:
+        repaired_wheels.append(Path(source).name)
+        with ZipFile(source) as wheel:
+            assert LIBDDWAF_PATH not in wheel.namelist()
+        shutil.copyfile(source, destination)
+        return set()
+
+    monkeypatch.setitem(sys.modules, 'delocate', SimpleNamespace(delocate_wheel=fake_delocate_wheel))
+    monkeypatch.setenv('MACOSX_DEPLOYMENT_TARGET', '12.0')
+
+    repair_wheels.repair_darwin(
+        str(source_built_dir), str(source_external_dir), str(built_dir), str(external_dir)
+    )
+
+    assert repaired_wheels == [ddtrace_wheel.name]
+    assert not (external_dir / ddtrace_wheel.name).exists()
+    with ZipFile(built_dir / ddtrace_wheel.name) as wheel:
+        assert LIBDDWAF_PATH not in wheel.namelist()
+        record_path = next(name for name in wheel.namelist() if name.endswith('.dist-info/RECORD'))
+        record_rows = list(csv.reader(io.TextIOWrapper(wheel.open(record_path), encoding='utf-8')))
+        assert all(row[0] != LIBDDWAF_PATH for row in record_rows)
+    assert (external_dir / other_wheel.name).read_bytes() == original_other_contents


### PR DESCRIPTION
### What does this PR do?
Removes the bundled `libddwaf.dylib` from Agent macOS ddtrace wheels before `delocate` validates and repacks them. The wheel's `RECORD` is updated, and downloaded ddtrace wheels containing the dylib are routed through the same repair path because their bytes change. Other wheels and platforms keep their existing behavior.

Adds builder tests for source-built and downloaded ddtrace wheels, unrelated external wheels, archive metadata, and `RECORD` consistency.

### Motivation

ddtrace 4.12.2 bundles libddwaf with a macOS 14+ runtime requirement, while the Agent supports macOS 12. The Agent's embedded Python does not use ddtrace AppSec, so this distribution can omit libddwaf without raising the Agent's minimum macOS version.

This PR is stacked on #24864 and should merge after it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
