### PR TITLE
Add Supported OS::AIX tag to the http check

### DIFF
--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -16,6 +16,7 @@
       "Supported OS::Linux",
       "Supported OS::macOS",
       "Supported OS::Windows",
+      "Supported OS::AIX",
       "Category::Network",
       "Offering::Integration"
     ]


### PR DESCRIPTION
### What does this PR do?

Adds the `Supported OS::AIX` classifier tag to the `http_check` integration manifest, marking the check as supporting AIX.

### Motivation

Add the `http_check` to the AIX datadog-agent package. The check was validated on an AIX 7.3 builder.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged