### PR TITLE
Make a worker-thread submission reach the event bus

### DIFF
--- a/ddev/changelog.d/24962.fixed
+++ b/ddev/changelog.d/24962.fixed
@@ -1,0 +1,1 @@
+Fix a message submitted from a worker thread being lost, leaving the event bus running until its timeout.

--- a/ddev/src/ddev/event_bus/exceptions.py
+++ b/ddev/src/ddev/event_bus/exceptions.py
@@ -21,7 +21,7 @@ class HookName(StrEnum):
 
 class ProcessorQueueError(Exception):
     """
-    Exception raised when a processor queue is not initialized.
+    Exception raised when a processor has not been registered in an event bus.
     """
 
     pass

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -48,20 +48,11 @@ class BaseMessage:
     id: str
 
 
-def running_loop() -> asyncio.AbstractEventLoop | None:
-    """The loop running on this thread, or ``None`` outside one."""
-    try:
-        return asyncio.get_running_loop()
-    except RuntimeError:
-        return None
-
-
 class BaseProcessor[T: BaseMessage]:
     def __init__(self, name: str):
         self.name = name
-        self.queue: asyncio.Queue[BaseMessage] | None = None
-        # Both set by the bus: the queue at registration, the loop when the bus starts.
-        self.loop: asyncio.AbstractEventLoop | None = None
+        # Set by the bus at registration.
+        self.bus: EventBusOrchestrator | None = None
 
     async def on_success(self, message: T) -> None:
         pass
@@ -86,27 +77,11 @@ class BaseProcessor[T: BaseMessage]:
         raise error
 
     def submit_message(self, message: BaseMessage) -> None:
-        """Put *message* on the bus, from any thread.
-
-        A ``SyncProcessor`` runs in an executor thread, and ``asyncio.Queue`` is not thread-safe: a
-        put landing between ``get``'s ``empty()`` check and its waiter being registered wakes nobody,
-        leaving the bus spinning on a message it never reads. Such a put is handed to the loop
-        thread instead. A caller already on that thread, or with no live loop to hand it to, puts
-        directly, so the message is queued by the time this returns.
-        """
-        if self.queue is None:
+        """Put *message* on the bus this processor was registered in, from any thread."""
+        if self.bus is None:
             raise ProcessorQueueError("This processor has not been added to an active event bus")
 
-        # ``asyncio.run`` closes the loop when the bus stops, and a stopped bus is queued into
-        # directly, as it was before there was a loop to hop onto.
-        if self.loop is None or self.loop.is_closed() or running_loop() is self.loop:
-            self.queue.put_nowait(message)
-            return
-
-        try:
-            self.loop.call_soon_threadsafe(self.queue.put_nowait, message)
-        except RuntimeError as error:
-            raise ProcessorQueueError("The event bus is no longer running") from error
+        self.bus.submit_message(message)
 
     def should_process_message(self, message: BaseMessage) -> bool:
         return True
@@ -168,6 +143,7 @@ class EventBusOrchestrator(ABC):
         # These will be initialized in the running loop
         self._queue = asyncio.Queue[BaseMessage]()
         self._running = False
+        self._loop: asyncio.AbstractEventLoop | None = None
 
     def __validate_parameters(self, max_timeout: float, grace_period: float):
         """
@@ -182,19 +158,23 @@ class EventBusOrchestrator(ABC):
 
     def register_processor[T: BaseMessage](self, processor: Processor[T], message_types: list[type[T]]):
         """Registers a processor to receive specific message types."""
-        processor.queue = self._queue
-        # Registering while the bus runs — from `on_initialize`, say — still needs the loop, or a
-        # `SyncProcessor` added that way submits unsafely from its executor thread.
-        if self._running:
-            processor.loop = asyncio.get_running_loop()
+        processor.bus = self
         for msg_type in message_types:
             self._subscribers.setdefault(msg_type, []).append(processor)
 
     def submit_message(self, message: BaseMessage):
+        """Adds a message to the queue, from any thread.
+
+        A ``SyncProcessor`` runs in an executor thread, and ``asyncio.Queue`` is not thread-safe: a
+        put landing between ``get``'s ``empty()`` check and its waiter being registered wakes nobody,
+        leaving the bus spinning on a message it never reads. So while the bus runs, every put is
+        handed to the loop thread, whichever thread asked for it. Before it starts and after it
+        stops there is no loop to hand it to, and the queue takes the message directly.
         """
-        Adds a message to the queue.
-        """
-        self._queue.put_nowait(message)
+        if self._loop is not None and self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._queue.put_nowait, message)
+        else:
+            self._queue.put_nowait(message)
 
     def run(self):
         """
@@ -228,12 +208,6 @@ class EventBusOrchestrator(ABC):
         Initializes the orchestrator.
         """
         self._running = True
-        # The first point a running loop exists: processors are registered from __init__, on a
-        # thread that has none. Each one needs it to submit safely from an executor thread.
-        loop = asyncio.get_running_loop()
-        for processors in self._subscribers.values():
-            for processor in processors:
-                processor.loop = loop
         try:
             await self.on_initialize()
         except (FatalProcessingError, asyncio.CancelledError):
@@ -243,6 +217,10 @@ class EventBusOrchestrator(ABC):
                 OrchestratorHookError(HookName.ON_INITIALIZE, e),
                 self.on_error,
             )
+        # Only now, so what the hook submitted is already queued. A deferred put is read because the
+        # callback that queues it precedes the task completion that wakes the loop, and the hook has
+        # no task to be ordered behind: a zero grace period would stop the bus before it ran.
+        self._loop = asyncio.get_running_loop()
 
     @abstractmethod
     async def on_initialize(self):  # pragma: no cover

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -48,10 +48,20 @@ class BaseMessage:
     id: str
 
 
+def running_loop() -> asyncio.AbstractEventLoop | None:
+    """The loop running on this thread, or ``None`` outside one."""
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+
+
 class BaseProcessor[T: BaseMessage]:
     def __init__(self, name: str):
         self.name = name
         self.queue: asyncio.Queue[BaseMessage] | None = None
+        # Both set by the bus: the queue at registration, the loop when the bus starts.
+        self.loop: asyncio.AbstractEventLoop | None = None
 
     async def on_success(self, message: T) -> None:
         pass
@@ -76,9 +86,25 @@ class BaseProcessor[T: BaseMessage]:
         raise error
 
     def submit_message(self, message: BaseMessage) -> None:
+        """Put *message* on the bus, from any thread.
+
+        A ``SyncProcessor`` runs in an executor thread, and ``asyncio.Queue`` is not thread-safe: a
+        put landing between ``get``'s ``empty()`` check and its waiter being registered wakes nobody,
+        leaving the bus spinning on a message it never reads. Such a put is handed to the loop
+        thread instead. A caller already on that thread, or with no bus running, puts directly, so
+        the message is queued by the time this returns.
+        """
         if self.queue is None:
             raise ProcessorQueueError("This processor has not been added to an active event bus")
-        self.queue.put_nowait(message)
+
+        if self.loop is None or running_loop() is self.loop:
+            self.queue.put_nowait(message)
+            return
+
+        try:
+            self.loop.call_soon_threadsafe(self.queue.put_nowait, message)
+        except RuntimeError as error:
+            raise ProcessorQueueError("The event bus is no longer running") from error
 
     def should_process_message(self, message: BaseMessage) -> bool:
         return True
@@ -196,6 +222,12 @@ class EventBusOrchestrator(ABC):
         Initializes the orchestrator.
         """
         self._running = True
+        # The first point a running loop exists: processors are registered from __init__, on a
+        # thread that has none. Each one needs it to submit safely from an executor thread.
+        loop = asyncio.get_running_loop()
+        for processors in self._subscribers.values():
+            for processor in processors:
+                processor.loop = loop
         try:
             await self.on_initialize()
         except (FatalProcessingError, asyncio.CancelledError):

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -91,13 +91,15 @@ class BaseProcessor[T: BaseMessage]:
         A ``SyncProcessor`` runs in an executor thread, and ``asyncio.Queue`` is not thread-safe: a
         put landing between ``get``'s ``empty()`` check and its waiter being registered wakes nobody,
         leaving the bus spinning on a message it never reads. Such a put is handed to the loop
-        thread instead. A caller already on that thread, or with no bus running, puts directly, so
-        the message is queued by the time this returns.
+        thread instead. A caller already on that thread, or with no live loop to hand it to, puts
+        directly, so the message is queued by the time this returns.
         """
         if self.queue is None:
             raise ProcessorQueueError("This processor has not been added to an active event bus")
 
-        if self.loop is None or running_loop() is self.loop:
+        # ``asyncio.run`` closes the loop when the bus stops, and a stopped bus is queued into
+        # directly, as it was before there was a loop to hop onto.
+        if self.loop is None or self.loop.is_closed() or running_loop() is self.loop:
             self.queue.put_nowait(message)
             return
 
@@ -181,6 +183,10 @@ class EventBusOrchestrator(ABC):
     def register_processor[T: BaseMessage](self, processor: Processor[T], message_types: list[type[T]]):
         """Registers a processor to receive specific message types."""
         processor.queue = self._queue
+        # Registering while the bus runs — from `on_initialize`, say — still needs the loop, or a
+        # `SyncProcessor` added that way submits unsafely from its executor thread.
+        if self._running:
+            processor.loop = asyncio.get_running_loop()
         for msg_type in message_types:
             self._subscribers.setdefault(msg_type, []).append(processor)
 

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -165,11 +165,8 @@ class EventBusOrchestrator(ABC):
     def submit_message(self, message: BaseMessage):
         """Adds a message to the queue, from any thread.
 
-        A ``SyncProcessor`` runs in an executor thread, and ``asyncio.Queue`` is not thread-safe: a
-        put landing between ``get``'s ``empty()`` check and its waiter being registered wakes nobody,
-        leaving the bus spinning on a message it never reads. So while the bus runs, every put is
-        handed to the loop thread, whichever thread asked for it. Before it starts and after it
-        stops there is no loop to hand it to, and the queue takes the message directly.
+        ``asyncio.Queue`` is not thread-safe, and a put it loses leaves the bus spinning on a message
+        it never reads, so while the bus runs the loop thread makes every put.
         """
         if self._loop is not None and self._loop.is_running():
             self._loop.call_soon_threadsafe(self._queue.put_nowait, message)

--- a/ddev/tests/cli/ci/tests/helpers.py
+++ b/ddev/tests/cli/ci/tests/helpers.py
@@ -157,6 +157,16 @@ def copied(source: str, destination: str) -> ChangedFile:
     return ChangedFile(change_type=ChangeType.COPIED, path=destination, previous_path=source)
 
 
+class RecordingBus:
+    """Stands in for the event bus in processor unit tests, recording what the processor submits."""
+
+    def __init__(self):
+        self.queue: asyncio.Queue[BaseMessage] = asyncio.Queue()
+
+    def submit_message(self, message: BaseMessage) -> None:
+        self.queue.put_nowait(message)
+
+
 def drain_queue(queue: asyncio.Queue[BaseMessage]) -> list[BaseMessage]:
     messages: list[BaseMessage] = []
     while not queue.empty():

--- a/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
@@ -11,7 +11,6 @@ of every job's result — not just failures.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import shutil
 import threading
@@ -37,7 +36,7 @@ from ddev.event_bus.orchestrator import BaseMessage, EventBusOrchestrator
 from ddev.utils.github_async.models import JobStep, WorkflowJob
 from ddev.utils.junit import TestStatus
 from ddev.utils.platform import PlatformName
-from tests.cli.ci.tests.helpers import drain_queue, jobs_reported, make_job
+from tests.cli.ci.tests.helpers import RecordingBus, drain_queue, jobs_reported, make_job
 from tests.helpers.github_async import FakeAsyncGitHubClient
 
 # ---------------------------------------------------------------------------
@@ -146,7 +145,7 @@ def _make_gatherer(tmp_path: Path, plan: dict[str, list[BatchJob]] | None = None
         output_base_path=tmp_path / "out",
         batches=[_test_batch(batch_id, jobs) for batch_id, jobs in plan.items()],
     )
-    gatherer.queue = asyncio.Queue()
+    gatherer.bus = RecordingBus()  # type: ignore[assignment]
     return gatherer
 
 
@@ -198,7 +197,7 @@ def test_happy_path_organizes_artifacts_and_emits_update(tmp_path: Path):
         )
     )
 
-    messages = drain_queue(gatherer.queue)
+    messages = drain_queue(gatherer.bus.queue)
     assert len(messages) == 1
     update = messages[0]
     assert isinstance(update, UpdatePRComment)
@@ -232,7 +231,7 @@ def test_failure_path_records_failed_steps_and_reports(tmp_path: Path):
         )
     )
 
-    drain_queue(gatherer.queue)
+    drain_queue(gatherer.bus.queue)
     [status] = _registry(gatherer)
     assert status.failed_count == 1
 
@@ -274,7 +273,7 @@ def test_timed_out_batch_marks_all_jobs_failed(tmp_path: Path) -> None:
     batch_jobs = [_batch_job_result(job) for job in jobs]
     gatherer.process_message(_batch_finished("", status="failure", run_id=300, batch_jobs=batch_jobs, timed_out=True))
 
-    drain_queue(gatherer.queue)
+    drain_queue(gatherer.bus.queue)
     [status] = _registry(gatherer)
     assert status.failed_count == 2
     # The timeout is the batch's, not a step of any job: no step name is invented for it.
@@ -295,7 +294,7 @@ def test_multiple_jobs_aggregate_into_one_workflow_status(tmp_path: Path):
     ]
     gatherer.process_message(_batch_finished(artifacts, status="failure", batch_jobs=batch_jobs))
 
-    drain_queue(gatherer.queue)
+    drain_queue(gatherer.bus.queue)
     [status] = _registry(gatherer)
     assert status.success_count == 1
     assert status.failed_count == 1
@@ -367,7 +366,7 @@ def test_emits_update_per_batch_done_on_last(tmp_path: Path) -> None:
     )
 
     # First of two batches: an update is emitted immediately (live updates), but not yet done.
-    first = drain_queue(gatherer.queue)
+    first = drain_queue(gatherer.bus.queue)
     assert len(first) == 1
     assert first[0].revision == 1
     assert first[0].progress.done is False
@@ -385,7 +384,7 @@ def test_emits_update_per_batch_done_on_last(tmp_path: Path) -> None:
     )
 
     # Final batch: revision 2, done, aggregating both runs.
-    second = drain_queue(gatherer.queue)
+    second = drain_queue(gatherer.bus.queue)
     assert len(second) == 1
     assert second[0].revision == 2
     assert second[0].progress.done is True
@@ -504,7 +503,7 @@ def test_empty_batch_jobs_still_terminates_the_batch(tmp_path: Path) -> None:
     gatherer = _make_gatherer(tmp_path)
     gatherer.process_message(_batch_finished("", status="failure", run_id=100, batch_jobs=[]))
 
-    update = drain_queue(gatherer.queue)[0]
+    update = drain_queue(gatherer.bus.queue)[0]
     assert update.revision == 1
     batch = update.progress.batches[0]
     assert batch.state == ExecutionState.FINISHED
@@ -522,7 +521,7 @@ def test_empty_batch_does_not_block_completion(tmp_path: Path) -> None:
     gatherer = _make_gatherer(tmp_path, _one_job_plan("b1", "b2"))
 
     gatherer.process_message(_batch_finished("", id="b1", run_id=100, batch_jobs=[]))
-    assert drain_queue(gatherer.queue)[0].progress.done is False
+    assert drain_queue(gatherer.bus.queue)[0].progress.done is False
 
     gatherer.process_message(
         _batch_finished(
@@ -533,7 +532,7 @@ def test_empty_batch_does_not_block_completion(tmp_path: Path) -> None:
         )
     )
 
-    final = drain_queue(gatherer.queue)[0]
+    final = drain_queue(gatherer.bus.queue)[0]
     assert final.progress.done is True
     assert _batch_progress(final, "b1").error == ProgressError.NO_JOB_RESULTS
 
@@ -552,7 +551,7 @@ def test_unplanned_batch_is_ignored(tmp_path: Path) -> None:
         )
     )
 
-    assert drain_queue(gatherer.queue) == []
+    assert drain_queue(gatherer.bus.queue) == []
     assert gatherer._revision == 0
     assert [batch.batch_id for batch in gatherer.build_initial_update("initial").progress.batches] == ["batch-1"]
     # Nor may it write into the output tree the planned batches publish from.
@@ -570,7 +569,7 @@ def test_duplicate_batch_finished_is_ignored(tmp_path: Path) -> None:
 
     gatherer = _make_gatherer(tmp_path)
     gatherer.process_message(batch)
-    first = drain_queue(gatherer.queue)
+    first = drain_queue(gatherer.bus.queue)
     assert len(first) == 1
     assert first[0].revision == 1
 
@@ -578,7 +577,7 @@ def test_duplicate_batch_finished_is_ignored(tmp_path: Path) -> None:
     shutil.rmtree(tmp_path / "out")
 
     gatherer.process_message(batch)
-    assert drain_queue(gatherer.queue) == []
+    assert drain_queue(gatherer.bus.queue) == []
     assert gatherer._revision == 1
     assert not (tmp_path / "out").exists()
 
@@ -593,7 +592,7 @@ def test_duplicate_is_detected_by_batch_id_not_message_id(tmp_path: Path) -> Non
     gatherer.process_message(_batch_finished(artifacts, id="msg-a", batch_id="batch-1", batch_jobs=[job]))
     gatherer.process_message(_batch_finished(artifacts, id="msg-b", batch_id="batch-1", batch_jobs=[job]))
 
-    updates = drain_queue(gatherer.queue)
+    updates = drain_queue(gatherer.bus.queue)
     assert [update.revision for update in updates] == [1]
     assert gatherer._revision == 1
     assert len(_registry(gatherer)) == 1
@@ -617,7 +616,7 @@ def test_correlates_on_batch_id_not_message_id(tmp_path: Path):
     )
 
     assert set(gatherer._results_by_batch) == {"batch-09"}
-    drain_queue(gatherer.queue)
+    drain_queue(gatherer.bus.queue)
     [status] = _registry(gatherer)
     assert status.batch_id == "batch-09"
     assert status.id == 555
@@ -632,17 +631,17 @@ def test_duplicate_correlates_on_batch_id_across_reruns(tmp_path: Path):
 
     gatherer = _make_gatherer(tmp_path, {"batch-09": [make_job("j1")]})
     gatherer.process_message(_batch_finished(artifacts, id="msg-a", batch_id="batch-09", run_id=100, batch_jobs=jobs))
-    assert len(drain_queue(gatherer.queue)) == 1
+    assert len(drain_queue(gatherer.bus.queue)) == 1
 
     gatherer.process_message(_batch_finished(artifacts, id="msg-b", batch_id="batch-09", run_id=200, batch_jobs=jobs))
-    assert drain_queue(gatherer.queue) == []
+    assert drain_queue(gatherer.bus.queue) == []
     assert gatherer._revision == 1
 
 
 def test_no_emission_without_batch_finished(tmp_path: Path):
     # Invariant: the gatherer's state changes only when a BatchFinished is consumed.
     gatherer = _make_gatherer(tmp_path)
-    assert drain_queue(gatherer.queue) == []
+    assert drain_queue(gatherer.bus.queue) == []
     assert gatherer._results_by_batch == {}
     assert gatherer._revision == 0
 
@@ -696,7 +695,7 @@ def test_finished_batch_leaves_other_batches_planned(tmp_path: Path) -> None:
         )
     )
 
-    update = drain_queue(gatherer.queue)[0]
+    update = drain_queue(gatherer.bus.queue)[0]
     assert update.progress.done is False
     assert _batch_progress(update, "b1").state == ExecutionState.FINISHED
     assert _batch_progress(update, "b2").state == ExecutionState.PLANNED
@@ -724,7 +723,7 @@ def test_progress_and_registry_agree(tmp_path: Path) -> None:
         )
     )
 
-    update = drain_queue(gatherer.queue)[0]
+    update = drain_queue(gatherer.bus.queue)[0]
     [workflow] = _registry(gatherer)
     assert (update.progress.passed, update.progress.failed, update.progress.skipped) == (
         workflow.success_count,
@@ -750,7 +749,7 @@ def test_batch_status_comes_from_the_workflow_not_from_its_jobs(tmp_path: Path) 
         )
     )
 
-    update = drain_queue(gatherer.queue)[0]
+    update = drain_queue(gatherer.bus.queue)[0]
     batch = _batch_progress(update, "batch-1")
     assert batch.status == Status.FAILURE
     assert [job.latest.status for job in batch.jobs_progress] == [Status.SUCCESS]
@@ -775,7 +774,7 @@ def test_unplanned_job_is_warned_about_but_left_out_of_the_totals(tmp_path: Path
         )
     )
 
-    update = drain_queue(gatherer.queue)[0]
+    update = drain_queue(gatherer.bus.queue)[0]
     batch = _batch_progress(update, "batch-1")
     assert [job.job.name for job in batch.jobs_progress] == ["j1"]
     assert (update.progress.total, update.progress.complete) == (1, 1)
@@ -793,7 +792,7 @@ def test_timed_out_batch_is_recorded_on_the_batch(tmp_path: Path) -> None:
         )
     )
 
-    batch = _batch_progress(drain_queue(gatherer.queue)[0], "batch-1")
+    batch = _batch_progress(drain_queue(gatherer.bus.queue)[0], "batch-1")
     assert batch.status == Status.FAILURE
     assert batch.error == ProgressError.TIMED_OUT
     assert batch.jobs_progress[0].latest is not None
@@ -823,7 +822,7 @@ def test_concurrent_batches_produce_one_revision_each(tmp_path: Path) -> None:
         for future in [pool.submit(gather, message) for message in messages]:
             future.result()
 
-    updates = drain_queue(gatherer.queue)
+    updates = drain_queue(gatherer.bus.queue)
     assert sorted(update.revision for update in updates) == [1, 2, 3, 4, 5]
     assert [update.progress.done for update in updates].count(True) == 1
 
@@ -838,7 +837,7 @@ def test_missing_artifact_dir_is_recorded_as_an_attempt_error(tmp_path: Path) ->
         _batch_finished("", batch_jobs=[_batch_job_result(_batch_job("j1"), _workflow_job("j1", "success"), None)])
     )
 
-    attempt = _batch_progress(drain_queue(gatherer.queue)[0], "batch-1").jobs_progress[0].latest
+    attempt = _batch_progress(drain_queue(gatherer.bus.queue)[0], "batch-1").jobs_progress[0].latest
     assert attempt is not None
     assert attempt.error == ProgressError.NO_ARTIFACTS
     assert attempt.reports == ()
@@ -863,7 +862,7 @@ def test_second_run_appends_an_attempt_and_keeps_untouched_jobs(tmp_path: Path) 
             ],
         )
     )
-    drain_queue(gatherer.queue)
+    drain_queue(gatherer.bus.queue)
 
     rerun_dir = _make_job_tree(tmp_path / "artifacts" / "101", "j2")
     rerun = _batch_finished(
@@ -952,7 +951,7 @@ def test_dispatcher_scenario_three_batches(tmp_path: Path) -> None:
         _scenario_job(a1, "kafka", "success", JUNIT_PASSING, run_id=1),
     ]
     gatherer.process_message(_batch_finished(a1, id="b1", run_id=1, batch_jobs=batch_01))
-    rev1 = drain_queue(gatherer.queue)
+    rev1 = drain_queue(gatherer.bus.queue)
     assert len(rev1) == 1
     assert (rev1[0].revision, rev1[0].progress.done) == (1, False)
     assert _totals(rev1[0]) == (4, 0, 0, 4)
@@ -966,7 +965,7 @@ def test_dispatcher_scenario_three_batches(tmp_path: Path) -> None:
         _scenario_job(a2, "mysql", "failure", JUNIT_FAILING, run_id=2, failed_step="Run unit tests"),
     ]
     gatherer.process_message(_batch_finished(a2, id="b2", status="failure", run_id=2, batch_jobs=batch_02))
-    rev2 = drain_queue(gatherer.queue)
+    rev2 = drain_queue(gatherer.bus.queue)
     assert len(rev2) == 1
     assert (rev2[0].revision, rev2[0].progress.done) == (2, False)
     assert _totals(rev2[0]) == (7, 1, 0, 8)
@@ -980,7 +979,7 @@ def test_dispatcher_scenario_three_batches(tmp_path: Path) -> None:
         _scenario_job(a3, "consul", "skipped", None, run_id=3),
     ]
     gatherer.process_message(_batch_finished(a3, id="b3", run_id=3, batch_jobs=batch_03))
-    rev3 = drain_queue(gatherer.queue)
+    rev3 = drain_queue(gatherer.bus.queue)
     assert len(rev3) == 1
     final = rev3[0]
     assert (final.revision, final.progress.done) == (3, True)
@@ -1045,7 +1044,7 @@ def test_dispatcher_scenario_revisions_are_monotonic(tmp_path: Path):
         artifacts = tmp_path / "artifacts" / str(index)
         jobs = [_scenario_job(artifacts, f"int{index}", "success", JUNIT_PASSING, run_id=index)]
         gatherer.process_message(_batch_finished(artifacts, id=f"b{index}", run_id=index, batch_jobs=jobs))
-        emitted = drain_queue(gatherer.queue)
+        emitted = drain_queue(gatherer.bus.queue)
         assert len(emitted) == 1
         revisions.append(emitted[0].revision)
 

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 from pathlib import Path
 from typing import Any
@@ -23,7 +22,7 @@ from ddev.utils.github_async.models import (
     WorkflowJobsList,
     WorkflowRun,
 )
-from tests.cli.ci.tests.helpers import drain_queue, make_job
+from tests.cli.ci.tests.helpers import RecordingBus, drain_queue, make_job
 from tests.helpers.github_async import FakeAsyncGitHubClient
 
 # ---------------------------------------------------------------------------
@@ -98,7 +97,7 @@ def make_runner(client: FakeAsyncGitHubClient, tmp_path: Path) -> TaskTestRunner
         client=client,  # type: ignore[arg-type]
         options=options,
     )
-    runner.queue = asyncio.Queue()
+    runner.bus = RecordingBus()  # type: ignore[assignment]
     return runner
 
 
@@ -129,7 +128,7 @@ async def run_happy_path(tmp_path: Path) -> tuple[FakeAsyncGitHubClient, BatchFi
     )
     await runner.process_message(batch)
 
-    submitted = drain_queue(runner.queue)
+    submitted = drain_queue(runner.bus.queue)
     assert len(submitted) == 1
     finished = submitted[0]
     assert isinstance(finished, BatchFinished)
@@ -289,7 +288,7 @@ async def test_uses_batch_id_not_message_id_for_correlation(tmp_path: Path):
     assert fake.calls_to("create_check_run")[0].kwargs["name"] == "test-batch/batch-07"
     assert fake.calls_to("create_workflow_dispatch")[0].kwargs["inputs"]["batch_id"] == "batch-07"
 
-    finished = drain_queue(runner.queue)[0]
+    finished = drain_queue(runner.bus.queue)[0]
     assert isinstance(finished, BatchFinished)
     assert finished.id == "msg-uuid-xyz"
     assert finished.batch_id == "batch-07"
@@ -328,7 +327,7 @@ async def test_process_message_correlates_batch_jobs(tmp_path: Path):
         TestBatch(id="batch-c", batch_id="batch-c", job_list=[j1, j2], jobs_count=2, integrations=["ntp"])
     )
 
-    finished = drain_queue(runner.queue)[0]
+    finished = drain_queue(runner.bus.queue)[0]
     assert isinstance(finished, BatchFinished)
     assert finished.status == "failure"
 
@@ -360,7 +359,7 @@ async def test_process_message_batch_job_without_workflow_match(tmp_path: Path):
         TestBatch(id="batch-d", batch_id="batch-d", job_list=[job], jobs_count=1, integrations=["ntp"])
     )
 
-    finished = drain_queue(runner.queue)[0]
+    finished = drain_queue(runner.bus.queue)[0]
     assert isinstance(finished, BatchFinished)
     [result] = finished.batch_jobs
     assert result.job == job
@@ -382,7 +381,7 @@ async def test_process_message_batch_job_without_artifacts(tmp_path: Path):
         TestBatch(id="batch-e", batch_id="batch-e", job_list=[job], jobs_count=1, integrations=["ntp"])
     )
 
-    finished = drain_queue(runner.queue)[0]
+    finished = drain_queue(runner.bus.queue)[0]
     assert isinstance(finished, BatchFinished)
     [result] = finished.batch_jobs
     assert result.workflow_job is not None and result.workflow_job.conclusion == "success"
@@ -406,7 +405,7 @@ async def test_process_message_emits_batch_finished_when_listing_jobs_fails(tmp_
     # correlated job carrying no workflow job.
     await runner.process_message(make_batch())
 
-    finished = drain_queue(runner.queue)[0]
+    finished = drain_queue(runner.bus.queue)[0]
     assert isinstance(finished, BatchFinished)
     assert finished.status == "success"
     assert all(result.workflow_job is None for result in finished.batch_jobs)
@@ -423,7 +422,7 @@ async def test_process_message_failure_path(tmp_path: Path):
         TestBatch(id="batch-2", batch_id="batch-2", job_list=[make_job()], jobs_count=1, integrations=["ntp"])
     )
 
-    submitted = drain_queue(runner.queue)
+    submitted = drain_queue(runner.bus.queue)
     assert len(submitted) == 1
     finished = submitted[0]
     assert isinstance(finished, BatchFinished)
@@ -445,7 +444,7 @@ async def test_process_message_skipped_conclusion(tmp_path: Path):
     await runner.process_message(make_batch())
 
     # A "skipped" GitHub conclusion maps to a "skipped" BatchFinished and a "skipped" check run.
-    submitted = drain_queue(runner.queue)
+    submitted = drain_queue(runner.bus.queue)
     assert len(submitted) == 1
     finished = submitted[0]
     assert isinstance(finished, BatchFinished)
@@ -470,7 +469,7 @@ async def test_process_message_polls_until_completed(tmp_path: Path):
     )
 
     assert len(fake.calls_to("get_workflow_run")) == 4
-    submitted = drain_queue(runner.queue)
+    submitted = drain_queue(runner.bus.queue)
     assert len(submitted) == 1
     assert isinstance(submitted[0], BatchFinished)
     assert submitted[0].status == "success"
@@ -510,7 +509,7 @@ async def test_process_message_null_conclusion(tmp_path: Path):
     await runner.process_message(make_batch())
 
     # A null GitHub conclusion maps to a "failure" BatchFinished and a "neutral" check run.
-    submitted = drain_queue(runner.queue)
+    submitted = drain_queue(runner.bus.queue)
     assert len(submitted) == 1
     finished = submitted[0]
     assert isinstance(finished, BatchFinished)
@@ -536,7 +535,7 @@ async def test_process_message_emits_batch_finished_when_listing_artifacts_fails
     assert len(update_calls) == 1
     assert update_calls[0].kwargs["conclusion"] == "success"
 
-    submitted = drain_queue(runner.queue)
+    submitted = drain_queue(runner.bus.queue)
     assert len(submitted) == 1
     finished = submitted[0]
     assert isinstance(finished, BatchFinished)
@@ -555,7 +554,7 @@ async def test_process_message_swallows_check_run_close_failure(tmp_path: Path):
     await runner.process_message(make_batch())
 
     assert len(fake.calls_to("update_check_run")) == 1
-    submitted = drain_queue(runner.queue)
+    submitted = drain_queue(runner.bus.queue)
     assert len(submitted) == 1
     assert isinstance(submitted[0], BatchFinished)
     assert submitted[0].status == "success"
@@ -582,7 +581,7 @@ async def test_download_failure_for_one_artifact_does_not_abort_others(tmp_path:
         "https://api.github.com/artifact/2/zip",
         "https://api.github.com/artifact/3/zip",
     ]
-    submitted = drain_queue(runner.queue)
+    submitted = drain_queue(runner.bus.queue)
     assert len(submitted) == 1
     assert isinstance(submitted[0], BatchFinished)
     assert submitted[0].status == "success"
@@ -657,11 +656,11 @@ async def test_failure_at_submit_message_closes_check_run_as_success(tmp_path: P
     mock_artifacts(fake, [make_artifact(1)])
     runner = make_runner(fake, tmp_path)
 
-    class _BoomQueue:
-        def put_nowait(self, _: Any):
+    class _BoomBus:
+        def submit_message(self, _: Any):
             raise boom
 
-    runner.queue = _BoomQueue()  # type: ignore[assignment]
+    runner.bus = _BoomBus()  # type: ignore[assignment]
 
     with pytest.raises(RuntimeError, match="boom-submit-message"):
         await runner.process_message(make_batch())

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -746,17 +746,10 @@ def test_sync_processor_thread_execution(orchestrator: MockOrchestrator, secreta
 
 
 def test_a_worker_thread_submission_is_delivered(analyst: Analyst):
-    """A `SyncProcessor` runs in an executor thread, and what it submits must still be delivered.
+    """A `SyncProcessor` submits from an executor thread, where `asyncio.Queue` can lose the put.
 
-    `asyncio.Queue` is not thread-safe: a put from another thread landing between `get`'s `empty()`
-    check and its waiter being registered wakes nobody, so the message is never read and the bus
-    spins until `max_timeout` with the results of whatever produced it lost.
-
-    That window is a few bytecodes wide and cannot be forced without reimplementing `Queue.get`, so
-    the queue below stands in for it: it loses every off-loop put rather than the unlucky ones. That
-    is stricter than the real queue on purpose — it turns "delivery depends on winning a race" into a
-    deterministic failure, and leaves the assertion on the contract that matters, which is that the
-    message arrives at all.
+    The real queue loses only the unlucky ones; this one loses every off-loop put, so delivery fails
+    deterministically rather than by winning a race.
     """
 
     class LoseOffLoopPuts(asyncio.Queue):
@@ -777,8 +770,7 @@ def test_a_worker_thread_submission_is_delivered(analyst: Analyst):
 
     logger = logging.getLogger("test_thread_safe_submit")
     orchestrator = MockOrchestrator(logger, max_timeout=2, grace_period=0.1)
-    # `asyncio.run` runs the loop on the calling thread. Replaced before registration, which is what
-    # hands the queue to each processor.
+    # `asyncio.run` runs the loop here, and registration is what hands the queue to each processor.
     orchestrator._queue = LoseOffLoopPuts(threading.get_ident())
     orchestrator.register_processor(Delegator("delegator"), [Memo])
     orchestrator.register_processor(analyst, [Announcement])

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -745,6 +745,20 @@ def test_sync_processor_thread_execution(orchestrator: MockOrchestrator, secreta
     assert secretary.delivered_memos[0].id == "async_memo"
 
 
+class AsyncDelegator(AsyncProcessor[Memo]):
+    """Submits a follow-up from the loop thread."""
+
+    async def process_message(self, message: Memo):
+        self.submit_message(Announcement(id="delegated", announcement_type="Delegated"))
+
+
+class SyncDelegator(SyncProcessor[Memo]):
+    """Submits a follow-up from an executor thread."""
+
+    def process_message(self, message: Memo):
+        self.submit_message(Announcement(id="delegated", announcement_type="Delegated"))
+
+
 def test_a_worker_thread_submission_is_delivered(analyst: Analyst):
     """A `SyncProcessor` submits from an executor thread, where `asyncio.Queue` can lose the put.
 
@@ -764,15 +778,11 @@ def test_a_worker_thread_submission_is_delivered(analyst: Analyst):
                 return
             super().put_nowait(item)
 
-    class Delegator(SyncProcessor[Memo]):
-        def process_message(self, message: Memo):
-            self.submit_message(Announcement(id="delegated", announcement_type="FromWorkerThread"))
-
     logger = logging.getLogger("test_thread_safe_submit")
     orchestrator = MockOrchestrator(logger, max_timeout=2, grace_period=0.1)
-    # `asyncio.run` runs the loop here, and registration is what hands the queue to each processor.
+    # `asyncio.run` runs the loop on this thread, so this is the id the queue lets a put through on.
     orchestrator._queue = LoseOffLoopPuts(threading.get_ident())
-    orchestrator.register_processor(Delegator("delegator"), [Memo])
+    orchestrator.register_processor(SyncDelegator("delegator"), [Memo])
     orchestrator.register_processor(analyst, [Announcement])
 
     orchestrator.submit_message(Memo("delegate_me"))
@@ -780,6 +790,52 @@ def test_a_worker_thread_submission_is_delivered(analyst: Analyst):
     orchestrator.run()
 
     assert [message.id for message in analyst.completed_tasks] == ["delegated"]
+
+
+@pytest.mark.parametrize("delegator_class", [AsyncDelegator, SyncDelegator], ids=["async", "sync"])
+def test_a_processor_submission_survives_a_zero_grace_period(
+    analyst: Analyst, delegator_class: type[AsyncDelegator | SyncDelegator]
+):
+    """A follow-up is queued before the bus can decide it has nothing left to do.
+
+    Every put is now handed to the loop thread, so it happens after `submit_message` returns, and a
+    zero grace period stops the bus the moment the queue looks empty. Both kinds of processor are
+    covered because the callback that queues the message precedes the task completion that wakes the
+    bus by a different route for each.
+    """
+    logger = logging.getLogger("test_zero_grace_period")
+    orchestrator = MockOrchestrator(logger, max_timeout=2, grace_period=0)
+    orchestrator.register_processor(delegator_class("delegator"), [Memo])
+    orchestrator.register_processor(analyst, [Announcement])
+
+    orchestrator.submit_message(Memo("delegate_me"))
+
+    orchestrator.run()
+
+    assert [message.id for message in analyst.completed_tasks] == ["delegated"]
+
+
+def test_an_on_initialize_submission_survives_a_zero_grace_period(secretary: Secretary):
+    """The bus reads what `on_initialize` submitted, with no grace period to fall back on.
+
+    Nothing awaits between the hook and the bus's first look at the queue, so a put deferred to a loop
+    callback would not have happened yet, and a zero grace period stops instead of waiting for it.
+    """
+    logger = logging.getLogger("test_initialize_submit")
+    orchestrator = MockOrchestrator(logger, max_timeout=2, grace_period=0)
+    orchestrator.register_processor(secretary, [Memo])
+
+    original_on_initialize = orchestrator.on_initialize
+
+    async def on_initialize_submitting():
+        await original_on_initialize()
+        orchestrator.submit_message(Memo("from_initialize"))
+
+    orchestrator.on_initialize = on_initialize_submitting  # type: ignore[method-assign]
+
+    orchestrator.run()
+
+    assert [message.id for message in secretary.delivered_memos] == ["from_initialize"]
 
 
 def test_processor_submit_without_bus():

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -745,23 +745,30 @@ def test_sync_processor_thread_execution(orchestrator: MockOrchestrator, secreta
     assert secretary.delivered_memos[0].id == "async_memo"
 
 
-def test_sync_processor_submits_on_the_loop_thread(analyst: Analyst):
-    """A sync processor's submission must reach the queue on the loop thread.
+def test_a_worker_thread_submission_is_delivered(analyst: Analyst):
+    """A `SyncProcessor` runs in an executor thread, and what it submits must still be delivered.
 
-    `asyncio.Queue` is not thread-safe. A put from an executor thread that lands between `get`'s
-    `empty()` check and its waiter being registered wakes nobody, so the message is never read and
-    the bus spins until `max_timeout` — with the results of whatever produced it lost. The window is
-    a few bytecodes wide, so this asserts the invariant that closes it rather than trying to lose the
-    race on demand.
+    `asyncio.Queue` is not thread-safe: a put from another thread landing between `get`'s `empty()`
+    check and its waiter being registered wakes nobody, so the message is never read and the bus
+    spins until `max_timeout` with the results of whatever produced it lost.
+
+    That window is a few bytecodes wide and cannot be forced without reimplementing `Queue.get`, so
+    the queue below stands in for it: it loses every off-loop put rather than the unlucky ones. That
+    is stricter than the real queue on purpose — it turns "delivery depends on winning a race" into a
+    deterministic failure, and leaves the assertion on the contract that matters, which is that the
+    message arrives at all.
     """
 
-    class RecordingQueue(asyncio.Queue):
-        def __init__(self):
+    class LoseOffLoopPuts(asyncio.Queue):
+        """Drops a put made anywhere but the loop thread, the worst case of the real race."""
+
+        def __init__(self, loop_thread: int):
             super().__init__()
-            self.put_threads: list[int] = []
+            self._loop_thread = loop_thread
 
         def put_nowait(self, item):
-            self.put_threads.append(threading.get_ident())
+            if threading.get_ident() != self._loop_thread:
+                return
             super().put_nowait(item)
 
     class Delegator(SyncProcessor[Memo]):
@@ -769,22 +776,18 @@ def test_sync_processor_submits_on_the_loop_thread(analyst: Analyst):
             self.submit_message(Announcement(id="delegated", announcement_type="FromWorkerThread"))
 
     logger = logging.getLogger("test_thread_safe_submit")
-    orchestrator = MockOrchestrator(logger, max_timeout=10, grace_period=0.1)
-    queue = RecordingQueue()
-    # Replaced before registration, which is what hands the queue to each processor.
-    orchestrator._queue = queue
+    orchestrator = MockOrchestrator(logger, max_timeout=2, grace_period=0.1)
+    # `asyncio.run` runs the loop on the calling thread. Replaced before registration, which is what
+    # hands the queue to each processor.
+    orchestrator._queue = LoseOffLoopPuts(threading.get_ident())
     orchestrator.register_processor(Delegator("delegator"), [Memo])
     orchestrator.register_processor(analyst, [Announcement])
 
     orchestrator.submit_message(Memo("delegate_me"))
 
-    with assert_time(0, 5.0):
-        orchestrator.run()
+    orchestrator.run()
 
-    # The chain completed rather than stalling on a message nobody woke up for.
     assert [message.id for message in analyst.completed_tasks] == ["delegated"]
-    # Every put landed on the loop thread, which `asyncio.run` runs on the calling thread.
-    assert set(queue.put_threads) == {threading.get_ident()}
 
 
 def test_processor_submit_without_bus():

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+import threading
 import time
 from collections.abc import Generator
 from contextlib import AbstractContextManager, contextmanager, suppress
@@ -742,6 +743,48 @@ def test_sync_processor_thread_execution(orchestrator: MockOrchestrator, secreta
     # Verify async processor also ran
     assert len(secretary.delivered_memos) == 1
     assert secretary.delivered_memos[0].id == "async_memo"
+
+
+def test_sync_processor_submits_on_the_loop_thread(analyst: Analyst):
+    """A sync processor's submission must reach the queue on the loop thread.
+
+    `asyncio.Queue` is not thread-safe. A put from an executor thread that lands between `get`'s
+    `empty()` check and its waiter being registered wakes nobody, so the message is never read and
+    the bus spins until `max_timeout` — with the results of whatever produced it lost. The window is
+    a few bytecodes wide, so this asserts the invariant that closes it rather than trying to lose the
+    race on demand.
+    """
+
+    class RecordingQueue(asyncio.Queue):
+        def __init__(self):
+            super().__init__()
+            self.put_threads: list[int] = []
+
+        def put_nowait(self, item):
+            self.put_threads.append(threading.get_ident())
+            super().put_nowait(item)
+
+    class Delegator(SyncProcessor[Memo]):
+        def process_message(self, message: Memo):
+            self.submit_message(Announcement(id="delegated", announcement_type="FromWorkerThread"))
+
+    logger = logging.getLogger("test_thread_safe_submit")
+    orchestrator = MockOrchestrator(logger, max_timeout=10, grace_period=0.1)
+    queue = RecordingQueue()
+    # Replaced before registration, which is what hands the queue to each processor.
+    orchestrator._queue = queue
+    orchestrator.register_processor(Delegator("delegator"), [Memo])
+    orchestrator.register_processor(analyst, [Announcement])
+
+    orchestrator.submit_message(Memo("delegate_me"))
+
+    with assert_time(0, 5.0):
+        orchestrator.run()
+
+    # The chain completed rather than stalling on a message nobody woke up for.
+    assert [message.id for message in analyst.completed_tasks] == ["delegated"]
+    # Every put landed on the loop thread, which `asyncio.run` runs on the calling thread.
+    assert set(queue.put_threads) == {threading.get_ident()}
 
 
 def test_processor_submit_without_bus():


### PR DESCRIPTION
### What does this PR do?

Makes `BaseProcessor.submit_message` safe to call from a worker thread. `asyncio.Queue` is not thread-safe, and a `SyncProcessor` runs in an executor thread: a `put_nowait` landing between `Queue.get`'s `empty()` check and its waiter being registered wakes nobody, so the message is never read and the bus spins until `max_timeout`. Such a put now hops onto the loop thread via `call_soon_threadsafe`; a caller already on that thread, or with no bus running, still puts directly.

The window is a few bytecodes wide, so the test asserts the invariant that closes it — every put reaches the queue on the loop thread — rather than trying to lose the race on demand. It fails deterministically with the fix reverted.

### Motivation

 #24935 is shared `ddev` infrastructure with implications beyond the Dispatcher, so it should be reviewable on its own. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
