### PR TITLE
Warn on unexpected negative committed offsets in kafka_consumer

### DIFF
--- a/kafka_consumer/changelog.d/25026.fixed
+++ b/kafka_consumer/changelog.d/25026.fixed
@@ -1,0 +1,1 @@
+Warn in `agent status` when a monitored committed offset holds an unexpected negative value, naming up to five affected `(consumer_group, topic, partition, offset)` tuples, and keep reporting `kafka.broker_offset` for those partitions.

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -256,21 +256,32 @@ class KafkaCheck(AgentCheck):
             payload['connect_api_status'] = connect_status
         self._emit_cluster_monitoring_event(payload)
 
-    def _warn_on_unexpected_negative_offsets(self, unexpected_negatives: list[tuple], monitored_offsets: int) -> None:
+    def _warn_on_unexpected_negative_offsets(
+        self,
+        unexpected_negatives: list[tuple[str, str, int, int]],
+        monitored_offsets: int,
+    ) -> None:
         if not unexpected_negatives:
             return
+        # Only mention the cap when it actually drops something. Naming it unconditionally makes the
+        # common one-or-two-offender case read as though the report were incomplete.
+        truncated_note = (
+            f" Only the first {MAX_REPORTED_NEGATIVE_OFFSETS} are shown."
+            if len(unexpected_negatives) > MAX_REPORTED_NEGATIVE_OFFSETS
+            else ""
+        )
         self.warning(
             "%d of %d monitored committed offset(s) hold an unexpected negative value and are being "
             "discarded: a committed offset is never negative, so these are not consumer positions. "
             "consumer_offset and consumer_lag will be missing for those partitions; broker_offset is "
-            "still reported. Showing up to %d as (consumer_group, topic, partition, offset): %s",
+            "still reported. Affected (consumer_group, topic, partition, offset): %s%s",
             len(unexpected_negatives),
             monitored_offsets,
-            MAX_REPORTED_NEGATIVE_OFFSETS,
             unexpected_negatives[:MAX_REPORTED_NEGATIVE_OFFSETS],
+            truncated_note,
         )
 
-    def get_consumer_offsets(self) -> tuple[dict, set]:
+    def get_consumer_offsets(self) -> tuple[dict[str, dict[tuple[str, int], int]], set[tuple[str, int]]]:
         """Collect the committed offsets of every monitored consumer group.
 
         Returns ``({consumer_group: {(topic, partition): offset}}, {(topic, partition)})``. The

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -16,9 +16,14 @@ from datadog_checks.kafka_consumer.client import KafkaClient
 from datadog_checks.kafka_consumer.cluster_metadata import ClusterMetadataCollector
 from datadog_checks.kafka_consumer.config import KafkaConfig
 from datadog_checks.kafka_consumer.connectors import KafkaConnectCollector
-from datadog_checks.kafka_consumer.constants import HIGH_WATERMARK, KAFKA_INTERNAL_TOPICS
+from datadog_checks.kafka_consumer.constants import HIGH_WATERMARK, KAFKA_INTERNAL_TOPICS, OFFSET_INVALID
 
 MAX_TIMESTAMPS = 1000
+
+# Cap on how many offending (consumer_group, topic, partition, offset) tuples one
+# unexpected-negative-offset warning names, so `agent status` stays readable on a cluster where
+# many partitions are affected. The warning always reports the full count alongside the sample.
+MAX_REPORTED_NEGATIVE_OFFSETS = 5
 
 # Total broker-timestamp entries retained per cluster, ~0.5 GiB at ~89 bytes/entry. The
 # per-partition history is scaled down from this budget as the partition count grows.
@@ -84,6 +89,7 @@ class KafkaCheck(AgentCheck):
         # Fetch Kafka consumer offsets
 
         consumer_offsets = {}
+        discarded_partitions = set()
 
         try:
             self.client.request_metadata_update()
@@ -99,8 +105,7 @@ class KafkaCheck(AgentCheck):
 
         try:
             # Fetch consumer offsets
-            # Expected format: {consumer_group: {(topic, partition): offset}}
-            consumer_offsets = self.get_consumer_offsets()
+            consumer_offsets, discarded_partitions = self.get_consumer_offsets()
         except Exception:
             self.log.exception("There was a problem collecting consumer offsets from Kafka.")
             # don't raise because we might get valid broker offsets
@@ -123,7 +128,10 @@ class KafkaCheck(AgentCheck):
                 if self.config._cluster_monitoring_enabled or self.config._monitor_all_broker_highwatermarks:
                     partitions = None
                 else:
-                    partitions = set()
+                    # Seed with the partitions whose committed offset was discarded. A highwater
+                    # mark belongs to the partition, not to any group's committed position, so
+                    # broker_offset stays available even where consumer_offset cannot be computed.
+                    partitions = set(discarded_partitions)
                     for _, offsets in consumer_offsets.items():
                         for topic, partition in offsets:
                             partitions.add((topic, partition))
@@ -248,8 +256,27 @@ class KafkaCheck(AgentCheck):
             payload['connect_api_status'] = connect_status
         self._emit_cluster_monitoring_event(payload)
 
-    def get_consumer_offsets(self):
-        # {(consumer_group, topic, partition): offset}
+    def _warn_on_unexpected_negative_offsets(self, unexpected_negatives: list[tuple], monitored_offsets: int) -> None:
+        if not unexpected_negatives:
+            return
+        self.warning(
+            "%d of %d monitored committed offset(s) hold an unexpected negative value and are being "
+            "discarded: a committed offset is never negative, so these are not consumer positions. "
+            "consumer_offset and consumer_lag will be missing for those partitions; broker_offset is "
+            "still reported. Showing up to %d as (consumer_group, topic, partition, offset): %s",
+            len(unexpected_negatives),
+            monitored_offsets,
+            MAX_REPORTED_NEGATIVE_OFFSETS,
+            unexpected_negatives[:MAX_REPORTED_NEGATIVE_OFFSETS],
+        )
+
+    def get_consumer_offsets(self) -> tuple[dict, set]:
+        """Collect the committed offsets of every monitored consumer group.
+
+        Returns ``({consumer_group: {(topic, partition): offset}}, {(topic, partition)})``. The
+        second element holds the partitions whose committed offset was discarded: they have no
+        consumer offset, but they still need a highwater mark.
+        """
         self.log.debug('Getting consumer offsets')
         consumer_offsets = defaultdict(dict)
 
@@ -259,6 +286,9 @@ class KafkaCheck(AgentCheck):
         offsets = self._get_offsets_for_groups(consumer_groups)
         self.log.debug('%s futures to be waited on', len(offsets))
 
+        monitored_offsets = 0
+        unexpected_negatives = []
+        discarded_partitions = set()
         for consumer_group, topic_partitions in offsets:
             self.log.debug('RESULT CONSUMER GROUP: %s', consumer_group)
 
@@ -266,6 +296,19 @@ class KafkaCheck(AgentCheck):
                 self.log.debug('RESULTS TOPIC: %s', topic)
                 self.log.debug('RESULTS PARTITION: %s', partition)
                 self.log.debug('RESULTS OFFSET: %s', offset)
+
+                # Filter on the consumer group first. A group the operator excluded from their
+                # config should not reach the warning below, and should not keep a partition in
+                # the highwater request set either.
+                is_monitored = (
+                    self.config._monitor_unlisted_consumer_groups
+                    or not self.config._consumer_groups_compiled_regex
+                    or self.config._consumer_groups_compiled_regex.match(f"{consumer_group},{topic},{partition}")
+                )
+                if not is_monitored:
+                    continue
+
+                monitored_offsets += 1
 
                 # A real committed offset is always a non-negative, monotonically increasing
                 # per-partition sequence number assigned by the broker. librdkafka reuses the
@@ -275,17 +318,24 @@ class KafkaCheck(AgentCheck):
                 # any other negative sentinel librdkafka may return here.
                 # https://github.com/confluentinc/librdkafka/blob/master/src/rdkafka.h
                 if offset < 0:
+                    # OFFSET_INVALID is the routine case, and a high-volume one: every partition a
+                    # group has never committed to reports it on every run. So it stays silent, and
+                    # its partition is left out of the highwater request set rather than spending
+                    # the context limit on partitions nobody asked about. Any other negative means
+                    # __consumer_offsets holds a value that is not a position at all: name it so the
+                    # operator can explain the missing metrics, and keep the partition's
+                    # broker_offset, which the bad committed value does not affect.
+                    if offset != OFFSET_INVALID:
+                        unexpected_negatives.append((consumer_group, topic, partition, offset))
+                        discarded_partitions.add((topic, partition))
                     continue
 
-                if (
-                    self.config._monitor_unlisted_consumer_groups
-                    or not self.config._consumer_groups_compiled_regex
-                    or self.config._consumer_groups_compiled_regex.match(f"{consumer_group},{topic},{partition}")
-                ):
-                    consumer_offsets[consumer_group][(topic, partition)] = offset
+                consumer_offsets[consumer_group][(topic, partition)] = offset
+
+        self._warn_on_unexpected_negative_offsets(unexpected_negatives, monitored_offsets)
 
         self.log.debug('Got %s consumer offsets', len(consumer_offsets))
-        return consumer_offsets
+        return consumer_offsets, discarded_partitions
 
     def _get_consumer_groups(self):
         # Get all consumer groups to monitor

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -13,6 +13,7 @@ import pytest
 
 from datadog_checks.kafka_consumer import KafkaCheck
 from datadog_checks.kafka_consumer.client import KafkaClient
+from datadog_checks.kafka_consumer.kafka_consumer import MAX_REPORTED_NEGATIVE_OFFSETS
 
 pytestmark = [pytest.mark.unit]
 
@@ -275,22 +276,6 @@ def test_when_consumer_lag_less_than_zero_then_emit_event(check, kafka_instance,
             'kafka_cluster_id:cluster_id',
         ],
     )
-
-
-def test_when_no_committed_offset_then_consumer_metrics_are_skipped(check, kafka_instance, dd_run_check, aggregator):
-    # Given: a partition with no committed offset, which librdkafka can surface as a negative
-    # logical offset (e.g. -1001 OFFSET_INVALID, or -2 OFFSET_BEGINNING) rather than a real offset.
-    mock_client = seed_mock_client()
-    mock_client.list_consumer_group_offsets.return_value = [("consumer_group1", [("topic1", "partition1", -2)])]
-    kafka_consumer_check = check(kafka_instance)
-    kafka_consumer_check.client = mock_client
-
-    # When
-    dd_run_check(kafka_consumer_check)
-
-    # Then: the partition is skipped rather than reporting a negative offset and inflated lag
-    aggregator.assert_metric("kafka.consumer_offset", count=0)
-    aggregator.assert_metric("kafka.consumer_lag", count=0)
 
 
 def test_when_collect_consumer_group_state_is_enabled(check, kafka_instance, dd_run_check, aggregator):
@@ -1238,3 +1223,180 @@ def test_get_partition_offsets_drops_negative_offsets():
     results = client.get_partition_offsets([("healthy_topic", 0), ("wrapped_topic", 0)])
 
     assert results == [("healthy_topic", 0, 100)]
+
+
+@pytest.mark.parametrize(
+    'offset, expected_consumer_count, expected_broker_count, expect_warning',
+    [
+        # librdkafka's logical offsets. None is a consumer position, so none may become a
+        # kafka.consumer_offset -- that much #24938 already guarantees. They split on what else
+        # they produce: OFFSET_INVALID is what a group that has never committed to a partition
+        # reports on every run, so it is silent and its partition is kept out of the highwater
+        # request set. Every other negative is a value that has no business being in
+        # __consumer_offsets, so the operator is warned and the partition keeps its
+        # kafka.broker_offset.
+        pytest.param(-1001, 0, 0, False, id='OFFSET_INVALID'),
+        pytest.param(-1000, 0, 1, True, id='OFFSET_STORED'),
+        pytest.param(-2, 0, 1, True, id='OFFSET_BEGINNING'),
+        pytest.param(-1, 0, 1, True, id='OFFSET_END'),
+        # 0 is a legitimate committed offset: a group that has consumed only the first record of
+        # a partition sits there. It is also the most common value on a real cluster, so the
+        # guard has to be `< 0` and never `<= 0`.
+        pytest.param(0, 1, 1, False, id='first_record'),
+        pytest.param(5, 1, 1, False, id='mid_partition'),
+    ],
+)
+def test_committed_offset_value_handling(
+    check,
+    kafka_instance,
+    dd_run_check,
+    aggregator,
+    offset,
+    expected_consumer_count,
+    expected_broker_count,
+    expect_warning,
+):
+    mock_client = seed_mock_client()
+    mock_client.list_consumer_group_offsets.return_value = [("consumer_group1", [("topic1", "partition1", offset)])]
+    kafka_consumer_check = check(kafka_instance)
+    kafka_consumer_check.client = mock_client
+
+    dd_run_check(kafka_consumer_check)
+
+    aggregator.assert_metric("kafka.consumer_offset", count=expected_consumer_count)
+    aggregator.assert_metric("kafka.consumer_lag", count=expected_consumer_count)
+    # The broker count is what pins the asymmetry in both directions. Widening the discard branch
+    # to every negative would push each never-committed partition into the highwater request set,
+    # spending the context limit on partitions nobody asked to monitor, and only the
+    # OFFSET_INVALID row here would catch it.
+    aggregator.assert_metric("kafka.broker_offset", count=expected_broker_count)
+
+    # Assert on the collected warnings rather than the log text: these are what `agent status`
+    # renders, and an empty list cannot pass vacuously the way an absent substring can.
+    if expect_warning:
+        assert len(kafka_consumer_check.warnings) == 1
+        assert "hold an unexpected negative value" in kafka_consumer_check.warnings[0]
+        assert f"('consumer_group1', 'topic1', 'partition1', {offset})" in kafka_consumer_check.warnings[0]
+    else:
+        assert kafka_consumer_check.warnings == []
+
+
+def test_negative_committed_offset_does_not_suppress_sibling_partitions(
+    check, kafka_instance, dd_run_check, aggregator
+):
+    """One partition holding a logical offset must not cost the rest of the topic its metrics."""
+    partitions = ['partition1', 'partition2', 'partition3']
+    mock_client = seed_mock_client()
+    mock_client.consumer_get_cluster_id_and_list_topics.return_value = ('cluster_id', [('topic1', partitions)])
+    mock_client.get_partitions_for_topic.return_value = partitions
+    mock_client.list_consumer_group_offsets.return_value = [
+        (
+            "consumer_group1",
+            [("topic1", "partition1", 10), ("topic1", "partition2", -2), ("topic1", "partition3", 20)],
+        )
+    ]
+    kafka_consumer_check = check(kafka_instance)
+    kafka_consumer_check.client = mock_client
+
+    dd_run_check(kafka_consumer_check)
+
+    aggregator.assert_metric("kafka.consumer_offset", count=2)
+    aggregator.assert_metric(
+        "kafka.consumer_offset",
+        value=10,
+        count=1,
+        tags=[
+            'consumer_group:consumer_group1',
+            'optional:tag1',
+            'partition:partition1',
+            'topic:topic1',
+            'kafka_cluster_id:cluster_id',
+        ],
+    )
+    aggregator.assert_metric(
+        "kafka.consumer_offset",
+        value=20,
+        count=1,
+        tags=[
+            'consumer_group:consumer_group1',
+            'optional:tag1',
+            'partition:partition3',
+            'topic:topic1',
+            'kafka_cluster_id:cluster_id',
+        ],
+    )
+    # The highwater offset is 80 for every partition, so lag follows the two surviving offsets.
+    aggregator.assert_metric("kafka.consumer_lag", count=2)
+    aggregator.assert_metric(
+        "kafka.consumer_lag",
+        value=70,
+        count=1,
+        tags=[
+            'consumer_group:consumer_group1',
+            'optional:tag1',
+            'partition:partition1',
+            'topic:topic1',
+            'kafka_cluster_id:cluster_id',
+        ],
+    )
+    # partition2 keeps its broker_offset despite the discarded commit: the highwater request set
+    # is seeded with the discarded partitions, so only the consumer-side metrics go missing.
+    aggregator.assert_metric("kafka.broker_offset", count=3)
+    for partition in partitions:
+        aggregator.assert_metric(
+            "kafka.broker_offset",
+            value=80,
+            count=1,
+            tags=['topic:topic1', f'partition:{partition}', 'kafka_cluster_id:cluster_id', 'optional:tag1'],
+        )
+
+
+def test_negative_offset_outside_configured_partitions_is_silent(check, kafka_instance, dd_run_check):
+    """A partition the operator did not ask to monitor must not reach the warning."""
+    # `consumer_groups_regex` is the option that compiles into _consumer_groups_compiled_regex, and
+    # its patterns are unioned with those from `consumer_groups` -- so clear the latter to keep the
+    # match set to exactly what this test declares. The broker returns committed offsets for every
+    # partition a group has an entry for, not only the ones the regex selects, so the filter has to
+    # run before the negative check or an excluded partition still reaches `agent status`.
+    kafka_instance['consumer_groups'] = {}
+    kafka_instance['consumer_groups_regex'] = {'consumer_group1': {'topic1': [0]}}
+    mock_client = seed_mock_client()
+    mock_client.list_consumer_group_offsets.return_value = [("consumer_group1", [("topic1", 0, -2), ("topic1", 1, -2)])]
+    kafka_consumer_check = check(kafka_instance)
+    kafka_consumer_check.client = mock_client
+
+    dd_run_check(kafka_consumer_check)
+
+    assert len(kafka_consumer_check.warnings) == 1
+    warning = kafka_consumer_check.warnings[0]
+    # Assert on the rendered tuple list as a whole rather than on the excluded partition's absence.
+    # A bare `not in` would also pass if the message stopped naming tuples altogether, and the
+    # excluded partition's tuple is a substring-match away from the included one's.
+    assert warning.endswith("[('consumer_group1', 'topic1', 0, -2)]")
+    # Partition 1 was filtered out before the negative check, so it is not in the denominator.
+    assert "1 of 1 monitored committed offset(s)" in warning
+
+
+def test_unexpected_negative_offset_report_is_capped(check, kafka_instance, dd_run_check, aggregator):
+    """The sample of offending tuples is capped; the count and the broker offsets are not."""
+    affected = MAX_REPORTED_NEGATIVE_OFFSETS + 3
+    partitions = [f'partition{i}' for i in range(affected)]
+    mock_client = seed_mock_client()
+    mock_client.consumer_get_cluster_id_and_list_topics.return_value = ('cluster_id', [('topic1', partitions)])
+    mock_client.get_partitions_for_topic.return_value = partitions
+    mock_client.list_consumer_group_offsets.return_value = [
+        ("consumer_group1", [("topic1", partition, -2) for partition in partitions])
+    ]
+    kafka_consumer_check = check(kafka_instance)
+    kafka_consumer_check.client = mock_client
+
+    dd_run_check(kafka_consumer_check)
+
+    assert len(kafka_consumer_check.warnings) == 1
+    warning = kafka_consumer_check.warnings[0]
+    # The count is the whole population, so an operator can tell a truncated sample from a
+    # complete one; only the rendered tuple list is capped. Each tuple names the topic once.
+    assert f"{affected} of {affected} monitored committed offset(s)" in warning
+    assert warning.count("'topic1'") == MAX_REPORTED_NEGATIVE_OFFSETS
+    # The cap governs the message only -- every affected partition still keeps its highwater mark.
+    aggregator.assert_metric("kafka.broker_offset", count=affected)

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -1372,6 +1372,8 @@ def test_negative_offset_outside_configured_partitions_is_silent(check, kafka_in
     # Assert on the rendered tuple list as a whole rather than on the excluded partition's absence.
     # A bare `not in` would also pass if the message stopped naming tuples altogether, and the
     # excluded partition's tuple is a substring-match away from the included one's.
+    # The endswith also pins the absence of the truncation note: nothing was dropped from a
+    # one-tuple report, so the cap must not be announced, and the note would land right here.
     assert warning.endswith("[('consumer_group1', 'topic1', 0, -2)]")
     # Partition 1 was filtered out before the negative check, so it is not in the denominator.
     assert "1 of 1 monitored committed offset(s)" in warning
@@ -1398,5 +1400,7 @@ def test_unexpected_negative_offset_report_is_capped(check, kafka_instance, dd_r
     # complete one; only the rendered tuple list is capped. Each tuple names the topic once.
     assert f"{affected} of {affected} monitored committed offset(s)" in warning
     assert warning.count("'topic1'") == MAX_REPORTED_NEGATIVE_OFFSETS
+    # The cap is announced only because it actually dropped tuples here.
+    assert warning.endswith(f"Only the first {MAX_REPORTED_NEGATIVE_OFFSETS} are shown.")
     # The cap governs the message only -- every affected partition still keeps its highwater mark.
     aggregator.assert_metric("kafka.broker_offset", count=affected)


### PR DESCRIPTION
### What does this PR do?

Follow-up to #24938, now merged. For the negative committed offsets that are not `OFFSET_INVALID`, this warns once per run naming up to five `(consumer_group, topic, partition, offset)` tuples, and keeps those partitions in the highwater request set so `kafka.broker_offset` survives.

It also removes `test_when_no_committed_offset_then_consumer_metrics_are_skipped`, added by #24938: the parametrized test here covers the same `-2` case plus the five other offset values, the broker-offset counts and the warning contents.

### Motivation

#24938 stops every negative committed offset from becoming a `kafka.consumer_offset`, which fixes the inflated `kafka.consumer_lag`. Two gaps remain for the negatives that are not -1001: the partition drops out of the highwater request set and so loses `kafka.broker_offset` as well, and nothing above debug level says why the consumer metrics went missing — which is why AGENT-16813 needed a support case to diagnose.

-1001 keeps its current behaviour. Every partition a group has never committed to reports it on every run (716 times per run on the reporting cluster), so warning on it would flood `agent status`. Any other negative means `__consumer_offsets` holds a value that is not a position at all, which is rare and always wrong.

### Test plan

- [x] Parametrized unit test pins the per-value contract for every librdkafka logical offset and for legitimate offsets: which metrics are emitted, and whether the warning fires
- [x] Unit tests cover a corrupted partition alongside healthy siblings, a partition outside the configured consumer groups, and the five-tuple cap
- [x] `ddev test kafka_consumer` and `ddev test kafka_consumer --lint` pass

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

---

_This PR has been created and validated using the paired-review skill from agent-integrations. **Ready for human review**._

