### PR TITLE
Raise the default page size from 30 to 300

### DIFF
--- a/octopus_deploy/assets/configuration/spec.yaml
+++ b/octopus_deploy/assets/configuration/spec.yaml
@@ -241,9 +241,13 @@ files:
         example: {}
     - name: paginated_limit
       description: |
-          Sets the number of items API calls should return at a time. Default is 30.
+          Sets the number of items API calls should return at a time. Default is 300.
+
+          Octopus endpoints cost about the same to serve whether they return 30 rows or 300, so a
+          small page size mostly multiplies the number of round trips. Lower this if your Octopus
+          server is memory constrained or sits behind a proxy with a small response limit.
       value:
-        example: 30
+        example: 300
         type: integer
       required: false
       fleet_configurable: false

--- a/octopus_deploy/changelog.d/24994.fixed
+++ b/octopus_deploy/changelog.d/24994.fixed
@@ -1,0 +1,1 @@
+Raise the default page size from 30 to 300, which cuts the number of requests a collection makes without changing the data it reports.

--- a/octopus_deploy/datadog_checks/octopus_deploy/config_models/defaults.py
+++ b/octopus_deploy/datadog_checks/octopus_deploy/config_models/defaults.py
@@ -61,7 +61,7 @@ def instance_min_collection_interval():
 
 
 def instance_paginated_limit():
-    return 30
+    return 300
 
 
 def instance_persist_connections():

--- a/octopus_deploy/datadog_checks/octopus_deploy/data/conf.yaml.example
+++ b/octopus_deploy/datadog_checks/octopus_deploy/data/conf.yaml.example
@@ -237,10 +237,14 @@ instances:
     #     <OPTION_1>: <VALUE_1>
     #     <OPTION_2>: <VALUE_2>
 
-    ## @param paginated_limit - integer - optional - default: 30
-    ## Sets the number of items API calls should return at a time. Default is 30.
+    ## @param paginated_limit - integer - optional - default: 300
+    ## Sets the number of items API calls should return at a time. Default is 300.
+    ##
+    ## Octopus endpoints cost about the same to serve whether they return 30 rows or 300, so a
+    ## small page size mostly multiplies the number of round trips. Lower this if your Octopus
+    ## server is memory constrained or sits behind a proxy with a small response limit.
     #
-    # paginated_limit: 30
+    # paginated_limit: 300
 
     ## @param collect_events - boolean - optional - default: false
     ## Whether or not to collect audit events about machines, deployments, and failed logins.

--- a/octopus_deploy/tests/conftest.py
+++ b/octopus_deploy/tests/conftest.py
@@ -87,6 +87,17 @@ PARAMS_TO_FILENAME_MAPPING = {
     'skip=0/take=30': 'high_limit_pg1',
 }
 
+# The shipped page size is 300, while the pagination tests pin it to 30 or 2. Responses named
+# "high_limit" hold everything on a single page, so a request at the default resolves to the same
+# fixture as the take=30 case.
+PARAMS_TO_FILENAME_MAPPING.update(
+    {
+        key.replace('take=30', 'take=300'): filename
+        for key, filename in PARAMS_TO_FILENAME_MAPPING.items()
+        if key.endswith('take=30')
+    }
+)
+
 
 # https://docs.python.org/3/library/unittest.mock-examples.html#coping-with-mutable-arguments
 class CopyingMock(mock.MagicMock):

--- a/octopus_deploy/tests/test_unit.py
+++ b/octopus_deploy/tests/test_unit.py
@@ -2170,6 +2170,20 @@ def test_deployments_caching(get_current_datetime, dd_run_check, mock_http_get, 
     assert args_list.count('http://localhost:80/api/Spaces-1/environments') == 5
 
 
+@pytest.mark.usefixtures('mock_http_get')
+@mock.patch("datadog_checks.octopus_deploy.check.get_current_datetime")
+def test_default_page_size(get_current_datetime, dd_run_check, mock_http_get, instance):
+    check = OctopusDeployCheck('octopus_deploy', {}, [instance])
+    get_current_datetime.return_value = MOCKED_TIME1
+
+    dd_run_check(check)
+
+    # An instance that does not set paginated_limit pages every endpoint at the shipped default.
+    # This fails if spec.yaml and the generated config models ever disagree about that value.
+    takes = {call[1]['params']['take'] for call in mock_http_get.call_args_list if 'take' in call[1].get('params', {})}
+    assert takes == {300}
+
+
 @pytest.mark.parametrize(
     ('paginated_limit'),
     [pytest.param(30, id='high limit'), pytest.param(2, id='low limit')],


### PR DESCRIPTION
### What does this PR do?

Raises the default `paginated_limit` from 30 to 300.

Octopus list endpoints have a large fixed cost per request that barely changes with page size, so a small page size mostly multiplies round trips rather than reducing work.

Measured on an instance with 217 spaces, 1,002 project groups, 5,002 projects and 14,702 machines:

| | `take=30` | `take=300` | |
|---|---:|---:|---|
| `{spaceId}/machines` | 707 req · 824 s | 266 req · 345 s | **−58%** |
| `{spaceId}/projects` | 383 req · 71 s | 233 req · 50 s | −29% |
| `{spaceId}/environments` | 383 req · 36 s | 233 req · 21 s | −42% |
| `{spaceId}/projectgroups` | 250 req · 15 s | 220 req · 11 s | −26% |

Cost per machines page rose from 1.166 s to 1.297 s — **11% more per page for 62% fewer pages**. Across a whole collection this took the check from 1,756 requests in 16m05s to **960 requests in 7m17s**.

### Why 300 and not larger

1000 was within a few percent of 300 in the same test, so 300 captures nearly all of the available saving. Keeping responses smaller leaves headroom for memory-constrained servers and for proxies with modest response size limits, and the option stays configurable for anyone who needs to lower it.

### Motivation

Octopus traced high API load and database CPU on several mutually shared cloud-hosted customers back to this integration. Three PRs address the request *count* (#24968, #24969, #24970); this addresses the request *size*, and is independent of all three — it touches no call sites, only a default.

With #24968 applied, `{spaceId}/machines` was 86% of all remaining HTTP time in a full collection, and no other open PR touches it. This is the cheapest remaining change: no new API calls, just a different number.

### Note for reviewers

`config_models/defaults.py` and `data/conf.yaml.example` are generated. I updated them by hand to match `spec.yaml` because `ddev` was not available in my environment. Please regenerate with `ddev validate config -s octopus_deploy` and `ddev validate models -s octopus_deploy` to confirm they match. A test was added that fails if the shipped default and the generated model ever disagree.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
