### PR TITLE
[SEC-35270] Normalize live CrowdStrike FDR data

### DIFF
--- a/crowdstrike_fdr/assets/logs/crowdstrike-fdr.yaml
+++ b/crowdstrike_fdr/assets/logs/crowdstrike-fdr.yaml
@@ -134,6 +134,17 @@ pipeline:
   filter:
     query: source:crowdstrike-fdr
   processors:
+    - type: category-processor
+      name: Classify the CrowdStrike FDR dataset from the S3 object path
+      enabled: true
+      categories:
+        - filter:
+            query: "s3_key:*/data/*"
+          name: sensor
+        - filter:
+            query: "s3_key:*/fdrv2/userinfo/*"
+          name: userinfo
+      target: crowdstrike_fdr.dataset
     - type: arithmetic-processor
       name: Convert `ContextTimeStamp` epoch to milliseconds epoch
       enabled: true
@@ -197,6 +208,29 @@ pipeline:
           name: detection
       target: evt.category
     - type: attribute-remapper
+      name: Map `ContextProcessId`, `TargetProcessId` to `crowdstrike_fdr.process.id`
+      enabled: true
+      sources:
+        - ContextProcessId
+        - TargetProcessId
+      sourceType: attribute
+      target: crowdstrike_fdr.process.id
+      targetType: attribute
+      targetFormat: string
+      preserveSource: true
+      overrideOnConflict: false
+    - type: attribute-remapper
+      name: Map `ParentProcessId` to `crowdstrike_fdr.process.parent.id`
+      enabled: true
+      sources:
+        - ParentProcessId
+      sourceType: attribute
+      target: crowdstrike_fdr.process.parent.id
+      targetType: attribute
+      targetFormat: string
+      preserveSource: true
+      overrideOnConflict: false
+    - type: attribute-remapper
       name: Map `UserSid`, `UID`, `UserRid`, `OriginalUserSid` to `usr.id`
       enabled: true
       sources:
@@ -224,6 +258,22 @@ pipeline:
       targetType: attribute
       preserveSource: false
       overrideOnConflict: false
+    - type: pipeline
+      name: User Inventory
+      enabled: true
+      filter:
+        query: "@crowdstrike_fdr.dataset:userinfo"
+      processors:
+        - type: attribute-remapper
+          name: Map `UserSid_readable` to `usr.id`
+          enabled: true
+          sources:
+            - UserSid_readable
+          sourceType: attribute
+          target: usr.id
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: false
     - type: attribute-remapper
       name: Map `LocalAddressIP4`, `LocalAddressIP6`, `SourceEndpointAddressIP4`,
         `SourceEndpointAddressIP6` to `network.client.ip`
@@ -366,6 +416,16 @@ pipeline:
             58,ICMPV6
             255,UNKNOWN
           type: lookup-processor
+        - type: attribute-remapper
+          name: Map `ProtocolValue` to `network.protocol`
+          enabled: true
+          sources:
+            - ProtocolValue
+          sourceType: attribute
+          target: network.protocol
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: false
         - name: Lookup on `ConnectionDirection` Field
           enabled: true
           source: ConnectionDirection

--- a/crowdstrike_fdr/assets/logs/crowdstrike-fdr.yaml
+++ b/crowdstrike_fdr/assets/logs/crowdstrike-fdr.yaml
@@ -154,9 +154,10 @@ pipeline:
     # `UTCTimestamp` is deliberately not scaled: on the detection feed it is
     # already an epoch in milliseconds, so multiplying it would push the log
     # thousands of years into the future.
-    # `timestamp` is the last resort: it is the sensor upload time rather than the
-    # time the activity occurred, and it is the only date field present on every
-    # FDR event shape.
+    # `timestamp` is the last resort for event shapes that carry it. User inventory
+    # may contain only older vendor timestamps such as `_time`; when no supported
+    # event timestamp exists, retain intake time so newly ingested inventory remains
+    # visible in recent searches.
     - type: date-remapper
       name: Define `ContextTimeStamp`, `UTCTimestamp`, `timestamp` as the official
         date of the log

--- a/crowdstrike_fdr/assets/logs/crowdstrike-fdr_tests.yaml
+++ b/crowdstrike_fdr/assets/logs/crowdstrike-fdr_tests.yaml
@@ -77,6 +77,11 @@ tests:
       aid: "ffffffff3a5a424fa02450da53619745"
       aip: "10.10.10.10"
       cid: "ffffffff30a3407dae27d0503611022d"
+      crowdstrike_fdr:
+        process:
+          id: "583707537390"
+          parent:
+            id: "17346335177"
       event_platform: "Win"
       event_platform_value: "Windows"
       evt:
@@ -174,6 +179,9 @@ tests:
       aid: "fffffffff000426eb99afaa2ccdcbc17"
       aip: "10.10.10.10"
       cid: "ffffffff30a3407dae27d0503611022d"
+      crowdstrike_fdr:
+        process:
+          id: "223442259384"
       event_platform: "Win"
       event_platform_value: "Windows"
       evt:
@@ -190,6 +198,7 @@ tests:
           geoip: {}
           ip: "10.20.30.40"
           port: "443"
+        protocol: "TCP"
       timestamp: "1604855116942"
     message: |-
       {
@@ -265,6 +274,9 @@ tests:
       aid: "31e92a267c044d57b1c1e14109079e89"
       aip: "10.10.10.10"
       cid: "ffffffff30a3407dae27d0503611022d"
+      crowdstrike_fdr:
+        process:
+          id: "683613242245"
       dns:
         question:
           name: "metadata.google.internal"
@@ -367,6 +379,9 @@ tests:
       aid: "ffffffff8d2e4b4f9b21b40633a8d579"
       aip: "10.10.10.10"
       cid: "ffffffff30a3407dae27d0503611022d"
+      crowdstrike_fdr:
+        process:
+          id: "816054990879"
       event_platform: "Win"
       event_platform_value: "Windows"
       evt:
@@ -478,6 +493,9 @@ tests:
       aid: "ffffffff73164cfa9656c4caff8a2a38"
       aip: "10.10.10.10"
       cid: "ffffffff30a3407dae27d0503611022d"
+      crowdstrike_fdr:
+        process:
+          id: "30254389526587"
       event_platform: "Win"
       event_platform_value: "Windows"
       evt:
@@ -670,6 +688,10 @@ tests:
       Technique: "Sensor-based ML"
       UTCTimestamp: 1680759530000
       cid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      crowdstrike_fdr:
+        process:
+          parent:
+            id: "1680759529306198500"
       eid: 118
       evt:
         category: "detection"
@@ -800,6 +822,9 @@ tests:
       aid: "ffffffff6854438eb4181691ec47e43d"
       aip: "67.43.156.14"
       cid: "ffffffff30a3407dae27d0503611022d"
+      crowdstrike_fdr:
+        process:
+          id: "56042872298"
       event_platform: "Win"
       event_platform_value: "Windows"
       evt:
@@ -816,6 +841,7 @@ tests:
           geoip: {}
           ip: "2606:4700:4700::1111"
           port: "443"
+        protocol: "TCP"
       timestamp: "1604855199798"
     message: |-
       {
@@ -889,6 +915,9 @@ tests:
       aid: "fffffffff000426eb99afaa2ccdcbc17"
       aip: "10.10.10.10"
       cid: "ffffffff30a3407dae27d0503611022d"
+      crowdstrike_fdr:
+        process:
+          id: "223442259385"
       event_platform: "Win"
       event_platform_value: "Windows"
       evt:
@@ -905,6 +934,7 @@ tests:
           geoip: {}
           ip: "10.20.30.41"
           port: "445"
+        protocol: "TCP"
       timestamp: "1604855120310"
     message: |-
       {
@@ -978,6 +1008,9 @@ tests:
       aid: "fffffffff000426eb99afaa2ccdcbc17"
       aip: "10.10.10.10"
       cid: "ffffffff30a3407dae27d0503611022d"
+      crowdstrike_fdr:
+        process:
+          id: "223442259386"
       event_platform: "Win"
       event_platform_value: "Windows"
       evt:
@@ -994,6 +1027,7 @@ tests:
           geoip: {}
           ip: "10.20.30.42"
           port: "8080"
+        protocol: "UDP"
       timestamp: "1604855124638"
     message: |-
       {
@@ -1070,6 +1104,9 @@ tests:
       aid: "31e92a267c044d57b1c1e14109079e89"
       aip: "10.10.10.10"
       cid: "ffffffff30a3407dae27d0503611022d"
+      crowdstrike_fdr:
+        process:
+          id: "683613242246"
       dns:
         answer:
           name: "10.20.30.43"
@@ -1231,3 +1268,226 @@ tests:
     tags:
      - "source:LOGS_SOURCE"
     timestamp: 1680759540000
+ # The following fixtures are sanitized reconstructions of processed Log Explorer
+ # exports. They preserve only fields needed to exercise deterministic processors
+ # and do not claim byte-for-byte fidelity with the raw CrowdStrike objects.
+ # The sensor-shaped fixtures omit S3 tags to verify unknown datasets stay unclassified.
+ -
+  sample: |-
+    {
+      "ComputerName" : "demo-mac-01",
+      "ContextProcessId" : "987654321012345678",
+      "ParentProcessId" : "876543210123456789",
+      "SHA256HashData" : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "TargetProcessId" : "765432101234567890",
+      "aid" : "11111111111111111111111111111111",
+      "cid" : "22222222222222222222222222222222",
+      "event_platform" : "Mac",
+      "event_simpleName" : "ProcessRollup2",
+      "name" : "ProcessRollup2MacV12",
+      "timestamp" : "1787000000000"
+    }
+  result:
+    custom:
+      ComputerName: "demo-mac-01"
+      ContextProcessId: "987654321012345678"
+      ParentProcessId: "876543210123456789"
+      SHA256HashData: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      TargetProcessId: "765432101234567890"
+      aid: "11111111111111111111111111111111"
+      cid: "22222222222222222222222222222222"
+      crowdstrike_fdr:
+        process:
+          id: "987654321012345678"
+          parent:
+            id: "876543210123456789"
+      event_platform: "Mac"
+      event_platform_value: "Mac"
+      evt:
+        category: "process"
+        name: "ProcessRollup2"
+      name: "ProcessRollup2MacV12"
+      timestamp: "1787000000000"
+    message: |-
+      {
+        "event_simpleName" : "ProcessRollup2",
+        "event_platform" : "Mac",
+        "TargetProcessId" : "765432101234567890",
+        "ContextProcessId" : "987654321012345678",
+        "ParentProcessId" : "876543210123456789",
+        "ComputerName" : "demo-mac-01",
+        "name" : "ProcessRollup2MacV12",
+        "SHA256HashData" : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "aid" : "11111111111111111111111111111111",
+        "cid" : "22222222222222222222222222222222",
+        "timestamp" : "1787000000000"
+      }
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1787000000000
+ -
+  sample: |-
+    {
+      "ConnectionDirection" : "0",
+      "ConnectionFlags" : "0",
+      "ContextProcessId" : "987654321012345678",
+      "LocalAddressIP4" : "192.0.2.10",
+      "LocalPort" : "51515",
+      "Protocol" : "6",
+      "RemoteAddressIP4" : "198.51.100.20",
+      "RemotePort" : "443",
+      "aid" : "11111111111111111111111111111111",
+      "cid" : "22222222222222222222222222222222",
+      "event_platform" : "Mac",
+      "event_simpleName" : "NetworkConnectIP4",
+      "name" : "NetworkConnectIP4V15",
+      "timestamp" : "1787000001000"
+    }
+  result:
+    custom:
+      ConnectionDirection: "0"
+      ConnectionDirectionValue: "DIRECTION_OUTBOUND"
+      ConnectionFlags: "0"
+      ConnectionFlagsValue: "NONE"
+      ContextProcessId: "987654321012345678"
+      Protocol: "6"
+      ProtocolValue: "TCP"
+      aid: "11111111111111111111111111111111"
+      cid: "22222222222222222222222222222222"
+      crowdstrike_fdr:
+        process:
+          id: "987654321012345678"
+      event_platform: "Mac"
+      event_platform_value: "Mac"
+      evt:
+        category: "network"
+        name: "NetworkConnectIP4"
+      name: "NetworkConnectIP4V15"
+      network:
+        client:
+          geoip: {}
+          ip: "192.0.2.10"
+          port: "51515"
+        destination:
+          geoip: {}
+          ip: "198.51.100.20"
+          port: "443"
+        protocol: "TCP"
+      timestamp: "1787000001000"
+    message: |-
+      {
+        "LocalAddressIP4" : "192.0.2.10",
+        "event_simpleName" : "NetworkConnectIP4",
+        "ConnectionFlags" : "0",
+        "ContextProcessId" : "987654321012345678",
+        "RemotePort" : "443",
+        "event_platform" : "Mac",
+        "LocalPort" : "51515",
+        "name" : "NetworkConnectIP4V15",
+        "Protocol" : "6",
+        "RemoteAddressIP4" : "198.51.100.20",
+        "aid" : "11111111111111111111111111111111",
+        "ConnectionDirection" : "0",
+        "cid" : "22222222222222222222222222222222",
+        "timestamp" : "1787000001000"
+      }
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1787000001000
+ -
+  sample: |-
+    {
+      "ContextBaseFileName" : "demo-resolver",
+      "ContextProcessId" : "987654321012345678",
+      "DomainName" : "demo.example",
+      "QueryStatus" : "0",
+      "RequestType" : "1",
+      "aid" : "11111111111111111111111111111111",
+      "cid" : "22222222222222222222222222222222",
+      "event_platform" : "Mac",
+      "event_simpleName" : "DnsRequest",
+      "name" : "DnsRequestMacV6",
+      "timestamp" : "1787000002000"
+    }
+  result:
+    custom:
+      ContextBaseFileName: "demo-resolver"
+      ContextProcessId: "987654321012345678"
+      QueryStatus: "0"
+      RequestType: "1"
+      aid: "11111111111111111111111111111111"
+      cid: "22222222222222222222222222222222"
+      crowdstrike_fdr:
+        process:
+          id: "987654321012345678"
+      dns:
+        question:
+          name: "demo.example"
+          type: "A"
+      event_platform: "Mac"
+      event_platform_value: "Mac"
+      evt:
+        category: "dns"
+        name: "DnsRequest"
+      name: "DnsRequestMacV6"
+      timestamp: "1787000002000"
+    message: |-
+      {
+        "ContextBaseFileName" : "demo-resolver",
+        "event_simpleName" : "DnsRequest",
+        "event_platform" : "Mac",
+        "ContextProcessId" : "987654321012345678",
+        "DomainName" : "demo.example",
+        "name" : "DnsRequestMacV6",
+        "QueryStatus" : "0",
+        "aid" : "11111111111111111111111111111111",
+        "RequestType" : "1",
+        "cid" : "22222222222222222222222222222222",
+        "timestamp" : "1787000002000"
+      }
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1787000002000
+ -
+  sample: |-
+    {
+      "LogonTime" : "1735689600",
+      "PasswordLastSet" : "1704067200",
+      "User" : "DEMO\\demo.user",
+      "UserName" : "demo.user",
+      "UserSid_readable" : "S-1-5-21-111111111-222222222-333333333-1001",
+      "_time" : "1735689600",
+      "crowdstrike_fdr" : {
+        "dataset" : "userinfo"
+      },
+      "timestamp" : "1787000003000"
+    }
+  result:
+    custom:
+      LogonTime: "1735689600"
+      PasswordLastSet: "1704067200"
+      User: "DEMO\\demo.user"
+      UserSid_readable: "S-1-5-21-111111111-222222222-333333333-1001"
+      _time: "1735689600"
+      crowdstrike_fdr:
+        dataset: "userinfo"
+      timestamp: "1787000003000"
+      usr:
+        id: "S-1-5-21-111111111-222222222-333333333-1001"
+        name: "demo.user"
+    message: |-
+      {
+        "User" : "DEMO\\demo.user",
+        "UserName" : "demo.user",
+        "LogonTime" : "1735689600",
+        "PasswordLastSet" : "1704067200",
+        "UserSid_readable" : "S-1-5-21-111111111-222222222-333333333-1001",
+        "crowdstrike_fdr" : {
+          "dataset" : "userinfo"
+        },
+        "_time" : "1735689600",
+        "timestamp" : "1787000003000"
+      }
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1787000003000


### PR DESCRIPTION
### What does this PR do?

- Classifies CrowdStrike FDR sensor and userinfo datasets from their S3 object paths.
  - Unknown paths remain unclassified.
  - Userinfo stays inventory data and receives no event name or category.
- Adds searchable process correlation attributes while preserving the raw process IDs.
  - `ContextProcessId` takes precedence over `TargetProcessId`.
  - Process IDs are normalized as strings so 18-digit values remain exact.
- Normalizes the resolved network protocol and readable userinfo SID onto established standard attributes.
  - Raw protocol and SID attributes remain available.
- Adds sanitized fixtures reconstructed from processed Log Explorer exports for process, network, DNS, and userinfo shapes.
  - All 15 expected results match the logs-backend sample processor output exactly.
  - `ddev validate all crowdstrike_fdr` passes 20 applicable validators. The asset-only integration triggers the known `agent-reqs` Python-package assumption.
- Keeps investigation facets in the stacked [SEC-35329 PR #25028](https://github.com/DataDog/integrations-core/pull/25028).
  - That PR adds dataset and network protocol facets. High-cardinality process identifiers remain searchable without facets.

### Motivation

- FanDuel needs a consistent process-correlation field across the observed process, network, DNS, and authentication telemetry.
  - All four families are confirmed live. `UserLogon` carries `ContextProcessId`, so authentication events receive the same correlation field as the other three.
- Detection correlation is out of scope because CrowdStrike is not sending detections. A full `@evt.name` census over the two days ending 2026-08-28T14:42Z found zero `DetectionSummaryEvent` among 221 event names and 10,852,339 events.
- The demo must distinguish endpoint telemetry from user inventory without inventing event semantics or copying values between events.
- S3-tag classification requires live validation after the updated integration definition is published because the asset fixture format cannot inject arbitrary input tags.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

