### PR TITLE
Abandon gathering when the bus is shutting down

### DIFF
--- a/ddev/changelog.d/24980.fixed
+++ b/ddev/changelog.d/24980.fixed
@@ -1,0 +1,1 @@
+Abandon a batch's gathering when the event bus is shutting down.

--- a/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
@@ -82,13 +82,32 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             if not self._accepts(message.batch_id, log_extra):
                 return
 
-        gathered = [self._gather_job(batch_job_result, message) for batch_job_result in message.batch_jobs]
+        gathered: list[tuple[JobResult, JobAttemptProgress]] = []
+        for batch_job_result in message.batch_jobs:
+            # Checked per job because a repository-wide batch has hundreds, and this runs in a thread
+            # the bus cannot interrupt. Abandoned rather than partly registered: the batch stays
+            # planned, so the run reports what it is, unfinished.
+            if self.stopping:
+                self._logger.warning(
+                    "Gathering abandoned after %s of %s jobs: the bus is shutting down",
+                    len(gathered),
+                    len(message.batch_jobs),
+                    extra=log_extra,
+                )
+                return
+            gathered.append(self._gather_job(batch_job_result, message))
+
         results = [result for result, _ in gathered]
         status = self._build_workflow_status(message, results)
 
         # Register, bump the revision, and emit under one lock, so two batches finishing at once
         # cannot build a comment from half-updated state.
         with self._lock:
+            # The per-job check cannot see a flip during the last job or while the status was built,
+            # and this block is the publish gate: registering now would contradict a cancelled run.
+            if self.stopping:
+                self._logger.warning("Batch gathered but left unregistered: the bus is shutting down", extra=log_extra)
+                return
             # Re-checked: another thread may have gathered this batch while this one parsed.
             if not self._accepts(message.batch_id, log_extra):
                 return

--- a/ddev/tests/cli/ci/tests/helpers.py
+++ b/ddev/tests/cli/ci/tests/helpers.py
@@ -171,8 +171,9 @@ def copied(source: str, destination: str) -> ChangedFile:
 class RecordingBus:
     """Stands in for the event bus in processor unit tests, recording what the processor submits."""
 
-    def __init__(self):
+    def __init__(self, stopping: bool = False):
         self.queue: asyncio.Queue[BaseMessage] = asyncio.Queue()
+        self.stopping = stopping
 
     def submit_message(self, message: BaseMessage) -> None:
         self.queue.put_nowait(message)

--- a/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import shutil
 import threading
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -184,6 +185,57 @@ def _find_result(gatherer: TaskTestGatherer, integration: str) -> JobResult:
 # ---------------------------------------------------------------------------
 # process_message
 # ---------------------------------------------------------------------------
+
+
+def _stopping_before_gathering(gatherer: TaskTestGatherer, bus: RecordingBus) -> None:
+    bus.stopping = True
+
+
+def _stopping_once_the_last_job_is_gathered(gatherer: TaskTestGatherer, bus: RecordingBus) -> None:
+    """Flips after the per-job loop, the window that loop's own check cannot see."""
+    build_status = gatherer._build_workflow_status
+
+    def cancelled_while_building(*args, **kwargs):
+        bus.stopping = True
+        return build_status(*args, **kwargs)
+
+    gatherer._build_workflow_status = cancelled_while_building  # type: ignore[method-assign]
+
+
+@pytest.mark.parametrize(
+    "start_stopping",
+    [
+        pytest.param(_stopping_before_gathering, id="before_gathering"),
+        pytest.param(_stopping_once_the_last_job_is_gathered, id="after_the_last_job"),
+    ],
+)
+def test_a_shutting_down_bus_abandons_gathering_without_registering_the_batch(
+    tmp_path: Path, start_stopping: Callable[[TaskTestGatherer, RecordingBus], None]
+):
+    """Gathering runs in a thread the bus cannot interrupt, so it has to give up on its own.
+
+    Registering what it managed to gather would be worse than registering nothing: the batch would
+    read as finished while holding a fraction of its jobs, and a run that never completed could then
+    report as done.
+    """
+    artifacts = tmp_path / "artifacts" / "100"
+    job_dir = _make_job_tree(artifacts, "j1")
+
+    gatherer = _make_gatherer(tmp_path)
+    bus = RecordingBus()
+    gatherer.bus = bus  # type: ignore[assignment]
+    start_stopping(gatherer, bus)
+
+    gatherer.process_message(
+        _batch_finished(
+            artifacts, batch_jobs=[_batch_job_result(make_job("j1"), _workflow_job("j1", "success"), job_dir)]
+        )
+    )
+
+    assert drain_queue(bus.queue) == []
+    assert _registry(gatherer) == []
+    # Still planned, so nothing downstream can read the batch as one that finished.
+    assert gatherer._progress_by_batch["batch-1"].state is ExecutionState.PLANNED
 
 
 def test_happy_path_organizes_artifacts_and_emits_update(tmp_path: Path):


### PR DESCRIPTION
> **Stack**
>
> 1. #24978 Wait for sync processors and retire the thread pool on shutdown
> 2. **#24980 Abandon gathering when the bus is shutting down** :point_left: this PR
> 3. #25002 Let a caller ask the event bus to stop
> 4. #25042 Report and clean up after a cancelled Dispatcher run

### What does this PR do?

Makes `TaskTestGatherer` honour the stop flag the bus sets on shutdown, so a batch's gathering can be abandoned instead of running to completion after the run is over.

The check sits per job rather than once per message. A repository-wide batch is around 200 jobs, each parsing JUnit and copying coverage, so per-message granularity would still overshoot by a whole batch.

Granularity is what decides whether cancellation can be handled at all. A cancelled run gives about ten seconds before the process is killed (measured in #24978), and the drain added there waits for whatever a processor is still doing. Checking once per message would spend that budget finishing a batch nobody will read.

It returns without registering anything. Registering the jobs gathered so far would be worse than registering none: the batch would read as finished while holding a fraction of its jobs, and `DispatcherProgress.done` could then be true for a run that never completed. Leaving the batch planned means the run reports what it is, unfinished.

### Motivation

Stacked on #24978, which added the flag and waits for these threads. Without something honouring it, that wait is as long as the work takes and `max_timeout` still bounds nothing. This is the change that makes the timeout mean something for the Dispatcher.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged




