### PR TITLE
Register Measure Disk Usage as a post-pr-comment.yml producer

### DIFF
--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -49,6 +49,7 @@ on:
   workflow_run:
     workflows:
       - 'Validate skip QA label'
+      - 'Measure Disk Usage'
     types: [completed]
 
 permissions:


### PR DESCRIPTION
### What does this PR do?
Adds `Measure Disk Usage` to `post-pr-comment.yml`'s `on.workflow_run.workflows` allowlist, onboarding it as a producer of the `pr-comment` artifact that the centralized poster workflow picks up and posts/updates on the pull request.

### Motivation
`measure-disk-usage.yml` is being migrated (in #24895) to delegate PR-comment posting to the fork-safe, dd-octo-sts-based `post-pr-comment.yml` poster instead of managing its own `GITHUB_TOKEN` permissions and calling `peter-evans/find-comment`/`create-or-update-comment` directly. Since `post-pr-comment.yml`'s `workflow_run` trigger only reads its allowlist from the version of the file on the default branch, this one-line registration needs to land on `master` before the artifact hand-off can be exercised end to end on that PR.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged