### PR TITLE
Wait for online bricks with populated stats before glusterfs E2E tests

### DIFF
--- a/glusterfs/tests/conftest.py
+++ b/glusterfs/tests/conftest.py
@@ -11,6 +11,7 @@ import pytest
 
 from datadog_checks.base.utils.common import get_docker_hostname
 from datadog_checks.dev import WaitFor, docker_run, run_command
+from datadog_checks.glusterfs.metrics import BRICK_STATS
 
 from .common import CONFIG, INSTANCE
 
@@ -106,8 +107,14 @@ def gstatus_ready():
             if not bricks:
                 raise Exception("No brick data yet")
             for brick in bricks:
-                if 'block_size' not in brick:
-                    raise Exception("Brick stats not fully populated yet")
+                if not brick.get('online'):
+                    raise Exception(f"Brick {brick.get('name')} is not online yet")
+                # gstatus reports filesystem-derived stats as 'N/A' until it can stat the brick's
+                # backing device. The check skips 'N/A' values, so the metric would never be
+                # submitted and the E2E assertions would fail.
+                unpopulated = [field for field in BRICK_STATS if str(brick.get(field)).lower() in ('none', 'n/a')]
+                if unpopulated:
+                    raise Exception(f"Brick {brick.get('name')} stats not populated yet: {unpopulated}")
 
 
 def delete_volume():


### PR DESCRIPTION
### What does this PR do?

Tightens the `gstatus_ready` gate in the glusterfs E2E environment setup. It now waits for every brick to be online and for the fields the check actually submits (`BRICK_STATS`) to hold real values, instead of only checking that the `block_size` key exists.

### Motivation

`test_e2e` has been failing intermittently on Master, most recently on Aug 24 ([job 97568417582](https://github.com/DataDog/integrations-core/actions/runs/32770077924/job/97568417582)) and Aug 25 (`RETRY FAILED` then `RETRY PASSED` in [job 97853334142](https://github.com/DataDog/integrations-core/actions/runs/32860251846/job/97853334142)):

```
AssertionError: Needed at least 1 candidates for 'glusterfs.brick.block_size', got 0
0.79  MetricStub(name='glusterfs.brick.online', type=0, value=0,
      tags=[...'fs_name:N/A'...], device='N/A', ...)
```

Every brick metric was submitted except `block_size`, the bricks were `online=0`, and `device`/`fs_name` came back `N/A`. gstatus reports filesystem-derived brick stats as `N/A` until it can stat the brick's backing device, and `submit_metrics` deliberately skips `N/A` values:

```python
if isinstance(value, str) and value.lower() == 'n/a':
    continue
```

The old gate only checked `'block_size' not in brick`, so a brick carrying `block_size: "N/A"` satisfied it. The gate passed, the check then skipped the metric, and `assert_metric` failed. Waiting on the key's presence never covered the state that actually breaks the test, which is why #22606 and #22945 did not settle this.

Driving the gate off `BRICK_STATS` keeps it in sync with whatever the check submits. `device` and `fs_name` are excluded on purpose: they are tags rather than metrics, so `N/A` there does not fail an assertion.

Verified against the payload from the Aug 24 failure and a healthy brick:

| brick state | old gate | new gate |
| --- | --- | --- |
| Aug 24 CI failure (`online=False`, `N/A` stats) | READY | NOT READY: not online yet |
| healthy, online, populated | READY | READY |

`WaitFor` retries 60 times at 1s intervals, so the gate stays bounded and raises rather than hanging. It previously passed on the first attempt, so there is headroom.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
