### PR TITLE
Port the 7.83.x cryptography CVE release to master

### DIFF
--- a/cisco_aci/CHANGELOG.md
+++ b/cisco_aci/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 5.1.0 / 2026-08-24
+
+***Security***:
+
+* Bump cryptography to 50.0.0 to remediate CVE-2026-69247, GHSA-jwv3-5hgf-82ww, and GHSA-m2h6-j472-rp4c. ([#24948](https://github.com/DataDog/integrations-core/pull/24948))
+
 ## 5.0.1 / 2026-06-18 / Agent 7.81.0
 
 ***Fixed***:

--- a/cisco_aci/changelog.d/24817.added
+++ b/cisco_aci/changelog.d/24817.added
@@ -1,1 +1,0 @@
-Update dependencies

--- a/cisco_aci/datadog_checks/cisco_aci/__about__.py
+++ b/cisco_aci/datadog_checks/cisco_aci/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "5.0.1"
+__version__ = "5.1.0"

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -15,6 +15,14 @@
 * Fix AIA chasing crashing when the CA Issuers response is DER-encoded. ([#24683](https://github.com/DataDog/integrations-core/pull/24683))
 * Stop the check logging adapter from holding a reference to the check, so a cancelled check is reclaimed without waiting for a garbage collection pass. ([#24914](https://github.com/DataDog/integrations-core/pull/24914))
 
+## 38.0.1 / 2026-08-24
+
+***Fixed***:
+
+* Bump cryptography to 50.0.0 to remediate CVE-2026-69247, GHSA-jwv3-5hgf-82ww, and GHSA-m2h6-j472-rp4c, and bump pyopenssl to 26.4.0 for compatibility. ([#24948](https://github.com/DataDog/integrations-core/pull/24948))
+
+*Note: This release is bundled with the `7.83.x` Agent and does not include changes from the `38.1.0` release.*
+
 ## 38.0.0 / 2026-08-05
 
 ***Changed***:

--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 13.1.0 / 2026-08-24
+
+***Security***:
+
+* Bump cryptography to 50.0.0 to remediate CVE-2026-69247, GHSA-jwv3-5hgf-82ww, and GHSA-m2h6-j472-rp4c. ([#24948](https://github.com/DataDog/integrations-core/pull/24948))
+
 ## 13.0.0 / 2026-07-29 / Agent 7.82.0
 
 ***Changed***:

--- a/http_check/changelog.d/24817.added
+++ b/http_check/changelog.d/24817.added
@@ -1,1 +1,0 @@
-Update dependencies

--- a/http_check/datadog_checks/http_check/__about__.py
+++ b/http_check/datadog_checks/http_check/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = "13.0.0"
+__version__ = "13.1.0"

--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 15.20.0 / 2026-08-24
+
+***Security***:
+
+* Bump cryptography to 50.0.0 to remediate CVE-2026-69247, GHSA-jwv3-5hgf-82ww, and GHSA-m2h6-j472-rp4c. ([#24948](https://github.com/DataDog/integrations-core/pull/24948))
+
 ## 15.19.0 / 2026-08-05
 
 ***Added***:

--- a/mysql/datadog_checks/mysql/__about__.py
+++ b/mysql/datadog_checks/mysql/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "15.19.0"
+__version__ = "15.20.0"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -38,7 +38,7 @@ datadog-checks-base==38.1.0
 datadog-checks-dependency-provider==3.2.0
 datadog-checks-downloader==9.3.0
 datadog-cilium==6.4.1
-datadog-cisco-aci==5.0.1
+datadog-cisco-aci==5.1.0
 datadog-cisco-asa==1.0.0
 datadog-cisco-secure-client==1.0.0
 datadog-cisco-secure-firewall==1.3.0
@@ -99,7 +99,7 @@ datadog-hdfs-namenode==7.4.0; sys_platform != 'win32'
 datadog-hive==2.4.0
 datadog-hivemq==2.4.0
 datadog-hpe-aruba-edgeconnect==1.0.1
-datadog-http-check==13.0.0
+datadog-http-check==13.1.0
 datadog-hudi==4.3.0
 datadog-hugging-face-tgi==1.5.1
 datadog-hyperv==3.4.0; sys_platform == 'win32'
@@ -162,7 +162,7 @@ datadog-microsoft-dns==1.2.0; sys_platform == 'win32'
 datadog-microsoft-sysmon==1.2.0; sys_platform == 'win32'
 datadog-milvus==2.6.0
 datadog-mongo==10.12.0
-datadog-mysql==15.19.0
+datadog-mysql==15.20.0
 datadog-n8n==2.1.1
 datadog-nagios==3.4.0
 datadog-network==5.7.0
@@ -235,7 +235,7 @@ datadog-temporal==4.7.1
 datadog-tenable==3.2.0
 datadog-teradata==4.3.0; sys_platform != 'darwin'
 datadog-tibco-ems==2.6.1; sys_platform != 'win32'
-datadog-tls==5.7.0
+datadog-tls==5.8.0
 datadog-tomcat==4.3.0
 datadog-torchserve==4.4.1
 datadog-traefik-mesh==3.5.1

--- a/tls/CHANGELOG.md
+++ b/tls/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## 5.8.0 / 2026-08-24
+
+***Security***:
+
+* Bump cryptography to 50.0.0 to remediate CVE-2026-69247, GHSA-jwv3-5hgf-82ww, and GHSA-m2h6-j472-rp4c. ([#24948](https://github.com/DataDog/integrations-core/pull/24948))
+
 ## 5.7.0 / 2026-08-05
 
 ***Added***:

--- a/tls/changelog.d/24817.added
+++ b/tls/changelog.d/24817.added
@@ -1,1 +1,0 @@
-Update dependencies

--- a/tls/datadog_checks/tls/__about__.py
+++ b/tls/datadog_checks/tls/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '5.7.0'
+__version__ = '5.8.0'


### PR DESCRIPTION
### What does this PR do?

Ports #24961 to `master`. `cisco_aci` 5.1.0, `http_check` 13.1.0, `mysql` 15.20.0 and `tls` 5.8.0 get the version bump, changelog section and pin. `datadog_checks_base` is already ahead at 38.1.0, so it gets the 38.0.1 changelog record only, as with 37.18.1 in #21249.

The now-released `24817.added` fragments for `cisco_aci`, `http_check` and `tls` are deleted. `mysql` keeps its own, since #24817 also bumped `boto3` and `cachetools` there.

### Motivation

`master` was behind four versions published from `7.83.x`, so its next release would have reused version numbers already on PyPI. No dependency changes.

Fixed by #24948: [VULN-92334](https://datadoghq.atlassian.net/browse/VULN-92334) (CVE-2026-69247), [VULN-92350](https://datadoghq.atlassian.net/browse/VULN-92350) (GHSA-jwv3-5hgf-82ww), [VULN-92337](https://datadoghq.atlassian.net/browse/VULN-92337) (GHSA-m2h6-j472-rp4c).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[VULN-92334]: https://datadoghq.atlassian.net/browse/VULN-92334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VULN-92350]: https://datadoghq.atlassian.net/browse/VULN-92350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VULN-92337]: https://datadoghq.atlassian.net/browse/VULN-92337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ