### PR TITLE
Remove preview note from collect_raw_query_statement

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -1528,7 +1528,6 @@ files:
         Enabling this option will allow the collection and ingestion of raw query statements and 
         explain plans into Datadog, which can then become viewable in query samples or explain plans. 
         This option is disabled by default.
-        Note: Collection of raw query statements is currently in preview.
         This option only applies when dbm is enabled.
       options:
         - name: enabled

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -884,7 +884,6 @@ instances:
     ## Enabling this option will allow the collection and ingestion of raw query statements and 
     ## explain plans into Datadog, which can then become viewable in query samples or explain plans. 
     ## This option is disabled by default.
-    ## Note: Collection of raw query statements is currently in preview.
     ## This option only applies when dbm is enabled.
     #
     # collect_raw_query_statement:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -1047,7 +1047,6 @@ files:
         Enabling this option will allow the collection and ingestion of raw query statements 
         into Datadog, which can then become viewable in query samples.
         This option is disabled by default.
-        Note: Collection of raw query statements is currently in preview.
         This option only applies when dbm is enabled.
       options:
         - name: enabled

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -704,7 +704,6 @@ instances:
     ## Enabling this option will allow the collection and ingestion of raw query statements 
     ## into Datadog, which can then become viewable in query samples.
     ## This option is disabled by default.
-    ## Note: Collection of raw query statements is currently in preview.
     ## This option only applies when dbm is enabled.
     #
     # collect_raw_query_statement:


### PR DESCRIPTION
### What does this PR do?
Removes preview note from `collect_raw_query_statement` description in the SQL Server and Postgres - this was dropped from the public documentation already in [DataDog/documentation#32528](https://github.com/DataDog/documentation/pull/32528).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
