### PR TITLE
Bump stamina to 26.1.0 in ddev

### DIFF
--- a/ddev/changelog.d/24960.fixed
+++ b/ddev/changelog.d/24960.fixed
@@ -1,0 +1,1 @@
+Bump stamina from 23.2.0 to 26.1.0.

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "jsonpointer",
     "pluggy",
     "rich>=12.5.1",
-    "stamina==23.2.0",
+    "stamina==26.1.0",
     "tomli; python_version < '3.11'",
     "tomli-w",
     "tomlkit",


### PR DESCRIPTION
### What does this PR do?

Bumps ddev's `stamina` pin from 23.2.0 to 26.1.0. No code changes: the only usage in ddev is the `@stamina.retry(on=RuntimeError, attempts=3)` decorator in `ddev/src/ddev/e2e/agent/docker.py`, and that signature is unchanged across all releases in between. The resolved `tenacity` version is unchanged (9.1.4).

### Motivation

Groundwork for adding a real retry strategy to the async GitHub client used by the Dispatcher. On 23.2.0 the `on` argument only accepts exception types, so "retry this 503 but not this 422" cannot be expressed. Later releases add what that work needs:

- 24.2.0: `RetryingCaller` / `AsyncRetryingCaller`
- 24.3.0: `on` accepts a predicate, and `set_testing()` for deterministic tests
- 25.1.0: `set_testing()` usable as a context manager
- 25.2.0: an `on` hook can return a custom backoff

Doing the bump on its own keeps it out of the diff of the retry work.

#### Why the changelog entry is `fixed` and not `changed`

`changed` means backward-incompatible, and it bumps ddev's major version. Nothing here breaks, so a major bump would be noise:

- The single call site passes only `on` and `attempts`. Every other parameter comes from the defaults, and those are identical in both versions (`attempts=10`, `timeout=45.0`, `wait_initial=0.1`, `wait_max=5.0`, `wait_jitter=1.0`). The one difference is `wait_exp_base`, `2.0` in 23.2.0 and `2` in 26.1.0, an overflow fix that is numerically the same and that we do not pass anyway.
- The breaking changes in that span do not reach us: 25.2.0 dropped Python 3.8/3.9 (ddev requires >= 3.13), and 26.1.0 warns on `timeout=0` (we never pass `timeout`). Everything else in between is additive.
- Nothing else in the repo pins or imports stamina, and ddev does not re-export it, so no consumer can observe the change.

This also matches the closer precedent in `ddev/CHANGELOG.md`, where "Bump requests to 2.34.2" and "Bump the pinned embedded Python version" are both under Fixed. The two dependency bumps filed under Changed are `datadog-checks-dev` pin widenings, which do change what ddev pulls in for its users.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
