### PR TITLE
[TXP-333] Set data_type for saas-integrations dataflows

### DIFF
--- a/bluecat_edge/assets/dataflows.yaml
+++ b/bluecat_edge/assets/dataflows.yaml
@@ -2,3 +2,4 @@ provides:
   - id: bluecat-edge-dns-query-logs
     always_on: false
     granular: true
+    data_type: logs

--- a/cisco_sdwan/assets/dataflows.yaml
+++ b/cisco_sdwan/assets/dataflows.yaml
@@ -1,3 +1,4 @@
 provides:
   - id: cisco-sdwan-network-device-metrics
     always_on: false
+    data_type: metrics

--- a/databricks/assets/dataflows.yaml
+++ b/databricks/assets/dataflows.yaml
@@ -7,6 +7,8 @@ provides:
   - id: databricks-reference-tables
     always_on: false
     granular: false
+    data_type: resources
   - id: databricks-metrics
     always_on: false
     granular: false
+    data_type: metrics

--- a/hubspot_content_hub/assets/dataflows.yaml
+++ b/hubspot_content_hub/assets/dataflows.yaml
@@ -2,6 +2,7 @@ provides:
   - id: hubspot-content-hub-reference-tables
     always_on: false
     granular: false
+    data_type: resources
     direction: inbound
   - id: hubspot-content-hub-metrics
     always_on: false


### PR DESCRIPTION
Set `data_type` for the missing saas-integrations dataflows. We will soon be making this a required field; but looking to make sure all existing dataflows define a "data_type".

Initially gathered alignment through this spreadsheet - https://docs.google.com/spreadsheets/d/1AGbEs1TBfdH_Y3QqFACiS74LwZ08YZEaHJ1vhSDJh50/edit?pli=1&gid=992123986#gid=992123986

This PR modifies:
* bluecat_edge
* cisco_sdwan
* databricks
* hubspot_content_hub