### PR TITLE
[DBMON-6896] Use the cached Agent version in Clickhouse

### DIFF
--- a/clickhouse/changelog.d/25024.fixed
+++ b/clickhouse/changelog.d/25024.fixed
@@ -1,0 +1,1 @@
+Cache the Agent version instead of resolving it for every payload.

--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -38,12 +38,6 @@ from .utils import (
     cluster_nodes_query,
 )
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
-
 # Database instance collection interval in seconds (not user-configurable)
 DATABASE_INSTANCE_COLLECTION_INTERVAL = 300
 
@@ -240,7 +234,7 @@ class ClickhouseCheck(DatabaseCheck):
                 "port": self._config.port,
                 "database_instance": self.database_identifier,
                 "database_hostname": self.database_hostname,
-                "agent_version": datadog_agent.get_version(),
+                "agent_version": self.agent_version,
                 "ddagenthostname": self.agent_hostname,
                 "dbms": self.dbms,
                 "kind": "database_instance",

--- a/clickhouse/datadog_checks/clickhouse/explain_plans.py
+++ b/clickhouse/datadog_checks/clickhouse/explain_plans.py
@@ -10,11 +10,6 @@ from typing import TYPE_CHECKING, Callable, Iterator
 if TYPE_CHECKING:
     from datadog_checks.clickhouse import ClickhouseCheck
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 from datadog_checks.base.utils.db.sql import compute_exec_plan_signature
 from datadog_checks.base.utils.db.utils import RateLimitingTTLCache
 from datadog_checks.base.utils.serialization import json
@@ -197,7 +192,7 @@ class ClickhouseExplainPlans:
             'host': self._check.reported_hostname,
             'database_instance': self._check.database_identifier,
             'ddsource': 'clickhouse',
-            'ddagentversion': datadog_agent.get_version(),
+            'ddagentversion': self._check.agent_version,
             'dbm_type': 'plan',
             'timestamp': row.get('event_time_microseconds', 0) / 1000,
             'ddtags': ','.join(tags_no_db),

--- a/clickhouse/datadog_checks/clickhouse/parts_and_merges.py
+++ b/clickhouse/datadog_checks/clickhouse/parts_and_merges.py
@@ -22,11 +22,6 @@ if TYPE_CHECKING:
     from datadog_checks.clickhouse import ClickhouseCheck
     from datadog_checks.clickhouse.config_models.instance import PartsAndMerges
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
 from datadog_checks.base.utils.serialization import json
@@ -826,7 +821,7 @@ class ClickhousePartsAndMerges(DBMAsyncJob):
         payload = {
             "host": self._check.reported_hostname,
             "database_instance": self._check.database_identifier,
-            "ddagentversion": datadog_agent.get_version(),
+            "ddagentversion": self._check.agent_version,
             "ddagenthostname": self._check.agent_hostname,
             "dbms": self._check.dbms,
             "ddsource": "clickhouse",

--- a/clickhouse/datadog_checks/clickhouse/query_completions.py
+++ b/clickhouse/datadog_checks/clickhouse/query_completions.py
@@ -10,11 +10,6 @@ if TYPE_CHECKING:
     from datadog_checks.clickhouse import ClickhouseCheck
     from datadog_checks.clickhouse.config_models.instance import CollectAsyncInserts
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 from datadog_checks.base.utils.db.utils import RateLimitingTTLCache, default_json_event_encoding
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
@@ -399,7 +394,7 @@ class ClickhouseQueryCompletions(ClickhouseQueryLogJob):
         payload = {
             'host': self._check.reported_hostname,
             'database_instance': self._check.database_identifier,
-            'ddagentversion': datadog_agent.get_version(),
+            'ddagentversion': self._check.agent_version,
             'ddsource': 'clickhouse',
             'dbm_type': 'query_completion',
             'collection_interval': self._collection_interval,
@@ -545,7 +540,7 @@ class ClickhouseQueryCompletions(ClickhouseQueryLogJob):
         return {
             'host': self._check.reported_hostname,
             'database_instance': self._check.database_identifier,
-            'ddagentversion': datadog_agent.get_version(),
+            'ddagentversion': self._check.agent_version,
             'ddsource': 'clickhouse',
             'dbm_type': DBM_TYPE_FLUSH,
             'collection_interval': self._flush_collection_interval,

--- a/clickhouse/datadog_checks/clickhouse/query_errors.py
+++ b/clickhouse/datadog_checks/clickhouse/query_errors.py
@@ -9,11 +9,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from datadog_checks.clickhouse import ClickhouseCheck
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 from clickhouse_connect.driver.exceptions import Error
 
 from datadog_checks.base.utils.db.utils import RateLimitingTTLCache, default_json_event_encoding
@@ -316,7 +311,7 @@ class ClickhouseQueryErrors(ClickhouseQueryLogJob):
         payload = {
             'host': self._check.reported_hostname,
             'database_instance': self._check.database_identifier,
-            'ddagentversion': datadog_agent.get_version(),
+            'ddagentversion': self._check.agent_version,
             'ddsource': 'clickhouse',
             'dbm_type': 'query_error',
             'collection_interval': self._collection_interval,

--- a/clickhouse/datadog_checks/clickhouse/statement_samples.py
+++ b/clickhouse/datadog_checks/clickhouse/statement_samples.py
@@ -19,11 +19,6 @@ if TYPE_CHECKING:
     from datadog_checks.clickhouse import ClickhouseCheck
     from datadog_checks.clickhouse.config_models.instance import CollectPendingAsyncInserts, QuerySamples
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.utils import (
@@ -459,7 +454,7 @@ class ClickhouseStatementSamples(DBMAsyncJob):
         event = {
             "host": self._check.reported_hostname,
             "database_instance": self._check.database_identifier,
-            "ddagentversion": datadog_agent.get_version(),
+            "ddagentversion": self._check.agent_version,
             "ddsource": "clickhouse",
             "dbm_type": "activity",
             "collection_interval": self._collection_interval,
@@ -666,7 +661,7 @@ class ClickhouseStatementSamples(DBMAsyncJob):
         return {
             "host": self._check.reported_hostname,
             "database_instance": self._check.database_identifier,
-            "ddagentversion": datadog_agent.get_version(),
+            "ddagentversion": self._check.agent_version,
             "ddsource": "clickhouse",
             "kind": BUFFER_PAYLOAD_KIND,
             "min_collection_interval": self._buffer_collection_interval,

--- a/clickhouse/datadog_checks/clickhouse/statements.py
+++ b/clickhouse/datadog_checks/clickhouse/statements.py
@@ -12,11 +12,6 @@ from cachetools import TTLCache
 if TYPE_CHECKING:
     from datadog_checks.clickhouse import ClickhouseCheck
 
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
-
 from datadog_checks.base.utils.db.utils import default_json_event_encoding
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
@@ -145,7 +140,7 @@ class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
                 'timestamp': time.time() * 1000,
                 'min_collection_interval': self._collection_interval,
                 'tags': self._tags_no_db,
-                'ddagentversion': datadog_agent.get_version(),
+                'ddagentversion': self._check.agent_version,
                 'clickhouse_version': self._check.dbms_version,
             }
 
@@ -402,7 +397,7 @@ class ClickhouseStatementMetrics(ClickhouseQueryLogJob):
                 "timestamp": time.time() * 1000,
                 "host": self._check.reported_hostname,
                 "database_instance": self._check.database_identifier,
-                "ddagentversion": datadog_agent.get_version(),
+                "ddagentversion": self._check.agent_version,
                 "ddsource": "clickhouse",
                 "ddtags": ",".join(row_tags),
                 "dbm_type": "fqt",

--- a/clickhouse/pyproject.toml
+++ b/clickhouse/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=38.1.0",
+    "datadog-checks-base>=38.2.0",
 ]
 dynamic = [
     "version",

--- a/clickhouse/tests/test_dbm_integration.py
+++ b/clickhouse/tests/test_dbm_integration.py
@@ -120,7 +120,7 @@ def test_statement_metrics(aggregator, dbm_instance, dd_run_check, datadog_agent
     event = events[-1]
     assert event['host'] is not None
     assert event['database_instance'] is not None
-    assert event['ddagentversion'] == datadog_agent.get_version()
+    assert event['ddagentversion'] == '0.0.0'
     assert event['timestamp'] > 0
     assert event['min_collection_interval'] is not None
     assert 'tags' in event
@@ -164,7 +164,7 @@ def test_statement_metrics(aggregator, dbm_instance, dd_run_check, datadog_agent
     assert 'commands' in fqt_event['db']['metadata']
     assert fqt_event['timestamp'] > 0
     assert fqt_event['host'] is not None
-    assert fqt_event['ddagentversion'] == datadog_agent.get_version()
+    assert fqt_event['ddagentversion'] == '0.0.0'
 
 
 def test_statement_metrics_with_metadata(aggregator, dbm_instance, dd_run_check, datadog_agent):
@@ -296,9 +296,7 @@ def test_samples_event_structure(instance):
     ]
     active_connections = [{'user': 'default', 'query_kind': 'Select', 'current_database': 'default', 'connections': 1}]
 
-    with mock.patch('datadog_checks.clickhouse.statement_samples.datadog_agent') as mock_agent:
-        mock_agent.get_version.return_value = '7.64.0'
-        event = samples._create_samples_event(rows, active_connections)
+    event = samples._create_samples_event(rows, active_connections)
 
     assert event['ddsource'] == 'clickhouse'
     assert event['dbm_type'] == 'activity'
@@ -410,7 +408,7 @@ def test_explain_plan_collected(aggregator, instance, dd_run_check, datadog_agen
     assert plan_event['ddsource'] == 'clickhouse'
     assert plan_event['host'] is not None
     assert plan_event['database_instance'] is not None
-    assert plan_event['ddagentversion'] == datadog_agent.get_version()
+    assert plan_event['ddagentversion'] == '0.0.0'
     assert plan_event['timestamp'] > 0
 
     db = plan_event['db']

--- a/clickhouse/tests/test_explain_plans.py
+++ b/clickhouse/tests/test_explain_plans.py
@@ -233,10 +233,8 @@ def test_collect_plan_for_statement_no_plans_possible(explain_plans):
     assert result is None
 
 
-@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
-def test_plan_event_structure(mock_agent, explain_plans):
+def test_plan_event_structure(explain_plans):
     """A successful plan event has the required fields and correct dbm_type."""
-    mock_agent.get_version.return_value = '7.64.0'
 
     explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
 
@@ -257,7 +255,7 @@ def test_plan_event_structure(mock_agent, explain_plans):
     assert event is not None
     assert event['dbm_type'] == 'plan'
     assert event['ddsource'] == 'clickhouse'
-    assert event['ddagentversion'] == '7.64.0'
+    assert event['ddagentversion'] == '0.0.0'
     assert event['host'] is not None
     assert event['database_instance'] is not None
     assert event['timestamp'] == 1746205423150500 / 1000
@@ -277,10 +275,8 @@ def test_plan_event_structure(mock_agent, explain_plans):
     assert ch['query_duration_ms'] == 100.0
 
 
-@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
-def test_collect_plans_rate_limiting(mock_agent, explain_plans):
+def test_collect_plans_rate_limiting(explain_plans):
     """The same query_signature is only explained once within the rate-limit TTL."""
-    mock_agent.get_version.return_value = '7.64.0'
 
     explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
 
@@ -319,10 +315,8 @@ def test_collect_plans_rate_limiting(mock_agent, explain_plans):
     assert explain_plans._execute_query_fn.call_count == 1
 
 
-@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
-def test_collect_plans_skips_cte_insert(mock_agent, explain_plans):
+def test_collect_plans_skips_cte_insert(explain_plans):
     """WITH ... INSERT queries pass _can_explain_statement but are skipped via query_kind."""
-    mock_agent.get_version.return_value = '7.64.0'
     explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
 
     rows = [
@@ -346,10 +340,8 @@ def test_collect_plans_skips_cte_insert(mock_agent, explain_plans):
     explain_plans._execute_query_fn.assert_not_called()
 
 
-@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
-def test_collect_plans_skips_missing_signature(mock_agent, explain_plans):
+def test_collect_plans_skips_missing_signature(explain_plans):
     """Rows without a query_signature are skipped."""
-    mock_agent.get_version.return_value = '7.64.0'
 
     rows = [
         {
@@ -364,10 +356,8 @@ def test_collect_plans_skips_missing_signature(mock_agent, explain_plans):
     assert len(plans) == 0
 
 
-@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
-def test_collect_plans_error_event(mock_agent, explain_plans):
+def test_collect_plans_error_event(explain_plans):
     """When EXPLAIN fails, the error is recorded in collection_errors."""
-    mock_agent.get_version.return_value = '7.64.0'
     explain_plans._execute_query_fn = mock.MagicMock(side_effect=Exception("DB error"))
 
     rows = [
@@ -398,10 +388,8 @@ def test_collect_plans_error_event(mock_agent, explain_plans):
     assert errors[0]['code'] == DBExplainError.database_error.value
 
 
-@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
-def test_collect_plans_unsupported_statements_skip_rate_limiter(mock_agent, explain_plans):
+def test_collect_plans_unsupported_statements_skip_rate_limiter(explain_plans):
     """Unsupported statements are skipped before acquiring a rate limit slot."""
-    mock_agent.get_version.return_value = '7.64.0'
     explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
 
     # Fill the cache with DDL queries up to maxsize so any further acquire would fail
@@ -444,10 +432,8 @@ def test_collect_plans_unsupported_statements_skip_rate_limiter(mock_agent, expl
     explain_plans._execute_query_fn.assert_not_called()
 
 
-@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
-def test_collect_plans_different_databases_explained_separately(mock_agent, explain_plans):
+def test_collect_plans_different_databases_explained_separately(explain_plans):
     """Same query_signature in different databases each get an EXPLAIN."""
-    mock_agent.get_version.return_value = '7.64.0'
     explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
 
     rows = [
@@ -495,10 +481,8 @@ def test_run_explain_uses_indexes_and_actions(explain_plans):
     assert "actions = 1" in call_args
 
 
-@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
-def test_plan_definition_preserves_indexes(mock_agent, explain_plans):
+def test_plan_definition_preserves_indexes(explain_plans):
     """Plan definition keeps Indexes fields intact."""
-    mock_agent.get_version.return_value = '7.64.0'
     explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN_WITH_INDEXES),)])
 
     row = {
@@ -523,10 +507,8 @@ def test_plan_definition_preserves_indexes(mock_agent, explain_plans):
     assert read_node['Indexes'][0]['Keys'] == ['order_date']
 
 
-@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
-def test_plan_definition_preserves_actions(mock_agent, explain_plans):
+def test_plan_definition_preserves_actions(explain_plans):
     """Plan definition keeps Actions fields intact."""
-    mock_agent.get_version.return_value = '7.64.0'
     explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN_WITH_ACTIONS),)])
 
     row = {
@@ -576,10 +558,8 @@ def test_normalize_clickhouse_plan_strips_stats():
     assert child['Description'] == 'default.inventory_items'
 
 
-@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
-def test_plan_definition_preserves_descriptions(mock_agent, explain_plans):
+def test_plan_definition_preserves_descriptions(explain_plans):
     """Plan definition keeps ClickHouse Description fields intact (not replaced with '?')."""
-    mock_agent.get_version.return_value = '7.64.0'
     explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
 
     row = {
@@ -776,10 +756,8 @@ def test_run_explain_safe_captures_empty_rows_as_database_error(explain_plans):
     assert error_code == DBExplainError.database_error
 
 
-@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
-def test_collect_plan_for_statement_serialization_failure(mock_agent, explain_plans):
+def test_collect_plan_for_statement_serialization_failure(explain_plans):
     """A serialization failure during plan obfuscation is recorded as invalid_result."""
-    mock_agent.get_version.return_value = '7.64.0'
 
     explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
 
@@ -810,10 +788,8 @@ def test_collect_plan_for_statement_serialization_failure(mock_agent, explain_pl
     assert event['db']['plan']['signature'] is None
 
 
-@mock.patch('datadog_checks.clickhouse.explain_plans.datadog_agent')
-def test_collect_plan_for_statement_no_collection_errors_on_success(mock_agent, explain_plans):
+def test_collect_plan_for_statement_no_collection_errors_on_success(explain_plans):
     """collection_errors is None (not an empty list) when the plan is collected successfully."""
-    mock_agent.get_version.return_value = '7.64.0'
     explain_plans._execute_query_fn = mock.MagicMock(return_value=[(json.dumps(SAMPLE_PLAN),)])
 
     row = {

--- a/clickhouse/tests/test_parts_and_merges.py
+++ b/clickhouse/tests/test_parts_and_merges.py
@@ -836,9 +836,7 @@ def test_emit_events_shape(check):
     captured = []
     with (
         mock.patch.object(check, 'database_monitoring_query_activity', side_effect=captured.append),
-        mock.patch('datadog_checks.clickhouse.parts_and_merges.datadog_agent') as agent_mock,
     ):
-        agent_mock.get_version.return_value = '7.64.0'
         job._emit_events(
             _collected_parts(),
             _collected_merges(),
@@ -870,9 +868,7 @@ def test_emit_events_uses_query_activity_channel_not_metadata(check):
     with (
         mock.patch.object(check, 'database_monitoring_query_activity') as activity_mock,
         mock.patch.object(check, 'database_monitoring_metadata') as metadata_mock,
-        mock.patch('datadog_checks.clickhouse.parts_and_merges.datadog_agent') as agent_mock,
     ):
-        agent_mock.get_version.return_value = '7.64.0'
         job._emit_events(_collected_parts(), [], [], [], [])
 
     activity_mock.assert_called_once()
@@ -886,9 +882,7 @@ def test_emit_events_skips_when_all_collections_empty(check):
 
     with (
         mock.patch.object(check, 'database_monitoring_query_activity') as activity_mock,
-        mock.patch('datadog_checks.clickhouse.parts_and_merges.datadog_agent') as agent_mock,
     ):
-        agent_mock.get_version.return_value = '7.64.0'
         job._emit_events([], [], [], [], [], [])
 
     activity_mock.assert_not_called()
@@ -928,9 +922,7 @@ def test_collect_and_emit_runs_with_partial_failures(check):
         mock.patch.object(job, '_collect_detached_parts', return_value=[]),
         mock.patch.object(job, '_collect_thresholds', return_value=[]),
         mock.patch.object(check, 'database_monitoring_query_activity', side_effect=captured.append),
-        mock.patch('datadog_checks.clickhouse.parts_and_merges.datadog_agent') as agent_mock,
     ):
-        agent_mock.get_version.return_value = '7.64.0'
         job._collect_and_emit()
 
     assert len(captured) == 1
@@ -954,9 +946,7 @@ def test_collect_and_emit_skips_when_all_collectors_empty(check):
         mock.patch.object(job, '_collect_detached_parts', return_value=[]),
         mock.patch.object(job, '_collect_thresholds', return_value=[]),
         mock.patch.object(check, 'database_monitoring_query_activity') as activity_mock,
-        mock.patch('datadog_checks.clickhouse.parts_and_merges.datadog_agent') as agent_mock,
     ):
-        agent_mock.get_version.return_value = '7.64.0'
         job._collect_and_emit()
 
     activity_mock.assert_not_called()

--- a/clickhouse/tests/test_query_completions.py
+++ b/clickhouse/tests/test_query_completions.py
@@ -149,9 +149,7 @@ def test_create_batched_payload_query_details(check_with_dbm):
         }
     ]
 
-    with mock.patch('datadog_checks.clickhouse.query_completions.datadog_agent') as mock_agent:
-        mock_agent.get_version.return_value = '7.64.0'
-        payload = query_completions._create_batched_payload(rows)
+    payload = query_completions._create_batched_payload(rows)
 
     # Verify payload has completions
     assert payload is not None
@@ -191,9 +189,7 @@ def test_create_batched_payload_carries_clickhouse_node(check_with_dbm):
         }
     ]
 
-    with mock.patch('datadog_checks.clickhouse.query_completions.datadog_agent') as mock_agent:
-        mock_agent.get_version.return_value = '7.64.0'
-        payload = query_completions._create_batched_payload(rows)
+    payload = query_completions._create_batched_payload(rows)
 
     query_details = payload['clickhouse_query_completions'][0]['query_details']
     assert query_details['clickhouse_node'] == 'ch-node-1'
@@ -214,9 +210,7 @@ def test_create_batched_payload_clickhouse_node_defaults_empty(check_with_dbm):
         }
     ]
 
-    with mock.patch('datadog_checks.clickhouse.query_completions.datadog_agent') as mock_agent:
-        mock_agent.get_version.return_value = '7.64.0'
-        payload = query_completions._create_batched_payload(rows)
+    payload = query_completions._create_batched_payload(rows)
 
     query_details = payload['clickhouse_query_completions'][0]['query_details']
     assert query_details['clickhouse_node'] == ''
@@ -244,9 +238,7 @@ def test_create_batched_payload_structure(check_with_dbm):
         },
     ]
 
-    with mock.patch('datadog_checks.clickhouse.query_completions.datadog_agent') as mock_agent:
-        mock_agent.get_version.return_value = '7.64.0'
-        payload = query_completions._create_batched_payload(rows)
+    payload = query_completions._create_batched_payload(rows)
 
     # Verify payload structure
     assert payload['ddsource'] == 'clickhouse'
@@ -276,9 +268,7 @@ def test_create_batched_payload_service_field(check_with_dbm, service):
         },
     ]
 
-    with mock.patch('datadog_checks.clickhouse.query_completions.datadog_agent') as mock_agent:
-        mock_agent.get_version.return_value = '7.64.0'
-        payload = check_with_dbm.query_completions._create_batched_payload(rows)
+    payload = check_with_dbm.query_completions._create_batched_payload(rows)
 
     assert payload['service'] == service
 
@@ -358,8 +348,7 @@ def test_normalize_query_with_obfuscation(check_with_dbm):
     assert normalized_row['query_signature'] is not None
 
 
-@mock.patch('datadog_checks.clickhouse.query_completions.datadog_agent')
-def test_checkpoint_persistence(mock_agent, check_with_dbm):
+def test_checkpoint_persistence(check_with_dbm):
     """Test checkpoint save and load functionality"""
     query_completions = check_with_dbm.query_completions
 
@@ -531,9 +520,7 @@ def test_create_flush_event_structure(check_with_flush):
         {'database': 'default', 'table': 'events', 'status': 'Ok', 'rows': 2, 'flush_latency_us': 250000},
     ]
 
-    with mock.patch('datadog_checks.clickhouse.query_completions.datadog_agent') as mock_agent:
-        mock_agent.get_version.return_value = '7.64.0'
-        payload = query_completions._create_flush_event(records)
+    payload = query_completions._create_flush_event(records)
 
     assert payload['ddsource'] == 'clickhouse'
     assert payload['dbm_type'] == DBM_TYPE_FLUSH

--- a/clickhouse/tests/test_query_errors.py
+++ b/clickhouse/tests/test_query_errors.py
@@ -150,9 +150,7 @@ def test_create_batched_payload_error_fields(check_with_dbm):
         }
     ]
 
-    with mock.patch('datadog_checks.clickhouse.query_errors.datadog_agent') as mock_agent:
-        mock_agent.get_version.return_value = '7.64.0'
-        payload = query_errors._create_batched_payload(rows)
+    payload = query_errors._create_batched_payload(rows)
 
     assert payload is not None
     assert len(payload['clickhouse_query_errors']) == 1
@@ -183,9 +181,7 @@ def test_create_batched_payload_carries_clickhouse_node(check_with_dbm):
         },
     ]
 
-    with mock.patch('datadog_checks.clickhouse.query_errors.datadog_agent') as mock_agent:
-        mock_agent.get_version.return_value = '7.64.0'
-        payload = query_errors._create_batched_payload(rows)
+    payload = query_errors._create_batched_payload(rows)
 
     query_details = payload['clickhouse_query_errors'][0]['query_details']
     assert query_details['clickhouse_node'] == 'ch-node-1'
@@ -208,9 +204,7 @@ def test_create_batched_payload_clickhouse_node_defaults_empty(check_with_dbm):
         },
     ]
 
-    with mock.patch('datadog_checks.clickhouse.query_errors.datadog_agent') as mock_agent:
-        mock_agent.get_version.return_value = '7.64.0'
-        payload = query_errors._create_batched_payload(rows)
+    payload = query_errors._create_batched_payload(rows)
 
     query_details = payload['clickhouse_query_errors'][0]['query_details']
     assert query_details['clickhouse_node'] == ''
@@ -234,9 +228,7 @@ def test_create_batched_payload_structure(check_with_dbm):
         },
     ]
 
-    with mock.patch('datadog_checks.clickhouse.query_errors.datadog_agent') as mock_agent:
-        mock_agent.get_version.return_value = '7.64.0'
-        payload = query_errors._create_batched_payload(rows)
+    payload = query_errors._create_batched_payload(rows)
 
     assert payload['ddsource'] == 'clickhouse'
     assert payload['dbm_type'] == 'query_error'
@@ -244,7 +236,7 @@ def test_create_batched_payload_structure(check_with_dbm):
     assert 'timestamp' in payload
     assert 'host' in payload
     assert 'database_instance' in payload
-    assert payload['ddagentversion'] == '7.64.0'
+    assert payload['ddagentversion'] == '0.0.0'
     assert payload['ddtags'] == ['test:clickhouse', 'server:localhost']
     assert payload['collection_interval'] == query_errors._collection_interval
     assert 'clickhouse_version' in payload

--- a/clickhouse/tests/test_statement_samples.py
+++ b/clickhouse/tests/test_statement_samples.py
@@ -123,9 +123,7 @@ def test_create_samples_event(check_with_dbm):
 
     active_connections = [{'user': 'default', 'query_kind': 'Select', 'current_database': 'default', 'connections': 5}]
 
-    with mock.patch('datadog_checks.clickhouse.statement_samples.datadog_agent') as mock_agent:
-        mock_agent.get_version.return_value = '7.64.0'
-        event = samples._create_samples_event(rows, active_connections)
+    event = samples._create_samples_event(rows, active_connections)
 
     # Verify event structure
     assert event['ddsource'] == 'clickhouse'
@@ -646,9 +644,7 @@ def test_create_buffer_event(check_with_dbm):
         }
     ]
 
-    with mock.patch('datadog_checks.clickhouse.statement_samples.datadog_agent') as mock_agent:
-        mock_agent.get_version.return_value = '7.64.0'
-        payload = samples._create_buffer_event(buffer_snapshot)
+    payload = samples._create_buffer_event(buffer_snapshot)
 
     # Verify event structure
     assert payload['ddsource'] == 'clickhouse'


### PR DESCRIPTION
### What does this PR do?
Use the cached Agent version in Clickhouse

### Motivation
Avoids an FFI call each time we call agent_version

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
