### PR TITLE
Test backend-neutral HTTP core without integration migrations

### DIFF
--- a/datadog_checks_base/changelog.d/25020.added
+++ b/datadog_checks_base/changelog.d/25020.added
@@ -1,0 +1,1 @@
+Add backend-agnostic HTTP protocols, exceptions, and structural test fakes, so checks and their tests can avoid depending on ``requests``.

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
 
     from datadog_checks.base.utils.diagnose import Diagnosis
     from datadog_checks.base.utils.discovery import Service
-    from datadog_checks.base.utils.http import RequestsWrapper
+    from datadog_checks.base.utils.http_protocol import HTTPClient
     from datadog_checks.base.utils.metadata import MetadataManager
 
 inspect: _module_inspect = lazy_loader.load('inspect')
@@ -488,19 +488,28 @@ class AgentCheck(object):
         self._log_adapter.set_check_id(value)
 
     @property
-    def http(self) -> RequestsWrapper:
+    def http(self) -> HTTPClient:
         """
         Provides logic to yield consistent network behavior based on user configuration.
 
         Only new checks or checks on Agent 6.13+ can and should use this for HTTP requests.
         """
         if not hasattr(self, '_http'):
-            # See Performance Optimizations in this package's README.md.
-            from datadog_checks.base.utils.http import RequestsWrapper
-
-            self._http = RequestsWrapper(self.instance or {}, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log)
+            self._http = self.create_http_client()
 
         return self._http
+
+    def create_http_client(self, instance: dict | None = None) -> HTTPClient:
+        """Construct the HTTP client backing self.http, optionally from a given instance config."""
+        # See Performance Optimizations in this package's README.md.
+        from datadog_checks.base.utils.http import create_http_client
+
+        return create_http_client(
+            self.instance if instance is None else instance,
+            self.init_config,
+            self.HTTP_CONFIG_REMAPPER,
+            self.log,
+        )
 
     @property
     def logs_enabled(self):

--- a/datadog_checks_base/datadog_checks/base/checks/kubelet_base/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/kubelet_base/base.py
@@ -41,15 +41,16 @@ class KubeletBase(AgentCheck):
         try:
             cutoff_date = self.compute_pod_expiration_datetime()
             with self.perform_kubelet_query(self.pod_list_url, stream=True) as r:
+                # text/* without a charset decodes as ISO-8859-1, so parse the bytes.
                 if cutoff_date:
                     f = ExpiredPodFilter(cutoff_date)
-                    pod_list = json.load(r.raw, object_hook=f.json_hook)
+                    pod_list = json.loads(r.content, object_hook=f.json_hook)
                     pod_list['expired_count'] = f.expired_count
                     if pod_list.get('items') is not None:
                         # Filter out None items from the list
                         pod_list['items'] = [p for p in pod_list['items'] if p is not None]
                 else:
-                    pod_list = json.load(r.raw)
+                    pod_list = json.loads(r.content)
 
             if pod_list.get('items') is None:
                 # Sanitize input: if no pods are running, 'items' is a NoneObject

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -3,10 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy
 
-import requests
-
 from datadog_checks.base.checks import AgentCheck
 from datadog_checks.base.errors import CheckException
+from datadog_checks.base.utils.http_exceptions import HTTPClientRequestError, HTTPClientStatusError
 from datadog_checks.base.utils.tracing import traced_class
 
 from .mixins import OpenMetricsScraperMixin
@@ -120,7 +119,7 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
                             instance['prometheus_url'] = url
                             self.get_scraper_config(instance)
                             break
-                        except (IOError, requests.HTTPError, requests.exceptions.SSLError) as e:
+                        except (IOError, HTTPClientRequestError, HTTPClientStatusError) as e:
                             self.log.info("Couldn't connect to %s: %s, trying next possible URL.", url, str(e))
                     else:
                         raise CheckException(

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -10,7 +10,6 @@ from math import isinf, isnan
 from os.path import isfile
 from re import compile
 
-import requests
 from prometheus_client.samples import Sample
 
 from datadog_checks.base.agent import datadog_agent
@@ -19,7 +18,13 @@ from datadog_checks.base.checks.libs.prometheus import text_fd_to_metric_familie
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.errors import CheckException
 from datadog_checks.base.utils.common import to_native_string
-from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.headers import DEFAULT_ACCEPT, DEFAULT_ACCEPT_ENCODING
+from datadog_checks.base.utils.http import create_http_client
+from datadog_checks.base.utils.http_exceptions import (
+    HTTPClientRequestError,
+    HTTPClientSSLError,
+    HTTPClientStatusError,
+)
 
 
 class OpenMetricsScraperMixin(object):
@@ -392,21 +397,22 @@ class OpenMetricsScraperMixin(object):
         if scraper_config['ssl_verify'] is False:
             scraper_config.setdefault('tls_ignore_warning', True)
 
-        http_handler = self._http_handlers[prometheus_url] = RequestsWrapper(
+        http_handler = self._http_handlers[prometheus_url] = create_http_client(
             scraper_config, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log
         )
 
-        headers = http_handler.options['headers']
-
         bearer_token = scraper_config['_bearer_token']
         if bearer_token is not None:
-            headers['Authorization'] = 'Bearer {}'.format(bearer_token)
+            http_handler.set_header('Authorization', 'Bearer {}'.format(bearer_token))
 
+        # Seeded defaults count as unset; user values do not.
         # TODO: Determine if we really need this
-        headers.setdefault('accept-encoding', 'gzip')
+        if http_handler.get_header('accept-encoding') in (None, DEFAULT_ACCEPT_ENCODING):
+            http_handler.set_header('accept-encoding', 'gzip')
 
         # Explicitly set the content type we accept
-        headers.setdefault('accept', 'text/plain')
+        if http_handler.get_header('accept') in (None, DEFAULT_ACCEPT):
+            http_handler.set_header('accept', 'text/plain')
 
         return http_handler
 
@@ -818,10 +824,10 @@ class OpenMetricsScraperMixin(object):
 
     def poll(self, scraper_config, headers=None):
         """
-        Returns a valid `requests.Response`, otherwise raise requests.HTTPError if the status code of the
+        Returns a valid response, otherwise raise HTTPClientStatusError if the status code of the
         response isn't valid - see `response.raise_for_status()`
 
-        The caller needs to close the requests.Response.
+        The caller needs to close the response.
 
         Custom headers can be added to the default headers.
         """
@@ -835,10 +841,11 @@ class OpenMetricsScraperMixin(object):
 
         try:
             response = self.send_request(endpoint, scraper_config, headers)
-        except requests.exceptions.SSLError:
+        except HTTPClientSSLError:
             self.log.error("Invalid SSL settings for requesting %s endpoint", endpoint)
             raise
-        except IOError:
+        # Auth-token fetching can raise HTTPClientStatusError, a sibling of HTTPClientRequestError.
+        except (IOError, HTTPClientRequestError, HTTPClientStatusError):
             if health_service_check:
                 self.service_check(service_check_name, AgentCheck.CRITICAL, tags=service_check_tags)
             raise
@@ -847,7 +854,7 @@ class OpenMetricsScraperMixin(object):
             if health_service_check:
                 self.service_check(service_check_name, AgentCheck.OK, tags=service_check_tags)
             return response
-        except requests.HTTPError:
+        except HTTPClientStatusError:
             response.close()
             if health_service_check:
                 self.service_check(service_check_name, AgentCheck.CRITICAL, tags=service_check_tags)

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -9,10 +9,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import yaml
-from requests.exceptions import RequestException
 
 from datadog_checks.base.checks import AgentCheck
 from datadog_checks.base.errors import ConfigurationError
+from datadog_checks.base.utils.http_exceptions import HTTPClientError
 from datadog_checks.base.utils.tracing import traced_class
 
 from .scraper import OpenMetricsScraper
@@ -92,7 +92,7 @@ class OpenMetricsBaseCheckV2(AgentCheck):
             with self.adopt_namespace(scraper.namespace):
                 try:
                     scraper.scrape()
-                except (ConnectionError, RequestException) as e:
+                except (ConnectionError, HTTPClientError) as e:
                     self.log.error("There was an error scraping endpoint %s: %s", endpoint, str(e))
                     raise type(e)("There was an error scraping endpoint {}: {}".format(endpoint, e)) from None
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/base_scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper/base_scraper.py
@@ -13,7 +13,6 @@ from typing import List  # noqa: F401
 from prometheus_client import Metric
 from prometheus_client.openmetrics.parser import text_fd_to_metric_families as parse_openmetrics
 from prometheus_client.parser import text_fd_to_metric_families as parse_prometheus
-from requests.exceptions import ConnectionError
 
 from datadog_checks.base.agent import datadog_agent
 from datadog_checks.base.checks.openmetrics import parser_optimizations
@@ -24,7 +23,8 @@ from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.base.errors import ConfigurationError
 from datadog_checks.base.utils.functions import no_op, return_true
-from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.headers import DEFAULT_ACCEPT
+from datadog_checks.base.utils.http_exceptions import HTTPClientConnectionError, HTTPClientTimeoutError
 
 
 class OpenMetricsScraper:
@@ -218,18 +218,16 @@ class OpenMetricsScraper:
 
             self.raw_line_filter = re.compile('|'.join(raw_line_filters))
 
-        self.http = RequestsWrapper(config, self.check.init_config, self.check.HTTP_CONFIG_REMAPPER, self.check.log)
+        self.http = self.check.create_http_client(config)
 
         self._content_type = ''
         self._use_latest_spec = is_affirmative(config.get('use_latest_spec', False))
-        if self._use_latest_spec:
-            accept_header = 'application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1'
-        else:
-            accept_header = 'text/plain'
-
-        # Request the appropriate exposition format
-        if self.http.options['headers'].get('Accept') == '*/*':
-            self.http.options['headers']['Accept'] = accept_header
+        if self.http.get_header('Accept') in (None, DEFAULT_ACCEPT):
+            if self._use_latest_spec:
+                accept_header = 'application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1'
+            else:
+                accept_header = 'text/plain'
+            self.http.set_header('Accept', accept_header)
 
         self.use_process_start_time = is_affirmative(config.get('use_process_start_time'))
 
@@ -417,11 +415,12 @@ class OpenMetricsScraper:
                 self._content_type = connection.headers.get('Content-Type', '')
                 for line in connection.iter_lines(decode_unicode=True):
                     yield line
-        except ConnectionError as e:
+        # A timeout at any phase means the endpoint is unreachable, same as a connection failure.
+        except (HTTPClientConnectionError, HTTPClientTimeoutError):
             if self.ignore_connection_errors:
                 self.log.warning("OpenMetrics endpoint %s is not accessible", self.endpoint)
             else:
-                raise e
+                raise
 
     def filter_connection_lines(self, line_streamer):
         """

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -8,13 +8,18 @@ from collections import defaultdict
 from fnmatch import fnmatchcase
 from math import isinf, isnan
 
-import requests
 from google.protobuf.internal.decoder import _DecodeVarint32  # pylint: disable=E0611,E0401
 
 from datadog_checks.base.checks import AgentCheck
 from datadog_checks.base.checks.libs.prometheus import text_fd_to_metric_families
 from datadog_checks.base.config import is_affirmative
-from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.headers import DEFAULT_ACCEPT, DEFAULT_ACCEPT_ENCODING
+from datadog_checks.base.utils.http import create_http_client
+from datadog_checks.base.utils.http_exceptions import (
+    HTTPClientRequestError,
+    HTTPClientSSLError,
+    HTTPClientStatusError,
+)
 from datadog_checks.base.utils.prometheus import metrics_pb2
 
 
@@ -206,6 +211,8 @@ class PrometheusScraperMixin(object):
                 yield message
 
         elif 'text/plain' in response.headers['Content-Type']:
+            if response.encoding is None:
+                response.encoding = 'utf-8'
             input_gen = response.iter_lines(chunk_size=self.REQUESTS_CHUNK_SIZE, decode_unicode=True)
             if self._text_filter_blacklist:
                 input_gen = self._text_filter_input(input_gen)
@@ -464,20 +471,21 @@ class PrometheusScraperMixin(object):
             http_config['ssl_ignore_warning'] = True
             http_config['ssl_verify'] = False
 
-        http_handler = self._http_handlers[endpoint] = RequestsWrapper(
+        http_handler = self._http_handlers[endpoint] = create_http_client(
             http_config, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log
         )
 
-        headers = http_handler.options['headers']
-
         bearer_token = http_config.get('_bearer_token')
         if bearer_token is not None:
-            headers['Authorization'] = 'Bearer {}'.format(bearer_token)
+            http_handler.set_header('Authorization', 'Bearer {}'.format(bearer_token))
 
-        headers.setdefault('accept-encoding', 'gzip')
+        # Seeded defaults count as unset; user values do not.
+        if http_handler.get_header('accept-encoding') in (None, DEFAULT_ACCEPT_ENCODING):
+            http_handler.set_header('accept-encoding', 'gzip')
 
         # Explicitly set the content type we accept
-        headers.setdefault('accept', 'text/plain')
+        if http_handler.get_header('accept') in (None, DEFAULT_ACCEPT):
+            http_handler.set_header('accept', 'text/plain')
 
         return http_handler
 
@@ -545,15 +553,15 @@ class PrometheusScraperMixin(object):
         the PrometheusFormat class.
         Custom headers can be added to the default headers.
 
-        Returns a valid requests.Response, raise requests.HTTPError if the status code of the requests.Response
+        Returns a valid response, raise HTTPClientStatusError if the status code of the response
         isn't valid - see response.raise_for_status()
 
-        The caller needs to close the requests.Response
+        The caller needs to close the response
 
         :param endpoint: string url endpoint
         :param pFormat: the preferred format defined in PrometheusFormat
         :param headers: extra headers
-        :return: requests.Response
+        :return: the response object
         """
         if headers is None:
             headers = {}
@@ -573,10 +581,11 @@ class PrometheusScraperMixin(object):
 
         try:
             response = handler.get(endpoint, extra_headers=headers, stream=False)
-        except requests.exceptions.SSLError:
+        except HTTPClientSSLError:
             self.log.error("Invalid SSL settings for requesting %s endpoint", endpoint)
             raise
-        except IOError:
+        # Auth-token fetching can raise HTTPClientStatusError, a sibling of HTTPClientRequestError.
+        except (IOError, HTTPClientRequestError, HTTPClientStatusError):
             if self.health_service_check:
                 self._submit_service_check(
                     "{}{}".format(self.NAMESPACE, ".prometheus.health"),
@@ -591,7 +600,7 @@ class PrometheusScraperMixin(object):
                     "{}{}".format(self.NAMESPACE, ".prometheus.health"), AgentCheck.OK, tags=["endpoint:" + endpoint]
                 )
             return response
-        except requests.HTTPError:
+        except HTTPClientStatusError:
             response.close()
             if self.health_service_check:
                 self._submit_service_check(

--- a/datadog_checks_base/datadog_checks/base/stubs/http.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/http.py
@@ -1,0 +1,289 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass, field
+from datetime import timedelta
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Unpack
+
+from datadog_checks.base.utils.http_exceptions import HTTPClientStatusError
+from datadog_checks.base.utils.http_protocol import HTTPHeaders, HTTPRequestOptions, HTTPResponse
+
+__all__ = ['FakeHTTPClient', 'FakeHTTPResponse', 'RecordedRequest']
+
+JSON_RESULT_UNSET = object()
+SUPPRESSED_AUTH = object()
+
+
+@dataclass(frozen=True, slots=True)
+class RecordedRequest:
+    """A request captured by :class:`FakeHTTPClient`."""
+
+    method: str
+    url: str
+    options: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, 'method', self.method.upper())
+        object.__setattr__(self, 'options', MappingProxyType(dict(self.options)))
+
+
+@dataclass(frozen=True, slots=True)
+class RegisteredResponse:
+    method: str
+    url: str
+    outcome: HTTPResponse | Exception
+    match_options: Mapping[str, Any]
+
+
+class FakeHTTPResponse:
+    """Backend-neutral response whose outcomes are configured directly by tests."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        content: bytes = b'',
+        text: str = '',
+        headers: Mapping[str, str] | None = None,
+        json_result: Any = JSON_RESULT_UNSET,
+        json_error: Exception | None = None,
+        content_chunks: Iterable[bytes | str] = (),
+        lines: Iterable[bytes | str] = (),
+        status_error: HTTPClientStatusError | None = None,
+        encoding: str | None = None,
+        elapsed: timedelta = timedelta(),
+        cookies: Mapping[str, str] | None = None,
+        links: Mapping[str, Mapping[str, str]] | None = None,
+        url: str = '',
+        history: Iterable[HTTPResponse] = (),
+        reason: str = '',
+        peer_cert: bytes | dict | None = None,
+    ) -> None:
+        self.status_code: int = status_code
+        self.content: bytes = content
+        self.text: str = text
+        self.headers: Mapping[str, str] = HTTPHeaders(headers or {})
+        self.encoding: str | None = encoding
+        self.elapsed: timedelta = elapsed
+        self.cookies: Mapping[str, str] = MappingProxyType(dict(cookies or {}))
+        self.links: Mapping[str, Mapping[str, str]] = MappingProxyType(
+            {name: MappingProxyType(dict(link)) for name, link in (links or {}).items()}
+        )
+        self.url: str = url
+        self.history: list[HTTPResponse] = list(history)
+        self.closed = False
+        self._json_result = json_result
+        self._json_error = json_error
+        self._content_chunks = tuple(content_chunks)
+        self._lines = tuple(lines)
+        self._status_error = status_error
+        self._reason = reason
+        self._peer_cert = peer_cert
+
+    @property
+    def ok(self) -> bool:
+        return self.status_code < 400
+
+    @property
+    def reason(self) -> str:
+        return self._reason
+
+    def json(self, **kwargs: Any) -> Any:
+        if self._json_error is not None:
+            raise self._json_error
+        if self._json_result is JSON_RESULT_UNSET:
+            raise ValueError('No JSON result was configured for this fake response.')
+        return self._json_result
+
+    def raise_for_status(self) -> None:
+        if self._status_error is None:
+            return
+        if self._status_error.response is None:
+            self._status_error.response = self
+        raise self._status_error
+
+    def close(self) -> None:
+        self.closed = True
+
+    def get_peer_cert(self, binary_form: bool = False) -> bytes | dict | None:
+        return self._peer_cert
+
+    def iter_content(self, chunk_size: int | None = None, decode_unicode: bool = False) -> Iterator[bytes | str]:
+        yield from self._content_chunks
+
+    def iter_lines(
+        self,
+        chunk_size: int | None = None,
+        decode_unicode: bool = False,
+        delimiter: bytes | str | None = None,
+    ) -> Iterator[bytes | str]:
+        yield from self._lines
+
+    def __enter__(self) -> HTTPResponse:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool | None:
+        self.close()
+        return None
+
+    def __iter__(self) -> Iterator[bytes | str]:
+        return self.iter_content()
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
+class FakeHTTPClient:
+    """Backend-neutral HTTP client fake with explicit response registration."""
+
+    def __init__(
+        self,
+        *,
+        options: Mapping[str, Any] | None = None,
+        tls_config: Mapping[str, Any] | None = None,
+        cookies: Mapping[str, str] | None = None,
+        should_bypass_proxy: bool = False,
+    ) -> None:
+        self.options: dict[str, Any] = {
+            'auth': None,
+            'cert': None,
+            'headers': {},
+            'proxies': None,
+            'timeout': (10.0, 10.0),
+            'verify': True,
+            'allow_redirects': True,
+        }
+        if options is not None:
+            self.options.update(options)
+        self.options['headers'] = dict(self.options.get('headers') or {})
+        self.tls_config = dict(tls_config or {})
+        self.trust_env = True
+        self.ignore_tls_warning = False
+        self.persist_connections = False
+        self.requests: list[RecordedRequest] = []
+        self.closed = False
+        self._cookies = dict(cookies or {})
+        self._should_bypass_proxy = should_bypass_proxy
+        self._responses: list[RegisteredResponse] = []
+
+    def register_response(
+        self,
+        method: str,
+        url: str,
+        response: HTTPResponse | Exception,
+        *,
+        match_options: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Queue a response or exception for the first matching request."""
+        self._responses.append(
+            RegisteredResponse(
+                method=method.upper(),
+                url=url,
+                outcome=response,
+                match_options=MappingProxyType(dict(match_options or {})),
+            )
+        )
+
+    def get(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        return self._request('GET', url, options)
+
+    def post(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        return self._request('POST', url, options)
+
+    def head(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        return self._request('HEAD', url, options)
+
+    def put(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        return self._request('PUT', url, options)
+
+    def patch(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        return self._request('PATCH', url, options)
+
+    def delete(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        return self._request('DELETE', url, options)
+
+    def options_method(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        return self._request('OPTIONS', url, options)
+
+    def get_header(self, name: str, default: str | None = None) -> str | None:
+        found = default
+        for header_name, value in self.options['headers'].items():
+            if header_name.lower() == name.lower():
+                found = value
+        return found
+
+    def set_header(self, name: str, value: str) -> None:
+        matching_names = [header_name for header_name in self.options['headers'] if header_name.lower() == name.lower()]
+        if not matching_names:
+            self.options['headers'][name] = value
+            return
+
+        retained_name = matching_names[0]
+        self.options['headers'][retained_name] = value
+        for duplicate_name in matching_names[1:]:
+            del self.options['headers'][duplicate_name]
+
+    def disable_auth(self) -> None:
+        self.options['auth'] = SUPPRESSED_AUTH
+
+    def close(self) -> None:
+        self.closed = True
+
+    def get_cookie(self, name: str, default: str | None = None) -> str | None:
+        return self._cookies.get(name, default)
+
+    def should_bypass_proxy(self, url: str) -> bool:
+        return self._should_bypass_proxy
+
+    def assert_requests(self, expected: Iterable[RecordedRequest]) -> None:
+        expected_requests = list(expected)
+        if self.requests != expected_requests:
+            raise AssertionError(f'Expected recorded requests {expected_requests!r}, got {self.requests!r}.')
+
+    def assert_has_request(self, expected: RecordedRequest) -> None:
+        if expected not in self.requests:
+            raise AssertionError(f'No recorded request matched {expected!r}. Recorded requests: {self.requests!r}.')
+
+    def assert_all_responses_consumed(self) -> None:
+        count = len(self._responses)
+        if count:
+            noun = 'response was' if count == 1 else 'responses were'
+            raise AssertionError(f'{count} registered {noun} not consumed: {self._responses!r}.')
+
+    def _request(self, method: str, url: str, options: Mapping[str, Any]) -> HTTPResponse:
+        request = RecordedRequest(method=method, url=url, options=options)
+        self.requests.append(request)
+
+        for index, registered in enumerate(self._responses):
+            if self._matches(registered, request):
+                outcome = self._responses.pop(index).outcome
+                if isinstance(outcome, Exception):
+                    raise outcome
+                return outcome
+
+        raise AssertionError(
+            f'No registered response matched {request.method} {request.url} with options {dict(request.options)!r}. '
+            f'Pending responses: {self._responses!r}.'
+        )
+
+    @staticmethod
+    def _matches(registered: RegisteredResponse, request: RecordedRequest) -> bool:
+        return (
+            registered.method == request.method
+            and registered.url == request.url
+            and all(
+                request.options.get(name, JSON_RESULT_UNSET) == value
+                for name, value in registered.match_options.items()
+            )
+        )
+
+
+if TYPE_CHECKING:
+    from datadog_checks.base.utils.http_protocol import HTTPClient
+
+    client: HTTPClient = FakeHTTPClient()
+    response: HTTPResponse = FakeHTTPResponse()

--- a/datadog_checks_base/datadog_checks/base/utils/headers.py
+++ b/datadog_checks_base/datadog_checks/base/utils/headers.py
@@ -1,16 +1,22 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from collections.abc import MutableMapping
+
 from datadog_checks.base.agent import datadog_agent
+
+# Seeded defaults count as unset when negotiating a more specific value.
+DEFAULT_ACCEPT = '*/*'
+DEFAULT_ACCEPT_ENCODING = 'gzip, deflate'
 
 
 def _get_common_headers():
     return {  # Required by the HTTP spec. If missing, some websites may return junk (eg 404 responses).
-        'Accept': '*/*',
+        'Accept': DEFAULT_ACCEPT,
         # Allow websites to send compressed responses.
         # (In theory, not including this header allows servers to send anything, but in practice servers are
         # typically conservative and send plain text, i.e. uncompressed responses.)
-        'Accept-Encoding': 'gzip, deflate',
+        'Accept-Encoding': DEFAULT_ACCEPT_ENCODING,
         # NOTE: we don't include a 'Connection' header. This is equivalent to using the spec-specific default
         # behavior, i.e. 'keep-alive' for HTTP/1.1, and 'close' for HTTP/1.0.
     }
@@ -22,6 +28,18 @@ def get_default_headers():
     headers = {'User-Agent': 'Datadog Agent/{}'.format(datadog_agent.get_version() or '0.0.0')}
     headers.update(_get_common_headers())
     return headers
+
+
+def set_header(headers: MutableMapping[str, str], name: str, value: str) -> None:
+    matching_names = [header_name for header_name in headers if header_name.lower() == name.lower()]
+    if not matching_names:
+        headers[name] = value
+        return
+
+    retained_name = matching_names[0]
+    headers[retained_name] = value
+    for duplicate_name in matching_names[1:]:
+        del headers[duplicate_name]
 
 
 def update_headers(headers, extra_headers):

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -18,17 +18,37 @@ import lazy_loader
 import requests
 from binary import KIBIBYTE
 from requests import auth as requests_auth
+from requests import cookies as requests_cookies
 from requests.exceptions import SSLError
+from requests.structures import CaseInsensitiveDict
 from urllib3.exceptions import InsecureRequestWarning
-from wrapt import ObjectProxy
 
 from datadog_checks.base.agent import datadog_agent
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.errors import ConfigurationError
 from datadog_checks.base.utils import _http_utils
 
+from . import requests_adapter
 from .common import ensure_bytes, ensure_unicode
 from .headers import get_default_headers, update_headers
+from .headers import set_header as set_header_value
+from .http_exceptions import (  # noqa: F401
+    HTTPClientConnectionError,
+    HTTPClientConnectTimeoutError,
+    HTTPClientError,
+    HTTPClientInvalidURLError,
+    HTTPClientReadTimeoutError,
+    HTTPClientRequestError,
+    HTTPClientSSLError,
+    HTTPClientStatusError,
+    HTTPClientTimeoutError,
+)
+from .http_protocol import (  # noqa: F401
+    HTTPClient,
+    HTTPRequest,
+    HTTPRequestSnapshot,
+    HTTPResponse,
+)
 from .time import get_timestamp
 from .tls import SUPPORTED_PROTOCOL_VERSIONS, TlsConfig, create_ssl_context
 
@@ -189,62 +209,15 @@ def get_tls_config_from_options(new_options):
     return tls_config
 
 
-class _SSLContextAdapter(requests.adapters.HTTPAdapter):
-    """
-    This adapter lets us hook into requests.Session and make it use the SSLContext that we manage.
-    """
-
-    def __init__(self, ssl_context, **kwargs):
-        self.ssl_context = ssl_context
-        super().__init__()
-
-    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
-        pool_kwargs['ssl_context'] = self.ssl_context
-        return super().init_poolmanager(connections, maxsize, block=block, **pool_kwargs)
-
-    def cert_verify(self, conn, url, verify, cert):
-        """
-        This method is overridden to ensure that the SSL context
-        is configured on the integration side.
-        """
-        pass
-
-    def build_connection_pool_key_attributes(self, request, verify, cert=None):
-        """
-        This method is overridden according to the requests library's
-        expectations to ensure that the custom SSL context is passed to urllib3.
-        """
-        # See: https://github.com/psf/requests/blob/7341690e842a23cf18ded0abd9229765fa88c4e2/src/requests/adapters.py#L419-L423
-        host_params, _ = super().build_connection_pool_key_attributes(request, verify, cert)
-        return host_params, {"ssl_context": self.ssl_context}
-
-
-class ResponseWrapper(ObjectProxy):
-    def __init__(self, response, default_chunk_size):
-        super(ResponseWrapper, self).__init__(response)
-
-        # See https://github.com/psf/requests/pull/5942
-        self.__default_chunk_size = default_chunk_size
-
-    def iter_content(self, chunk_size=None, decode_unicode=False):
-        if chunk_size is None:
-            chunk_size = self.__default_chunk_size
-
-        return self.__wrapped__.iter_content(chunk_size=chunk_size, decode_unicode=decode_unicode)
-
-    def iter_lines(self, chunk_size=None, decode_unicode=False, delimiter=None):
-        if chunk_size is None:
-            chunk_size = self.__default_chunk_size
-
-        return self.__wrapped__.iter_lines(chunk_size=chunk_size, decode_unicode=decode_unicode, delimiter=delimiter)
-
-    def __enter__(self):
-        return self
+def suppress_default_auth(request):
+    """Truthy no-op requests auth callable that leaves the prepared request unchanged."""
+    return request
 
 
 class RequestsWrapper(object):
     __slots__ = (
         '_session',
+        '_trust_env',
         '_https_adapters',
         'tls_use_host_header',
         'ignore_tls_warning',
@@ -436,6 +409,9 @@ class RequestsWrapper(object):
         self.persist_connections = self.tls_use_host_header or is_affirmative(config['persist_connections'])
         self._session = session
 
+        # Match an injected session's trust_env; otherwise use the requests default.
+        self._trust_env = getattr(session, 'trust_env', True) if session is not None else True
+
         # Whether or not to log request information like method and url
         self.log_requests = is_affirmative(config['log_requests'])
 
@@ -455,6 +431,49 @@ class RequestsWrapper(object):
 
         self.tls_config = {key: value for key, value in config.items() if key.startswith('tls_')}
         self._https_adapters = {}
+
+    @property
+    def trust_env(self) -> bool:
+        """Whether the client trusts environment config (proxies, auth, CA bundles)."""
+        return self._trust_env
+
+    @trust_env.setter
+    def trust_env(self, value: bool) -> None:
+        self._trust_env = value
+        if self._session is not None:
+            self._session.trust_env = value
+
+    def close(self) -> None:
+        """Close connections; the next request rebuilds a default session."""
+        if self._session is not None:
+            self._session.close()
+            self._session = None
+
+    def get_cookie(self, name: str, default: str | None = None) -> str | None:
+        """Return a persistent cookie, or default if it is missing or ambiguous."""
+        try:
+            return self.session.cookies.get(name, default)
+        except requests_cookies.CookieConflictError:
+            return default
+
+    def should_bypass_proxy(self, url: str) -> bool:
+        """Whether url should bypass any configured proxy under the client's no_proxy rules."""
+        return should_bypass_proxy(url, self.no_proxy_uris or [])
+
+    def get_header(self, name: str, default: str | None = None) -> str | None:
+        """Return the last case-insensitive match, which requests sends on the wire."""
+        found = default
+        for key, value in self.options['headers'].items():
+            if key.lower() == name.lower():
+                found = value
+        return found
+
+    def set_header(self, name: str, value: str) -> None:
+        set_header_value(self.options['headers'], name, value)
+
+    def disable_auth(self) -> None:
+        """Suppress configured and .netrc auth without disabling other environment settings."""
+        self.options['auth'] = suppress_default_auth
 
     def get(self, url, **options):
         return self._request('get', url, options)
@@ -488,21 +507,25 @@ class RequestsWrapper(object):
         if persist is None:
             persist = self.persist_connections
 
-        new_options = ChainMap(options, self.options)
-
-        if url.startswith('https') and not self.ignore_tls_warning and not new_options['verify']:
-            self.logger.debug('An unverified HTTPS request is being made to %s', url)
-
         extra_headers = options.pop('extra_headers', None)
-        if extra_headers is not None:
-            new_options['headers'] = new_options['headers'].copy()
-            new_options['headers'].update(extra_headers)
+        explicit_headers = options.get('headers')
 
         if is_uds_url(url):
             persist = True  # UDS support is only enabled on the shared session.
             url = quote_uds_url(url)
 
         self.handle_auth_token(method=method, url=url, default_options=self.options)
+
+        new_options = ChainMap(options, self.options)
+        request_headers = CaseInsensitiveDict(
+            explicit_headers if explicit_headers is not None else self.options['headers']
+        )
+        if extra_headers is not None:
+            request_headers.update(extra_headers)
+        new_options['headers'] = request_headers
+
+        if url.startswith('https') and not self.ignore_tls_warning and not new_options['verify']:
+            self.logger.debug('An unverified HTTPS request is being made to %s', url)
 
         with ExitStack() as stack:
             for hook in self.request_hooks:
@@ -520,52 +543,61 @@ class RequestsWrapper(object):
                 except Exception as e:
                     self.logger.debug('Renewing auth token, as an error occurred: %s', e)
                     self.handle_auth_token(method=method, url=url, default_options=self.options, error=str(e))
+                    retry_headers = CaseInsensitiveDict(
+                        explicit_headers if explicit_headers is not None else self.options['headers']
+                    )
+                    if extra_headers is not None:
+                        retry_headers.update(extra_headers)
+                    new_options['headers'] = retry_headers
                     response = self.make_request_aia_chasing(request_method, method, url, new_options, persist)
             else:
                 response = self.make_request_aia_chasing(request_method, method, url, new_options, persist)
 
-            return ResponseWrapper(response, self.request_size)
+            return requests_adapter.RequestsResponseAdapter(response, self.request_size)
 
     def make_request_aia_chasing(self, request_method, method, url, new_options, persist):
-        try:
-            response = request_method(url, **new_options)
-        except SSLError as e:
-            self.logger.debug(
-                'AIA chasing: request to `%s` failed with an SSLError (%s); attempting to recover missing '
-                'intermediate certificate(s)',
-                url,
-                e,
-            )
-            # fetch the intermediate certs
-            parsed_url = urlparse(url)
-            hostname = parsed_url.hostname
-            port = parsed_url.port
-            certs = self.fetch_intermediate_certs(hostname, port)
-            if not certs:
-                self.logger.error(
-                    'AIA chasing: no intermediate certificate(s) could be recovered for `%s`; raising the '
-                    'original SSLError',
-                    url,
-                )
-                raise e
-            self.logger.debug(
-                'AIA chasing: recovered %d intermediate certificate(s) for `%s`; retrying the request', len(certs), url
-            )
-            session = self.session if persist else self._create_session()
-            if parsed_url.scheme == "https":
-                self._mount_https_adapter(session, ChainMap({'tls_intermediate_ca_certs': certs}, self.tls_config))
-            request_method = getattr(session, method)
+        with requests_adapter.translate_http_errors():
             try:
                 response = request_method(url, **new_options)
-            except SSLError:
-                self.logger.error(
-                    'AIA chasing: request to `%s` still failed after mounting %d recovered intermediate '
-                    'certificate(s); the certificate chain is still incomplete',
+            except SSLError as e:
+                self.logger.debug(
+                    'AIA chasing: request to `%s` failed with an SSLError (%s); attempting to recover missing '
+                    'intermediate certificate(s)',
                     url,
-                    len(certs),
+                    e,
                 )
-                raise
-        return response
+                # fetch the intermediate certs
+                parsed_url = urlparse(url)
+                hostname = parsed_url.hostname
+                port = parsed_url.port
+                certs = self.fetch_intermediate_certs(hostname, port)
+                if not certs:
+                    self.logger.error(
+                        'AIA chasing: no intermediate certificate(s) could be recovered for `%s`; raising the '
+                        'original SSLError',
+                        url,
+                    )
+                    raise e
+                self.logger.debug(
+                    'AIA chasing: recovered %d intermediate certificate(s) for `%s`; retrying the request',
+                    len(certs),
+                    url,
+                )
+                session = self.session if persist else self._create_session()
+                if parsed_url.scheme == "https":
+                    self._mount_https_adapter(session, ChainMap({'tls_intermediate_ca_certs': certs}, self.tls_config))
+                request_method = getattr(session, method)
+                try:
+                    response = request_method(url, **new_options)
+                except SSLError:
+                    self.logger.error(
+                        'AIA chasing: request to `%s` still failed after mounting %d recovered intermediate '
+                        'certificate(s); the certificate chain is still incomplete',
+                        url,
+                        len(certs),
+                    )
+                    raise
+            return response
 
     def fetch_intermediate_certs(self, hostname, port=443):
         # TODO: prefer stdlib implementation when available, see https://bugs.python.org/issue18617
@@ -706,6 +738,7 @@ class RequestsWrapper(object):
         # but can be set as attributes on an initialized Session instance.
         for option, value in self.options.items():
             setattr(session, option, value)
+        session.trust_env = self._trust_env
         return session
 
     @property
@@ -718,7 +751,8 @@ class RequestsWrapper(object):
 
     def handle_auth_token(self, **request):
         if self.auth_token_handler is not None:
-            self.auth_token_handler.poll(**request)
+            with requests_adapter.translate_http_errors():
+                self.auth_token_handler.poll(**request)
 
     def __del__(self):  # no cov
         try:
@@ -731,34 +765,19 @@ class RequestsWrapper(object):
     def _mount_https_adapter(self, session, tls_config):
         # Reuse existing adapter if it matches the TLS config
         tls_config_key = TlsConfig(**tls_config)
-        if tls_config_key in self._https_adapters:
-            session.mount('https://', self._https_adapters[tls_config_key])
-            return
+        if tls_config_key not in self._https_adapters:
+            self._https_adapters[tls_config_key] = requests_adapter.create_https_adapter(
+                tls_config, use_host_header=self.tls_use_host_header
+            )
 
-        context = create_ssl_context(tls_config)
-        # Enables HostHeaderSSLAdapter if needed
-        # https://toolbelt.readthedocs.io/en/latest/adapters.html#hostheaderssladapter
-        if self.tls_use_host_header:
-            # Create a combined adapter that supports both TLS context and host headers
-            class SSLContextHostHeaderAdapter(_SSLContextAdapter, _http_utils.HostHeaderSSLAdapter):
-                def __init__(self, ssl_context, **kwargs):
-                    _SSLContextAdapter.__init__(self, ssl_context, **kwargs)
-                    _http_utils.HostHeaderSSLAdapter.__init__(self, **kwargs)
+        session.mount('https://', self._https_adapters[tls_config_key])
 
-                def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
-                    # Use TLS context from wrapper
-                    pool_kwargs['ssl_context'] = self.ssl_context
-                    return _http_utils.HostHeaderSSLAdapter.init_poolmanager(
-                        self, connections, maxsize, block=block, **pool_kwargs
-                    )
 
-            https_adapter = SSLContextHostHeaderAdapter(context)
-        else:
-            https_adapter = _SSLContextAdapter(context)
-
-        # Cache the adapter for reuse
-        self._https_adapters[tls_config_key] = https_adapter
-        session.mount('https://', https_adapter)
+def create_http_client(
+    instance: dict | None, init_config: dict, remapper: dict | None = None, logger: logging.Logger | None = None
+) -> HTTPClient:
+    """Construct the HTTP client."""
+    return RequestsWrapper(instance or {}, init_config, remapper, logger)
 
 
 @contextmanager

--- a/datadog_checks_base/datadog_checks/base/utils/http_exceptions.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http_exceptions.py
@@ -1,0 +1,76 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datadog_checks.base.utils.http_protocol import HTTPRequest, HTTPResponse
+
+__all__ = [
+    'HTTPClientError',
+    'HTTPClientRequestError',
+    'HTTPClientStatusError',
+    'HTTPClientTimeoutError',
+    'HTTPClientConnectTimeoutError',
+    'HTTPClientReadTimeoutError',
+    'HTTPClientConnectionError',
+    'HTTPClientInvalidURLError',
+    'HTTPClientSSLError',
+]
+
+
+class HTTPClientError(Exception):
+    """Backend-agnostic HTTP error root under Exception, not OSError or ValueError.
+
+    The client raises compatibility subclasses so existing requests exception handlers still match.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        response: HTTPResponse | None = None,
+        request: HTTPRequest | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.response = response
+        self.request = request
+
+
+class HTTPClientRequestError(HTTPClientError):
+    """A request that produced no usable response, including unmapped backend failures."""
+
+
+class HTTPClientStatusError(HTTPClientError):
+    """An error status on a received response.
+
+    This is a sibling of HTTPClientRequestError. ``response`` may be None outside ``raise_for_status``.
+    """
+
+
+class HTTPClientTimeoutError(HTTPClientRequestError):
+    """A request that exceeded its configured timeout, at either phase."""
+
+
+class HTTPClientConnectTimeoutError(HTTPClientTimeoutError):
+    """A timeout while establishing the connection, before any request was sent."""
+
+
+class HTTPClientReadTimeoutError(HTTPClientTimeoutError):
+    """A timeout waiting for response headers or body data."""
+
+
+class HTTPClientConnectionError(HTTPClientRequestError):
+    """A connection failure, excluding timeouts.
+
+    Ports of ``except requests.ConnectionError`` usually also need ``HTTPClientTimeoutError``.
+    """
+
+
+class HTTPClientInvalidURLError(HTTPClientRequestError):
+    """A URL the client rejected before attempting a connection."""
+
+
+class HTTPClientSSLError(HTTPClientConnectionError):
+    """A TLS failure; catch before HTTPClientConnectionError when distinguishing them."""

--- a/datadog_checks_base/datadog_checks/base/utils/http_protocol.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http_protocol.py
@@ -1,0 +1,188 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Provisional backend-neutral HTTP interfaces.
+
+Coordinate member and semantic changes across implementations until a second backend implements the protocols.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from datetime import timedelta
+from types import MappingProxyType
+from typing import Any, Protocol, TypedDict, Unpack
+
+
+class HTTPHeaders(Mapping[str, str]):
+    """Immutable, case-insensitive HTTP headers."""
+
+    __slots__ = ('_values',)
+
+    def __init__(self, headers: Mapping[str, str]) -> None:
+        values = {name.lower(): (name, value) for name, value in headers.items()}
+        self._values = MappingProxyType(values)
+
+    def __getitem__(self, name: str) -> str:
+        return self._values[name.lower()][1]
+
+    def __iter__(self) -> Iterator[str]:
+        return (name for name, _ in self._values.values())
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+
+class HTTPRequest(Protocol):
+    @property
+    def method(self) -> str | None: ...
+
+    @property
+    def url(self) -> str | None: ...
+
+    @property
+    def headers(self) -> Mapping[str, str]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class HTTPRequestSnapshot:
+    """Backend-neutral request metadata captured when an HTTP error occurs."""
+
+    method: str | None
+    url: str | None
+    headers: Mapping[str, str]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, 'headers', HTTPHeaders(self.headers))
+
+
+class HTTPResponse(Protocol):
+    status_code: int
+    content: bytes
+    text: str
+    headers: Mapping[str, str]
+    """Case-insensitive headers whose iteration casing is backend-defined."""
+    encoding: str | None
+    elapsed: timedelta
+    cookies: Mapping[str, str]
+    links: Mapping[str, Mapping[str, str]]
+    url: str
+    history: list[HTTPResponse]
+
+    @property
+    def ok(self) -> bool: ...
+    @property
+    def reason(self) -> str: ...
+
+    def json(self, **kwargs: Any) -> Any: ...
+    def raise_for_status(self) -> None: ...
+    def close(self) -> None: ...
+    def get_peer_cert(self, binary_form: bool = False) -> bytes | dict | None:
+        """Return None for plain HTTP or a released connection."""
+        ...
+
+    def iter_content(self, chunk_size: int | None = None, decode_unicode: bool = False) -> Iterator[bytes | str]: ...
+    def iter_lines(
+        self,
+        chunk_size: int | None = None,
+        decode_unicode: bool = False,
+        delimiter: bytes | str | None = None,
+    ) -> Iterator[bytes | str]:
+        """Iterate records with requests-compatible line and delimiter boundaries."""
+        ...
+
+    def __enter__(self) -> HTTPResponse: ...
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool | None: ...
+    def __iter__(self) -> Iterator[bytes | str]: ...
+
+
+class HTTPRequestOptions(TypedDict, total=False):
+    params: Mapping[str, Any] | None
+    """Query parameters appended to the request URL."""
+    headers: Mapping[str, str] | None
+    """Request headers used instead of the configured client headers."""
+    data: Any
+    """Request body encoded according to the value's type."""
+    json: Any
+    """JSON-serializable request body."""
+    auth: Any
+    """Authentication applied to the request."""
+    cookies: Mapping[str, str] | None
+    """Cookies sent with the request."""
+    timeout: float | tuple[float, float] | None
+    """Timeout in seconds, or separate connect and read timeouts."""
+    allow_redirects: bool
+    """Whether the request should follow redirects."""
+    verify: bool | str | None
+    """Whether to verify TLS, or the path to a CA bundle."""
+    cert: str | tuple[str, str] | None
+    """Client certificate, optionally paired with its private key."""
+    proxies: Mapping[str, str] | None
+    """Proxy URLs keyed by scheme; None uses configured client proxies."""
+    extra_headers: Mapping[str, str]
+    """Headers merged after configured and per-request headers."""
+    stream: bool
+    """Whether response body consumption should be deferred."""
+    persist: bool
+    """Whether this request should use the persistent client."""
+
+
+class HTTPClient(Protocol):
+    options: dict[str, Any]
+    """Mutable defaults read by the backend before every request."""
+
+    tls_config: dict[str, Any]
+    """TLS settings for callers that build their own SSL context."""
+
+    trust_env: bool
+
+    ignore_tls_warning: bool
+
+    persist_connections: bool
+
+    def get(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        """Perform a GET request using :class:`HTTPRequestOptions`."""
+        ...
+
+    def post(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        """Perform a POST request using :class:`HTTPRequestOptions`."""
+        ...
+
+    def head(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        """Perform a HEAD request using :class:`HTTPRequestOptions`."""
+        ...
+
+    def put(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        """Perform a PUT request using :class:`HTTPRequestOptions`."""
+        ...
+
+    def patch(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        """Perform a PATCH request using :class:`HTTPRequestOptions`."""
+        ...
+
+    def delete(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        """Perform a DELETE request using :class:`HTTPRequestOptions`."""
+        ...
+
+    def options_method(self, url: str, **options: Unpack[HTTPRequestOptions]) -> HTTPResponse:
+        """Perform an OPTIONS request using :class:`HTTPRequestOptions`; suffixed to avoid the defaults attribute."""
+        ...
+
+    def get_header(self, name: str, default: str | None = None) -> str | None:
+        """Return the wire value using case-insensitive lookup."""
+        ...
+
+    def set_header(self, name: str, value: str) -> None: ...
+
+    def disable_auth(self) -> None:
+        """Clear configured and .netrc auth without disabling other environment settings."""
+        ...
+
+    def close(self) -> None: ...
+
+    def get_cookie(self, name: str, default: str | None = None) -> str | None:
+        """Return default for missing or ambiguous persisted cookies."""
+        ...
+
+    def should_bypass_proxy(self, url: str) -> bool: ...

--- a/datadog_checks_base/datadog_checks/base/utils/requests_adapter.py
+++ b/datadog_checks_base/datadog_checks/base/utils/requests_adapter.py
@@ -1,0 +1,325 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import json
+import ssl
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from datetime import timedelta
+from typing import Any
+
+import requests
+from requests import exceptions as requests_exceptions
+from urllib3.exceptions import ReadTimeoutError as Urllib3ReadTimeoutError
+
+from datadog_checks.base.config import is_affirmative
+from datadog_checks.base.utils import _http_utils
+
+from .http_exceptions import (
+    HTTPClientConnectionError,
+    HTTPClientConnectTimeoutError,
+    HTTPClientError,
+    HTTPClientInvalidURLError,
+    HTTPClientReadTimeoutError,
+    HTTPClientRequestError,
+    HTTPClientSSLError,
+    HTTPClientStatusError,
+    HTTPClientTimeoutError,
+)
+from .http_protocol import HTTPClient, HTTPRequestSnapshot, HTTPResponse
+from .tls import create_ssl_context
+
+
+def _translate_requests_request(
+    request: requests.Request | requests.PreparedRequest | None,
+) -> HTTPRequestSnapshot | None:
+    if request is None:
+        return None
+
+    return HTTPRequestSnapshot(
+        method=request.method,
+        url=request.url,
+        headers=request.headers or {},
+    )
+
+
+def _backend_compat_type[T: BaseException](agnostic: type[T], *backend: type[BaseException]) -> type[T]:
+    """Add requests bases so released checks' exception handlers keep matching."""
+    bases = tuple(dict.fromkeys((agnostic, *backend)))
+    # Keep only the most-derived bases to avoid an invalid parent-before-child MRO.
+    most_derived_bases = tuple(
+        base for base in bases if not any(base is not candidate and issubclass(candidate, base) for candidate in bases)
+    )
+    compat = type(agnostic.__name__, most_derived_bases, {})
+    compat.__module__ = agnostic.__module__
+    compat.__qualname__ = agnostic.__qualname__
+    compat.__doc__ = agnostic.__doc__
+    return compat
+
+
+_COMPAT_EXCEPTIONS: dict[type[HTTPClientError], type[HTTPClientError]] = {
+    HTTPClientError: _backend_compat_type(HTTPClientError, requests_exceptions.RequestException),
+    HTTPClientRequestError: _backend_compat_type(HTTPClientRequestError, requests_exceptions.RequestException),
+    HTTPClientStatusError: _backend_compat_type(HTTPClientStatusError, requests_exceptions.HTTPError),
+    HTTPClientTimeoutError: _backend_compat_type(HTTPClientTimeoutError, requests_exceptions.Timeout),
+    HTTPClientConnectTimeoutError: _backend_compat_type(
+        HTTPClientConnectTimeoutError, requests_exceptions.ConnectTimeout
+    ),
+    # requests used ReadTimeout for headers and ConnectionError for body reads.
+    HTTPClientReadTimeoutError: _backend_compat_type(
+        HTTPClientReadTimeoutError, requests_exceptions.ReadTimeout, requests_exceptions.ConnectionError
+    ),
+    HTTPClientConnectionError: _backend_compat_type(HTTPClientConnectionError, requests_exceptions.ConnectionError),
+    HTTPClientInvalidURLError: _backend_compat_type(
+        HTTPClientInvalidURLError,
+        requests_exceptions.InvalidURL,
+        requests_exceptions.MissingSchema,
+        requests_exceptions.InvalidSchema,
+        requests_exceptions.URLRequired,
+    ),
+    HTTPClientSSLError: _backend_compat_type(HTTPClientSSLError, requests_exceptions.SSLError),
+}
+
+# stdlib and requests JSONDecodeError are siblings, so the compatibility type carries both.
+_COMPAT_JSON_DECODE_ERROR = _backend_compat_type(json.JSONDecodeError, requests_exceptions.JSONDecodeError)
+
+
+def _translate_requests_exception(exc: BaseException, *, response: HTTPResponse | None = None) -> HTTPClientError:
+    """Map a requests exception to its agnostic compatibility type, most-specific first."""
+    message = str(exc) or exc.__class__.__name__
+    request = _translate_requests_request(getattr(exc, 'request', None))
+    if isinstance(
+        exc,
+        (
+            requests_exceptions.InvalidURL,
+            requests_exceptions.MissingSchema,
+            requests_exceptions.InvalidSchema,
+            requests_exceptions.URLRequired,
+        ),
+    ):
+        return _COMPAT_EXCEPTIONS[HTTPClientInvalidURLError](message, request=request)
+    if isinstance(exc, requests_exceptions.SSLError):
+        return _COMPAT_EXCEPTIONS[HTTPClientSSLError](message, request=request)
+    if isinstance(exc, requests_exceptions.ConnectTimeout):
+        return _COMPAT_EXCEPTIONS[HTTPClientConnectTimeoutError](message, request=request)
+    if isinstance(exc, requests_exceptions.ReadTimeout):
+        return _COMPAT_EXCEPTIONS[HTTPClientReadTimeoutError](message, request=request)
+    if isinstance(exc, requests_exceptions.Timeout):
+        return _COMPAT_EXCEPTIONS[HTTPClientTimeoutError](message, request=request)
+    if isinstance(exc, requests_exceptions.ConnectionError) and any(
+        isinstance(cause, Urllib3ReadTimeoutError) for cause in (exc.__context__, exc.args[0] if exc.args else None)
+    ):
+        return _COMPAT_EXCEPTIONS[HTTPClientReadTimeoutError](message, request=request)
+    if isinstance(exc, requests_exceptions.ConnectionError):
+        return _COMPAT_EXCEPTIONS[HTTPClientConnectionError](message, request=request)
+    if isinstance(exc, requests_exceptions.ContentDecodingError):
+        return _COMPAT_EXCEPTIONS[HTTPClientRequestError](message, request=request)
+    if isinstance(exc, requests_exceptions.HTTPError):
+        return _COMPAT_EXCEPTIONS[HTTPClientStatusError](message, request=request, response=response)
+    if isinstance(exc, requests_exceptions.RequestException):
+        return _COMPAT_EXCEPTIONS[HTTPClientRequestError](message, request=request)
+    return _COMPAT_EXCEPTIONS[HTTPClientError](message)
+
+
+@contextmanager
+def translate_http_errors() -> Iterator[None]:
+    """Re-raise requests exceptions as their backend-neutral equivalents."""
+    try:
+        yield
+    except requests_exceptions.RequestException as exc:
+        raise _translate_requests_exception(exc) from exc
+
+
+class RequestsResponseAdapter:
+    """Expose a requests response through the backend-neutral response contract."""
+
+    __slots__ = ('_default_chunk_size', '_response')
+
+    def __init__(self, response: requests.Response, default_chunk_size: int) -> None:
+        self._response = response
+        self._default_chunk_size = default_chunk_size
+
+    @property
+    def status_code(self) -> int:
+        return self._response.status_code
+
+    @property
+    def content(self) -> bytes:
+        with translate_http_errors():
+            return self._response.content
+
+    @property
+    def text(self) -> str:
+        with translate_http_errors():
+            return self._response.text
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        return self._response.headers
+
+    @property
+    def encoding(self) -> str | None:
+        return self._response.encoding
+
+    @encoding.setter
+    def encoding(self, value: str | None) -> None:
+        self._response.encoding = value
+
+    @property
+    def elapsed(self) -> timedelta:
+        return self._response.elapsed
+
+    @property
+    def cookies(self) -> Mapping[str, str]:
+        return self._response.cookies
+
+    @property
+    def links(self) -> Mapping[str, Mapping[str, str]]:
+        return self._response.links
+
+    @property
+    def url(self) -> str:
+        return self._response.url
+
+    @property
+    def history(self) -> list[RequestsResponseAdapter]:
+        return [RequestsResponseAdapter(response, self._default_chunk_size) for response in self._response.history]
+
+    @property
+    def ok(self) -> bool:
+        return self._response.ok
+
+    @property
+    def reason(self) -> str:
+        return self._response.reason
+
+    def json(self, **kwargs: Any) -> Any:
+        # Raise parse errors outside the transport translator. The compatibility type carries
+        # requests' JSONDecodeError as a base, which otherwise looks like a transport failure.
+        decode_error = None
+        with translate_http_errors():
+            try:
+                return self._response.json(**kwargs)
+            except requests_exceptions.JSONDecodeError as exc:
+                decode_error = exc
+
+        raise _COMPAT_JSON_DECODE_ERROR(decode_error.msg, decode_error.doc, decode_error.pos) from decode_error
+
+    def raise_for_status(self) -> None:
+        try:
+            self._response.raise_for_status()
+        except requests_exceptions.HTTPError as exc:
+            raise _translate_requests_exception(exc, response=self) from exc
+
+    def close(self) -> None:
+        self._response.close()
+
+    def get_peer_cert(self, binary_form: bool = False) -> bytes | dict | None:
+        raw = getattr(self._response, 'raw', None)
+        connection = getattr(raw, 'connection', None)
+        sock = getattr(connection, 'sock', None)
+        getpeercert = getattr(sock, 'getpeercert', None)
+        if getpeercert is None:
+            return None
+        return getpeercert(binary_form=binary_form)
+
+    def iter_content(self, chunk_size: int | None = None, decode_unicode: bool = False) -> Iterator[bytes | str]:
+        if chunk_size is None:
+            chunk_size = self._default_chunk_size
+
+        with translate_http_errors():
+            yield from self._response.iter_content(chunk_size=chunk_size, decode_unicode=decode_unicode)
+
+    def iter_lines(
+        self,
+        chunk_size: int | None = None,
+        decode_unicode: bool = False,
+        delimiter: bytes | str | None = None,
+    ) -> Iterator[bytes | str]:
+        if chunk_size is None:
+            chunk_size = self._default_chunk_size
+
+        with translate_http_errors():
+            yield from self._response.iter_lines(
+                chunk_size=chunk_size, decode_unicode=decode_unicode, delimiter=delimiter
+            )
+
+    def __enter__(self) -> RequestsResponseAdapter:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.close()
+
+    def __iter__(self) -> Iterator[bytes | str]:
+        return self.iter_content(128)
+
+    def __bool__(self) -> bool:
+        return bool(self._response)
+
+    def __repr__(self) -> str:
+        return repr(self._response)
+
+    def __str__(self) -> str:
+        return str(self._response)
+
+
+class SSLContextAdapter(requests.adapters.HTTPAdapter):
+    """Use an integration-managed SSL context for requests connections."""
+
+    def __init__(self, ssl_context: ssl.SSLContext, **kwargs: Any) -> None:
+        self.ssl_context = ssl_context
+        super().__init__()
+
+    def init_poolmanager(self, connections: int, maxsize: int, block: bool = False, **pool_kwargs: Any) -> None:
+        pool_kwargs['ssl_context'] = self.ssl_context
+        return super().init_poolmanager(connections, maxsize, block=block, **pool_kwargs)
+
+    def cert_verify(self, conn: Any, url: str, verify: bool | str, cert: Any) -> None:
+        """Keep certificate verification in the integration-managed SSL context."""
+        pass
+
+    def build_connection_pool_key_attributes(
+        self,
+        request: requests.PreparedRequest,
+        verify: bool | str,
+        cert: Any = None,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Include the managed SSL context in requests' connection-pool key."""
+        host_params, _ = super().build_connection_pool_key_attributes(request, verify, cert)
+        return host_params, {'ssl_context': self.ssl_context}
+
+
+def create_https_adapter(
+    tls_config: Mapping[str, Any], *, use_host_header: bool = False
+) -> requests.adapters.HTTPAdapter:
+    """Create a requests adapter for the supplied TLS behavior."""
+    context = create_ssl_context(tls_config)
+    if use_host_header:
+
+        class SSLContextHostHeaderAdapter(SSLContextAdapter, _http_utils.HostHeaderSSLAdapter):
+            def __init__(self, ssl_context: ssl.SSLContext, **kwargs: Any) -> None:
+                SSLContextAdapter.__init__(self, ssl_context, **kwargs)
+                _http_utils.HostHeaderSSLAdapter.__init__(self, **kwargs)
+
+            def init_poolmanager(self, connections: int, maxsize: int, block: bool = False, **pool_kwargs: Any) -> None:
+                pool_kwargs['ssl_context'] = self.ssl_context
+                return _http_utils.HostHeaderSSLAdapter.init_poolmanager(
+                    self, connections, maxsize, block=block, **pool_kwargs
+                )
+
+        return SSLContextHostHeaderAdapter(context)
+
+    return SSLContextAdapter(context)
+
+
+def apply_tls(client: HTTPClient, session: requests.Session) -> None:
+    """Apply an HTTP client's TLS behavior to a requests session."""
+    use_host_header = (
+        is_affirmative(client.tls_config.get('tls_use_host_header')) and client.get_header('Host') is not None
+    )
+    session.mount(
+        'https://',
+        create_https_adapter(client.tls_config, use_host_header=use_host_header),
+    )

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_compat_scraper.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_compat_scraper.py
@@ -6,6 +6,31 @@ import pytest
 from .utils import get_legacy_check
 
 
+def test_legacy_bearer_token_translation_reaches_http_client(tmp_path, mocker):
+    token_path = str(tmp_path / 'token')
+    check = get_legacy_check({'bearer_token_auth': True, 'bearer_token_path': token_path})
+    create_http_client = mocker.spy(check, 'create_http_client')
+    check.configure_scrapers()
+
+    create_http_client.assert_called_once()
+    assert create_http_client.call_args.args[0]['auth_token'] == {
+        'reader': {'type': 'file', 'path': token_path},
+        'writer': {'type': 'header', 'name': 'Authorization', 'value': 'Bearer <TOKEN>'},
+    }
+
+
+def test_scraper_http_configuration_is_endpoint_scoped():
+    check = get_legacy_check()
+    check.scraper_configs = [
+        {'openmetrics_endpoint': 'http://first', 'headers': {'X-Endpoint': 'first'}},
+        {'openmetrics_endpoint': 'http://second', 'headers': {'X-Endpoint': 'second'}},
+    ]
+    check.configure_scrapers()
+
+    assert check.scrapers['http://first'].http.get_header('X-Endpoint') == 'first'
+    assert check.scrapers['http://second'].http.get_header('X-Endpoint') == 'second'
+
+
 class TestRawMetricPrefix:
     def test_not_string(self, dd_run_check):
         check = get_legacy_check({'prometheus_metrics_prefix': 9000})

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
@@ -4,7 +4,6 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import copy
-import io
 import logging
 import math
 import os
@@ -13,21 +12,21 @@ import time
 
 import mock
 import pytest
-import requests
 from mock import patch
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily, HistogramMetricFamily, SummaryMetricFamily
 from prometheus_client.samples import Sample
 
-from datadog_checks.base import ensure_bytes
+from datadog_checks.base.stubs.http import FakeHTTPClient, FakeHTTPResponse, RecordedRequest
+from datadog_checks.base.utils.http_exceptions import HTTPClientConnectionError, HTTPClientStatusError
 from datadog_checks.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.dev import get_here
-from datadog_checks.dev.http import MockResponse
 
 text_content_type = 'text/plain; version=0.0.4'
 FIXTURE_PATH = os.path.abspath(os.path.join(get_here(), '..', '..', '..', '..', 'fixtures', 'prometheus'))
 TOKENS_PATH = os.path.abspath(os.path.join(get_here(), '..', '..', '..', '..', 'fixtures', 'bearer_tokens'))
 
 FAKE_ENDPOINT = 'http://fake.endpoint:10055/metrics'
+OPENMETRICS_REQUEST = RecordedRequest('GET', FAKE_ENDPOINT, {'stream': True})
 
 PROMETHEUS_CHECK_INSTANCE = {
     'prometheus_url': FAKE_ENDPOINT,
@@ -43,6 +42,25 @@ OPENMETRICS_CHECK_INSTANCE = {
     'metrics': [{'process_virtual_memory_bytes': 'process.vm.bytes'}],
     'namespace': 'openmetrics',
 }
+
+
+def _text_response(text: str, *, content_type: str = text_content_type) -> FakeHTTPResponse:
+    return FakeHTTPResponse(
+        content=text.encode('utf-8'),
+        text=text,
+        headers={'Content-Type': content_type},
+        lines=text.splitlines(),
+    )
+
+
+def _register_openmetrics_text(fake_http: FakeHTTPClient, text: str, *, count: int = 1) -> None:
+    for _ in range(count):
+        fake_http.register_response(
+            'GET',
+            FAKE_ENDPOINT,
+            _text_response(text),
+            match_options={'stream': True},
+        )
 
 
 @pytest.fixture
@@ -95,10 +113,9 @@ def text_data():
 
 
 @pytest.fixture
-def mock_get(mock_http_response):
-    yield mock_http_response(
-        file_path=os.path.join(FIXTURE_PATH, 'ksm.txt'), headers={'Content-Type': text_content_type}
-    ).return_value.text
+def ksm_text() -> str:
+    with open(os.path.join(FIXTURE_PATH, 'ksm.txt')) as fixture:
+        return fixture.read()
 
 
 def test_config_instance(mocked_prometheus_check):
@@ -113,7 +130,7 @@ def test_config_instance(mocked_prometheus_check):
 
 def test_process(text_data, mocked_prometheus_check, mocked_prometheus_scraper_config, ref_gauge):
     check = mocked_prometheus_check
-    check.poll = mock.MagicMock(return_value=MockResponse(text_data, headers={'Content-Type': text_content_type}))
+    check.poll = mock.MagicMock(return_value=_text_response(text_data))
     check.process_metric = mock.MagicMock()
     check.process(mocked_prometheus_scraper_config)
     check.poll.assert_called_with(mocked_prometheus_scraper_config)
@@ -151,33 +168,42 @@ def test_process_metric_filtered(aggregator, mocked_prometheus_check, mocked_pro
     aggregator.assert_all_metrics_covered()
 
 
-def test_poll_text_plain(mocked_prometheus_check, mocked_prometheus_scraper_config, text_data):
+def test_poll_text_plain(fake_openmetrics_http, mocked_prometheus_check, mocked_prometheus_scraper_config, text_data):
     """Tests poll using the text format"""
     check = mocked_prometheus_check
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': text_content_type}
+    fake_openmetrics_http.register_response(
+        'GET',
+        FAKE_ENDPOINT,
+        _text_response(text_data),
+        match_options={'stream': True},
     )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
-        response = check.poll(mocked_prometheus_scraper_config)
-        messages = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
-        messages.sort(key=lambda x: x.name)
-        assert len(messages) == 40
-        assert messages[-1].name == 'skydns_skydns_dns_response_size_bytes'
+
+    response = check.poll(mocked_prometheus_scraper_config)
+    messages = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
+
+    messages.sort(key=lambda x: x.name)
+    assert len(messages) == 40
+    assert messages[-1].name == 'skydns_skydns_dns_response_size_bytes'
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST])
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
-def test_poll_octet_stream(mocked_prometheus_check, mocked_prometheus_scraper_config, text_data):
+def test_poll_octet_stream(fake_openmetrics_http, mocked_prometheus_check, mocked_prometheus_scraper_config, text_data):
     """Tests poll using the text format"""
     check = mocked_prometheus_check
+    fake_openmetrics_http.register_response(
+        'GET',
+        FAKE_ENDPOINT,
+        _text_response(text_data, content_type='application/octet-stream'),
+        match_options={'stream': True},
+    )
 
-    mock_response = requests.Response()
-    mock_response.raw = io.BytesIO(ensure_bytes(text_data))
-    mock_response.status_code = 200
-    mock_response.headers = {'Content-Type': 'application/octet-stream'}
+    response = check.poll(mocked_prometheus_scraper_config)
+    messages = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
 
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
-        response = check.poll(mocked_prometheus_scraper_config)
-        messages = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
-        assert len(messages) == 40
+    assert len(messages) == 40
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST])
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
 def test_submit_gauge_with_labels(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
@@ -734,7 +760,7 @@ def test_filter_sample_on_gauge(p_check, mocked_prometheus_scraper_config):
     expected_metric.add_metric(['heapster-v1.4.3'], 1)
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     mocked_prometheus_scraper_config['_text_filter_blacklist'] = ["deployment=\"kube-dns\""]
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
@@ -767,7 +793,7 @@ def test_parse_one_gauge(p_check, mocked_prometheus_scraper_config):
     expected_etcd_metric.add_metric([], 1)
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
 
@@ -799,7 +825,7 @@ def test_parse_one_counter(p_check, mocked_prometheus_scraper_config):
     expected_etcd_metric.name = 'go_memstats_mallocs_total'
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
 
@@ -857,7 +883,7 @@ def test_parse_one_histograms_with_label(p_check, mocked_prometheus_scraper_conf
     )
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
 
@@ -991,7 +1017,7 @@ def test_parse_one_histogram(p_check, mocked_prometheus_scraper_config):
     )
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
     assert 1 == len(metrics)
@@ -1093,7 +1119,7 @@ def test_parse_two_histograms_with_label(p_check, mocked_prometheus_scraper_conf
     )
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
 
@@ -1131,7 +1157,7 @@ def test_decumulate_histogram_buckets(p_check, mocked_prometheus_scraper_config)
         'rest_client_request_latency_seconds_count{url="http://127.0.0.1:8080/api",verb="GET"} 755\n'
     )
 
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
 
@@ -1220,7 +1246,7 @@ def test_decumulate_histogram_buckets_single_bucket(p_check, mocked_prometheus_s
         'rest_client_request_latency_seconds_count{url="http://127.0.0.1:8080/api",verb="GET"} 755\n'
     )
 
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
 
@@ -1283,7 +1309,7 @@ def test_decumulate_histogram_buckets_multiple_contexts(p_check, mocked_promethe
         'rest_client_request_latency_seconds_count{url="http://127.0.0.1:8080/api",verb="POST"} 150\n'
     )
 
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
 
@@ -1351,7 +1377,7 @@ def test_decumulate_histogram_buckets_negative_buckets(p_check, mocked_prometheu
         'random_histogram_count{url="http://127.0.0.1:8080/api",verb="GET"} 70\n'
     )
 
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
 
@@ -1403,7 +1429,7 @@ def test_decumulate_histogram_buckets_no_buckets(p_check, mocked_prometheus_scra
         'rest_client_request_latency_seconds_count{url="http://127.0.0.1:8080/api",verb="GET"} 755\n'
     )
 
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
 
@@ -1474,7 +1500,7 @@ def test_parse_one_summary(p_check, mocked_prometheus_scraper_config):
     expected_etcd_metric.add_sample("http_response_size_bytes", {"handler": "prometheus", "quantile": "0.99"}, 25763.0)
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
 
@@ -1517,7 +1543,7 @@ def test_parse_one_summary_with_no_quantile(p_check, mocked_prometheus_scraper_c
     expected_etcd_metric.add_metric(["prometheus"], 5.0, 120512.0)
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
 
@@ -1572,7 +1598,7 @@ def test_parse_two_summaries_with_labels(p_check, mocked_prometheus_scraper_conf
     )
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
 
@@ -1613,7 +1639,7 @@ def test_parse_one_summary_with_none_values(p_check, mocked_prometheus_scraper_c
     )
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, headers={'Content-Type': text_content_type})
+    response = _text_response(text_data)
     check = p_check
     metrics = list(check.parse_metric_family(response, mocked_prometheus_scraper_config))
     assert 1 == len(metrics)
@@ -1660,7 +1686,11 @@ def test_ignore_metric_wildcard(aggregator, mocked_prometheus_check, ref_gauge):
 
 
 def test_ignore_metrics_multiple_wildcards(
-    aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config, text_data
+    aggregator,
+    fake_openmetrics_http,
+    mocked_prometheus_check,
+    mocked_prometheus_scraper_config,
+    text_data,
 ):
     """
     Test that metrics that matched an ignored metrics pattern is properly discarded.
@@ -1691,25 +1721,24 @@ def test_ignore_metrics_multiple_wildcards(
     ]
 
     config = check.create_scraper_configuration(instance)
+    _register_openmetrics_text(fake_openmetrics_http, text_data)
 
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': text_content_type}
-    )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
-        check.process(config)
+    check.process(config)
 
-        # Make sure metrics are ignored
-        aggregator.assert_metric('prometheus.go_memstats.mspan.inuse_bytes', count=0)
-        aggregator.assert_metric('prometheus.go_memstats.mallocs.total', count=0)
-        aggregator.assert_metric('prometheus.go_memstats.mspan.sys_bytes', count=0)
-        aggregator.assert_metric('prometheus.go_memstats.alloc_bytes', count=0)
-        aggregator.assert_metric('prometheus.go_memstats.gc.sys_bytes', count=0)
-        aggregator.assert_metric('prometheus.go_memstats.buck_hash.sys_bytes', count=0)
+    # Make sure metrics are ignored
+    aggregator.assert_metric('prometheus.go_memstats.mspan.inuse_bytes', count=0)
+    aggregator.assert_metric('prometheus.go_memstats.mallocs.total', count=0)
+    aggregator.assert_metric('prometheus.go_memstats.mspan.sys_bytes', count=0)
+    aggregator.assert_metric('prometheus.go_memstats.alloc_bytes', count=0)
+    aggregator.assert_metric('prometheus.go_memstats.gc.sys_bytes', count=0)
+    aggregator.assert_metric('prometheus.go_memstats.buck_hash.sys_bytes', count=0)
 
-        # Make sure we don't ignore other metrics
-        aggregator.assert_metric('prometheus.go_memstats.mcache.sys_bytes', count=1)
-        aggregator.assert_metric('prometheus.go_memstats.heap.released.bytes_total', count=1)
-        aggregator.assert_all_metrics_covered()
+    # Make sure we don't ignore other metrics
+    aggregator.assert_metric('prometheus.go_memstats.mcache.sys_bytes', count=1)
+    aggregator.assert_metric('prometheus.go_memstats.heap.released.bytes_total', count=1)
+    aggregator.assert_all_metrics_covered()
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST])
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
 def test_gauge_with_ignore_label_wildcard(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
@@ -1780,7 +1809,11 @@ def test_gauge_with_invalid_ignore_label_value(aggregator, mocked_prometheus_che
 
 
 def test_metrics_with_ignore_label_values(
-    aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config, text_data
+    aggregator,
+    fake_openmetrics_http,
+    mocked_prometheus_check,
+    mocked_prometheus_scraper_config,
+    text_data,
 ):
     """
     Test that metrics that matched an ignored label values is properly discarded.
@@ -1800,23 +1833,21 @@ def test_metrics_with_ignore_label_values(
     instance['ignore_metrics_by_labels'] = {'system': ['auth', 'recursive'], 'cache': ['*']}
     config = check.create_scraper_configuration(instance)
     expected_tags = ['cause:nxdomain']
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': text_content_type}
-    )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
-        check.process(config)
+    _register_openmetrics_text(fake_openmetrics_http, text_data)
 
-        # Make sure metrics are ignored
-        aggregator.assert_metric('prometheus.skydns.dns.error.count', count=0, tags=expected_tags + ['system:auth'])
-        aggregator.assert_metric(
-            'prometheus.skydns.dns.error.count', count=0, tags=expected_tags + ['system:recursive']
-        )
-        aggregator.assert_metric('prometheus.skydns.dns.cache_missed', count=0)
-        # Make sure we don't ignore other metrics
-        aggregator.assert_metric('prometheus.skydns.dns.error.count', count=1, tags=expected_tags + ['system:reverse'])
-        aggregator.assert_metric('prometheus.go_memstats.mspan.inuse_bytes', count=1)
+    check.process(config)
 
-        aggregator.assert_all_metrics_covered()
+    # Make sure metrics are ignored
+    aggregator.assert_metric('prometheus.skydns.dns.error.count', count=0, tags=expected_tags + ['system:auth'])
+    aggregator.assert_metric('prometheus.skydns.dns.error.count', count=0, tags=expected_tags + ['system:recursive'])
+    aggregator.assert_metric('prometheus.skydns.dns.cache_missed', count=0)
+    # Make sure we don't ignore other metrics
+    aggregator.assert_metric('prometheus.skydns.dns.error.count', count=1, tags=expected_tags + ['system:reverse'])
+    aggregator.assert_metric('prometheus.go_memstats.mspan.inuse_bytes', count=1)
+
+    aggregator.assert_all_metrics_covered()
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST])
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
 def test_match_metric_wildcard(aggregator, mocked_prometheus_check, ref_gauge):
@@ -1835,7 +1866,11 @@ def test_match_metric_wildcard(aggregator, mocked_prometheus_check, ref_gauge):
 
 
 def test_match_metrics_multiple_wildcards(
-    aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config, text_data
+    aggregator,
+    fake_openmetrics_http,
+    mocked_prometheus_check,
+    mocked_prometheus_scraper_config,
+    text_data,
 ):
     """
     Test that matched metric patterns are properly collected.
@@ -1850,25 +1885,27 @@ def test_match_metrics_multiple_wildcards(
     ]
 
     config = check.create_scraper_configuration(instance)
+    _register_openmetrics_text(fake_openmetrics_http, text_data)
 
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': text_content_type}
-    )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
-        check.process(config)
+    check.process(config)
 
-        aggregator.assert_metric('prometheus.go_memstats_mcache_inuse_bytes', count=1)
-        aggregator.assert_metric('prometheus.go_memstats_mcache_sys_bytes', count=1)
-        aggregator.assert_metric('prometheus.go_memstats.heap.released.bytes_total', count=1)
-        aggregator.assert_metric('prometheus.go_memstats_alloc_bytes', count=1)
-        aggregator.assert_metric('prometheus.go_memstats_alloc_bytes_total', count=1)
-        aggregator.assert_metric('prometheus.go_memstats_lookups_total', count=1)
-        aggregator.assert_all_metrics_covered()
+    aggregator.assert_metric('prometheus.go_memstats_mcache_inuse_bytes', count=1)
+    aggregator.assert_metric('prometheus.go_memstats_mcache_sys_bytes', count=1)
+    aggregator.assert_metric('prometheus.go_memstats.heap.released.bytes_total', count=1)
+    aggregator.assert_metric('prometheus.go_memstats_alloc_bytes', count=1)
+    aggregator.assert_metric('prometheus.go_memstats_alloc_bytes_total', count=1)
+    aggregator.assert_metric('prometheus.go_memstats_lookups_total', count=1)
+    aggregator.assert_all_metrics_covered()
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST])
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
-def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
+def test_label_joins(
+    aggregator, fake_openmetrics_http, mocked_prometheus_check, mocked_prometheus_scraper_config, ksm_text
+):
     """Tests label join on text format"""
     check = mocked_prometheus_check
+    _register_openmetrics_text(fake_openmetrics_http, ksm_text, count=2)
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
     mocked_prometheus_scraper_config['label_joins'] = {
         'kube_global_labels': {'label_to_match': '*', 'labels_to_get': ['*']},
@@ -2251,11 +2288,20 @@ def test_label_joins(aggregator, mocked_prometheus_check, mocked_prometheus_scra
         tags=['leader:true', 'foo:bar', 'namespace:default', 'deployment:ungaged-panther-kube-state-metrics'],
         count=1,
     )
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST] * 2)
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
-def test_label_joins_gc(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
+def test_label_joins_gc(
+    aggregator,
+    fake_openmetrics_http,
+    ksm_text,
+    mocked_prometheus_check,
+    mocked_prometheus_scraper_config,
+):
     """Tests label join GC on text format"""
     check = mocked_prometheus_check
+    _register_openmetrics_text(fake_openmetrics_http, ksm_text, count=2)
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
     mocked_prometheus_scraper_config['label_joins'] = {
         'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node', 'pod_ip']},
@@ -2297,23 +2343,25 @@ def test_label_joins_gc(aggregator, mocked_prometheus_check, mocked_prometheus_s
     )
 
     assert 15 == len(mocked_prometheus_scraper_config['_label_mapping']['pod'])
-    text_data = mock_get.replace('dd-agent-62bgh', 'dd-agent-1337')
+    text_data = ksm_text.replace('dd-agent-62bgh', 'dd-agent-1337')
     pvc_replace = re.compile(r'^kube_persistentvolumeclaim_.*\n', re.MULTILINE)
     text_data = pvc_replace.sub('', text_data)
+    _register_openmetrics_text(fake_openmetrics_http, text_data)
 
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': text_content_type}
-    )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
-        check.process(mocked_prometheus_scraper_config)
-        assert 'dd-agent-1337' in mocked_prometheus_scraper_config['_label_mapping']['pod']
-        assert 'dd-agent-62bgh' not in mocked_prometheus_scraper_config['_label_mapping']['pod']
-        assert 15 == len(mocked_prometheus_scraper_config['_label_mapping']['pod'])
+    check.process(mocked_prometheus_scraper_config)
+    assert 'dd-agent-1337' in mocked_prometheus_scraper_config['_label_mapping']['pod']
+    assert 'dd-agent-62bgh' not in mocked_prometheus_scraper_config['_label_mapping']['pod']
+    assert 15 == len(mocked_prometheus_scraper_config['_label_mapping']['pod'])
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST] * 3)
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
-def test_label_joins_missconfigured(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
+def test_label_joins_missconfigured(
+    aggregator, fake_openmetrics_http, ksm_text, mocked_prometheus_check, mocked_prometheus_scraper_config
+):
     """Tests label join missconfigured label is ignored"""
     check = mocked_prometheus_check
+    _register_openmetrics_text(fake_openmetrics_http, ksm_text, count=2)
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
     mocked_prometheus_scraper_config['label_joins'] = {
         'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node', 'not_existing']}
@@ -2348,11 +2396,16 @@ def test_label_joins_missconfigured(aggregator, mocked_prometheus_check, mocked_
         ],
         count=1,
     )
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST] * 2)
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
-def test_label_join_not_existing(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
+def test_label_join_not_existing(
+    aggregator, fake_openmetrics_http, ksm_text, mocked_prometheus_check, mocked_prometheus_scraper_config
+):
     """Tests label join on non existing matching label is ignored"""
     check = mocked_prometheus_check
+    _register_openmetrics_text(fake_openmetrics_http, ksm_text, count=2)
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
     mocked_prometheus_scraper_config['label_joins'] = {
         'kube_pod_info': {'label_to_match': 'not_existing', 'labels_to_get': ['node', 'pod_ip']}
@@ -2369,13 +2422,16 @@ def test_label_join_not_existing(aggregator, mocked_prometheus_check, mocked_pro
     aggregator.assert_metric(
         'ksm.pod.ready', 1.0, tags=['pod:fluentd-gcp-v2.0.9-z348z', 'namespace:kube-system', 'condition:true'], count=1
     )
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST] * 2)
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
 def test_label_join_metric_not_existing(
-    aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get
+    aggregator, fake_openmetrics_http, ksm_text, mocked_prometheus_check, mocked_prometheus_scraper_config
 ):
     """Tests label join on non existing metric is ignored"""
     check = mocked_prometheus_check
+    _register_openmetrics_text(fake_openmetrics_http, ksm_text, count=2)
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
     mocked_prometheus_scraper_config['label_joins'] = {
         'not_existing': {'label_to_match': 'pod', 'labels_to_get': ['node', 'pod_ip']}
@@ -2392,11 +2448,16 @@ def test_label_join_metric_not_existing(
     aggregator.assert_metric(
         'ksm.pod.ready', 1.0, tags=['pod:fluentd-gcp-v2.0.9-z348z', 'namespace:kube-system', 'condition:true'], count=1
     )
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST] * 2)
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
-def test_label_join_with_hostname(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
+def test_label_join_with_hostname(
+    aggregator, fake_openmetrics_http, ksm_text, mocked_prometheus_check, mocked_prometheus_scraper_config
+):
     """Tests label join and hostname override on a metric"""
     check = mocked_prometheus_check
+    _register_openmetrics_text(fake_openmetrics_http, ksm_text, count=2)
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
     mocked_prometheus_scraper_config['label_joins'] = {
         'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node']}
@@ -2432,14 +2493,23 @@ def test_label_join_with_hostname(aggregator, mocked_prometheus_check, mocked_pr
         hostname='gke-foobar-test-kube-default-pool-9b4ff111-j75z',
         count=1,
     )
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST] * 2)
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
-def test_label_join_state_change(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
+def test_label_join_state_change(
+    aggregator,
+    fake_openmetrics_http,
+    ksm_text,
+    mocked_prometheus_check,
+    mocked_prometheus_scraper_config,
+):
     """
     This test checks that the label join picks up changes for already watched labels.
     If a phase changes for example, the tag should change as well.
     """
     check = mocked_prometheus_check
+    _register_openmetrics_text(fake_openmetrics_http, ksm_text, count=2)
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
     mocked_prometheus_scraper_config['label_joins'] = {
         'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node']},
@@ -2456,23 +2526,23 @@ def test_label_join_state_change(aggregator, mocked_prometheus_check, mocked_pro
     for _, tags in mocked_prometheus_scraper_config['_label_mapping']['pod'].items():
         assert tags.get('phase') == 'Running'
 
-    text_data = mock_get.replace(
+    text_data = ksm_text.replace(
         'kube_pod_status_phase{namespace="default",phase="Running",pod="dd-agent-62bgh"} 1',
         'kube_pod_status_phase{namespace="default",phase="Test",pod="dd-agent-62bgh"} 1',
     )
+    _register_openmetrics_text(fake_openmetrics_http, text_data)
 
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': text_content_type}
-    )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
-        check.process(mocked_prometheus_scraper_config)
-        assert 15 == len(mocked_prometheus_scraper_config['_label_mapping']['pod'])
-        assert mocked_prometheus_scraper_config['_label_mapping']['pod']['dd-agent-62bgh']['phase'] == 'Test'
+    check.process(mocked_prometheus_scraper_config)
+    assert 15 == len(mocked_prometheus_scraper_config['_label_mapping']['pod'])
+    assert mocked_prometheus_scraper_config['_label_mapping']['pod']['dd-agent-62bgh']['phase'] == 'Test'
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST] * 3)
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
-def test_label_to_match_single(benchmark, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
+def test_label_to_match_single(benchmark, ksm_text, mocked_prometheus_check, mocked_prometheus_scraper_config):
     """Tests label join and hostname override on a metric"""
     check = mocked_prometheus_check
+    check.poll = mock.MagicMock(side_effect=lambda *_: _text_response(ksm_text))
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
     mocked_prometheus_scraper_config['label_joins'] = {
         'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node']},
@@ -2497,9 +2567,10 @@ def test_label_to_match_single(benchmark, mocked_prometheus_check, mocked_promet
         check.process(mocked_prometheus_scraper_config)
 
 
-def test_label_to_match_multiple(benchmark, mocked_prometheus_check, mocked_prometheus_scraper_config, mock_get):
+def test_label_to_match_multiple(benchmark, ksm_text, mocked_prometheus_check, mocked_prometheus_scraper_config):
     """Tests label join and hostname override on a metric"""
     check = mocked_prometheus_check
+    check.poll = mock.MagicMock(side_effect=lambda *_: _text_response(ksm_text))
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
     mocked_prometheus_scraper_config['label_joins'] = {
         'kube_pod_info': {'labels_to_match': ['pod', 'namespace'], 'labels_to_get': ['node']},
@@ -2524,9 +2595,12 @@ def test_label_to_match_multiple(benchmark, mocked_prometheus_check, mocked_prom
         check.process(mocked_prometheus_scraper_config)
 
 
-def test_health_service_check_ok(mock_get, aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+def test_health_service_check_ok(
+    aggregator, fake_openmetrics_http, ksm_text, mocked_prometheus_check, mocked_prometheus_scraper_config
+):
     """Tests endpoint health service check OK"""
     check = mocked_prometheus_check
+    _register_openmetrics_text(fake_openmetrics_http, ksm_text)
 
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
     mocked_prometheus_scraper_config['custom_tags'] = ['foo:bar']
@@ -2539,16 +2613,26 @@ def test_health_service_check_ok(mock_get, aggregator, mocked_prometheus_check, 
         tags=['endpoint:http://fake.endpoint:10055/metrics', 'foo:bar'],
         count=1,
     )
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST])
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
-def test_health_service_check_failing(aggregator, mocked_prometheus_check, mocked_prometheus_scraper_config):
+def test_health_service_check_failing(
+    aggregator, fake_openmetrics_http, mocked_prometheus_check, mocked_prometheus_scraper_config
+):
     """Tests endpoint health service check failing"""
     check = mocked_prometheus_check
+    fake_openmetrics_http.register_response(
+        'GET',
+        FAKE_ENDPOINT,
+        HTTPClientConnectionError('Connection failed'),
+        match_options={'stream': True},
+    )
 
     mocked_prometheus_scraper_config['namespace'] = 'ksm'
     mocked_prometheus_scraper_config['custom_tags'] = ['foo:bar']
     mocked_prometheus_scraper_config['_metric_tags'] = ['bar:foo']
-    with pytest.raises(requests.ConnectionError):
+    with pytest.raises(HTTPClientConnectionError):
         check.process(mocked_prometheus_scraper_config)
     aggregator.assert_service_check(
         'ksm.prometheus.health',
@@ -2556,6 +2640,34 @@ def test_health_service_check_failing(aggregator, mocked_prometheus_check, mocke
         tags=['endpoint:http://fake.endpoint:10055/metrics', 'foo:bar'],
         count=1,
     )
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST])
+    fake_openmetrics_http.assert_all_responses_consumed()
+
+
+def test_health_service_check_failing_on_status_error(
+    aggregator, fake_openmetrics_http, mocked_prometheus_check, mocked_prometheus_scraper_config
+):
+    check = mocked_prometheus_check
+    fake_openmetrics_http.register_response(
+        'GET',
+        FAKE_ENDPOINT,
+        HTTPClientStatusError('503 Server Error'),
+        match_options={'stream': True},
+    )
+
+    mocked_prometheus_scraper_config['namespace'] = 'ksm'
+    mocked_prometheus_scraper_config['custom_tags'] = ['foo:bar']
+    with pytest.raises(HTTPClientStatusError):
+        check.process(mocked_prometheus_scraper_config)
+
+    aggregator.assert_service_check(
+        'ksm.prometheus.health',
+        status=OpenMetricsBaseCheck.CRITICAL,
+        tags=['endpoint:http://fake.endpoint:10055/metrics', 'foo:bar'],
+        count=1,
+    )
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST])
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
 def test_text_filter_input(mocked_prometheus_check, mocked_prometheus_scraper_config):
@@ -2576,20 +2688,9 @@ def test_text_filter_input(mocked_prometheus_check, mocked_prometheus_scraper_co
 
 
 @pytest.fixture()
-def mock_filter_get():
-    text_data = None
-    f_name = os.path.join(FIXTURE_PATH, 'deprecated.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    with mock.patch(
-        'requests.Session.get',
-        return_value=mock.MagicMock(
-            status_code=200,
-            iter_lines=lambda **kwargs: text_data.split("\n"),
-            headers={'Content-Type': text_content_type},
-        ),
-    ):
-        yield text_data
+def deprecated_text() -> str:
+    with open(os.path.join(FIXTURE_PATH, 'deprecated.txt')) as fixture:
+        return fixture.read()
 
 
 class FilterOpenMetricsCheck(OpenMetricsBaseCheck):
@@ -2611,10 +2712,15 @@ def mocked_filter_openmetrics_check_scraper_config(mocked_filter_openmetrics_che
 
 
 def test_filter_metrics(
-    aggregator, mocked_filter_openmetrics_check, mocked_filter_openmetrics_check_scraper_config, mock_filter_get
+    aggregator,
+    deprecated_text,
+    fake_openmetrics_http,
+    mocked_filter_openmetrics_check,
+    mocked_filter_openmetrics_check_scraper_config,
 ):
     """Tests label join GC on text format"""
     check = mocked_filter_openmetrics_check
+    _register_openmetrics_text(fake_openmetrics_http, deprecated_text, count=2)
     mocked_filter_openmetrics_check_scraper_config['namespace'] = 'filter'
     mocked_filter_openmetrics_check_scraper_config['metrics_mapper'] = {
         'kube_pod_container_status_restarts': 'pod.restart',
@@ -2629,12 +2735,14 @@ def test_filter_metrics(
         'filter.pod.restart', tags=['pod:kube-dns-autoscaler-97162954-mf6d3', 'namespace:kube-system'], value=42
     )
     aggregator.assert_all_metrics_covered()
+    fake_openmetrics_http.assert_requests([OPENMETRICS_REQUEST] * 2)
+    fake_openmetrics_http.assert_all_responses_consumed()
 
 
 def test_metadata_default(mocked_openmetrics_check_factory, text_data, datadog_agent):
     instance = dict(OPENMETRICS_CHECK_INSTANCE)
     check = mocked_openmetrics_check_factory(instance)
-    check.poll = mock.MagicMock(return_value=MockResponse(text_data, headers={'Content-Type': text_content_type}))
+    check.poll = mock.MagicMock(return_value=_text_response(text_data))
 
     check.check(instance)
     datadog_agent.assert_metadata_count(0)
@@ -2645,7 +2753,7 @@ def test_metadata_transformer(mocked_openmetrics_check_factory, text_data, datad
     instance['metadata_metric_name'] = 'kubernetes_build_info'
     instance['metadata_label_map'] = {'version': 'gitVersion'}
     check = mocked_openmetrics_check_factory(instance)
-    check.poll = mock.MagicMock(return_value=MockResponse(text_data, headers={'Content-Type': text_content_type}))
+    check.poll = mock.MagicMock(return_value=_text_response(text_data))
 
     version_metadata = {
         'version.major': '1',
@@ -2662,64 +2770,136 @@ def test_metadata_transformer(mocked_openmetrics_check_factory, text_data, datad
     datadog_agent.assert_metadata_count(len(version_metadata))
 
 
-def test_ssl_verify_not_raise_warning(caplog, mocked_openmetrics_check_factory, text_data):
+@pytest.mark.parametrize(
+    ('instance_overrides', 'expected_verify', 'expected_ignore_warning'),
+    [
+        pytest.param({'ssl_ca_cert': False}, False, True, id='ssl_ca_cert false disables verification'),
+        pytest.param({'ssl_verify': False}, False, True, id='ssl_verify false suppresses the warning'),
+        pytest.param({}, True, False, id='verification on by default'),
+    ],
+)
+def test_get_http_handler_applies_tls_deprecation_shims(
+    mocked_openmetrics_check_factory, instance_overrides, expected_verify, expected_ignore_warning
+):
     instance = {
-        'prometheus_url': 'https://www.example.com',
+        'prometheus_url': 'https://www.example.com/metrics',
         'metrics': [{'foo': 'bar'}],
         'namespace': 'openmetrics',
-        'ssl_verify': False,
-    }
-    check = mocked_openmetrics_check_factory(instance)
-    scraper_config = check.get_scraper_config(instance)
-
-    with caplog.at_level(logging.DEBUG), mock.patch('requests.Session.get', return_value=MockResponse('httpbin.org')):
-        resp = check.send_request('https://httpbin.org/get', scraper_config)
-
-    assert "httpbin.org" in resp.content.decode('utf-8')
-
-    expected_message = 'An unverified HTTPS request is being made to https://httpbin.org/get'
-    for _, _, message in caplog.record_tuples:
-        assert message != expected_message
-
-
-def test_send_request_with_dynamic_prometheus_url(caplog, mocked_openmetrics_check_factory, text_data):
-    instance = {
-        'prometheus_url': 'https://www.example.com',
-        'metrics': [{'foo': 'bar'}],
-        'namespace': 'openmetrics',
-        'ssl_verify': False,
-    }
-
-    check = mocked_openmetrics_check_factory(instance)
-    scraper_config = check.get_scraper_config(instance)
-
-    # `prometheus_url` changed just before calling `send_request`
-    scraper_config['prometheus_url'] = 'https://www.example.com/foo/bar'
-
-    with caplog.at_level(logging.DEBUG), mock.patch('requests.Session.get', return_value=MockResponse('httpbin.org')):
-        resp = check.send_request('https://httpbin.org/get', scraper_config)
-
-    assert "httpbin.org" in resp.content.decode('utf-8')
-
-    expected_message = 'An unverified HTTPS request is being made to https://httpbin.org/get'
-    for _, _, message in caplog.record_tuples:
-        assert message != expected_message
-
-
-def test_http_handler(mocked_openmetrics_check_factory):
-    instance = {
-        'prometheus_url': 'https://www.example.com',
-        'metrics': [{'foo': 'bar'}],
-        'namespace': 'openmetrics',
-        'ssl_verify': False,
+        **instance_overrides,
     }
     check = mocked_openmetrics_check_factory(instance)
     scraper_config = check.get_scraper_config(instance)
 
     http_handler = check.get_http_handler(scraper_config)
 
-    assert http_handler.options['headers']['accept-encoding'] == 'gzip'
-    assert http_handler.options['headers']['accept'] == 'text/plain'
+    assert http_handler.options['verify'] == expected_verify
+    assert http_handler.ignore_tls_warning is expected_ignore_warning
+
+
+def test_http_handler(mocked_openmetrics_check_factory, mocker):
+    instance = {
+        'prometheus_url': 'https://www.example.com',
+        'metrics': [{'foo': 'bar'}],
+        'namespace': 'openmetrics',
+        'ssl_verify': False,
+    }
+    check = mocked_openmetrics_check_factory(instance)
+    scraper_config = check.get_scraper_config(instance)
+    fake_http = FakeHTTPClient()
+    mocker.patch('datadog_checks.base.checks.openmetrics.mixins.create_http_client', return_value=fake_http)
+
+    http_handler = check.get_http_handler(scraper_config)
+
+    assert http_handler is fake_http
+    assert fake_http.get_header('accept-encoding') == 'gzip'
+    assert fake_http.get_header('accept') == 'text/plain'
+
+
+def test_reset_http_config_rebuilds_a_handler_whose_credentials_changed(mocked_openmetrics_check_factory):
+    instance = {
+        'prometheus_url': 'https://www.example.com',
+        'metrics': [{'foo': 'bar'}],
+        'namespace': 'openmetrics',
+    }
+    check = mocked_openmetrics_check_factory(instance)
+    scraper_config = check.get_scraper_config(instance)
+
+    first = check.get_http_handler(scraper_config)
+    assert first.options['verify'] is True
+    assert check.get_http_handler(scraper_config) is first
+
+    scraper_config['ssl_ca_cert'] = False
+    assert check.get_http_handler(scraper_config) is first
+
+    check.reset_http_config()
+    rebuilt = check.get_http_handler(scraper_config)
+
+    assert rebuilt is not first
+    assert rebuilt.options['verify'] is False
+
+
+def test_http_handler_negotiates_over_seeded_default_headers(mocked_openmetrics_check_factory):
+    instance = {
+        'prometheus_url': 'https://www.example.com',
+        'metrics': [{'foo': 'bar'}],
+        'namespace': 'openmetrics',
+    }
+    check = mocked_openmetrics_check_factory(instance)
+    scraper_config = check.get_scraper_config(instance)
+
+    http_handler = check.get_http_handler(scraper_config)
+
+    assert http_handler.get_header('accept') == 'text/plain'
+    assert http_handler.get_header('accept-encoding') == 'gzip'
+
+
+def test_http_handler_preserves_user_configured_headers(mocked_openmetrics_check_factory):
+    instance = {
+        'prometheus_url': 'https://www.example.com',
+        'metrics': [{'foo': 'bar'}],
+        'namespace': 'openmetrics',
+        'headers': {'Accept': 'application/openmetrics-text', 'Accept-Encoding': 'br'},
+    }
+    check = mocked_openmetrics_check_factory(instance)
+    scraper_config = check.get_scraper_config(instance)
+
+    http_handler = check.get_http_handler(scraper_config)
+
+    assert http_handler.get_header('accept') == 'application/openmetrics-text'
+    assert http_handler.get_header('accept-encoding') == 'br'
+
+
+def test_http_handler_preserves_non_canonically_cased_extra_headers(mocked_openmetrics_check_factory):
+    instance = {
+        'prometheus_url': 'https://www.example.com',
+        'metrics': [{'foo': 'bar'}],
+        'namespace': 'openmetrics',
+        'extra_headers': {'accept': 'application/openmetrics-text', 'accept-encoding': 'br'},
+    }
+    check = mocked_openmetrics_check_factory(instance)
+    scraper_config = check.get_scraper_config(instance)
+
+    http_handler = check.get_http_handler(scraper_config)
+
+    assert http_handler.get_header('accept') == 'application/openmetrics-text'
+    assert http_handler.get_header('accept-encoding') == 'br'
+
+
+def test_get_http_handler_routes_through_create_http_client(mocked_openmetrics_check_factory):
+    instance = {
+        'prometheus_url': 'https://www.example.com',
+        'metrics': [{'foo': 'bar'}],
+        'namespace': 'openmetrics',
+    }
+    check = mocked_openmetrics_check_factory(instance)
+    scraper_config = check.get_scraper_config(instance)
+    sentinel = mock.MagicMock()
+
+    with mock.patch(
+        'datadog_checks.base.checks.openmetrics.mixins.create_http_client', return_value=sentinel
+    ) as factory:
+        assert check.get_http_handler(scraper_config) is sentinel
+        factory.assert_called_once_with(scraper_config, check.init_config, check.HTTP_CONFIG_REMAPPER, check.log)
 
 
 def test_simple_type_overrides(aggregator, mocked_prometheus_check, text_data):
@@ -2736,7 +2916,7 @@ def test_simple_type_overrides(aggregator, mocked_prometheus_check, text_data):
     config = check.get_scraper_config(instance)
     config['_dry_run'] = False
 
-    check.poll = mock.MagicMock(return_value=MockResponse(text_data, headers={'Content-Type': text_content_type}))
+    check.poll = mock.MagicMock(return_value=_text_response(text_data))
     check.process(config)
 
     aggregator.assert_metric('prometheus.process.vm.bytes', count=1, metric_type=aggregator.MONOTONIC_COUNT)
@@ -2759,7 +2939,7 @@ def test_wildcard_type_overrides(aggregator, mocked_prometheus_check, text_data)
     config = check.get_scraper_config(instance)
     config['_dry_run'] = False
 
-    check.poll = mock.MagicMock(return_value=MockResponse(text_data, headers={'Content-Type': text_content_type}))
+    check.poll = mock.MagicMock(return_value=_text_response(text_data))
     check.process(config)
 
     aggregator.assert_metric('prometheus.process.vm.bytes', count=1, metric_type=aggregator.MONOTONIC_COUNT)
@@ -2942,7 +3122,7 @@ def test_use_process_start_time(
 
     check = mocked_openmetrics_check_factory(instance)
     test_data = _make_test_use_process_start_time_data(process_start_time)
-    check.poll = mock.MagicMock(return_value=MockResponse(test_data, headers={'Content-Type': text_content_type}))
+    check.poll = mock.MagicMock(return_value=_text_response(test_data))
 
     for _ in range(0, 5):
         aggregator.reset()
@@ -2995,7 +3175,7 @@ def test_refresh_bearer_token(text_data, mocked_openmetrics_check_factory):
 
     with patch.object(OpenMetricsBaseCheck, 'KUBERNETES_TOKEN_PATH', os.path.join(TOKENS_PATH, 'default_token')):
         check = mocked_openmetrics_check_factory(instance)
-        check.poll = mock.MagicMock(return_value=MockResponse(text_data, headers={'Content-Type': text_content_type}))
+        check.poll = mock.MagicMock(return_value=_text_response(text_data))
         instance = check.get_scraper_config(instance)
         assert instance['_bearer_token'] == 'my default token'
         time.sleep(1.5)

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_stream_connection_lines.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/scraper/test_stream_connection_lines.py
@@ -1,0 +1,89 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
+from collections.abc import Iterator
+from unittest import mock
+
+import pytest
+
+from datadog_checks.base.checks.openmetrics.v2.scraper.base_scraper import OpenMetricsScraper
+from datadog_checks.base.utils.http_exceptions import (
+    HTTPClientConnectionError,
+    HTTPClientConnectTimeoutError,
+    HTTPClientReadTimeoutError,
+)
+
+AGNOSTIC_CONNECTION_ERRORS = [
+    HTTPClientConnectionError,
+    HTTPClientConnectTimeoutError,
+    HTTPClientReadTimeoutError,
+]
+
+
+def _scraper(*, ignore_connection_errors):
+    scraper = OpenMetricsScraper.__new__(OpenMetricsScraper)
+    scraper.endpoint = 'http://example.test/metrics'
+    scraper.ignore_connection_errors = ignore_connection_errors
+    scraper.log = logging.getLogger('test_stream_connection_lines')
+    return scraper
+
+
+@pytest.mark.parametrize('error_cls', AGNOSTIC_CONNECTION_ERRORS)
+def test_connection_error_swallowed_when_ignored(caplog, error_cls):
+    scraper = _scraper(ignore_connection_errors=True)
+    scraper.get_connection = mock.Mock(side_effect=error_cls('refused'))
+
+    with caplog.at_level(logging.WARNING, logger='test_stream_connection_lines'):
+        assert list(scraper.stream_connection_lines()) == []
+
+    assert any(
+        'OpenMetrics endpoint http://example.test/metrics is not accessible' in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.parametrize('error_cls', AGNOSTIC_CONNECTION_ERRORS)
+def test_connection_error_reraised_when_not_ignored(error_cls):
+    scraper = _scraper(ignore_connection_errors=False)
+    scraper.get_connection = mock.Mock(side_effect=error_cls('refused'))
+
+    with pytest.raises(error_cls):
+        list(scraper.stream_connection_lines())
+
+
+def test_mid_stream_read_timeout_swallowed_when_connection_errors_are_ignored() -> None:
+    def lines() -> Iterator[str]:
+        yield 'first'
+        raise HTTPClientReadTimeoutError('slow')
+
+    connection = mock.MagicMock()
+    connection.__enter__.return_value = connection
+    connection.headers = {'Content-Type': 'text/plain'}
+    connection.iter_lines.return_value = lines()
+
+    scraper = _scraper(ignore_connection_errors=True)
+    scraper.get_connection = mock.Mock(return_value=connection)
+    stream = scraper.stream_connection_lines()
+
+    assert next(stream) == 'first'
+    assert list(stream) == []
+
+
+def test_mid_stream_read_timeout_reraised_when_connection_errors_are_not_ignored() -> None:
+    def lines() -> Iterator[str]:
+        yield 'first'
+        raise HTTPClientReadTimeoutError('slow')
+
+    connection = mock.MagicMock()
+    connection.__enter__.return_value = connection
+    connection.headers = {'Content-Type': 'text/plain'}
+    connection.iter_lines.return_value = lines()
+
+    scraper = _scraper(ignore_connection_errors=False)
+    scraper.get_connection = mock.Mock(return_value=connection)
+    stream = scraper.stream_connection_lines()
+
+    assert next(stream) == 'first'
+    with pytest.raises(HTTPClientReadTimeoutError, match='slow'):
+        next(stream)

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_config.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_config.py
@@ -1,9 +1,12 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
 import pytest
 
 from .utils import get_check
+
+LATEST_SPEC_ACCEPT = 'application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1'
 
 
 class TestPrometheusEndpoint:
@@ -417,12 +420,70 @@ class TestUseLatestSpec:
         check = get_check({'use_latest_spec': True})
         check.configure_scrapers()
         scraper = check.scrapers['test']
-        assert scraper.http.options['headers']['Accept'] == (
-            'application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1'
-        )
+        assert scraper._use_latest_spec is True
+        assert scraper.http.get_header('Accept') == LATEST_SPEC_ACCEPT
 
     def test_dynamic_spec(self, dd_run_check):
         check = get_check({'use_latest_spec': False})
         check.configure_scrapers()
         scraper = check.scrapers['test']
-        assert scraper.http.options['headers']['Accept'] == 'text/plain'
+        assert scraper._use_latest_spec is False
+        assert scraper.http.get_header('Accept') == 'text/plain'
+
+    def test_user_accept_header_is_preserved(self, dd_run_check):
+        check = get_check({'use_latest_spec': True, 'headers': {'Accept': 'application/json'}})
+        check.configure_scrapers()
+        scraper = check.scrapers['test']
+
+        assert scraper.http.get_header('Accept') == 'application/json'
+
+    def test_non_canonically_cased_configured_accept_header_is_preserved(self, dd_run_check):
+        check = get_check({'use_latest_spec': True, 'extra_headers': {'accept': 'application/json'}})
+        check.configure_scrapers()
+        scraper = check.scrapers['test']
+
+        assert scraper.http.get_header('Accept') == 'application/json'
+
+    def test_per_request_accept_header_is_preserved(self, dd_run_check):
+        check = get_check({'use_latest_spec': True})
+        check.configure_scrapers()
+        scraper = check.scrapers['test']
+
+        with mock.patch.object(type(scraper.http), 'get') as mock_get:
+            scraper.send_request(headers={'Accept': 'application/json'})
+
+        assert mock_get.call_args.kwargs['headers'] == {'Accept': 'application/json'}
+        assert 'extra_headers' not in mock_get.call_args.kwargs
+
+    def test_unrelated_per_request_headers_replace_negotiated_accept(self, dd_run_check):
+        check = get_check({'use_latest_spec': True})
+        check.configure_scrapers()
+        scraper = check.scrapers['test']
+
+        with mock.patch.object(type(scraper.http), 'get') as mock_get:
+            scraper.send_request(headers={'Authorization': 'Bearer token'})
+
+        assert mock_get.call_args.kwargs['headers'] == {'Authorization': 'Bearer token'}
+        assert 'extra_headers' not in mock_get.call_args.kwargs
+
+    def test_per_request_extra_headers_are_not_mutated(self, dd_run_check):
+        check = get_check({'use_latest_spec': True})
+        check.configure_scrapers()
+        scraper = check.scrapers['test']
+        extra_headers = {'X-Custom': 'value'}
+
+        with mock.patch.object(type(scraper.http), 'get') as mock_get:
+            scraper.send_request(extra_headers=extra_headers)
+
+        assert extra_headers == {'X-Custom': 'value'}
+        assert mock_get.call_args.kwargs['extra_headers'] == {'X-Custom': 'value'}
+
+    def test_lowercase_per_request_accept_header_is_preserved(self, dd_run_check):
+        check = get_check({'use_latest_spec': True})
+        check.configure_scrapers()
+        scraper = check.scrapers['test']
+
+        with mock.patch.object(type(scraper.http), 'get') as mock_get:
+            scraper.send_request(extra_headers={'accept': 'application/json'})
+
+        assert mock_get.call_args.kwargs['extra_headers'] == {'accept': 'application/json'}

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_interface.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_interface.py
@@ -1,10 +1,25 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
 from datadog_checks.base import OpenMetricsBaseCheckV2
 from datadog_checks.base.constants import ServiceCheck
+from datadog_checks.base.utils.http_exceptions import HTTPClientError
 
 from .utils import get_check
+
+
+def test_check_adds_endpoint_context_to_root_http_client_errors(mocker):
+    check = get_check()
+    scraper = mocker.Mock(namespace='test')
+    scraper.scrape.side_effect = HTTPClientError('transport failed')
+    check.scrapers['test'] = scraper
+
+    with pytest.raises(HTTPClientError) as exc_info:
+        check.check(None)
+
+    assert str(exc_info.value) == 'There was an error scraping endpoint test: transport failed'
 
 
 def test_default_config(aggregator, dd_run_check, mock_http_response):

--- a/datadog_checks_base/tests/base/checks/prometheus/test_prometheus.py
+++ b/datadog_checks_base/tests/base/checks/prometheus/test_prometheus.py
@@ -5,37 +5,62 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import logging
 import os
-import ssl
-from collections import OrderedDict
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import mock
 import pytest
-import requests
 
+from datadog_checks.base.stubs.http import FakeHTTPClient, FakeHTTPResponse, RecordedRequest
+from datadog_checks.base.utils.http_exceptions import HTTPClientConnectionError, HTTPClientStatusError
 from datadog_checks.checks.prometheus import PrometheusCheck, UnknownFormatError
 from datadog_checks.utils.prometheus import metrics_pb2, parse_metric_family
 
 protobuf_content_type = 'application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited'
+FAKE_ENDPOINT = 'http://fake.endpoint:10055/metrics'
+PROMETHEUS_REQUEST_OPTIONS = {
+    'extra_headers': {
+        'Accept-Encoding': 'gzip',
+        'accept': protobuf_content_type,
+    },
+    'stream': False,
+}
+PROMETHEUS_REQUEST = RecordedRequest('GET', FAKE_ENDPOINT, PROMETHEUS_REQUEST_OPTIONS)
 
 
 FIXTURES_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', 'fixtures', 'prometheus'))
 
 
-class MockResponse:
-    """
-    MockResponse is used to simulate the object requests.Response commonly returned by requests.get
-    """
+def _text_response(text: str, *, content_type: str = 'text/plain') -> FakeHTTPResponse:
+    return FakeHTTPResponse(
+        content=text.encode('utf-8'),
+        text=text,
+        headers={'Content-Type': content_type},
+        lines=text.splitlines(),
+    )
 
-    def __init__(self, content, content_type):
-        self.content = content
-        self.headers = {'Content-Type': content_type}
 
-    def iter_lines(self, **_):
-        for elt in self.content.split("\n"):
-            yield elt
+def _file_response(file_path: str, *, content_type: str) -> FakeHTTPResponse:
+    with open(file_path, 'rb') as fixture:
+        return FakeHTTPResponse(content=fixture.read(), headers={'Content-Type': content_type})
 
-    def close(self):
-        pass
+
+def _register_prometheus_text(fake_http: FakeHTTPClient, text: str, *, count: int = 1) -> None:
+    for _ in range(count):
+        fake_http.register_response(
+            'GET',
+            FAKE_ENDPOINT,
+            _text_response(text),
+            match_options=PROMETHEUS_REQUEST_OPTIONS,
+        )
+
+
+@contextmanager
+def _registered_prometheus_text(fake_http: FakeHTTPClient, text: str, *, count: int) -> Iterator[None]:
+    _register_prometheus_text(fake_http, text, count=count)
+    yield
+    fake_http.assert_requests([PROMETHEUS_REQUEST] * count)
+    fake_http.assert_all_responses_consumed()
 
 
 class SortedTagsPrometheusCheck(PrometheusCheck):
@@ -89,13 +114,11 @@ def ref_gauge():
 
 
 @pytest.fixture
-def bin_data():
+def bin_data_path():
     f_name = os.path.join(FIXTURES_PATH, 'protobuf.bin')
-    with open(f_name, 'rb') as f:
-        bin_data = f.read()
-        assert len(bin_data) == 51855
+    assert os.path.getsize(f_name) == 51855
 
-    return bin_data
+    return f_name
 
 
 @pytest.fixture
@@ -107,6 +130,12 @@ def text_data():
         assert len(text_data) == 14494
 
     return text_data
+
+
+@pytest.fixture
+def ksm_text() -> str:
+    with open(os.path.join(FIXTURES_PATH, 'ksm.txt')) as fixture:
+        return fixture.read()
 
 
 def test_parse_metric_family():
@@ -125,8 +154,8 @@ def test_check(mocked_prometheus_check):
         mocked_prometheus_check.check(None)
 
 
-def test_parse_metric_family_protobuf(bin_data, mocked_prometheus_check):
-    response = MockResponse(bin_data, protobuf_content_type)
+def test_parse_metric_family_protobuf(bin_data_path, mocked_prometheus_check):
+    response = _file_response(bin_data_path, content_type=protobuf_content_type)
     check = mocked_prometheus_check
 
     messages = list(check.parse_metric_family(response))
@@ -142,7 +171,7 @@ def test_parse_metric_family_protobuf(bin_data, mocked_prometheus_check):
     # override the type:
     check.type_overrides = {"go_goroutines": "summary"}
 
-    response = MockResponse(bin_data, protobuf_content_type)
+    response = _file_response(bin_data_path, content_type=protobuf_content_type)
 
     messages = list(check.parse_metric_family(response))
 
@@ -155,7 +184,7 @@ def test_parse_metric_family_text(text_data, mocked_prometheus_check):
     """Test the high level method for loading metrics from text format"""
     check = mocked_prometheus_check
 
-    response = MockResponse(text_data, 'text/plain; version=0.0.4')
+    response = _text_response(text_data, content_type='text/plain; version=0.0.4')
 
     messages = list(check.parse_metric_family(response))
     # total metrics are 41 but one is typeless and we expect it not to be
@@ -163,7 +192,7 @@ def test_parse_metric_family_text(text_data, mocked_prometheus_check):
     assert len(messages) == 40
     # ...unless the check ovverrides the type manually
     check.type_overrides = {"go_goroutines": "gauge"}
-    response = MockResponse(text_data, 'text/plain; version=0.0.4')
+    response = _text_response(text_data, content_type='text/plain; version=0.0.4')
     messages = list(check.parse_metric_family(response))
     assert len(messages) == 41
     # Tests correct parsing of counters
@@ -252,51 +281,51 @@ def test_parse_metric_family_text(text_data, mocked_prometheus_check):
     assert _histo in messages
 
 
-def test_parse_metric_family_unsupported(bin_data, mocked_prometheus_check):
+def test_parse_metric_family_unsupported(bin_data_path, mocked_prometheus_check):
     check = mocked_prometheus_check
     with pytest.raises(UnknownFormatError):
-        response = MockResponse(bin_data, 'application/json')
+        response = _file_response(bin_data_path, content_type='application/json')
         list(check.parse_metric_family(response))
 
 
-def test_process(bin_data, mocked_prometheus_check, ref_gauge):
-    endpoint = "http://fake.endpoint:10055/metrics"
+def test_process(bin_data_path, mocked_prometheus_check, ref_gauge):
+    endpoint = FAKE_ENDPOINT
     check = mocked_prometheus_check
 
-    check.poll = mock.MagicMock(return_value=MockResponse(bin_data, protobuf_content_type))
+    check.poll = mock.MagicMock(return_value=_file_response(bin_data_path, content_type=protobuf_content_type))
     check.process_metric = mock.MagicMock()
     check.process(endpoint, instance=None)
     check.poll.assert_called_with(endpoint, instance={})
     check.process_metric.assert_called_with(ref_gauge, instance=None)
 
 
-def test_process_send_histograms_buckets(bin_data, mocked_prometheus_check, ref_gauge):
+def test_process_send_histograms_buckets(bin_data_path, mocked_prometheus_check, ref_gauge):
     """Checks that the send_histograms_buckets parameter is passed along"""
-    endpoint = "http://fake.endpoint:10055/metrics"
+    endpoint = FAKE_ENDPOINT
     check = mocked_prometheus_check
-    check.poll = mock.MagicMock(return_value=MockResponse(bin_data, protobuf_content_type))
+    check.poll = mock.MagicMock(return_value=_file_response(bin_data_path, content_type=protobuf_content_type))
     check.process_metric = mock.MagicMock()
     check.process(endpoint, send_histograms_buckets=False, instance=None)
     check.poll.assert_called_with(endpoint, instance={})
     check.process_metric.assert_called_with(ref_gauge, instance=None, send_histograms_buckets=False)
 
 
-def test_process_send_monotonic_counter(bin_data, mocked_prometheus_check, ref_gauge):
+def test_process_send_monotonic_counter(bin_data_path, mocked_prometheus_check, ref_gauge):
     """Checks that the send_monotonic_counter parameter is passed along"""
-    endpoint = "http://fake.endpoint:10055/metrics"
+    endpoint = FAKE_ENDPOINT
     check = mocked_prometheus_check
-    check.poll = mock.MagicMock(return_value=MockResponse(bin_data, protobuf_content_type))
+    check.poll = mock.MagicMock(return_value=_file_response(bin_data_path, content_type=protobuf_content_type))
     check.process_metric = mock.MagicMock()
     check.process(endpoint, send_monotonic_counter=False, instance=None)
     check.poll.assert_called_with(endpoint, instance={})
     check.process_metric.assert_called_with(ref_gauge, instance=None, send_monotonic_counter=False)
 
 
-def test_process_instance_with_tags(bin_data, mocked_prometheus_check, ref_gauge):
+def test_process_instance_with_tags(bin_data_path, mocked_prometheus_check, ref_gauge):
     """Checks that an instances with tags passes them as custom tag"""
-    endpoint = "http://fake.endpoint:10055/metrics"
+    endpoint = FAKE_ENDPOINT
     check = mocked_prometheus_check
-    check.poll = mock.MagicMock(return_value=MockResponse(bin_data, protobuf_content_type))
+    check.poll = mock.MagicMock(return_value=_file_response(bin_data_path, content_type=protobuf_content_type))
     check.process_metric = mock.MagicMock()
     instance = {'endpoint': 'IgnoreMe', 'tags': ['tag1:tagValue1', 'tag2:tagValue2']}
     check.process(endpoint, instance=instance)
@@ -331,29 +360,38 @@ def test_process_metric_filtered(mocked_prometheus_check):
     check.gauge.assert_not_called()
 
 
-def test_poll_protobuf(mocked_prometheus_check, bin_data):
+def test_poll_protobuf(bin_data_path, fake_prometheus_http, mocked_prometheus_check):
     """Tests poll using the protobuf format"""
     check = mocked_prometheus_check
-    mock_response = mock.MagicMock(status_code=200, content=bin_data, headers={'Content-Type': protobuf_content_type})
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
-        response = check.poll("http://fake.endpoint:10055/metrics")
-        messages = list(check.parse_metric_family(response))
-        assert len(messages) == 61
-        assert messages[-1].name == 'process_virtual_memory_bytes'
+    fake_prometheus_http.register_response(
+        'GET',
+        FAKE_ENDPOINT,
+        _file_response(bin_data_path, content_type=protobuf_content_type),
+        match_options=PROMETHEUS_REQUEST_OPTIONS,
+    )
+
+    response = check.poll(FAKE_ENDPOINT)
+    messages = list(check.parse_metric_family(response))
+
+    assert len(messages) == 61
+    assert messages[-1].name == 'process_virtual_memory_bytes'
+    fake_prometheus_http.assert_requests([PROMETHEUS_REQUEST])
+    fake_prometheus_http.assert_all_responses_consumed()
 
 
-def test_poll_text_plain(mocked_prometheus_check, text_data):
+def test_poll_text_plain(fake_prometheus_http, mocked_prometheus_check, text_data):
     """Tests poll using the text format"""
     check = mocked_prometheus_check
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-    )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
-        response = check.poll("http://fake.endpoint:10055/metrics")
-        messages = list(check.parse_metric_family(response))
-        messages.sort(key=lambda x: x.name)
-        assert len(messages) == 40
-        assert messages[-1].name == 'skydns_skydns_dns_response_size_bytes'
+    _register_prometheus_text(fake_prometheus_http, text_data)
+
+    response = check.poll(FAKE_ENDPOINT)
+    messages = list(check.parse_metric_family(response))
+    messages.sort(key=lambda x: x.name)
+
+    assert len(messages) == 40
+    assert messages[-1].name == 'skydns_skydns_dns_response_size_bytes'
+    fake_prometheus_http.assert_requests([PROMETHEUS_REQUEST])
+    fake_prometheus_http.assert_all_responses_consumed()
 
 
 def test_submit_gauge_with_labels(mocked_prometheus_check, ref_gauge):
@@ -627,7 +665,7 @@ def test_filter_sample_on_gauge(p_check):
     label2.value = "heapster-v1.4.3"
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, 'text/plain; version=0.0.4')
+    response = _text_response(text_data, content_type='text/plain; version=0.0.4')
     check = p_check
     check._text_filter_blacklist = ["deployment=\"kube-dns\""]
     metrics = list(check.parse_metric_family(response))
@@ -661,7 +699,7 @@ def test_parse_one_gauge(p_check):
     expected_etcd_metric.metric.add().gauge.value = 1
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, 'text/plain; version=0.0.4')
+    response = _text_response(text_data, content_type='text/plain; version=0.0.4')
     check = p_check
     metrics = list(check.parse_metric_family(response))
 
@@ -704,7 +742,7 @@ def test_parse_one_counter(p_check):
     expected_etcd_metric.metric.add().counter.value = 18713
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, 'text/plain; version=0.0.4')
+    response = _text_response(text_data, content_type='text/plain; version=0.0.4')
     check = p_check
     metrics = list(check.parse_metric_family(response))
 
@@ -778,7 +816,7 @@ def test_parse_one_histograms_with_label(p_check):
     histogram_metric.histogram.sample_sum = 0.026131671
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, 'text/plain; version=0.0.4')
+    response = _text_response(text_data, content_type='text/plain; version=0.0.4')
     check = p_check
     metrics = list(check.parse_metric_family(response))
 
@@ -913,7 +951,7 @@ def test_parse_one_histogram(p_check):
     histogram_metric.histogram.sample_sum = 0.026131671
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, 'text/plain; version=0.0.4')
+    response = _text_response(text_data, content_type='text/plain; version=0.0.4')
     check = p_check
     metrics = list(check.parse_metric_family(response))
 
@@ -1036,7 +1074,7 @@ def test_parse_two_histograms_with_label(p_check):
     histogram_metric.histogram.sample_sum = 0.3097010759999998
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, 'text/plain; version=0.0.4')
+    response = _text_response(text_data, content_type='text/plain; version=0.0.4')
     check = p_check
     metrics = list(check.parse_metric_family(response))
 
@@ -1122,7 +1160,7 @@ def test_parse_one_summary(p_check):
     quantile_099.value = 25763
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, 'text/plain; version=0.0.4')
+    response = _text_response(text_data, content_type='text/plain; version=0.0.4')
     check = p_check
     metrics = list(check.parse_metric_family(response))
 
@@ -1207,7 +1245,7 @@ def test_parse_two_summaries_with_labels(p_check):
     quantile_099.value = 24627
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, 'text/plain; version=0.0.4')
+    response = _text_response(text_data, content_type='text/plain; version=0.0.4')
     check = p_check
     metrics = list(check.parse_metric_family(response))
 
@@ -1266,7 +1304,7 @@ def test_parse_one_summary_with_none_values(p_check):
     quantile_099.value = float('nan')
 
     # Iter on the generator to get all metrics
-    response = MockResponse(text_data, 'text/plain; version=0.0.4')
+    response = _text_response(text_data, content_type='text/plain; version=0.0.4')
     check = p_check
     metrics = list(check.parse_metric_family(response))
     assert 1 == len(metrics)
@@ -1276,16 +1314,9 @@ def test_parse_one_summary_with_none_values(p_check):
     assert expected_etcd_metric.__repr__() == current_metric.__repr__()
 
 
-def test_label_joins(sorted_tags_check):
+def test_label_joins(fake_prometheus_http, ksm_text, sorted_tags_check):
     """Tests label join on text format"""
-    text_data = None
-    f_name = os.path.join(FIXTURES_PATH, 'ksm.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-    )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
+    with _registered_prometheus_text(fake_prometheus_http, ksm_text, count=2):
         check = sorted_tags_check
         check.NAMESPACE = 'ksm'
         check.label_joins = {
@@ -1626,16 +1657,9 @@ def test_label_joins(sorted_tags_check):
         )
 
 
-def test_label_joins_gc(sorted_tags_check):
+def test_label_joins_gc(fake_prometheus_http, ksm_text, sorted_tags_check):
     """Tests label join GC on text format"""
-    text_data = None
-    f_name = os.path.join(FIXTURES_PATH, 'ksm.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-    )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
+    with _registered_prometheus_text(fake_prometheus_http, ksm_text, count=2):
         check = sorted_tags_check
         check.NAMESPACE = 'ksm'
         check.label_joins = {'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node', 'pod_ip']}}
@@ -1680,28 +1704,20 @@ def test_label_joins_gc(sorted_tags_check):
             any_order=True,
         )
         assert 15 == len(check._label_mapping['pod'])
-        text_data = text_data.replace('dd-agent-62bgh', 'dd-agent-1337')
+        text_data = ksm_text.replace('dd-agent-62bgh', 'dd-agent-1337')
 
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-    )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
-        check.process("http://fake.endpoint:10055/metrics")
-        assert 'dd-agent-1337' in check._label_mapping['pod']
-        assert 'dd-agent-62bgh' not in check._label_mapping['pod']
-        assert 15 == len(check._label_mapping['pod'])
+    _register_prometheus_text(fake_prometheus_http, text_data)
+    check.process(FAKE_ENDPOINT)
+    assert 'dd-agent-1337' in check._label_mapping['pod']
+    assert 'dd-agent-62bgh' not in check._label_mapping['pod']
+    assert 15 == len(check._label_mapping['pod'])
+    fake_prometheus_http.assert_requests([PROMETHEUS_REQUEST] * 3)
+    fake_prometheus_http.assert_all_responses_consumed()
 
 
-def test_label_joins_missconfigured(sorted_tags_check):
+def test_label_joins_missconfigured(fake_prometheus_http, ksm_text, sorted_tags_check):
     """Tests label join missconfigured label is ignored"""
-    text_data = None
-    f_name = os.path.join(FIXTURES_PATH, 'ksm.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-    )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
+    with _registered_prometheus_text(fake_prometheus_http, ksm_text, count=2):
         check = sorted_tags_check
         check.NAMESPACE = 'ksm'
         check.label_joins = {'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node', 'not_existing']}}
@@ -1745,16 +1761,9 @@ def test_label_joins_missconfigured(sorted_tags_check):
         )
 
 
-def test_label_join_not_existing(sorted_tags_check):
+def test_label_join_not_existing(fake_prometheus_http, ksm_text, sorted_tags_check):
     """Tests label join on non existing matching label is ignored"""
-    text_data = None
-    f_name = os.path.join(FIXTURES_PATH, 'ksm.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-    )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
+    with _registered_prometheus_text(fake_prometheus_http, ksm_text, count=2):
         check = sorted_tags_check
         check.NAMESPACE = 'ksm'
         check.label_joins = {'kube_pod_info': {'label_to_match': 'not_existing', 'labels_to_get': ['node', 'pod_ip']}}
@@ -1784,16 +1793,9 @@ def test_label_join_not_existing(sorted_tags_check):
         )
 
 
-def test_label_join_metric_not_existing(sorted_tags_check):
+def test_label_join_metric_not_existing(fake_prometheus_http, ksm_text, sorted_tags_check):
     """Tests label join on non existing metric is ignored"""
-    text_data = None
-    f_name = os.path.join(FIXTURES_PATH, 'ksm.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-    )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
+    with _registered_prometheus_text(fake_prometheus_http, ksm_text, count=2):
         check = sorted_tags_check
         check.NAMESPACE = 'ksm'
         check.label_joins = {'not_existing': {'label_to_match': 'pod', 'labels_to_get': ['node', 'pod_ip']}}
@@ -1823,16 +1825,9 @@ def test_label_join_metric_not_existing(sorted_tags_check):
         )
 
 
-def test_label_join_with_hostname(sorted_tags_check):
+def test_label_join_with_hostname(fake_prometheus_http, ksm_text, sorted_tags_check):
     """Tests label join and hostname override on a metric"""
-    text_data = None
-    f_name = os.path.join(FIXTURES_PATH, 'ksm.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    mock_response = mock.MagicMock(
-        status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-    )
-    with mock.patch('requests.Session.get', return_value=mock_response, __name__="get"):
+    with _registered_prometheus_text(fake_prometheus_http, ksm_text, count=2):
         check = sorted_tags_check
         check.NAMESPACE = 'ksm'
         check.label_joins = {'kube_pod_info': {'label_to_match': 'pod', 'labels_to_get': ['node']}}
@@ -1877,48 +1872,62 @@ def test_label_join_with_hostname(sorted_tags_check):
         )
 
 
-@pytest.fixture()
-def mock_get():
-    text_data = None
-    f_name = os.path.join(FIXTURES_PATH, 'ksm.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    mock_get = mock.patch(
-        'requests.Session.get',
-        return_value=mock.MagicMock(
-            status_code=200, iter_lines=lambda **kwargs: text_data.split("\n"), headers={'Content-Type': "text/plain"}
-        ),
-    )
-
-    try:
-        yield mock_get.start()
-    finally:
-        mock_get.stop()
-
-
-def test_health_service_check_ok(mock_get):
+def test_health_service_check_ok(fake_prometheus_http, ksm_text):
     """Tests endpoint health service check OK"""
+    _register_prometheus_text(fake_prometheus_http, ksm_text)
     check = PrometheusCheck('prometheus_check', {}, {}, {})
     check.NAMESPACE = 'ksm'
     check.health_service_check = True
     check.service_check = mock.MagicMock()
-    check.process("http://fake.endpoint:10055/metrics")
+    check.process(FAKE_ENDPOINT)
     check.service_check.assert_called_with(
         "ksm.prometheus.health", PrometheusCheck.OK, tags=["endpoint:http://fake.endpoint:10055/metrics"]
     )
+    fake_prometheus_http.assert_requests([PROMETHEUS_REQUEST])
+    fake_prometheus_http.assert_all_responses_consumed()
 
 
-def test_health_service_check_failing():
+def test_health_service_check_failing(fake_prometheus_http):
     """Tests endpoint health service check failing"""
+    fake_prometheus_http.register_response(
+        'GET',
+        FAKE_ENDPOINT,
+        HTTPClientConnectionError('Connection failed'),
+        match_options=PROMETHEUS_REQUEST_OPTIONS,
+    )
     check = PrometheusCheck('prometheus_check', {}, {}, {})
     check.NAMESPACE = 'ksm'
     check.health_service_check = True
     check.service_check = mock.MagicMock()
-    with pytest.raises(requests.ConnectionError):
-        check.process("http://fake.endpoint:10055/metrics")
+    with pytest.raises(HTTPClientConnectionError):
+        check.process(FAKE_ENDPOINT)
     check.service_check.assert_called_with(
         "ksm.prometheus.health", PrometheusCheck.CRITICAL, tags=["endpoint:http://fake.endpoint:10055/metrics"]
     )
+    fake_prometheus_http.assert_requests([PROMETHEUS_REQUEST])
+    fake_prometheus_http.assert_all_responses_consumed()
+
+
+def test_health_service_check_failing_on_status_error(fake_prometheus_http):
+    fake_prometheus_http.register_response(
+        'GET',
+        FAKE_ENDPOINT,
+        HTTPClientStatusError('503 Server Error'),
+        match_options=PROMETHEUS_REQUEST_OPTIONS,
+    )
+    check = PrometheusCheck('prometheus_check', {}, {}, {})
+    check.NAMESPACE = 'ksm'
+    check.health_service_check = True
+    check.service_check = mock.MagicMock()
+
+    with pytest.raises(HTTPClientStatusError):
+        check.process(FAKE_ENDPOINT)
+
+    check.service_check.assert_called_with(
+        "ksm.prometheus.health", PrometheusCheck.CRITICAL, tags=["endpoint:http://fake.endpoint:10055/metrics"]
+    )
+    fake_prometheus_http.assert_requests([PROMETHEUS_REQUEST])
+    fake_prometheus_http.assert_all_responses_consumed()
 
 
 def test_set_prometheus_timeout():
@@ -1962,38 +1971,24 @@ def test_text_filter_input():
     assert filtered == expected_out
 
 
-def test_ssl_verify_not_raise_warning(caplog, mocked_prometheus_check, text_data):
-    from datadog_checks.dev.http import MockResponse
-
-    check = mocked_prometheus_check
-
-    with caplog.at_level(logging.DEBUG), mock.patch('requests.Session.get', return_value=MockResponse('httpbin.org')):
-        resp = check.poll('https://httpbin.org/get')
-
-    assert 'httpbin.org' in resp.content.decode('utf-8')
-
-    expected_message = 'An unverified HTTPS request is being made to https://httpbin.org/get'
-    for _, _, message in caplog.record_tuples:
-        assert message != expected_message
-
-
-def test_ssl_verify_not_raise_warning_cert_false(caplog, mocked_prometheus_check, text_data):
-    from datadog_checks.dev.http import MockResponse
-
+def test_ssl_ca_cert_false_disables_verification(mocked_prometheus_check, mocker):
     check = mocked_prometheus_check
     check.ssl_ca_cert = False
+    fake_http = FakeHTTPClient()
+    create_http_client = mocker.patch(
+        'datadog_checks.base.checks.prometheus.mixins.create_http_client',
+        return_value=fake_http,
+    )
 
-    with caplog.at_level(logging.DEBUG), mock.patch('requests.Session.get', return_value=MockResponse('httpbin.org')):
-        resp = check.poll('https://httpbin.org/get')
+    check.get_http_handler('https://httpbin.org/get', None)
 
-    assert 'httpbin.org' in resp.content.decode('utf-8')
-
-    expected_message = 'An unverified HTTPS request is being made to https://httpbin.org/get'
-    for _, _, message in caplog.record_tuples:
-        assert message != expected_message
+    http_config = create_http_client.call_args.args[0]
+    assert http_config['ssl_ca_cert'] is False
+    assert http_config['ssl_ignore_warning'] is True
+    assert http_config['ssl_verify'] is False
 
 
-def test_requests_wrapper_config():
+def test_prometheus_http_config(mocker):
     instance_http = {
         'prometheus_endpoint': 'http://localhost:8080',
         'extra_headers': {'foo': 'bar'},
@@ -2004,47 +1999,70 @@ def test_requests_wrapper_config():
     }
     init_config_http = {'timeout': 42}
     check = PrometheusCheck('prometheus_check', init_config_http, {}, [instance_http])
-
-    expected_headers = OrderedDict(
-        [
-            ('User-Agent', 'Datadog Agent/0.0.0'),
-            ('Accept', '*/*'),
-            ('Accept-Encoding', 'gzip'),
-            ('foo', 'bar'),
-            ('accept-encoding', 'gzip'),
-            (
-                'accept',
-                'application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited',
-            ),
-        ]
+    fake_http = FakeHTTPClient()
+    for _ in range(2):
+        fake_http.register_response(
+            'GET',
+            instance_http['prometheus_endpoint'],
+            FakeHTTPResponse(),
+            match_options=PROMETHEUS_REQUEST_OPTIONS,
+        )
+    create_http_client = mocker.patch(
+        'datadog_checks.base.checks.prometheus.mixins.create_http_client',
+        return_value=fake_http,
     )
 
-    with mock.patch("requests.Session.get") as get:
-        with mock.patch.object(ssl.SSLContext, 'load_cert_chain') as mock_load_cert_chain:
-            mock_load_cert_chain.return_value = None
+    check.poll(instance_http['prometheus_endpoint'], instance=instance_http)
+    check.poll(instance_http['prometheus_endpoint'])
 
-            check.poll(instance_http['prometheus_endpoint'], instance=instance_http)
-            get.assert_called_with(
-                instance_http['prometheus_endpoint'],
-                stream=False,
-                headers=expected_headers,
-                auth=requests.auth.HTTPDigestAuth('data', 'dog'),
-                cert='/path/to/cert',
-                timeout=(42.0, 42.0),
-                proxies=None,
-                verify=True,
-                allow_redirects=True,
-            )
+    expected_http_config = {
+        **instance_http,
+        'headers': {},
+        'ssl_cert': None,
+        'ssl_private_key': None,
+        'ssl_verify': True,
+        'ssl_ignore_warning': False,
+        'ssl_ca_cert': None,
+    }
+    create_http_client.assert_called_once_with(
+        expected_http_config,
+        init_config_http,
+        check.HTTP_CONFIG_REMAPPER,
+        check.log,
+    )
+    expected_request = RecordedRequest(
+        'GET',
+        instance_http['prometheus_endpoint'],
+        PROMETHEUS_REQUEST_OPTIONS,
+    )
+    fake_http.assert_requests([expected_request, expected_request])
+    fake_http.assert_all_responses_consumed()
 
-            check.poll(instance_http['prometheus_endpoint'])
-            get.assert_called_with(
-                instance_http['prometheus_endpoint'],
-                stream=False,
-                headers=expected_headers,
-                auth=requests.auth.HTTPDigestAuth('data', 'dog'),
-                cert='/path/to/cert',
-                timeout=(42.0, 42.0),
-                proxies=None,
-                verify=True,
-                allow_redirects=True,
-            )
+
+def test_get_http_handler_negotiates_over_seeded_default_headers(p_check):
+    endpoint = 'http://fake.endpoint:10055/metrics'
+
+    http_handler = p_check.get_http_handler(endpoint, {})
+
+    assert http_handler.get_header('accept') == 'text/plain'
+    assert http_handler.get_header('accept-encoding') == 'gzip'
+
+
+def test_get_http_handler_preserves_user_configured_headers(p_check):
+    endpoint = 'http://fake.endpoint:10055/metrics'
+    instance = {'headers': {'Accept': 'application/openmetrics-text', 'Accept-Encoding': 'br'}}
+
+    http_handler = p_check.get_http_handler(endpoint, instance)
+
+    assert http_handler.get_header('accept') == 'application/openmetrics-text'
+    assert http_handler.get_header('accept-encoding') == 'br'
+
+
+def test_get_http_handler_preserves_non_canonically_cased_extra_headers(p_check):
+    endpoint = 'http://fake.endpoint:10055/metrics'
+    instance = {'extra_headers': {'accept': 'application/openmetrics-text', 'accept-encoding': 'br'}}
+
+    http_handler = p_check.get_http_handler(endpoint, instance)
+
+    assert http_handler.get_header('accept') == 'application/openmetrics-text'
+    assert http_handler.get_header('accept-encoding') == 'br'

--- a/datadog_checks_base/tests/base/checks/test_kubelet_base.py
+++ b/datadog_checks_base/tests/base/checks/test_kubelet_base.py
@@ -6,8 +6,10 @@ import os
 from datetime import datetime, timezone
 
 import mock
+import pytest
 
-from datadog_checks.base.checks.kubelet_base.base import KubeletBase, urljoin
+from datadog_checks.base.checks.kubelet_base.base import KubeletBase, KubeletCredentials, urljoin
+from datadog_checks.base.stubs.http import FakeHTTPResponse, RecordedRequest
 from datadog_checks.dev import get_here
 
 HERE = get_here()
@@ -22,28 +24,153 @@ def mock_from_file(filename):
         return f.read()
 
 
-def test_retrieve_pod_list_success(monkeypatch, mock_http_response):
+def test_retrieve_pod_list_success(fake_http):
+    url = 'https://kubelet:10250/pods'
+    response = FakeHTTPResponse(content=mock_from_file('kubelet_base/pod_list_raw.dat').encode('utf-8'))
+    fake_http.register_response('GET', url, response)
     check = KubeletBase('kubelet', {}, [{}])
-    check.pod_list_url = "dummyurl"
-    monkeypatch.setattr(
-        check, 'perform_kubelet_query', mock_http_response(file_path=get_fixture_path('kubelet_base/pod_list_raw.dat'))
-    )
+    check.pod_list_url = url
+    check.kubelet_credentials = KubeletCredentials({})
 
     retrieved = check.retrieve_pod_list()
     expected = json.loads(mock_from_file("kubelet_base/pod_list_raw.json"))
     assert json.dumps(retrieved, sort_keys=True) == json.dumps(expected, sort_keys=True)
+    fake_http.assert_requests(
+        [
+            RecordedRequest(
+                method='GET',
+                url=url,
+                options={'verify': None, 'cert': None, 'headers': None, 'params': {'verbose': True}, 'stream': True},
+            )
+        ]
+    )
+    fake_http.assert_all_responses_consumed()
 
 
-def test_retrieved_pod_list_failure(monkeypatch):
+def test_retrieve_pod_list_parses_via_json(fake_http):
+    url = 'http://kubelet:10255/pods'
+    fake_http.register_response('GET', url, FakeHTTPResponse(content=b'{"items": [{"name": "p1"}]}'))
+    check = KubeletBase('kubelet', {}, [{}])
+    check.pod_list_url = url
+    check.kubelet_credentials = KubeletCredentials({})
+
+    pod_list = check.retrieve_pod_list()
+    assert pod_list['items'] == [{'name': 'p1'}]
+    fake_http.assert_requests(
+        [
+            RecordedRequest(
+                method='GET',
+                url=url,
+                options={'verify': None, 'cert': None, 'headers': None, 'params': {'verbose': True}, 'stream': True},
+            )
+        ]
+    )
+    fake_http.assert_all_responses_consumed()
+
+
+@pytest.mark.parametrize('verbose', [True, False], ids=['verbose', 'terse'])
+def test_perform_kubelet_query_forwards_credentials_and_verbosity(fake_http, verbose):
+    url = 'https://kubelet:10250/healthz'
+    response = FakeHTTPResponse(status_code=200)
+    fake_http.register_response('GET', url, response)
+    check = KubeletBase('kubelet', {}, [{}])
+    check.kubelet_credentials = KubeletCredentials(
+        {'token': 'tkn', 'ca_cert': '/ca.pem', 'client_crt': '/crt.pem', 'client_key': '/key.pem'}
+    )
+
+    assert check.perform_kubelet_query(url, verbose=verbose) is response
+
+    fake_http.assert_requests(
+        [
+            RecordedRequest(
+                method='GET',
+                url=url,
+                options={
+                    'verify': '/ca.pem',
+                    'cert': ('/crt.pem', '/key.pem'),
+                    'headers': None,
+                    'params': {'verbose': verbose},
+                    'stream': False,
+                },
+            )
+        ]
+    )
+    fake_http.assert_all_responses_consumed()
+
+
+def test_perform_kubelet_query_forwards_the_bearer_token(fake_http):
+    url = 'https://kubelet:10250/healthz'
+    fake_http.register_response('GET', url, FakeHTTPResponse(status_code=200))
+    check = KubeletBase('kubelet', {}, [{}])
+    check.kubelet_credentials = KubeletCredentials({'token': 'tkn'})
+
+    check.perform_kubelet_query(url)
+
+    fake_http.assert_requests(
+        [
+            RecordedRequest(
+                method='GET',
+                url=url,
+                options={
+                    'verify': None,
+                    'cert': None,
+                    'headers': {'Authorization': 'Bearer tkn'},
+                    'params': {'verbose': True},
+                    'stream': False,
+                },
+            )
+        ]
+    )
+    fake_http.assert_all_responses_consumed()
+
+
+@pytest.mark.parametrize('expiration_duration', ['0', '900'], ids=['no_expiration_filter', 'expiration_filter'])
+def test_retrieve_pod_list_decodes_a_utf8_body_under_a_non_utf8_encoding(fake_http, expiration_duration):
+    url = 'http://kubelet:10255/pods'
+    labels = {'owner': 'café-münchen'}
+    body = json.dumps({'items': [{'metadata': {'labels': labels}}]}, ensure_ascii=False).encode('utf-8')
+    assert max(body) > 127, 'the body must carry multibyte UTF-8 for this test to mean anything'
+
+    response = FakeHTTPResponse(
+        content=body,
+        text=body.decode('ISO-8859-1'),
+        headers={'Content-Type': 'text/plain'},
+        encoding='ISO-8859-1',
+    )
+    assert 'café-münchen' not in response.text
+    fake_http.register_response('GET', url, response)
+
+    check = KubeletBase('kubelet', {}, [{}])
+    check.pod_list_url = url
+    check.kubelet_credentials = KubeletCredentials({})
+
+    with mock.patch('datadog_checks.base.checks.kubelet_base.base.get_config', return_value=expiration_duration):
+        pod_list = check.retrieve_pod_list()
+
+    assert pod_list['items'][0]['metadata']['labels'] == labels
+    fake_http.assert_requests(
+        [
+            RecordedRequest(
+                method='GET',
+                url=url,
+                options={'verify': None, 'cert': None, 'headers': None, 'params': {'verbose': True}, 'stream': True},
+            )
+        ]
+    )
+    fake_http.assert_all_responses_consumed()
+
+
+def test_retrieved_pod_list_failure(caplog, monkeypatch):
     def mock_perform_kubelet_query(s, stream=False):
         raise Exception("network error")
 
     check = KubeletBase('kubelet', {}, [{}])
-    check.pod_list_url = "dummyurl"
+    check.pod_list_url = 'https://kubelet:10250/pods'
     monkeypatch.setattr(check, 'perform_kubelet_query', mock_perform_kubelet_query)
 
     retrieved = check.retrieve_pod_list()
     assert retrieved == {}
+    assert 'failed to retrieve pod list from the kubelet at https://kubelet:10250/pods : network error' in caplog.text
 
 
 def test_compute_pod_expiration_datetime(monkeypatch):

--- a/datadog_checks_base/tests/base/utils/http/common.py
+++ b/datadog_checks_base/tests/base/utils/http/common.py
@@ -3,7 +3,15 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import os
-from collections import OrderedDict
+from collections import OrderedDict, deque
+from collections.abc import Iterable, Iterator, Mapping
+from http.client import responses as http_reasons
+from typing import Any
+
+import requests
+from requests.adapters import HTTPAdapter
+
+from datadog_checks.base.utils.http import RequestsWrapper
 
 DEFAULT_OPTIONS = {
     'auth': None,
@@ -22,3 +30,118 @@ DEFAULT_OPTIONS = {
 }
 
 FIXTURE_PATH = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'fixtures')
+
+
+class RawResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        content: bytes,
+        headers: Mapping[str, str],
+        reason: str,
+        content_chunks: Iterable[bytes] | None,
+        stream_error: Exception | None,
+    ) -> None:
+        self.status = status_code
+        self.headers = headers
+        self.reason = reason
+        self.version = 11
+        self.closed = False
+        self.released = False
+        self._content = content
+        self._content_chunks = tuple(content_chunks) if content_chunks is not None else None
+        self._stream_error = stream_error
+
+    def stream(self, chunk_size: int, decode_content: bool = False) -> Iterator[bytes]:
+        if self._content_chunks is None:
+            yield from (
+                self._content[offset : offset + chunk_size] for offset in range(0, len(self._content), chunk_size)
+            )
+        else:
+            yield from self._content_chunks
+        if self._stream_error is not None:
+            raise self._stream_error
+
+    def close(self) -> None:
+        self.closed = True
+
+    def release_conn(self) -> None:
+        self.released = True
+
+
+class RequestsTransport(HTTPAdapter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.closed = False
+        self.requests: list[requests.PreparedRequest] = []
+        self.raw_responses: list[RawResponse] = []
+        self._outcomes: deque[RawResponse | Exception] = deque()
+
+    def respond(
+        self,
+        *,
+        status_code: int = 200,
+        content: bytes = b'',
+        headers: Mapping[str, str] | None = None,
+        reason: str | None = None,
+        content_chunks: Iterable[bytes] | None = None,
+        stream_error: Exception | None = None,
+    ) -> None:
+        self._outcomes.append(
+            RawResponse(
+                status_code=status_code,
+                content=content,
+                headers=headers or {},
+                reason=http_reasons.get(status_code, '') if reason is None else reason,
+                content_chunks=content_chunks,
+                stream_error=stream_error,
+            )
+        )
+
+    def raise_exception(self, error: Exception) -> None:
+        self._outcomes.append(error)
+
+    def close(self) -> None:
+        self.closed = True
+        super().close()
+
+    def send(
+        self,
+        request: requests.PreparedRequest,
+        stream: bool = False,
+        timeout: Any = None,
+        verify: bool | str = True,
+        cert: Any = None,
+        proxies: Mapping[str, str] | None = None,
+    ) -> requests.Response:
+        self.requests.append(request)
+        if not self._outcomes:
+            raise AssertionError(f'No transport outcome configured for {request.method} {request.url}')
+
+        outcome = self._outcomes.popleft()
+        if isinstance(outcome, Exception):
+            if isinstance(outcome, requests.RequestException) and outcome.request is None:
+                outcome.request = request
+            raise outcome
+
+        self.raw_responses.append(outcome)
+        return self.build_response(request, outcome)
+
+
+def create_requests_client(transport: RequestsTransport) -> RequestsWrapper:
+    session = requests.Session()
+    session.mount('http://', transport)
+    client = RequestsWrapper({}, {}, session=session)
+    client.persist_connections = True
+    return client
+
+
+def get_wire_headers(http, url='http://example.com/hello', **options):
+    """Return headers from the prepared outgoing request."""
+    transport = RequestsTransport()
+    transport.respond()
+    http.session.mount('http://', transport)
+    http.get(url, persist=True, **options)
+
+    return transport.requests[0].headers

--- a/datadog_checks_base/tests/base/utils/http/test_auth.py
+++ b/datadog_checks_base/tests/base/utils/http/test_auth.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from base64 import b64encode
+
 import mock
 import pytest
 import requests_ntlm
@@ -9,6 +11,8 @@ from requests import auth as requests_auth
 
 from datadog_checks.base import ConfigurationError
 from datadog_checks.base.utils.http import RequestsWrapper
+
+from .common import get_wire_headers
 
 pytestmark = [pytest.mark.unit]
 
@@ -27,6 +31,14 @@ def test_config_basic():
     http = RequestsWrapper(instance, init_config)
 
     assert http.options['auth'] == ('user', 'pass')
+
+
+def test_config_basic_reaches_the_request():
+    http = RequestsWrapper({'username': 'user', 'password': 'pass'}, {})
+
+    wire_headers = get_wire_headers(http)
+
+    assert wire_headers['Authorization'] == 'Basic {}'.format(b64encode(b'user:pass').decode())
 
 
 def test_config_basic_authtype():

--- a/datadog_checks_base/tests/base/utils/http/test_authtoken.py
+++ b/datadog_checks_base/tests/base/utils/http/test_authtoken.py
@@ -9,11 +9,12 @@ import mock
 import pytest
 
 from datadog_checks.base import ConfigurationError
+from datadog_checks.base.stubs.http import FakeHTTPResponse
 from datadog_checks.base.utils.http import DEFAULT_EXPIRATION, RequestsWrapper
+from datadog_checks.base.utils.http_exceptions import HTTPClientStatusError
 from datadog_checks.base.utils.time import get_timestamp
 from datadog_checks.dev import TempDir
 from datadog_checks.dev.fs import read_file, write_file
-from datadog_checks.dev.http import MockResponse
 
 from .common import DEFAULT_OPTIONS, FIXTURE_PATH
 
@@ -607,14 +608,20 @@ class TestAuthTokenDCOS:
                 assert isinstance(decoded['exp'], int)
                 assert abs(decoded['exp'] - (get_timestamp() + exp)) < 10
 
-                return MockResponse(json_data={'token': 'auth-token'})
-            return MockResponse(status_code=404)
+                return FakeHTTPResponse(json_result={'token': 'auth-token'})
+            return FakeHTTPResponse(
+                status_code=404,
+                status_error=HTTPClientStatusError('404 Client Error'),
+            )
 
         def auth(*args, **kwargs):
             if args[0] == 'https://leader.mesos/service/some-service':
                 assert kwargs['headers']['Authorization'] == 'token=auth-token'
-                return MockResponse(json_data={})
-            return MockResponse(status_code=404)
+                return FakeHTTPResponse(status_code=200)
+            return FakeHTTPResponse(
+                status_code=404,
+                status_error=HTTPClientStatusError('404 Client Error'),
+            )
 
         with mock.patch('requests.post', side_effect=login), mock.patch('requests.Session.get', side_effect=auth):
             http = RequestsWrapper(instance, init_config)
@@ -655,6 +662,55 @@ class TestAuthTokenWriteHeader:
 
 
 class TestAuthTokenFileReaderWithHeaderWriter:
+    def test_initial_request_with_extra_headers_uses_file_token(self):
+        with TempDir() as temp_dir:
+            token_file = os.path.join(temp_dir, 'token.txt')
+            instance = {
+                'auth_token': {
+                    'reader': {'type': 'file', 'path': token_file},
+                    'writer': {'type': 'header', 'name': 'Authorization', 'value': 'Bearer <TOKEN>'},
+                }
+            }
+            http = RequestsWrapper(instance, {})
+
+            with mock.patch('requests.Session.get', return_value=FakeHTTPResponse(status_code=200)) as get:
+                write_file(token_file, '\nsecret1\n')
+                http.get('https://www.google.com', extra_headers={'Accept': 'text/plain'})
+
+            request_headers = get.call_args.kwargs['headers']
+            assert request_headers['Accept'] == 'text/plain'
+            assert request_headers['Authorization'] == 'Bearer secret1'
+
+    def test_retry_with_extra_headers_uses_refreshed_file_token(self):
+        with TempDir() as temp_dir:
+            token_file = os.path.join(temp_dir, 'token.txt')
+            instance = {
+                'auth_token': {
+                    'reader': {'type': 'file', 'path': token_file},
+                    'writer': {'type': 'header', 'name': 'Authorization', 'value': 'Bearer <TOKEN>'},
+                }
+            }
+            http = RequestsWrapper(instance, {})
+
+            with mock.patch('requests.Session.get', return_value=FakeHTTPResponse(status_code=200)):
+                write_file(token_file, '\nsecret1\n')
+                http.get('https://www.google.com')
+
+            responses = [
+                FakeHTTPResponse(
+                    status_code=401,
+                    status_error=HTTPClientStatusError('401 Client Error'),
+                ),
+                FakeHTTPResponse(status_code=200),
+            ]
+            with mock.patch('requests.Session.get', side_effect=responses) as get:
+                write_file(token_file, '\nsecret2\n')
+                http.get('https://www.google.com', extra_headers={'Accept': 'text/plain'})
+
+            retry_headers = get.call_args_list[1].kwargs['headers']
+            assert retry_headers['Accept'] == 'text/plain'
+            assert retry_headers['Authorization'] == 'Bearer secret2'
+
     def test_read_before_first_request(self):
         with TempDir() as temp_dir:
             token_file = os.path.join(temp_dir, 'token.txt')
@@ -726,7 +782,7 @@ class TestAuthTokenFileReaderWithHeaderWriter:
                 if counter['errors'] <= 1:
                     raise Exception
 
-                return MockResponse()
+                return FakeHTTPResponse(status_code=200)
 
             expected_headers = {'Authorization': 'Bearer secret2'}
             expected_headers.update(DEFAULT_OPTIONS['headers'])
@@ -764,12 +820,13 @@ class TestAuthTokenFileReaderWithHeaderWriter:
                 write_file(token_file, '\nsecret1\n')
                 http.get('https://www.google.com')
 
-            def error():
-                raise Exception()
-
             expected_headers = {'Authorization': 'Bearer secret2'}
             expected_headers.update(DEFAULT_OPTIONS['headers'])
-            with mock.patch('requests.Session.get', return_value=mock.MagicMock(raise_for_status=error)) as get:
+            response = FakeHTTPResponse(
+                status_code=500,
+                status_error=HTTPClientStatusError('500 Server Error'),
+            )
+            with mock.patch('requests.Session.get', return_value=response) as get:
                 write_file(token_file, '\nsecret2\n')
                 http.get('https://www.google.com')
 

--- a/datadog_checks_base/tests/base/utils/http/test_capabilities.py
+++ b/datadog_checks_base/tests/base/utils/http/test_capabilities.py
@@ -1,0 +1,371 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datetime import timedelta
+
+import mock
+import pytest
+import requests
+
+from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.http_protocol import HTTPResponse
+from datadog_checks.base.utils.requests_adapter import RequestsResponseAdapter
+
+from . import common
+from .common import get_wire_headers
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_requests_transport_builds_response_through_requests():
+    transport = common.RequestsTransport()
+    transport.respond(
+        status_code=202,
+        content=b'{"result": "ok"}',
+        headers={
+            'Content-Type': 'application/json',
+            'Link': '<http://example.test/items?page=2>; rel="next"',
+        },
+    )
+    http = common.create_requests_client(transport)
+
+    response = http.get('http://example.test/items')
+
+    assert response.status_code == 202
+    assert response.content == b'{"result": "ok"}'
+    assert response.text == '{"result": "ok"}'
+    assert response.json() == {'result': 'ok'}
+    assert response.headers['content-type'] == 'application/json'
+    assert response.encoding == 'utf-8'
+    assert response.elapsed >= timedelta()
+    assert response.ok
+    assert response.reason == 'Accepted'
+    assert response.url == 'http://example.test/items'
+    assert response.links == {'next': {'url': 'http://example.test/items?page=2', 'rel': 'next'}}
+    assert len(transport.requests) == 1
+
+
+class TestClose:
+    def test_close_without_session_is_noop(self):
+        http = RequestsWrapper({}, {})
+        http.close()
+        assert http._session is None
+
+    def test_close_closes_underlying_session(self):
+        transport = common.RequestsTransport()
+        http = common.create_requests_client(transport)
+
+        http.close()
+
+        assert transport.closed
+
+    def test_close_resets_session(self):
+        http = RequestsWrapper({}, {})
+        first = http.session
+        http.close()
+        assert http._session is None
+        assert http.session is not first
+
+    def test_close_is_idempotent_after_open(self):
+        http = RequestsWrapper({}, {})
+        assert http.session is not None
+        http.close()
+        http.close()
+        assert http._session is None
+
+    def test_request_succeeds_after_close(self):
+        first_transport = common.RequestsTransport()
+        first_transport.respond()
+        http = RequestsWrapper({}, {})
+        http.persist_connections = True
+        first = http.session
+        first.mount('http://', first_transport)
+        http.get('http://example.com')
+        http.close()
+
+        second_transport = common.RequestsTransport()
+        second_transport.respond()
+        second = http.session
+        second.mount('http://', second_transport)
+        http.get('http://example.com')
+
+        assert len(first_transport.requests) == 1
+        assert len(second_transport.requests) == 1
+        assert second is not first
+
+
+class TestDisableAuth:
+    def test_disable_auth_overrides_config_basic_auth(self):
+        http = RequestsWrapper({'username': 'user', 'password': 'pass'}, {})
+        assert http.options['auth'] == ('user', 'pass')
+        http.disable_auth()
+        assert http.options['auth'] is not None
+        assert http.options['auth'] != ('user', 'pass')
+
+    def test_disable_auth_preserves_trust_env(self):
+        http = RequestsWrapper({}, {})
+        http.disable_auth()
+        assert http.trust_env is True
+
+    def test_netrc_header_injected_without_disable_auth(self):
+        transport = common.RequestsTransport()
+        transport.respond()
+        http = common.create_requests_client(transport)
+        http.options['auth'] = None
+
+        with mock.patch('requests.sessions.get_netrc_auth', return_value=('netrc-user', 'netrc-pass')):
+            http.get('http://example.com')
+
+        assert 'Authorization' in transport.requests[0].headers
+
+    def test_disable_auth_suppresses_netrc_header(self):
+        transport = common.RequestsTransport()
+        transport.respond()
+        http = common.create_requests_client(transport)
+
+        with mock.patch('requests.sessions.get_netrc_auth', return_value=('netrc-user', 'netrc-pass')):
+            http.disable_auth()
+            http.get('http://example.com')
+
+        assert 'Authorization' not in transport.requests[0].headers
+
+
+class TestCookies:
+    def test_get_cookie_missing_returns_default(self):
+        http = RequestsWrapper({}, {})
+        assert http.get_cookie('missing') is None
+        assert http.get_cookie('missing', 'fallback') == 'fallback'
+
+    def test_get_cookie_returns_value(self):
+        http = RequestsWrapper({}, {})
+        http.session.cookies.set('csrftoken', 'abc123')
+        value = http.get_cookie('csrftoken')
+        assert value == 'abc123'
+        assert isinstance(value, str)
+
+    def test_get_cookie_conflict_returns_default(self):
+        http = RequestsWrapper({}, {})
+        http.session.cookies.set('dup', 'a', domain='a.example.com')
+        http.session.cookies.set('dup', 'b', domain='b.example.com')
+        assert http.get_cookie('dup', 'fallback') == 'fallback'
+
+    def test_per_request_cookies_reach_the_request(self):
+        http = RequestsWrapper({}, {})
+
+        wire_headers = get_wire_headers(http, cookies={'proxy': 'approved'})
+
+        assert wire_headers['Cookie'] == 'proxy=approved'
+
+
+class TestTrustEnv:
+    def test_trust_env_defaults_to_true(self):
+        http = RequestsWrapper({}, {})
+        assert http.trust_env is True
+
+    def test_trust_env_propagates_to_existing_session(self):
+        http = RequestsWrapper({}, {})
+        session = http.session
+        http.trust_env = False
+        assert http.trust_env is False
+        assert session.trust_env is False
+
+    def test_trust_env_applies_to_new_session(self):
+        http = RequestsWrapper({}, {})
+        http.trust_env = False
+        assert http.session.trust_env is False
+
+    def test_trust_env_reset_to_true(self):
+        http = RequestsWrapper({}, {})
+        http.trust_env = False
+        http.trust_env = True
+        assert http.session.trust_env is True
+
+    def test_trust_env_adopts_injected_session(self):
+        session = requests.Session()
+        session.trust_env = False
+        http = RequestsWrapper({}, {}, session=session)
+        assert http.trust_env is False
+
+    def test_trust_env_defaults_true_when_injected_session_lacks_attribute(self):
+        http = RequestsWrapper({}, {}, session=mock.Mock(spec=[]))
+        assert http.trust_env is True
+
+
+class TestShouldBypassProxy:
+    def test_no_no_proxy_rules_never_bypasses(self):
+        http = RequestsWrapper({}, {})
+        assert http.no_proxy_uris is None
+        assert http.should_bypass_proxy('http://example.com') is False
+
+    def test_matching_host_bypasses(self):
+        http = RequestsWrapper({'proxy': {'http': 'http://p:3128', 'no_proxy': 'example.com'}}, {})
+        assert http.should_bypass_proxy('http://example.com/path') is True
+
+    def test_non_matching_host_does_not_bypass(self):
+        http = RequestsWrapper({'proxy': {'http': 'http://p:3128', 'no_proxy': 'example.com'}}, {})
+        assert http.should_bypass_proxy('http://other.com') is False
+
+    def test_wildcard_bypasses_all(self):
+        http = RequestsWrapper({'proxy': {'http': 'http://p:3128', 'no_proxy': '*'}}, {})
+        assert http.should_bypass_proxy('http://anything.example') is True
+
+
+class TestResponseProtocolSurface:
+    def test_promoted_attributes_declared(self):
+        annotations = HTTPResponse.__annotations__
+        for name in ('encoding', 'elapsed', 'cookies', 'links', 'url', 'history'):
+            assert name in annotations, f'{name} missing from HTTPResponse'
+
+    def test_get_peer_cert_declared(self):
+        assert callable(HTTPResponse.get_peer_cert)
+
+    def test_context_manager_closes_underlying_response(self):
+        transport = common.RequestsTransport()
+        transport.respond(content=b'body')
+        http = common.create_requests_client(transport)
+        response = http.get('http://example.test/items', stream=True)
+        raw_response = transport.raw_responses[0]
+
+        with response as entered:
+            assert entered is response
+
+        assert raw_response.closed
+        assert raw_response.released
+
+    def test_requests_members_are_not_exposed(self):
+        transport = common.RequestsTransport()
+        transport.respond()
+        http = common.create_requests_client(transport)
+        response = http.get('http://example.test/items')
+
+        assert not hasattr(response, 'raw')
+        assert not hasattr(response, 'request')
+
+
+@pytest.mark.parametrize(
+    ('headers', 'expected'),
+    [
+        (None, None),
+        ({'Content-Type': 'application/octet-stream'}, None),
+        ({'Content-Type': 'text/plain'}, 'ISO-8859-1'),
+        ({'Content-Type': 'text/plain; charset=latin-1'}, 'latin-1'),
+        ({'Content-Type': 'application/json'}, 'utf-8'),
+        ({'Content-Type': 'application/openmetrics-text; version=1.0.0'}, 'ISO-8859-1'),
+        ({'Content-Type': 'TEXT/PLAIN; CHARSET=UTF-8'}, 'UTF-8'),
+    ],
+)
+def test_requests_encoding_derived_from_content_type(headers, expected):
+    transport = common.RequestsTransport()
+    transport.respond(content=b'abc', headers=headers)
+    http = common.create_requests_client(transport)
+
+    response = http.get('http://example.test/items')
+
+    assert response.encoding == expected
+
+
+def test_requests_decode_unicode_yields_bytes_when_the_encoding_is_undetermined():
+    content = 'a: café\nb: 2'.encode('utf-8')
+    transport = common.RequestsTransport()
+    transport.respond(content=content)
+    transport.respond(content=content)
+    http = common.create_requests_client(transport)
+    lines_response = http.get('http://example.test/lines', stream=True)
+    chunks_response = http.get('http://example.test/chunks', stream=True)
+
+    assert lines_response.encoding is None
+    assert chunks_response.encoding is None
+    assert list(lines_response.iter_lines(decode_unicode=True)) == [b'a: caf\xc3\xa9', b'b: 2']
+    assert list(chunks_response.iter_content(chunk_size=4, decode_unicode=True)) == [
+        b'a: c',
+        b'af\xc3\xa9',
+        b'\nb: ',
+        b'2',
+    ]
+
+
+@pytest.mark.parametrize(
+    ('content', 'delimiter', 'decode_unicode', 'expected', 'element_type'),
+    [
+        (b'', None, False, [], bytes),
+        (b'a\n', None, False, [b'a'], bytes),
+        (b'a\n\n', None, False, [b'a', b''], bytes),
+        (b'a|', b'||', False, [b'a|'], bytes),
+        (b'a||', b'||', False, [b'a', b''], bytes),
+        ('café\n\n'.encode('utf-8'), None, True, ['café', ''], str),
+        ('café||'.encode('utf-8'), '||', True, ['café', ''], str),
+    ],
+)
+def test_requests_iter_lines_contract(
+    content: bytes,
+    delimiter: bytes | str | None,
+    decode_unicode: bool,
+    expected: list[bytes | str],
+    element_type: type[bytes] | type[str],
+) -> None:
+    transport = common.RequestsTransport()
+    transport.respond(content=content)
+    http = common.create_requests_client(transport)
+    response = http.get('http://example.test/items', stream=True)
+
+    if decode_unicode:
+        response.encoding = 'utf-8'
+
+    actual = list(response.iter_lines(decode_unicode=decode_unicode, delimiter=delimiter))
+
+    assert actual == expected
+    assert [type(line) for line in actual] == [element_type] * len(expected)
+
+
+class TestPeerCert:
+    def test_returns_cert_from_connection_socket(self):
+        response = mock.Mock()
+        response.raw.connection.sock.getpeercert.return_value = b'der-bytes'
+        adapter = RequestsResponseAdapter(response, 1024)
+        assert adapter.get_peer_cert(binary_form=True) == b'der-bytes'
+        response.raw.connection.sock.getpeercert.assert_called_once_with(binary_form=True)
+
+    def test_returns_decoded_cert_with_default_binary_form(self):
+        response = mock.Mock()
+        response.raw.connection.sock.getpeercert.return_value = {'subject': ()}
+        adapter = RequestsResponseAdapter(response, 1024)
+        assert adapter.get_peer_cert() == {'subject': ()}
+        response.raw.connection.sock.getpeercert.assert_called_once_with(binary_form=False)
+
+    def test_returns_none_when_socket_absent(self):
+        response = mock.Mock()
+        response.raw.connection.sock = None
+        adapter = RequestsResponseAdapter(response, 1024)
+        assert adapter.get_peer_cert() is None
+
+    def test_returns_none_for_non_tls_socket(self):
+        response = mock.Mock()
+        response.raw.connection.sock = object()
+        adapter = RequestsResponseAdapter(response, 1024)
+        assert adapter.get_peer_cert() is None
+
+
+class TestHistory:
+    def test_history_items_are_wrapped(self):
+        transport = common.RequestsTransport()
+        transport.respond(status_code=302, headers={'Location': '/final'})
+        transport.respond(content=b'complete')
+        http = common.create_requests_client(transport)
+
+        response = http.get('http://example.test/start')
+
+        history = response.history
+        assert len(history) == 1
+        assert isinstance(history[0], RequestsResponseAdapter)
+        assert history[0].status_code == 302
+        assert history[0].url == 'http://example.test/start'
+        assert response.url == 'http://example.test/final'
+
+    def test_empty_history(self):
+        transport = common.RequestsTransport()
+        transport.respond()
+        http = common.create_requests_client(transport)
+
+        response = http.get('http://example.test/items')
+
+        assert response.history == []

--- a/datadog_checks_base/tests/base/utils/http/test_config.py
+++ b/datadog_checks_base/tests/base/utils/http/test_config.py
@@ -159,3 +159,13 @@ class TestAllowRedirect:
         init_config = {}
         http = RequestsWrapper(instance, init_config)
         assert http.options['allow_redirects'] is False
+
+    def test_per_request_override_reaches_the_request(self):
+        # requests HEAD defaults to False; cAdvisor requires the explicit per-request value.
+        http = RequestsWrapper({}, {})
+        assert http.options['allow_redirects'] is True
+
+        with mock.patch('requests.Session.head') as head:
+            http.head('https://www.example.com', allow_redirects=False)
+
+        assert head.call_args.kwargs['allow_redirects'] is False

--- a/datadog_checks_base/tests/base/utils/http/test_exceptions.py
+++ b/datadog_checks_base/tests/base/utils/http/test_exceptions.py
@@ -1,0 +1,343 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+
+import mock
+import pytest
+import requests
+from urllib3.exceptions import ReadTimeoutError
+
+from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.http_exceptions import (
+    HTTPClientConnectionError,
+    HTTPClientConnectTimeoutError,
+    HTTPClientError,
+    HTTPClientInvalidURLError,
+    HTTPClientReadTimeoutError,
+    HTTPClientRequestError,
+    HTTPClientSSLError,
+    HTTPClientStatusError,
+    HTTPClientTimeoutError,
+)
+from datadog_checks.base.utils.requests_adapter import (
+    _COMPAT_EXCEPTIONS,
+    _backend_compat_type,
+    _translate_requests_exception,
+)
+
+from . import common
+
+
+@pytest.mark.parametrize(
+    'raised, expected',
+    [
+        pytest.param(requests.exceptions.ConnectTimeout('boom'), HTTPClientConnectTimeoutError, id='connect-timeout'),
+        pytest.param(requests.exceptions.ReadTimeout('slow'), HTTPClientReadTimeoutError, id='read-timeout'),
+        pytest.param(requests.exceptions.Timeout('generic'), HTTPClientTimeoutError, id='generic-timeout'),
+        pytest.param(requests.exceptions.ProxyError('proxy'), HTTPClientConnectionError, id='proxy-error'),
+        pytest.param(requests.exceptions.ConnectionError('refused'), HTTPClientConnectionError, id='connection-error'),
+        pytest.param(requests.exceptions.InvalidURL('bad-url'), HTTPClientInvalidURLError, id='invalid-url'),
+        pytest.param(requests.exceptions.MissingSchema('no-scheme'), HTTPClientInvalidURLError, id='missing-schema'),
+    ],
+)
+def test_transport_exception_mapping(raised, expected):
+    transport = common.RequestsTransport()
+    transport.raise_exception(raised)
+    http = common.create_requests_client(transport)
+
+    with pytest.raises(expected) as exc_info:
+        http.get('http://example.test/')
+
+    assert type(exc_info.value) is _COMPAT_EXCEPTIONS[expected]
+    assert exc_info.value.request.method == 'GET'
+    assert exc_info.value.request.url == 'http://example.test/'
+
+
+def test_phase_specific_timeouts_share_generic_base():
+    assert isinstance(HTTPClientConnectTimeoutError('connect'), HTTPClientTimeoutError)
+    assert isinstance(HTTPClientReadTimeoutError('read'), HTTPClientTimeoutError)
+    assert not isinstance(HTTPClientConnectTimeoutError('connect'), HTTPClientConnectionError)
+
+
+def test_ssl_error_maps_to_http_ssl_error():
+    transport = common.RequestsTransport()
+    transport.raise_exception(requests.exceptions.SSLError('bad cert'))
+    http = common.create_requests_client(transport)
+
+    with pytest.raises(HTTPClientSSLError):
+        http.get('http://example.test/')
+
+
+def test_raise_for_status_maps_to_status_error():
+    transport = common.RequestsTransport()
+    transport.respond(status_code=404, content=b'missing')
+    http = common.create_requests_client(transport)
+    wrapped = http.get('http://example.test/')
+
+    with pytest.raises(HTTPClientStatusError) as exc_info:
+        wrapped.raise_for_status()
+
+    assert exc_info.value.response is wrapped
+
+
+@pytest.mark.parametrize(
+    'raised, expected',
+    [
+        pytest.param(requests.exceptions.InvalidURL('bad'), HTTPClientInvalidURLError, id='invalid-url'),
+        pytest.param(requests.exceptions.MissingSchema('no-scheme'), HTTPClientInvalidURLError, id='missing-schema'),
+        pytest.param(requests.exceptions.InvalidSchema('bad-scheme'), HTTPClientInvalidURLError, id='invalid-schema'),
+        pytest.param(requests.exceptions.URLRequired('no-url'), HTTPClientInvalidURLError, id='url-required'),
+        pytest.param(requests.exceptions.SSLError('cert'), HTTPClientSSLError, id='ssl'),
+        pytest.param(requests.exceptions.ConnectTimeout('boom'), HTTPClientConnectTimeoutError, id='connect-timeout'),
+        pytest.param(requests.exceptions.ReadTimeout('slow'), HTTPClientReadTimeoutError, id='read-timeout'),
+        pytest.param(requests.exceptions.Timeout('generic'), HTTPClientTimeoutError, id='generic-timeout'),
+        pytest.param(requests.exceptions.ConnectionError('refused'), HTTPClientConnectionError, id='connection-error'),
+        pytest.param(requests.exceptions.ProxyError('proxy'), HTTPClientConnectionError, id='proxy-error'),
+        pytest.param(requests.exceptions.ContentDecodingError('decode'), HTTPClientRequestError, id='content-decoding'),
+        pytest.param(requests.exceptions.InvalidHeader('multiple values'), HTTPClientRequestError, id='invalid-header'),
+        pytest.param(requests.exceptions.HTTPError('500'), HTTPClientStatusError, id='http-error'),
+        pytest.param(requests.exceptions.RequestException('generic'), HTTPClientRequestError, id='request-exception'),
+        pytest.param(RuntimeError('not-requests'), HTTPClientError, id='non-requests-fallback'),
+    ],
+)
+def test_translate_maps_requests_to_agnostic(raised, expected):
+    result = _translate_requests_exception(raised)
+    assert type(result) is _COMPAT_EXCEPTIONS[expected], (
+        f"{type(raised).__name__} -> {type(result).__name__}, expected {expected.__name__}"
+    )
+
+
+def test_invalid_header_leaves_the_value_error_family():
+    assert isinstance(requests.exceptions.InvalidHeader('multiple values'), ValueError)
+
+    translated = _translate_requests_exception(requests.exceptions.InvalidHeader('multiple values'))
+
+    assert not isinstance(translated, ValueError)
+
+
+@pytest.mark.parametrize(
+    'raised, still_caught_by',
+    [
+        pytest.param(
+            requests.exceptions.ConnectTimeout('boom'),
+            [requests.exceptions.Timeout, requests.exceptions.ConnectionError],
+            id='connect-timeout',
+        ),
+        pytest.param(
+            requests.exceptions.ReadTimeout('slow'),
+            [requests.exceptions.Timeout, requests.exceptions.ReadTimeout],
+            id='read-timeout-header-phase',
+        ),
+        pytest.param(
+            requests.exceptions.ConnectionError('refused'),
+            [requests.exceptions.ConnectionError],
+            id='connection-error',
+        ),
+        pytest.param(
+            requests.exceptions.SSLError('cert'),
+            [requests.exceptions.SSLError, requests.exceptions.ConnectionError],
+            id='ssl',
+        ),
+        pytest.param(requests.exceptions.HTTPError('500'), [requests.exceptions.HTTPError], id='status'),
+        pytest.param(
+            requests.exceptions.MissingSchema('no-scheme'),
+            [requests.exceptions.MissingSchema, requests.exceptions.InvalidURL, ValueError],
+            id='missing-schema',
+        ),
+        pytest.param(
+            requests.exceptions.TooManyRedirects('loop'),
+            [requests.exceptions.RequestException],
+            id='fallthrough',
+        ),
+    ],
+)
+def test_translated_exceptions_keep_matching_the_requests_arms(raised, still_caught_by):
+    translated = _translate_requests_exception(raised)
+
+    assert isinstance(translated, requests.exceptions.RequestException)
+    assert isinstance(translated, OSError)
+
+    for arm in still_caught_by:
+        assert isinstance(translated, arm), f'{type(raised).__name__} no longer caught by except {arm.__name__}'
+
+
+def test_body_phase_read_timeout_keeps_matching_connection_error():
+    raised = requests.exceptions.ConnectionError(ReadTimeoutError(None, 'http://example.test/', 'timed out'))
+
+    translated = _translate_requests_exception(raised)
+
+    assert isinstance(translated, HTTPClientReadTimeoutError)
+    assert isinstance(translated, requests.exceptions.ConnectionError)
+
+
+def test_compat_bases_do_not_leak_into_the_agnostic_tree():
+    assert not isinstance(_translate_requests_exception(requests.exceptions.HTTPError('500')), HTTPClientRequestError)
+    assert not isinstance(
+        _translate_requests_exception(requests.exceptions.ConnectTimeout('boom')), HTTPClientConnectionError
+    )
+    for agnostic, compat in _COMPAT_EXCEPTIONS.items():
+        assert compat.__bases__[0] is agnostic
+        assert compat.__name__ == agnostic.__name__
+        assert compat.__module__ == agnostic.__module__
+
+
+def test_backend_compat_type_supports_backend_subclassing_agnostic():
+    class BackendSubclass(json.JSONDecodeError):
+        pass
+
+    compat = _backend_compat_type(json.JSONDecodeError, BackendSubclass)
+
+    assert issubclass(compat, json.JSONDecodeError)
+    assert issubclass(compat, BackendSubclass)
+
+
+def requests_exception_types():
+    """Return requests' own RequestException subclasses."""
+    found: dict[str, type] = {}
+    pending = [requests.exceptions.RequestException]
+    while pending:
+        exc_type = pending.pop()
+        if exc_type.__module__.split('.')[0] != 'requests':
+            continue
+        found[exc_type.__name__] = exc_type
+        pending.extend(exc_type.__subclasses__())
+
+    return sorted(found.values(), key=lambda exc_type: exc_type.__name__)
+
+
+@pytest.mark.parametrize('exc_type', requests_exception_types(), ids=lambda exc_type: exc_type.__name__)
+def test_every_requests_exception_lands_under_a_handled_agnostic_type(exc_type):
+    translated = _translate_requests_exception(exc_type.__new__(exc_type))
+
+    assert isinstance(translated, (HTTPClientRequestError, HTTPClientStatusError))
+
+
+def test_a_non_requests_failure_reaches_the_caller_untranslated():
+    transport = common.RequestsTransport()
+    transport.raise_exception(RuntimeError('not a requests failure'))
+    http = common.create_requests_client(transport)
+
+    with pytest.raises(RuntimeError, match='not a requests failure'):
+        http.get('http://example.test/')
+
+
+def test_translate_does_not_leak_raw_response():
+    err = requests.exceptions.HTTPError('500 Server Error')
+    err.response = object()
+    result = _translate_requests_exception(err)
+    assert isinstance(result, HTTPClientStatusError)
+    assert result.response is None
+
+
+def test_translate_converts_raw_request_to_agnostic_snapshot():
+    request = requests.Request('GET', 'https://example.test/resource', headers={'X-Test-Header': 'original'}).prepare()
+    err = requests.exceptions.HTTPError('500 Server Error', request=request)
+
+    result = _translate_requests_exception(err)
+
+    assert not isinstance(result.request, (requests.Request, requests.PreparedRequest))
+    assert result.request.method == 'GET'
+    assert result.request.url == 'https://example.test/resource'
+    assert result.request.headers == {'X-Test-Header': 'original'}
+    assert result.request.headers['x-test-header'] == 'original'
+
+    request.headers['X-Test-Header'] = 'changed'
+    assert result.request.headers == {'X-Test-Header': 'original'}
+
+
+@pytest.mark.parametrize(
+    'raised, expected',
+    [
+        pytest.param(requests.exceptions.ConnectionError('dropped'), HTTPClientConnectionError, id='connection-error'),
+        pytest.param(requests.exceptions.ReadTimeout('slow'), HTTPClientReadTimeoutError, id='read-timeout'),
+    ],
+)
+@pytest.mark.parametrize('iter_method', ['iter_content', 'iter_lines'])
+def test_stream_seam_maps_mid_stream_exceptions(raised, expected, iter_method):
+    transport = common.RequestsTransport()
+    transport.respond(stream_error=raised)
+    http = common.create_requests_client(transport)
+    wrapped = http.get('http://example.test/', stream=True)
+
+    with pytest.raises(expected):
+        list(getattr(wrapped, iter_method)())
+
+
+def test_response_adapter_maps_requests_wrapped_mid_stream_read_timeout() -> None:
+    transport = common.RequestsTransport()
+    transport.respond(
+        headers={'Content-Type': 'text/plain; charset=utf-8'},
+        content_chunks=(b'first\n',),
+        stream_error=ReadTimeoutError(None, None, 'slow'),
+    )
+    http = common.create_requests_client(transport)
+    response = http.get('http://example.test/', stream=True)
+    stream = response.iter_lines(decode_unicode=True)
+
+    assert next(stream) == 'first'
+    with pytest.raises(HTTPClientReadTimeoutError, match='slow'):
+        next(stream)
+
+
+@pytest.mark.parametrize(
+    'read',
+    [
+        pytest.param(lambda r: r.content, id='content'),
+        pytest.param(lambda r: r.text, id='text'),
+        pytest.param(lambda r: r.json(), id='json'),
+    ],
+)
+def test_buffered_seam_maps_exceptions(read):
+    transport = common.RequestsTransport()
+    transport.respond(stream_error=requests.exceptions.ConnectionError('dropped'))
+    http = common.create_requests_client(transport)
+    wrapped = http.get('http://example.test/', stream=True)
+
+    with pytest.raises(HTTPClientConnectionError):
+        read(wrapped)
+
+
+def test_json_parse_error_converges_to_stdlib():
+    transport = common.RequestsTransport()
+    transport.respond(content=b'not json')
+    http = common.create_requests_client(transport)
+    wrapped = http.get('http://example.test/')
+
+    with pytest.raises(json.JSONDecodeError) as exc_info:
+        wrapped.json()
+
+    assert exc_info.value.msg == 'Expecting value'
+    assert exc_info.value.doc == 'not json'
+    assert exc_info.value.pos == 0
+
+
+def test_json_parse_error_keeps_matching_requests_arms():
+    transport = common.RequestsTransport()
+    transport.respond(content=b'not json')
+    http = common.create_requests_client(transport)
+    wrapped = http.get('http://example.test/')
+
+    with pytest.raises(requests.exceptions.JSONDecodeError):
+        wrapped.json()
+
+
+def test_auth_token_fetch_error_maps_to_agnostic():
+    http = RequestsWrapper({}, {})
+    http.auth_token_handler = mock.MagicMock()
+    http.auth_token_handler.poll.side_effect = requests.exceptions.ConnectionError('token endpoint refused')
+    with pytest.raises(HTTPClientConnectionError):
+        http.get('http://example.test/')
+
+
+def test_direct_iteration_maps_mid_stream_exceptions():
+    transport = common.RequestsTransport()
+    transport.respond(
+        content_chunks=(b'first',),
+        stream_error=requests.exceptions.ConnectionError('dropped'),
+    )
+    http = common.create_requests_client(transport)
+    wrapped = http.get('http://example.test/', stream=True)
+
+    with pytest.raises(HTTPClientConnectionError):
+        list(wrapped)

--- a/datadog_checks_base/tests/base/utils/http/test_headers.py
+++ b/datadog_checks_base/tests/base/utils/http/test_headers.py
@@ -9,7 +9,7 @@ import pytest
 from datadog_checks.base.utils.headers import headers as agent_headers
 from datadog_checks.base.utils.http import RequestsWrapper
 
-from .common import DEFAULT_OPTIONS
+from .common import DEFAULT_OPTIONS, get_wire_headers
 
 pytestmark = [pytest.mark.unit]
 
@@ -68,6 +68,49 @@ def test_config_extra_headers_string_values():
     assert http.options['headers'] == complete_headers
 
 
+def test_config_extra_headers_non_canonical_case_takes_precedence_over_the_seeded_default():
+    instance = {'extra_headers': {'accept': 'application/openmetrics-text'}}
+    init_config = {}
+    http = RequestsWrapper(instance, init_config)
+
+    assert http.get_header('Accept') == 'application/openmetrics-text'
+
+
+def test_config_extra_headers_override_config_headers_across_case():
+    instance = {'headers': {'x-token': 'from-headers'}, 'extra_headers': {'X-Token': 'from-extra-headers'}}
+    init_config = {}
+    http = RequestsWrapper(instance, init_config)
+
+    assert http.get_header('X-Token') == 'from-extra-headers'
+
+
+def test_get_header_reports_the_value_that_reaches_the_wire():
+    http = RequestsWrapper({'extra_headers': {'accept': 'application/openmetrics-text'}}, {})
+
+    with mock.patch('requests.Session.get') as get:
+        http.get('http://example.com/hello')
+
+    assert get.call_args.kwargs['headers']['accept'] == http.get_header('Accept')
+
+
+def test_config_headers_keep_every_configured_spelling():
+    # HostHeaderSSLAdapter detects the exact configured spelling.
+    instance = {'headers': {'host': 'first'}, 'extra_headers': {'Host': 'second'}, 'tls_use_host_header': True}
+    init_config = {}
+    http = RequestsWrapper(instance, init_config)
+
+    assert http.options['headers'] == {'host': 'first', 'Host': 'second'}
+    assert http.tls_use_host_header is True
+
+
+def test_tls_use_host_header_sees_a_canonically_spelled_host_header():
+    instance = {'headers': {'Host': 'example.com'}, 'tls_use_host_header': True}
+    init_config = {}
+    http = RequestsWrapper(instance, init_config)
+
+    assert http.tls_use_host_header is True
+
+
 def test_extra_headers_on_http_method_call():
     instance = {'extra_headers': {'answer': 42}}
     init_config = {}
@@ -97,3 +140,68 @@ def test_extra_headers_on_http_method_call():
     # make sure the original headers are not modified
     assert http.options['headers'] == complete_headers
     assert extra_headers == {"foo": "bar"}
+
+
+def test_request_headers_override_defaults_before_extra_headers():
+    http = RequestsWrapper({'headers': {'X-Default': 'default', 'X-Precedence': 'default'}}, {})
+
+    wire_headers = get_wire_headers(
+        http,
+        headers={'X-Request': 'request', 'X-Precedence': 'request'},
+        extra_headers={'X-Extra': 'extra', 'X-Precedence': 'extra'},
+    )
+
+    assert wire_headers['X-Request'] == 'request'
+    assert wire_headers['X-Extra'] == 'extra'
+    assert wire_headers['X-Precedence'] == 'extra'
+    assert wire_headers['X-Default'] == 'default'
+
+
+def test_a_per_request_mapping_keeps_the_configured_headers():
+    http = RequestsWrapper({'extra_headers': {'X-Configured': 'configured'}}, {})
+
+    wire_headers = get_wire_headers(http, headers={'Cookie': 'APIC-cookie=token'})
+
+    assert wire_headers['Cookie'] == 'APIC-cookie=token'
+    assert wire_headers['User-Agent'] == 'Datadog Agent/0.0.0'
+    assert wire_headers['X-Configured'] == 'configured'
+
+
+def test_get_header_default_for_missing():
+    http = RequestsWrapper({}, {})
+    assert http.get_header('X-Missing') is None
+    assert http.get_header('X-Missing', 'fallback') == 'fallback'
+
+
+def test_get_header_case_insensitive():
+    http = RequestsWrapper({}, {})
+    assert http.get_header('accept') == '*/*'
+    assert http.get_header('Accept') == '*/*'
+    assert http.get_header('ACCEPT') == '*/*'
+
+
+def test_set_header():
+    http = RequestsWrapper({}, {})
+    http.set_header('X-Token', 'abc123')
+    assert http.get_header('X-Token') == 'abc123'
+    http.set_header('Accept', 'application/json')
+    assert http.get_header('Accept') == 'application/json'
+
+
+def test_set_header_case_insensitive():
+    http = RequestsWrapper({}, {})
+    http.set_header('accept', 'application/json')
+    assert http.get_header('Accept') == 'application/json'
+    assert sum(1 for k in http.options['headers'] if k.lower() == 'accept') == 1
+
+
+def test_set_header_collapses_case_insensitive_duplicates():
+    http = RequestsWrapper({}, {})
+    http.options['headers'] = OrderedDict(
+        (('x-vault-token', 'configured-lower'), ('X-Vault-Token', 'configured-canonical'))
+    )
+
+    http.set_header('X-Vault-Token', 'runtime-token')
+
+    assert http.get_header('X-Vault-Token') == 'runtime-token'
+    assert sum(1 for key in http.options['headers'] if key.lower() == 'x-vault-token') == 1

--- a/datadog_checks_base/tests/base/utils/http/test_http.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http.py
@@ -15,6 +15,7 @@ import requests_unixsocket
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.http import RequestsWrapper, is_uds_url, quote_uds_url
+from datadog_checks.base.utils.http_exceptions import HTTPClientSSLError, HTTPClientTimeoutError
 from datadog_checks.dev.utils import ON_WINDOWS
 
 
@@ -90,6 +91,56 @@ class TestAttribute:
         assert check.http == check._http
         assert isinstance(check.http, RequestsWrapper)
 
+    def test_factory_default_returns_requests_wrapper(self):
+        check = AgentCheck('test', {}, [{}])
+
+        assert isinstance(check.create_http_client(), RequestsWrapper)
+
+    def test_factory_override_swaps_client(self):
+        sentinel = object()
+
+        class CustomCheck(AgentCheck):
+            def create_http_client(self, instance=None):
+                return sentinel
+
+        check = CustomCheck('test', {}, [{}])
+        assert check.http is sentinel
+
+    def test_factory_default_uses_instance_config(self):
+        check = AgentCheck('test', {}, [{'timeout': 7}])
+
+        assert check.create_http_client().options['timeout'] == (7.0, 7.0)
+
+    def test_factory_instance_override(self):
+        check = AgentCheck('test', {}, [{'timeout': 7}])
+
+        client = check.create_http_client({'timeout': 42})
+
+        assert client.options['timeout'] == (42.0, 42.0)
+
+    def test_factory_empty_instance_override_is_honored(self):
+        from datadog_checks.base.utils.http import create_http_client
+
+        check = AgentCheck('test', {}, [{'timeout': 7}])
+
+        # {} is an explicit override, distinct from None, so self.instance's timeout must not leak in.
+        empty_default = create_http_client({}, {}).options['timeout']
+        assert check.create_http_client({}).options['timeout'] == empty_default
+
+    def test_module_factory_builds_from_given_config(self):
+        from datadog_checks.base.utils.http import create_http_client
+
+        client = create_http_client({'timeout': 24.5}, {})
+
+        assert client.options['timeout'] == (24.5, 24.5)
+
+    def test_module_factory_applies_remapper(self):
+        from datadog_checks.base.utils.http import create_http_client
+
+        client = create_http_client({'prometheus_timeout': 9}, {}, {'prometheus_timeout': {'name': 'timeout'}})
+
+        assert client.options['timeout'] == (9, 9)
+
 
 class TestTLSCiphers:
     @pytest.mark.parametrize(
@@ -151,7 +202,7 @@ class TestTLSCiphers:
         init_config = {}
         http = RequestsWrapper(instance, init_config)
         assert http.session.verify == cert_path  # The session attribute instantiates the SSLContext
-        with pytest.raises(requests.exceptions.SSLError):
+        with pytest.raises(HTTPClientSSLError):
             http.get(url)
 
     def test_http_failure_with_ssl_defaults(self, openssl_https_server):
@@ -168,7 +219,7 @@ class TestTLSCiphers:
         # Mock SSL set_ciphers to disable it and use the default ciphers
         with mock.patch.object(ssl.SSLContext, 'set_ciphers'):
             http = RequestsWrapper(instance, init_config)
-            with pytest.raises(requests.exceptions.SSLError):
+            with pytest.raises(HTTPClientSSLError):
                 http.get(url)
 
 
@@ -263,21 +314,13 @@ class TestSession:
             assert getattr(http.session, key) == value
 
     def test_timeout(self):
-        """
-        Respect the request timeout.
-
-        Here we test two things:
-        - We pass the timemout option correctly to the requests library.
-        - We let the requests.exceptions.Timeout bubble up from the requests library.
-
-        We trust requests to respect the timeout so we mock its response.
-        """
+        """Forward the configured timeout and translate backend timeout errors."""
 
         mock_session = mock.create_autospec(requests.Session)
         mock_session.get.side_effect = requests.exceptions.Timeout()
         http = RequestsWrapper({'persist_connections': True}, {'timeout': 0.08}, session=mock_session)
 
-        with pytest.raises(requests.exceptions.Timeout):
+        with pytest.raises(HTTPClientTimeoutError):
             http.get('https://foobar.com')
 
         assert 'timeout' in mock_session.get.call_args.kwargs, mock_session.get.call_args.kwargs

--- a/datadog_checks_base/tests/base/utils/http/test_http_testing.py
+++ b/datadog_checks_base/tests/base/utils/http/test_http_testing.py
@@ -1,0 +1,179 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+import requests
+
+from datadog_checks.base import AgentCheck
+from datadog_checks.base.checks.openmetrics.mixins import OpenMetricsScraperMixin
+from datadog_checks.base.checks.prometheus.mixins import PrometheusScraperMixin
+from datadog_checks.base.stubs.http import FakeHTTPClient, FakeHTTPResponse, RecordedRequest
+from datadog_checks.dev import http as http_testing
+
+
+class OpenMetricsFixtureCheck(OpenMetricsScraperMixin, AgentCheck):
+    pass
+
+
+class PrometheusFixtureCheck(PrometheusScraperMixin, AgentCheck):
+    pass
+
+
+def test_fake_http_patches_explicit_agentcheck_client(fake_http):
+    check = AgentCheck('test', {}, [{}])
+    assert check.create_http_client({'url': 'https://example.test'}) is fake_http
+
+
+def test_http_module_reexports_base_fakes():
+    assert http_testing.FakeHTTPClient is FakeHTTPClient
+    assert http_testing.FakeHTTPResponse is FakeHTTPResponse
+    assert http_testing.MockHTTPResponse is FakeHTTPResponse
+    assert http_testing.RecordedRequest is RecordedRequest
+
+
+def test_fake_http_installs_registered_response_and_records_request(fake_http):
+    url = 'https://example.test/items'
+    response = FakeHTTPResponse(json_result={'items': []})
+    fake_http.register_response('GET', url, response)
+    check = AgentCheck('test', {}, [{}])
+
+    assert check.http.get(url, stream=True) is response
+    fake_http.assert_requests([RecordedRequest(method='GET', url=url, options={'stream': True})])
+    fake_http.assert_all_responses_consumed()
+
+
+def test_fake_openmetrics_http_routes_send_request(fake_openmetrics_http):
+    url = 'https://example.test/metrics'
+    response = FakeHTTPResponse(text='metric 1')
+    headers = {'Authorization': 'Bearer token'}
+    fake_openmetrics_http.register_response('GET', url, response)
+    check = OpenMetricsFixtureCheck('test', {}, [{}])
+
+    result = check.send_request(url, {'prometheus_url': url}, headers=headers)
+
+    assert result is response
+    fake_openmetrics_http.assert_requests(
+        [RecordedRequest(method='GET', url=url, options={'headers': headers, 'stream': True})]
+    )
+    fake_openmetrics_http.assert_all_responses_consumed()
+
+
+def test_fake_prometheus_http_routes_poll(fake_prometheus_http):
+    url = 'https://example.test/metrics'
+    response = FakeHTTPResponse(text='metric 1')
+    fake_prometheus_http.register_response('GET', url, response)
+    check = PrometheusFixtureCheck('test', {}, [{}])
+
+    result = check.poll(url, headers={'X-Test': 'value'})
+
+    assert result is response
+    fake_prometheus_http.assert_requests(
+        [
+            RecordedRequest(
+                method='GET',
+                url=url,
+                options={
+                    'extra_headers': {
+                        'X-Test': 'value',
+                        'Accept-Encoding': 'gzip',
+                        'accept': (
+                            'application/vnd.google.protobuf; '
+                            'proto=io.prometheus.client.MetricFamily; encoding=delimited'
+                        ),
+                    },
+                    'stream': False,
+                },
+            )
+        ]
+    )
+    fake_prometheus_http.assert_all_responses_consumed()
+
+
+def test_legacy_mock_response_is_a_requests_response_without_loading_base_fakes(mocker):
+    real_import_module = http_testing.importlib.import_module
+
+    def import_legacy(name):
+        if name == 'datadog_checks.base.stubs.http':
+            raise AssertionError('legacy compatibility must not load the base HTTP fakes')
+        return real_import_module(name)
+
+    mocker.patch.object(http_testing.importlib, 'import_module', side_effect=import_legacy)
+    with pytest.warns(DeprecationWarning, match='FakeHTTPResponse'):
+        legacy = http_testing.MockResponse
+
+    assert issubclass(legacy, requests.Response)
+
+
+def test_legacy_mock_response_raises_on_the_requests_exception_tree():
+    with pytest.warns(DeprecationWarning):
+        legacy = http_testing.MockResponse
+
+    with pytest.raises(requests.HTTPError):
+        legacy(json_data={'message': 'Session expired.'}, status_code=401).raise_for_status()
+
+
+def test_legacy_mock_response_reads_json_and_headers():
+    with pytest.warns(DeprecationWarning):
+        legacy = http_testing.MockResponse
+
+    response = legacy(json_data={'key': 'value'}, headers={'X-Custom': 'value'}, status_code=200)
+
+    assert response.json() == {'key': 'value'}
+    assert response.headers['x-custom'] == 'value'
+    assert response.status_code == 200
+
+
+def test_legacy_mock_response_reads_a_file(tmp_path):
+    path = tmp_path / 'payload.json'
+    path.write_text('{"key": "value"}')
+
+    with pytest.warns(DeprecationWarning):
+        legacy = http_testing.MockResponse
+
+    assert legacy(file_path=str(path)).json() == {'key': 'value'}
+
+
+def test_mock_response_fixture_builds_requests_response(tmp_path, mock_response):
+    path = tmp_path / 'payload.txt'
+    path.write_bytes(b'line one\nline two')
+
+    response = mock_response(file_path=str(path), headers={'X-Test': 'value'})
+
+    assert isinstance(response, requests.Response)
+    assert response.content == b'line one\nline two'
+    assert list(response.iter_lines()) == [b'line one', b'line two']
+    assert response.headers['x-test'] == 'value'
+
+
+def test_mock_response_fixture_preserves_requests_status_errors(mock_response):
+    response = mock_response(json_data={'error': 'unavailable'}, status_code=503)
+
+    assert response.json() == {'error': 'unavailable'}
+    with pytest.raises(requests.HTTPError, match='503 Server Error') as exc_info:
+        response.raise_for_status()
+    assert exc_info.value.response is response
+
+
+def test_mock_http_response_preserves_requests_responses(mock_http_response):
+    url = 'https://example.test/items'
+    mock_http_response(content='payload')
+
+    response = requests.Session().get(url)
+
+    assert isinstance(response, requests.Response)
+    assert response.text == 'payload'
+
+
+def test_mock_http_response_per_endpoint_preserves_requests_responses(mock_http_response_per_endpoint, mock_response):
+    url = 'https://example.test/items'
+    response = mock_response()
+    mock_http_response_per_endpoint({url: [response]}, mode='exhaust')
+
+    assert isinstance(response, requests.Response)
+    assert requests.Session().get(url) is response
+
+
+def test_unknown_module_attribute_still_raises():
+    absent = 'MockNonsense'
+    with pytest.raises(AttributeError, match=absent):
+        getattr(http_testing, absent)

--- a/datadog_checks_base/tests/base/utils/http/test_kerberos_unit.py
+++ b/datadog_checks_base/tests/base/utils/http/test_kerberos_unit.py
@@ -8,9 +8,9 @@ import pytest
 import requests_kerberos
 
 from datadog_checks.base import ConfigurationError
+from datadog_checks.base.stubs.http import FakeHTTPResponse
 from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.dev import EnvVars
-from datadog_checks.dev.http import MockResponse
 
 pytestmark = [pytest.mark.unit]
 
@@ -115,7 +115,7 @@ def test_config_kerberos_keytab_file():
 
     with mock.patch(
         'requests.Session.get',
-        side_effect=lambda *args, **kwargs: MockResponse(os.environ.get('KRB5_CLIENT_KTNAME', '')),
+        side_effect=lambda *args, **kwargs: FakeHTTPResponse(text=os.environ.get('KRB5_CLIENT_KTNAME', '')),
     ):
         response = http.get('https://www.google.com')
         assert response.text == '/test/file'
@@ -132,7 +132,8 @@ def test_config_kerberos_cache():
     assert os.environ.get('KRB5CCNAME') is None
 
     with mock.patch(
-        'requests.Session.get', side_effect=lambda *args, **kwargs: MockResponse(os.environ.get('KRB5CCNAME', ''))
+        'requests.Session.get',
+        side_effect=lambda *args, **kwargs: FakeHTTPResponse(text=os.environ.get('KRB5CCNAME', '')),
     ):
         response = http.get('https://www.google.com')
         assert response.text == '/test/file'
@@ -148,7 +149,8 @@ def test_config_kerberos_cache_restores_rollback():
 
     with EnvVars({'KRB5CCNAME': 'old'}):
         with mock.patch(
-            'requests.Session.get', side_effect=lambda *args, **kwargs: MockResponse(os.environ.get('KRB5CCNAME', ''))
+            'requests.Session.get',
+            side_effect=lambda *args, **kwargs: FakeHTTPResponse(text=os.environ.get('KRB5CCNAME', '')),
         ):
             response = http.get('https://www.google.com')
             assert response.text == '/test/file'
@@ -167,7 +169,7 @@ def test_config_kerberos_keytab_file_rollback():
 
         with mock.patch(
             'requests.Session.get',
-            side_effect=lambda *args, **kwargs: MockResponse(os.environ.get('KRB5_CLIENT_KTNAME', '')),
+            side_effect=lambda *args, **kwargs: FakeHTTPResponse(text=os.environ.get('KRB5_CLIENT_KTNAME', '')),
         ):
             response = http.get('https://www.google.com')
             assert response.text == '/test/file'

--- a/datadog_checks_base/tests/base/utils/http/test_legacy_options.py
+++ b/datadog_checks_base/tests/base/utils/http/test_legacy_options.py
@@ -1,0 +1,114 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Pin the public ``HTTPClient.options`` compatibility surface."""
+
+import mock
+import pytest
+
+from datadog_checks.base.stubs.http import FakeHTTPClient
+from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.http_protocol import HTTPClient
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestLegacyOptionsSurface:
+    def test_options_is_a_plain_mutable_dict(self):
+        http = RequestsWrapper({}, {})
+        assert isinstance(http.options, dict)
+
+    def test_protocol_declares_options(self):
+        assert 'options' in HTTPClient.__annotations__
+
+    def test_wholesale_header_replacement(self):
+        http = RequestsWrapper({}, {})
+        http.options['headers'] = {'Authorization': 'api-key'}
+        assert http.options['headers'] == {'Authorization': 'api-key'}
+
+    def test_replaced_headers_are_visible_through_get_header(self):
+        http = RequestsWrapper({}, {})
+        http.options['headers'] = {'Authorization': 'api-key'}
+        assert http.get_header('authorization') == 'api-key'
+
+    def test_connect_timeout_read_by_index(self):
+        http = RequestsWrapper({'connect_timeout': 4, 'read_timeout': 9}, {})
+        assert http.options['timeout'] == (4, 9)
+        assert http.options['timeout'][0] == 4
+
+    def test_update_clears_configured_auth(self):
+        http = RequestsWrapper({'username': 'user', 'password': 'pass'}, {})
+        assert http.options['auth'] == ('user', 'pass')
+        http.options.update({'auth': None})
+        assert http.options['auth'] is None
+
+    def test_nested_header_assignment(self):
+        http = RequestsWrapper({}, {})
+        http.options['headers']['Authorization'] = 'token'
+        assert http.get_header('Authorization') == 'token'
+
+    def test_update_applies_proxies_and_verify(self):
+        http = RequestsWrapper({}, {})
+        http.options.update({'proxies': {'https': 'http://proxy:3128'}, 'verify': False})
+        assert http.options['proxies'] == {'https': 'http://proxy:3128'}
+        assert http.options['verify'] is False
+
+    def test_set_header_writes_through_to_options(self):
+        http = RequestsWrapper({}, {})
+        http.set_header('X-Token', 'abc')
+        assert http.options['headers']['X-Token'] == 'abc'
+
+    def test_tls_config_is_a_mapping_of_tls_fields(self):
+        http = RequestsWrapper({'tls_ca_cert': '/tmp/ca.pem'}, {})
+        assert isinstance(http.tls_config, dict)
+        assert http.tls_config['tls_ca_cert'] == '/tmp/ca.pem'
+
+
+class TestOptionsReachTheWire:
+    """Verify post-construction options writes affect requests."""
+
+    def test_replaced_timeout_reaches_the_request(self):
+        http = RequestsWrapper({'connect_timeout': 4, 'read_timeout': 9}, {})
+        http.options['timeout'] = (1, 2)
+
+        with mock.patch('requests.Session.get') as get:
+            http.get('https://www.example.com')
+
+        assert get.call_args.kwargs['timeout'] == (1, 2)
+
+    def test_nested_header_write_reaches_the_request(self):
+        http = RequestsWrapper({}, {})
+        http.options['headers']['X-Auth-Token'] = 'token'
+
+        with mock.patch('requests.Session.get') as get:
+            http.get('https://www.example.com')
+
+        assert get.call_args.kwargs['headers']['X-Auth-Token'] == 'token'
+
+    def test_updated_verify_reaches_the_request(self):
+        http = RequestsWrapper({}, {})
+        http.options.update({'verify': False})
+
+        with mock.patch('requests.Session.get') as get:
+            http.get('https://www.example.com')
+
+        assert get.call_args.kwargs['verify'] is False
+
+
+class TestFakeHttpLegacyOptions:
+    def test_header_views_share_storage(self):
+        http = FakeHTTPClient()
+        http.options['headers']['X-Token'] = 'abc'
+        assert http.get_header('x-token') == 'abc'
+
+        http.set_header('X-Other', 'def')
+        assert http.options['headers']['X-Other'] == 'def'
+
+    def test_set_header_collapses_duplicate_spellings(self):
+        http = FakeHTTPClient()
+        http.options['headers'].update({'x-vault-token': 'stale', 'X-Vault-Token': 'canon'})
+
+        http.set_header('X-Vault-Token', 'fresh')
+
+        assert http.get_header('X-Vault-Token') == 'fresh'
+        assert sum(1 for key in http.options['headers'] if key.lower() == 'x-vault-token') == 1

--- a/datadog_checks_base/tests/base/utils/http/test_socks5_proxy_integration.py
+++ b/datadog_checks_base/tests/base/utils/http/test_socks5_proxy_integration.py
@@ -2,9 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
-from requests.exceptions import ConnectTimeout, ProxyError
 
 from datadog_checks.base.utils.http import RequestsWrapper
+from datadog_checks.base.utils.http_exceptions import HTTPClientConnectionError, HTTPClientConnectTimeoutError
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.dev.ci import running_on_ci, running_on_windows_ci
 
@@ -61,18 +61,18 @@ def test_no_proxy_domain_fail(socks5_proxy):
 
     # no_proxy not match: .google.com
     # ".y.com" matches "x.y.com" but not "y.com"
-    with pytest.raises((ConnectTimeout, ProxyError)):
+    with pytest.raises((HTTPClientConnectTimeoutError, HTTPClientConnectionError)):
         http.get('http://google.com', timeout=1)
 
     # no_proxy not match: example or example.com
-    with pytest.raises((ConnectTimeout, ProxyError)):
+    with pytest.raises((HTTPClientConnectTimeoutError, HTTPClientConnectionError)):
         http.get('http://notexample.com', timeout=1)
 
-    with pytest.raises((ConnectTimeout, ProxyError)):
+    with pytest.raises((HTTPClientConnectTimeoutError, HTTPClientConnectionError)):
         http.get('http://example.org', timeout=1)
 
     # no_proxy not match: 9
-    with pytest.raises((ConnectTimeout, ProxyError)):
+    with pytest.raises((HTTPClientConnectTimeoutError, HTTPClientConnectionError)):
         http.get('http://127.0.0.99', timeout=1)
 
 
@@ -117,24 +117,24 @@ def test_no_proxy_ip_fail(socks5_proxy):
     http = RequestsWrapper(instance, init_config)
 
     # no_proxy not match: 127.0.0.1
-    with pytest.raises((ConnectTimeout, ProxyError)):
+    with pytest.raises((HTTPClientConnectTimeoutError, HTTPClientConnectionError)):
         http.get('http://127.0.0.11', timeout=1)
 
     # no_proxy not match: 127.0.0.2/32
-    with pytest.raises((ConnectTimeout, ProxyError)):
+    with pytest.raises((HTTPClientConnectTimeoutError, HTTPClientConnectionError)):
         http.get('http://127.0.0.22', timeout=1)
 
     # no_proxy not match: IP outside 127.1.0.0/25 subnet - cidr bits format
-    with pytest.raises((ConnectTimeout, ProxyError)):
+    with pytest.raises((HTTPClientConnectTimeoutError, HTTPClientConnectionError)):
         http.get('http://127.1.0.150', timeout=1)
         http.get('http://127.1.0.200', timeout=1)
 
     # no_proxy not match: IP outside 127.1.1.0/255.255.255.128 subnet - net mask format
-    with pytest.raises((ConnectTimeout, ProxyError)):
+    with pytest.raises((HTTPClientConnectTimeoutError, HTTPClientConnectionError)):
         http.get('http://127.1.1.150', timeout=1)
         http.get('http://127.1.1.200', timeout=1)
 
     # no_proxy not match: IP outside 127.1.2.0/0.0.0.127 subnet - host mask format
-    with pytest.raises((ConnectTimeout, ProxyError)):
+    with pytest.raises((HTTPClientConnectTimeoutError, HTTPClientConnectionError)):
         http.get('http://127.1.2.150', timeout=1)
         http.get('http://127.1.2.200', timeout=1)

--- a/datadog_checks_base/tests/base/utils/http/test_tls_and_certs.py
+++ b/datadog_checks_base/tests/base/utils/http/test_tls_and_certs.py
@@ -7,13 +7,17 @@ import ssl
 
 import mock
 import pytest
+import requests
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import AuthorityInformationAccessOID, NameOID
 from requests.exceptions import SSLError
 
+from datadog_checks.base.utils import _http_utils
 from datadog_checks.base.utils.http import RequestsWrapper, load_x509_certificates
+from datadog_checks.base.utils.http_exceptions import HTTPClientSSLError
+from datadog_checks.base.utils.requests_adapter import apply_tls
 from datadog_checks.base.utils.tls import TlsConfig
 from datadog_checks.dev.utils import ON_WINDOWS
 
@@ -126,6 +130,15 @@ class TestCert:
 
             mock_load_cert_chain.assert_called_once()
             mock_load_cert_chain.assert_called_with(expected_cert, keyfile=expected_key, password=None)
+
+    def test_missing_ca_cert_file_is_reported(self, tmp_path, caplog):
+        missing_ca_cert = str(tmp_path / 'unexisting.crt')
+        http = RequestsWrapper({'tls_ca_cert': missing_ca_cert}, {})
+
+        with mock.patch('requests.Session.get'), caplog.at_level(logging.WARNING):
+            http.get('https://example.com')
+
+        assert 'TLS CA certificate file not found: {}'.format(missing_ca_cert) in caplog.text
 
     @pytest.mark.skipif(ON_WINDOWS, reason="Windows uses the default store locations.")
     def test_bad_default_verify_paths_and_fallback_to_certifi(self, monkeypatch, caplog):
@@ -344,7 +357,7 @@ class TestAIAChasing:
 
         with mock.patch('datadog_checks.base.utils.http.create_socket_connection') as mock_create_socket_connection:
             with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.handle_auth_token'):
-                with pytest.raises(SSLError):
+                with pytest.raises(HTTPClientSSLError):
                     with mock.patch('requests.Session.get', side_effect=SSLError):
                         http.get('https://localhost:{}'.format(port))
 
@@ -507,10 +520,10 @@ class TestSSLContext:
 
 class TestSSLContextAdapter:
     def test_adapter_caching(self):
-        """_SSLContextAdapter should be recovered from cache when possible."""
+        """SSLContextAdapter should be recovered from cache when possible."""
 
         with mock.patch('requests.Session.get'):
-            with mock.patch('datadog_checks.base.utils.http.create_ssl_context') as mock_create_ssl_context:
+            with mock.patch('datadog_checks.base.utils.requests_adapter.create_ssl_context') as mock_create_ssl_context:
                 http = RequestsWrapper({'persist_connections': True, 'tls_verify': True}, {})
                 # Verify that the adapter is created and cached
                 default_config_key = TlsConfig(**http.tls_config)
@@ -526,10 +539,10 @@ class TestSSLContextAdapter:
                 mock_create_ssl_context.assert_called_once_with(http.tls_config)
 
     def test_adapter_caching_new_adapter(self):
-        """A new _SSLContextAdapter should be created when a new TLS config is requested."""
+        """A new SSLContextAdapter should be created when a new TLS config is requested."""
 
         with mock.patch('requests.Session.get'):
-            with mock.patch('datadog_checks.base.utils.http.create_ssl_context') as mock_create_ssl_context:
+            with mock.patch('datadog_checks.base.utils.requests_adapter.create_ssl_context') as mock_create_ssl_context:
                 http = RequestsWrapper({'persist_connections': True, 'tls_verify': True}, {})
                 # Verify that the adapter is created and cached for the default TLS config
                 default_config_key = TlsConfig(**http.tls_config)
@@ -552,3 +565,32 @@ class TestSSLContextAdapter:
                 http.get('https://example.com', verify=True)
 
                 assert http._https_adapters == {default_config_key: adapter, new_config_key: new_adapter}
+
+    def test_foreign_session_does_not_share_this_client_adapter(self):
+        """Closing a foreign session must not close this client's adapter."""
+        http = RequestsWrapper({'persist_connections': True, 'tls_verify': True}, {})
+        own_adapter = http.session.get_adapter('https://example.com')
+        foreign_session = requests.Session()
+
+        apply_tls(http, foreign_session)
+
+        foreign_adapter = foreign_session.get_adapter('https://example.com')
+        assert foreign_adapter.ssl_context.verify_mode == ssl.CERT_REQUIRED
+        assert foreign_adapter.ssl_context.check_hostname is True
+
+        own_adapter.poolmanager.connection_from_url('https://example.com')
+        foreign_session.close()
+
+        assert len(own_adapter.poolmanager.pools) == 1
+
+    def test_foreign_session_uses_host_header_tls(self):
+        http = RequestsWrapper(
+            {'headers': {'Host': 'example.com'}, 'tls_use_host_header': True},
+            {},
+        )
+        foreign_session = requests.Session()
+
+        apply_tls(http, foreign_session)
+
+        adapter = foreign_session.get_adapter('https://example.com')
+        assert isinstance(adapter, _http_utils.HostHeaderSSLAdapter)

--- a/datadog_checks_base/tests/stubs/test_http.py
+++ b/datadog_checks_base/tests/stubs/test_http.py
@@ -1,0 +1,152 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datetime import timedelta
+
+import pytest
+
+from datadog_checks.base.stubs.http import FakeHTTPClient, FakeHTTPResponse, RecordedRequest
+from datadog_checks.base.utils.http_exceptions import HTTPClientStatusError, HTTPClientTimeoutError
+
+
+def test_fake_response_returns_only_configured_results():
+    json_result = {'items': []}
+    response = FakeHTTPResponse(
+        status_code=202,
+        content=b'complete body',
+        text='configured text',
+        headers={'X-Test': 'value'},
+        json_result=json_result,
+        content_chunks=(b'complete ', b'body'),
+        lines=('first', 'second'),
+        encoding='utf-8',
+        elapsed=timedelta(seconds=2),
+        cookies={'session': 'abc'},
+        links={'next': {'url': 'https://example.test/items?page=2'}},
+        url='https://example.test/items',
+        reason='Accepted',
+        peer_cert=b'certificate',
+    )
+
+    assert response.json(parse_float=str) is json_result
+    assert list(response.iter_content(chunk_size=1, decode_unicode=True)) == [b'complete ', b'body']
+    assert list(response.iter_lines(chunk_size=1, decode_unicode=True, delimiter='|')) == ['first', 'second']
+    assert list(response) == [b'complete ', b'body']
+    assert response.get_peer_cert(binary_form=True) == b'certificate'
+    assert response.headers['x-test'] == 'value'
+
+
+def test_fake_response_does_not_derive_results_from_content_or_headers():
+    response = FakeHTTPResponse(
+        content=b'{"items": []}\nsecond line',
+        headers={
+            'Content-Type': 'application/json; charset=utf-8',
+            'Link': '<https://example.test/items?page=2>; rel=next',
+        },
+    )
+
+    assert response.text == ''
+    assert response.encoding is None
+    assert response.links == {}
+    assert list(response.iter_content()) == []
+    assert list(response.iter_lines()) == []
+    with pytest.raises(ValueError, match='No JSON result'):
+        response.json()
+
+
+def test_fake_response_raises_configured_json_error():
+    error = ValueError('invalid JSON')
+    response = FakeHTTPResponse(json_error=error)
+
+    with pytest.raises(ValueError) as exc_info:
+        response.json()
+
+    assert exc_info.value is error
+
+
+def test_fake_response_raises_configured_status_error():
+    error = HTTPClientStatusError('503 Service Unavailable')
+    response = FakeHTTPResponse(status_code=503, status_error=error)
+
+    with pytest.raises(HTTPClientStatusError) as exc_info:
+        response.raise_for_status()
+
+    assert exc_info.value is error
+    assert error.response is response
+
+
+def test_fake_client_matches_responses_and_records_requests():
+    client = FakeHTTPClient()
+    page_one = FakeHTTPResponse(status_code=202)
+    page_two = FakeHTTPResponse(status_code=204)
+    url = 'https://example.test/items'
+    client.register_response('GET', url, page_two, match_options={'params': {'page': 2}})
+    client.register_response('GET', url, page_one, match_options={'params': {'page': 1}})
+
+    assert client.get(url, params={'page': 1}) is page_one
+    assert client.get(url, params={'page': 2}) is page_two
+    assert client.requests == [
+        RecordedRequest(method='GET', url=url, options={'params': {'page': 1}}),
+        RecordedRequest(method='GET', url=url, options={'params': {'page': 2}}),
+    ]
+    client.assert_all_responses_consumed()
+
+
+def test_fake_client_returns_registered_responses_in_queue_order():
+    client = FakeHTTPClient()
+    first = FakeHTTPResponse(status_code=202)
+    second = FakeHTTPResponse(status_code=204)
+    url = 'https://example.test/items'
+    client.register_response('GET', url, first)
+    client.register_response('GET', url, second)
+
+    assert client.get(url) is first
+    assert client.get(url) is second
+    client.assert_all_responses_consumed()
+
+
+def test_fake_client_raises_registered_exception():
+    client = FakeHTTPClient()
+    error = HTTPClientTimeoutError('timed out')
+    client.register_response('GET', 'https://example.test/items', error)
+
+    with pytest.raises(HTTPClientTimeoutError) as exc_info:
+        client.get('https://example.test/items')
+
+    assert exc_info.value is error
+    client.assert_all_responses_consumed()
+
+
+def test_fake_client_reads_configured_cookies_and_falls_back_for_missing_names():
+    client = FakeHTTPClient(cookies={'session': 'abc'})
+
+    assert client.get_cookie('session') == 'abc'
+    assert client.get_cookie('missing', 'fallback') == 'fallback'
+
+
+def test_fake_client_reports_unmatched_request_and_pending_responses():
+    client = FakeHTTPClient()
+    client.register_response('POST', 'https://example.test/items', FakeHTTPResponse())
+
+    with pytest.raises(AssertionError, match=r'No registered response matched GET https://example\.test/items'):
+        client.get('https://example.test/items')
+
+    with pytest.raises(AssertionError, match='1 registered response was not consumed'):
+        client.assert_all_responses_consumed()
+
+
+def test_fake_client_request_assertions():
+    client = FakeHTTPClient()
+    url = 'https://example.test/items'
+    client.register_response('PUT', url, FakeHTTPResponse())
+    client.put(url, json={'name': 'widget'})
+    expected = RecordedRequest(method='PUT', url=url, options={'json': {'name': 'widget'}})
+
+    client.assert_requests([expected])
+    client.assert_has_request(expected)
+
+    with pytest.raises(AssertionError, match='Expected recorded requests'):
+        client.assert_requests([])
+
+    with pytest.raises(AssertionError, match='No recorded request matched'):
+        client.assert_has_request(RecordedRequest(method='GET', url=url))

--- a/datadog_checks_dev/changelog.d/25020.added
+++ b/datadog_checks_dev/changelog.d/25020.added
@@ -1,0 +1,1 @@
+Add fixtures backed by the base-owned HTTP fakes for backend-neutral check tests, and deprecate ``MockResponse``.

--- a/datadog_checks_dev/datadog_checks/dev/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/http.py
@@ -1,48 +1,41 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import json
-from io import BytesIO
-from textwrap import dedent
+"""Compatibility re-exports for backend-neutral HTTP test fakes."""
 
-from requests import Response
+import importlib
+import warnings
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    # Runtime imports stay lazy so downstream suites can still use MockResponse with an older base release.
+    from datadog_checks.base.stubs.http import FakeHTTPClient, FakeHTTPResponse, RecordedRequest
+
+    MockHTTPResponse = FakeHTTPResponse
+
+__all__ = ['FakeHTTPClient', 'FakeHTTPResponse', 'MockHTTPResponse', 'RecordedRequest']
+
+BASE_HTTP_REEXPORTS = {
+    'FakeHTTPClient': 'FakeHTTPClient',
+    'FakeHTTPResponse': 'FakeHTTPResponse',
+    'MockHTTPResponse': 'FakeHTTPResponse',
+    'RecordedRequest': 'RecordedRequest',
+}
 
 
-class MockResponse(Response):
-    def __init__(
-        self,
-        content='',
-        file_path=None,
-        json_data=None,
-        status_code=200,
-        headers=None,
-        cookies=None,
-        normalize_content=True,
-    ):
-        super(MockResponse, self).__init__()
+def __getattr__(name: str) -> Any:
+    if target := BASE_HTTP_REEXPORTS.get(name):
+        return getattr(importlib.import_module('datadog_checks.base.stubs.http'), target)
 
-        if file_path is not None:
-            with open(file_path, 'rb') as f:
-                self._content = f.read()
-                self.raw = BytesIO(self._content)
-        elif json_data is not None:
-            self._content = json.dumps(json_data).encode('utf-8')
-            self.raw = BytesIO(self._content)
-        else:
-            # For multi-line string literals
-            if normalize_content and content.startswith('\n'):
-                content = dedent(content[1:])
+    if name == 'MockResponse':
+        legacy = importlib.import_module('datadog_checks.dev.http_legacy').MockResponse
+        warnings.warn(
+            'datadog_checks.dev.http.MockResponse is deprecated and will be removed in a future release. '
+            'Use FakeHTTPResponse from datadog_checks.base.stubs.http once your integration runs against '
+            'a datadog-checks-base release that exposes it.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return legacy
 
-            self._content = content.encode('utf-8')
-            self.raw = BytesIO(self._content)
-
-        # Add new keyword arguments to set as needed
-        self.status_code = status_code
-
-        if headers is not None:
-            self.headers.clear()
-            self.headers.update(headers)
-
-        if cookies is not None:
-            self.cookies.clear()
-            self.cookies.update(cookies)
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/datadog_checks_dev/datadog_checks/dev/http_legacy.py
+++ b/datadog_checks_dev/datadog_checks/dev/http_legacy.py
@@ -1,0 +1,52 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Deprecated requests-backed ``datadog_checks.dev.http.MockResponse``.
+
+Isolated to keep ``requests`` out of ``http`` while downstream repositories test against
+a released base without the agnostic HTTP protocol. Remove after those repositories migrate.
+"""
+
+import json
+from io import BytesIO
+from textwrap import dedent
+
+from requests import Response
+
+
+class MockResponse(Response):
+    def __init__(
+        self,
+        content='',
+        file_path=None,
+        json_data=None,
+        status_code=200,
+        headers=None,
+        cookies=None,
+        normalize_content=True,
+    ):
+        super(MockResponse, self).__init__()
+
+        if file_path is not None:
+            with open(file_path, 'rb') as f:
+                self._content = f.read()
+                self.raw = BytesIO(self._content)
+        elif json_data is not None:
+            self._content = json.dumps(json_data).encode('utf-8')
+            self.raw = BytesIO(self._content)
+        else:
+            if normalize_content and content.startswith('\n'):
+                content = dedent(content[1:])
+
+            self._content = content.encode('utf-8')
+            self.raw = BytesIO(self._content)
+
+        self.status_code = status_code
+
+        if headers is not None:
+            self.headers.clear()
+            self.headers.update(headers)
+
+        if cookies is not None:
+            self.cookies.clear()
+            self.cookies.update(cookies)

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import absolute_import
 
+import importlib
 import json
 import os
 import re
@@ -10,6 +11,7 @@ from base64 import urlsafe_b64encode
 from collections import namedtuple  # Not using dataclasses for Py2 compatibility
 from io import open
 from typing import Any, Dict, List, Literal, Optional, Tuple, overload  # noqa: F401
+from unittest.mock import PropertyMock
 
 import pytest
 
@@ -34,6 +36,8 @@ from datadog_checks.dev._env import (
 __aggregator = None
 __datadog_agent = None
 MockResponse = None
+
+_DEFAULT_MOCK_METHOD = 'requests.Session.get'
 
 
 @pytest.fixture
@@ -369,10 +373,9 @@ def dd_default_hostname():
 
 @pytest.fixture
 def mock_response():
-    # Lazily import `requests` as it may be costly under certain conditions
     global MockResponse
     if MockResponse is None:
-        from datadog_checks.dev.http import MockResponse
+        MockResponse = importlib.import_module('datadog_checks.dev.http_legacy').MockResponse
 
     yield MockResponse
 
@@ -380,18 +383,50 @@ def mock_response():
 @pytest.fixture
 def mock_http_response(mocker, mock_response):
     yield lambda *args, **kwargs: mocker.patch(
-        kwargs.pop('method', 'requests.Session.get'), return_value=mock_response(*args, **kwargs)
+        kwargs.pop('method', _DEFAULT_MOCK_METHOD), return_value=mock_response(*args, **kwargs)
     )
+
+
+@pytest.fixture
+def fake_http(mocker):
+    """Install a base-owned HTTP fake on checks created by the test."""
+    AgentCheck = importlib.import_module('datadog_checks.base.checks.base').AgentCheck
+    FakeHTTPClient = importlib.import_module('datadog_checks.base.stubs.http').FakeHTTPClient
+    client = FakeHTTPClient()
+
+    mocker.patch.object(AgentCheck, 'http', new_callable=PropertyMock, return_value=client)
+    mocker.patch.object(AgentCheck, 'create_http_client', return_value=client)
+    return client
+
+
+@pytest.fixture
+def fake_openmetrics_http(fake_http, mocker):
+    """Patch the OpenMetrics v1 handler to use the base-owned HTTP fake."""
+    mocker.patch(
+        'datadog_checks.base.checks.openmetrics.mixins.OpenMetricsScraperMixin.get_http_handler',
+        return_value=fake_http,
+    )
+    return fake_http
+
+
+@pytest.fixture
+def fake_prometheus_http(fake_http, mocker):
+    """Patch the legacy Prometheus handler to use the base-owned HTTP fake."""
+    mocker.patch(
+        'datadog_checks.base.checks.prometheus.mixins.PrometheusScraperMixin.get_http_handler',
+        return_value=fake_http,
+    )
+    return fake_http
 
 
 @pytest.fixture
 def mock_http_response_per_endpoint(mocker, mock_response):
     @overload
     def _mock(
-        responses_by_endpoint: Dict[str, list[MockResponse]],
+        responses_by_endpoint: Dict[str, list[Any]],
         *,
         mode: Literal["default"],
-        default_response: MockResponse,
+        default_response: Any,
         method: str = ...,
         url_arg_index: int = ...,
         url_kwarg_name: str = ...,
@@ -399,7 +434,7 @@ def mock_http_response_per_endpoint(mocker, mock_response):
     ): ...
     @overload
     def _mock(
-        responses_by_endpoint: Dict[str, list[MockResponse]],
+        responses_by_endpoint: Dict[str, list[Any]],
         *,
         mode: Literal["cycle", "exhaust"],
         default_response: None = None,
@@ -409,10 +444,10 @@ def mock_http_response_per_endpoint(mocker, mock_response):
         strict: bool = ...,
     ): ...
     def _mock(
-        responses_by_endpoint: Dict[str, list[MockResponse]],
+        responses_by_endpoint: Dict[str, list[Any]],
         mode: Literal['cycle', 'exhaust', 'default'] = 'cycle',
-        default_response: MockResponse | None = None,
-        method: str = 'requests.Session.get',
+        default_response: Any = None,
+        method: str = _DEFAULT_MOCK_METHOD,
         url_arg_index: int = 1,
         url_kwarg_name: str = "url",
         strict: bool = True,
@@ -447,7 +482,7 @@ def mock_http_response_per_endpoint(mocker, mock_response):
                 if strict:
                     raise ValueError(f"Endpoint {url} not found in mocked responses")
                 else:
-                    return MockResponse(status_code=404)
+                    return mock_response(status_code=404)
             else:
                 try:
                     return next(queues[url])

--- a/docs/developer/base/http.md
+++ b/docs/developer/base/http.md
@@ -2,8 +2,10 @@
 
 -----
 
-Whenever you need to make HTTP requests, the base class provides a convenience member that has the same interface as the
-popular [requests][requests-github] library and ensures consistent behavior across all integrations.
+Whenever you need to make HTTP requests, the base class provides a convenience member that ensures consistent behavior
+across all integrations. Its request methods and response objects follow the shape of the popular
+[requests][requests-github] library, but the member is defined by its own interface rather than by that library.
+Anything this page does not document is an implementation detail and may change.
 
 The wrapper automatically parses and uses configuration from the `instance`, `init_config`, and Agent config. Also, this
 is only done once during initialization and cached to reduce the overhead of every call.
@@ -14,7 +16,8 @@ For example, to make a GET request you would use:
 response = self.http.get(url)
 ```
 
-and the wrapper will pass the right things to `requests`. All methods accept optional keyword arguments like `stream`, etc.
+and the wrapper will pass the right things to the underlying HTTP library. All methods accept optional keyword arguments
+like `stream`, etc.
 
 Any method-level option will override configuration. So for example if `tls_verify` was set to false and you do
 `self.http.get(url, verify=True)`, then SSL certificates will be verified on that particular request. You can
@@ -47,6 +50,41 @@ response = self.http.get(url)
 Some options can be set globally in `init_config` (with `instances` taking precedence).
 For complete documentation of every option, see the associated configuration templates for the
 [instances][config-spec-template-instances-http] and [init_config][config-spec-template-init-config-http] sections.
+
+## Errors
+
+A failed request raises one of the backend-agnostic types in `datadog_checks.base.utils.http_exceptions`, never an
+exception class belonging to the underlying HTTP library. Catch these instead:
+
+| Exception | Raised when |
+| --- | --- |
+| `HTTPClientError` | Root of the tree. Catch this to handle any HTTP failure. |
+| `HTTPClientRequestError` | The request never produced a usable response. |
+| `HTTPClientConnectionError` | The connection could not be established or was lost. |
+| `HTTPClientSSLError` | The TLS handshake or certificate verification failed. |
+| `HTTPClientInvalidURLError` | The URL was rejected before a connection was attempted. |
+| `HTTPClientTimeoutError` | The request exceeded its configured timeout. |
+| `HTTPClientConnectTimeoutError` | The timeout elapsed while establishing the connection. |
+| `HTTPClientReadTimeoutError` | The timeout elapsed while waiting for response data. |
+| `HTTPClientStatusError` | An error status was raised through `raise_for_status()`. |
+
+A check reporting connectivity therefore looks like this:
+
+```python
+from datadog_checks.base.utils.http_exceptions import HTTPClientError
+
+try:
+    response = self.http.get(url)
+    response.raise_for_status()
+except HTTPClientError as e:
+    self.service_check('can_connect', AgentCheck.CRITICAL, message=str(e))
+else:
+    self.service_check('can_connect', AgentCheck.OK)
+```
+
+Body decoding is the one exception to that rule. Calling `response.json()` on a body that is not valid JSON raises the
+standard library's `json.JSONDecodeError`, a subclass of `ValueError` that is not part of the tree above, so handle it
+separately from the types listed here.
 
 ## Future
 


### PR DESCRIPTION
### What does this PR do?

Extract the backend-neutral HTTP protocols, Requests adapter and backend tests, base-owned HTTP fake with additive pytest wiring, and base OpenMetrics/Prometheus adoption from #24815.

The 17 integration migrations from #24815 are intentionally excluded. This draft exists to let CI determine whether those migrations are required by the foundational changes.

Local lint passes for `datadog_checks_base` and `datadog_checks_dev`. Base tests are locally blocked by the missing `krb5-config` system dependency; the dev suite reached 548 passing tests before three unrelated git-signing fixture failures.

### Motivation

Validate a smaller review boundary based on the revised testing architecture before restructuring #24815.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

Made with [Cursor](https://cursor.com)