### PR TITLE
Add object name filters for SQL Server index usage and table size metrics

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -532,6 +532,26 @@ files:
         items:
           type: string
       fleet_configurable: false
+    - name: index_usage_object_names
+      description: |
+        Index usage metrics normally emit metrics for all objects within a database.
+        This option allows you to specify database object names to query for index usage metrics.
+        Note: Each object name is unique to each database.
+      value:
+        type: array
+        items:
+          type: string
+      fleet_configurable: false
+    - name: table_size_object_names
+      description: |
+        Table size metrics normally emit metrics for all objects within a database.
+        This option allows you to specify database object names to query for table size metrics.
+        Note: Each object name is unique to each database.
+      value:
+        type: array
+        items:
+          type: string
+      fleet_configurable: false
     - name: adoprovider
       fleet_configurable: true
       description: |

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -532,21 +532,22 @@ files:
         items:
           type: string
       fleet_configurable: false
-    - name: index_usage_object_names
+    - name: index_usage_table_names
       description: |
-        Index usage metrics normally emit metrics for all objects within a database.
-        This option allows you to specify database object names to query for index usage metrics.
-        Note: Each object name is unique to each database.
+        Index usage metrics normally emit metrics for all user tables and their indexes within a database.
+        This option allows you to specify exact table names to query for index usage metrics.
+        Specify table names, not index names; metrics are collected for every index belonging to each matching table.
+        Note: Each table name is unique to each database.
       value:
         type: array
         items:
           type: string
       fleet_configurable: false
-    - name: table_size_object_names
+    - name: table_size_table_names
       description: |
-        Table size metrics normally emit metrics for all objects within a database.
-        This option allows you to specify database object names to query for table size metrics.
-        Note: Each object name is unique to each database.
+        Table size metrics normally emit metrics for all user tables within a database.
+        This option allows you to specify exact table names to query for table size metrics.
+        Note: Each table name is unique to each database.
       value:
         type: array
         items:

--- a/sqlserver/changelog.d/24951.added
+++ b/sqlserver/changelog.d/24951.added
@@ -1,0 +1,1 @@
+Add ``index_usage_object_names`` and ``table_size_object_names`` to bound the objects scanned by index usage and table size metrics.

--- a/sqlserver/changelog.d/24951.added
+++ b/sqlserver/changelog.d/24951.added
@@ -1,1 +1,1 @@
-Add ``index_usage_object_names`` and ``table_size_object_names`` to bound the objects scanned by index usage and table size metrics.
+Add ``index_usage_table_names`` and ``table_size_table_names`` to bound the tables scanned by index usage and table size metrics.

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -133,8 +133,8 @@ class SQLServerConfig:
         self.connection_host: str = instance['host']
         self.service = instance.get('service') or init_config.get('service') or ''
         self.db_fragmentation_object_names = instance.get('db_fragmentation_object_names', []) or []
-        self.index_usage_object_names = instance.get('index_usage_object_names', []) or []
-        self.table_size_object_names = instance.get('table_size_object_names', []) or []
+        self.index_usage_table_names = instance.get('index_usage_table_names', []) or []
+        self.table_size_table_names = instance.get('table_size_table_names', []) or []
         self.data_observability: DataObservability = DataObservability.model_validate(
             instance.get('data_observability') or {}
         )

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -133,6 +133,8 @@ class SQLServerConfig:
         self.connection_host: str = instance['host']
         self.service = instance.get('service') or init_config.get('service') or ''
         self.db_fragmentation_object_names = instance.get('db_fragmentation_object_names', []) or []
+        self.index_usage_object_names = instance.get('index_usage_object_names', []) or []
+        self.table_size_object_names = instance.get('table_size_object_names', []) or []
         self.data_observability: DataObservability = DataObservability.model_validate(
             instance.get('data_observability') or {}
         )

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -550,25 +550,19 @@ class InstanceConfig(BaseModel):
     @model_validator(mode='before')
     def _handle_deprecations(cls, values, info):
         fields = info.context['configured_fields']
-        validation.utils.handle_deprecations(
-            'instances', deprecations.instance(), fields, info.context
-        )
+        validation.utils.handle_deprecations('instances', deprecations.instance(), fields, info.context)
         return values
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):
-        return validation.core.initialize_config(
-            getattr(validators, 'initialize_instance', identity)(values)
-        )
+        return validation.core.initialize_config(getattr(validators, 'initialize_instance', identity)(values))
 
     @field_validator('*', mode='before')
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
-            value = getattr(validators, f'instance_{info.field_name}', identity)(
-                value, field=field
-            )
+            value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 
@@ -576,6 +570,4 @@ class InstanceConfig(BaseModel):
 
     @model_validator(mode='after')
     def _final_validation(cls, model):
-        return validation.core.check_model(
-            getattr(validators, 'check_instance', identity)(model)
-        )
+        return validation.core.check_model(getattr(validators, 'check_instance', identity)(model))

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -520,7 +520,7 @@ class InstanceConfig(BaseModel):
     host: str
     ignore_missing_database: Optional[bool] = None
     include_instance_metrics: Optional[bool] = None
-    index_usage_object_names: Optional[tuple[str, ...]] = None
+    index_usage_table_names: Optional[tuple[str, ...]] = None
     log_unobfuscated_plans: Optional[bool] = None
     log_unobfuscated_queries: Optional[bool] = None
     managed_identity: Optional[ManagedIdentity] = None
@@ -541,7 +541,7 @@ class InstanceConfig(BaseModel):
     service: Optional[str] = None
     stored_procedure: Optional[str] = None
     stored_procedure_characters_limit: Optional[int] = None
-    table_size_object_names: Optional[tuple[str, ...]] = None
+    table_size_table_names: Optional[tuple[str, ...]] = None
     tags: Optional[tuple[str, ...]] = None
     use_global_custom_queries: Optional[str] = None
     username: Optional[str] = None
@@ -550,19 +550,25 @@ class InstanceConfig(BaseModel):
     @model_validator(mode='before')
     def _handle_deprecations(cls, values, info):
         fields = info.context['configured_fields']
-        validation.utils.handle_deprecations('instances', deprecations.instance(), fields, info.context)
+        validation.utils.handle_deprecations(
+            'instances', deprecations.instance(), fields, info.context
+        )
         return values
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):
-        return validation.core.initialize_config(getattr(validators, 'initialize_instance', identity)(values))
+        return validation.core.initialize_config(
+            getattr(validators, 'initialize_instance', identity)(values)
+        )
 
     @field_validator('*', mode='before')
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
-            value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+            value = getattr(validators, f'instance_{info.field_name}', identity)(
+                value, field=field
+            )
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 
@@ -570,4 +576,6 @@ class InstanceConfig(BaseModel):
 
     @model_validator(mode='after')
     def _final_validation(cls, model):
-        return validation.core.check_model(getattr(validators, 'check_instance', identity)(model))
+        return validation.core.check_model(
+            getattr(validators, 'check_instance', identity)(model)
+        )

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -520,6 +520,7 @@ class InstanceConfig(BaseModel):
     host: str
     ignore_missing_database: Optional[bool] = None
     include_instance_metrics: Optional[bool] = None
+    index_usage_object_names: Optional[tuple[str, ...]] = None
     log_unobfuscated_plans: Optional[bool] = None
     log_unobfuscated_queries: Optional[bool] = None
     managed_identity: Optional[ManagedIdentity] = None
@@ -540,6 +541,7 @@ class InstanceConfig(BaseModel):
     service: Optional[str] = None
     stored_procedure: Optional[str] = None
     stored_procedure_characters_limit: Optional[int] = None
+    table_size_object_names: Optional[tuple[str, ...]] = None
     tags: Optional[tuple[str, ...]] = None
     use_global_custom_queries: Optional[str] = None
     username: Optional[str] = None
@@ -548,19 +550,25 @@ class InstanceConfig(BaseModel):
     @model_validator(mode='before')
     def _handle_deprecations(cls, values, info):
         fields = info.context['configured_fields']
-        validation.utils.handle_deprecations('instances', deprecations.instance(), fields, info.context)
+        validation.utils.handle_deprecations(
+            'instances', deprecations.instance(), fields, info.context
+        )
         return values
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):
-        return validation.core.initialize_config(getattr(validators, 'initialize_instance', identity)(values))
+        return validation.core.initialize_config(
+            getattr(validators, 'initialize_instance', identity)(values)
+        )
 
     @field_validator('*', mode='before')
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
-            value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+            value = getattr(validators, f'instance_{info.field_name}', identity)(
+                value, field=field
+            )
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 
@@ -568,4 +576,6 @@ class InstanceConfig(BaseModel):
 
     @model_validator(mode='after')
     def _final_validation(cls, model):
-        return validation.core.check_model(getattr(validators, 'check_instance', identity)(model))
+        return validation.core.check_model(
+            getattr(validators, 'check_instance', identity)(model)
+        )

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -65,6 +65,7 @@ AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPES = {
     "virtual_machine": "azure_virtual_machine_instance",
 }
 AZURE_SERVER_SUFFIX = ".database.windows.net"
+SQLSERVER_PARAMETER_LIMIT = 2100
 
 
 # Metric discovery queries

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -340,6 +340,20 @@ instances:
     #
     # db_fragmentation_object_names: []
 
+    ## @param index_usage_object_names - list of strings - optional
+    ## Index usage metrics normally emit metrics for all objects within a database.
+    ## This option allows you to specify database object names to query for index usage metrics.
+    ## Note: Each object name is unique to each database.
+    #
+    # index_usage_object_names: []
+
+    ## @param table_size_object_names - list of strings - optional
+    ## Table size metrics normally emit metrics for all objects within a database.
+    ## This option allows you to specify database object names to query for table size metrics.
+    ## Note: Each object name is unique to each database.
+    #
+    # table_size_object_names: []
+
     ## @param adoprovider - string - optional - default: MSOLEDBSQL
     ## Choose the ADO provider.  Note that SQLOLEDB is deprecated.  To use the MSOLEDBSQL
     ## provider, set the adoprovider to "MSOLEDBSQL" below or "MSOLEDBSQL19" for version 19 of the driver.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -340,19 +340,20 @@ instances:
     #
     # db_fragmentation_object_names: []
 
-    ## @param index_usage_object_names - list of strings - optional
-    ## Index usage metrics normally emit metrics for all objects within a database.
-    ## This option allows you to specify database object names to query for index usage metrics.
-    ## Note: Each object name is unique to each database.
+    ## @param index_usage_table_names - list of strings - optional
+    ## Index usage metrics normally emit metrics for all user tables and their indexes within a database.
+    ## This option allows you to specify exact table names to query for index usage metrics.
+    ## Specify table names, not index names; metrics are collected for every index belonging to each matching table.
+    ## Note: Each table name is unique to each database.
     #
-    # index_usage_object_names: []
+    # index_usage_table_names: []
 
-    ## @param table_size_object_names - list of strings - optional
-    ## Table size metrics normally emit metrics for all objects within a database.
-    ## This option allows you to specify database object names to query for table size metrics.
-    ## Note: Each object name is unique to each database.
+    ## @param table_size_table_names - list of strings - optional
+    ## Table size metrics normally emit metrics for all user tables within a database.
+    ## This option allows you to specify exact table names to query for table size metrics.
+    ## Note: Each table name is unique to each database.
     #
-    # table_size_object_names: []
+    # table_size_table_names: []
 
     ## @param adoprovider - string - optional - default: MSOLEDBSQL
     ## Choose the ADO provider.  Note that SQLOLEDB is deprecated.  To use the MSOLEDBSQL

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/base.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/base.py
@@ -9,9 +9,12 @@ from typing import Callable, List, Optional
 from datadog_checks.base.log import get_check_logger
 from datadog_checks.base.utils.db.core import QueryExecutor
 from datadog_checks.sqlserver.config import SQLServerConfig
-from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_INFO_MAJOR_VERSION, STATIC_INFO_RDS
-
-SQLSERVER_PARAMETER_LIMIT = 2100
+from datadog_checks.sqlserver.const import (
+    SQLSERVER_PARAMETER_LIMIT,
+    STATIC_INFO_ENGINE_EDITION,
+    STATIC_INFO_MAJOR_VERSION,
+    STATIC_INFO_RDS,
+)
 
 
 class SqlserverDatabaseMetricsBase:

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import copy
 import functools
 
 from datadog_checks.base.errors import ConfigurationError
@@ -53,6 +54,10 @@ class SqlserverIndexUsageMetrics(SqlserverDatabaseMetricsBase):
         return self.config.database_metrics_config["index_usage_metrics"]["enabled_tempdb"]
 
     @property
+    def index_usage_object_names(self) -> list[str]:
+        return self.config.index_usage_object_names
+
+    @property
     def collection_interval(self) -> int:
         '''
         Returns the interval in seconds at which to collect index usage metrics.
@@ -100,9 +105,19 @@ class SqlserverIndexUsageMetrics(SqlserverDatabaseMetricsBase):
 
     def _build_query_executors(self):
         executors = []
+        if self.index_usage_object_names:
+            placeholders = ','.join(['?'] * len(self.index_usage_object_names))
+            object_name_filter = f" WHERE OBJECT_NAME(ind.object_id) IN ({placeholders})"
+        else:
+            object_name_filter = None
         for database in self.databases:
+            queries = copy.deepcopy(self.queries)
+            if object_name_filter:
+                for query in queries:
+                    query['query'] += object_name_filter
+                    query['params'] = tuple(self.index_usage_object_names)
             executor = self.new_query_executor(
-                self.queries,
+                queries,
                 executor=functools.partial(self.execute_query_handler, db=database),
                 track_operation_time=self.track_operation_time,
             )

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
@@ -55,8 +55,8 @@ class SqlserverIndexUsageMetrics(SqlserverDatabaseMetricsBase):
         return self.config.database_metrics_config["index_usage_metrics"]["enabled_tempdb"]
 
     @property
-    def index_usage_object_names(self) -> list[str]:
-        return self.config.index_usage_object_names
+    def index_usage_table_names(self) -> list[str]:
+        return self.config.index_usage_table_names
 
     @property
     def collection_interval(self) -> int:
@@ -106,23 +106,23 @@ class SqlserverIndexUsageMetrics(SqlserverDatabaseMetricsBase):
 
     def _build_query_executors(self):
         executors = []
-        if self.index_usage_object_names:
-            object_name_batches = [
-                self.index_usage_object_names[start : start + SQLSERVER_PARAMETER_LIMIT]
-                for start in range(0, len(self.index_usage_object_names), SQLSERVER_PARAMETER_LIMIT)
+        if self.index_usage_table_names:
+            table_name_batches = [
+                self.index_usage_table_names[start : start + SQLSERVER_PARAMETER_LIMIT]
+                for start in range(0, len(self.index_usage_table_names), SQLSERVER_PARAMETER_LIMIT)
             ]
         else:
-            object_name_batches = [None]
+            table_name_batches = [None]
         for database in self.databases:
             queries = []
-            for object_names in object_name_batches:
+            for table_names in table_name_batches:
                 batch_queries = copy.deepcopy(self.queries)
-                if object_names:
-                    placeholders = ','.join(['?'] * len(object_names))
-                    object_name_filter = f" WHERE o.name IN ({placeholders})"
+                if table_names:
+                    placeholders = ','.join(['?'] * len(table_names))
+                    table_name_filter = f" WHERE o.name IN ({placeholders})"
                     for query in batch_queries:
-                        query['query'] += object_name_filter
-                        query['params'] = tuple(object_names)
+                        query['query'] += table_name_filter
+                        query['params'] = tuple(table_names)
                 queries.extend(batch_queries)
             executor = self.new_query_executor(
                 queries,

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
@@ -14,9 +14,9 @@ INDEX_USAGE_STATS_QUERY = {
     "query": """
     SELECT
         DB_NAME(ixus.database_id) AS db,
-        COALESCE(ind.name, 'HeapIndex_' + OBJECT_NAME(ind.object_id)) AS index_name,
+        COALESCE(ind.name, 'HeapIndex_' + o.name) AS index_name,
         OBJECT_SCHEMA_NAME(ind.object_id, ixus.database_id) AS "schema",
-        OBJECT_NAME(ind.object_id) AS table_name,
+        o.name AS table_name,
         ixus.user_seeks as user_seeks,
         ixus.user_scans as user_scans,
         ixus.user_lookups as user_lookups,
@@ -107,7 +107,7 @@ class SqlserverIndexUsageMetrics(SqlserverDatabaseMetricsBase):
         executors = []
         if self.index_usage_object_names:
             placeholders = ','.join(['?'] * len(self.index_usage_object_names))
-            object_name_filter = f" WHERE OBJECT_NAME(ind.object_id) IN ({placeholders})"
+            object_name_filter = f" WHERE o.name IN ({placeholders})"
         else:
             object_name_filter = None
         for database in self.databases:

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/index_usage_metrics.py
@@ -6,6 +6,7 @@ import copy
 import functools
 
 from datadog_checks.base.errors import ConfigurationError
+from datadog_checks.sqlserver.const import SQLSERVER_PARAMETER_LIMIT
 
 from .base import SqlserverDatabaseMetricsBase
 
@@ -106,16 +107,23 @@ class SqlserverIndexUsageMetrics(SqlserverDatabaseMetricsBase):
     def _build_query_executors(self):
         executors = []
         if self.index_usage_object_names:
-            placeholders = ','.join(['?'] * len(self.index_usage_object_names))
-            object_name_filter = f" WHERE o.name IN ({placeholders})"
+            object_name_batches = [
+                self.index_usage_object_names[start : start + SQLSERVER_PARAMETER_LIMIT]
+                for start in range(0, len(self.index_usage_object_names), SQLSERVER_PARAMETER_LIMIT)
+            ]
         else:
-            object_name_filter = None
+            object_name_batches = [None]
         for database in self.databases:
-            queries = copy.deepcopy(self.queries)
-            if object_name_filter:
-                for query in queries:
-                    query['query'] += object_name_filter
-                    query['params'] = tuple(self.index_usage_object_names)
+            queries = []
+            for object_names in object_name_batches:
+                batch_queries = copy.deepcopy(self.queries)
+                if object_names:
+                    placeholders = ','.join(['?'] * len(object_names))
+                    object_name_filter = f" WHERE o.name IN ({placeholders})"
+                    for query in batch_queries:
+                        query['query'] += object_name_filter
+                        query['params'] = tuple(object_names)
+                queries.extend(batch_queries)
             executor = self.new_query_executor(
                 queries,
                 executor=functools.partial(self.execute_query_handler, db=database),

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/table_size_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/table_size_metrics.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+import copy
 import functools
 
 from datadog_checks.base.errors import ConfigurationError
@@ -63,6 +65,10 @@ class SqlserverTableSizeMetrics(SqlserverDatabaseMetricsBase):
         return self.config.database_metrics_config["table_size_metrics"]["collection_interval"]
 
     @property
+    def table_size_object_names(self) -> list[str]:
+        return self.config.table_size_object_names
+
+    @property
     def databases(self):
         '''
         Returns a list of databases to collect table size metrics for.
@@ -93,9 +99,19 @@ class SqlserverTableSizeMetrics(SqlserverDatabaseMetricsBase):
 
     def _build_query_executors(self):
         executors = []
+        if self.table_size_object_names:
+            placeholders = ','.join(['?'] * len(self.table_size_object_names))
+            object_name_filter = f" WHERE t.name IN ({placeholders})"
+        else:
+            object_name_filter = None
         for database in self.databases:
+            queries = copy.deepcopy(self.queries)
+            if object_name_filter:
+                for query in queries:
+                    query['query'] = query['query'].replace("    GROUP BY", object_name_filter + "\n    GROUP BY")
+                    query['params'] = tuple(self.table_size_object_names)
             executor = self.new_query_executor(
-                self.queries,
+                queries,
                 executor=functools.partial(self.execute_query_handler, db=database),
                 track_operation_time=self.track_operation_time,
             )

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/table_size_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/table_size_metrics.py
@@ -6,6 +6,7 @@ import copy
 import functools
 
 from datadog_checks.base.errors import ConfigurationError
+from datadog_checks.sqlserver.const import SQLSERVER_PARAMETER_LIMIT
 
 from .base import SqlserverDatabaseMetricsBase
 
@@ -100,16 +101,23 @@ class SqlserverTableSizeMetrics(SqlserverDatabaseMetricsBase):
     def _build_query_executors(self):
         executors = []
         if self.table_size_object_names:
-            placeholders = ','.join(['?'] * len(self.table_size_object_names))
-            object_name_filter = f" WHERE t.name IN ({placeholders})"
+            object_name_batches = [
+                self.table_size_object_names[start : start + SQLSERVER_PARAMETER_LIMIT]
+                for start in range(0, len(self.table_size_object_names), SQLSERVER_PARAMETER_LIMIT)
+            ]
         else:
-            object_name_filter = None
+            object_name_batches = [None]
         for database in self.databases:
-            queries = copy.deepcopy(self.queries)
-            if object_name_filter:
-                for query in queries:
-                    query['query'] = query['query'].replace("    GROUP BY", object_name_filter + "\n    GROUP BY")
-                    query['params'] = tuple(self.table_size_object_names)
+            queries = []
+            for object_names in object_name_batches:
+                batch_queries = copy.deepcopy(self.queries)
+                if object_names:
+                    placeholders = ','.join(['?'] * len(object_names))
+                    object_name_filter = f" WHERE t.name IN ({placeholders})"
+                    for query in batch_queries:
+                        query['query'] = query['query'].replace("    GROUP BY", object_name_filter + "\n    GROUP BY")
+                        query['params'] = tuple(object_names)
+                queries.extend(batch_queries)
             executor = self.new_query_executor(
                 queries,
                 executor=functools.partial(self.execute_query_handler, db=database),

--- a/sqlserver/datadog_checks/sqlserver/database_metrics/table_size_metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/database_metrics/table_size_metrics.py
@@ -66,8 +66,8 @@ class SqlserverTableSizeMetrics(SqlserverDatabaseMetricsBase):
         return self.config.database_metrics_config["table_size_metrics"]["collection_interval"]
 
     @property
-    def table_size_object_names(self) -> list[str]:
-        return self.config.table_size_object_names
+    def table_size_table_names(self) -> list[str]:
+        return self.config.table_size_table_names
 
     @property
     def databases(self):
@@ -100,23 +100,23 @@ class SqlserverTableSizeMetrics(SqlserverDatabaseMetricsBase):
 
     def _build_query_executors(self):
         executors = []
-        if self.table_size_object_names:
-            object_name_batches = [
-                self.table_size_object_names[start : start + SQLSERVER_PARAMETER_LIMIT]
-                for start in range(0, len(self.table_size_object_names), SQLSERVER_PARAMETER_LIMIT)
+        if self.table_size_table_names:
+            table_name_batches = [
+                self.table_size_table_names[start : start + SQLSERVER_PARAMETER_LIMIT]
+                for start in range(0, len(self.table_size_table_names), SQLSERVER_PARAMETER_LIMIT)
             ]
         else:
-            object_name_batches = [None]
+            table_name_batches = [None]
         for database in self.databases:
             queries = []
-            for object_names in object_name_batches:
+            for table_names in table_name_batches:
                 batch_queries = copy.deepcopy(self.queries)
-                if object_names:
-                    placeholders = ','.join(['?'] * len(object_names))
-                    object_name_filter = f" WHERE t.name IN ({placeholders})"
+                if table_names:
+                    placeholders = ','.join(['?'] * len(table_names))
+                    table_name_filter = f" WHERE t.name IN ({placeholders})"
                     for query in batch_queries:
-                        query['query'] = query['query'].replace("    GROUP BY", object_name_filter + "\n    GROUP BY")
-                        query['params'] = tuple(object_names)
+                        query['query'] = query['query'].replace("    GROUP BY", table_name_filter + "\n    GROUP BY")
+                        query['params'] = tuple(table_names)
                 queries.extend(batch_queries)
             executor = self.new_query_executor(
                 queries,

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -63,7 +63,6 @@ AUTODISCOVERY_FILTERED_INSTANCE_METRICS = [
     'sqlserver.database.user_access',
     'sqlserver.database.backup_count',
 ]
-SQLSERVER_PARAMETER_LIMIT = 2100
 
 
 @pytest.mark.unit

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -1211,11 +1211,12 @@ def test_sqlserver_index_usage_metrics_object_names(
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
 
     def execute_query_handler_mocked(query, db=None, params=None):
+        assert "OBJECT_NAME(" not in query
         if object_names:
-            assert "OBJECT_NAME(ind.object_id) IN (?)" in query
+            assert "WHERE o.name IN (?)" in query
             assert params == tuple(object_names)
             return [row for row in mocked_results if row[3] in params]
-        assert "OBJECT_NAME(ind.object_id) IN" not in query
+        assert "WHERE o.name IN" not in query
         assert params is None
         return mocked_results
 

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -13,6 +13,7 @@ from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.const import (
     ENGINE_EDITION_AZURE_MANAGED_INSTANCE,
     ENGINE_EDITION_SQL_DATABASE,
+    SQLSERVER_PARAMETER_LIMIT,
     STATIC_INFO_ENGINE_EDITION,
     STATIC_INFO_MAJOR_VERSION,
     STATIC_INFO_SERVERNAME,
@@ -1911,6 +1912,57 @@ def test_sqlserver_table_size_metrics_object_names(
             if tag.startswith('table:')
         }
         assert emitted_tables == expected_tables
+
+
+@pytest.mark.parametrize(
+    'metrics_class, database_metrics_config, object_names_option, object_name_filter',
+    [
+        pytest.param(
+            SqlserverIndexUsageMetrics,
+            {'index_usage_metrics': {'enabled': True, 'enabled_tempdb': False}},
+            'index_usage_object_names',
+            'WHERE o.name IN',
+            id='index-usage',
+        ),
+        pytest.param(
+            SqlserverTableSizeMetrics,
+            {'table_size_metrics': {'enabled': True}},
+            'table_size_object_names',
+            'WHERE t.name IN',
+            id='table-size',
+        ),
+    ],
+)
+def test_object_name_filters_stay_within_parameter_limit(
+    init_config,
+    instance_docker_metrics,
+    metrics_class,
+    database_metrics_config,
+    object_names_option,
+    object_name_filter,
+):
+    object_names = [f'table_{n}' for n in range(SQLSERVER_PARAMETER_LIMIT + 1)]
+    instance_docker_metrics['database_metrics'] = database_metrics_config
+    instance_docker_metrics[object_names_option] = object_names
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+    query_configs = []
+
+    def new_query_executor(queries: list[dict], **_kwargs) -> mock.Mock:
+        query_configs.extend(queries)
+        return mock.Mock()
+
+    metrics = metrics_class(
+        config=sqlserver_check._config,
+        new_query_executor=new_query_executor,
+        server_static_info=STATIC_SERVER_INFO,
+        execute_query_handler=mock.Mock(),
+        databases=['master'],
+    )
+
+    assert len(metrics._build_query_executors()) == 1
+    assert [len(query['params']) for query in query_configs] == [SQLSERVER_PARAMETER_LIMIT, 1]
+    assert [name for query in query_configs for name in query['params']] == object_names
+    assert all(object_name_filter in query['query'] for query in query_configs)
 
 
 @pytest.mark.integration

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -1181,6 +1181,65 @@ def test_sqlserver_index_usage_metrics(
         aggregator.assert_metric(metric_name, count=0)
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize(
+    'object_names, expected_tables',
+    [
+        pytest.param([], {'some_table', 'other_table'}, id='unbounded'),
+        pytest.param(['some_table'], {'some_table'}, id='bounded'),
+    ],
+)
+def test_sqlserver_index_usage_metrics_object_names(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+    object_names,
+    expected_tables,
+):
+    instance_docker_metrics['database_autodiscovery'] = True
+    instance_docker_metrics['database_metrics'] = {
+        'index_usage_metrics': {'enabled': True, 'enabled_tempdb': False},
+    }
+    instance_docker_metrics['index_usage_object_names'] = object_names
+    mocked_results = [
+        ('master', 'some_index', 'dbo', 'some_table', 10, 20, 30, 40),
+        ('master', 'other_index', 'dbo', 'other_table', 50, 60, 70, 80),
+    ]
+
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+
+    def execute_query_handler_mocked(query, db=None, params=None):
+        if object_names:
+            assert "OBJECT_NAME(ind.object_id) IN (?)" in query
+            assert params == tuple(object_names)
+            return [row for row in mocked_results if row[3] in params]
+        assert "OBJECT_NAME(ind.object_id) IN" not in query
+        assert params is None
+        return mocked_results
+
+    index_usage_metrics = SqlserverIndexUsageMetrics(
+        config=sqlserver_check._config,
+        new_query_executor=sqlserver_check._new_query_executor,
+        server_static_info=STATIC_SERVER_INFO,
+        execute_query_handler=execute_query_handler_mocked,
+        databases=['master'],
+    )
+    sqlserver_check._database_metrics = [index_usage_metrics]
+
+    dd_run_check(sqlserver_check)
+
+    for metric_name in index_usage_metrics.metric_names()[0]:
+        emitted_tables = {
+            tag.split(':', 1)[1]
+            for metric in aggregator.metrics(metric_name)
+            for tag in metric.tags
+            if tag.startswith('table:')
+        }
+        assert emitted_tables == expected_tables
+
+
 def test_sqlserver_db_fragmentation_query_uses_parameterized_queries(init_config, instance_docker_metrics):
     instance_docker_metrics['database_autodiscovery'] = True
     instance_docker_metrics['database_metrics'] = {
@@ -1792,6 +1851,65 @@ def test_sqlserver_table_size_metrics(
             # check that the aggregator got the mocked metrics
             for metric_name, metric_value in metrics:
                 aggregator.assert_metric(metric_name, value=metric_value, tags=expected_tags)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize(
+    'object_names, expected_tables',
+    [
+        pytest.param([], {'table1', 'table2'}, id='unbounded'),
+        pytest.param(['table1'], {'table1'}, id='bounded'),
+    ],
+)
+def test_sqlserver_table_size_metrics_object_names(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+    object_names,
+    expected_tables,
+):
+    instance_docker_metrics['database_autodiscovery'] = True
+    instance_docker_metrics['database_metrics'] = {
+        'table_size_metrics': {'enabled': True},
+    }
+    instance_docker_metrics['table_size_object_names'] = object_names
+    mocked_results = [
+        ('table1', 'dbo', 'master', 100, 1024, 500, 200),
+        ('table2', 'dbo', 'master', 200, 2048, 1000, 400),
+    ]
+
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+
+    def execute_query_handler_mocked(query, db=None, params=None):
+        if object_names:
+            assert "WHERE t.name IN (?)" in query
+            assert params == tuple(object_names)
+            return [row for row in mocked_results if row[0] in params]
+        assert "WHERE t.name IN" not in query
+        assert params is None
+        return mocked_results
+
+    table_size_metrics = SqlserverTableSizeMetrics(
+        config=sqlserver_check._config,
+        new_query_executor=sqlserver_check._new_query_executor,
+        server_static_info=STATIC_SERVER_INFO,
+        execute_query_handler=execute_query_handler_mocked,
+        databases=['master'],
+    )
+    sqlserver_check._database_metrics = [table_size_metrics]
+
+    dd_run_check(sqlserver_check)
+
+    for metric_name in table_size_metrics.metric_names()[0]:
+        emitted_tables = {
+            tag.split(':', 1)[1]
+            for metric in aggregator.metrics(metric_name)
+            for tag in metric.tags
+            if tag.startswith('table:')
+        }
+        assert emitted_tables == expected_tables
 
 
 @pytest.mark.integration

--- a/sqlserver/tests/test_database_metrics.py
+++ b/sqlserver/tests/test_database_metrics.py
@@ -1185,25 +1185,25 @@ def test_sqlserver_index_usage_metrics(
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
-    'object_names, expected_tables',
+    'table_names, expected_tables',
     [
         pytest.param([], {'some_table', 'other_table'}, id='unbounded'),
         pytest.param(['some_table'], {'some_table'}, id='bounded'),
     ],
 )
-def test_sqlserver_index_usage_metrics_object_names(
+def test_sqlserver_index_usage_metrics_table_names(
     aggregator,
     dd_run_check,
     init_config,
     instance_docker_metrics,
-    object_names,
+    table_names,
     expected_tables,
 ):
     instance_docker_metrics['database_autodiscovery'] = True
     instance_docker_metrics['database_metrics'] = {
         'index_usage_metrics': {'enabled': True, 'enabled_tempdb': False},
     }
-    instance_docker_metrics['index_usage_object_names'] = object_names
+    instance_docker_metrics['index_usage_table_names'] = table_names
     mocked_results = [
         ('master', 'some_index', 'dbo', 'some_table', 10, 20, 30, 40),
         ('master', 'other_index', 'dbo', 'other_table', 50, 60, 70, 80),
@@ -1213,9 +1213,9 @@ def test_sqlserver_index_usage_metrics_object_names(
 
     def execute_query_handler_mocked(query, db=None, params=None):
         assert "OBJECT_NAME(" not in query
-        if object_names:
+        if table_names:
             assert "WHERE o.name IN (?)" in query
-            assert params == tuple(object_names)
+            assert params == tuple(table_names)
             return [row for row in mocked_results if row[3] in params]
         assert "WHERE o.name IN" not in query
         assert params is None
@@ -1858,25 +1858,25 @@ def test_sqlserver_table_size_metrics(
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
-    'object_names, expected_tables',
+    'table_names, expected_tables',
     [
         pytest.param([], {'table1', 'table2'}, id='unbounded'),
         pytest.param(['table1'], {'table1'}, id='bounded'),
     ],
 )
-def test_sqlserver_table_size_metrics_object_names(
+def test_sqlserver_table_size_metrics_table_names(
     aggregator,
     dd_run_check,
     init_config,
     instance_docker_metrics,
-    object_names,
+    table_names,
     expected_tables,
 ):
     instance_docker_metrics['database_autodiscovery'] = True
     instance_docker_metrics['database_metrics'] = {
         'table_size_metrics': {'enabled': True},
     }
-    instance_docker_metrics['table_size_object_names'] = object_names
+    instance_docker_metrics['table_size_table_names'] = table_names
     mocked_results = [
         ('table1', 'dbo', 'master', 100, 1024, 500, 200),
         ('table2', 'dbo', 'master', 200, 2048, 1000, 400),
@@ -1885,9 +1885,9 @@ def test_sqlserver_table_size_metrics_object_names(
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
 
     def execute_query_handler_mocked(query, db=None, params=None):
-        if object_names:
+        if table_names:
             assert "WHERE t.name IN (?)" in query
-            assert params == tuple(object_names)
+            assert params == tuple(table_names)
             return [row for row in mocked_results if row[0] in params]
         assert "WHERE t.name IN" not in query
         assert params is None
@@ -1915,35 +1915,35 @@ def test_sqlserver_table_size_metrics_object_names(
 
 
 @pytest.mark.parametrize(
-    'metrics_class, database_metrics_config, object_names_option, object_name_filter',
+    'metrics_class, database_metrics_config, table_names_option, table_name_filter',
     [
         pytest.param(
             SqlserverIndexUsageMetrics,
             {'index_usage_metrics': {'enabled': True, 'enabled_tempdb': False}},
-            'index_usage_object_names',
+            'index_usage_table_names',
             'WHERE o.name IN',
             id='index-usage',
         ),
         pytest.param(
             SqlserverTableSizeMetrics,
             {'table_size_metrics': {'enabled': True}},
-            'table_size_object_names',
+            'table_size_table_names',
             'WHERE t.name IN',
             id='table-size',
         ),
     ],
 )
-def test_object_name_filters_stay_within_parameter_limit(
+def test_table_name_filters_stay_within_parameter_limit(
     init_config,
     instance_docker_metrics,
     metrics_class,
     database_metrics_config,
-    object_names_option,
-    object_name_filter,
+    table_names_option,
+    table_name_filter,
 ):
-    object_names = [f'table_{n}' for n in range(SQLSERVER_PARAMETER_LIMIT + 1)]
+    table_names = [f'table_{n}' for n in range(SQLSERVER_PARAMETER_LIMIT + 1)]
     instance_docker_metrics['database_metrics'] = database_metrics_config
-    instance_docker_metrics[object_names_option] = object_names
+    instance_docker_metrics[table_names_option] = table_names
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
     query_configs = []
 
@@ -1961,8 +1961,8 @@ def test_object_name_filters_stay_within_parameter_limit(
 
     assert len(metrics._build_query_executors()) == 1
     assert [len(query['params']) for query in query_configs] == [SQLSERVER_PARAMETER_LIMIT, 1]
-    assert [name for query in query_configs for name in query['params']] == object_names
-    assert all(object_name_filter in query['query'] for query in query_configs)
+    assert [name for query in query_configs for name in query['params']] == table_names
+    assert all(table_name_filter in query['query'] for query in query_configs)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### What does this PR do?

Adds two optional configuration options that bound the table sets scanned by the two highest-fan-out database metric collectors:

- `index_usage_table_names`, applied to `index_usage_metrics`
- `table_size_table_names`, applied to `table_size_metrics`

When unset, behavior is unchanged. When set, the collector filters to the named tables. For index usage, these are table names—not index names—and metrics are collected for every index belonging to each matching table. This mirrors the existing `db_fragmentation_object_names` option, which provides the same escape hatch for the third high-fan-out collector; that legacy option also accepts table names despite its broader name. Postgres offers the equivalent lever as `relations`, whose own documentation warns that "patterns that match many relations can emit metrics in the thousands."

#### Measured effect

Sample volume scales with schema size, which is the fan-out being bounded (15-database pool):

| tables/db | tables | indexes | samples | samples/db |
|---|---|---|---|---|
| 2 | 45 | 120 | 809 | 53.9 |
| 20 | 315 | 930 | 5,129 | 341.9 |
| 100 | 1,515 | 4,530 | 24,329 | 1,621.9 |
| 300 | 4,515 | 13,530 | 72,329 | 4,821.9 |

Bounding on the 300-table pool (15 databases x 301 tables):

| bound | total samples | `table.row_count` | `fragment_count` |
|---|---|---|---|
| unset | 72,328 | 4,515 | 13,530 |
| 10 names | 2,488 | 150 | 435 |
| 3 names | **808** | **45** | **120** |

And on a partitioned pool (5 databases x 10 tables, 1,200 index partitions), confirming the filter reaches partitioned indexes:

| bound | total samples | `table.row_count` | `fragment_count` |
|---|---|---|---|
| unset | 5,078 | 50 | 1,200 |
| 3 names | **1,578** | **15** | **360** |

Sample counts land exactly where the configuration predicts — 45 = 15 databases x 3 tables, 15 = 5 x 3, and fragmentation falls to 3/10 of unbounded on the partitioned pool. **A 3-name bound cuts the wide pool by 89x.**

### Motivation

These collectors emit four samples per index and four per table respectively, giving a floor of roughly 28 samples per table before partitioning is taken into account. On instances with large schemas this produces both very large sample volumes and very large result sets, and row volume is the dominant cost: a separate experiment showed the check's `dm_os_performance_counters` query inflating 18.79x across 16 threads but only 2.25x across 16 processes with the server held constant, which places the serialization in CPython's GIL while pyodbc materializes rows rather than in SQL Server.

The failure this addresses is also directly reproducible. On a bench instance with 3,586 autodiscovered databases, an unmodified check produces:

```
Error querying sys.dm_db_index_usage_stats: [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]
There is insufficient system memory in resource pool 'default' to run this query. (701)
```

Bounding the table set is the only lever that reduces row volume without disabling the collector outright. Today a user can reach for that lever on fragmentation metrics but not on the other two, which is the inconsistency this closes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
