### PR TITLE
Make SQL Server database_metrics.instance_metrics.enabled gate collection

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -488,7 +488,7 @@ files:
           fleet_configurable: false
     - name: include_instance_metrics
       deprecation:
-        Agent version: 7.80.0
+        Agent version: 7.84.0
         Migration: Use `database_metrics.instance_metrics.enabled` instead.
       description: |
         DEPRECATED: Use `database_metrics.instance_metrics.enabled` instead.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -486,6 +486,17 @@ files:
               example: 600
               display_default: 600
           fleet_configurable: false
+    - name: include_instance_metrics
+      deprecation:
+        Agent version: 7.80.0
+        Migration: Use `database_metrics.instance_metrics.enabled` instead.
+      description: |
+        DEPRECATED: Use `database_metrics.instance_metrics.enabled` instead.
+        Enable collection of server-level instance metrics. Defaults to true.
+      value:
+        type: boolean
+        example: true
+      fleet_configurable: false
     - name: agent_jobs
       description: Configure collection of SQL Server Agent jobs events and metrics
       options:

--- a/sqlserver/changelog.d/24953.deprecated
+++ b/sqlserver/changelog.d/24953.deprecated
@@ -1,0 +1,1 @@
+Deprecate ``include_instance_metrics`` in favor of ``database_metrics.instance_metrics.enabled``.

--- a/sqlserver/changelog.d/24953.fixed
+++ b/sqlserver/changelog.d/24953.fixed
@@ -1,0 +1,1 @@
+Make ``database_metrics.instance_metrics.enabled`` gate instance metric collection instead of being ignored.

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -283,6 +283,13 @@ class SQLServerConfig:
             for key, value in metric_config.items():
                 if value is not None:
                     config[key] = value
+
+        legacy_instance_metrics = instance.get('include_instance_metrics')
+        instance_metrics = database_metrics.get('instance_metrics', {}).get('enabled')
+        if (legacy_instance_metrics is not None and not is_affirmative(legacy_instance_metrics)) or (
+            instance_metrics is not None and not is_affirmative(instance_metrics)
+        ):
+            configurable_metrics['instance_metrics']['enabled'] = False
         return configurable_metrics
 
     def _validate_only_custom_queries(self, instance):

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -72,6 +72,10 @@ def instance_ignore_missing_database():
     return False
 
 
+def instance_include_instance_metrics():
+    return True
+
+
 def instance_log_unobfuscated_plans():
     return False
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/deprecations.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/deprecations.py
@@ -7,7 +7,7 @@ def instance():
     return {
         'deadlocks_collection': {'Agent version': '7.69.0', 'Migration': 'Use `collect_deadlocks` instead.'},
         'include_instance_metrics': {
-            'Agent version': '7.80.0',
+            'Agent version': '7.84.0',
             'Migration': 'Use `database_metrics.instance_metrics.enabled` instead.',
         },
         'schemas_collection': {'Agent version': '7.69.0', 'Migration': 'Use `collect_schemas` instead.'},

--- a/sqlserver/datadog_checks/sqlserver/config_models/deprecations.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/deprecations.py
@@ -6,6 +6,10 @@
 def instance():
     return {
         'deadlocks_collection': {'Agent version': '7.69.0', 'Migration': 'Use `collect_deadlocks` instead.'},
+        'include_instance_metrics': {
+            'Agent version': '7.80.0',
+            'Migration': 'Use `database_metrics.instance_metrics.enabled` instead.',
+        },
         'schemas_collection': {'Agent version': '7.69.0', 'Migration': 'Use `collect_schemas` instead.'},
         'xe_collection': {'Agent version': '7.69.0', 'Migration': 'Use `collect_xe` instead.'},
     }

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -519,6 +519,7 @@ class InstanceConfig(BaseModel):
     gcp: Optional[Gcp] = None
     host: str
     ignore_missing_database: Optional[bool] = None
+    include_instance_metrics: Optional[bool] = None
     log_unobfuscated_plans: Optional[bool] = None
     log_unobfuscated_queries: Optional[bool] = None
     managed_identity: Optional[ManagedIdentity] = None
@@ -547,19 +548,25 @@ class InstanceConfig(BaseModel):
     @model_validator(mode='before')
     def _handle_deprecations(cls, values, info):
         fields = info.context['configured_fields']
-        validation.utils.handle_deprecations('instances', deprecations.instance(), fields, info.context)
+        validation.utils.handle_deprecations(
+            'instances', deprecations.instance(), fields, info.context
+        )
         return values
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):
-        return validation.core.initialize_config(getattr(validators, 'initialize_instance', identity)(values))
+        return validation.core.initialize_config(
+            getattr(validators, 'initialize_instance', identity)(values)
+        )
 
     @field_validator('*', mode='before')
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
-            value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
+            value = getattr(validators, f'instance_{info.field_name}', identity)(
+                value, field=field
+            )
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 
@@ -567,4 +574,6 @@ class InstanceConfig(BaseModel):
 
     @model_validator(mode='after')
     def _final_validation(cls, model):
-        return validation.core.check_model(getattr(validators, 'check_instance', identity)(model))
+        return validation.core.check_model(
+            getattr(validators, 'check_instance', identity)(model)
+        )

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -548,25 +548,19 @@ class InstanceConfig(BaseModel):
     @model_validator(mode='before')
     def _handle_deprecations(cls, values, info):
         fields = info.context['configured_fields']
-        validation.utils.handle_deprecations(
-            'instances', deprecations.instance(), fields, info.context
-        )
+        validation.utils.handle_deprecations('instances', deprecations.instance(), fields, info.context)
         return values
 
     @model_validator(mode='before')
     def _initial_validation(cls, values):
-        return validation.core.initialize_config(
-            getattr(validators, 'initialize_instance', identity)(values)
-        )
+        return validation.core.initialize_config(getattr(validators, 'initialize_instance', identity)(values))
 
     @field_validator('*', mode='before')
     def _validate(cls, value, info):
         field = cls.model_fields[info.field_name]
         field_name = field.alias or info.field_name
         if field_name in info.context['configured_fields']:
-            value = getattr(validators, f'instance_{info.field_name}', identity)(
-                value, field=field
-            )
+            value = getattr(validators, f'instance_{info.field_name}', identity)(value, field=field)
         else:
             value = getattr(defaults, f'instance_{info.field_name}', lambda: value)()
 
@@ -574,6 +568,4 @@ class InstanceConfig(BaseModel):
 
     @model_validator(mode='after')
     def _final_validation(cls, model):
-        return validation.core.check_model(
-            getattr(validators, 'check_instance', identity)(model)
-        )
+        return validation.core.check_model(getattr(validators, 'check_instance', identity)(model))

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -308,7 +308,7 @@ instances:
     ##
     ## <<< DEPRECATED >>>
     ##
-    ## Agent version: 7.80.0
+    ## Agent version: 7.84.0
     ## Migration: Use `database_metrics.instance_metrics.enabled` instead.
     #
     # include_instance_metrics: true

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -301,6 +301,18 @@ instances:
         #
         # table_size_metrics: {}
 
+    ## @param include_instance_metrics - boolean - optional - default: true
+    ## DEPRECATED: Use `database_metrics.instance_metrics.enabled` instead.
+    ## Enable collection of server-level instance metrics. Defaults to true.
+    ##
+    ##
+    ## <<< DEPRECATED >>>
+    ##
+    ## Agent version: 7.80.0
+    ## Migration: Use `database_metrics.instance_metrics.enabled` instead.
+    #
+    # include_instance_metrics: true
+
     ## Configure collection of SQL Server Agent jobs events and metrics
     #
     # agent_jobs:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -625,7 +625,7 @@ class SQLServer(DatabaseCheck):
         # Load instance-level (previously Performance metrics)
         # If several check instances are querying the same server host, it can be wise to turn these off
         # to avoid sending duplicate metrics
-        if is_affirmative(self.instance.get("include_instance_metrics", True)):
+        if is_affirmative(self._config.database_metrics_config['instance_metrics']['enabled']):
             common_metrics = list(INSTANCE_METRICS)
             if year and year >= 2016:
                 common_metrics.extend(INSTANCE_METRICS_NEWER_2016)

--- a/sqlserver/tests/test_metrics.py
+++ b/sqlserver/tests/test_metrics.py
@@ -22,8 +22,10 @@ from datadog_checks.sqlserver.const import (
     DATABASE_STATS_METRICS,
     DBM_MIGRATED_METRICS,
     INSTANCE_METRICS,
+    INSTANCE_METRICS_DATABASE,
     INSTANCE_METRICS_DATABASE_AO,
     INSTANCE_METRICS_DATABASE_SINGLE,
+    INSTANCE_METRICS_NEWER_2016,
     OS_SCHEDULER_METRICS,
     SERVICE_CHECK_NAME,
     STATIC_INFO_SERVERNAME,
@@ -45,6 +47,15 @@ from .utils import always_on, is_always_on, not_windows_ci
 
 INCR_FRACTION_METRICS = {'sqlserver.latches.latch_waits'}
 AUTODISCOVERY_DBS = ['master', 'msdb', 'datadog_test-1']
+INSTANCE_METRIC_NAMES = {
+    metric_name
+    for metric_name, _, _, _ in (
+        INSTANCE_METRICS + INSTANCE_METRICS_NEWER_2016 + DBM_MIGRATED_METRICS + INSTANCE_METRICS_DATABASE
+    )
+}
+EXPECTED_INSTANCE_METRIC_NAMES = {
+    metric_name for metric_name, _, _, _ in INSTANCE_METRICS + INSTANCE_METRICS_DATABASE_SINGLE
+} - INCR_FRACTION_METRICS
 
 
 @pytest.mark.integration
@@ -74,45 +85,81 @@ def test_check_server_metrics(
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-@pytest.mark.parametrize("dbm_enabled", [True, False])
-def test_check_instance_metrics(
+@pytest.mark.parametrize('enabled', [True, False])
+@pytest.mark.parametrize('dbm_enabled', [True, False])
+def test_legacy_instance_metrics_option(
     aggregator,
     dd_run_check,
     init_config,
     instance_docker_metrics,
+    enabled,
     dbm_enabled,
 ):
     instance_docker_metrics['database_autodiscovery'] = False
     instance_docker_metrics['dbm'] = dbm_enabled
-    instance_docker_metrics['include_instance_metrics'] = True
+    instance_docker_metrics['include_instance_metrics'] = enabled
 
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
     dd_run_check(sqlserver_check)
 
-    tags = sqlserver_check._config.tags + [
-        "database_hostname:{}".format("stubbed.hostname"),
-        "database_instance:{}".format("stubbed.hostname"),
-        "dd.internal.resource:database_instance:{}".format("stubbed.hostname"),
-        "sqlserver_servername:{}".format(sqlserver_check.static_info_cache[STATIC_INFO_SERVERNAME].lower()),
-    ]
+    emitted_instance_metrics = set(aggregator.metric_names) & INSTANCE_METRIC_NAMES
+    if enabled:
+        assert EXPECTED_INSTANCE_METRIC_NAMES <= emitted_instance_metrics
+        if not dbm_enabled:
+            assert {metric_name for metric_name, _, _, _ in DBM_MIGRATED_METRICS} <= emitted_instance_metrics
+    else:
+        assert emitted_instance_metrics == set()
 
-    check_sqlserver_can_connect(
-        aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags, False
-    )
 
-    for metric_name, _, _, _ in INSTANCE_METRICS:
-        # TODO: we should find a better way to test these metrics
-        # remove SQL Server incremental sql fraction metrics for now
-        if metric_name in INCR_FRACTION_METRICS:
-            continue
-        aggregator.assert_metric(metric_name, tags=tags, hostname=sqlserver_check.resolved_hostname, count=1)
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize('enabled', [True, False])
+def test_database_instance_metrics_option(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+    enabled,
+):
+    instance_docker_metrics['database_autodiscovery'] = False
+    instance_docker_metrics['database_metrics'] = {'instance_metrics': {'enabled': enabled}}
 
-    for metric_name, _, _, _ in INSTANCE_METRICS_DATABASE_SINGLE:
-        aggregator.assert_metric(metric_name, tags=tags, hostname=sqlserver_check.resolved_hostname, count=1)
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+    dd_run_check(sqlserver_check)
 
-    if not dbm_enabled:
-        for metric_name, _, _, _ in DBM_MIGRATED_METRICS:
-            aggregator.assert_metric(metric_name, tags=tags, hostname=sqlserver_check.resolved_hostname, count=1)
+    emitted_instance_metrics = set(aggregator.metric_names) & INSTANCE_METRIC_NAMES
+    if enabled:
+        assert EXPECTED_INSTANCE_METRIC_NAMES <= emitted_instance_metrics
+    else:
+        assert emitted_instance_metrics == set()
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize(
+    'legacy_enabled, documented_enabled',
+    [(True, True), (True, False), (False, True), (False, False)],
+)
+def test_instance_metrics_options_agree(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+    legacy_enabled,
+    documented_enabled,
+):
+    instance_docker_metrics['database_autodiscovery'] = False
+    instance_docker_metrics['include_instance_metrics'] = legacy_enabled
+    instance_docker_metrics['database_metrics'] = {'instance_metrics': {'enabled': documented_enabled}}
+
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+    dd_run_check(sqlserver_check)
+
+    emitted_instance_metrics = set(aggregator.metric_names) & INSTANCE_METRIC_NAMES
+    if legacy_enabled and documented_enabled:
+        assert EXPECTED_INSTANCE_METRIC_NAMES <= emitted_instance_metrics
+    else:
+        assert emitted_instance_metrics == set()
 
 
 @pytest.mark.integration

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -1587,6 +1587,20 @@ def test_database_identifier(instance_docker, template, expected, tags):
     assert check.database_identifier == expected
 
 
+def test_legacy_instance_metrics_option_emits_deprecation_warning(instance_docker_defaults):
+    instance_docker_defaults['include_instance_metrics'] = True
+    check = SQLServer(CHECK_NAME, {}, [instance_docker_defaults])
+
+    check.load_configuration_models()
+
+    assert check.warnings == [
+        """Option `include_instance_metrics` in `instances` is deprecated ->
+Agent version: 7.80.0
+Migration: Use `database_metrics.instance_metrics.enabled` instead.
+"""
+    ]
+
+
 def test_only_custom_queries_validation_warnings(caplog):
     """Test that appropriate warning logs are emitted when only_custom_queries conflicts with other configurations."""
     from datadog_checks.sqlserver.config import SQLServerConfig

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -1595,7 +1595,7 @@ def test_legacy_instance_metrics_option_emits_deprecation_warning(instance_docke
 
     assert check.warnings == [
         """Option `include_instance_metrics` in `instances` is deprecated ->
-Agent version: 7.80.0
+Agent version: 7.84.0
 Migration: Use `database_metrics.instance_metrics.enabled` instead.
 """
     ]


### PR DESCRIPTION
### What does this PR do?

Makes `database_metrics.instance_metrics.enabled` actually gate instance metric collection, and marks the legacy `include_instance_metrics` option as deprecated in favor of it.

#### Measured effect

Three configurations against the same bench instance, expected fan-out 1,400 samples:

| configuration | master samples | this PR |
|---|---|---|
| `instance_metrics.enabled: true` | 1,477 | 878 |
| `instance_metrics.enabled: false` | 1,477 (**no effect**) | **0** |
| legacy `include_instance_metrics: false` | 1,400 | 0 |

**The documented option goes from inert to working.** On master, setting it to `false` produced byte-identical output to setting it to `true`; on this branch it emits zero samples and zero residual metric names. The legacy option continues to work, so nobody's existing configuration changes meaning.

### Motivation

The documented switch is currently inert. A user following the current documentation to turn instance metrics off gets no effect and no warning — the check keeps collecting and they keep paying for it, with nothing in the logs to suggest the option was ignored.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [x] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
