### PR TITLE
Cache namespaced metric names on the submission path

### DIFF
--- a/datadog_checks_base/changelog.d/24993.fixed
+++ b/datadog_checks_base/changelog.d/24993.fixed
@@ -1,0 +1,1 @@
+Cache namespaced metric names so they are not recomputed for every submitted metric.

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -378,6 +378,7 @@ class AgentCheck(object):
 
         # Setup metric limits
         self.metric_limiter = self._get_metric_limiter(self.name, instance=self.instance)
+        self._namespace_cache = {}  # type: dict[tuple[str, bool, str], str]
 
         # Lazily load and validate config
         self._config_model_instance = None  # type: Any
@@ -1562,10 +1563,22 @@ class AgentCheck(object):
 
     def _format_namespace(self, s, raw=False):
         # type: (str, bool) -> str
-        if not raw and self.__NAMESPACE__:
-            return '{}.{}'.format(self.__NAMESPACE__, to_native_string(s))
+        # Runs once per submitted metric, and a check reports the same names every run, so the result is cached.
+        # The namespace is part of the key because `adopt_namespace` swaps `__NAMESPACE__` for the duration of a
+        # context manager, so one name can format two different ways within a single check run.
+        namespace = self.__NAMESPACE__
+        key = (s, raw, namespace)
+        cached = self._namespace_cache.get(key)
+        if cached is not None:
+            return cached
 
-        return to_native_string(s)
+        if not raw and namespace:
+            formatted = '{}.{}'.format(namespace, to_native_string(s))
+        else:
+            formatted = to_native_string(s)
+
+        self._namespace_cache[key] = formatted
+        return formatted
 
     def normalize(self, metric, prefix=None, fix_case=False):
         # type: (Union[str, bytes], Union[str, bytes], bool) -> str

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -696,6 +696,23 @@ class TestMetrics:
 
         aggregator.assert_metric('metric', count=len(methods))
 
+    def test_namespace_changes_between_submissions(self, aggregator):
+        # `adopt_namespace` in the OpenMetrics and Windows perf-counter base classes swaps `__NAMESPACE__` for
+        # the duration of a context manager, so the same metric name can format two different ways within one
+        # check run.
+        check = AgentCheck()
+        check.__NAMESPACE__ = 'first'
+        check.gauge('metric', 0)
+
+        check.__NAMESPACE__ = 'second'
+        check.gauge('metric', 0)
+
+        check.__NAMESPACE__ = 'first'
+        check.gauge('metric', 0)
+
+        aggregator.assert_metric('first.metric', count=2)
+        aggregator.assert_metric('second.metric', count=1)
+
     def test_non_float_metric(self, aggregator):
         check = AgentCheck()
         metric_name = 'test_metric'


### PR DESCRIPTION
### What does this PR do?

Caches the result of `AgentCheck._format_namespace` per check instance. It is called once for every
submitted metric and recomputes an identical result each time, because a check reports the same set
of metric names on every run.

The cache key includes the namespace, not just the metric name. `adopt_namespace` — in the
OpenMetrics v2 and Windows perf-counter base classes — swaps `__NAMESPACE__` for the duration of a
context manager, so one metric name can legitimately format two different ways within a single check
run. Keying on the name alone returns the adopted namespace's result after the context exits. The
added test covers that case and fails without the namespace in the key.

Stacks on #24992, which is in the same function's caller but does not touch this function.

### Motivation

While investigating why the SQL Server check does not scale with additional check runners, GIL
profiling showed a large share of Python time in the metric submission path rather than in query
execution.

Measured on SQL Server with 1270 databases across 10 check instances at 4 check runners, as a
six-arm interleaved A/B against a single baseline (two replicates per arm, 600 s window each):

| | master | #24992 only | #24992 + this PR |
|---|---|---|---|
| CPU seconds per check run | 3.282 | 2.937 (-10.5%) | 2.602 (**-20.7%**) |
| check runs per minute | 27.24 | 29.32 | 30.39 (+11.6%) |
| average execution time | 6.95 s | 6.35 s | 5.80 s |
| `_format_namespace` share of GIL time | 5.10% | 5.93% | 2.55% |

So this change is worth a further -11.4% on top of #24992. Replicates within each arm agreed to
within 3%.

### A note for reviewers on memory

The cache is unbounded. It holds one short string per distinct (metric name, raw, namespace) seen by
the instance. For nearly all checks the set of metric names is fixed by the integration, so the
cache is small and static.

The exception is OpenMetrics v2 configured with a regex or wildcard entry in `metrics`, where the
submitted name comes from the scraped endpoint (`openmetrics/v2/transform.py`, in `get`), so the
name set is bounded by the exporter rather than by config. That path already keeps an uncapped
per-name dict of its own in the same method — `self.transformer_data[metric_name]`, gated by
`cache_metric_wildcards`, which defaults to true — so this adds a second entry keyed by strings that
are already retained, rather than introducing a new unbounded growth pattern.

I considered capping the cache and discarding it past the cap, but that costs a bounds check on
every miss and measurably regresses exactly the dynamic-name case it is meant to protect, so it
seemed worse than following the existing precedent. Happy to add a cap or a config gate if the
owners of this package would prefer one.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
