### PR TITLE
Skip redundant tag conversion on the metric submission path

### DIFF
--- a/datadog_checks_base/changelog.d/24992.fixed
+++ b/datadog_checks_base/changelog.d/24992.fixed
@@ -1,0 +1,1 @@
+Skip the redundant string conversion for tags that are already strings when submitting metrics.

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1761,15 +1761,20 @@ class AgentCheck(object):
                     'Encoding error with device name `%r` for metric `%r`, ignoring tag', device_name, metric_name
                 )
 
+        # This runs for every tag of every submitted metric, so read the generic-tag setting once instead of
+        # once per tag, and skip the conversion call for tags that are already `str` -- in practice nearly all
+        # of them. `to_native_string` returns those unchanged, so the fast path is equivalent.
+        disable_generic_tags = self.disable_generic_tags
         for tag in tags:
             if tag is None:
                 continue
-            try:
-                tag = to_native_string(tag)
-            except UnicodeError:
-                self.log.warning('Encoding error with tag `%s` for metric `%s`, ignoring tag', tag, metric_name)
-                continue
-            if self.disable_generic_tags:
+            if type(tag) is not str:
+                try:
+                    tag = to_native_string(tag)
+                except UnicodeError:
+                    self.log.warning('Encoding error with tag `%s` for metric `%s`, ignoring tag', tag, metric_name)
+                    continue
+            if disable_generic_tags:
                 normalized_tags.append(self.degeneralise_tag(tag))
             else:
                 normalized_tags.append(tag)


### PR DESCRIPTION
### What does this PR do?

Adds a fast path to `AgentCheck._normalize_tags_type`, which runs for every tag of every metric
submitted by every Python integration.

- `to_native_string` is skipped for tags that are already `str`. It returns those unchanged, so the
  fast path is equivalent; `bytes` tags and the `UnicodeError` handling are untouched.
- `self.disable_generic_tags` is read once per call instead of once per tag.

### Motivation

GIL profiling of the SQL Server check showed `ensure_unicode`, reached through
`_normalize_tags_type`, among the largest Python leaf costs. On Python 3 it is a no-op for `str`
input — a leftover from the Python 2/3 shim.

Measured on SQL Server as an interleaved A/B (clean/patched, four replicates per arm, 600 s
windows, 3204 check runs, zero errors):

| | master | this PR |
|---|---|---|
| `ensure_unicode`, share of Python samples | 8.03% | 1.22% |
| CPU seconds per check run | 0.244 | 0.231 (**-5.3%**) |

Per-arm ranges do not overlap: 0.242-0.245 against 0.227-0.232.

Two caveats on how far that generalizes:

- **This is CPU headroom, not throughput.** Completed runs per minute were unchanged (40.03 against
  40.05). The bench is not CPU-bound, so removing CPU does not produce more work; it only helps
  where the agent is CPU-constrained.
- **The effect size tracks metrics submitted per run.** This workload submits roughly 1M per run.
  Earlier runs against a larger database set measured -8.8% and -10.5%. Checks that submit few
  metrics will see proportionally the same saving on a much smaller base.

Emitted output was verified unchanged: running `agent check sqlserver --json` on both builds over
20 databases produced identical sets of (metric name, tags, type) and identical service checks —
31742 series, 44 service checks, zero differences.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
