### PR TITLE
Avoid bundling Agent-provided curl and unixODBC libraries

### DIFF
--- a/.builders/scripts/repair_wheels.py
+++ b/.builders/scripts/repair_wheels.py
@@ -123,6 +123,9 @@ def repair_linux(source_built_dir: str, source_external_dir: str, built_dir: str
         {
             # pymqi
             'libmqic_r.so',
+            # The Agent package provides these libraries in its embedded runtime.
+            'libcurl.so.4',
+            'libodbc.so.2',
         }
     )
 

--- a/.builders/tests/test_repair_wheels.py
+++ b/.builders/tests/test_repair_wheels.py
@@ -4,7 +4,7 @@ import io
 import shutil
 import sys
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from zipfile import ZIP_DEFLATED
 from zipfile import ZipFile
 from zipfile import ZipInfo
@@ -38,6 +38,51 @@ def write_wheel(path: Path) -> None:
             info.external_attr = 0o644 << 16
             wheel.writestr(info, contents)
         wheel.writestr(record_path, record.getvalue())
+
+
+def test_repair_linux_excludes_agent_provided_libraries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_built_dir = tmp_path / 'source-built'
+    source_external_dir = tmp_path / 'source-external'
+    built_dir = tmp_path / 'built'
+    external_dir = tmp_path / 'external'
+    for directory in (source_built_dir, source_external_dir, built_dir, external_dir):
+        directory.mkdir()
+    (source_built_dir / 'package-1.0.0-cp313-cp313-linux_x86_64.whl').touch()
+
+    captured_exclusions: list[frozenset[str]] = []
+
+    class FakePolicies:
+        def get_policy_by_name(self, name: str) -> dict:
+            assert name == 'manylinux2014_x86_64'
+            return {
+                'name': name,
+                'aliases': [],
+                'lib_whitelist': ['libz.so.1'],
+                'symbol_versions': {'ZLIB': []},
+            }
+
+    class NonPlatformWheel(Exception):
+        pass
+
+    def fake_repair_wheel(*_args, exclude: frozenset[str], **_kwargs) -> None:
+        captured_exclusions.append(exclude)
+
+    auditwheel = ModuleType('auditwheel')
+    auditwheel.__path__ = []
+    monkeypatch.setitem(sys.modules, 'auditwheel', auditwheel)
+    monkeypatch.setitem(sys.modules, 'auditwheel.patcher', SimpleNamespace(Patchelf=object))
+    monkeypatch.setitem(sys.modules, 'auditwheel.policy', SimpleNamespace(WheelPolicies=FakePolicies))
+    monkeypatch.setitem(sys.modules, 'auditwheel.repair', SimpleNamespace(repair_wheel=fake_repair_wheel))
+    monkeypatch.setitem(sys.modules, 'auditwheel.wheel_abi', SimpleNamespace(NonPlatformWheel=NonPlatformWheel))
+    monkeypatch.setenv('MANYLINUX_POLICY', 'manylinux2014_x86_64')
+
+    repair_wheels.repair_linux(
+        str(source_built_dir), str(source_external_dir), str(built_dir), str(external_dir)
+    )
+
+    assert captured_exclusions == [frozenset({'libmqic_r.so', 'libcurl.so.4', 'libodbc.so.2'})]
 
 
 def test_strip_macos_ddtrace_libddwaf_removes_only_dylib_and_record_entry(tmp_path: Path) -> None:


### PR DESCRIPTION
### What does this PR do?

Configures Linux `auditwheel` repair to exclude `libcurl.so.4` and `libodbc.so.2` from Datadog-built integration dependency wheels. External wheels, Windows and macOS repair, and all other native libraries are unchanged.

The Agent package already provides these two canonical libraries in its embedded runtime. Keeping their ordinary SONAME dependencies in the repaired wheels lets the packaged extensions use the Agent-owned copies instead of shipping private auditwheel copies.

### Motivation

The Linux Agent currently includes redundant wheel-private copies even though the wheel builder and Agent use aligned dependency versions:

- curl 8.21.0 / `libcurl.so.4`
- unixODBC 2.3.9 / `libodbc.so.2`

In the audited Agent amd64 package, the private copies consume 1,314,168 logical bytes (1.253 MiB): 845,368 bytes for libcurl and 468,800 bytes for unixODBC. This uses auditwheel's supported `exclude` mechanism at wheel creation time instead of mutating installed ELF files later.

Validation:

- Added a focused test that exercises the Linux repair boundary and verifies the exact exclusion set passed to auditwheel.
- `.builders` test suite: 74 passed.
- `.builders` mypy: 13 source files passed.
- Repository `ddev --no-interactive test --lint`: formatting, Ruff, and mypy passed.
- Independent code review found no correctness issues.

The downstream Agent package and integration smoke matrix should validate the regenerated x86_64 and arm64 wheels before broadening the exclusion list to other native libraries.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
