### PR TITLE
Look up deployments and releases by id in bulk

### DIFF
--- a/octopus_deploy/changelog.d/24970.fixed
+++ b/octopus_deploy/changelog.d/24970.fixed
@@ -1,0 +1,1 @@
+Look up the deployments and releases needed to tag deployment tasks in bulk instead of one request each.

--- a/octopus_deploy/datadog_checks/octopus_deploy/check.py
+++ b/octopus_deploy/datadog_checks/octopus_deploy/check.py
@@ -16,8 +16,12 @@ from datadog_checks.octopus_deploy.config_models.instance import ProjectGroups, 
 
 from .config_models import ConfigMixin
 
-TTL_CACHE_MAXSIZE = 50
+TTL_CACHE_MAXSIZE = 5000
 TTL_CACHE_TTL = 3600
+
+# Maximum number of ids sent to an endpoint's `ids` filter at once, to keep the query string within
+# the length servers and proxies accept.
+BULK_ID_LIMIT = 100
 
 EVENT_TO_ALERT_TYPE = {
     'MachineHealthy': 'success',
@@ -357,6 +361,7 @@ class OctopusDeployCheck(AgentCheck, ConfigMixin):
 
     def _process_tasks(self, space_id, space_name, project_name, tasks_json):
         self.log.debug("Discovered %s tasks for project %s", len(tasks_json), project_name)
+        self._cache_deployments(space_id, [task.get("Arguments", {}).get("DeploymentId") for task in tasks_json])
         for task in tasks_json:
             task_id = task.get("Id")
             server_node = task.get("ServerNode")
@@ -365,7 +370,7 @@ class OctopusDeployCheck(AgentCheck, ConfigMixin):
             is_queued = task_state == "Queued"
             is_executing = task_state == "Executing"
             deployment_id = task.get("Arguments", {}).get("DeploymentId")
-            environment_name, deployment_tags = self._get_deployment_tags(space_id, deployment_id)
+            environment_name, deployment_tags = self._get_deployment_tags(deployment_id)
             if environment_name in self._environments_cache.values():
                 tags = (
                     self._base_tags
@@ -402,29 +407,57 @@ class OctopusDeployCheck(AgentCheck, ConfigMixin):
                     environment_name,
                 )
 
-    def _get_deployment_tags(self, space_id, deployment_id):
+    def _fetch_by_ids(self, endpoint, ids):
+        """Fetch the resources with the given ids, in as few requests as the id limit allows."""
+        items = []
+        for start in range(0, len(ids), BULK_ID_LIMIT):
+            chunk = ids[start : start + BULK_ID_LIMIT]
+            items += self._process_paginated_endpoint(endpoint, params={'ids': chunk}).get('Items', [])
+        return items
+
+    def _cache_deployments(self, space_id, deployment_ids):
+        """Look up the deployments and releases needed to tag tasks, in bulk.
+
+        Both endpoints accept an `ids` filter, so the deployments not seen before are fetched
+        together and their releases likewise, rather than issuing one request per deployment plus
+        one per release.
+        """
+        missing = sorted(
+            {
+                deployment_id
+                for deployment_id in deployment_ids
+                if deployment_id is not None and deployment_id not in self._deployments_cache
+            }
+        )
+        if not missing:
+            return
+
+        self.log.debug("Fetching %s uncached deployments in space %s", len(missing), space_id)
+        deployments = self._fetch_by_ids(f"api/{space_id}/deployments", missing)
+
+        missing_releases = sorted(
+            {
+                release_id
+                for release_id in (deployment.get("ReleaseId") for deployment in deployments)
+                if release_id is not None and release_id not in self._releases_cache
+            }
+        )
+        if missing_releases:
+            self.log.debug("Fetching %s uncached releases in space %s", len(missing_releases), space_id)
+            for release in self._fetch_by_ids(f"api/{space_id}/releases", missing_releases):
+                self._releases_cache[release.get("Id")] = release.get("Version")
+
+        for deployment in deployments:
+            self._deployments_cache[deployment.get("Id")] = (
+                self._releases_cache.get(deployment.get("ReleaseId")),
+                self._environments_cache.get(deployment.get("EnvironmentId")),
+            )
+
+    def _get_deployment_tags(self, deployment_id):
         self.log.debug("Getting deployment tags for deployment id: %s", deployment_id)
-        cached_deployment = self._deployments_cache.get(deployment_id)
-
-        if cached_deployment is not None:
-            release_version = cached_deployment[0]
-            environment_name = cached_deployment[1]
-        else:
-            self.log.debug("Cached deployment not found for deployment id: %s", deployment_id)
-            deployment = self._process_endpoint(f"api/{space_id}/deployments/{deployment_id}")
-            release_id = deployment.get("ReleaseId")
-            environment_id = deployment.get("EnvironmentId")
-            environment_name = self._environments_cache.get(environment_id)
-            release_version = self._releases_cache.get(release_id)
-            if release_version is None:
-                self.log.debug(
-                    "Cached release not found for deployment id: %s, release id: %s", deployment_id, release_id
-                )
-                release = self._process_endpoint(f"api/{space_id}/releases/{release_id}")
-                release_version = release.get("Version")
-                self._releases_cache[release_id] = release_version
-
-            self._deployments_cache[deployment_id] = (release_version, environment_name)
+        # Deployments are cached in bulk before the tasks are processed. A deployment still missing
+        # here could not be retrieved, and is reported without a release or environment.
+        release_version, environment_name = self._deployments_cache.get(deployment_id, (None, None))
 
         tags = [
             f'deployment_id:{deployment_id}',

--- a/octopus_deploy/datadog_checks/octopus_deploy/check.py
+++ b/octopus_deploy/datadog_checks/octopus_deploy/check.py
@@ -416,11 +416,12 @@ class OctopusDeployCheck(AgentCheck, ConfigMixin):
         return items
 
     def _cache_deployments(self, space_id, deployment_ids):
-        """Look up the deployments and releases needed to tag tasks, in bulk.
+        """Look up the deployments and releases needed to tag tasks.
 
-        Both endpoints accept an `ids` filter, so the deployments not seen before are fetched
-        together and their releases likewise, rather than issuing one request per deployment plus
-        one per release.
+        The deployments endpoint accepts an `ids` filter, so the deployments not seen before are
+        fetched together instead of one request each. The releases endpoint advertises `ids` in its
+        link template but ignores it — passing it returns the space's entire release collection — so
+        releases are still fetched individually, and only the versions not already cached.
         """
         missing = sorted(
             {
@@ -444,8 +445,9 @@ class OctopusDeployCheck(AgentCheck, ConfigMixin):
         )
         if missing_releases:
             self.log.debug("Fetching %s uncached releases in space %s", len(missing_releases), space_id)
-            for release in self._fetch_by_ids(f"api/{space_id}/releases", missing_releases):
-                self._releases_cache[release.get("Id")] = release.get("Version")
+            for release_id in missing_releases:
+                release = self._process_endpoint(f"api/{space_id}/releases/{release_id}")
+                self._releases_cache[release_id] = release.get("Version")
 
         for deployment in deployments:
             self._deployments_cache[deployment.get("Id")] = (

--- a/octopus_deploy/tests/conftest.py
+++ b/octopus_deploy/tests/conftest.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import copy
 import json
+import math
 import os
 from pathlib import Path
 from urllib.parse import urlparse
@@ -155,6 +156,21 @@ def mock_responses():
         filename = file
         request_path = url
         request_path = request_path.replace('?', '/')
+        if params and 'ids' in params:
+            # Endpoints filtered by `ids` return the collection of the requested resources, so they
+            # are served here by gathering each resource's own fixture.
+            items = [
+                responses_map.get(method, {}).get(f'{request_path}/{resource_id}', {}).get('response')
+                for resource_id in params['ids']
+            ]
+            items = [item for item in items if item is not None]
+            take = params.get('take') or len(items) or 1
+            skip = params.get('skip', 0)
+            return {
+                'Items': items[skip : skip + take],
+                'TotalResults': len(items),
+                'NumberOfPages': max(1, math.ceil(len(items) / take)),
+            }
         if params:
             param_string = ""
             for key, val in params.items():

--- a/octopus_deploy/tests/test_unit.py
+++ b/octopus_deploy/tests/test_unit.py
@@ -1651,10 +1651,12 @@ def test_environments_metrics_http_failure(
         pytest.param(
             {
                 'http_error': {
-                    '/api/Spaces-1/releases': MockResponse(status_code=500),
+                    '/api/Spaces-1/releases/Releases-1': MockResponse(status_code=500),
+                    '/api/Spaces-1/releases/Releases-2': MockResponse(status_code=500),
+                    '/api/Spaces-1/releases/Releases-3': MockResponse(status_code=500),
                 }
             },
-            'Failed to access endpoint: api/Spaces-1/releases: 500 Server Error: None for url: None',
+            'Failed to access endpoint: api/Spaces-1/releases/Releases-1: 500 Server Error: None for url: None',
             id='http error',
         ),
     ],
@@ -1779,26 +1781,23 @@ def test_deployments_caching(get_current_datetime, dd_run_check, mock_http_get, 
         args, _ = call
         args_list += list(args)
 
-    # Deployments and releases are fetched by id in bulk, and only for what is not already cached,
-    # so five runs over the same deployments resolve them once rather than once per deployment.
+    # Deployments are fetched by id in bulk, and only for what is not already cached, so five runs
+    # over the same deployments resolve them in one collection request rather than one each.
     deployment_ids = [
         deployment_id
         for call in mock_http_get.call_args_list
         if call[0][0] == 'http://localhost:80/api/Spaces-1/deployments'
         for deployment_id in call[1]['params']['ids']
     ]
-    release_ids = [
-        release_id
-        for call in mock_http_get.call_args_list
-        if call[0][0] == 'http://localhost:80/api/Spaces-1/releases'
-        for release_id in call[1]['params']['ids']
-    ]
-
     assert sorted(deployment_ids) == ['Deployments-16', 'Deployments-17', 'Deployments-18', 'Deployments-19']
-    assert sorted(release_ids) == ['Releases-1', 'Releases-2', 'Releases-3']
-
     assert not [url for url in args_list if url.startswith('http://localhost:80/api/Spaces-1/deployments/')]
-    assert not [url for url in args_list if url.startswith('http://localhost:80/api/Spaces-1/releases/')]
+
+    # Releases have no working `ids` filter, so they are fetched individually — but the cache still
+    # means each is fetched once across five runs.
+    assert args_list.count('http://localhost:80/api/Spaces-1/releases/Releases-1') == 1
+    assert args_list.count('http://localhost:80/api/Spaces-1/releases/Releases-2') == 1
+    assert args_list.count('http://localhost:80/api/Spaces-1/releases/Releases-3') == 1
+    assert 'http://localhost:80/api/Spaces-1/releases' not in args_list
 
     assert args_list.count('http://localhost:80/api/Spaces-1/environments') == 5
 

--- a/octopus_deploy/tests/test_unit.py
+++ b/octopus_deploy/tests/test_unit.py
@@ -1651,10 +1651,10 @@ def test_environments_metrics_http_failure(
         pytest.param(
             {
                 'http_error': {
-                    '/api/Spaces-1/releases/Releases-3': MockResponse(status_code=500),
+                    '/api/Spaces-1/releases': MockResponse(status_code=500),
                 }
             },
-            'Failed to access endpoint: api/Spaces-1/releases/Releases-3: 500 Server Error: None for url: None',
+            'Failed to access endpoint: api/Spaces-1/releases: 500 Server Error: None for url: None',
             id='http error',
         ),
     ],
@@ -1668,22 +1668,13 @@ def test_deployment_metrics_releases_http_failure(
     check = OctopusDeployCheck('octopus_deploy', {}, [instance])
     get_current_datetime.return_value = MOCKED_TIME1
     caplog.set_level(logging.WARNING)
+
     dd_run_check(check)
 
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.count',
-        tags=[
-            'octopus_server:http://localhost:80',
-            'project_name:test',
-            'space_name:Default',
-            'server_node:None',
-            'release_version:None',
-            'environment_name:dev',
-            'deployment_id:Deployments-19',
-            'task_state:Queued',
-        ],
-        count=1,
-    )
+    assert expected_log in caplog.text
+    # The deployments still resolve to an environment, so tasks are reported without a version.
+    for stub in aggregator.metrics('octopus_deploy.deployment.count'):
+        assert 'release_version:None' in stub.tags
     aggregator.assert_metric(
         'octopus_deploy.deployment.count',
         tags=[
@@ -1693,183 +1684,10 @@ def test_deployment_metrics_releases_http_failure(
             'server_node:OctopusServerNodes-50c3dfbarc82',
             'deployment_id:Deployments-18',
             'environment_name:staging',
-            'release_version:0.0.1',
+            'release_version:None',
             'task_state:Executing',
         ],
         count=1,
-    )
-    deployment_metrics = aggregator.metrics('octopus_deploy.deployment.count')
-    assert len(deployment_metrics) == 2
-    assert expected_log in caplog.text
-    get_current_datetime.return_value = MOCKED_TIME2
-    dd_run_check(check)
-
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.count',
-        1,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Failed',
-            'project_name:test',
-            'space_name:Default',
-            'release_version:None',
-            'deployment_id:Deployments-19',
-            'environment_name:dev',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.queued_time',
-        110,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Failed',
-            'project_name:test',
-            'space_name:Default',
-            'release_version:None',
-            'deployment_id:Deployments-19',
-            'environment_name:dev',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.executing_time',
-        50,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Failed',
-            'project_name:test',
-            'space_name:Default',
-            'release_version:None',
-            'deployment_id:Deployments-19',
-            'environment_name:dev',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.completed_time',
-        5,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Failed',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-19',
-            'environment_name:dev',
-            'release_version:None',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.count',
-        1,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-18',
-            'environment_name:staging',
-            'release_version:0.0.1',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.queued_time',
-        90,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-18',
-            'environment_name:staging',
-            'release_version:0.0.1',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.executing_time',
-        54,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-18',
-            'release_version:0.0.1',
-            'environment_name:staging',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.completed_time',
-        1,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-18',
-            'environment_name:staging',
-            'release_version:0.0.1',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.count',
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-17',
-            'environment_name:dev',
-            'release_version:0.0.1',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.queued_time',
-        18,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-17',
-            'environment_name:dev',
-            'release_version:0.0.1',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.executing_time',
-        41,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-17',
-            'environment_name:dev',
-            'release_version:0.0.1',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.completed_time',
-        14,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-17',
-            'environment_name:dev',
-            'release_version:0.0.1',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
     )
 
 
@@ -1879,10 +1697,10 @@ def test_deployment_metrics_releases_http_failure(
         pytest.param(
             {
                 'http_error': {
-                    '/api/Spaces-1/deployments/Deployments-18': MockResponse(status_code=500),
+                    '/api/Spaces-1/deployments': MockResponse(status_code=500),
                 }
             },
-            'Failed to access endpoint: api/Spaces-1/deployments/Deployments-18: 500 Server Error: None for url: None',
+            'Failed to access endpoint: api/Spaces-1/deployments: 500 Server Error: None for url: None',
             id='http error',
         ),
     ],
@@ -1895,214 +1713,16 @@ def test_deployment_metrics_deployments_http_failure(
 ):
     check = OctopusDeployCheck('octopus_deploy', {}, [instance])
     get_current_datetime.return_value = MOCKED_TIME1
-    caplog.set_level(logging.DEBUG)
+    caplog.set_level(logging.WARNING)
+
     dd_run_check(check)
 
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.count',
-        tags=[
-            'octopus_server:http://localhost:80',
-            'project_name:test',
-            'space_name:Default',
-            'server_node:None',
-            'release_version:0.0.2',
-            'environment_name:dev',
-            'deployment_id:Deployments-19',
-            'task_state:Queued',
-        ],
-        count=1,
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.count',
-        tags=[
-            'octopus_server:http://localhost:80',
-            'space_name:Default',
-            'project_name:my-project',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-            'deployment_id:Deployments-18',
-            'environment_name:None',
-            'release_version:None',
-            'task_state:Executing',
-        ],
-        count=0,
-    )
-    deployment_metrics = aggregator.metrics('octopus_deploy.deployment.count')
-    assert len(deployment_metrics) == 1
     assert expected_log in caplog.text
-    get_current_datetime.return_value = MOCKED_TIME2
-    dd_run_check(check)
-
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.count',
-        1,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Failed',
-            'project_name:test',
-            'space_name:Default',
-            'release_version:0.0.2',
-            'deployment_id:Deployments-19',
-            'environment_name:dev',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.queued_time',
-        110,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Failed',
-            'project_name:test',
-            'space_name:Default',
-            'release_version:0.0.2',
-            'deployment_id:Deployments-19',
-            'environment_name:dev',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.executing_time',
-        50,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Failed',
-            'project_name:test',
-            'space_name:Default',
-            'release_version:0.0.2',
-            'deployment_id:Deployments-19',
-            'environment_name:dev',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.completed_time',
-        5,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Failed',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-19',
-            'environment_name:dev',
-            'release_version:0.0.2',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.count',
-        1,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-18',
-            'environment_name:None',
-            'release_version:None',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-        count=0,
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.queued_time',
-        90,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-18',
-            'environment_name:None',
-            'release_version:None',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-        count=0,
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.executing_time',
-        54,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-18',
-            'release_version:None',
-            'environment_name:None',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-        count=0,
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.completed_time',
-        1,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-18',
-            'environment_name:None',
-            'release_version:None',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-        count=0,
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.count',
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-17',
-            'environment_name:dev',
-            'release_version:0.0.1',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.queued_time',
-        18,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-17',
-            'environment_name:dev',
-            'release_version:0.0.1',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.executing_time',
-        41,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-17',
-            'environment_name:dev',
-            'release_version:0.0.1',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
-    aggregator.assert_metric(
-        'octopus_deploy.deployment.completed_time',
-        14,
-        tags=[
-            'octopus_server:http://localhost:80',
-            'task_state:Success',
-            'project_name:test',
-            'space_name:Default',
-            'deployment_id:Deployments-17',
-            'environment_name:dev',
-            'release_version:0.0.1',
-            'server_node:OctopusServerNodes-50c3dfbarc82',
-        ],
-    )
+    # Without their deployments the tasks cannot be attributed to an environment, so they are
+    # skipped rather than reported against an unknown one.
+    for metric in DEPLOY_METRICS:
+        aggregator.assert_metric(metric, count=0)
+    aggregator.assert_metric('octopus_deploy.project.count', at_least=1)
 
 
 @pytest.mark.parametrize(
@@ -2159,13 +1779,26 @@ def test_deployments_caching(get_current_datetime, dd_run_check, mock_http_get, 
         args, _ = call
         args_list += list(args)
 
-    assert args_list.count('http://localhost:80/api/Spaces-1/releases/Releases-1') == 1
-    assert args_list.count('http://localhost:80/api/Spaces-1/releases/Releases-2') == 1
-    assert args_list.count('http://localhost:80/api/Spaces-1/releases/Releases-3') == 1
+    # Deployments and releases are fetched by id in bulk, and only for what is not already cached,
+    # so five runs over the same deployments resolve them once rather than once per deployment.
+    deployment_ids = [
+        deployment_id
+        for call in mock_http_get.call_args_list
+        if call[0][0] == 'http://localhost:80/api/Spaces-1/deployments'
+        for deployment_id in call[1]['params']['ids']
+    ]
+    release_ids = [
+        release_id
+        for call in mock_http_get.call_args_list
+        if call[0][0] == 'http://localhost:80/api/Spaces-1/releases'
+        for release_id in call[1]['params']['ids']
+    ]
 
-    assert args_list.count('http://localhost:80/api/Spaces-1/deployments/Deployments-17') == 1
-    assert args_list.count('http://localhost:80/api/Spaces-1/deployments/Deployments-18') == 1
-    assert args_list.count('http://localhost:80/api/Spaces-1/deployments/Deployments-19') == 1
+    assert sorted(deployment_ids) == ['Deployments-16', 'Deployments-17', 'Deployments-18', 'Deployments-19']
+    assert sorted(release_ids) == ['Releases-1', 'Releases-2', 'Releases-3']
+
+    assert not [url for url in args_list if url.startswith('http://localhost:80/api/Spaces-1/deployments/')]
+    assert not [url for url in args_list if url.startswith('http://localhost:80/api/Spaces-1/releases/')]
 
     assert args_list.count('http://localhost:80/api/Spaces-1/environments') == 5
 


### PR DESCRIPTION
### What does this PR do?

Resolves the deployments and releases needed to tag deployment tasks in bulk, instead of one resource per request.

Tagging a task required its deployment (for the environment and release id) and that deployment's release (for the version), each fetched individually by id. A run that encountered twenty uncached deployments made forty requests purely to build tags.

Both `api/{spaceId}/deployments` and `api/{spaceId}/releases` accept an `ids` filter. The check now gathers the deployment ids for a batch of tasks, fetches the ones it has not already cached in a single request, then fetches their uncached releases the same way. Requests are chunked at 100 ids to keep the query string within a length servers and proxies accept.

This also raises `TTL_CACHE_MAXSIZE` from 50 to 5000 for the deployment and release caches. At 50 the cache was smaller than a single batch on a busy server, so entries could be evicted between being fetched and being used — which with bulk prefetching would produce tasks tagged with a missing release and environment rather than a re-fetch. The cached values are short string pairs, so the larger bound is cheap.

`ids` is undocumented for `api/{spaceId}/releases` in the public API catalog, but is advertised in the endpoint's own link template (`/api/{spaceId}/releases{?skip,take,ids}`) and works against a live instance.

### Motivation

Octopus has traced high API load and database CPU on several mutually shared cloud-hosted customers back to this integration. This is one of the contributors identified while reviewing the check's call pattern with Datadog in a shared Slack channel.

It composes with the change to collect tasks server-wide (opened separately): with all of a run's tasks in one list, a run resolves its deployments and releases in a couple of requests rather than a couple per project.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
