### PR TITLE
Probe which signals reach ddev when a workflow run is cancelled

### DIFF
--- a/.github/workflows/signal-probe.yml
+++ b/.github/workflows/signal-probe.yml
@@ -4,10 +4,9 @@ name: signal probe
 # cancelled, and whether being a child of the step's bash costs us them. Delete once recorded.
 
 on:
-  pull_request:
-    paths:
-    - '.github/workflows/signal-probe.yml'
-    - 'ddev/src/ddev/cli/ci/signal_probe.py'
+  push:
+    branches:
+    - 'aarakke/signal-probe'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/signal-probe.yml
+++ b/.github/workflows/signal-probe.yml
@@ -1,0 +1,52 @@
+name: signal probe
+
+# Temporary. Answers one question: which signals reach a ddev process when a workflow run is
+# cancelled, and whether being a child of the step's bash costs us them. Delete once recorded.
+
+on:
+  pull_request:
+    paths:
+    - '.github/workflows/signal-probe.yml'
+    - 'ddev/src/ddev/cli/ci/signal_probe.py'
+  workflow_dispatch:
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        # ddev is a child of the step's bash, which is how a workflow would normally call it.
+        - invocation: child
+          command: ddev ci signal-probe --duration 300
+        # bash replaces itself with ddev, making ddev the step's entry process.
+        - invocation: exec
+          command: exec ddev ci signal-probe --duration 300
+
+    name: probe (${{ matrix.invocation }})
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: '3.13'
+
+    - name: Install ddev
+      uses: ./.github/actions/setup-ddev
+      with:
+        install-mode: local
+        cache-profile: local-ddev
+
+    - name: Configure ddev
+      run: |
+        ddev config set upgrade_check false
+        ddev config set repos.core .
+        ddev config set repo core
+
+    - name: Run the probe, then cancel this run from the Actions tab
+      run: ${{ matrix.command }}

--- a/ddev/src/ddev/cli/ci/__init__.py
+++ b/ddev/src/ddev/cli/ci/__init__.py
@@ -5,6 +5,7 @@ import click
 from datadog_checks.dev.tooling.commands.ci.setup import setup
 
 from ddev.cli.ci.codeowners import codeowners
+from ddev.cli.ci.signal_probe import signal_probe
 
 
 @click.group(short_help='Collection of CI utilities')
@@ -17,3 +18,4 @@ def ci():
 
 ci.add_command(setup)
 ci.add_command(codeowners)
+ci.add_command(signal_probe)

--- a/ddev/src/ddev/cli/ci/signal_probe.py
+++ b/ddev/src/ddev/cli/ci/signal_probe.py
@@ -1,0 +1,77 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Temporary probe: records which signals a ddev process receives when a workflow is cancelled.
+
+GitHub documents SIGINT, then 7.5s, then SIGTERM, then 2.5s, then a hard kill of the process tree,
+and also says a child of the step's entry process may get nothing before that kill. The Dispatcher's
+cancellation handling depends on which of those actually reaches ddev, so this measures it rather
+than assuming. Delete once the answer is recorded.
+"""
+
+from __future__ import annotations
+
+import click
+
+WATCHED_SIGNALS = ("SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT")
+
+
+@click.command(short_help='Report which signals reach ddev, for cancellation testing', hidden=True)
+@click.option('--duration', type=float, default=300.0, help='Seconds to stay alive.')
+@click.option('--heartbeat', type=float, default=10.0, help='Seconds between heartbeat lines.')
+def signal_probe(duration: float, heartbeat: float) -> None:
+    """Stay alive, log every signal received, and keep going so a following signal is seen too.
+
+    Deliberately does not exit on the first signal: the point is to observe the whole sequence, and
+    exiting early would hide whether SIGTERM follows SIGINT.
+    """
+    import os
+    import signal
+    import sys
+    import time
+
+    start = time.monotonic()
+    received: list[str] = []
+
+    def report(line: str) -> None:
+        print(f"[{time.monotonic() - start:7.2f}s] {line}", flush=True)
+
+    def handler(signal_number: int, _frame: object) -> None:
+        name = signal.Signals(signal_number).name
+        received.append(name)
+        report(f"RECEIVED {name}")
+
+    for name in WATCHED_SIGNALS:
+        number = getattr(signal, name, None)
+        if number is not None:
+            signal.signal(number, handler)
+
+    report(f"pid={os.getpid()} ppid={os.getppid()} parent_cmd={_parent_command()}")
+    report(f"watching {', '.join(WATCHED_SIGNALS)} for {duration}s")
+
+    next_heartbeat = heartbeat
+    while (elapsed := time.monotonic() - start) < duration:
+        # Short sleeps so a handler runs promptly and the loop notices the deadline.
+        time.sleep(0.2)
+        if elapsed >= next_heartbeat:
+            report(f"alive, signals so far: {received or 'none'}")
+            next_heartbeat += heartbeat
+
+    report(f"exiting normally, signals received: {received or 'none'}")
+    sys.exit(0)
+
+
+def _parent_command() -> str:
+    """The parent's command line, to show whether ddev is the step's entry process or a child of it."""
+    import os
+    import subprocess
+
+    try:
+        return subprocess.run(
+            ['ps', '-o', 'command=', '-p', str(os.getppid())],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except Exception as error:  # noqa: BLE001 - a probe must not fail on its own diagnostics
+        return f"unavailable ({error})"


### PR DESCRIPTION
### What does this PR do?

Adds a throwaway `ddev ci signal-probe` command and a workflow that runs it for five minutes, so we can cancel the run and see which signals actually reach ddev. **Not for merge**: it exists to produce one answer, which then goes in the Dispatcher's cancellation design.

The probe logs every signal it receives with a timestamp and keeps running afterwards, deliberately. Exiting on the first one would hide whether a second follows.

Two matrix jobs, so one cancellation answers both variants:

- `child`: `ddev ci signal-probe`, ddev as a child of the step's bash, which is how a workflow would normally call it.
- `exec`: `exec ddev ci signal-probe`, bash replaced by ddev, making ddev the step's entry process.

### Motivation

GitHub documents cancellation as SIGINT, then 7.5 seconds, then SIGTERM, then 2.5 seconds, then a hard kill of the process tree. It also says a child of the step's entry process typically gets nothing before that kill, and there are reports of SIGHUP arriving instead of SIGINT.

The Dispatcher needs to react to a cancelled job: close its check runs, which otherwise sit `in_progress` forever and can block the pull request, post a final comment, and cancel the workflow runs it dispatched. All of that depends on a signal arriving, and on how much time there is once it does. Worth measuring before designing around it.

### How to use it

Cancel the run from the Actions tab while both jobs are in their probe step, then read the job logs. Each line is `[elapsed] RECEIVED <SIGNAL>`, and the first line records the pid and the parent command so it is clear whether ddev was the entry process.

Locally, sending SIGINT, SIGTERM and SIGHUP to the probe produces:

```
[   0.02s] watching SIGINT, SIGTERM, SIGHUP, SIGQUIT for 20.0s
[   1.12s] RECEIVED SIGINT
[   2.13s] RECEIVED SIGTERM
[   3.14s] RECEIVED SIGHUP
```

so a job log showing no signals means none arrived, rather than the probe missing them.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
