### PR TITLE
postgres: keep DO scheduling state per query

### DIFF
--- a/postgres/changelog.d/25000.fixed
+++ b/postgres/changelog.d/25000.fixed
@@ -1,0 +1,1 @@
+Fix Data Observability scheduling so queries with the same monitor ID execute independently.

--- a/postgres/datadog_checks/postgres/data_observability.py
+++ b/postgres/datadog_checks/postgres/data_observability.py
@@ -7,7 +7,7 @@ import json
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import psycopg
 
@@ -31,17 +31,17 @@ CRON_STARTUP_LOOKBACK_SECONDS = 300
 # Fallback per-query statement timeout.
 DEFAULT_DO_QUERY_TIMEOUT_S = 60
 
-Mode = Literal["cron", "interval"]
-
 
 @dataclass
 class CronScheduledQuery:
+    mode: ClassVar[Literal["cron"]] = "cron"
     query: Query
     scheduler: CronScheduler
 
 
 @dataclass
 class IntervalScheduledQuery:
+    mode: ClassVar[Literal["interval"]] = "interval"
     query: Query
     interval_seconds: int
     last_execution: float | None = None
@@ -58,10 +58,6 @@ class DueQuery:
     @property
     def query(self) -> Query:
         return self.scheduled_query.query
-
-    @property
-    def mode(self) -> Mode:
-        return "cron" if isinstance(self.scheduled_query, CronScheduledQuery) else "interval"
 
 
 class PostgresDataObservability(DBMAsyncJob):
@@ -284,7 +280,7 @@ class PostgresDataObservability(DBMAsyncJob):
                 self._check.gauge(
                     'dd.postgres.data_observability.query_fire_lateness_seconds',
                     lateness,
-                    tags=tags + [f'mode:{due.mode}'],
+                    tags=tags + [f'mode:{due.scheduled_query.mode}'],
                     hostname=self._check.reported_hostname,
                     raw=True,
                 )

--- a/postgres/datadog_checks/postgres/data_observability.py
+++ b/postgres/datadog_checks/postgres/data_observability.py
@@ -34,18 +34,28 @@ DEFAULT_DO_QUERY_TIMEOUT_S = 60
 Mode = Literal["cron", "interval"]
 
 
+@dataclass
+class ScheduledQuery:
+    query: Query
+    scheduler: CronScheduler | None
+    last_execution: float | None = None
+
+
 @dataclass(frozen=True)
 class DueQuery:
-    query: Query
+    scheduled_query: ScheduledQuery
     scheduled_time: float
     mode: Mode
+
+    @property
+    def query(self) -> Query:
+        return self.scheduled_query.query
 
 
 class PostgresDataObservability(DBMAsyncJob):
     def __init__(self, check: PostgreSql, config: InstanceConfig):
         self._check = check
         self._config = config
-        self._last_execution: dict[int, float] = {}
         collection_interval = config.data_observability.collection_interval or 10
         super(PostgresDataObservability, self).__init__(
             check,
@@ -58,7 +68,7 @@ class PostgresDataObservability(DBMAsyncJob):
             job_name="data-observability",
         )
         # Filter bad queries on check construction.
-        self._queries, self._schedulers = self._filter_valid_queries(self._do_config.queries or ())
+        self._scheduled_queries = self._filter_valid_queries(self._do_config.queries or ())
 
     def shutdown(self) -> None:
         self._check = None
@@ -67,13 +77,13 @@ class PostgresDataObservability(DBMAsyncJob):
     def _do_config(self):
         return self._config.data_observability
 
-    def _filter_valid_queries(self, queries: Iterable[Query]) -> tuple[tuple[Query, ...], dict[int, CronScheduler]]:
-        valid: list[Query] = []
-        schedulers: dict[int, CronScheduler] = {}
+    def _filter_valid_queries(self, queries: Iterable[Query]) -> tuple[ScheduledQuery, ...]:
+        valid: list[ScheduledQuery] = []
         for q in queries:
+            scheduler = None
             if q.schedule:
                 try:
-                    schedulers[q.monitor_id] = CronScheduler(q.schedule, startup_lookback=CRON_STARTUP_LOOKBACK_SECONDS)
+                    scheduler = CronScheduler(q.schedule, startup_lookback=CRON_STARTUP_LOOKBACK_SECONDS)
                 except (ValueError, TypeError) as e:
                     self._log.warning(
                         "Skipping DO query monitor_id=%d: invalid cron schedule %r (%s). "
@@ -90,28 +100,31 @@ class PostgresDataObservability(DBMAsyncJob):
                     q.monitor_id,
                 )
                 continue
-            valid.append(q)
-        return tuple(valid), schedulers
+            valid.append(ScheduledQuery(query=q, scheduler=scheduler))
+        return tuple(valid)
 
     def _get_due_queries(self) -> list[DueQuery]:
         now = time.time()
         due: list[DueQuery] = []
-        for q in self._queries:
+        for scheduled_query in self._scheduled_queries:
+            q = scheduled_query.query
             if q.schedule:
+                scheduler = scheduled_query.scheduler
+                assert scheduler is not None
                 # +0.001 so a poll landing exactly on a tick boundary is treated
                 # as due (CronScheduler.previous_tick uses strict less-than).
-                ticks = self._schedulers[q.monitor_id].due_ticks(now + 0.001)
+                ticks = scheduler.due_ticks(now + 0.001)
                 if ticks:
                     # Take the latest elapsed tick; earlier ones are already in the past
                     # and do not need separate execution.
-                    due.append(DueQuery(q, ticks[-1], "cron"))
+                    due.append(DueQuery(scheduled_query, ticks[-1], "cron"))
             else:
-                last = self._last_execution.get(q.monitor_id)
+                last = scheduled_query.last_execution
                 if last is None or now - last >= q.interval_seconds:
                     # Seed: treat first sight as if the previous interval just completed,
                     # so the scheduled_time for DueQuery is now and lateness is 0.
                     scheduled = (last + q.interval_seconds) if last is not None else now
-                    due.append(DueQuery(q, scheduled, "interval"))
+                    due.append(DueQuery(scheduled_query, scheduled, "interval"))
         return due
 
     def _build_base_tags(self) -> list[str]:
@@ -235,7 +248,7 @@ class PostgresDataObservability(DBMAsyncJob):
             # For cron mode, due_ticks() already advanced the scheduler's internal state.
             now_at_fire_end = time.time()
             if due.mode == "interval":
-                self._last_execution[q.monitor_id] = now_at_fire_end
+                due.scheduled_query.last_execution = now_at_fire_end
 
             try:
                 self._check.gauge(

--- a/postgres/datadog_checks/postgres/data_observability.py
+++ b/postgres/datadog_checks/postgres/data_observability.py
@@ -110,7 +110,12 @@ class PostgresDataObservability(DBMAsyncJob):
             q = scheduled_query.query
             if q.schedule:
                 scheduler = scheduled_query.scheduler
-                assert scheduler is not None
+                if scheduler is None:
+                    self._log.error(
+                        "Skipping DO query monitor_id=%d: cron scheduler is unavailable",
+                        q.monitor_id,
+                    )
+                    continue
                 # +0.001 so a poll landing exactly on a tick boundary is treated
                 # as due (CronScheduler.previous_tick uses strict less-than).
                 ticks = scheduler.due_ticks(now + 0.001)

--- a/postgres/datadog_checks/postgres/data_observability.py
+++ b/postgres/datadog_checks/postgres/data_observability.py
@@ -35,21 +35,33 @@ Mode = Literal["cron", "interval"]
 
 
 @dataclass
-class ScheduledQuery:
+class CronScheduledQuery:
     query: Query
-    scheduler: CronScheduler | None
+    scheduler: CronScheduler
+
+
+@dataclass
+class IntervalScheduledQuery:
+    query: Query
+    interval_seconds: int
     last_execution: float | None = None
+
+
+ScheduledQuery = CronScheduledQuery | IntervalScheduledQuery
 
 
 @dataclass(frozen=True)
 class DueQuery:
     scheduled_query: ScheduledQuery
     scheduled_time: float
-    mode: Mode
 
     @property
     def query(self) -> Query:
         return self.scheduled_query.query
+
+    @property
+    def mode(self) -> Mode:
+        return "cron" if isinstance(self.scheduled_query, CronScheduledQuery) else "interval"
 
 
 class PostgresDataObservability(DBMAsyncJob):
@@ -80,7 +92,6 @@ class PostgresDataObservability(DBMAsyncJob):
     def _filter_valid_queries(self, queries: Iterable[Query]) -> tuple[ScheduledQuery, ...]:
         valid: list[ScheduledQuery] = []
         for q in queries:
-            scheduler = None
             if q.schedule:
                 try:
                     scheduler = CronScheduler(q.schedule, startup_lookback=CRON_STARTUP_LOOKBACK_SECONDS)
@@ -94,42 +105,38 @@ class PostgresDataObservability(DBMAsyncJob):
                         q.monitor_id,
                     )
                     continue
-            elif not (q.interval_seconds and q.interval_seconds > 0):
+                valid.append(CronScheduledQuery(query=q, scheduler=scheduler))
+                continue
+
+            interval_seconds = q.interval_seconds
+            if not interval_seconds or interval_seconds <= 0:
                 self._log.warning(
                     "Skipping DO query monitor_id=%d: neither schedule nor positive interval_seconds set",
                     q.monitor_id,
                 )
                 continue
-            valid.append(ScheduledQuery(query=q, scheduler=scheduler))
+            valid.append(IntervalScheduledQuery(query=q, interval_seconds=interval_seconds))
         return tuple(valid)
 
     def _get_due_queries(self) -> list[DueQuery]:
         now = time.time()
         due: list[DueQuery] = []
         for scheduled_query in self._scheduled_queries:
-            q = scheduled_query.query
-            if q.schedule:
-                scheduler = scheduled_query.scheduler
-                if scheduler is None:
-                    self._log.error(
-                        "Skipping DO query monitor_id=%d: cron scheduler is unavailable",
-                        q.monitor_id,
-                    )
-                    continue
+            if isinstance(scheduled_query, CronScheduledQuery):
                 # +0.001 so a poll landing exactly on a tick boundary is treated
                 # as due (CronScheduler.previous_tick uses strict less-than).
-                ticks = scheduler.due_ticks(now + 0.001)
+                ticks = scheduled_query.scheduler.due_ticks(now + 0.001)
                 if ticks:
                     # Take the latest elapsed tick; earlier ones are already in the past
                     # and do not need separate execution.
-                    due.append(DueQuery(scheduled_query, ticks[-1], "cron"))
+                    due.append(DueQuery(scheduled_query, ticks[-1]))
             else:
                 last = scheduled_query.last_execution
-                if last is None or now - last >= q.interval_seconds:
+                if last is None or now - last >= scheduled_query.interval_seconds:
                     # Seed: treat first sight as if the previous interval just completed,
                     # so the scheduled_time for DueQuery is now and lateness is 0.
-                    scheduled = (last + q.interval_seconds) if last is not None else now
-                    due.append(DueQuery(scheduled_query, scheduled, "interval"))
+                    scheduled = (last + scheduled_query.interval_seconds) if last is not None else now
+                    due.append(DueQuery(scheduled_query, scheduled))
         return due
 
     def _build_base_tags(self) -> list[str]:
@@ -252,7 +259,7 @@ class PostgresDataObservability(DBMAsyncJob):
             # leave the query stuck re-firing the same tick.
             # For cron mode, due_ticks() already advanced the scheduler's internal state.
             now_at_fire_end = time.time()
-            if due.mode == "interval":
+            if isinstance(due.scheduled_query, IntervalScheduledQuery):
                 due.scheduled_query.last_execution = now_at_fire_end
 
             try:

--- a/postgres/tests/test_data_observability.py
+++ b/postgres/tests/test_data_observability.py
@@ -201,7 +201,7 @@ def test_per_query_interval_tracking(aggregator, pg_instance):
 
     # Reset last_execution to force re-run
     aggregator.reset()
-    check.data_observability._last_execution[1] = 0.0
+    check.data_observability._scheduled_queries[0].last_execution = 0.0
     check.data_observability.run_job()
     assert len(aggregator.metrics('dd.postgres.data_observability.query_executions')) == 1
 
@@ -410,8 +410,7 @@ def test_failed_query_updates_last_execution(aggregator, pg_instance):
     check.db_pool = _mock_db_pool(mock_conn)
 
     check.data_observability.run_job()
-    assert 1 in check.data_observability._last_execution
-    assert check.data_observability._last_execution[1] > 0
+    assert check.data_observability._scheduled_queries[0].last_execution > 0
 
     # Immediate re-run should skip the query (interval not elapsed)
     aggregator.reset()
@@ -634,13 +633,13 @@ def test_schedule_advances_after_run(pg_instance, monkeypatch):
     # First run at 00:50:05: lookback recovery fires (5s within 300s window); scheduler
     # caches next_tick = 01:50:00.
     check.data_observability.run_job()
-    mid = CRON_QUERY['monitor_id']
-    first_next_run = check.data_observability._schedulers[mid].next_tick
+    scheduler = check.data_observability._scheduled_queries[0].scheduler
+    first_next_run = scheduler.next_tick
 
     current_time[0] = _BASE_EPOCH + 3665  # ~01:50:05
     check.data_observability.run_job()
 
-    second_next_run = check.data_observability._schedulers[mid].next_tick
+    second_next_run = scheduler.next_tick
     # After firing at 01:50:05, next_tick should advance to 02:50:00
     assert second_next_run > first_next_run
     # Should be approximately 1 hour later
@@ -685,7 +684,7 @@ def test_invalid_cron_schedule_filtered_at_init(pg_instance, aggregator, caplog)
     mock_conn, _ = _make_mock_conn()
     with caplog.at_level(logging.WARNING):
         check = _create_check(pg_instance, queries=[bad, good])
-    assert {q.monitor_id for q in check.data_observability._queries} == {1}
+    assert {scheduled.query.monitor_id for scheduled in check.data_observability._scheduled_queries} == {1}
     assert any('invalid cron schedule' in r.message and "'not-a-cron'" in r.message for r in caplog.records)
 
     check.db_pool = _mock_db_pool(mock_conn)
@@ -719,7 +718,7 @@ def test_query_without_schedule_or_positive_interval_filtered_at_init(pg_instanc
     }
     with caplog.at_level(logging.WARNING):
         check = _create_check(pg_instance, queries=[query])
-    assert check.data_observability._queries == ()
+    assert check.data_observability._scheduled_queries == ()
     assert any('neither schedule nor positive interval_seconds' in r.message for r in caplog.records)
 
 
@@ -743,7 +742,7 @@ def test_lateness_metric_emitted_for_cron(pg_instance, aggregator, monkeypatch):
     # Scheduler caches next_tick = 00:50:00.
     check.data_observability.run_job()
     mid = CRON_QUERY['monitor_id']
-    scheduled_tick = check.data_observability._schedulers[mid].next_tick
+    scheduled_tick = check.data_observability._scheduled_queries[0].scheduler.next_tick
 
     # Step 2: Advance to 00:52:00 — 2 minutes late
     current_time[0] = fire_time
@@ -811,11 +810,11 @@ def test_lateness_clamped_at_zero(pg_instance, aggregator, monkeypatch):
     from datadog_checks.postgres.data_observability import DueQuery
 
     skewed_scheduled = current_time[0] + 100.0
-    q = check.data_observability._do_config.queries[0]
+    scheduled_query = check.data_observability._scheduled_queries[0]
     with patch.object(
         check.data_observability,
         '_get_due_queries',
-        return_value=[DueQuery(q, skewed_scheduled, "cron")],
+        return_value=[DueQuery(scheduled_query, skewed_scheduled, "cron")],
     ):
         aggregator.reset()
         check.data_observability.run_job()
@@ -875,6 +874,45 @@ def test_starved_query_eventually_fires(pg_instance, aggregator, monkeypatch):
     b_lateness = [m for m in lateness_metrics if 'monitor_id:51' in m.tags]
     assert len(b_lateness) == 1
     assert b_lateness[0].value > 0.0
+
+
+def test_cron_queries_with_same_monitor_id_have_independent_schedulers(pg_instance, monkeypatch):
+    query_a = {
+        **deepcopy(CRON_QUERY),
+        'monitor_id': 0,
+        'query': 'SELECT 1',
+        'schedule': '50 * * * *',
+    }
+    query_b = {
+        **deepcopy(CRON_QUERY),
+        'monitor_id': 0,
+        'query': 'SELECT 2',
+        'schedule': '51 * * * *',
+    }
+    current_time = [float(_BASE_EPOCH)]
+    monkeypatch.setattr('datadog_checks.postgres.data_observability.time.time', lambda: current_time[0])
+
+    check = _create_check(pg_instance, queries=[query_a, query_b])
+    assert check.data_observability._get_due_queries() == []
+
+    current_time[0] = _BASE_EPOCH + 65
+    assert [due.query.query for due in check.data_observability._get_due_queries()] == ['SELECT 1']
+
+    current_time[0] = _BASE_EPOCH + 125
+    assert [due.query.query for due in check.data_observability._get_due_queries()] == ['SELECT 2']
+
+
+def test_interval_queries_with_same_monitor_id_track_execution_independently(pg_instance, monkeypatch):
+    queries = [
+        {**deepcopy(BASE_QUERY), 'monitor_id': 0, 'query': 'SELECT 1'},
+        {**deepcopy(BASE_QUERY), 'monitor_id': 0, 'query': 'SELECT 2'},
+    ]
+    monkeypatch.setattr('datadog_checks.postgres.data_observability.time.time', lambda: 1_000.0)
+    check = _create_check(pg_instance, queries=queries)
+
+    check.data_observability._scheduled_queries[0].last_execution = 1_000.0
+
+    assert [due.query.query for due in check.data_observability._get_due_queries()] == ['SELECT 2']
 
 
 # ---------------------------------------------------------------------------
@@ -969,8 +1007,8 @@ def test_failed_cron_query_advances_next_run(pg_instance, aggregator, monkeypatc
     # First run: lookback recovery fires (5s within 300s window); scheduler caches next_tick = 01:50:00.
     # The query fails; aggregator records an error metric that we discard below.
     check.data_observability.run_job()
-    mid = CRON_QUERY['monitor_id']
-    registered = check.data_observability._schedulers[mid].next_tick
+    scheduler = check.data_observability._scheduled_queries[0].scheduler
+    registered = scheduler.next_tick
 
     # Jump past the next tick and let the failing query fire again.
     current_time[0] = _BASE_EPOCH + 3665  # ~01:50:05
@@ -982,7 +1020,7 @@ def test_failed_cron_query_advances_next_run(pg_instance, aggregator, monkeypatc
 
     # next_tick must have advanced past the just-fired tick; otherwise the very next
     # poll would re-fire the same tick in a tight loop.
-    advanced = check.data_observability._schedulers[mid].next_tick
+    advanced = scheduler.next_tick
     assert advanced > registered
     assert advanced >= current_time[0]
 

--- a/postgres/tests/test_data_observability.py
+++ b/postgres/tests/test_data_observability.py
@@ -904,15 +904,30 @@ def test_cron_queries_with_same_monitor_id_have_independent_schedulers(pg_instan
 
 def test_interval_queries_with_same_monitor_id_track_execution_independently(pg_instance, monkeypatch):
     queries = [
-        {**deepcopy(BASE_QUERY), 'monitor_id': 0, 'query': 'SELECT 1'},
-        {**deepcopy(BASE_QUERY), 'monitor_id': 0, 'query': 'SELECT 2'},
+        {**deepcopy(BASE_QUERY), 'monitor_id': 0, 'query': 'SELECT 1', 'interval_seconds': 60},
+        {**deepcopy(BASE_QUERY), 'monitor_id': 0, 'query': 'SELECT 2', 'interval_seconds': 100},
     ]
-    monkeypatch.setattr('datadog_checks.postgres.data_observability.time.time', lambda: 1_000.0)
+    current_time = [1_000.0]
+    monkeypatch.setattr('datadog_checks.postgres.data_observability.time.time', lambda: current_time[0])
+    mock_conn, mock_cursor = _make_mock_conn()
     check = _create_check(pg_instance, queries=queries)
+    check.db_pool = _mock_db_pool(mock_conn)
 
-    check.data_observability._scheduled_queries[0].last_execution = 1_000.0
+    check.data_observability.run_job()
+    mock_cursor.execute.reset_mock()
 
-    assert [due.query.query for due in check.data_observability._get_due_queries()] == ['SELECT 2']
+    current_time[0] = 1_060.0
+    check.data_observability.run_job()
+    executed = [call.args[0] for call in mock_cursor.execute.call_args_list]
+    assert 'SELECT 1' in executed
+    assert 'SELECT 2' not in executed
+    mock_cursor.execute.reset_mock()
+
+    current_time[0] = 1_100.0
+    check.data_observability.run_job()
+    executed = [call.args[0] for call in mock_cursor.execute.call_args_list]
+    assert 'SELECT 1' not in executed
+    assert 'SELECT 2' in executed
 
 
 # ---------------------------------------------------------------------------

--- a/postgres/tests/test_data_observability.py
+++ b/postgres/tests/test_data_observability.py
@@ -814,7 +814,7 @@ def test_lateness_clamped_at_zero(pg_instance, aggregator, monkeypatch):
     with patch.object(
         check.data_observability,
         '_get_due_queries',
-        return_value=[DueQuery(scheduled_query, skewed_scheduled, "cron")],
+        return_value=[DueQuery(scheduled_query, skewed_scheduled)],
     ):
         aggregator.reset()
         check.data_observability.run_job()


### PR DESCRIPTION
### What does this PR do?

Keeps each PostgreSQL Data Observability query's scheduler and interval state on its own `ScheduledQuery`. Adds regression coverage for multiple queries with same monitor id.

### Motivation

There are cases where monitors can share multiple queries (source-to-target monitors) and where single query can provide metric for multiple monitors. Monitor id is not the right id for scheduling - at the level of check, it's just the query.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
