### PR TITLE
Collect PostgreSQL view schema metadata

### DIFF
--- a/datadog_checks_base/changelog.d/24947.fixed
+++ b/datadog_checks_base/changelog.d/24947.fixed
@@ -1,0 +1,1 @@
+Allow schema collectors to report object-specific count telemetry.

--- a/datadog_checks_base/datadog_checks/base/utils/db/schemas.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/schemas.py
@@ -116,7 +116,7 @@ class SchemaCollector(ABC):
                 raw=True,
             )
             self._check.gauge(
-                f"dd.{self._check.dbms}.schema.tables_count",
+                self.object_count_metric_name,
                 self._total_rows_count,
                 tags=self._check.tags + ["status:" + status],
                 hostname=self._check.reported_hostname,
@@ -131,6 +131,10 @@ class SchemaCollector(ABC):
             )
             self._reset()
         return True
+
+    @property
+    def object_count_metric_name(self) -> str:
+        return f"dd.{self._check.dbms}.schema.tables_count"
 
     @property
     def base_event(self):

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -988,6 +988,14 @@ files:
           value:
             type: boolean
             example: true
+        - name: collect_views
+          fleet_configurable: true
+          description: |
+            Enable collection of PostgreSQL views and materialized views. Set to false to continue collecting table
+            schemas without collecting views. Defaults to true.
+          value:
+            type: boolean
+            example: true
         - name: max_tables
           fleet_configurable: true
           description: |
@@ -996,6 +1004,14 @@ files:
             type: number
             example: 300
             display_default: 300
+        - name: max_views
+          fleet_configurable: true
+          description: |
+            Maximum amount of views and materialized views the Agent collects from each database.
+          value:
+            type: number
+            example: 1000
+            display_default: 1000
         - name: max_query_duration
           fleet_configurable: true
           description: |

--- a/postgres/changelog.d/24972.added
+++ b/postgres/changelog.d/24972.added
@@ -1,0 +1,1 @@
+Collect PostgreSQL view definitions and column metadata during schema collection.

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -158,6 +158,8 @@ def build_config(check: PostgreSql) -> Tuple[InstanceConfig, ValidationResult]:
             },
             "collect_schemas": {
                 **dict_defaults.instance_collect_schemas().model_dump(),
+                "collect_views": True,
+                "max_views": 1000,
                 **(instance.get('collect_schemas', {})),
             },
             "collect_column_statistics": {

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -116,6 +116,7 @@ class CollectSchemas(BaseModel):
         arbitrary_types_allowed=True,
         frozen=True,
     )
+    collect_views: Optional[bool] = None
     collection_interval: Optional[float] = None
     enabled: Optional[bool] = None
     exclude_databases: Optional[tuple[str, ...]] = None
@@ -127,6 +128,7 @@ class CollectSchemas(BaseModel):
     max_columns: Optional[float] = None
     max_query_duration: Optional[float] = None
     max_tables: Optional[float] = None
+    max_views: Optional[float] = None
 
 
 class CollectSettings(BaseModel):

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -515,10 +515,21 @@ instances:
         #
         # enabled: true
 
+        ## @param collect_views - boolean - optional - default: true
+        ## Enable collection of PostgreSQL views and materialized views. Set to false to continue collecting table
+        ## schemas without collecting views. Defaults to true.
+        #
+        # collect_views: true
+
         ## @param max_tables - number - optional - default: 300
         ## Maximum amount of tables the Agent collects from the instance.
         #
         # max_tables: 300
+
+        ## @param max_views - number - optional - default: 1000
+        ## Maximum amount of views and materialized views the Agent collects from each database.
+        #
+        # max_views: 1000
 
         ## @param max_query_duration - number - optional - default: 60
         ## Maximum duration of the query to collect schema information in seconds.

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -13,6 +13,7 @@ from psycopg.rows import dict_row
 from .column_statistics import PostgresColumnStatisticsCollector
 from .schemas import PostgresSchemaCollector
 from .util import collection_interval_gcd
+from .views import PostgresViewCollector
 
 try:
     import datadog_agent  # type: ignore
@@ -121,6 +122,7 @@ class PostgresMetadata(DBMAsyncJob):
         self._collect_extensions_enabled = self._collect_pg_settings_enabled
         self._collect_schemas_enabled = config.collect_schemas.enabled
         self._schema_collector = PostgresSchemaCollector(check) if config.collect_schemas.enabled else None
+        self._view_collector = PostgresViewCollector(check) if config.collect_schemas.enabled else None
         self._collect_column_statistics_enabled = config.collect_column_statistics.enabled and config.dbm
         self._column_statistics_collector = (
             PostgresColumnStatisticsCollector(check, self._cancel_event)
@@ -140,6 +142,7 @@ class PostgresMetadata(DBMAsyncJob):
     def shutdown(self) -> None:
         self._check = None
         self._schema_collector = None
+        self._view_collector = None
         self._column_statistics_collector = None
         self._compiled_patterns_cache = None
 
@@ -245,6 +248,8 @@ class PostgresMetadata(DBMAsyncJob):
         if not started:
             # TODO: Emit health event for over-long collection
             self._log.warning("Previous schema collection still in progress, skipping this collection")
+        if self._config.collect_schemas.collect_views is not False:
+            self._view_collector.collect_schemas()
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_postgres_settings(self):

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -10,6 +10,8 @@ import time
 import psycopg
 from psycopg.rows import dict_row
 
+from datadog_checks.base.utils.db.schemas import SchemaCollector
+
 from .column_statistics import PostgresColumnStatisticsCollector
 from .schemas import PostgresSchemaCollector
 from .util import collection_interval_gcd
@@ -122,7 +124,13 @@ class PostgresMetadata(DBMAsyncJob):
         self._collect_extensions_enabled = self._collect_pg_settings_enabled
         self._collect_schemas_enabled = config.collect_schemas.enabled
         self._schema_collector = PostgresSchemaCollector(check) if config.collect_schemas.enabled else None
-        self._view_collector = PostgresViewCollector(check) if config.collect_schemas.enabled else None
+        collect_views_requested = config.collect_schemas.enabled and config.collect_schemas.collect_views is not False
+        self._collect_views_enabled = collect_views_requested and hasattr(SchemaCollector, 'object_count_metric_name')
+        self._view_collector = PostgresViewCollector(check) if self._collect_views_enabled else None
+        if collect_views_requested and not self._collect_views_enabled:
+            self._log.warning(
+                "PostgreSQL view collection requires object-specific schema count telemetry; skipping view collection"
+            )
         self._collect_column_statistics_enabled = config.collect_column_statistics.enabled and config.dbm
         self._column_statistics_collector = (
             PostgresColumnStatisticsCollector(check, self._cancel_event)
@@ -248,7 +256,7 @@ class PostgresMetadata(DBMAsyncJob):
         if not started:
             # TODO: Emit health event for over-long collection
             self._log.warning("Previous schema collection still in progress, skipping this collection")
-        if self._config.collect_schemas.collect_views is not False:
+        if self._collect_views_enabled:
             self._view_collector.collect_schemas()
 
     @tracked_method(agent_check_getter=agent_check_getter)

--- a/postgres/datadog_checks/postgres/views.py
+++ b/postgres/datadog_checks/postgres/views.py
@@ -13,31 +13,21 @@ if TYPE_CHECKING:
     from datadog_checks.postgres import PostgreSql
 
 
-PG_VIEWS_QUERY = """
-SELECT c.oid                         AS view_id,
-       c.relnamespace                AS schema_id,
-       c.relname                     AS view_name,
-       c.relowner::regrole::text     AS view_owner,
-       c.relkind::text               AS relkind,
-       pg_get_viewdef(c.oid, true)   AS definition
-FROM   pg_class c
-WHERE  c.relkind IN ('v', 'm')
-"""
-
-
 VIEW_COLUMNS_QUERY = """
-SELECT attname                           AS name,
-       format_type(atttypid, atttypmod)  AS data_type,
-       NOT attnotnull                    AS nullable,
-       pg_get_expr(adbin, adrelid)       AS default,
-       attrelid                          AS view_id,
-       attnum                            AS ordinal_position
-FROM   pg_attribute
+SELECT a.attname                            AS name,
+       format_type(a.atttypid, a.atttypmod) AS data_type,
+       NOT a.attnotnull                     AS nullable,
+       pg_get_expr(ad.adbin, ad.adrelid)    AS default,
+       selected_views.view_id,
+       a.attnum                            AS ordinal_position
+FROM   selected_views
+       INNER JOIN pg_attribute a
+               ON a.attrelid = selected_views.view_id
        LEFT JOIN pg_attrdef ad
-              ON adrelid = attrelid
-                 AND adnum = attnum
-WHERE  attnum > 0
-       AND NOT attisdropped
+              ON ad.adrelid = a.attrelid
+                 AND ad.adnum = a.attnum
+WHERE  a.attnum > 0
+       AND NOT a.attisdropped
 """
 
 
@@ -88,24 +78,28 @@ class PostgresViewCollector(PostgresSchemaCollector):
             schemas AS (
                 {schemas_query}
             ),
-            views AS (
-                {PG_VIEWS_QUERY}
-            ),
-            schema_views AS (
+            selected_views AS (
                 SELECT schemas.schema_id, schemas.schema_name, schemas.schema_owner,
-                    views.view_id, views.view_name, views.view_owner, views.relkind, views.definition
+                    c.oid AS view_id, c.relname AS view_name,
+                    c.relowner::regrole::text AS view_owner, c.relkind::text AS relkind
                 FROM schemas
-                INNER JOIN views ON schemas.schema_id = views.schema_id
-                ORDER BY schemas.schema_name, views.view_name
+                INNER JOIN pg_class c ON schemas.schema_id = c.relnamespace
+                WHERE c.relkind IN ('v', 'm')
+                ORDER BY schemas.schema_name, c.relname
                 LIMIT {limit}
+            ),
+            views AS (
+                SELECT selected_views.*,
+                    pg_get_viewdef(selected_views.view_id, true) AS definition
+                FROM selected_views
             ),
             columns AS (
                 {VIEW_COLUMNS_QUERY}
             )
 
-            SELECT schema_views.schema_id, schema_views.schema_name, schema_views.schema_owner,
-                schema_views.view_id, schema_views.view_name, schema_views.view_owner,
-                schema_views.relkind, schema_views.definition,
+            SELECT views.schema_id, views.schema_name, views.schema_owner,
+                views.view_id, views.view_name, views.view_owner,
+                views.relkind, views.definition,
                 array_agg(
                     json_build_object(
                         'data_type', columns.data_type,
@@ -114,11 +108,11 @@ class PostgresViewCollector(PostgresSchemaCollector):
                         'nullable', columns.nullable
                     ) ORDER BY columns.ordinal_position
                 ) FILTER (WHERE columns.name IS NOT NULL) AS columns
-            FROM schema_views
-                LEFT JOIN columns ON schema_views.view_id = columns.view_id
-            GROUP BY schema_views.schema_id, schema_views.schema_name, schema_views.schema_owner,
-                schema_views.view_id, schema_views.view_name, schema_views.view_owner,
-                schema_views.relkind, schema_views.definition
+            FROM views
+                LEFT JOIN columns ON views.view_id = columns.view_id
+            GROUP BY views.schema_id, views.schema_name, views.schema_owner,
+                views.view_id, views.view_name, views.view_owner,
+                views.relkind, views.definition
             ;
         """
         return query, schemas_params

--- a/postgres/datadog_checks/postgres/views.py
+++ b/postgres/datadog_checks/postgres/views.py
@@ -1,0 +1,146 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
+from datadog_checks.base.utils.db.schemas import SchemaCollector
+from datadog_checks.postgres.schemas import DatabaseInfo, DatabaseObject, PostgresSchemaCollector
+
+if TYPE_CHECKING:
+    from datadog_checks.postgres import PostgreSql
+
+
+PG_VIEWS_QUERY = """
+SELECT c.oid                         AS view_id,
+       c.relnamespace                AS schema_id,
+       c.relname                     AS view_name,
+       c.relowner::regrole::text     AS view_owner,
+       c.relkind::text               AS relkind,
+       pg_get_viewdef(c.oid, true)   AS definition
+FROM   pg_class c
+WHERE  c.relkind IN ('v', 'm')
+"""
+
+
+VIEW_COLUMNS_QUERY = """
+SELECT attname                           AS name,
+       format_type(atttypid, atttypmod)  AS data_type,
+       NOT attnotnull                    AS nullable,
+       pg_get_expr(adbin, adrelid)       AS default,
+       attrelid                          AS view_id,
+       attnum                            AS ordinal_position
+FROM   pg_attribute
+       LEFT JOIN pg_attrdef ad
+              ON adrelid = attrelid
+                 AND adnum = attnum
+WHERE  attnum > 0
+       AND NOT attisdropped
+"""
+
+
+class ViewColumnObject(TypedDict):
+    data_type: str
+    default: str | None
+    name: str
+    nullable: bool
+
+
+class ViewObject(TypedDict):
+    columns: list[ViewColumnObject]
+    definition: str | None
+    id: str
+    name: str
+    owner: str
+    relkind: str
+
+
+class ViewSchemaObject(TypedDict):
+    id: str
+    name: str
+    owner: str
+    tables: list
+    views: list[ViewObject]
+
+
+class PostgresViewCollector(PostgresSchemaCollector):
+    _check: PostgreSql
+
+    def __init__(self, check: PostgreSql):
+        super().__init__(check)
+        self._max_views = int(check._config.collect_schemas.max_views or 1000)
+
+    @property
+    def kind(self) -> str:
+        return "pg_views"
+
+    @property
+    def object_count_metric_name(self) -> str:
+        return f"dd.{self._check.dbms}.schema.views_count"
+
+    def get_rows_query(self) -> tuple[str, list[str]]:
+        schemas_query, schemas_params = self._get_schemas_query()
+        limit = self._max_views or 1_000_000
+        query = f"""
+            WITH
+            schemas AS (
+                {schemas_query}
+            ),
+            views AS (
+                {PG_VIEWS_QUERY}
+            ),
+            schema_views AS (
+                SELECT schemas.schema_id, schemas.schema_name, schemas.schema_owner,
+                    views.view_id, views.view_name, views.view_owner, views.relkind, views.definition
+                FROM schemas
+                INNER JOIN views ON schemas.schema_id = views.schema_id
+                ORDER BY schemas.schema_name, views.view_name
+                LIMIT {limit}
+            ),
+            columns AS (
+                {VIEW_COLUMNS_QUERY}
+            )
+
+            SELECT schema_views.schema_id, schema_views.schema_name, schema_views.schema_owner,
+                schema_views.view_id, schema_views.view_name, schema_views.view_owner,
+                schema_views.relkind, schema_views.definition,
+                array_agg(
+                    json_build_object(
+                        'data_type', columns.data_type,
+                        'default', columns.default,
+                        'name', columns.name,
+                        'nullable', columns.nullable
+                    ) ORDER BY columns.ordinal_position
+                ) FILTER (WHERE columns.name IS NOT NULL) AS columns
+            FROM schema_views
+                LEFT JOIN columns ON schema_views.view_id = columns.view_id
+            GROUP BY schema_views.schema_id, schema_views.schema_name, schema_views.schema_owner,
+                schema_views.view_id, schema_views.view_name, schema_views.view_owner,
+                schema_views.relkind, schema_views.definition
+            ;
+        """
+        return query, schemas_params
+
+    def _map_row(self, database: DatabaseInfo, cursor_row) -> DatabaseObject:
+        object = SchemaCollector._map_row(self, database, cursor_row)
+        object["schemas"] = [
+            {
+                "id": str(cursor_row.get("schema_id")),
+                "name": cursor_row.get("schema_name"),
+                "owner": cursor_row.get("schema_owner"),
+                "tables": [],
+                "views": [
+                    {
+                        "columns": (cursor_row.get("columns") or [])[: self._config.max_columns],
+                        "definition": cursor_row.get("definition"),
+                        "id": str(cursor_row.get("view_id")),
+                        "name": cursor_row.get("view_name"),
+                        "owner": cursor_row.get("view_owner"),
+                        "relkind": cursor_row.get("relkind"),
+                    }
+                ],
+            }
+        ]
+        return object

--- a/postgres/tests/compose/resources/02_load_data.sh
+++ b/postgres/tests/compose/resources/02_load_data.sh
@@ -40,6 +40,8 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" datadog_test <<-EOSQL
     SELECT * FROM persons;
     CREATE SCHEMA public2;
     CREATE TABLE public2.cities (city VARCHAR(255), country VARCHAR(255), PRIMARY KEY(city));
+    CREATE VIEW public2.active_persons AS SELECT personid, lastname, city FROM persons;
+    CREATE MATERIALIZED VIEW public2.materialized_persons AS SELECT personid, firstname, city FROM persons;
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO bob;
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO blocking_bob;
 EOSQL

--- a/postgres/tests/test_config_defaults.py
+++ b/postgres/tests/test_config_defaults.py
@@ -127,7 +127,9 @@ EXPECTED_DEFAULTS = {
     # === DBM: Schema collection ===
     'collect_schemas': {
         'enabled': True,
+        'collect_views': True,
         'max_tables': 300,
+        'max_views': 1000,
         'max_columns': 50,
         'collection_interval': 600,
         'max_query_duration': 60,

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -100,6 +100,42 @@ def test_collect_schema_snapshot(integration_check, dbm_instance, aggregator):
     assert normalize_object(snapshot) == normalize_object(schema_events[0]['metadata'])
 
 
+def test_collect_views(integration_check, dbm_instance, aggregator):
+    dbm_instance["collect_schemas"] = {
+        'enabled': True,
+        'run_sync': True,
+        'include_databases': ['datadog_test'],
+        'include_schemas': ['^public2$'],
+    }
+    dbm_instance['dbname'] = 'datadog_test'
+    check = integration_check(dbm_instance)
+
+    run_one_check(check, dbm_instance)
+
+    view_events = [
+        event for event in aggregator.get_event_platform_events("dbm-metadata") if event['kind'] == 'pg_views'
+    ]
+    assert len(view_events) == 1
+    schemas = [database['schemas'][0] for event in view_events for database in event['metadata']]
+    assert all(schema['tables'] == [] for schema in schemas)
+    views = [view for schema in schemas for view in schema['views']]
+    views_by_name = {view['name']: view for view in views}
+
+    assert set(views_by_name) == {'active_persons', 'materialized_persons'}
+    assert views_by_name['active_persons']['relkind'] == 'v'
+    assert views_by_name['materialized_persons']['relkind'] == 'm'
+    for view in (views_by_name['active_persons'], views_by_name['materialized_persons']):
+        assert view['id'].isdigit()
+        assert view['owner'] == 'postgres'
+        assert view['definition']
+        assert [column['name'] for column in view['columns']] in [
+            ['personid', 'lastname', 'city'],
+            ['personid', 'firstname', 'city'],
+        ]
+        for column in view['columns']:
+            assert set(column) == {'data_type', 'default', 'name', 'nullable'}
+
+
 @pytest.mark.parametrize(
     "use_default_ignore_schemas_owned_by",
     [

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -7,6 +7,7 @@ from typing import List
 
 import pytest
 
+from datadog_checks.base.utils.db.schemas import SchemaCollector
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
 
 from .common import POSTGRES_LOCALE, POSTGRES_VERSION
@@ -115,6 +116,9 @@ def test_collect_views(integration_check, dbm_instance, aggregator):
     view_events = [
         event for event in aggregator.get_event_platform_events("dbm-metadata") if event['kind'] == 'pg_views'
     ]
+    if not hasattr(SchemaCollector, 'object_count_metric_name'):
+        assert view_events == []
+        return
     assert len(view_events) == 1
     schemas = [database['schemas'][0] for event in view_events for database in event['metadata']]
     assert all(schema['tables'] == [] for schema in schemas)

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -35,6 +35,9 @@ def test_schema_collectors_use_independent_queries_and_limits(pg_instance, integ
     assert "LIMIT 1000" in view_query
     assert "c.relkind IN ('v', 'm')" in view_query
     assert "pg_get_viewdef" in view_query
+    assert view_query.index("LIMIT 1000") < view_query.index("pg_get_viewdef")
+    assert view_query.index("LIMIT 1000") < view_query.index("INNER JOIN pg_attribute")
+    assert "a.attrelid = selected_views.view_id" in view_query
 
 
 def test_view_collector_maps_view_metadata(pg_instance, integration_check):

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -12,11 +12,117 @@ from pytest import fail
 from semver import VersionInfo
 
 from datadog_checks.postgres import PostgreSql, util
+from datadog_checks.postgres.metadata import PostgresMetadata
 from datadog_checks.postgres.schemas import PostgresSchemaCollector
 from datadog_checks.postgres.statements import PostgresStatementMetrics
 from datadog_checks.postgres.statements_v2 import PostgresStatementMetricsV2
+from datadog_checks.postgres.views import PostgresViewCollector
 
 pytestmark = pytest.mark.unit
+
+
+def test_schema_collectors_use_independent_queries_and_limits(pg_instance, integration_check):
+    pg_instance['collect_schemas'] = {'max_tables': 25, 'max_views': 1000}
+    check = integration_check(pg_instance)
+    check.version = VersionInfo(18, 0, 0)
+
+    table_query, _ = PostgresSchemaCollector(check).get_rows_query()
+    view_query, _ = PostgresViewCollector(check).get_rows_query()
+
+    assert "LIMIT 25" in table_query
+    assert "c.relkind IN ( 'r', 'p', 'f' )" in table_query
+    assert "pg_get_viewdef" not in table_query
+    assert "LIMIT 1000" in view_query
+    assert "c.relkind IN ('v', 'm')" in view_query
+    assert "pg_get_viewdef" in view_query
+
+
+def test_view_collector_maps_view_metadata(pg_instance, integration_check):
+    check = integration_check(pg_instance)
+    collector = PostgresViewCollector(check)
+    database = {
+        'description': 'application database',
+        'encoding': 'UTF8',
+        'id': '1',
+        'name': 'app',
+        'owner': 'postgres',
+    }
+    row = {
+        'schema_id': 2200,
+        'schema_name': 'public',
+        'schema_owner': 'postgres',
+        'view_id': 16420,
+        'view_name': 'active_users',
+        'view_owner': 'app',
+        'definition': 'SELECT id, email FROM users;',
+        'relkind': 'v',
+        'columns': [
+            {'data_type': 'integer', 'default': None, 'name': 'id', 'nullable': True},
+            {'data_type': 'text', 'default': None, 'name': 'email', 'nullable': True},
+        ],
+    }
+
+    mapped = collector._map_row(database, row)
+
+    assert mapped == {
+        **database,
+        'schemas': [
+            {
+                'id': '2200',
+                'name': 'public',
+                'owner': 'postgres',
+                'tables': [],
+                'views': [
+                    {
+                        'columns': row['columns'],
+                        'definition': 'SELECT id, email FROM users;',
+                        'id': '16420',
+                        'name': 'active_users',
+                        'owner': 'app',
+                        'relkind': 'v',
+                    }
+                ],
+            }
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    ('collector_class', 'expected_metric', 'unexpected_metric'),
+    [
+        (PostgresSchemaCollector, 'dd.postgres.schema.tables_count', 'dd.postgres.schema.views_count'),
+        (PostgresViewCollector, 'dd.postgres.schema.views_count', 'dd.postgres.schema.tables_count'),
+    ],
+)
+def test_schema_collectors_report_separate_object_counts(
+    pg_instance, integration_check, collector_class, expected_metric, unexpected_metric
+):
+    check = integration_check(pg_instance)
+    check.gauge = mock.Mock()
+    collector = collector_class(check)
+    collector._get_databases = mock.Mock(return_value=[])
+
+    collector.collect_schemas()
+
+    submitted_metrics = {call.args[0] for call in check.gauge.call_args_list}
+    assert expected_metric in submitted_metrics
+    assert unexpected_metric not in submitted_metrics
+
+
+@pytest.mark.parametrize(('collect_views', 'views_collected'), [(True, True), (False, False)])
+def test_schema_collection_can_disable_views(collect_views, views_collected):
+    metadata = object.__new__(PostgresMetadata)
+    metadata._config = mock.Mock()
+    metadata._config.collect_schemas.collect_views = collect_views
+    metadata._schema_collector = mock.Mock()
+    metadata._schema_collector.collect_schemas.return_value = True
+    metadata._view_collector = mock.Mock()
+    metadata._log = mock.Mock()
+
+    metadata._collect_postgres_schemas()
+
+    metadata._schema_collector.collect_schemas.assert_called_once_with()
+    assert metadata._view_collector.collect_schemas.called is views_collected
 
 
 def test_get_instance_metrics_lt_92(integration_check, pg_instance):

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -11,6 +11,7 @@ import pytest
 from pytest import fail
 from semver import VersionInfo
 
+from datadog_checks.base.utils.db.schemas import SchemaCollector
 from datadog_checks.postgres import PostgreSql, util
 from datadog_checks.postgres.metadata import PostgresMetadata
 from datadog_checks.postgres.schemas import PostgresSchemaCollector
@@ -100,6 +101,8 @@ def test_view_collector_maps_view_metadata(pg_instance, integration_check):
 def test_schema_collectors_report_separate_object_counts(
     pg_instance, integration_check, collector_class, expected_metric, unexpected_metric
 ):
+    if collector_class is PostgresViewCollector and not hasattr(SchemaCollector, 'object_count_metric_name'):
+        pytest.skip("The minimum base package does not schedule PostgreSQL view collection")
     check = integration_check(pg_instance)
     check.gauge = mock.Mock()
     collector = collector_class(check)
@@ -115,8 +118,7 @@ def test_schema_collectors_report_separate_object_counts(
 @pytest.mark.parametrize(('collect_views', 'views_collected'), [(True, True), (False, False)])
 def test_schema_collection_can_disable_views(collect_views, views_collected):
     metadata = object.__new__(PostgresMetadata)
-    metadata._config = mock.Mock()
-    metadata._config.collect_schemas.collect_views = collect_views
+    metadata._collect_views_enabled = collect_views
     metadata._schema_collector = mock.Mock()
     metadata._schema_collector.collect_schemas.return_value = True
     metadata._view_collector = mock.Mock()


### PR DESCRIPTION
### What does this PR do?

Adds a dedicated PostgreSQL view collector that runs alongside table schema collection and emits a separate `pg_views` DBM metadata payload. Each schema contains an empty `tables` array and a populated `views` array. Regular and materialized views include their ID, name, owner, reconstructed definition, relation kind, and table-compatible column metadata.

Adds `collect_views`, enabled by default, and an independent `max_views` limit of 1000. Existing `pg_databases` collection, table queries, filters, and connection handling remain unchanged. View counts are reported as `dd.postgres.schema.views_count`.

Shared telemetry dependency: https://github.com/DataDog/integrations-core/pull/24947

Companion backend change: https://github.com/ddoghq/dd-go/pull/12199

### Motivation

PostgreSQL schema collection currently discovers only ordinary, partitioned, and foreign tables. UGP needs regular and materialized view definitions and projected columns without treating those objects as physical tables or applying the table limit to them.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
