### PR TITLE
Publish redisdb activity-gen task for OCI federation

### DIFF
--- a/redisdb/tests/evalya.yaml
+++ b/redisdb/tests/evalya.yaml
@@ -44,6 +44,10 @@ tasks:
   # `with: [redis-full, activity-gen]`.
   - id: activity-gen
     image: "redis:${REDIS_VERSION:-7.4}"
+    labels:
+      # Published so other repos (e.g. semantic-core FTF) can OCI-federate this
+      # workload instead of vendoring a copy of the script.
+      evalya.io/publish: "true"
     command: ["sh", "/opt/activity-gen.sh"]
     volumes:
       - ./activity-gen.sh:/opt/activity-gen.sh:ro


### PR DESCRIPTION
### TL;DR

Publish the redisdb `activity-gen` evalya task so other repos can OCI-federate the workload instead of vendoring a copy of the script.

### What does this PR do?

Adds `evalya.io/publish: "true"` to the `activity-gen` task in `redisdb/tests/evalya.yaml`.

### Motivation

semantic-core's redis FTF scenario currently vendors a copy of `activity-gen.sh` because the task was not federatable. Publishing it lets that scenario reference the task over OCI, keeping a single source of the workload.

### Review checklist (to be filled by the reviewer)

- [ ] Test fixture only (one label); nothing shipped with the Agent, so no changelog entry is required.
- [x] `qa/skip-qa` (no Agent-impacting change).