### PR TITLE
[CONTP-2014] Add `instrumentation_controller.*` metrics to default cluster agent integration

### DIFF
--- a/datadog_cluster_agent/changelog.d/24966.added
+++ b/datadog_cluster_agent/changelog.d/24966.added
@@ -1,0 +1,1 @@
+Collect DatadogInstrumentation controller resource and reconciliation telemetry by default.

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -70,6 +70,8 @@ DEFAULT_METRICS = {
     'go_goroutines': 'go.goroutines',
     'go_memstats_alloc_bytes': 'go.memstats.alloc_bytes',
     'go_threads': 'go.threads',
+    'instrumentation_controller__reconciliations': 'instrumentation_controller.reconciliations',
+    'instrumentation_controller__resources': 'instrumentation_controller.resources',
     'kubernetes_apiserver_emitted_events': 'kubernetes_apiserver.emitted_events',
     'kubernetes_apiserver_kube_events': 'kubernetes_apiserver.kube_events',
     'language_detection_dca_handler_processed_requests': 'language_detection_dca_handler.processed_requests',

--- a/datadog_cluster_agent/metadata.csv
+++ b/datadog_cluster_agent/metadata.csv
@@ -77,6 +77,8 @@ datadog.cluster_agent.external_metrics.processed_value,gauge,,,,Value processed 
 datadog.cluster_agent.go.goroutines,gauge,,,,Number of goroutines that currently exist,0,datadog_cluster_agent,go goroutines,,
 datadog.cluster_agent.go.memstats.alloc_bytes,gauge,,byte,,Number of bytes allocated and still in use,0,datadog_cluster_agent,go memstats alloc bytes,,
 datadog.cluster_agent.go.threads,gauge,,thread,,Number of OS threads created,0,datadog_cluster_agent,go threads,,
+datadog.cluster_agent.instrumentation_controller.reconciliations,count,,,,Number of DatadogInstrumentation section reconciliation attempts by outcome,0,datadog_cluster_agent,instrumentation controller reconciliations,,
+datadog.cluster_agent.instrumentation_controller.resources,gauge,,,,Number of DatadogInstrumentation resources tracked by the controller,0,datadog_cluster_agent,instrumentation controller resources,,
 datadog.cluster_agent.kubernetes_apiserver.emitted_events,count,,,,Datadog events emitted by the kubernetes_apiserver check,0,datadog_cluster_agent,datadog events events,,
 datadog.cluster_agent.kubernetes_apiserver.kube_events,count,,,,Kubernetes events processed by the kubernetes_apiserver check,0,datadog_cluster_agent,apiserver events,,
 datadog.cluster_agent.language_detection_dca_handler.processed_requests,count,,,,The number of process language detection requests processed by the handler,0,datadog_cluster_agent,language detection processed requests,,

--- a/datadog_cluster_agent/tests/fixtures/metrics.txt
+++ b/datadog_cluster_agent/tests/fixtures/metrics.txt
@@ -247,6 +247,13 @@ go_memstats_sys_bytes 7.5580416e+07
 # HELP go_threads Number of OS threads created.
 # TYPE go_threads gauge
 go_threads 11
+# HELP instrumentation_controller__reconciliations Number of DatadogInstrumentation section reconciliation attempts by outcome.
+# TYPE instrumentation_controller__reconciliations counter
+instrumentation_controller__reconciliations{section="checks",status="success"} 3
+instrumentation_controller__reconciliations{section="logs",status="error"} 1
+# HELP instrumentation_controller__resources Number of DatadogInstrumentation resources tracked by the controller.
+# TYPE instrumentation_controller__resources gauge
+instrumentation_controller__resources 3
 # HELP jsonstream__blocked_time Total time spent waiting for the compressor to be available
 # TYPE jsonstream__blocked_time counter
 jsonstream__blocked_time 6.1130524e+07

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -68,6 +68,8 @@ METRICS = [
     'go.goroutines',
     'go.memstats.alloc_bytes',
     'go.threads',
+    'instrumentation_controller.reconciliations',
+    'instrumentation_controller.resources',
     'kubernetes_apiserver.emitted_events',
     'kubernetes_apiserver.kube_events',
     'language_detection_dca_handler.processed_requests',
@@ -94,6 +96,16 @@ def test_check(aggregator, instance, mock_metrics_endpoint):
     for metric in METRICS:
         aggregator.assert_metric(NAMESPACE + '.' + metric)
         aggregator.assert_metric_has_tag_prefix(NAMESPACE + '.' + metric, 'is_leader:')
+
+    aggregator.assert_metric(
+        NAMESPACE + '.instrumentation_controller.reconciliations',
+        tags=['is_leader:true', 'section:checks', 'status:success'],
+    )
+    aggregator.assert_metric(
+        NAMESPACE + '.instrumentation_controller.reconciliations',
+        tags=['is_leader:true', 'section:logs', 'status:error'],
+    )
+    aggregator.assert_metric(NAMESPACE + '.instrumentation_controller.resources', tags=['is_leader:true'])
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -97,16 +97,6 @@ def test_check(aggregator, instance, mock_metrics_endpoint):
         aggregator.assert_metric(NAMESPACE + '.' + metric)
         aggregator.assert_metric_has_tag_prefix(NAMESPACE + '.' + metric, 'is_leader:')
 
-    aggregator.assert_metric(
-        NAMESPACE + '.instrumentation_controller.reconciliations',
-        tags=['is_leader:true', 'section:checks', 'status:success'],
-    )
-    aggregator.assert_metric(
-        NAMESPACE + '.instrumentation_controller.reconciliations',
-        tags=['is_leader:true', 'section:logs', 'status:error'],
-    )
-    aggregator.assert_metric(NAMESPACE + '.instrumentation_controller.resources', tags=['is_leader:true'])
-
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 


### PR DESCRIPTION
### What does this PR do?

Adds two metrics to the `datadog_cluster_agent` default collected metrics:
* `instrumentation_controller.reconciliations`
* `instrumentation_controller.resources`

Related to https://github.com/DataDog/datadog-agent/pull/55311

### Motivation

Customers would benefit from OOTB collection of the DDI controller to get insight of how the DCA is reconciling the CRs they're applying.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
