### PR TITLE
Bump ddtrace to dogfooding build 4.15.0rc1

### DIFF
--- a/agent_requirements.in
+++ b/agent_requirements.in
@@ -11,7 +11,7 @@ clickhouse-connect==1.4.1
 cm-client==45.0.4
 confluent-kafka==2.13.2
 cryptography==50.0.0
-ddtrace==4.12.2
+ddtrace==4.15.0rc1.dev133908296+internal.dogfooding.3b183e8531f8847172afc3ffb830547463124a9a
 dnspython==2.8.0
 fastavro==1.12.2
 foundationdb==6.3.25

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -37,7 +37,7 @@ deps = [
     "binary==1.0.2",
     "cachetools==7.1.4",
     "cryptography==50.0.0",
-    "ddtrace==4.12.2",
+    "ddtrace==4.15.0rc1.dev133908296+internal.dogfooding.3b183e8531f8847172afc3ffb830547463124a9a",
     "jellyfish==1.2.1",
     "lazy-loader==0.5",
     "prometheus-client==0.25.0",


### PR DESCRIPTION
### What does this PR do?
Bumps `ddtrace` in `agent_requirements.in` and `datadog_checks_base/pyproject.toml` from `4.12.2` to the dogfooding build `4.15.0rc1.dev133908296+internal.dogfooding.3b183e8531f8847172afc3ffb830547463124a9a`.

### Motivation
Pick up an internal dogfooding build of `ddtrace` for testing ahead of the 4.15.0 release.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged