### PR TITLE
[DBMON-6896] Use the cached Agent version in Mysql

### DIFF
--- a/mysql/changelog.d/25022.fixed
+++ b/mysql/changelog.d/25022.fixed
@@ -1,0 +1,1 @@
+Cache the Agent version instead of resolving it for every payload.

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -20,12 +20,6 @@ from datadog_checks.mysql.cursor import CommenterDictCursor
 
 from .util import DatabaseConfigurationError, ManagedAuthConnectionMixin, get_truncation_state, warning_with_tags
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
-
 ACTIVITY_QUERY = """\
 SELECT
     thread_a.thread_id,
@@ -411,7 +405,7 @@ class MySQLActivity(ManagedAuthConnectionMixin, DBMAsyncJob):
         # type: (List[Dict[str]], List[Dict[str]]) -> Dict[str]
         return {
             "host": self._check.reported_hostname,
-            "ddagentversion": datadog_agent.get_version(),
+            "ddagentversion": self._check.agent_version,
             "ddsource": "mysql",
             "dbm_type": "activity",
             "collection_interval": self.collection_interval,

--- a/mysql/datadog_checks/mysql/databases_data.py
+++ b/mysql/datadog_checks/mysql/databases_data.py
@@ -2,10 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
 import json
 import time
 from collections import defaultdict
@@ -130,7 +126,7 @@ class DatabasesData:
         )
         base_event = {
             "host": None,
-            "agent_version": datadog_agent.get_version(),
+            "agent_version": self._check.agent_version,
             "dbms": self._check.dbms,
             "kind": "mysql_databases",
             "collection_interval": collection_interval,

--- a/mysql/datadog_checks/mysql/metadata.py
+++ b/mysql/datadog_checks/mysql/metadata.py
@@ -7,16 +7,6 @@ from operator import attrgetter
 
 import pymysql
 
-from datadog_checks.mysql.cursor import CommenterDictCursor
-from datadog_checks.mysql.databases_data import DEFAULT_DATABASES_DATA_COLLECTION_INTERVAL, DatabasesData
-
-from .util import ManagedAuthConnectionMixin, connect_with_session_variables
-
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.db.utils import (
     DBMAsyncJob,
@@ -24,6 +14,10 @@ from datadog_checks.base.utils.db.utils import (
 )
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
+from datadog_checks.mysql.cursor import CommenterDictCursor
+from datadog_checks.mysql.databases_data import DEFAULT_DATABASES_DATA_COLLECTION_INTERVAL, DatabasesData
+
+from .util import ManagedAuthConnectionMixin, connect_with_session_variables
 
 # default pg_settings collection interval in seconds
 DEFAULT_SETTINGS_COLLECTION_INTERVAL = 600
@@ -184,7 +178,7 @@ class MySQLMetadata(ManagedAuthConnectionMixin, DBMAsyncJob):
         event = {
             "host": self._check.reported_hostname,
             "database_instance": self._check.database_identifier,
-            "agent_version": datadog_agent.get_version(),
+            "agent_version": self._check.agent_version,
             "dbms": self._check.dbms,
             "kind": "mysql_variables",
             "collection_interval": self.collection_interval,

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -1430,7 +1430,7 @@ class MySql(DatabaseCheck):
                 "port": self._config.port,
                 "database_instance": self.database_identifier,
                 "database_hostname": self.database_hostname,
-                "agent_version": datadog_agent.get_version(),
+                "agent_version": self.agent_version,
                 "ddagenthostname": self.agent_hostname,
                 "dbms": self.dbms,
                 "kind": "database_instance",

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -465,7 +465,7 @@ class MySQLStatementSamples(ManagedAuthConnectionMixin, DBMAsyncJob):
                 "timestamp": event_timestamp,
                 "dbm_type": "plan",
                 "host": self._check.reported_hostname,
-                "ddagentversion": datadog_agent.get_version(),
+                "ddagentversion": self._check.agent_version,
                 "ddsource": "mysql",
                 "ddtags": self._tags_str,
                 "duration": row['timer_wait_ns'],

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -22,11 +22,6 @@ from datadog_checks.mysql.cursor import CommenterDictCursor
 
 from .util import DatabaseConfigurationError, ManagedAuthConnectionMixin, warning_with_tags
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 PyMysqlRow = Dict[str, Any]
 Row = Dict[str, Any]
 RowKey = Tuple[Any]
@@ -205,7 +200,7 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
             'timestamp': time.time() * 1000,
             'mysql_version': self._check.version.version + '+' + self._check.version.build,
             'mysql_flavor': self._check.version.flavor,
-            'ddagentversion': datadog_agent.get_version(),
+            'ddagentversion': self._check.agent_version,
             'min_collection_interval': self._metric_collection_interval,
             'tags': tags,
             'cloud_metadata': self._config.cloud_metadata,
@@ -418,7 +413,7 @@ class MySQLStatementMetrics(ManagedAuthConnectionMixin, DBMAsyncJob):
             yield {
                 "timestamp": time.time() * 1000,
                 "host": self._check.reported_hostname,
-                "ddagentversion": datadog_agent.get_version(),
+                "ddagentversion": self._check.agent_version,
                 "ddsource": "mysql",
                 "ddtags": ",".join(row_tags),
                 "dbm_type": "fqt",

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=38.1.0",
+    "datadog-checks-base>=38.2.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
Use the cached Agent version in Mysql

### Motivation
Avoids an FFI call each time we call agent_version

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
