### PR TITLE
Bake activity-gen workload into redis-full fixture

### DIFF
--- a/redisdb/tests/README.md
+++ b/redisdb/tests/README.md
@@ -65,3 +65,7 @@ variety, eviction, expiry, net bytes, blocked clients, forks/RDB, slowlog, and
 client-side caching so both scrapers see non-zero values across scrapes. It is
 part of the fixture, so any consumer of `redis-full` gets it automatically with no
 extra wiring. Tunable via `ACTIVITY_DB` / `ACTIVITY_DURATION`.
+
+For a quiescent `redis-full` (no generated traffic), set `ACTIVITY_GEN=0` in the
+host environment before starting the fixture; the container stays up but does
+nothing.

--- a/redisdb/tests/README.md
+++ b/redisdb/tests/README.md
@@ -56,11 +56,12 @@ No host port is published, to avoid clashing with a local Redis; reach it over t
 Compose network, or add `--publish 6379:6379` to inspect by hand. Source in
 `proxy/` (`main.go` request loop, `resp.go` framing).
 
-## Driving full coverage with activity-gen
+## Driving full coverage: the activity-gen service
 
 The `seed` service primes the fixture once, but most rate/counter metrics stay
-zero on an idle instance. The opt-in `activity-gen` task (`activity-gen.sh`) loops
-over keyspace, command variety, eviction, expiry, net bytes, blocked clients,
-forks/RDB, slowlog, and client-side caching so both scrapers see non-zero values.
-Add it with `with: [redis-full, activity-gen]`. It reads only
-`DB_HOST`/`DB_PORT`/`REDIS_PASSWORD` (plus optional `ACTIVITY_DB`/`ACTIVITY_DURATION`).
+zero on an idle instance. The `activity-gen` service (`activity-gen.sh`) runs
+continuously inside `full-coverage.compose`, looping over keyspace, command
+variety, eviction, expiry, net bytes, blocked clients, forks/RDB, slowlog, and
+client-side caching so both scrapers see non-zero values across scrapes. It is
+part of the fixture, so any consumer of `redis-full` gets it automatically with no
+extra wiring. Tunable via `ACTIVITY_DB` / `ACTIVITY_DURATION`.

--- a/redisdb/tests/README.md
+++ b/redisdb/tests/README.md
@@ -56,15 +56,15 @@ No host port is published, to avoid clashing with a local Redis; reach it over t
 Compose network, or add `--publish 6379:6379` to inspect by hand. Source in
 `proxy/` (`main.go` request loop, `resp.go` framing).
 
-## Driving full coverage: the activity-gen service
+## Drive full coverage with the activity-gen service
 
 The `seed` service primes the fixture once, but most rate/counter metrics stay
 zero on an idle instance. The `activity-gen` service (`activity-gen.sh`) runs
-continuously inside `full-coverage.compose`, looping over keyspace, command
+continuously inside `full-coverage.compose`. It loops over keyspace, command
 variety, eviction, expiry, net bytes, blocked clients, forks/RDB, slowlog, and
-client-side caching so both scrapers see non-zero values across scrapes. It is
+client-side caching. As a result, both scrapers see non-zero values across scrapes. It is
 part of the fixture, so any consumer of `redis-full` gets it automatically with no
-extra wiring. Tunable via `ACTIVITY_DB` / `ACTIVITY_DURATION`.
+extra wiring. You can configure it using `ACTIVITY_DB` / `ACTIVITY_DURATION`.
 
 For a quiescent `redis-full` (no generated traffic), set `ACTIVITY_GEN=0` in the
 host environment before starting the fixture; the container stays up but does

--- a/redisdb/tests/activity-gen.sh
+++ b/redisdb/tests/activity-gen.sh
@@ -11,6 +11,13 @@ DURATION="${ACTIVITY_DURATION:-0}"   # 0 = run forever
 
 log() { echo "activity-gen: $*"; }
 
+# Opt out of the workload for a quiescent redis-full: ACTIVITY_GEN=0 keeps the
+# container running (so dependents still start) but generates no traffic.
+if [ "${ACTIVITY_GEN:-1}" = "0" ]; then
+  log "disabled via ACTIVITY_GEN=0; idling"
+  exec sleep infinity
+fi
+
 # Eviction ceiling + policy (matches the compose master; re-set so the script
 # also works against a plain Redis) and a slowlog threshold above ordinary
 # commands but below the DEBUG SLEEP below.

--- a/redisdb/tests/compose/full-coverage.compose
+++ b/redisdb/tests/compose/full-coverage.compose
@@ -97,6 +97,8 @@ services:
   # slowlog, client-side caching), not just the one-shot seed. Writes straight to
   # the master; scrapers read the same data through the proxy. See ../activity-gen.sh.
   activity-gen:
+    # Same image as the other services (no extra pull); used only for its
+    # redis-cli client to drive the workload against the master.
     image: "redis:${REDIS_VERSION:-7.4}"
     depends_on:
       redis-master:

--- a/redisdb/tests/compose/full-coverage.compose
+++ b/redisdb/tests/compose/full-coverage.compose
@@ -110,6 +110,9 @@ services:
       DB_HOST: redis-master
       REDIS_PASSWORD: devops-best-friend
       ACTIVITY_DB: "14"
+      # Set ACTIVITY_GEN=0 (host env) for a quiescent redis-full: the container
+      # stays up but generates no traffic. Defaults to on.
+      ACTIVITY_GEN: "${ACTIVITY_GEN:-1}"
     volumes:
       - ../activity-gen.sh:/opt/activity-gen.sh:ro
     command: ["sh", "/opt/activity-gen.sh"]

--- a/redisdb/tests/compose/full-coverage.compose
+++ b/redisdb/tests/compose/full-coverage.compose
@@ -92,6 +92,28 @@ services:
         echo "expired_keys=$$($$R INFO stats | grep expired_keys || true)"
         echo "seed-done"
 
+  # Continuous workload so rate/counter metrics keep moving across scrapes
+  # (keyspace, commands, eviction, expiry, net bytes, blocked clients, forks/RDB,
+  # slowlog, client-side caching), not just the one-shot seed. Writes straight to
+  # the master; scrapers read the same data through the proxy. See ../activity-gen.sh.
+  activity-gen:
+    image: "redis:${REDIS_VERSION:-7.4}"
+    depends_on:
+      redis-master:
+        condition: service_healthy
+      seed:
+        condition: service_completed_successfully
+    networks:
+      - network1
+    restart: unless-stopped
+    environment:
+      DB_HOST: redis-master
+      REDIS_PASSWORD: devops-best-friend
+      ACTIVITY_DB: "14"
+    volumes:
+      - ../activity-gen.sh:/opt/activity-gen.sh:ro
+    command: ["sh", "/opt/activity-gen.sh"]
+
   info-proxy:
     build:
       context: ../proxy
@@ -111,6 +133,8 @@ services:
         condition: service_healthy
       seed:
         condition: service_completed_successfully
+      activity-gen:
+        condition: service_started
     environment:
       LISTEN_ADDR: ":6379"
       BACKEND_ADDR: "redis-master:6379"

--- a/redisdb/tests/evalya.yaml
+++ b/redisdb/tests/evalya.yaml
@@ -21,7 +21,8 @@ tasks:
 
   # Full metric-coverage fixture: master/replica behind an info-proxy that adds
   # the fields OSS Redis can't emit (managed-service, cluster, sentinel,
-  # RediSearch). Presents on 6379 like a standalone. See ./proxy and its README.
+  # RediSearch), plus a built-in workload that keeps rate/counter metrics moving.
+  # Presents on 6379 like a standalone. See ./proxy and its README.
   - id: redis-full
     task: ./compose/full-coverage.compose@info-proxy
     labels:
@@ -38,18 +39,3 @@ tasks:
       timeout: 5s
       retries: 5
       start_period: 10s
-
-  # Opt-in workload that drives redis-full's counters non-zero (see activity-gen.sh).
-  # Kept out of redis-full so the fixture stays quiescent by default; add it with
-  # `with: [redis-full, activity-gen]`.
-  - id: activity-gen
-    image: "redis:${REDIS_VERSION:-7.4}"
-    labels:
-      # Published so other repos (e.g. semantic-core FTF) can OCI-federate this
-      # workload instead of vendoring a copy of the script.
-      evalya.io/publish: "true"
-    command: ["sh", "/opt/activity-gen.sh"]
-    volumes:
-      - ./activity-gen.sh:/opt/activity-gen.sh:ro
-    with:
-      - redis-full


### PR DESCRIPTION
### TL;DR

Make the `redis-full` test fixture self-exercising by moving the `activity-gen` workload into the Compose file as a service, and drop the standalone `activity-gen` evalya task. Test assets only.

### What does this PR do?

- Adds an `activity-gen` service to `redisdb/tests/compose/full-coverage.compose` (next to `seed`) that runs `activity-gen.sh` continuously against `redis-master`.
- Removes the separate `activity-gen` evalya task from `redisdb/tests/evalya.yaml`.
- Updates the tests README.

### Motivation

`activity-gen` was a separate evalya task with `with: [redis-full]`. When another repo (semantic-core FTF) federated that task over OCI, evalya couldn't repoint its dependency at the scenario's own Redis, so it stood up a **second** info-proxy. Baking the workload into the fixture removes the standalone task entirely: `redis-full` now drives its own traffic, so consumers get a moving metric surface just by using it — no extra task, no `with:[redis-full]` to drag around, no second proxy, and nothing to vendor downstream.

Trade-off: `redis-full` is no longer quiescent (it always generates traffic). That's intended for a full-coverage fixture, and nothing uses `redis-full` as a static instance (the pytest suite uses the other compose files).

### Validation / Testing

`evalya run --task redis-full`:

- Single `info-proxy`, single `redis-master`/`redis-replica` — no duplicate fixture.
- The workload drives the master: `evicted_keys=157742`, `total_commands_processed>1M`, `total_net_input_bytes~248MB`.
- `docker compose config` on the compose file passes.

### Review checklist (to be filled by the reviewer)

- [ ] Test fixtures/dev assets only; nothing shipped with the Agent, so no changelog entry is required.
- [x] `qa/skip-qa` (no Agent-impacting change).