### PR TITLE
Let a caller ask the event bus to stop

### DIFF
--- a/ddev/changelog.d/25002.fixed
+++ b/ddev/changelog.d/25002.fixed
@@ -1,0 +1,1 @@
+Report a message dropped and a processor skipped once the bus is stopping.

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -198,7 +198,7 @@ class EventBusOrchestrator(ABC):
         ``on_initialize`` and ``on_message_received`` are abandoned if they are still waiting, since the
         loop awaits them directly and would otherwise be held for as long as they take.
         """
-        if self._stopping.is_set():
+        if self.stopping:
             return
 
         self._logger.info("Stop requested; the bus will wind down")

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -509,6 +509,10 @@ class EventBusOrchestrator(ABC):
                 # but capped by max_timeout
                 wait_time = min(self._grace_period, remaining)
                 if not await self.__wait_for_message(get_task, wait_time):
+                    if self.stopping:
+                        # Said here too, or a stop seen inside the wait leaves through this branch and
+                        # reads like the grace period simply expiring.
+                        self._logger.info("Stopping on request while idle.")
                     get_task.cancel()
                     return True
             except Exception:

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -77,6 +77,8 @@ class BaseProcessor[T: BaseMessage]:
 
         The default implementation re-raises so unmodified processors fall through to
         the orchestrator-level ``fail_fast`` policy.
+
+        Can be cancelled part-way when the bus it belongs to is asked to stop.
         """
         raise error
 
@@ -385,6 +387,9 @@ class EventBusOrchestrator(ABC):
 
         The default implementation re-raises so unmodified orchestrators fall through
         to the ``fail_fast`` policy.
+
+        Best-effort once a stop has been requested: whoever asked may be working to a deadline, and
+        the process can be killed before this returns. Keep it short.
         """
         raise error
 

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -28,6 +28,8 @@ from .exceptions import (
 type ErrorHandler[E: Exception] = Callable[[E], Awaitable[None]]
 
 DEFAULT_ORCHESTRATOR_MAX_TIMEOUT = 300.0
+# How long the loop may block before re-reading the timeout and the stop flag.
+STOP_CHECK_INTERVAL = 1.0
 
 
 class OrchestratorTimeout(Exception):
@@ -186,12 +188,32 @@ class EventBusOrchestrator(ABC):
         for msg_type in message_types:
             self._subscribers.setdefault(msg_type, []).append(processor)
 
+    def request_stop(self) -> None:
+        """Ask the bus to wind down, from any thread.
+
+        The loop acts on it within ``STOP_CHECK_INTERVAL``, so a caller under a deadline it does not
+        control, such as a cancelled CI job, reaches ``finalize`` without waiting out the grace period.
+        ``on_initialize`` and ``on_message_received`` are abandoned if they are still waiting, since the
+        loop awaits them directly and would otherwise be held for as long as they take.
+        """
+        if self._stopping.is_set():
+            return
+
+        self._logger.info("Stop requested; the bus will wind down")
+        self._stopping.set()
+
     def submit_message(self, message: BaseMessage):
         """Adds a message to the queue, from any thread.
 
         ``asyncio.Queue`` is not thread-safe, and a put it loses leaves the bus spinning on a message
         it never reads, so while the bus runs the loop thread makes every put.
         """
+        if self.stopping:
+            # Dropped rather than raised: processors submit from `finally` blocks, where raising would
+            # route an expected shutdown through the error policy.
+            self._logger.warning("Dropped %s(%s): the bus is shutting down", type(message).__name__, message.id)
+            return
+
         if self._loop is not None and self._loop.is_running():
             self._loop.call_soon_threadsafe(self._queue.put_nowait, message)
         else:
@@ -230,7 +252,7 @@ class EventBusOrchestrator(ABC):
         """
         self._running = True
         try:
-            await self.on_initialize()
+            await self._bounded_by_stop(self.on_initialize(), HookName.ON_INITIALIZE)
         except (FatalProcessingError, asyncio.CancelledError):
             raise
         except Exception as e:
@@ -247,6 +269,10 @@ class EventBusOrchestrator(ABC):
     async def on_initialize(self):  # pragma: no cover
         """
         Hook for subclasses to perform initial setup (e.g. submit initial messages).
+
+        Abandoned if :meth:`request_stop` is called, from any thread, while this is still waiting, so
+        it may be cancelled part-way and ``on_finalize`` then runs against whatever it had reached.
+        A hook that must finish what it starts should check :attr:`stopping` itself and return.
         """
         pass
 
@@ -336,6 +362,10 @@ class EventBusOrchestrator(ABC):
         hook. To stop the bus entirely, raise :class:`FatalProcessingError`. Any
         other exception is wrapped as :class:`OrchestratorHookError` and routed
         through :meth:`on_error`.
+
+        Abandoned if :meth:`request_stop` is called, from any thread, while this is still waiting, in
+        which case the message is not dispatched. A hook that must finish what it starts should check
+        :attr:`stopping` itself and return.
         """
         pass
 
@@ -410,7 +440,7 @@ class EventBusOrchestrator(ABC):
                 wait_set = running_tasks | {get_task}
                 # We use a small timeout to check for max_timeout periodically. If we leave this here blocking
                 # we can keep the loop alive much longer than the max_timeout.
-                done, _ = await asyncio.wait(wait_set, return_when=asyncio.FIRST_COMPLETED, timeout=1.0)
+                done, _ = await asyncio.wait(wait_set, return_when=asyncio.FIRST_COMPLETED, timeout=STOP_CHECK_INTERVAL)
 
                 current_get_task = get_task
                 if current_get_task in done:
@@ -442,10 +472,20 @@ class EventBusOrchestrator(ABC):
 
     async def __should_stop(self, start_time: float, running_tasks: set[asyncio.Task], get_task: asyncio.Task) -> bool:
         """
-        Checks whether the orchestrator should stop. This can happen in two ways:
+        Checks whether the orchestrator should stop. This can happen in three ways:
+        - A stop was requested
         - The max timeout is reached
         - The queue is empty and all processors have been completed and the grace period is reached
         """
+        # First, because a caller asking to stop outranks reporting a timeout it did not wait for.
+        if self.stopping:
+            self._logger.info(
+                "Stopping on request. A total of %s tasks were running.",
+                len(running_tasks),
+            )
+            get_task.cancel()
+            return True
+
         # Check first whether we are over the max timeout
         if self._remaining_time(start_time) <= 0:
             self._logger.error(
@@ -468,13 +508,51 @@ class EventBusOrchestrator(ABC):
                 # This ensures we wait for new message for a time period defined by grace_period
                 # but capped by max_timeout
                 wait_time = min(self._grace_period, remaining)
-                await asyncio.wait_for(asyncio.shield(get_task), timeout=wait_time)
-            except asyncio.TimeoutError:
-                get_task.cancel()
-                return True
+                if not await self.__wait_for_message(get_task, wait_time):
+                    get_task.cancel()
+                    return True
             except Exception:
                 # If the get_task failed, we return False to let the loop handle the exception
                 return False
+
+        return False
+
+    async def _bounded_by_stop(self, hook: Awaitable[None], name: HookName) -> None:
+        """Run a lifecycle hook the loop awaits directly, abandoning it if a stop is requested.
+
+        Without this a hook waiting on I/O holds the loop for as long as that takes, however long ago
+        the stop was asked for, and a caller with a deadline never reaches `finalize`.
+        """
+        work = asyncio.ensure_future(hook)
+        # Bounded by `asyncio.wait` rather than a sleeping waiter task: its timeout does not go through
+        # `asyncio.sleep`, so this cannot become a spin loop if something replaces that.
+        while not self.stopping:
+            done, _ = await asyncio.wait({work}, timeout=STOP_CHECK_INTERVAL)
+            if done:
+                # Awaited so a hook that failed still reaches the error policy rather than being lost
+                # with the future it failed in.
+                await work
+                return
+
+        work.cancel()
+        self._logger.warning("Abandoned %s: a stop was requested while it was still waiting", name)
+        with contextlib.suppress(asyncio.CancelledError):
+            await work
+
+    async def __wait_for_message(self, get_task: asyncio.Task, wait_time: float) -> bool:
+        """Whether a message arrived within ``wait_time``.
+
+        Waited out in slices rather than in one go, so a stop requested while the bus sits idle is
+        acted on promptly instead of after a grace period that can be far longer than the caller has.
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + wait_time
+        while (remaining := deadline - loop.time()) > 0:
+            if self.stopping:
+                return False
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(asyncio.shield(get_task), timeout=min(STOP_CHECK_INTERVAL, remaining))
+                return True
 
         return False
 
@@ -505,7 +583,7 @@ class EventBusOrchestrator(ABC):
         # directly from on_message_received skips dispatch for this message and
         # continues with the next one.
         try:
-            await self.on_message_received(msg)
+            await self._bounded_by_stop(self.on_message_received(msg), HookName.ON_MESSAGE_RECEIVED)
         except (asyncio.CancelledError, FatalProcessingError):
             raise
         except SkipMessageError as e:
@@ -571,6 +649,17 @@ class EventBusOrchestrator(ABC):
         and any on_success failure (wrapped as :class:`ProcessorHookError`)
         through the processor's ``on_error`` and applies the orchestrator's policy.
         """
+        if self.stopping:
+            # A task can be created before the stop and scheduled after it, so refusing here covers
+            # every processor without each having to check.
+            self._logger.warning(
+                "Not dispatching %s(%s) to %s: the bus is shutting down",
+                type(message).__name__,
+                message.id,
+                processor.name,
+            )
+            return
+
         try:
             match processor:
                 case AsyncProcessor():

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -1205,3 +1205,103 @@ async def test_pending_sync_work_can_be_read_while_workers_finish_underneath_it(
         await asyncio.gather(*running)
 
     assert orchestrator._pending_sync_work() == set()
+
+class StopRequester(AsyncProcessor[Memo]):
+    """Asks the bus to stop from inside a processor, then submits as the runner's `finally` does."""
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.processed: list[Memo] = []
+
+    async def process_message(self, message: Memo):
+        self.processed.append(message)
+        assert self.bus is not None
+        self.bus.request_stop()
+        self.submit_message(Memo("after_stop", subject="late"))
+
+
+def test_a_requested_stop_ends_an_idle_bus_without_waiting_out_the_grace_period(secretary: Secretary):
+    """A caller under a deadline it does not control cannot afford the grace period.
+
+    The dispatcher's default grace is 30s against the ~10s a cancelled CI job gets, so a stop that
+    lands while the bus sits idle has to interrupt that wait rather than be seen once it expires.
+    """
+    grace_period = 10.0
+    orchestrator = MockOrchestrator(logging.getLogger("test_request_stop"), max_timeout=60, grace_period=grace_period)
+    orchestrator.register_processor(secretary, [Memo])
+    orchestrator.submit_message(Memo("memo1"))
+    # From a thread, and only once the bus is already idle inside the grace wait.
+    threading.Timer(0.3, orchestrator.request_stop).start()
+
+    start = time.perf_counter()
+    orchestrator.run()
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < grace_period / 2
+    assert "finalize" in orchestrator.events
+
+
+def test_work_submitted_after_a_stop_request_is_reported_rather_than_lost(
+    secretary: Secretary, caplog: pytest.LogCaptureFixture
+):
+    """A stopping bus exits before draining its queue, so a late put is never read by anyone.
+
+    Processors submit follow-up work from `finally` blocks, and without refusing it at the door that
+    work disappears with nothing in the log to say the run dropped it.
+    """
+    requester = StopRequester("requester")
+    orchestrator = MockOrchestrator(logging.getLogger("test_stop_guard"), max_timeout=30, grace_period=1)
+    orchestrator.register_processor(requester, [Memo])
+    orchestrator.register_processor(secretary, [Memo])
+
+    orchestrator.submit_message(Memo("memo1"))
+    with caplog.at_level(logging.WARNING):
+        orchestrator.run()
+
+    assert [message.id for message in requester.processed] == ["memo1"]
+    assert "Dropped Memo(after_stop)" in caplog.text
+
+
+def test_a_processor_is_not_dispatched_to_after_a_stop_request(secretary: Secretary):
+    """Both processors' tasks are created together, so the second is scheduled after the stop.
+
+    Refusing centrally is what makes that hold for every processor, including ones that never learn
+    to check the flag themselves.
+    """
+    requester = StopRequester("requester")
+    orchestrator = MockOrchestrator(logging.getLogger("test_dispatch_guard"), max_timeout=30, grace_period=1)
+    orchestrator.register_processor(requester, [Memo])
+    orchestrator.register_processor(secretary, [Memo])
+
+    orchestrator.submit_message(Memo("memo1"))
+    orchestrator.run()
+
+    assert [message.id for message in requester.processed] == ["memo1"]
+    assert secretary.delivered_memos == []
+
+
+def test_a_hook_waiting_on_io_does_not_hold_up_a_requested_stop(secretary: Secretary):
+    """The loop awaits this hook directly, so one waiting on I/O holds shutdown for as long as it takes.
+
+    A caller working to a deadline it does not control would never reach `finalize`, which is where the
+    run reports and cleans up.
+    """
+
+    class Bus(MockOrchestrator):
+        async def on_message_received(self, message: BaseMessage):
+            await super().on_message_received(message)
+            await asyncio.sleep(30)
+
+    orchestrator = Bus(logging.getLogger("test_hook_stop"), max_timeout=60, grace_period=1)
+    orchestrator.register_processor(secretary, [Memo])
+    orchestrator.submit_message(Memo("memo1"))
+    threading.Timer(0.3, orchestrator.request_stop).start()
+
+    start = time.perf_counter()
+    orchestrator.run()
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 5
+    assert "finalize" in orchestrator.events
+    # Abandoned before dispatch, so the message it was about never reaches a processor.
+    assert secretary.delivered_memos == []

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -1206,6 +1206,7 @@ async def test_pending_sync_work_can_be_read_while_workers_finish_underneath_it(
 
     assert orchestrator._pending_sync_work() == set()
 
+
 class StopRequester(AsyncProcessor[Memo]):
     """Asks the bus to stop from inside a processor, then submits as the runner's `finally` does."""
 
@@ -1220,7 +1221,9 @@ class StopRequester(AsyncProcessor[Memo]):
         self.submit_message(Memo("after_stop", subject="late"))
 
 
-def test_a_requested_stop_ends_an_idle_bus_without_waiting_out_the_grace_period(secretary: Secretary):
+def test_a_requested_stop_ends_an_idle_bus_without_waiting_out_the_grace_period(
+    secretary: Secretary, caplog: pytest.LogCaptureFixture
+):
     """A caller under a deadline it does not control cannot afford the grace period.
 
     The dispatcher's default grace is 30s against the ~10s a cancelled CI job gets, so a stop that
@@ -1234,11 +1237,14 @@ def test_a_requested_stop_ends_an_idle_bus_without_waiting_out_the_grace_period(
     threading.Timer(0.3, orchestrator.request_stop).start()
 
     start = time.perf_counter()
-    orchestrator.run()
+    with caplog.at_level(logging.INFO):
+        orchestrator.run()
     elapsed = time.perf_counter() - start
 
     assert elapsed < grace_period / 2
     assert "finalize" in orchestrator.events
+    # Said at the exit, or this reads in the logs like the grace period expiring on its own.
+    assert "Stopping on request while idle." in caplog.text
 
 
 def test_work_submitted_after_a_stop_request_is_reported_rather_than_lost(


### PR DESCRIPTION
> **Stack**
>
> 1. ~~#24978 Wait for sync processors and retire the thread pool on shutdown~~ (merged)
> 2. ~~#24980 Abandon gathering when the bus is shutting down~~ (merged)
> 3. **#25002 Let a caller ask the event bus to stop** :point_left: this PR
> 4. #25042 Report and clean up after a cancelled Dispatcher run

### What does this PR do?

Adds `EventBusOrchestrator.request_stop()`, which sets the existing stop flag from any thread and has the loop act on it within `STOP_CHECK_INTERVAL` (1s).

The grace-period wait is now taken in slices rather than in one `wait_for`, so a stop that arrives while the bus sits idle is acted on promptly instead of when that wait expires.

Two guards come with it, both central so that no processor has to repeat them:

- The dispatch site refuses to invoke a processor whose task was created before the stop but scheduled after it.
- `submit_message` refuses work handed to a bus that will not read it, and logs the drop.

Nothing calls `request_stop()` yet. The signal handling that will, and the cleanup it needs to run, are the next two PRs in the stack.

### Motivation

A cancelled GitHub Actions job gives the process about 10 seconds: SIGINT, then SIGTERM 7.5s later, then a hard kill. Measured on a probe run, not inferred.

The dispatcher runs with `grace_period_seconds` defaulting to 30. Without a way to interrupt that wait, a stop arriving while the bus is idle would be seen up to 30 seconds later, which is three times the whole budget, so the process would be killed before `finalize` ever ran.

The two guards exist because the stop flag alone does not stop work that is already queued or already scheduled. Enforcing centrally rather than per processor means a processor added later cannot forget it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

