### PR TITLE
Update self.gitlab.release.branches.sts.yaml

### DIFF
--- a/.github/chainguard/self.gitlab.release.branches.sts.yaml
+++ b/.github/chainguard/self.gitlab.release.branches.sts.yaml
@@ -37,3 +37,4 @@ claim_pattern:
 
 permissions:
   contents: write
+  workflows: write


### PR DESCRIPTION
### What does this PR do?
We're currently blocked in the release due to a timeout issue:

> cisco_aci-5.1.0 -> cisco_aci-5.1.0 (Unable to determine if workflow can be created or updated due to timeout; `workflows` scope may be required.)

This has been going on for over a day. Trying to add the additional permissions so that we can get unblocked and continue with the whl release.

https://gitlab.ddbuild.io/DataDog/integrations-core/-/jobs/1978930195
