### PR TITLE
Fix kafka_consumer dropping retention.ms/retention.bytes from topic config events

### DIFF
--- a/kafka_consumer/changelog.d/25012.fixed
+++ b/kafka_consumer/changelog.d/25012.fixed
@@ -1,0 +1,1 @@
+Fix retention.ms and retention.bytes being dropped from topic config events when a topic has 30+ configs (e.g. tiered-storage topics). The configs were truncated because they sorted late alphabetically and the max_configs cap cut them, even though the corresponding metrics were still emitted.

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -1376,11 +1376,31 @@ class ClusterMetadataCollector:
             'log.cleaner.enable',
         }
 
+        # Topic-level configs that should always be kept (not truncated).
+        # Without this, retention.ms and retention.bytes get dropped when a topic
+        # has 30+ configs (e.g. tiered-storage topics) because they sort late
+        # alphabetically and the max_configs cap cuts them.
+        important_topic_configs = {
+            # Retention (topic-level)
+            'retention.ms',
+            'retention.bytes',
+            'local.retention.ms',
+            'local.retention.bytes',
+            # Cleanup
+            'cleanup.policy',
+            # Message size
+            'max.message.bytes',
+            # Tiered storage
+            'remote.storage.enable',
+        }
+
+        all_important_configs = important_broker_configs | important_topic_configs
+
         important_found = {}
         remaining = {}
 
         for key, value in config_data.items():
-            if key in important_broker_configs:
+            if key in all_important_configs:
                 important_found[key] = value
             else:
                 remaining[key] = value

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -2079,3 +2079,62 @@ def test_collect_connect_status_degrades_to_empty_dict_on_exception(check):
         result = kafka_consumer_check._collect_connect_status('test-cluster')
 
     assert result == {}
+
+
+def test_truncate_config_preserves_retention_keys_for_topic(check):
+    """_truncate_config_for_event must keep retention.ms and retention.bytes even when
+    a topic has 30+ configs (e.g. tiered-storage topics).
+
+    Without the important_topic_configs set, retention.ms and retention.bytes sort
+    late alphabetically and get cut by the max_configs=30 cap.
+    """
+    instance = {'kafka_connect_str': 'localhost:9092', 'enable_cluster_monitoring': True}
+    kafka_consumer_check = check(instance)
+    collector = kafka_consumer_check.metadata_collector
+
+    # Simulate 32 topic configs (as returned by describe_configs for a tiered-storage topic)
+    topic_configs = {
+        'cleanup.policy': 'delete',
+        'compression.gzip.level': '-1',
+        'compression.lz4.level': '9',
+        'compression.type': 'producer',
+        'compression.zstd.level': '3',
+        'delete.retention.ms': '86400000',
+        'file.delete.delay.ms': '60000',
+        'flush.messages': '9223372036854775807',
+        'flush.ms': '9223372036854775807',
+        'follower.replication.throttled.replicas': '',
+        'index.interval.bytes': '4096',
+        'leader.replication.throttled.replicas': '',
+        'local.retention.bytes': '-2',
+        'local.retention.ms': '3600000',
+        'max.compaction.lag.ms': '9223372036854775807',
+        'max.message.bytes': '20971520',
+        'message.downconversion.enable': 'true',
+        'message.format.version': '3.0-IV1',
+        'message.timestamp.after.max.ms': '9223372036854775807',
+        'message.timestamp.before.max.ms': '9223372036854775807',
+        'message.timestamp.difference.max.ms': '9223372036854775807',
+        'message.timestamp.type': 'LogAppendTime',
+        'min.cleanable.dirty.ratio': '0.5',
+        'min.compaction.lag.ms': '0',
+        'min.insync.replicas': '1',
+        'preallocate': 'false',
+        'remote.log.copy.disable': 'false',
+        'remote.log.delete.on.disable': 'false',
+        'remote.storage.enable': 'true',
+        'retention.bytes': '-1',
+        'retention.ms': '14400000',
+        'unclean.leader.election.enable': 'false',
+    }
+
+    result = collector._truncate_config_for_event(topic_configs, max_configs=30)
+
+    assert 'retention.ms' in result, 'retention.ms must not be truncated'
+    assert 'retention.bytes' in result, 'retention.bytes must not be truncated'
+    assert 'local.retention.ms' in result, 'local.retention.ms must not be truncated'
+    assert 'local.retention.bytes' in result, 'local.retention.bytes must not be truncated'
+    assert 'cleanup.policy' in result, 'cleanup.policy must not be truncated'
+    assert 'max.message.bytes' in result, 'max.message.bytes must not be truncated'
+    assert 'remote.storage.enable' in result, 'remote.storage.enable must not be truncated'
+    assert len(result) == 30, 'should respect max_configs=30'


### PR DESCRIPTION
## Summary

Fix `retention.ms` and `retention.bytes` being dropped from topic config events when a topic has 30+ configs (e.g. tiered-storage topics).

## Problem

The `_truncate_config_for_event` function in `cluster_metadata.py` only had an `important_broker_configs` set — no equivalent for topic-level configs. When a Kafka topic has 30+ configs returned by `describe_configs` (common with tiered storage enabled), the `max_configs=30` cap would cut keys that sort late alphabetically. `retention.bytes` and `retention.ms` happen to sort after `remote.storage.enable`, so they were the ones that got dropped.

This caused a confusing discrepancy:
- The **metrics** (`kafka.topic.config.retention_ms`, `kafka.topic.config.retention_bytes`) were still emitted correctly, because they run on the full, untruncated config dict
- But the **config event** (which powers the UI Configuration section) was missing these keys, because it uses the truncated dict
- The health warning text could show "retention.ms setting of 6 hours" (from the metric), but the Configuration section below it didn't show `retention.ms` at all

Example: 
<img width="1616" height="1628" alt="Screenshot 2026-08-31 at 10 28 53 AM" src="https://github.com/user-attachments/assets/feb6164a-7348-456c-bd9e-12894b326fb2" />

## Fix

Add an `important_topic_configs` set alongside the existing `important_broker_configs`:

```python
important_topic_configs = {
    'retention.ms',
    'retention.bytes',
    'local.retention.ms',
    'local.retention.bytes',
    'cleanup.policy',
    'max.message.bytes',
    'remote.storage.enable',
}
```

These keys are now always preserved in the truncated config event, regardless of how many total configs Kafka returns.

## Validation

For a tiered-storage topic with 32 configs from `describe_configs`:
- **Before:** 3 important (broker) + 27 remaining = 30 selected, `retention.bytes` and `retention.ms` cut
- **After:** 10 important (3 broker + 7 topic) + 20 remaining = 30 selected, `remote.log.copy.disable` and `remote.log.delete.on.disable` cut instead

## Testing

- [ ] Unit test: `_truncate_config_for_event` with 32 topic configs preserves `retention.ms` and `retention.bytes`
- [ ] Manual: verify UI Configuration section shows `retention.ms` for tiered-storage topics
