### PR TITLE
[SEC-36700] Turn on public docs for ping_one_aic

### DIFF
--- a/ping_one_aic/manifest.json
+++ b/ping_one_aic/manifest.json
@@ -3,7 +3,7 @@
   "app_uuid": "5b78ef11-8d43-4695-96de-b09e85959e9c",
   "app_id": "ping-one-aic",
   "owner": "saas-integrations",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
## What does this PR do?
- Flips `display_on_public_website` from `false` to `true` in `ping_one_aic/manifest.json`, one line, one file.
  - This is the only change needed to publish `https://docs.datadoghq.com/integrations/ping-one-aic/`.

## Why is this being done?
- The `ping_one_aic` integration tile is already live for all orgs (Mosaic flag `display-tile-ping-one-aic` at 100%), but the docs page for it 404s.
  - The tile shows up, customers click into it, and the documentation link goes nowhere.
- PR #23504 (commit `86596991c50a3496bdeaccb7b8caa251c4cd2dd0`, 2026-08-24) added the tile media, the `assets.dashboards` mapping, and `assets.logs.source`, essentially the entire public payload, but never flipped `display_on_public_website`. This PR closes that gap.
- Checked the correlation between the flag and a live docs page across 8 integrations, 8 of 8 match:
  - Flag `true` (zk, disk, iis, asana, ping_one, ping_federate): all serve a live docs page.
  - Flag `false` (ping_one_aic, crowdstrike_fdr, carbon_black_cloud, anomali_threatstream): all return 404.
- CI stayed green through #23504 because `DisplayOnPublicValidator` in `datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py` only emits a warning for this mismatch, never a failure.
- This unblocks the Cloud SIEM logs Content Pack for PingOne AIC (SEC-36698). That pack's `documentationHref` and its only `learnMore` card both point at the currently-404 URL.
- Precedent for this exact fix: #23907, #22294, #19645, #15174.

### Reviewer note
CODEOWNERS has no entry for `ping_one_aic`, so review falls back to the generic `manifest.json` rule and routes to `@DataDog/documentation` and `@DataDog/agent-integrations`, even though the manifest's own `owner` field says `saas-integrations`. Sibling integrations `ping_one` and `ping_federate` both have explicit CODEOWNERS entries. Flagging this gap here, not fixing it in this PR.
