### PR TITLE
Port datadog_checks_base 38.0.2 release to master

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -15,6 +15,12 @@
 * Fix AIA chasing crashing when the CA Issuers response is DER-encoded. ([#24683](https://github.com/DataDog/integrations-core/pull/24683))
 * Stop the check logging adapter from holding a reference to the check, so a cancelled check is reclaimed without waiting for a garbage collection pass. ([#24914](https://github.com/DataDog/integrations-core/pull/24914))
 
+## 38.0.2 / 2026-08-26
+
+***Fixed***:
+
+* Bump ddtrace to 4.12.2 to remediate CVE-2026-50271 (W3C baggage header DoS). ([#24864](https://github.com/DataDog/integrations-core/pull/24864))
+
 ## 38.0.1 / 2026-08-24
 
 ***Fixed***:

--- a/datadog_checks_base/changelog.d/24864.security
+++ b/datadog_checks_base/changelog.d/24864.security
@@ -1,1 +1,0 @@
-Bump ddtrace to 4.12.2 to remediate CVE-2026-50271 (W3C baggage header DoS).


### PR DESCRIPTION
### What does this PR do?

Records the `datadog_checks_base` **38.0.2** release, published from `7.83.x` in #24995, on `master`.

Two edits, no version changes:

- Adds the 38.0.2 section to `datadog_checks_base/CHANGELOG.md`, slotted at its semver position between 38.1.0 and 38.0.1.
- Deletes the pending `changelog.d/24864.security` fragment, whose content shipped as 38.0.2 from the release branch.

`__about__.py` (38.1.0), `requirements-agent-release.txt` (`datadog-checks-base==38.1.0`), and `.in-toto/` are intentionally untouched. `master` is ahead of what `7.83.x` published, and `requirements-agent-release.txt` tracks the highest published version per package rather than any single branch, so nothing should be rolled back. Attestations are per-branch.

The `ddtrace==4.12.2` bump itself is already on `master` from #24864, so there is no dependency change here and no wheel promotion is needed.

The unrelated `changelog.d/24905.added` fragment is deliberately retained.

### Motivation

Without deleting the consumed fragment, the next release cut from `master` would re-announce the ddtrace CVE fix that already shipped as 38.0.2. Adding the changelog section keeps the published version history on `master` complete.

Follow-up to #24864 (master) and #24984 (`7.83.x` backport). Jira: [VULN-91804](https://datadoghq.atlassian.net/browse/VULN-91804).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[VULN-91804]: https://datadoghq.atlassian.net/browse/VULN-91804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ