### PR TITLE
sqlserver: keep DO scheduling state per query

### DIFF
--- a/sqlserver/changelog.d/24998.fixed
+++ b/sqlserver/changelog.d/24998.fixed
@@ -1,0 +1,1 @@
+Fix Data Observability scheduling so queries with the same monitor ID execute independently.

--- a/sqlserver/datadog_checks/sqlserver/data_observability.py
+++ b/sqlserver/datadog_checks/sqlserver/data_observability.py
@@ -49,11 +49,23 @@ DEFAULT_COLLECTION_INTERVAL_SECONDS = 10
 Mode = Literal["cron", "interval"]
 
 
+@dataclass
+class ScheduledQuery:
+    query: Query
+    scheduler: CronScheduler | None
+    last_execution: float | None = None
+    pending_retry: DueQuery | None = None
+
+
 @dataclass(frozen=True)
 class DueQuery:
-    query: Query
+    scheduled_query: ScheduledQuery
     scheduled_time: float
     mode: Mode
+
+    @property
+    def query(self) -> Query:
+        return self.scheduled_query.query
 
 
 _EXPECTED_DB_EXCEPTIONS: list[type[Exception]] = [SQLConnectionError]
@@ -67,11 +79,6 @@ class SqlServerDataObservability(DBMAsyncJob):
     def __init__(self, check: SQLServer, config: InstanceConfig):
         self._check = check
         self._config = config
-        self._last_execution: dict[int, float] = {}
-        # Due queries whose connection attempt failed last pass. Retried on the next
-        # poll regardless of mode, since CronScheduler.due_ticks() already consumed
-        # the tick for cron queries and cannot be "un-consumed".
-        self._pending_retries: dict[int, DueQuery] = {}
         collection_interval = config.data_observability.collection_interval
         if not collection_interval or collection_interval <= 0:
             collection_interval = DEFAULT_COLLECTION_INTERVAL_SECONDS
@@ -86,7 +93,7 @@ class SqlServerDataObservability(DBMAsyncJob):
             job_name="data-observability",
         )
         # Filter bad queries on check construction.
-        self._queries, self._schedulers = self._filter_valid_queries(self._do_config.queries or ())
+        self._scheduled_queries = self._filter_valid_queries(self._do_config.queries or ())
 
     def shutdown(self) -> None:
         self._check = None
@@ -95,13 +102,13 @@ class SqlServerDataObservability(DBMAsyncJob):
     def _do_config(self):
         return self._config.data_observability
 
-    def _filter_valid_queries(self, queries: Iterable[Query]) -> tuple[tuple[Query, ...], dict[int, CronScheduler]]:
-        valid: list[Query] = []
-        schedulers: dict[int, CronScheduler] = {}
+    def _filter_valid_queries(self, queries: Iterable[Query]) -> tuple[ScheduledQuery, ...]:
+        valid: list[ScheduledQuery] = []
         for q in queries:
+            scheduler = None
             if q.schedule:
                 try:
-                    schedulers[q.monitor_id] = CronScheduler(q.schedule, startup_lookback=CRON_STARTUP_LOOKBACK_SECONDS)
+                    scheduler = CronScheduler(q.schedule, startup_lookback=CRON_STARTUP_LOOKBACK_SECONDS)
                 except (ValueError, TypeError) as e:
                     self._log.warning(
                         "Skipping DO query monitor_id=%d: invalid cron schedule %r (%s). "
@@ -118,28 +125,39 @@ class SqlServerDataObservability(DBMAsyncJob):
                     q.monitor_id,
                 )
                 continue
-            valid.append(q)
-        return tuple(valid), schedulers
+            valid.append(ScheduledQuery(query=q, scheduler=scheduler))
+        return tuple(valid)
 
     def _get_due_queries(self) -> list[DueQuery]:
         now = time.time()
         due: list[DueQuery] = []
-        for q in self._queries:
+        for scheduled_query in self._scheduled_queries:
+            q = scheduled_query.query
+            newly_due = None
             if q.schedule:
+                scheduler = scheduled_query.scheduler
+                assert scheduler is not None
                 # +0.001 so a poll landing exactly on a tick boundary is treated
                 # as due (CronScheduler.previous_tick uses strict less-than).
-                ticks = self._schedulers[q.monitor_id].due_ticks(now + 0.001)
+                ticks = scheduler.due_ticks(now + 0.001)
                 if ticks:
                     # Take the latest elapsed tick; earlier ones are already in the past
                     # and do not need separate execution.
-                    due.append(DueQuery(q, ticks[-1], "cron"))
+                    newly_due = DueQuery(scheduled_query, ticks[-1], "cron")
             else:
-                last = self._last_execution.get(q.monitor_id)
+                last = scheduled_query.last_execution
                 if last is None or now - last >= q.interval_seconds:
                     # Seed: treat first sight as if the previous interval just completed,
                     # so the scheduled_time for DueQuery is now and lateness is 0.
                     scheduled = (last + q.interval_seconds) if last is not None else now
-                    due.append(DueQuery(q, scheduled, "interval"))
+                    newly_due = DueQuery(scheduled_query, scheduled, "interval")
+
+            if newly_due is not None:
+                scheduled_query.pending_retry = None
+                due.append(newly_due)
+            elif scheduled_query.pending_retry is not None:
+                due.append(scheduled_query.pending_retry)
+                scheduled_query.pending_retry = None
         return due
 
     def _build_base_tags(self) -> list[str]:
@@ -233,7 +251,7 @@ class SqlServerDataObservability(DBMAsyncJob):
 
     def _queue_for_retry(self, due: DueQuery, base_tags: list[str]) -> None:
         q = due.query
-        self._pending_retries[q.monitor_id] = due
+        due.scheduled_query.pending_retry = due
         self._check.count(
             'dd.sqlserver.data_observability.connection_failures',
             1,
@@ -267,7 +285,7 @@ class SqlServerDataObservability(DBMAsyncJob):
         # leave the query stuck re-firing the same tick.
         # For cron mode, due_ticks() already advanced the scheduler's internal state.
         if due.mode == "interval":
-            self._last_execution[q.monitor_id] = time.time()
+            due.scheduled_query.last_execution = time.time()
 
         try:
             self._check.gauge(
@@ -322,12 +340,9 @@ class SqlServerDataObservability(DBMAsyncJob):
                 pass
 
     def run_job(self):
-        # Merge queries still pending retry from a previous failed connection attempt
-        # with newly due queries, keyed by monitor_id so a fresher tick wins.
-        due_by_monitor_id = dict(self._pending_retries)
-        self._pending_retries = {}
-        due_by_monitor_id.update({due.query.monitor_id: due for due in self._get_due_queries()})
-        due_queries = list(due_by_monitor_id.values())
+        # Each physical query owns its scheduling and retry state. A newly due
+        # execution replaces that query's older retry so outages cannot build a backlog.
+        due_queries = self._get_due_queries()
         if not due_queries:
             self._log.debug("No data observability queries due for execution.")
             return

--- a/sqlserver/datadog_checks/sqlserver/data_observability.py
+++ b/sqlserver/datadog_checks/sqlserver/data_observability.py
@@ -50,22 +50,35 @@ Mode = Literal["cron", "interval"]
 
 
 @dataclass
-class ScheduledQuery:
+class CronScheduledQuery:
     query: Query
-    scheduler: CronScheduler | None
+    scheduler: CronScheduler
+    pending_retry: DueQuery | None = None
+
+
+@dataclass
+class IntervalScheduledQuery:
+    query: Query
+    interval_seconds: int
     last_execution: float | None = None
     pending_retry: DueQuery | None = None
+
+
+ScheduledQuery = CronScheduledQuery | IntervalScheduledQuery
 
 
 @dataclass(frozen=True)
 class DueQuery:
     scheduled_query: ScheduledQuery
     scheduled_time: float
-    mode: Mode
 
     @property
     def query(self) -> Query:
         return self.scheduled_query.query
+
+    @property
+    def mode(self) -> Mode:
+        return "cron" if isinstance(self.scheduled_query, CronScheduledQuery) else "interval"
 
 
 _EXPECTED_DB_EXCEPTIONS: list[type[Exception]] = [SQLConnectionError]
@@ -105,7 +118,6 @@ class SqlServerDataObservability(DBMAsyncJob):
     def _filter_valid_queries(self, queries: Iterable[Query]) -> tuple[ScheduledQuery, ...]:
         valid: list[ScheduledQuery] = []
         for q in queries:
-            scheduler = None
             if q.schedule:
                 try:
                     scheduler = CronScheduler(q.schedule, startup_lookback=CRON_STARTUP_LOOKBACK_SECONDS)
@@ -119,43 +131,39 @@ class SqlServerDataObservability(DBMAsyncJob):
                         q.monitor_id,
                     )
                     continue
-            elif not (q.interval_seconds and q.interval_seconds > 0):
+                valid.append(CronScheduledQuery(query=q, scheduler=scheduler))
+                continue
+
+            interval_seconds = q.interval_seconds
+            if not interval_seconds or interval_seconds <= 0:
                 self._log.warning(
                     "Skipping DO query monitor_id=%d: neither schedule nor positive interval_seconds set",
                     q.monitor_id,
                 )
                 continue
-            valid.append(ScheduledQuery(query=q, scheduler=scheduler))
+            valid.append(IntervalScheduledQuery(query=q, interval_seconds=interval_seconds))
         return tuple(valid)
 
     def _get_due_queries(self) -> list[DueQuery]:
         now = time.time()
         due: list[DueQuery] = []
         for scheduled_query in self._scheduled_queries:
-            q = scheduled_query.query
             newly_due = None
-            if q.schedule:
-                scheduler = scheduled_query.scheduler
-                if scheduler is None:
-                    self._log.error(
-                        "Skipping DO query monitor_id=%d: cron scheduler is unavailable",
-                        q.monitor_id,
-                    )
-                    continue
+            if isinstance(scheduled_query, CronScheduledQuery):
                 # +0.001 so a poll landing exactly on a tick boundary is treated
                 # as due (CronScheduler.previous_tick uses strict less-than).
-                ticks = scheduler.due_ticks(now + 0.001)
+                ticks = scheduled_query.scheduler.due_ticks(now + 0.001)
                 if ticks:
                     # Take the latest elapsed tick; earlier ones are already in the past
                     # and do not need separate execution.
-                    newly_due = DueQuery(scheduled_query, ticks[-1], "cron")
+                    newly_due = DueQuery(scheduled_query, ticks[-1])
             else:
                 last = scheduled_query.last_execution
-                if last is None or now - last >= q.interval_seconds:
+                if last is None or now - last >= scheduled_query.interval_seconds:
                     # Seed: treat first sight as if the previous interval just completed,
                     # so the scheduled_time for DueQuery is now and lateness is 0.
-                    scheduled = (last + q.interval_seconds) if last is not None else now
-                    newly_due = DueQuery(scheduled_query, scheduled, "interval")
+                    scheduled = (last + scheduled_query.interval_seconds) if last is not None else now
+                    newly_due = DueQuery(scheduled_query, scheduled)
 
             if newly_due is not None:
                 scheduled_query.pending_retry = None
@@ -289,7 +297,7 @@ class SqlServerDataObservability(DBMAsyncJob):
         # Advance scheduling state before emission so an emit-side error cannot
         # leave the query stuck re-firing the same tick.
         # For cron mode, due_ticks() already advanced the scheduler's internal state.
-        if due.mode == "interval":
+        if isinstance(due.scheduled_query, IntervalScheduledQuery):
             due.scheduled_query.last_execution = time.time()
 
         try:

--- a/sqlserver/datadog_checks/sqlserver/data_observability.py
+++ b/sqlserver/datadog_checks/sqlserver/data_observability.py
@@ -136,7 +136,12 @@ class SqlServerDataObservability(DBMAsyncJob):
             newly_due = None
             if q.schedule:
                 scheduler = scheduled_query.scheduler
-                assert scheduler is not None
+                if scheduler is None:
+                    self._log.error(
+                        "Skipping DO query monitor_id=%d: cron scheduler is unavailable",
+                        q.monitor_id,
+                    )
+                    continue
                 # +0.001 so a poll landing exactly on a tick boundary is treated
                 # as due (CronScheduler.previous_tick uses strict less-than).
                 ticks = scheduler.due_ticks(now + 0.001)

--- a/sqlserver/datadog_checks/sqlserver/data_observability.py
+++ b/sqlserver/datadog_checks/sqlserver/data_observability.py
@@ -7,7 +7,7 @@ import math
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from datadog_checks.base.utils.cron import CronScheduler
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding
@@ -46,11 +46,10 @@ CRON_STARTUP_LOOKBACK_SECONDS = 300
 
 DEFAULT_COLLECTION_INTERVAL_SECONDS = 10
 
-Mode = Literal["cron", "interval"]
-
 
 @dataclass
 class CronScheduledQuery:
+    mode: ClassVar[Literal["cron"]] = "cron"
     query: Query
     scheduler: CronScheduler
     pending_retry: DueQuery | None = None
@@ -58,6 +57,7 @@ class CronScheduledQuery:
 
 @dataclass
 class IntervalScheduledQuery:
+    mode: ClassVar[Literal["interval"]] = "interval"
     query: Query
     interval_seconds: int
     last_execution: float | None = None
@@ -75,10 +75,6 @@ class DueQuery:
     @property
     def query(self) -> Query:
         return self.scheduled_query.query
-
-    @property
-    def mode(self) -> Mode:
-        return "cron" if isinstance(self.scheduled_query, CronScheduledQuery) else "interval"
 
 
 _EXPECTED_DB_EXCEPTIONS: list[type[Exception]] = [SQLConnectionError]
@@ -322,7 +318,7 @@ class SqlServerDataObservability(DBMAsyncJob):
             self._check.gauge(
                 'dd.sqlserver.data_observability.query_fire_lateness_seconds',
                 lateness,
-                tags=tags + [f'mode:{due.mode}'],
+                tags=tags + [f'mode:{due.scheduled_query.mode}'],
                 hostname=self._check.reported_hostname,
                 raw=True,
             )

--- a/sqlserver/tests/test_data_observability.py
+++ b/sqlserver/tests/test_data_observability.py
@@ -179,6 +179,22 @@ def test_multi_query_execution(aggregator):
     assert all('status:success' in m.tags for m in status_metrics)
 
 
+def test_queries_with_same_monitor_id_all_execute(aggregator):
+    queries = [
+        {**deepcopy(BASE_QUERY), 'monitor_id': 0, 'query': 'SELECT first_query'},
+        {**deepcopy(BASE_QUERY), 'monitor_id': 0, 'query': 'SELECT second_query'},
+    ]
+    mock_cursor = _make_mock_cursor()
+
+    _setup_and_run(queries=queries, mock_cursor=mock_cursor)
+
+    assert [call.args[0] for call in mock_cursor.execute.call_args_list] == [
+        'SELECT first_query',
+        'SELECT second_query',
+    ]
+    assert len(aggregator.metrics('dd.sqlserver.data_observability.query_executions')) == 2
+
+
 # ── Per-dbname connections ────────────────────────────────────────────────────
 
 
@@ -356,7 +372,12 @@ def test_connection_failure_retries_every_query_in_group(aggregator):
     assert len(aggregator.metrics('dd.sqlserver.data_observability.query_executions')) == 0
     failure_metrics = aggregator.metrics('dd.sqlserver.data_observability.connection_failures')
     assert len(failure_metrics) == 2
-    assert set(check.data_observability._pending_retries.keys()) == {1, 2}
+    pending = [
+        scheduled.pending_retry
+        for scheduled in check.data_observability._scheduled_queries
+        if scheduled.pending_retry is not None
+    ]
+    assert {due.query.monitor_id for due in pending} == {1, 2}
 
 
 def test_connection_failure_retried_on_next_poll(aggregator, monkeypatch):
@@ -366,7 +387,7 @@ def test_connection_failure_retried_on_next_poll(aggregator, monkeypatch):
     Uses a cron query deliberately: CronScheduler.due_ticks() consumes the tick as soon as
     it's reported, so — unlike an interval query, which would naturally still look "due"
     on the next poll regardless of any retry bookkeeping — a cron query only fires again
-    here because of the `_pending_retries` mechanism. This protects that mechanism from
+    here because of the per-query pending retry state. This protects that mechanism from
     regressing silently.
     """
     from datadog_checks.sqlserver.connection_errors import SQLConnectionError
@@ -400,6 +421,45 @@ def test_connection_failure_retried_on_next_poll(aggregator, monkeypatch):
     aggregator.reset()
     check.data_observability.run_job()
     assert len(aggregator.metrics('dd.sqlserver.data_observability.query_executions')) == 1
+
+
+def test_cron_queries_with_same_monitor_id_are_retried_independently(aggregator, monkeypatch):
+    from datadog_checks.sqlserver.connection_errors import SQLConnectionError
+
+    queries = [
+        {**deepcopy(CRON_QUERY), 'monitor_id': 0, 'query': 'SELECT first_query'},
+        {**deepcopy(CRON_QUERY), 'monitor_id': 0, 'query': 'SELECT second_query'},
+    ]
+    monkeypatch.setattr(
+        'datadog_checks.sqlserver.data_observability.time.time',
+        lambda: float(_BASE_EPOCH + 65),
+    )
+    mock_cursor = _make_mock_cursor()
+    check = _make_cron_check(queries=queries)
+    mock_connection, _, _ = _attach_conn(check, mock_cursor)
+
+    call_count = 0
+    real_side_effect = mock_connection._open_managed_db_connections.side_effect
+
+    @contextmanager
+    def flaky_open_managed(db_key, db_name=None, key_prefix=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise SQLConnectionError("could not connect")
+        with real_side_effect(db_key, db_name=db_name, key_prefix=key_prefix) as ctx:
+            yield ctx
+
+    mock_connection._open_managed_db_connections = MagicMock(side_effect=flaky_open_managed)
+
+    check.data_observability.run_job()
+    check.data_observability.run_job()
+
+    assert [call.args[0] for call in mock_cursor.execute.call_args_list] == [
+        'SELECT first_query',
+        'SELECT second_query',
+    ]
+    assert len(aggregator.metrics('dd.sqlserver.data_observability.query_executions')) == 2
 
 
 def test_error_event_payload(aggregator):
@@ -448,15 +508,15 @@ def test_per_query_interval_tracking(aggregator):
     check.data_observability.run_job()
     assert len(aggregator.metrics('dd.sqlserver.data_observability.query_executions')) == 0
 
-    # Reset _last_execution to force re-run
+    # Reset last_execution to force re-run
     aggregator.reset()
-    check.data_observability._last_execution = {1: 0.0}
+    check.data_observability._scheduled_queries[0].last_execution = 0.0
     check.data_observability.run_job()
     assert len(aggregator.metrics('dd.sqlserver.data_observability.query_executions')) == 1
 
 
 def test_failed_query_updates_last_execution(aggregator):
-    """A failed query still updates _last_execution so it is not retried until the next interval."""
+    """A failed query still updates last_execution so it is not retried until the next interval."""
     import pyodbc
 
     mock_cursor = _make_mock_cursor()
@@ -468,7 +528,7 @@ def test_failed_query_updates_last_execution(aggregator):
     check._connection = mock_connection
 
     check.data_observability.run_job()
-    assert 1 in check.data_observability._last_execution
+    assert check.data_observability._scheduled_queries[0].last_execution is not None
 
     aggregator.reset()
     check.data_observability.run_job()
@@ -827,7 +887,7 @@ def test_invalid_cron_schedule_filtered_at_init(aggregator, caplog):
     instance = _make_do_instance(queries=[bad, good])
     with caplog.at_level(logging.WARNING):
         check = _create_check(instance)
-    assert {q.monitor_id for q in check.data_observability._queries} == {1}
+    assert {scheduled.query.monitor_id for scheduled in check.data_observability._scheduled_queries} == {1}
     assert any('invalid cron schedule' in r.message and "'not-a-cron'" in r.message for r in caplog.records)
 
     _attach_conn(check)
@@ -861,7 +921,7 @@ def test_query_without_schedule_or_positive_interval_filtered_at_init(caplog):
     instance = _make_do_instance(queries=[query])
     with caplog.at_level(logging.WARNING):
         check = _create_check(instance)
-    assert check.data_observability._queries == ()
+    assert check.data_observability._scheduled_queries == ()
     assert any('neither schedule nor positive interval_seconds' in r.message for r in caplog.records)
 
 
@@ -884,7 +944,7 @@ def test_lateness_metric_emitted_for_cron(aggregator, monkeypatch):
     # Scheduler caches next_tick = 00:50:00.
     check.data_observability.run_job()
     mid = CRON_QUERY['monitor_id']
-    scheduled_tick = check.data_observability._schedulers[mid].next_tick
+    scheduled_tick = check.data_observability._scheduled_queries[0].scheduler.next_tick
 
     # Step 2: Advance to 00:52:00 — 2 minutes late
     current_time[0] = fire_time
@@ -951,11 +1011,11 @@ def test_lateness_clamped_at_zero(aggregator, monkeypatch):
     from datadog_checks.sqlserver.data_observability import DueQuery
 
     skewed_scheduled = current_time[0] + 100.0
-    q = check.data_observability._queries[0]
+    scheduled_query = check.data_observability._scheduled_queries[0]
     with patch.object(
         check.data_observability,
         '_get_due_queries',
-        return_value=[DueQuery(q, skewed_scheduled, "cron")],
+        return_value=[DueQuery(scheduled_query, skewed_scheduled, "cron")],
     ):
         aggregator.reset()
         check.data_observability.run_job()
@@ -1016,6 +1076,24 @@ def test_starved_query_eventually_fires(aggregator, monkeypatch):
     assert b_lateness[0].value > 0.0
 
 
+def test_cron_queries_with_same_monitor_id_have_independent_schedulers(monkeypatch):
+    queries = [
+        {**deepcopy(CRON_QUERY), 'monitor_id': 0, 'query': 'SELECT first_query', 'schedule': '50 * * * *'},
+        {**deepcopy(CRON_QUERY), 'monitor_id': 0, 'query': 'SELECT second_query', 'schedule': '51 * * * *'},
+    ]
+    current_time = [float(_BASE_EPOCH)]
+    monkeypatch.setattr('datadog_checks.sqlserver.data_observability.time.time', lambda: current_time[0])
+    check = _make_cron_check(queries=queries)
+
+    assert check.data_observability._get_due_queries() == []
+
+    current_time[0] = _BASE_EPOCH + 65
+    assert [due.query.query for due in check.data_observability._get_due_queries()] == ['SELECT first_query']
+
+    current_time[0] = _BASE_EPOCH + 125
+    assert [due.query.query for due in check.data_observability._get_due_queries()] == ['SELECT second_query']
+
+
 # ---------------------------------------------------------------------------
 # Cron startup lookback window (recovery of fires lost across check restarts)
 # ---------------------------------------------------------------------------
@@ -1072,8 +1150,8 @@ def test_failed_cron_query_advances_next_run(aggregator, monkeypatch):
     # First run: lookback recovery fires (5s within 300s window); scheduler caches next_tick = 01:50:00.
     # The query fails; aggregator records an error metric that we discard below.
     check.data_observability.run_job()
-    mid = CRON_QUERY['monitor_id']
-    registered = check.data_observability._schedulers[mid].next_tick
+    scheduler = check.data_observability._scheduled_queries[0].scheduler
+    registered = scheduler.next_tick
 
     # Jump past the next tick and let the failing query fire again.
     current_time[0] = _BASE_EPOCH + 3665  # ~01:50:05
@@ -1085,7 +1163,7 @@ def test_failed_cron_query_advances_next_run(aggregator, monkeypatch):
 
     # next_tick must have advanced past the just-fired tick; otherwise the very next
     # poll would re-fire the same tick in a tight loop.
-    advanced = check.data_observability._schedulers[mid].next_tick
+    advanced = scheduler.next_tick
     assert advanced > registered
     assert advanced >= current_time[0]
 

--- a/sqlserver/tests/test_data_observability.py
+++ b/sqlserver/tests/test_data_observability.py
@@ -1015,7 +1015,7 @@ def test_lateness_clamped_at_zero(aggregator, monkeypatch):
     with patch.object(
         check.data_observability,
         '_get_due_queries',
-        return_value=[DueQuery(scheduled_query, skewed_scheduled, "cron")],
+        return_value=[DueQuery(scheduled_query, skewed_scheduled)],
     ):
         aggregator.reset()
         check.data_observability.run_job()


### PR DESCRIPTION
### What does this PR do?

Keeps each SQL Server Data Observability query's scheduler, interval, and retry state on its own `ScheduledQuery`. Adds regression coverage for multiple queries with same monitor id.

### Motivation

There are cases where monitors can share multiple queries (source-to-target monitors) and where single query can provide metric for multiple monitors. Monitor id is not the right id for scheduling - at the level of check, it's just the query.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
