### PR TITLE
Batch SQL Server per-database queries

### DIFF
--- a/sqlserver/changelog.d/24950.fixed
+++ b/sqlserver/changelog.d/24950.fixed
@@ -1,1 +1,1 @@
-Collapse the per-database service check and database files metrics loops into single batched queries.
+Collapse per-database service checks into a single batched query.

--- a/sqlserver/changelog.d/24950.fixed
+++ b/sqlserver/changelog.d/24950.fixed
@@ -1,0 +1,1 @@
+Collapse the per-database service check and database files metrics loops into single batched queries.

--- a/sqlserver/changelog.d/24950.fixed
+++ b/sqlserver/changelog.d/24950.fixed
@@ -1,1 +1,1 @@
-Collapse per-database service checks into a single batched query.
+Collapse per-database service checks and database file queries into batched requests.

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -86,7 +86,16 @@ expected_sys_databases_columns = [
     'physical_database_name',
 ]
 
-DATABASE_SERVICE_CHECK_QUERY = """SELECT 1;"""
+DATABASE_SERVICE_CHECK_QUERY = """
+DECLARE @monitored_databases xml = ?;
+WITH monitored_databases AS (
+    SELECT database_node.value('.', 'nvarchar(128)') AS name
+    FROM @monitored_databases.nodes('/databases/database') AS databases(database_node)
+)
+SELECT name, CASE WHEN state = 0 AND HAS_DBACCESS(name) = 1 THEN 1 ELSE 0 END AS can_connect
+FROM sys.databases
+WHERE name IN (SELECT name FROM monitored_databases);
+"""
 
 VALID_METRIC_TYPES = ('gauge', 'rate', 'histogram')
 

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/database_files_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/database_files_metrics.py
@@ -2,20 +2,13 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from datadog_checks.sqlserver.utils import serialize_database_names
+import functools
 
 from .base import SqlserverDatabaseMetricsBase
 
 DATABASE_FILES_METRICS_QUERY = {
     "name": "sys.database_files",
-    "query": """DECLARE @monitored_databases xml = ?;
-    WITH monitored_databases AS (
-        SELECT database_node.value('.', 'nvarchar(128)') AS name
-        FROM @monitored_databases.nodes('/databases/database') AS databases(database_node)
-    )
-    SELECT
-        monitored_databases.name as db,
-        monitored_databases.name as database_name,
+    "query": """SELECT
         file_id,
         CASE type
             WHEN 0 THEN 'data'
@@ -26,18 +19,14 @@ DATABASE_FILES_METRICS_QUERY = {
             ELSE 'other'
         END AS file_type,
         physical_name,
-        sys.master_files.name,
-        sys.master_files.state_desc,
+        name,
+        state_desc,
         ISNULL(size, 0) as size,
-        ISNULL(CAST(FILEPROPERTY(sys.master_files.name, 'SpaceUsed') as int), 0) as space_used,
-        sys.master_files.state
-        FROM monitored_databases
-        INNER JOIN sys.databases ON sys.databases.name = monitored_databases.name
-        INNER JOIN sys.master_files ON sys.master_files.database_id = sys.databases.database_id
+        ISNULL(CAST(FILEPROPERTY(name, 'SpaceUsed') as int), 0) as space_used,
+        state
+        FROM sys.database_files
     """,
     "columns": [
-        {"name": "db", "type": "tag"},
-        {"name": "database", "type": "tag"},
         {"name": "file_id", "type": "tag"},
         {"name": "file_type", "type": "tag"},
         {"name": "file_location", "type": "tag"},
@@ -79,8 +68,13 @@ class SqlserverDatabaseFilesMetrics(SqlserverDatabaseMetricsBase):
         )
 
     def _build_query_executors(self):
-        query = dict(DATABASE_FILES_METRICS_QUERY)
-        query['params'] = (serialize_database_names(self.databases or []),)
-        executor = self.new_query_executor([query], executor=self.execute_query_handler)
-        executor.compile_queries()
-        return [executor]
+        executors = []
+        for database in self.databases:
+            executor = self.new_query_executor(
+                self.queries,
+                executor=functools.partial(self.execute_query_handler, db=database),
+                extra_tags=['db:{}'.format(database), 'database:{}'.format(database)],
+            )
+            executor.compile_queries()
+            executors.append(executor)
+        return executors

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/database_files_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/database_files_metrics.py
@@ -2,13 +2,20 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import functools
+from datadog_checks.sqlserver.utils import serialize_database_names
 
 from .base import SqlserverDatabaseMetricsBase
 
 DATABASE_FILES_METRICS_QUERY = {
     "name": "sys.database_files",
-    "query": """SELECT
+    "query": """DECLARE @monitored_databases xml = ?;
+    WITH monitored_databases AS (
+        SELECT database_node.value('.', 'nvarchar(128)') AS name
+        FROM @monitored_databases.nodes('/databases/database') AS databases(database_node)
+    )
+    SELECT
+        monitored_databases.name as db,
+        monitored_databases.name as database_name,
         file_id,
         CASE type
             WHEN 0 THEN 'data'
@@ -19,14 +26,18 @@ DATABASE_FILES_METRICS_QUERY = {
             ELSE 'other'
         END AS file_type,
         physical_name,
-        name,
-        state_desc,
+        sys.master_files.name,
+        sys.master_files.state_desc,
         ISNULL(size, 0) as size,
-        ISNULL(CAST(FILEPROPERTY(name, 'SpaceUsed') as int), 0) as space_used,
-        state
-        FROM sys.database_files
+        ISNULL(CAST(FILEPROPERTY(sys.master_files.name, 'SpaceUsed') as int), 0) as space_used,
+        sys.master_files.state
+        FROM monitored_databases
+        INNER JOIN sys.databases ON sys.databases.name = monitored_databases.name
+        INNER JOIN sys.master_files ON sys.master_files.database_id = sys.databases.database_id
     """,
     "columns": [
+        {"name": "db", "type": "tag"},
+        {"name": "database", "type": "tag"},
         {"name": "file_id", "type": "tag"},
         {"name": "file_type", "type": "tag"},
         {"name": "file_location", "type": "tag"},
@@ -68,13 +79,8 @@ class SqlserverDatabaseFilesMetrics(SqlserverDatabaseMetricsBase):
         )
 
     def _build_query_executors(self):
-        executors = []
-        for database in self.databases:
-            executor = self.new_query_executor(
-                self.queries,
-                executor=functools.partial(self.execute_query_handler, db=database),
-                extra_tags=['db:{}'.format(database), 'database:{}'.format(database)],
-            )
-            executor.compile_queries()
-            executors.append(executor)
-        return executors
+        query = dict(DATABASE_FILES_METRICS_QUERY)
+        query['params'] = (serialize_database_names(self.databases or []),)
+        executor = self.new_query_executor([query], executor=self.execute_query_handler)
+        executor.compile_queries()
+        return [executor]

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/database_files_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/database_files_metrics.py
@@ -4,11 +4,13 @@
 
 import functools
 
+from datadog_checks.sqlserver.utils import is_azure_sql_database, serialize_database_names
+
 from .base import SqlserverDatabaseMetricsBase
 
-DATABASE_FILES_METRICS_QUERY = {
-    "name": "sys.database_files",
-    "query": """SELECT
+DATABASE_FILES_QUERY = """SELECT
+        DB_NAME() AS db,
+        DB_NAME() AS database_name,
         file_id,
         CASE type
             WHEN 0 THEN 'data'
@@ -25,8 +27,14 @@ DATABASE_FILES_METRICS_QUERY = {
         ISNULL(CAST(FILEPROPERTY(name, 'SpaceUsed') as int), 0) as space_used,
         state
         FROM sys.database_files
-    """,
+    """
+
+DATABASE_FILES_METRICS_QUERY = {
+    "name": "sys.database_files",
+    "query": DATABASE_FILES_QUERY,
     "columns": [
+        {"name": "db", "type": "tag"},
+        {"name": "database", "type": "tag"},
         {"name": "file_id", "type": "tag"},
         {"name": "file_type", "type": "tag"},
         {"name": "file_location", "type": "tag"},
@@ -42,6 +50,33 @@ DATABASE_FILES_METRICS_QUERY = {
         {"name": "database.files.space_used", "expression": "space_used*8", "submit_type": "gauge"},
     ],
 }
+
+DATABASE_FILES_BATCH_QUERY = """SET NOCOUNT ON;
+DECLARE @monitored_databases xml = ?;
+DECLARE @database sysname;
+DECLARE @module nvarchar(776);
+DECLARE @statement nvarchar(max) = N'{}';
+
+DECLARE database_cursor CURSOR LOCAL FAST_FORWARD FOR
+    SELECT database_node.value('.', 'sysname')
+    FROM @monitored_databases.nodes('/databases/database') AS databases(database_node);
+
+OPEN database_cursor;
+FETCH NEXT FROM database_cursor INTO @database;
+WHILE @@FETCH_STATUS = 0
+BEGIN
+    BEGIN TRY
+        SET @module = QUOTENAME(@database) + N'.sys.sp_executesql';
+        EXEC @module @statement;
+    END TRY
+    BEGIN CATCH
+        -- A database can become unavailable after autodiscovery. Skip it so later databases are still collected.
+    END CATCH;
+    FETCH NEXT FROM database_cursor INTO @database;
+END;
+CLOSE database_cursor;
+DEALLOCATE database_cursor;
+""".format(DATABASE_FILES_QUERY.replace("'", "''"))
 
 
 class SqlserverDatabaseFilesMetrics(SqlserverDatabaseMetricsBase):
@@ -68,12 +103,21 @@ class SqlserverDatabaseFilesMetrics(SqlserverDatabaseMetricsBase):
         )
 
     def _build_query_executors(self):
+        if not is_azure_sql_database(self.engine_edition):
+            query = dict(DATABASE_FILES_METRICS_QUERY)
+            query['query'] = DATABASE_FILES_BATCH_QUERY
+            query['params'] = (serialize_database_names(self.databases or []),)
+            executor = self.new_query_executor(
+                [query], executor=functools.partial(self.execute_query_handler, fetch_multiple_results=True)
+            )
+            executor.compile_queries()
+            return [executor]
+
         executors = []
         for database in self.databases:
             executor = self.new_query_executor(
                 self.queries,
                 executor=functools.partial(self.execute_query_handler, db=database),
-                extra_tags=['db:{}'.format(database), 'database:{}'.format(database)],
             )
             executor.compile_queries()
             executors.append(executor)

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -63,6 +63,7 @@ from datadog_checks.sqlserver.utils import (
     construct_use_statement,
     parse_sqlserver_major_version,
     parse_sqlserver_year,
+    serialize_database_names,
 )
 from datadog_checks.sqlserver.xe_collection.registry import get_xe_session_handlers
 
@@ -844,27 +845,24 @@ class SQLServer(DatabaseCheck):
     def _check_connections_by_use_db(self):
         with self.connection.open_managed_default_connection(KEY_PREFIX):
             with self.connection.get_managed_cursor(KEY_PREFIX) as cursor:
-                for db in self.databases:
-                    check_err_message = "Database {} connection service check failed: {}"
-                    try:
-                        switch_db_statement = construct_use_statement(db.name)
-                        cursor.execute(switch_db_statement)
-                        cursor.execute(DATABASE_SERVICE_CHECK_QUERY)
-                        cursor.fetchall()
-                        self.handle_service_check(AgentCheck.OK, self.connection.get_host_with_port(), db.name, False)
-                    except Exception as e:
-                        self.log.warning(check_err_message.format(db.name, str(e)))
-                        self.handle_service_check(
-                            AgentCheck.CRITICAL,
-                            self.connection.get_host_with_port(),
-                            db.name,
-                            check_err_message.format(db.name, str(e)),
-                            False,
-                        )
+                database_names = [db.name for db in self.databases]
+                if not database_names:
+                    return
+
+                cursor.execute(DATABASE_SERVICE_CHECK_QUERY, (serialize_database_names(database_names),))
+                database_access = dict(cursor.fetchall())
+
+                connection_host = self.connection.get_host_with_port()
+                for database_name in database_names:
+                    if database_access.get(database_name) == 1:
+                        self.handle_service_check(AgentCheck.OK, connection_host, database_name, False)
                         continue
-                # Switch DB back to MASTER
-                switch_db_statement = construct_use_statement(self.connection.DEFAULT_DATABASE)
-                cursor.execute(switch_db_statement)
+
+                    message = "Database {} connection service check failed: database is not accessible".format(
+                        database_name
+                    )
+                    self.log.warning(message)
+                    self.handle_service_check(AgentCheck.CRITICAL, connection_host, database_name, message, False)
 
     def get_databases(self):
         engine_edition = self.static_info_cache.get(STATIC_INFO_ENGINE_EDITION)

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -1093,7 +1093,7 @@ class SQLServer(DatabaseCheck):
                 with self.connection.get_managed_cursor(KEY_PREFIX) as cursor:
                     cursor.execute("SET NOCOUNT OFF")
 
-    def execute_query_raw(self, query, db=None, params=None):
+    def execute_query_raw(self, query, db=None, params=None, fetch_multiple_results=False):
         with self.connection.get_managed_cursor(KEY_PREFIX) as cursor:
             if db:
                 ctx = construct_use_statement(db)
@@ -1103,7 +1103,15 @@ class SQLServer(DatabaseCheck):
                 cursor.execute(query, params)
             else:
                 cursor.execute(query)
-            return cursor.fetchall()
+            if not fetch_multiple_results:
+                return cursor.fetchall()
+
+            rows = []
+            while True:
+                if cursor.description is not None:
+                    rows.extend(cursor.fetchall())
+                if not cursor.nextset():
+                    return rows
 
     def do_stored_procedure_check(self):
         """

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import sys
 from typing import Dict, Optional, Sequence
+from xml.etree import ElementTree
 
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.sqlserver.const import ENGINE_EDITION_AZURE_MANAGED_INSTANCE, ENGINE_EDITION_SQL_DATABASE
@@ -25,6 +26,13 @@ DBM_COMMENT_MARKERS = (
     'traceparent=',
     'ddsh=',
 )
+
+
+def serialize_database_names(database_names: list[str]) -> str:
+    root = ElementTree.Element('databases')
+    for database_name in database_names:
+        ElementTree.SubElement(root, 'database').text = database_name
+    return ElementTree.tostring(root, encoding='unicode')
 
 
 # Database is used to store both the name and physical_database_name

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -1567,7 +1567,11 @@ def test_sqlserver_database_files_metrics(
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
 
     execute_query_handler_mocked = mock.MagicMock()
-    execute_query_handler_mocked.side_effect = mocked_results
+    execute_query_handler_mocked.return_value = [
+        (db, db, *file_row)
+        for db, database_rows in zip(AUTODISCOVERY_DBS, mocked_results)
+        for file_row in database_rows
+    ]
 
     database_files_metrics = SqlserverDatabaseFilesMetrics(
         config=sqlserver_check._config,
@@ -1591,8 +1595,17 @@ def test_sqlserver_database_files_metrics(
             "sqlserver_servername:{}".format(sqlserver_check.static_info_cache[STATIC_INFO_SERVERNAME].lower()),
         ]
         for db, result in zip(AUTODISCOVERY_DBS, mocked_results):
-            for row in result:
-                file_id, file_type, file_location, file_name, database_files_state_desc, size, space_used, state = row
+            for file_row in result:
+                (
+                    file_id,
+                    file_type,
+                    file_location,
+                    file_name,
+                    database_files_state_desc,
+                    size,
+                    space_used,
+                    state,
+                ) = file_row
                 size *= 8  # size is in pages, 1 page = 8 KB
                 space_used *= 8  # space_used is in pages, 1 page = 8 KB
                 metrics = zip(database_files_metrics.metric_names()[0], [state, size, space_used])
@@ -1607,6 +1620,30 @@ def test_sqlserver_database_files_metrics(
                 ] + tags
                 for metric_name, metric_value in metrics:
                     aggregator.assert_metric(metric_name, value=metric_value, tags=expected_tags)
+
+
+@pytest.mark.parametrize('database_count', [1, 1000])
+def test_database_files_metrics_batch_count_is_bounded(instance_docker_metrics, database_count):
+    instance_docker_metrics['database_metrics'] = {'db_files_metrics': {'enabled': True}}
+    sqlserver_check = SQLServer(CHECK_NAME, {}, [instance_docker_metrics])
+    new_query_executor = mock.MagicMock()
+
+    database_files_metrics = SqlserverDatabaseFilesMetrics(
+        config=sqlserver_check._config,
+        new_query_executor=new_query_executor,
+        server_static_info=STATIC_SERVER_INFO,
+        execute_query_handler=mock.MagicMock(),
+        databases=[f'database_{index}' for index in range(database_count)],
+    )
+
+    query_executors = database_files_metrics._build_query_executors()
+
+    assert len(query_executors) == 1
+    new_query_executor.assert_called_once()
+    query = new_query_executor.call_args.args[0][0]
+    assert query['query'].count('?') == 1
+    assert 'USE ' not in query['query']
+    assert query['params'][0].count('<database>') == database_count
 
 
 @pytest.mark.integration

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -1622,30 +1622,6 @@ def test_sqlserver_database_files_metrics(
                     aggregator.assert_metric(metric_name, value=metric_value, tags=expected_tags)
 
 
-@pytest.mark.parametrize('database_count', [1, 1000])
-def test_database_files_metrics_batch_count_is_bounded(instance_docker_metrics, database_count):
-    instance_docker_metrics['database_metrics'] = {'db_files_metrics': {'enabled': True}}
-    sqlserver_check = SQLServer(CHECK_NAME, {}, [instance_docker_metrics])
-    new_query_executor = mock.MagicMock()
-
-    database_files_metrics = SqlserverDatabaseFilesMetrics(
-        config=sqlserver_check._config,
-        new_query_executor=new_query_executor,
-        server_static_info=STATIC_SERVER_INFO,
-        execute_query_handler=mock.MagicMock(),
-        databases=[f'database_{index}' for index in range(database_count)],
-    )
-
-    query_executors = database_files_metrics._build_query_executors()
-
-    assert len(query_executors) == 1
-    new_query_executor.assert_called_once()
-    query = new_query_executor.call_args.args[0][0]
-    assert query['query'].count('?') == 1
-    assert 'USE ' not in query['query']
-    assert query['params'][0].count('<database>') == database_count
-
-
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize('include_table_size_metrics', [True, False])

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -1622,6 +1622,47 @@ def test_sqlserver_database_files_metrics(
                     aggregator.assert_metric(metric_name, value=metric_value, tags=expected_tags)
 
 
+@pytest.mark.parametrize('database_count', [1, 1000])
+def test_database_files_metrics_batch_count_is_bounded(instance_docker_metrics, database_count):
+    instance_docker_metrics['database_metrics'] = {'db_files_metrics': {'enabled': True}}
+    sqlserver_check = SQLServer(CHECK_NAME, {}, [instance_docker_metrics])
+    new_query_executor = mock.MagicMock()
+    database_files_metrics = SqlserverDatabaseFilesMetrics(
+        config=sqlserver_check._config,
+        new_query_executor=new_query_executor,
+        server_static_info=STATIC_SERVER_INFO,
+        execute_query_handler=mock.MagicMock(),
+        databases=[f'database_{index}' for index in range(database_count)],
+    )
+
+    query_executors = database_files_metrics._build_query_executors()
+
+    assert len(query_executors) == 1
+    new_query_executor.assert_called_once()
+    query = new_query_executor.call_args.args[0][0]
+    assert query['params'][0].count('<database>') == database_count
+    assert new_query_executor.call_args.kwargs['executor'].keywords == {'fetch_multiple_results': True}
+
+
+def test_database_files_metrics_keep_database_scoped_queries_on_azure_sql_database(instance_docker_metrics):
+    instance_docker_metrics['database_metrics'] = {'db_files_metrics': {'enabled': True}}
+    sqlserver_check = SQLServer(CHECK_NAME, {}, [instance_docker_metrics])
+    new_query_executor = mock.MagicMock()
+    database_files_metrics = SqlserverDatabaseFilesMetrics(
+        config=sqlserver_check._config,
+        new_query_executor=new_query_executor,
+        server_static_info={**STATIC_SERVER_INFO, STATIC_INFO_ENGINE_EDITION: ENGINE_EDITION_SQL_DATABASE},
+        execute_query_handler=mock.MagicMock(),
+        databases=['database_1', 'database_2'],
+    )
+
+    query_executors = database_files_metrics._build_query_executors()
+
+    assert len(query_executors) == 2
+    executors = [call.kwargs['executor'] for call in new_query_executor.call_args_list]
+    assert [executor.keywords for executor in executors] == [{'db': 'database_1'}, {'db': 'database_2'}]
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize('include_table_size_metrics', [True, False])

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -262,33 +262,34 @@ def test_database_files_metrics_match_database_context(
     databases = ('master', 'msdb', 'tempdb')
     instance_autodiscovery['autodiscovery_include'] = list(databases)
 
-    expected_values = {metric_name: {} for metric_name in ('size', 'space_used', 'state')}
+    # File allocation can change while the check runs, so use only stable metadata as the expected result.
+    expected_files = {}
     with datadog_conn_docker.cursor() as cursor:
         for database in databases:
             cursor.execute(f"USE [{database}]")
-            cursor.execute(
-                "SELECT file_id, type, size * 8, FILEPROPERTY(name, 'SpaceUsed') * 8, state FROM sys.database_files"
-            )
-            for file_id, file_type, size, space_used, state in cursor.fetchall():
-                key = (database, file_id)
-                expected_values['state'][key] = state
-                if file_type == 0:
-                    expected_values['size'][key] = size
-                    if database != 'tempdb':
-                        expected_values['space_used'][key] = space_used
+            cursor.execute("SELECT file_id, type FROM sys.database_files")
+            for file_id, file_type in cursor.fetchall():
+                expected_files[(database, file_id)] = file_type == 0
 
     check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
     dd_run_check(check)
 
-    for metric_name, expected in expected_values.items():
+    for metric_name in ('size', 'space_used', 'state'):
         actual = {}
         for metric in aggregator.metrics(f'sqlserver.database.files.{metric_name}'):
             tags = dict(tag.split(':', 1) for tag in metric.tags)
             key = (tags.get('db'), int(tags['file_id']))
-            if key in expected:
+            if key in expected_files:
+                assert tags['database'] == key[0]
                 actual[key] = metric.value
 
-        assert actual == expected
+        assert actual.keys() == expected_files.keys()
+        if metric_name == 'state':
+            assert all(value == 0 for value in actual.values())
+        elif metric_name == 'size':
+            assert all(value > 0 for value in actual.values())
+        else:
+            assert all(actual[key] > 0 for key, is_data_file in expected_files.items() if is_data_file)
 
 
 @not_windows_ci

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -315,13 +315,14 @@ def test_database_files_metrics_with_connect_any_database(
 def test_database_files_size_uses_current_tempdb_size(aggregator, dd_run_check, instance_autodiscovery, sa_conn):
     table_name = 'datadog_database_files_growth'
     with sa_conn.cursor() as cursor:
-        cursor.execute("SELECT size FROM sys.master_files WHERE database_id = DB_ID('tempdb') AND file_id = 1")
-        initial_size = cursor.fetchone()[0]
+        cursor.execute("SELECT file_id, size FROM sys.master_files WHERE database_id = DB_ID('tempdb') AND type = 0")
+        configured_sizes = dict(cursor.fetchall())
         cursor.execute("USE [tempdb]")
-        cursor.execute("SELECT size FROM sys.database_files WHERE file_id = 1")
-        current_size = cursor.fetchone()[0]
+        cursor.execute("SELECT file_id, size, FILEPROPERTY(name, 'SpaceUsed') FROM sys.database_files WHERE type = 0")
+        current_files = cursor.fetchall()
 
-        if current_size <= initial_size:
+        if not any(size > configured_sizes[file_id] for file_id, size, _ in current_files):
+            free_pages = sum(size - space_used for _, size, space_used in current_files)
             cursor.execute(
                 f"""
                 USE [tempdb];
@@ -332,14 +333,15 @@ def test_database_files_size_uses_current_tempdb_size(aggregator, dd_run_check, 
                 FROM sys.all_objects AS objects_a
                 CROSS JOIN sys.all_objects AS objects_b;
                 """,
-                initial_size + 1024,
+                free_pages + 1024,
             )
 
         cursor.execute("USE [tempdb]")
-        cursor.execute("SELECT size * 8 FROM sys.database_files WHERE file_id = 1")
-        expected_size = cursor.fetchone()[0]
+        cursor.execute("SELECT file_id, size FROM sys.database_files WHERE type = 0")
+        current_sizes = dict(cursor.fetchall())
 
-    assert expected_size > initial_size * 8
+    grown_file_id = next(file_id for file_id, size in current_sizes.items() if size > configured_sizes[file_id])
+    expected_size = current_sizes[grown_file_id] * 8
 
     try:
         instance_autodiscovery['autodiscovery_include'] = ['tempdb']
@@ -349,7 +351,7 @@ def test_database_files_size_uses_current_tempdb_size(aggregator, dd_run_check, 
         actual_sizes = []
         for metric in aggregator.metrics('sqlserver.database.files.size'):
             tags = dict(tag.split(':', 1) for tag in metric.tags)
-            if tags.get('db') == 'tempdb' and tags.get('file_id') == '1':
+            if tags.get('db') == 'tempdb' and tags.get('file_id') == str(grown_file_id):
                 actual_sizes.append(metric.value)
 
         assert actual_sizes == [expected_size]

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -256,29 +256,38 @@ def test_autodiscovery_database_metrics(aggregator, dd_run_check, instance_autod
 @not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_database_files_space_used_matches_database_context(
+def test_database_files_metrics_match_database_context(
     aggregator, dd_run_check, instance_autodiscovery, datadog_conn_docker
 ):
-    instance_autodiscovery['autodiscovery_include'] = ['master', 'msdb']
+    databases = ('master', 'msdb', 'tempdb')
+    instance_autodiscovery['autodiscovery_include'] = list(databases)
 
+    expected_values = {metric_name: {} for metric_name in ('size', 'space_used', 'state')}
     with datadog_conn_docker.cursor() as cursor:
-        cursor.execute("USE [master]")
-        cursor.execute("SELECT file_id, FILEPROPERTY(name, 'SpaceUsed') * 8 FROM sys.database_files")
-        expected_space_used = {('master', file_id): value for file_id, value in cursor.fetchall()}
-        cursor.execute("USE [msdb]")
-        cursor.execute("SELECT file_id, FILEPROPERTY(name, 'SpaceUsed') * 8 FROM sys.database_files")
-        expected_space_used.update({('msdb', file_id): value for file_id, value in cursor.fetchall()})
+        for database in databases:
+            cursor.execute(f"USE [{database}]")
+            cursor.execute(
+                "SELECT file_id, size * 8, FILEPROPERTY(name, 'SpaceUsed') * 8, state FROM sys.database_files"
+            )
+            for file_id, size, space_used, state in cursor.fetchall():
+                key = (database, file_id)
+                expected_values['size'][key] = size
+                expected_values['state'][key] = state
+                if database != 'tempdb':
+                    expected_values['space_used'][key] = space_used
 
     check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
     dd_run_check(check)
 
-    actual_space_used = {}
-    for metric in aggregator.metrics('sqlserver.database.files.space_used'):
-        tags = dict(tag.split(':', 1) for tag in metric.tags)
-        if tags.get('db') in ('master', 'msdb'):
-            actual_space_used[(tags['db'], int(tags['file_id']))] = metric.value
+    for metric_name, expected in expected_values.items():
+        actual = {}
+        for metric in aggregator.metrics(f'sqlserver.database.files.{metric_name}'):
+            tags = dict(tag.split(':', 1) for tag in metric.tags)
+            key = (tags.get('db'), int(tags['file_id']))
+            if key in expected:
+                actual[key] = metric.value
 
-    assert actual_space_used == expected_space_used
+        assert actual == expected
 
 
 @not_windows_ci
@@ -307,64 +316,6 @@ def test_database_files_metrics_with_connect_any_database(
     ):
         metrics = aggregator.metrics(metric_name)
         assert any('db:datadog_test-1' in metric.tags for metric in metrics)
-
-
-@not_windows_ci
-@pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
-def test_database_files_size_uses_current_tempdb_size(aggregator, dd_run_check, instance_autodiscovery, sa_conn):
-    table_name = 'datadog_database_files_growth'
-    with sa_conn.cursor() as cursor:
-        cursor.execute("SELECT size FROM sys.master_files WHERE database_id = DB_ID('tempdb') AND file_id = 2")
-        configured_size = cursor.fetchone()[0]
-        cursor.execute("USE [tempdb]")
-        cursor.execute("SELECT size FROM sys.database_files WHERE file_id = 2")
-        current_size = cursor.fetchone()[0]
-
-        if current_size <= configured_size:
-            cursor.execute("SELECT total_log_size_in_bytes - used_log_space_in_bytes FROM sys.dm_db_log_space_usage")
-            free_log_bytes = cursor.fetchone()[0]
-            cursor.execute(
-                f"""
-                USE [tempdb];
-                DROP TABLE IF EXISTS dbo.{table_name};
-                CREATE TABLE dbo.{table_name} (payload char(8000) NOT NULL);
-                INSERT INTO dbo.{table_name} VALUES (REPLICATE('x', 8000));
-
-                DECLARE @iterations int = ?;
-                BEGIN TRANSACTION;
-                WHILE @iterations > 0
-                BEGIN
-                    UPDATE dbo.{table_name}
-                    SET payload = REPLICATE(CHAR(120 + @iterations % 2), 8000);
-                    SET @iterations -= 1;
-                END;
-                ROLLBACK;
-                """,
-                free_log_bytes // 4000 + 1024,
-            )
-
-        cursor.execute("USE [tempdb]")
-        cursor.execute("SELECT size * 8 FROM sys.database_files WHERE file_id = 2")
-        expected_size = cursor.fetchone()[0]
-
-    assert expected_size > configured_size * 8
-
-    try:
-        instance_autodiscovery['autodiscovery_include'] = ['tempdb']
-        check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
-        dd_run_check(check)
-
-        actual_sizes = []
-        for metric in aggregator.metrics('sqlserver.database.files.size'):
-            tags = dict(tag.split(':', 1) for tag in metric.tags)
-            if tags.get('db') == 'tempdb' and tags.get('file_id') == '2':
-                actual_sizes.append(metric.value)
-
-        assert actual_sizes == [expected_size]
-    finally:
-        with sa_conn.cursor() as cursor:
-            cursor.execute(f"USE [tempdb]; DROP TABLE IF EXISTS dbo.{table_name}")
 
 
 @pytest.mark.integration

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -271,10 +271,11 @@ def test_database_files_metrics_match_database_context(
             )
             for file_id, file_type, size, space_used, state in cursor.fetchall():
                 key = (database, file_id)
-                expected_values['size'][key] = size
                 expected_values['state'][key] = state
-                if file_type == 0 and database != 'tempdb':
-                    expected_values['space_used'][key] = space_used
+                if file_type == 0:
+                    expected_values['size'][key] = size
+                    if database != 'tempdb':
+                        expected_values['space_used'][key] = space_used
 
     check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
     dd_run_check(check)

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -267,13 +267,13 @@ def test_database_files_metrics_match_database_context(
         for database in databases:
             cursor.execute(f"USE [{database}]")
             cursor.execute(
-                "SELECT file_id, size * 8, FILEPROPERTY(name, 'SpaceUsed') * 8, state FROM sys.database_files"
+                "SELECT file_id, type, size * 8, FILEPROPERTY(name, 'SpaceUsed') * 8, state FROM sys.database_files"
             )
-            for file_id, size, space_used, state in cursor.fetchall():
+            for file_id, file_type, size, space_used, state in cursor.fetchall():
                 key = (database, file_id)
                 expected_values['size'][key] = size
                 expected_values['state'][key] = state
-                if database != 'tempdb':
+                if file_type == 0 and database != 'tempdb':
                     expected_values['space_used'][key] = space_used
 
     check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -253,6 +253,111 @@ def test_autodiscovery_database_metrics(aggregator, dd_run_check, instance_autod
     aggregator.assert_metric('sqlserver.database.files.space_used', tags=msdb_tags)
 
 
+@not_windows_ci
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_database_files_space_used_matches_database_context(
+    aggregator, dd_run_check, instance_autodiscovery, datadog_conn_docker
+):
+    instance_autodiscovery['autodiscovery_include'] = ['master', 'msdb']
+
+    with datadog_conn_docker.cursor() as cursor:
+        cursor.execute("USE [master]")
+        cursor.execute("SELECT file_id, FILEPROPERTY(name, 'SpaceUsed') * 8 FROM sys.database_files")
+        expected_space_used = {('master', file_id): value for file_id, value in cursor.fetchall()}
+        cursor.execute("USE [msdb]")
+        cursor.execute("SELECT file_id, FILEPROPERTY(name, 'SpaceUsed') * 8 FROM sys.database_files")
+        expected_space_used.update({('msdb', file_id): value for file_id, value in cursor.fetchall()})
+
+    check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
+    dd_run_check(check)
+
+    actual_space_used = {}
+    for metric in aggregator.metrics('sqlserver.database.files.space_used'):
+        tags = dict(tag.split(':', 1) for tag in metric.tags)
+        if tags.get('db') in ('master', 'msdb'):
+            actual_space_used[(tags['db'], int(tags['file_id']))] = metric.value
+
+    assert actual_space_used == expected_space_used
+
+
+@not_windows_ci
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_database_files_metrics_with_connect_any_database(
+    aggregator, bob_conn_raw, dd_run_check, instance_autodiscovery
+):
+    with bob_conn_raw.cursor() as cursor:
+        cursor.execute("SELECT HAS_PERMS_BY_NAME(NULL, NULL, 'VIEW ANY DEFINITION')")
+        assert cursor.fetchone()[0] == 0
+        cursor.execute("USE [datadog_test-1]")
+        cursor.execute("SELECT COUNT(*) FROM sys.database_files")
+        assert cursor.fetchone()[0] > 0
+
+    instance_autodiscovery['username'] = 'bob'
+    instance_autodiscovery['password'] = 'Password12!'
+    instance_autodiscovery['autodiscovery_include'] = ['datadog_test-1']
+    check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
+    dd_run_check(check)
+
+    for metric_name in (
+        'sqlserver.database.files.size',
+        'sqlserver.database.files.space_used',
+        'sqlserver.database.files.state',
+    ):
+        metrics = aggregator.metrics(metric_name)
+        assert any('db:datadog_test-1' in metric.tags for metric in metrics)
+
+
+@not_windows_ci
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_database_files_size_uses_current_tempdb_size(aggregator, dd_run_check, instance_autodiscovery, sa_conn):
+    table_name = 'datadog_database_files_growth'
+    with sa_conn.cursor() as cursor:
+        cursor.execute("SELECT size FROM sys.master_files WHERE database_id = DB_ID('tempdb') AND file_id = 1")
+        initial_size = cursor.fetchone()[0]
+        cursor.execute("USE [tempdb]")
+        cursor.execute("SELECT size FROM sys.database_files WHERE file_id = 1")
+        current_size = cursor.fetchone()[0]
+
+        if current_size <= initial_size:
+            cursor.execute(
+                f"""
+                USE [tempdb];
+                DROP TABLE IF EXISTS dbo.{table_name};
+                CREATE TABLE dbo.{table_name} (payload char(8000) NOT NULL);
+                INSERT INTO dbo.{table_name}
+                SELECT TOP (?) REPLICATE('x', 8000)
+                FROM sys.all_objects AS objects_a
+                CROSS JOIN sys.all_objects AS objects_b;
+                """,
+                initial_size + 1024,
+            )
+
+        cursor.execute("USE [tempdb]")
+        cursor.execute("SELECT size * 8 FROM sys.database_files WHERE file_id = 1")
+        expected_size = cursor.fetchone()[0]
+
+    assert expected_size > initial_size * 8
+
+    try:
+        instance_autodiscovery['autodiscovery_include'] = ['tempdb']
+        check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
+        dd_run_check(check)
+
+        actual_sizes = []
+        for metric in aggregator.metrics('sqlserver.database.files.size'):
+            tags = dict(tag.split(':', 1) for tag in metric.tags)
+            if tags.get('db') == 'tempdb' and tags.get('file_id') == '1':
+                actual_sizes.append(metric.value)
+
+        assert actual_sizes == [expected_size]
+    finally:
+        with sa_conn.cursor() as cursor:
+            cursor.execute(f"USE [tempdb]; DROP TABLE IF EXISTS dbo.{table_name}")
+
+
 @pytest.mark.integration
 @pytest.mark.parametrize(
     'service_check_enabled,default_count,extra_count',

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -315,33 +315,40 @@ def test_database_files_metrics_with_connect_any_database(
 def test_database_files_size_uses_current_tempdb_size(aggregator, dd_run_check, instance_autodiscovery, sa_conn):
     table_name = 'datadog_database_files_growth'
     with sa_conn.cursor() as cursor:
-        cursor.execute("SELECT file_id, size FROM sys.master_files WHERE database_id = DB_ID('tempdb') AND type = 0")
-        configured_sizes = dict(cursor.fetchall())
+        cursor.execute("SELECT size FROM sys.master_files WHERE database_id = DB_ID('tempdb') AND file_id = 2")
+        configured_size = cursor.fetchone()[0]
         cursor.execute("USE [tempdb]")
-        cursor.execute("SELECT file_id, size, FILEPROPERTY(name, 'SpaceUsed') FROM sys.database_files WHERE type = 0")
-        current_files = cursor.fetchall()
+        cursor.execute("SELECT size FROM sys.database_files WHERE file_id = 2")
+        current_size = cursor.fetchone()[0]
 
-        if not any(size > configured_sizes[file_id] for file_id, size, _ in current_files):
-            free_pages = sum(size - space_used for _, size, space_used in current_files)
+        if current_size <= configured_size:
+            cursor.execute("SELECT total_log_size_in_bytes - used_log_space_in_bytes FROM sys.dm_db_log_space_usage")
+            free_log_bytes = cursor.fetchone()[0]
             cursor.execute(
                 f"""
                 USE [tempdb];
                 DROP TABLE IF EXISTS dbo.{table_name};
                 CREATE TABLE dbo.{table_name} (payload char(8000) NOT NULL);
-                INSERT INTO dbo.{table_name}
-                SELECT TOP (?) REPLICATE('x', 8000)
-                FROM sys.all_objects AS objects_a
-                CROSS JOIN sys.all_objects AS objects_b;
+                INSERT INTO dbo.{table_name} VALUES (REPLICATE('x', 8000));
+
+                DECLARE @iterations int = ?;
+                BEGIN TRANSACTION;
+                WHILE @iterations > 0
+                BEGIN
+                    UPDATE dbo.{table_name}
+                    SET payload = REPLICATE(CHAR(120 + @iterations % 2), 8000);
+                    SET @iterations -= 1;
+                END;
+                ROLLBACK;
                 """,
-                free_pages + 1024,
+                free_log_bytes // 4000 + 1024,
             )
 
         cursor.execute("USE [tempdb]")
-        cursor.execute("SELECT file_id, size FROM sys.database_files WHERE type = 0")
-        current_sizes = dict(cursor.fetchall())
+        cursor.execute("SELECT size * 8 FROM sys.database_files WHERE file_id = 2")
+        expected_size = cursor.fetchone()[0]
 
-    grown_file_id = next(file_id for file_id, size in current_sizes.items() if size > configured_sizes[file_id])
-    expected_size = current_sizes[grown_file_id] * 8
+    assert expected_size > configured_size * 8
 
     try:
         instance_autodiscovery['autodiscovery_include'] = ['tempdb']
@@ -351,7 +358,7 @@ def test_database_files_size_uses_current_tempdb_size(aggregator, dd_run_check, 
         actual_sizes = []
         for metric in aggregator.metrics('sqlserver.database.files.size'):
             tags = dict(tag.split(':', 1) for tag in metric.tags)
-            if tags.get('db') == 'tempdb' and tags.get('file_id') == str(grown_file_id):
+            if tags.get('db') == 'tempdb' and tags.get('file_id') == '2':
                 actual_sizes.append(metric.value)
 
         assert actual_sizes == [expected_size]

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -73,6 +73,54 @@ def test_construct_use_statement(db_name, expected):
     assert use_stmt == expected
 
 
+@pytest.mark.parametrize('database_count', [1, 1000])
+def test_autodiscovery_database_service_check_batch_count_is_bounded(instance_autodiscovery, database_count):
+    check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
+    database_names = [f'database_{index}' for index in range(database_count)]
+    check.databases = {Database(name) for name in database_names}
+    cursor = mock.MagicMock()
+    cursor.fetchall.return_value = [(name, 1) for name in database_names]
+    check._connection = mock.MagicMock()
+    check.connection.get_managed_cursor.return_value.__enter__.return_value = cursor
+    check.handle_service_check = mock.MagicMock()
+
+    check._check_connections_by_use_db()
+
+    cursor.execute.assert_called_once()
+    query, params = cursor.execute.call_args.args
+    assert query.count('?') == 1
+    assert 'USE ' not in query
+    assert params[0].count('<database>') == database_count
+    assert check.handle_service_check.call_count == database_count
+
+
+def test_autodiscovery_database_service_check_preserves_per_database_status(instance_autodiscovery):
+    check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
+    check.databases = {Database('available'), Database('unavailable')}
+    cursor = mock.MagicMock()
+    cursor.fetchall.return_value = [('available', 1), ('unavailable', 0)]
+    check._connection = mock.MagicMock()
+    check.connection.get_managed_cursor.return_value.__enter__.return_value = cursor
+    check.connection.get_host_with_port = mock.MagicMock(return_value='sql.example:1433')
+    check.handle_service_check = mock.MagicMock()
+
+    check._check_connections_by_use_db()
+
+    check.handle_service_check.assert_has_calls(
+        [
+            mock.call(check.OK, 'sql.example:1433', 'available', False),
+            mock.call(
+                check.CRITICAL,
+                'sql.example:1433',
+                'unavailable',
+                'Database unavailable connection service check failed: database is not accessible',
+                False,
+            ),
+        ],
+        any_order=True,
+    )
+
+
 def create_schema_collector(static_info_cache: dict | None = None) -> SQLServerSchemaCollector:
     check = mock.Mock()
     check._config.schema_config = {}

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -121,6 +121,21 @@ def test_autodiscovery_database_service_check_preserves_per_database_status(inst
     )
 
 
+def test_execute_query_raw_collects_multiple_result_sets(instance_docker):
+    check = SQLServer(CHECK_NAME, {}, [instance_docker])
+    cursor = mock.MagicMock()
+    cursor.description = [('value',)]
+    cursor.fetchall.side_effect = [[('first',)], [('second',)]]
+    cursor.nextset.side_effect = [True, False]
+    check._connection = mock.MagicMock()
+    check.connection.get_managed_cursor.return_value.__enter__.return_value = cursor
+
+    rows = check.execute_query_raw('SELECT 1; SELECT 2', fetch_multiple_results=True)
+
+    assert rows == [('first',), ('second',)]
+    assert cursor.fetchall.call_count == 2
+
+
 def create_schema_collector(static_info_cache: dict | None = None) -> SQLServerSchemaCollector:
     check = mock.Mock()
     check._config.schema_config = {}


### PR DESCRIPTION
### What does this PR do?

Collapses two SQL Server operations that previously scaled with the number of autodiscovered databases:

- Database connection service checks now use one query over the monitored database names and derive the same per-database statuses from its result.
- Database file metrics now use one compact TDS request. A server-side cursor invokes the original `sys.database_files` query through `[database].sys.sp_executesql`, preserving each database's execution context, and the client drains the streamed result sets with `nextset()`.

The database file query still uses `FILEPROPERTY(name, 'SpaceUsed')` inside each database, so it preserves current `tempdb` sizes and does not require `VIEW ANY DEFINITION`. Database names are supplied as an XML parameter and quoted with `QUOTENAME`. A database that becomes unavailable after autodiscovery is skipped so later databases are still collected.

Azure SQL Database retains the direct database-scoped query because it does not support cross-database execution. Azure SQL Managed Instance uses the batched path.

### Motivation

The previous implementation issued two SQL requests per autodiscovered database for each affected path. Both paths were benchmarked through the real SSH tunnel against the same SQL Server 2022 instance with 3,945 databases, with one workload running at a time:

| collection | previous requests | final requests | previous wall time | final wall time | speedup |
|---|---:|---:|---:|---:|---:|
| Database connection status | 7,891 | 1 | 327.936 s | 0.353 s median | 929.1x |
| Database file metrics | 7,890 | 1 | 368.700 s | 52.000 s | 7.1x |
| Combined scoped work | 15,781 | 2 | 696.636 s | 52.353 s | 13.31x |

This removes 15,779 requests (99.987%) and saves 644.283 seconds, or 10 minutes 44.3 seconds, per collection at this scale. The combined result is the arithmetic sum of separately measured components under the same tunnel and database population, not a separate end-to-end run.

The status benchmark ran the final path four times around one full legacy sweep. Final timings ranged from 0.334 to 0.425 seconds; the median was 0.353 seconds and the first row arrived in 0.134 to 0.186 seconds. A server-local control measured 2.086 seconds for the legacy path and 0.243 to 0.288 seconds for the final path, confirming that the large tunneled improvement comes primarily from eliminating round trips.

Correctness was compared against the original behavior across all 3,945 databases: every connection status matched, and database file coverage and every stable value matched across 7,897 rows. Restricted-permission probes also matched for accessible, inaccessible, and nonexistent databases. Database file collection was verified with `CONNECT ANY DATABASE` but not `VIEW ANY DEFINITION`, including rows from regular, partitioned, and `tempdb` databases. One-page changes observed in log `space_used` values followed whichever query ran later and were confirmed as live checkpoint activity rather than a code-path difference.

Focused tests cover bounded query count, multi-result draining, and the Azure SQL Database fallback. Integration tests compare database file size, used space, and state with database-local `sys.database_files` results and verify collection under restricted permissions. The full Linux ODBC/FreeTDS and Windows ODBC/OLE DB CI matrix passes.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
