### PR TITLE
Centralize the DDIGNORE query comment in one constant

### DIFF
--- a/postgres/changelog.d/25018.fixed
+++ b/postgres/changelog.d/25018.fixed
@@ -1,0 +1,1 @@
+Use a shared ``DDIGNORE_COMMENT`` constant for queries excluded from query metrics.

--- a/postgres/datadog_checks/postgres/cursor.py
+++ b/postgres/datadog_checks/postgres/cursor.py
@@ -6,6 +6,7 @@ import psycopg
 
 from datadog_checks.base.utils.db.sql_commenter import add_sql_comment
 from datadog_checks.postgres.encoding import decode_with_encodings
+from datadog_checks.postgres.util import DDIGNORE_COMMENT
 
 DD_QUERY_ATTRIBUTES = {
     'service': 'datadog-agent',
@@ -19,12 +20,12 @@ class BaseCommenterCursor:
 
     def execute(self, query, params=None, ignore_query_metric=False, binary=False, prepare=None):
         '''
-        When ignore is True, a /* DDIGNORE */ comment will be added to the query.
+        When ignore is True, a DDIGNORE comment will be added to the query.
         This comment indicates that the query should be ignored in query metrics.
         '''
         query = add_sql_comment(query, prepand=True, **self.__attributes)
         if ignore_query_metric:
-            query = '{} {}'.format('/* DDIGNORE */', query)
+            query = '{} {}'.format(DDIGNORE_COMMENT, query)
         return super().execute(query, params, binary=binary, prepare=prepare)
 
 

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -20,6 +20,7 @@ from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.postgres.config_models import InstanceConfig
 
 from .util import (
+    DDIGNORE_COMMENT,
     DatabaseConfigurationError,
     parse_shared_preload_libraries,
     payload_pg_version,
@@ -40,7 +41,7 @@ SELECT {cols}
   LEFT JOIN pg_database
          ON pg_stat_statements.dbid = pg_database.oid
   WHERE query != '<insufficient privilege>'
-  AND query NOT LIKE '/* DDIGNORE */%%'
+  AND query NOT LIKE '{ddignore_comment}%%'
   {queryid_filter}
   {filters}
   {extra_clauses}
@@ -59,6 +60,7 @@ def statements_query(**kwargs):
         filters=filters,
         extra_clauses=extra_clauses,
         queryid_filter="",
+        ddignore_comment=DDIGNORE_COMMENT,
     )
 
 

--- a/postgres/datadog_checks/postgres/statements_v2.py
+++ b/postgres/datadog_checks/postgres/statements_v2.py
@@ -29,6 +29,7 @@ from .statements import (
     statements_query,
 )
 from .util import (
+    DDIGNORE_COMMENT,
     DatabaseConfigurationError,
     parse_shared_preload_libraries,
     payload_pg_version,
@@ -361,8 +362,8 @@ class PostgresStatementMetricsV2(DBMAsyncJob):
             for pgss_key, text in raw_texts.items():
                 if not text:
                     continue
-                if text.startswith('/* DDIGNORE */'):
-                    # We want to ignore tracking query metrics for queries with the /* DDIGNORE */ comment.
+                if text.startswith(DDIGNORE_COMMENT):
+                    # We want to ignore tracking query metrics for queries with the DDIGNORE comment.
                     ignorable.add(pgss_key)
                     continue
                 if text == '<insufficient privilege>':

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -57,6 +57,9 @@ class DatabaseConfigurationError(Enum):
 # Docs anchor is appended to the troubleshooting URL to land the user on the right section.
 TROUBLESHOOTING_DOC_URL = "https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting/"
 
+# Prepended to queries that should be excluded from query metrics collection.
+DDIGNORE_COMMENT = '/* DDIGNORE */'
+
 
 # Central map of diagnostic metadata for every DatabaseConfigurationError code. Used by both the
 # runtime `record_warning` path (so `agent diagnose` sees the same remediation text as `agent status`)


### PR DESCRIPTION
### What does this PR do?
Moves the `/* DDIGNORE */` comment string we apply into a constant instead of repeating the string in multiple places

### Motivation
The ignore-query comment was duplicated as a string literal in several. This will make sure we don't misuse it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
