### PR TITLE
Emit topic config after update_topic_config for immediate UI updates

### DIFF
--- a/kafka_actions/changelog.d/emit-topic-config.added
+++ b/kafka_actions/changelog.d/emit-topic-config.added
@@ -1,0 +1,1 @@
+Emit updated topic config to the event platform after a successful update_topic_config or delete_topic_config action, so the UI reflects changes immediately without waiting for the kafka_consumer check cache to expire.

--- a/kafka_actions/datadog_checks/kafka_actions/check.py
+++ b/kafka_actions/datadog_checks/kafka_actions/check.py
@@ -689,6 +689,37 @@ class KafkaActionsCheck(AgentCheck):
             if not success:
                 raise Exception(f"Failed to delete configs for topic '{topic}'")
 
+        # Emit the updated topic config so the UI reflects changes immediately,
+        # without waiting for the kafka_consumer check's cache to expire.
+        self._emit_topic_config(topic)
+
+    def _emit_topic_config(self, topic: str):
+        """Fetch and emit the current topic config to the data-streams-message track.
+
+        Called after a successful update_topic_config or delete_topic_config action
+        so the backend UI reflects the change immediately, without waiting for
+        the kafka_consumer check's config cache (default 180s) to expire.
+        """
+        try:
+            topic_config = self.kafka_client.describe_topic_config(topic)
+            if not topic_config:
+                self.log.debug("No config returned for topic '%s', skipping emit", topic)
+                return
+
+            self.log.debug("Emitting updated config for topic '%s' after config change", topic)
+
+            payload = {
+                'collection_timestamp': int(time.time() * 1000),
+                'kafka_cluster_id': self.cluster,
+                'topic': topic,
+                'config_type': 'topic',
+                'config': topic_config,
+            }
+
+            self.event_platform_event(json.dumps(payload), "data-streams-message")
+        except Exception as e:
+            self.log.warning("Failed to emit topic config for '%s': %s", topic, e)
+
     def _action_delete_topic(self):
         """Delete a Kafka topic (RFC Action #4).
 

--- a/kafka_actions/datadog_checks/kafka_actions/kafka_client.py
+++ b/kafka_actions/datadog_checks/kafka_actions/kafka_client.py
@@ -549,6 +549,36 @@ class KafkaActionsClient:
                 self.log.error("Failed to delete topic '%s' config: %s", topic, e)
                 raise
 
+    def describe_topic_config(self, topic: str) -> dict[str, str]:
+        """Fetch current topic configuration via describe_configs.
+
+        Used after a config update to emit the updated config to the event
+        platform so the UI reflects changes immediately, without waiting for
+        the kafka_consumer check's cache to expire.
+
+        Args:
+            topic: Topic name
+
+        Returns:
+            Dict of config key-value pairs
+        """
+        admin = self.get_admin_client()
+
+        resource = ConfigResource(ResourceType.TOPIC, topic)
+        futures = admin.describe_configs([resource], request_timeout=10)
+
+        for _res, future in futures.items():
+            try:
+                config_result = future.result(timeout=10)
+                if not config_result:
+                    return {}
+                return {name: entry.value for name, entry in config_result.items() if entry.value is not None}
+            except Exception as e:
+                self.log.error("Failed to describe configs for topic '%s': %s", topic, e)
+                raise
+
+        return {}
+
     def delete_consumer_group(self, consumer_group: str) -> bool:
         """Delete a consumer group.
 


### PR DESCRIPTION
## What does this PR do?

After a successful `update_topic_config` or `delete_topic_config` action, the `kafka_actions` check now calls `describe_configs` on the modified topic and emits the updated config to the `data-streams-message` event platform track. This matches the format used by the `kafka_consumer` check's cluster metadata collection, so the backend UI reflects the change immediately instead of waiting for the `kafka_consumer` check's config cache (default 180s) to expire.

## Motivation

When a user updates a topic config via Kafka Actions, the Kafka broker reflects the change immediately, but the Datadog UI shows stale data for up to 3 minutes (the `kafka_consumer` check's `kafka_configs_refresh_interval` cache TTL). This is confusing for users who expect to see their config change reflected right away.

The `kafka_consumer` and `kafka_actions` checks use separate persistent cache namespaces (per check instance), so cross-check cache invalidation is not possible. Instead, this PR has `kafka_actions` emit the updated config directly to the same event platform track that `kafka_consumer` uses, so the backend picks it up immediately.

## Changes

- **`kafka_client.py`**: Add `describe_topic_config()` method that calls `AdminClient.describe_configs()` on a topic and returns the config key-value pairs
- **`check.py`**: Add `_emit_topic_config()` method that fetches the topic config and emits it as a `data-streams-message` event (matching the format from `kafka_consumer`'s `cluster_metadata.py`)
- **`check.py`**: Call `_emit_topic_config()` at the end of `_action_update_topic_config()` (after both `update_topic_config` and `delete_topic_config` succeed)
- The emit is wrapped in a try/except so failures don't affect the action result — the config update itself has already succeeded

## Event format

The emitted event matches the format used by `kafka_consumer`'s `_collect_topic_configs`:

```json
{
  "collection_timestamp": 1234567890000,
  "kafka_cluster_id": "cluster-id",
  "topic": "test-topic",
  "config_type": "topic",
  "config": {
    "retention.ms": "172800000",
    "compression.type": "snappy",
    "max.message.bytes": "10485760"
  }
}
```

## Testing

- [ ] Unit test for `describe_topic_config()` client method
- [ ] End-to-end test: trigger `update_topic_config`, verify UI updates within seconds (not 3 minutes)
- [ ] Verify event format matches what `kafka_consumer` emits

## Related

- integrations-core PR #24967 — Switch to `incremental_alter_configs` (PATCH semantics)
- dd-source PR #64962 — Add `update_topic_config` endpoint to dsm-api
- dd-source PR #66764 — Fix RC schema for kafka_actions (merged)