### PR TITLE
mysql: keep DO scheduling state per query

### DIFF
--- a/mysql/changelog.d/24999.fixed
+++ b/mysql/changelog.d/24999.fixed
@@ -1,0 +1,1 @@
+Fix Data Observability scheduling so queries with the same monitor ID execute independently.

--- a/mysql/datadog_checks/mysql/data_observability.py
+++ b/mysql/datadog_checks/mysql/data_observability.py
@@ -147,7 +147,12 @@ class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
             newly_due = None
             if query.schedule:
                 scheduler = scheduled_query.scheduler
-                assert scheduler is not None
+                if scheduler is None:
+                    self._log.error(
+                        "Skipping DO query monitor_id=%d: cron scheduler is unavailable",
+                        query.monitor_id,
+                    )
+                    continue
                 ticks = scheduler.due_ticks(now + 0.001)
                 if ticks:
                     newly_due = DueQuery(scheduled_query, ticks[-1], "cron")

--- a/mysql/datadog_checks/mysql/data_observability.py
+++ b/mysql/datadog_checks/mysql/data_observability.py
@@ -8,7 +8,7 @@ import time
 from collections.abc import Callable, Iterable, Mapping
 from contextlib import closing
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import pymysql
 
@@ -34,11 +34,10 @@ DEFAULT_COLLECTION_INTERVAL_SECONDS = 10
 
 DBNAME_PATTERN = re.compile(r'^[A-Za-z0-9_$]+$')
 
-Mode = Literal["cron", "interval"]
-
 
 @dataclass
 class CronScheduledQuery:
+    mode: ClassVar[Literal["cron"]] = "cron"
     query: Query
     scheduler: CronScheduler
     pending_retry: DueQuery | None = None
@@ -46,6 +45,7 @@ class CronScheduledQuery:
 
 @dataclass
 class IntervalScheduledQuery:
+    mode: ClassVar[Literal["interval"]] = "interval"
     query: Query
     interval_seconds: int
     last_execution: float | None = None
@@ -63,10 +63,6 @@ class DueQuery:
     @property
     def query(self) -> Query:
         return self.scheduled_query.query
-
-    @property
-    def mode(self) -> Mode:
-        return "cron" if isinstance(self.scheduled_query, CronScheduledQuery) else "interval"
 
 
 class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
@@ -339,7 +335,7 @@ class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
                 self._check.gauge(
                     'dd.mysql.data_observability.query_fire_lateness_seconds',
                     lateness,
-                    tags=tags + [f'mode:{due.mode}'],
+                    tags=tags + [f'mode:{due.scheduled_query.mode}'],
                     hostname=self._check.reported_hostname,
                     raw=True,
                 )

--- a/mysql/datadog_checks/mysql/data_observability.py
+++ b/mysql/datadog_checks/mysql/data_observability.py
@@ -37,11 +37,23 @@ DBNAME_PATTERN = re.compile(r'^[A-Za-z0-9_$]+$')
 Mode = Literal["cron", "interval"]
 
 
+@dataclass
+class ScheduledQuery:
+    query: Query
+    scheduler: CronScheduler | None
+    last_execution: float | None = None
+    pending_retry: DueQuery | None = None
+
+
 @dataclass(frozen=True)
 class DueQuery:
-    query: Query
+    scheduled_query: ScheduledQuery
     scheduled_time: float
     mode: Mode
+
+    @property
+    def query(self) -> Query:
+        return self.scheduled_query.query
 
 
 class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
@@ -55,10 +67,6 @@ class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
     ) -> None:
         self._check = check
         self._do_config = do_config
-        self._last_execution: dict[int, float] = {}
-        # CronScheduler consumes a tick when it reports it. Keep due work here if
-        # the connection fails so the next poll can retry the same execution.
-        self._pending_retries: dict[int, DueQuery] = {}
         self._connection_args_provider = connection_args_provider
         self._uses_managed_auth = uses_managed_auth
         self._db_created_at = 0.0
@@ -81,7 +89,7 @@ class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
             shutdown_callback=self._close_db_conn,
             job_name="data-observability",
         )
-        self._queries, self._schedulers = self._filter_valid_queries(do_config.queries or ())
+        self._scheduled_queries = self._filter_valid_queries(do_config.queries or ())
 
     def shutdown(self) -> None:
         self._close_db_conn()
@@ -100,20 +108,18 @@ class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
             except Exception:
                 self._log.debug("Failed to close Data Observability database connection", exc_info=True)
 
-    def _filter_valid_queries(self, queries: Iterable[Query]) -> tuple[tuple[Query, ...], dict[int, CronScheduler]]:
-        valid: list[Query] = []
-        schedulers: dict[int, CronScheduler] = {}
+    def _filter_valid_queries(self, queries: Iterable[Query]) -> tuple[ScheduledQuery, ...]:
+        valid: list[ScheduledQuery] = []
         for query in queries:
             try:
                 self._validate_dbname(query.dbname)
             except ValueError as e:
                 self._log.warning("Skipping DO query monitor_id=%d: %s", query.monitor_id, e)
                 continue
+            scheduler = None
             if query.schedule:
                 try:
-                    schedulers[query.monitor_id] = CronScheduler(
-                        query.schedule, startup_lookback=CRON_STARTUP_LOOKBACK_SECONDS
-                    )
+                    scheduler = CronScheduler(query.schedule, startup_lookback=CRON_STARTUP_LOOKBACK_SECONDS)
                 except (ValueError, TypeError) as e:
                     self._log.warning(
                         "Skipping DO query monitor_id=%d: invalid cron schedule %r (%s). "
@@ -130,22 +136,33 @@ class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
                     query.monitor_id,
                 )
                 continue
-            valid.append(query)
-        return tuple(valid), schedulers
+            valid.append(ScheduledQuery(query=query, scheduler=scheduler))
+        return tuple(valid)
 
     def _get_due_queries(self) -> list[DueQuery]:
         now = time.time()
         due: list[DueQuery] = []
-        for query in self._queries:
+        for scheduled_query in self._scheduled_queries:
+            query = scheduled_query.query
+            newly_due = None
             if query.schedule:
-                ticks = self._schedulers[query.monitor_id].due_ticks(now + 0.001)
+                scheduler = scheduled_query.scheduler
+                assert scheduler is not None
+                ticks = scheduler.due_ticks(now + 0.001)
                 if ticks:
-                    due.append(DueQuery(query, ticks[-1], "cron"))
+                    newly_due = DueQuery(scheduled_query, ticks[-1], "cron")
             else:
-                last = self._last_execution.get(query.monitor_id)
+                last = scheduled_query.last_execution
                 if last is None or now - last >= query.interval_seconds:
                     scheduled = last + query.interval_seconds if last is not None else now
-                    due.append(DueQuery(query, scheduled, "interval"))
+                    newly_due = DueQuery(scheduled_query, scheduled, "interval")
+
+            if newly_due is not None:
+                scheduled_query.pending_retry = None
+                due.append(newly_due)
+            elif scheduled_query.pending_retry is not None:
+                due.append(scheduled_query.pending_retry)
+                scheduled_query.pending_retry = None
         return due
 
     def _build_base_tags(self) -> list[str]:
@@ -252,15 +269,12 @@ class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
         }
 
     def run_job(self) -> None:
-        # A newly due execution replaces an older pending execution for the same
-        # monitor so an extended outage does not build an unbounded backlog.
-        due_by_monitor_id = dict(self._pending_retries)
-        self._pending_retries = {}
-        due_by_monitor_id.update({due.query.monitor_id: due for due in self._get_due_queries()})
+        # Each physical query owns its scheduling and retry state. A newly due
+        # execution replaces that query's older retry so outages cannot build a backlog.
         # Group shared session state so each database and timeout is selected as
         # few times as possible during this collection.
         due_queries = sorted(
-            due_by_monitor_id.values(),
+            self._get_due_queries(),
             key=lambda due: (due.query.dbname, due.query.query_timeout),
         )
         if not due_queries:
@@ -272,7 +286,8 @@ class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
             conn = self._get_db_connection()
         except (pymysql.err.DatabaseError, pymysql.err.InterfaceError):
             self._close_db_conn()
-            self._pending_retries.update(due_by_monitor_id)
+            for due in due_queries:
+                due.scheduled_query.pending_retry = due
             raise
 
         for index, due in enumerate(due_queries):
@@ -284,11 +299,12 @@ class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
                 result = self._execute_single_query(conn, query)
             except (pymysql.err.DatabaseError, pymysql.err.InterfaceError):
                 self._close_db_conn()
-                self._pending_retries.update({pending.query.monitor_id: pending for pending in due_queries[index:]})
+                for pending in due_queries[index:]:
+                    pending.scheduled_query.pending_retry = pending
                 raise
             now_at_fire_end = time.time()
             if due.mode == "interval":
-                self._last_execution[query.monitor_id] = now_at_fire_end
+                due.scheduled_query.last_execution = now_at_fire_end
 
             try:
                 self._check.gauge(

--- a/mysql/datadog_checks/mysql/data_observability.py
+++ b/mysql/datadog_checks/mysql/data_observability.py
@@ -38,22 +38,35 @@ Mode = Literal["cron", "interval"]
 
 
 @dataclass
-class ScheduledQuery:
+class CronScheduledQuery:
     query: Query
-    scheduler: CronScheduler | None
+    scheduler: CronScheduler
+    pending_retry: DueQuery | None = None
+
+
+@dataclass
+class IntervalScheduledQuery:
+    query: Query
+    interval_seconds: int
     last_execution: float | None = None
     pending_retry: DueQuery | None = None
+
+
+ScheduledQuery = CronScheduledQuery | IntervalScheduledQuery
 
 
 @dataclass(frozen=True)
 class DueQuery:
     scheduled_query: ScheduledQuery
     scheduled_time: float
-    mode: Mode
 
     @property
     def query(self) -> Query:
         return self.scheduled_query.query
+
+    @property
+    def mode(self) -> Mode:
+        return "cron" if isinstance(self.scheduled_query, CronScheduledQuery) else "interval"
 
 
 class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
@@ -116,7 +129,6 @@ class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
             except ValueError as e:
                 self._log.warning("Skipping DO query monitor_id=%d: %s", query.monitor_id, e)
                 continue
-            scheduler = None
             if query.schedule:
                 try:
                     scheduler = CronScheduler(query.schedule, startup_lookback=CRON_STARTUP_LOOKBACK_SECONDS)
@@ -130,37 +142,33 @@ class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
                         query.monitor_id,
                     )
                     continue
-            elif not (query.interval_seconds and query.interval_seconds > 0):
+                valid.append(CronScheduledQuery(query=query, scheduler=scheduler))
+                continue
+
+            interval_seconds = query.interval_seconds
+            if not interval_seconds or interval_seconds <= 0:
                 self._log.warning(
                     "Skipping DO query monitor_id=%d: neither schedule nor positive interval_seconds set",
                     query.monitor_id,
                 )
                 continue
-            valid.append(ScheduledQuery(query=query, scheduler=scheduler))
+            valid.append(IntervalScheduledQuery(query=query, interval_seconds=interval_seconds))
         return tuple(valid)
 
     def _get_due_queries(self) -> list[DueQuery]:
         now = time.time()
         due: list[DueQuery] = []
         for scheduled_query in self._scheduled_queries:
-            query = scheduled_query.query
             newly_due = None
-            if query.schedule:
-                scheduler = scheduled_query.scheduler
-                if scheduler is None:
-                    self._log.error(
-                        "Skipping DO query monitor_id=%d: cron scheduler is unavailable",
-                        query.monitor_id,
-                    )
-                    continue
-                ticks = scheduler.due_ticks(now + 0.001)
+            if isinstance(scheduled_query, CronScheduledQuery):
+                ticks = scheduled_query.scheduler.due_ticks(now + 0.001)
                 if ticks:
-                    newly_due = DueQuery(scheduled_query, ticks[-1], "cron")
+                    newly_due = DueQuery(scheduled_query, ticks[-1])
             else:
                 last = scheduled_query.last_execution
-                if last is None or now - last >= query.interval_seconds:
-                    scheduled = last + query.interval_seconds if last is not None else now
-                    newly_due = DueQuery(scheduled_query, scheduled, "interval")
+                if last is None or now - last >= scheduled_query.interval_seconds:
+                    scheduled = last + scheduled_query.interval_seconds if last is not None else now
+                    newly_due = DueQuery(scheduled_query, scheduled)
 
             if newly_due is not None:
                 scheduled_query.pending_retry = None
@@ -308,7 +316,7 @@ class MySQLDataObservability(ManagedAuthConnectionMixin, DBMAsyncJob):
                     pending.scheduled_query.pending_retry = pending
                 raise
             now_at_fire_end = time.time()
-            if due.mode == "interval":
+            if isinstance(due.scheduled_query, IntervalScheduledQuery):
                 due.scheduled_query.last_execution = now_at_fire_end
 
             try:

--- a/mysql/tests/test_data_observability.py
+++ b/mysql/tests/test_data_observability.py
@@ -272,6 +272,22 @@ def test_query_failure_does_not_block_subsequent(aggregator, instance_basic):
     assert len(aggregator.metrics('dd.mysql.data_observability.query_executions')) == 2
 
 
+def test_queries_with_same_monitor_id_all_execute(aggregator, instance_basic):
+    queries = [
+        {**deepcopy(BASE_QUERY), 'monitor_id': 0, 'query': 'SELECT first_query'},
+        {**deepcopy(BASE_QUERY), 'monitor_id': 0, 'query': 'SELECT second_query'},
+    ]
+
+    _, _, cursor = _setup_and_run(instance_basic, queries=queries)
+
+    assert [call.args[0] for call in cursor.execute.call_args_list] == [
+        'USE `test_db`',
+        'SELECT first_query',
+        'SELECT second_query',
+    ]
+    assert len(aggregator.metrics('dd.mysql.data_observability.query_executions')) == 2
+
+
 @pytest.mark.parametrize(
     'is_mariadb,variable,configured_timeout',
     [
@@ -406,7 +422,7 @@ def test_failed_query_updates_last_execution(aggregator, instance_basic):
     check.data_observability._db = mock_conn
 
     check.data_observability.run_job()
-    assert check.data_observability._last_execution[1] > 0
+    assert check.data_observability._scheduled_queries[0].last_execution > 0
 
     aggregator.reset()
     check.data_observability.run_job()
@@ -476,12 +492,30 @@ def test_schedule_takes_precedence_over_interval(instance_basic, aggregator, mon
     assert len(aggregator.metrics('dd.mysql.data_observability.query_executions')) == 1
 
 
+def test_cron_queries_with_same_monitor_id_have_independent_schedulers(instance_basic, monkeypatch):
+    queries = [
+        {**deepcopy(CRON_QUERY), 'monitor_id': 0, 'query': 'SELECT first_query', 'schedule': '50 * * * *'},
+        {**deepcopy(CRON_QUERY), 'monitor_id': 0, 'query': 'SELECT second_query', 'schedule': '51 * * * *'},
+    ]
+    current_time = [float(_BASE_EPOCH)]
+    monkeypatch.setattr('datadog_checks.mysql.data_observability.time.time', lambda: current_time[0])
+    check = _create_check(instance_basic, queries=queries)
+
+    assert check.data_observability._get_due_queries() == []
+
+    current_time[0] = _BASE_EPOCH + 65
+    assert [due.query.query for due in check.data_observability._get_due_queries()] == ['SELECT first_query']
+
+    current_time[0] = _BASE_EPOCH + 125
+    assert [due.query.query for due in check.data_observability._get_due_queries()] == ['SELECT second_query']
+
+
 def test_invalid_cron_filtered_at_init(instance_basic, aggregator, caplog):
     bad = {**deepcopy(CRON_QUERY), 'monitor_id': 20, 'schedule': 'not-a-cron'}
     with caplog.at_level(logging.WARNING):
         check = _create_check(instance_basic, queries=[bad, deepcopy(BASE_QUERY)])
 
-    assert {query.monitor_id for query in check.data_observability._queries} == {1}
+    assert {scheduled.query.monitor_id for scheduled in check.data_observability._scheduled_queries} == {1}
     assert any('invalid cron schedule' in record.message for record in caplog.records)
 
     mock_conn, _ = _make_mock_conn()
@@ -496,7 +530,7 @@ def test_missing_schedule_and_interval_filtered_at_init(instance_basic, caplog):
     with caplog.at_level(logging.WARNING):
         check = _create_check(instance_basic, queries=[query])
 
-    assert check.data_observability._queries == ()
+    assert check.data_observability._scheduled_queries == ()
     assert any('neither schedule nor positive interval_seconds' in record.message for record in caplog.records)
 
 
@@ -507,7 +541,7 @@ def test_lateness_metric_for_cron(instance_basic, aggregator, monkeypatch):
     check = _make_cron_check(instance_basic)
     check.data_observability._db = mock_conn
     check.data_observability.run_job()
-    scheduled_tick = check.data_observability._schedulers[10].next_tick
+    scheduled_tick = check.data_observability._scheduled_queries[0].scheduler.next_tick
 
     current_time[0] = _BASE_EPOCH + 180
     check.data_observability.run_job()
@@ -544,12 +578,12 @@ def test_lateness_clamped_at_zero(instance_basic, aggregator, monkeypatch):
     mock_conn, _ = _make_mock_conn()
     check = _make_cron_check(instance_basic)
     check.data_observability._db = mock_conn
-    query = check._do_config.queries[0]
+    scheduled_query = check.data_observability._scheduled_queries[0]
 
     with patch.object(
         check.data_observability,
         '_get_due_queries',
-        return_value=[DueQuery(query, current_time[0] + 100, 'cron')],
+        return_value=[DueQuery(scheduled_query, current_time[0] + 100, 'cron')],
     ):
         check.data_observability.run_job()
 
@@ -599,12 +633,13 @@ def test_failed_cron_query_advances_scheduler(instance_basic, aggregator, monkey
     check.data_observability._db = mock_conn
 
     check.data_observability.run_job()
-    next_tick = check.data_observability._schedulers[10].next_tick
+    scheduler = check.data_observability._scheduled_queries[0].scheduler
+    next_tick = scheduler.next_tick
 
     aggregator.reset()
     check.data_observability.run_job()
     assert not aggregator.metrics('dd.mysql.data_observability.query_executions')
-    assert check.data_observability._schedulers[10].next_tick == next_tick
+    assert scheduler.next_tick == next_tick
 
 
 def test_cron_query_is_retried_after_connection_failure(instance_basic, aggregator, monkeypatch):
@@ -624,6 +659,34 @@ def test_cron_query_is_retried_after_connection_failure(instance_basic, aggregat
 
     assert len(aggregator.metrics('dd.mysql.data_observability.query_executions')) == 1
     assert [call.args[0] for call in cursor.execute.call_args_list] == ['USE `test_db`', CRON_QUERY['query']]
+
+
+def test_cron_queries_with_same_monitor_id_are_retried_independently(instance_basic, aggregator, monkeypatch):
+    queries = [
+        {**deepcopy(CRON_QUERY), 'monitor_id': 0, 'query': 'SELECT first_query'},
+        {**deepcopy(CRON_QUERY), 'monitor_id': 0, 'query': 'SELECT second_query'},
+    ]
+    monkeypatch.setattr(
+        'datadog_checks.mysql.data_observability.time.time',
+        lambda: float(_BASE_EPOCH + 65),
+    )
+    mock_conn, cursor = _make_mock_conn()
+    check = _create_check(instance_basic, queries=queries)
+    check.data_observability._get_db_connection = MagicMock(
+        side_effect=[pymysql.err.OperationalError('Connection refused'), mock_conn]
+    )
+
+    with pytest.raises(pymysql.err.OperationalError, match='Connection refused'):
+        check.data_observability.run_job()
+
+    check.data_observability.run_job()
+
+    assert [call.args[0] for call in cursor.execute.call_args_list] == [
+        'USE `test_db`',
+        'SELECT first_query',
+        'SELECT second_query',
+    ]
+    assert len(aggregator.metrics('dd.mysql.data_observability.query_executions')) == 2
 
 
 @pytest.mark.parametrize('collection_interval', [None, -5, 0])
@@ -661,6 +724,6 @@ def test_cancelled_job_aborts_query_before_execution(instance_basic):
     job.cancel()
 
     with pytest.raises(Exception, match='cancelled'):
-        job._execute_single_query(conn, job._queries[0])
+        job._execute_single_query(conn, job._scheduled_queries[0].query)
 
     cursor.execute.assert_not_called()

--- a/mysql/tests/test_data_observability.py
+++ b/mysql/tests/test_data_observability.py
@@ -180,15 +180,17 @@ def test_queries_are_sorted_to_minimize_database_and_timeout_changes(instance_ba
 
 
 @pytest.mark.parametrize('dbname', ['bad-name', 'bad`name', 'db.name', 'db name', '', 'db;DROP TABLE users'])
-def test_invalid_database_name_is_skipped_without_blocking_valid_query(aggregator, instance_basic, dbname):
+def test_invalid_database_name_is_skipped_without_blocking_valid_query(aggregator, instance_basic, dbname, caplog):
     invalid_query = {**deepcopy(BASE_QUERY), 'monitor_id': 2, 'dbname': dbname}
-    _, _, cursor = _setup_and_run(instance_basic, queries=[invalid_query, deepcopy(BASE_QUERY)])
+    with caplog.at_level(logging.WARNING):
+        _, _, cursor = _setup_and_run(instance_basic, queries=[invalid_query, deepcopy(BASE_QUERY)])
 
     assert [call.args[0] for call in cursor.execute.call_args_list] == [
         'USE `test_db`',
         BASE_QUERY['query'],
     ]
     assert len(aggregator.metrics('dd.mysql.data_observability.query_executions')) == 1
+    assert any('Skipping DO query monitor_id=2: Invalid database name' in record.message for record in caplog.records)
 
 
 @pytest.mark.parametrize('dbname', ['shopist', 'shopist_analytics', 'shopist$raw', 'DB123'])
@@ -583,7 +585,7 @@ def test_lateness_clamped_at_zero(instance_basic, aggregator, monkeypatch):
     with patch.object(
         check.data_observability,
         '_get_due_queries',
-        return_value=[DueQuery(scheduled_query, current_time[0] + 100, 'cron')],
+        return_value=[DueQuery(scheduled_query, current_time[0] + 100)],
     ):
         check.data_observability.run_job()
 


### PR DESCRIPTION
### What does this PR do?

Keeps each MySQL Data Observability query's scheduler, interval, and retry state on its own `ScheduledQuery`. Adds regression coverage for multiple queries with same monitor id.

### Motivation

There are cases where monitors can share multiple queries (source-to-target monitors) and where single query can provide metric for multiple monitors. Monitor id is not the right id for scheduling - at the level of check, it's just the query.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
