### PR TITLE
[DBMON-6896] Use the cached Agent version in SqlServer

### DIFF
--- a/sqlserver/changelog.d/25023.fixed
+++ b/sqlserver/changelog.d/25023.fixed
@@ -1,0 +1,1 @@
+Cache the Agent version instead of resolving it for every payload.

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -22,11 +22,6 @@ from datadog_checks.sqlserver.config import SQLServerConfig
 from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_INFO_VERSION
 from datadog_checks.sqlserver.utils import is_statement_proc, needs_comment_recovery, raise_if_cancelled
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 DEFAULT_COLLECTION_INTERVAL = 10
 MAX_PAYLOAD_BYTES = 19e6
 
@@ -323,7 +318,7 @@ class SqlserverActivity(DBMAsyncJob):
                 "timestamp": time.time() * 1000,
                 "host": self._check.reported_hostname,
                 "database_instance": self._check.database_identifier,
-                "ddagentversion": datadog_agent.get_version(),
+                "ddagentversion": self._check.agent_version,
                 "ddsource": "sqlserver",
                 "dbm_type": "rqt",
                 "ddtags": ",".join(self._check.tag_manager.get_tags()),
@@ -471,7 +466,7 @@ class SqlserverActivity(DBMAsyncJob):
         event = {
             "host": self._check.reported_hostname,
             "database_instance": self._check.database_identifier,
-            "ddagentversion": datadog_agent.get_version(),
+            "ddagentversion": self._check.agent_version,
             "ddsource": "sqlserver",
             "dbm_type": "activity",
             "collection_interval": self.collection_interval,

--- a/sqlserver/datadog_checks/sqlserver/agent_history.py
+++ b/sqlserver/datadog_checks/sqlserver/agent_history.py
@@ -11,11 +11,6 @@ from datadog_checks.sqlserver.config import SQLServerConfig
 from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_INFO_VERSION
 from datadog_checks.sqlserver.utils import raise_if_cancelled
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 DEFAULT_COLLECTION_INTERVAL = 15
 DEFAULT_ROW_LIMIT = 10000
 
@@ -159,7 +154,7 @@ class SqlserverAgentHistory(DBMAsyncJob):
         event = {
             "host": self._check.reported_hostname,
             "database_instance": self._check.database_identifier,
-            "ddagentversion": datadog_agent.get_version(),
+            "ddagentversion": self._check.agent_version,
             "ddsource": "sqlserver",
             "dbm_type": "agent_jobs",
             "collection_interval": self.collection_interval,

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -25,11 +25,6 @@ from datadog_checks.sqlserver.queries import (
 )
 from datadog_checks.sqlserver.utils import is_azure_sql_database, raise_if_cancelled
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 DEFAULT_COLLECTION_INTERVAL = 600
 MAX_DEADLOCKS = 100
 MAX_PAYLOAD_BYTES = 19e6
@@ -274,7 +269,7 @@ class Deadlocks(DBMAsyncJob):
         event = {
             "host": self._check.reported_hostname,
             "database_instance": self._check.database_identifier,
-            "ddagentversion": datadog_agent.get_version(),
+            "ddagentversion": self._check.agent_version,
             "ddsource": "sqlserver",
             "dbm_type": "deadlocks",
             "collection_interval": self.collection_interval,

--- a/sqlserver/datadog_checks/sqlserver/metadata.py
+++ b/sqlserver/datadog_checks/sqlserver/metadata.py
@@ -13,16 +13,11 @@ from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.sqlserver.config import SQLServerConfig
 from datadog_checks.sqlserver.const import (
     DEFAULT_SCHEMAS_COLLECTION_INTERVAL,
+    STATIC_INFO_ENGINE_EDITION,
+    STATIC_INFO_VERSION,
 )
 from datadog_checks.sqlserver.schemas import SQLServerSchemaCollector
 from datadog_checks.sqlserver.utils import raise_if_cancelled
-
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
-from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_INFO_VERSION
 
 # default settings collection interval in seconds
 DEFAULT_SETTINGS_COLLECTION_INTERVAL = 600
@@ -153,7 +148,7 @@ class SqlserverMetadata(DBMAsyncJob):
                 event = {
                     "host": self._check.reported_hostname,
                     "database_instance": self._check.database_identifier,
-                    "agent_version": datadog_agent.get_version(),
+                    "agent_version": self._check.agent_version,
                     "dbms": self._check.dbms,
                     "kind": "sqlserver_configs",
                     "collection_interval": self.collection_interval,

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -1199,7 +1199,7 @@ class SQLServer(DatabaseCheck):
                 "host": self.reported_hostname,
                 "database_instance": self.database_identifier,
                 "database_hostname": self.database_hostname,
-                "agent_version": datadog_agent.get_version(),
+                "agent_version": self.agent_version,
                 "ddagenthostname": self.agent_hostname,
                 "dbms": self.dbms,
                 "kind": "database_instance",

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -23,14 +23,8 @@ from datadog_checks.base.utils.db.utils import (
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.sqlserver.config import SQLServerConfig
-from datadog_checks.sqlserver.utils import is_azure_sql_database, needs_comment_recovery, raise_if_cancelled
-
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_INFO_VERSION
+from datadog_checks.sqlserver.utils import is_azure_sql_database, needs_comment_recovery, raise_if_cancelled
 
 DEFAULT_COLLECTION_INTERVAL = 60
 
@@ -531,7 +525,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             'sqlserver_rows': [self._to_metrics_payload_row(r) for r in rows],
             'sqlserver_version': self._check.static_info_cache.get(STATIC_INFO_VERSION, ""),
             'sqlserver_engine_edition': self._check.static_info_cache.get(STATIC_INFO_ENGINE_EDITION, ""),
-            'ddagentversion': datadog_agent.get_version(),
+            'ddagentversion': self._check.agent_version,
             'service': self._config.service,
         }
 
@@ -591,7 +585,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                 "timestamp": time.time() * 1000,
                 "host": self._check.reported_hostname,
                 "database_instance": self._check.database_identifier,
-                "ddagentversion": datadog_agent.get_version(),
+                "ddagentversion": self._check.agent_version,
                 "ddsource": "sqlserver",
                 "ddtags": ",".join(tags),
                 "dbm_type": "fqt",
@@ -692,7 +686,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                 obfuscated_plan_event = {
                     "host": self._check.reported_hostname,
                     "database_instance": self._check.database_identifier,
-                    "ddagentversion": datadog_agent.get_version(),
+                    "ddagentversion": self._check.agent_version,
                     "ddsource": "sqlserver",
                     "ddtags": ",".join(tags),
                     "timestamp": time.time() * 1000,

--- a/sqlserver/datadog_checks/sqlserver/stored_procedures.py
+++ b/sqlserver/datadog_checks/sqlserver/stored_procedures.py
@@ -13,12 +13,6 @@ from datadog_checks.base.utils.db.utils import (
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.sqlserver.config import SQLServerConfig
-
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_INFO_VERSION
 from datadog_checks.sqlserver.utils import raise_if_cancelled
 
@@ -160,7 +154,7 @@ class SqlserverProcedureMetrics(DBMAsyncJob):
             'sqlserver_rows': rows,
             'sqlserver_version': self._check.static_info_cache.get(STATIC_INFO_VERSION, ""),
             'sqlserver_engine_edition': self._check.static_info_cache.get(STATIC_INFO_ENGINE_EDITION, ""),
-            'ddagentversion': datadog_agent.get_version(),
+            'ddagentversion': self._check.agent_version,
             'service': self._config.service,
             'tags': self._check.tag_manager.get_tags(),
         }

--- a/sqlserver/datadog_checks/sqlserver/xe_collection/base.py
+++ b/sqlserver/datadog_checks/sqlserver/xe_collection/base.py
@@ -27,11 +27,6 @@ from datadog_checks.sqlserver.utils import is_azure_sql_database, raise_if_cance
 
 from .xml_tools import extract_int_value, extract_value
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 
 def agent_check_getter(self):
     return self._check
@@ -473,7 +468,7 @@ class XESessionBase(DBMAsyncJob):
         return {
             "host": self._check.resolved_hostname,
             "database_instance": self._check.database_identifier,
-            "ddagentversion": datadog_agent.get_version(),
+            "ddagentversion": self._check.agent_version,
             "ddsource": "sqlserver",
             "dbm_type": self._determine_dbm_type(),
             "collection_interval": self.collection_interval,
@@ -604,7 +599,7 @@ class XESessionBase(DBMAsyncJob):
             batched_payload = {
                 "host": self._check.resolved_hostname,
                 "database_instance": self._check.database_identifier,
-                "ddagentversion": datadog_agent.get_version(),
+                "ddagentversion": self._check.agent_version,
                 "ddsource": "sqlserver",
                 "dbm_type": self._determine_dbm_type(),
                 "collection_interval": self.collection_interval,
@@ -802,7 +797,7 @@ class XESessionBase(DBMAsyncJob):
             "timestamp": time() * 1000,
             "host": self._check.resolved_hostname,
             "database_instance": self._check.database_identifier,
-            "ddagentversion": datadog_agent.get_version(),
+            "ddagentversion": self._check.agent_version,
             "ddsource": "sqlserver",
             "dbm_type": "rqt",
             "ddtags": ",".join(self._check.tag_manager.get_tags()),

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=38.1.0",
+    "datadog-checks-base>=38.2.0",
 ]
 dynamic = [
     "version",

--- a/sqlserver/tests/test_xe_collection.py
+++ b/sqlserver/tests/test_xe_collection.py
@@ -4,7 +4,6 @@
 
 import logging
 import os
-import sys
 from unittest.mock import Mock, patch
 
 import pytest
@@ -24,11 +23,6 @@ from datadog_checks.sqlserver.xe_collection.xml_tools import (
 )
 
 CHECK_NAME = 'sqlserver'
-
-# Mock datadog_agent before imports - ensure it's properly patched at module level
-datadog_agent_mock = Mock()
-datadog_agent_mock.get_version.return_value = '7.30.0'
-sys.modules['datadog_agent'] = datadog_agent_mock
 
 
 # Helper functions
@@ -101,6 +95,7 @@ def mock_check():
 
     check.static_info_cache = {'version': '2019', 'engine_edition': 'Standard Edition'}
     check.resolved_hostname = "test-host"
+    check.agent_version = '7.30.0'
     check.tag_manager = TagManager()
     check.tag_manager.set_tag('test', 'tag')
     check.database_monitoring_query_activity = Mock()
@@ -860,11 +855,8 @@ class TestPayloadGeneration:
         assert normalized['duration_ms'] == 328.677
         assert 'query_start' in normalized  # Query start should be calculated from timestamp and duration
 
-    @patch('datadog_checks.sqlserver.xe_collection.base.datadog_agent')
-    def test_create_event_payload(self, mock_agent, query_completion_handler):
+    def test_create_event_payload(self, query_completion_handler):
         """Test creation of event payload"""
-        mock_agent.get_version.return_value = '7.30.0'
-
         # Create a raw event
         raw_event = {
             'event_name': 'sql_batch_completed',
@@ -904,11 +896,8 @@ class TestPayloadGeneration:
         assert metadata['commands'] == ['SELECT']
         assert metadata['comments'] == []
 
-    @patch('datadog_checks.sqlserver.xe_collection.base.datadog_agent')
-    def test_create_rqt_event(self, mock_agent, query_completion_handler):
+    def test_create_rqt_event(self, query_completion_handler):
         """Test creation of Raw Query Text event"""
-        mock_agent.get_version.return_value = '7.30.0'
-
         # Create event with SQL fields
         event = {
             'event_name': 'sql_batch_completed',
@@ -960,11 +949,8 @@ class TestPayloadGeneration:
         assert rqt_event['sqlserver']['query_start'] == '2023-01-01T11:59:50.123Z'
         assert rqt_event['sqlserver']['primary_sql_field'] == 'batch_text'
 
-    @patch('datadog_checks.sqlserver.xe_collection.base.datadog_agent')
-    def test_create_rqt_event_attention(self, mock_agent, error_events_handler):
+    def test_create_rqt_event_attention(self, error_events_handler):
         """Test creation of Raw Query Text event for attention event"""
-        mock_agent.get_version.return_value = '7.30.0'
-
         # Create attention event with SQL fields - from the error_events_handler
         event = {
             'event_name': 'attention',
@@ -1062,11 +1048,8 @@ class TestPayloadGeneration:
         # Should return None when missing signature
         assert query_completion_handler._create_rqt_event(event, raw_sql_fields, query_details) is None
 
-    @patch('datadog_checks.sqlserver.xe_collection.base.datadog_agent')
-    def test_create_rqt_event_error_reported(self, mock_agent, error_events_handler):
+    def test_create_rqt_event_error_reported(self, error_events_handler):
         """Test creation of Raw Query Text event for error_reported event"""
-        mock_agent.get_version.return_value = '7.30.0'
-
         # Create error_reported event with SQL fields
         event = {
             'event_name': 'error_reported',


### PR DESCRIPTION
### What does this PR do?
Use the cached Agent version in SqlServer

### Motivation
Avoids an FFI call each time we call agent_version

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
