### PR TITLE
Report and clean up after a cancelled Dispatcher run

### DIFF
--- a/ddev/changelog.d/25042.added
+++ b/ddev/changelog.d/25042.added
@@ -1,0 +1,1 @@
+Report a cancelled Dispatcher run on its pull request and cancel the workflow runs it dispatched.

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -5,7 +5,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
+import signal
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING
@@ -28,6 +31,14 @@ if TYPE_CHECKING:
     from ddev.utils.github_async import AsyncGitHubClient
 
 logger = logging.getLogger(__name__)
+
+# Signals a cancelled GitHub Actions job sends: SIGINT first, SIGTERM about 7.5s later, then a hard
+# kill about 2.5s after that.
+CANCELLATION_SIGNALS = (signal.SIGINT, signal.SIGTERM)
+
+# A call that cannot go out within this is one the process will not live to see answered.
+CANCELLED_MAX_WAIT_SECONDS = 2.0
+CANCELLED_MAX_RATE = 10_000.0
 
 
 class RunContext(StrEnum):
@@ -109,9 +120,11 @@ class Dispatcher(EventBusOrchestrator):
         super().__init__(run_logger or logger, max_timeout=max_timeout, grace_period=grace_period)
         self._batches = batches
         self._client = client
+        self._runner = runner
         self._gatherer = gatherer
         self._reporter = reporter
         self._outcome: DispatcherOutcome | None = None
+        self._cancelled = False
 
         self.register_processor(runner, [TestBatch])
         self.register_processor(gatherer, [BatchFinished])
@@ -122,17 +135,63 @@ class Dispatcher(EventBusOrchestrator):
         """The result of the execution, or None before `run` has finished."""
         return self._outcome
 
+    @property
+    def cancelled(self) -> bool:
+        """Whether the run was cancelled from outside rather than finishing or timing out."""
+        return self._cancelled
+
     async def on_initialize(self):
+        self._listen_for_cancellation()
         self.submit_message(self._gatherer.build_initial_update())
         for batch in self._batches:
             self.submit_message(batch)
         self._logger.info("Dispatched %s batches", len(self._batches))
+
+    def _listen_for_cancellation(self) -> None:
+        """Handle the cancellation signals, so the run winds down instead of being killed mid-flight.
+
+        Handling SIGINT here also means it no longer arrives as `KeyboardInterrupt`, so shutdown takes
+        the same path whichever signal came first.
+        """
+        loop = asyncio.get_running_loop()
+        for received in CANCELLATION_SIGNALS:
+            # Only Unix event loops can do this. The Dispatcher runs on Linux runners, but ddev's own
+            # tests run on Windows too, where a run simply cannot be cancelled cleanly.
+            try:
+                loop.add_signal_handler(received, self._cancel, received)
+            except NotImplementedError:
+                self._logger.debug("This event loop cannot handle %s; cancellation will not be clean", received.name)
+
+    def _stop_listening_for_cancellation(self) -> None:
+        loop = asyncio.get_running_loop()
+        for received in CANCELLATION_SIGNALS:
+            with contextlib.suppress(NotImplementedError, RuntimeError):
+                loop.remove_signal_handler(received)
+
+    def _cancel(self, received: signal.Signals) -> None:
+        """Start winding down, and let the cleanup outrun the pacing built for a whole run.
+
+        Idempotent because both signals arrive on a cancelled job, seconds apart, and the second must
+        not restart anything the first began.
+        """
+        if self._cancelled:
+            self._logger.info("Already cancelling; ignoring %s", received.name)
+            return
+
+        self._cancelled = True
+        self._logger.warning("Received %s: cancelling the run", received.name)
+        # Relaxed before the stop, because stopping is what makes each batch close its check run, and
+        # those calls would otherwise be paced for a run that still had its whole window ahead of it.
+        self._client.relax_rate_limits(max_wait_seconds=CANCELLED_MAX_WAIT_SECONDS, max_rate=CANCELLED_MAX_RATE)
+        self.request_stop()
 
     async def on_message_received(self, message: BaseMessage):
         self._logger.debug("Message received: %s(%s)", type(message).__name__, message.id)
 
     async def on_finalize(self, exception: Exception | None):
         try:
+            if self._cancelled:
+                await self._report_cancellation()
             progress = self._gatherer.progress
             self._outcome = DispatcherOutcome(
                 progress=progress,
@@ -142,7 +201,27 @@ class Dispatcher(EventBusOrchestrator):
             if (body := self._reporter.latest_body) is not None:
                 write_step_summary(render_run_summary(body, pr_comment_failed=self._reporter.pr_comment_failed))
         finally:
+            self._stop_listening_for_cancellation()
             await self._client.aclose()
+
+    async def _report_cancellation(self) -> None:
+        """Say the run was cancelled, and stop the work it started.
+
+        Concurrent because both are independent calls competing for the same few seconds, and neither
+        is allowed to abandon the other: without `return_exceptions` the first failure would return
+        from here while the rest were still in flight, racing the kill.
+
+        Check runs are not closed here. Each batch closes its own on the way out, and that happens
+        before this hook runs, once the bus has awaited the tasks it cancelled.
+        """
+        outcomes = await asyncio.gather(
+            self._reporter.publish_cancelled(),
+            self._runner.cancel_dispatched_runs(),
+            return_exceptions=True,
+        )
+        for outcome in outcomes:
+            if isinstance(outcome, BaseException):
+                self._logger.error("Cancellation cleanup step failed: %s", outcome)
 
 
 def build_dispatcher(

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -180,10 +180,12 @@ class Dispatcher(EventBusOrchestrator):
 
         self._cancelled = True
         self._logger.warning("Received %s: cancelling the run", received.name)
-        # Relaxed before the stop, because stopping is what makes each batch close its check run, and
-        # those calls would otherwise be paced for a run that still had its whole window ahead of it.
-        self._client.relax_rate_limits(max_wait_seconds=CANCELLED_MAX_WAIT_SECONDS, max_rate=CANCELLED_MAX_RATE)
+        # Stop first: this runs as a signal-handler callback, so anything raised here goes to the
+        # loop's exception handler, and the second signal would find `_cancelled` already set and
+        # return without retrying. Relaxing still lands in time, because the stop only sets an event
+        # the loop acts on later, and it is what makes each batch close its check run.
         self.request_stop()
+        self._client.relax_rate_limits(max_wait_seconds=CANCELLED_MAX_WAIT_SECONDS, max_rate=CANCELLED_MAX_RATE)
 
     async def on_message_received(self, message: BaseMessage):
         self._logger.debug("Message received: %s(%s)", type(message).__name__, message.id)
@@ -219,9 +221,16 @@ class Dispatcher(EventBusOrchestrator):
             self._runner.cancel_dispatched_runs(),
             return_exceptions=True,
         )
+        # A cancellation is not a failed step, and must not be reported as one or swallowed: it is
+        # returned as a value here rather than raised, so it needs picking out by hand.
+        cancellation: asyncio.CancelledError | None = None
         for outcome in outcomes:
-            if isinstance(outcome, BaseException):
-                self._logger.error("Cancellation cleanup step failed: %s", outcome)
+            if isinstance(outcome, asyncio.CancelledError):
+                cancellation = outcome
+            elif isinstance(outcome, BaseException):
+                self._logger.error("Cancellation cleanup step failed: %s", outcome, exc_info=outcome)
+        if cancellation is not None:
+            raise cancellation
 
 
 def build_dispatcher(

--- a/ddev/src/ddev/cli/ci/tests/pr_comment.py
+++ b/ddev/src/ddev/cli/ci/tests/pr_comment.py
@@ -148,7 +148,8 @@ def render_cancelled_notice() -> str:
 
     There is no snapshot to render, and the comment is the only place a reader learns the run existed.
     """
-    return f"{COMMENT_MARKER}\n\n{CANCELLED_HEADING}\n\n{CANCELLED_WITHOUT_RESULTS_NOTE}"
+    footer = _footer(None, cancelled=True)
+    return f"{COMMENT_MARKER}\n\n{CANCELLED_HEADING}\n\n{CANCELLED_WITHOUT_RESULTS_NOTE}\n\n{footer}"
 
 
 def render_run_summary(body: str, *, pr_comment_failed: bool) -> str:
@@ -450,14 +451,14 @@ def _list_section(heading: str, entries: list[str], budget: int, noun: str) -> s
 # ---------------------------------------------------------------------------
 
 
-def _footer(progress: DispatcherProgress, *, cancelled: bool = False) -> str:
+def _footer(progress: DispatcherProgress | None, *, cancelled: bool = False) -> str:
     """Whether this is the last word, and where the run that produced it lives.
 
     No status emoji on a finished run: the outcome is the heading's job, and a ✅ here read as "all
     good" on a run that had failed. What a reader cannot get anywhere else in the comment is which
     commit was tested and where Dispatcher itself ran, so that is what this says.
     """
-    if not cancelled and not progress.done:
+    if not cancelled and (progress is None or not progress.done):
         return f"<sub>\n⏳ {FOOTER_RUNNING_NOTE}\n</sub>"
 
     note = "Dispatcher was cancelled" if cancelled else "Dispatcher finished"

--- a/ddev/src/ddev/cli/ci/tests/pr_comment.py
+++ b/ddev/src/ddev/cli/ci/tests/pr_comment.py
@@ -42,6 +42,12 @@ COMMENT_MARKER = "<!-- ddev-dispatcher-tests -->"
 # Width of the text progress bar, in cells.
 PROGRESS_BAR_WIDTH = 24
 
+# Terminal but unfinished, which no other state in a report expresses: the rest derive from `done`.
+CANCELLED_HEADING = "## 🚫 Dispatcher tests · cancelled"
+CANCELLED_NOTE = "Anything below is what had been gathered by then, and batches still running were cancelled too."
+# Said instead when no batch ever reported, where the note above would point at results that are absent.
+CANCELLED_WITHOUT_RESULTS_NOTE = "The run was cancelled before any batch reported, so there are no results to show."
+
 # Blocks are joined by a blank line, so each one costs two bytes beyond its own length. Newlines are
 # one byte in UTF-8, so this is the same number in either unit.
 SECTION_SEPARATOR = 2
@@ -79,41 +85,49 @@ def _size(text: str) -> int:
     return len(text.encode("utf-8"))
 
 
-def render_comment(progress: DispatcherProgress) -> str:
+def render_comment(progress: DispatcherProgress, *, cancelled: bool = False) -> str:
     """First of three tiers, budgeted in bytes against the client's own limit so the two cannot drift.
 
     The message's ``revision`` is deliberately not rendered: internal ordering metadata, already logged.
     """
-    return _render(progress, (partial(_failures, detail=True), _unavailable, _retried), shows_unavailable=True)
+    return _render(
+        progress, (partial(_failures, detail=True), _unavailable, _retried), shows_unavailable=True, cancelled=cancelled
+    )
 
 
-def render_compact_comment(progress: DispatcherProgress) -> str:
+def render_compact_comment(progress: DispatcherProgress, *, cancelled: bool = False) -> str:
     """Second tier: the failures keep their detail, the secondary sections go.
 
     Which tests failed is why anyone opens the comment; a retried-job list is one line per retry and can
     be the largest section in a flaky run.
     """
-    return _render(progress, (partial(_failures, detail=True),), shows_unavailable=False)
+    return _render(progress, (partial(_failures, detail=True),), shows_unavailable=False, cancelled=cancelled)
 
 
-def render_minimal_comment(progress: DispatcherProgress) -> str:
+def render_minimal_comment(progress: DispatcherProgress, *, cancelled: bool = False) -> str:
     """Last tier: batches, totals and a line per failed job, without naming the failed tests.
 
     The per-test lists are the dominant cost — 2.1 kB for a job with 40 failures against ~150 bytes for
     its summary line — so dropping them is what makes this fit. Only the batch table is unbudgeted, and
     it would need ~464 batches to exhaust the limit on its own.
     """
-    return _render(progress, (partial(_failures, detail=False),), shows_unavailable=False)
+    return _render(progress, (partial(_failures, detail=False),), shows_unavailable=False, cancelled=cancelled)
 
 
-def _render(progress: DispatcherProgress, sections: tuple[SectionBuilder, ...], *, shows_unavailable: bool) -> str:
+def _render(
+    progress: DispatcherProgress,
+    sections: tuple[SectionBuilder, ...],
+    *,
+    shows_unavailable: bool,
+    cancelled: bool = False,
+) -> str:
     """Assemble a body from the header, whichever *sections* this tier keeps, and the footer.
 
     ``shows_unavailable`` tells the header whether this tier keeps ``_unavailable``, so the alert can
     neither point at a section that is not here nor stay silent about results it dropped.
     """
-    header = _header(progress, shows_unavailable=shows_unavailable)
-    footer = _footer(progress)
+    header = _header(progress, shows_unavailable=shows_unavailable, cancelled=cancelled)
+    footer = _footer(progress, cancelled=cancelled)
 
     # The header and footer always survive; the detail sections compete for what is left. Two
     # newlines join every block, so each section costs its own length plus that separator.
@@ -127,6 +141,14 @@ def _render(progress: DispatcherProgress, sections: tuple[SectionBuilder, ...], 
         remaining -= _size(section) + SECTION_SEPARATOR
 
     return "\n\n".join([header, *built, footer])
+
+
+def render_cancelled_notice() -> str:
+    """What a run cancelled before any batch reported has to say: that it ran, and that it stopped.
+
+    There is no snapshot to render, and the comment is the only place a reader learns the run existed.
+    """
+    return f"{COMMENT_MARKER}\n\n{CANCELLED_HEADING}\n\n{CANCELLED_WITHOUT_RESULTS_NOTE}"
 
 
 def render_run_summary(body: str, *, pr_comment_failed: bool) -> str:
@@ -157,10 +179,10 @@ def summary_line(progress: DispatcherProgress) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _header(progress: DispatcherProgress, *, shows_unavailable: bool) -> str:
+def _header(progress: DispatcherProgress, *, shows_unavailable: bool, cancelled: bool = False) -> str:
     """Marker, heading, in-progress alert and totals: the part that must never be truncated."""
-    blocks = [COMMENT_MARKER, _heading(progress)]
-    alert = _alert(progress, shows_unavailable=shows_unavailable)
+    blocks = [COMMENT_MARKER, _heading(progress, cancelled=cancelled)]
+    alert = _alert(progress, shows_unavailable=shows_unavailable, cancelled=cancelled)
     if alert is not None:
         blocks.append(alert)
     blocks.append(_totals(progress))
@@ -168,8 +190,10 @@ def _header(progress: DispatcherProgress, *, shows_unavailable: bool) -> str:
     return "\n\n".join(blocks)
 
 
-def _heading(progress: DispatcherProgress) -> str:
+def _heading(progress: DispatcherProgress, *, cancelled: bool = False) -> str:
     """The run's outcome in one line. A failure outranks an unestablished result, which outranks a pass."""
+    if cancelled:
+        return CANCELLED_HEADING
     if not progress.done:
         return "## 🔄 Dispatcher tests · in progress"
     if _has_failure(progress):
@@ -179,13 +203,15 @@ def _heading(progress: DispatcherProgress) -> str:
     return "## ✅ Dispatcher tests · passed"
 
 
-def _alert(progress: DispatcherProgress, *, shows_unavailable: bool) -> str | None:
+def _alert(progress: DispatcherProgress, *, shows_unavailable: bool, cancelled: bool = False) -> str | None:
     """A native GitHub alert, so an unfinished run cannot be mistaken for a final one at a glance.
 
     A fallback tier sheds the section that lists unestablished results, so the alert states the count
     itself rather than pointing below, and carries it alongside a failure too. Without that, a fallback
     body would read as though every result was established.
     """
+    if cancelled:
+        return f"> [!CAUTION]\n> **The run was cancelled before it finished.** {CANCELLED_NOTE}"
     if not progress.done:
         return f"> [!NOTE]\n> **Tests are still running.** {_outstanding(progress)}\n> {FOOTER_RUNNING_NOTE}"
 
@@ -424,17 +450,17 @@ def _list_section(heading: str, entries: list[str], budget: int, noun: str) -> s
 # ---------------------------------------------------------------------------
 
 
-def _footer(progress: DispatcherProgress) -> str:
+def _footer(progress: DispatcherProgress, *, cancelled: bool = False) -> str:
     """Whether this is the last word, and where the run that produced it lives.
 
     No status emoji on a finished run: the outcome is the heading's job, and a ✅ here read as "all
     good" on a run that had failed. What a reader cannot get anywhere else in the comment is which
     commit was tested and where Dispatcher itself ran, so that is what this says.
     """
-    if not progress.done:
+    if not cancelled and not progress.done:
         return f"<sub>\n⏳ {FOOTER_RUNNING_NOTE}\n</sub>"
 
-    note = "Dispatcher finished"
+    note = "Dispatcher was cancelled" if cancelled else "Dispatcher finished"
     if sha := get_commit_sha():
         note += f" on <code>{html.escape(sha)}</code>"
     if run_url := get_workflow_run_url():

--- a/ddev/src/ddev/cli/ci/tests/task_run_reporter.py
+++ b/ddev/src/ddev/cli/ci/tests/task_run_reporter.py
@@ -35,6 +35,9 @@ UNUSABLE_COMMENT_STATUSES = (403, 404)
 # comment tiers, plus giving up on a comment we may not edit, which can repeat because the
 # replacement can itself be refused. One more than the sum, for the pass that lands.
 MAX_WRITE_PASSES = 5
+# The cancelled report competes with cancelling the dispatched runs for the same few seconds, and the
+# tier ladder can make several requests, so the whole write is bounded rather than each request.
+CANCELLED_WRITE_TIMEOUT = 4.0
 
 
 class CommentRenderer(Protocol):
@@ -171,7 +174,13 @@ class TaskRunReporter(AsyncProcessor["UpdatePRComment"]):
                 self._logger.warning("Run cancelled; no pull request to report it on", extra=log_extra)
                 return
 
-            published = await self._write(pr_number, body, progress, log_extra, cancelled=True)
+            # Recorded before the attempt, not after: the caller gathers this with `return_exceptions`,
+            # so anything raised here is absorbed and the run summary would otherwise be rendered as
+            # though the comment were current. `RateLimitWaitAbandoned` is the expected one, since the
+            # cancellation path shortens the limiter's wait precisely so it fires.
+            self._pr_comment_failed = True
+            async with asyncio.timeout(CANCELLED_WRITE_TIMEOUT):
+                published = await self._write(pr_number, body, progress, log_extra, cancelled=True)
             self._pr_comment_failed = not published
             if published:
                 self._logger.info("Run reported as cancelled", extra=log_extra)

--- a/ddev/src/ddev/cli/ci/tests/task_run_reporter.py
+++ b/ddev/src/ddev/cli/ci/tests/task_run_reporter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
@@ -162,6 +163,8 @@ class TaskRunReporter(AsyncProcessor["UpdatePRComment"]):
             log_extra: dict[str, object] = {"revision": self._latest_revision, "cancelled": True}
             # Before the write, and read by the run summary, so both places say the same thing.
             self._latest_body = body
+            # Held in state rather than left to call order, so a later revision cannot overwrite it.
+            self._latest_revision = sys.maxsize
 
             pr_number = self._options.pr_number
             if pr_number is None:

--- a/ddev/src/ddev/cli/ci/tests/task_run_reporter.py
+++ b/ddev/src/ddev/cli/ci/tests/task_run_reporter.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import httpx
 
 from ddev.cli.ci.tests.pr_comment import (
     COMMENT_MARKER,
+    render_cancelled_notice,
     render_comment,
     render_compact_comment,
     render_minimal_comment,
@@ -21,9 +22,8 @@ from ddev.event_bus.orchestrator import AsyncProcessor
 from ddev.utils.github_errors import GitHubBodyTooLongError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from ddev.cli.ci.tests.messages import UpdatePRComment
+    from ddev.cli.ci.tests.progress import DispatcherProgress
     from ddev.utils.github_async import AsyncGitHubClient
 
 # Editing the tracked comment can fail because it is not ours to edit (403) or no longer exists
@@ -34,6 +34,17 @@ UNUSABLE_COMMENT_STATUSES = (403, 404)
 # comment tiers, plus giving up on a comment we may not edit, which can repeat because the
 # replacement can itself be refused. One more than the sum, for the pass that lands.
 MAX_WRITE_PASSES = 5
+
+
+class CommentRenderer(Protocol):
+    """Renders a whole report from a snapshot. Every tier takes the same arguments."""
+
+    def __call__(self, progress: DispatcherProgress, *, cancelled: bool = False) -> str: ...
+
+
+# Smaller renderings to fall back on, largest first, when a body is refused for being too long.
+# Whether one differs from the tier above it depends on the snapshot, so each is compared once rendered.
+FALLBACK_TIERS: tuple[CommentRenderer, ...] = (render_compact_comment, render_minimal_comment)
 
 
 @dataclass(frozen=True)
@@ -79,6 +90,8 @@ class TaskRunReporter(AsyncProcessor["UpdatePRComment"]):
         # Revisions start at 0 (the initial plan), so nothing can have been rendered yet.
         self._latest_revision = -1
         self._latest_body: str | None = None
+        # Frozen, so holding a reference cannot read a half-updated snapshot.
+        self._latest_progress: DispatcherProgress | None = None
         self._pr_comment_failed = False
         self._final_report_published = False
         self._lock = asyncio.Lock()
@@ -117,48 +130,87 @@ class TaskRunReporter(AsyncProcessor["UpdatePRComment"]):
                 )
                 return
 
+            # Before the write, so a failed one keeps the report it should have published. `_write`
+            # can return False or raise something it does not catch, and both must not lose results.
+            self._latest_body = body
+            self._latest_progress = message.progress
+            self._latest_revision = message.revision
+
             pr_number = self._options.pr_number
             if pr_number is None:
                 self._logger.info("No pull request to update: %s", summary_line(message.progress), extra=log_extra)
                 published = True
             else:
-                published = await self._write(pr_number, message, body, log_extra)
+                published = await self._write(pr_number, body, message.progress, log_extra)
                 self._pr_comment_failed = not published
 
             if message.progress.done and published:
                 self._final_report_published = True
 
-            # Retained even when the write failed: this is the newest report we have, and losing the
-            # comment must not lose the results. The revision advances with it, so a later snapshot
-            # cannot be overtaken by an earlier one still in flight.
-            self._latest_body = body
-            self._latest_revision = message.revision
+    async def publish_cancelled(self) -> None:
+        """Report the run as cancelled, whatever it had rendered so far.
 
-    async def _write(self, pr_number: int, message: UpdatePRComment, body: str, log_extra: dict[str, object]) -> bool:
+        The comment is the only place a reader learns the run happened at all, so one goes out even
+        when no snapshot ever arrived; silence is indistinguishable from a run that hung.
+
+        Under the same lock as a normal report, so it cannot interleave with one in flight, and last
+        because nothing supersedes it.
+        """
+        async with self._lock:
+            progress = self._latest_progress
+            body = render_cancelled_notice() if progress is None else render_comment(progress, cancelled=True)
+            log_extra: dict[str, object] = {"revision": self._latest_revision, "cancelled": True}
+            # Before the write, and read by the run summary, so both places say the same thing.
+            self._latest_body = body
+
+            pr_number = self._options.pr_number
+            if pr_number is None:
+                self._logger.warning("Run cancelled; no pull request to report it on", extra=log_extra)
+                return
+
+            published = await self._write(pr_number, body, progress, log_extra, cancelled=True)
+            self._pr_comment_failed = not published
+            if published:
+                self._logger.info("Run reported as cancelled", extra=log_extra)
+
+    async def _write(
+        self,
+        pr_number: int,
+        body: str,
+        progress: DispatcherProgress | None,
+        log_extra: dict[str, object],
+        *,
+        cancelled: bool = False,
+    ) -> bool:
         """Write *body* to the comment, stepping down the tiers if it is too long. Did it land?
 
         Not a retry loop: a pass continues only after changing what the next one does — a smaller tier,
         or forgetting a comment GitHub will not let us edit — and stops otherwise. Both ways of learning
         a body is too long arrive as ``GitHubBodyTooLongError``, so there is one thing to catch.
         """
-        tiers: tuple[Callable[[], str], ...] = (
-            lambda: body,
-            lambda: render_compact_comment(message.progress),
-            lambda: render_minimal_comment(message.progress),
+        rendered = body
+        # Rendered lazily and never revisited, so a tier already refused is not sent again, and a tier
+        # that renders what was just refused costs nothing to skip.
+        tiers = (
+            (render(progress, cancelled=cancelled) for render in FALLBACK_TIERS) if progress is not None else iter(())
         )
-        tier, rendered = 0, body
         for _ in range(MAX_WRITE_PASSES):
             try:
                 await self._submit(pr_number, rendered)
             except GitHubBodyTooLongError as error:
-                smaller = _next_distinct_tier(tiers, tier, rendered)
+                smaller = next((candidate for candidate in tiers if candidate != rendered), None)
                 if smaller is None:
                     # Unreachable while the last tier drops the per-test detail and budgets the rest.
                     # Reported rather than asserted, because a wrong assumption here must not crash.
                     self._logger.error("PR comment too long at every tier: %s", error, extra=log_extra)
                     return False
-                tier, rendered = smaller
-                self._logger.warning("PR comment body too long (%s); retrying at tier %s", error, tier, extra=log_extra)
+                rendered = smaller
+                self._logger.warning(
+                    "PR comment body too long (%s); retrying with a smaller one (%s bytes)",
+                    error,
+                    len(rendered),
+                    extra=log_extra,
+                )
             except httpx.HTTPError as error:
                 if self._forget_unusable_comment(error, log_extra):
                     # The next pass creates a comment we own, rather than re-editing one we do not.
@@ -167,7 +219,7 @@ class TaskRunReporter(AsyncProcessor["UpdatePRComment"]):
                 return False
             else:
                 self._logger.info(
-                    "PR comment written", extra={**log_extra, "comment_id": self._comment_id, "tier": tier}
+                    "PR comment written", extra={**log_extra, "comment_id": self._comment_id, "bytes": len(rendered)}
                 )
                 return True
 
@@ -221,17 +273,3 @@ class TaskRunReporter(AsyncProcessor["UpdatePRComment"]):
         self._unusable_comment_ids.add(self._comment_id)
         self._comment_id = None
         return True
-
-
-def _next_distinct_tier(tiers: tuple[Callable[[], str], ...], tier: int, current: str) -> tuple[int, str] | None:
-    """The next tier that renders something different from *current*, or ``None`` if none does.
-
-    A snapshot with nothing to shed renders the compact tier byte-identical to the full one, and
-    resending a body GitHub just refused cannot succeed, so the ladder skips it rather than spending a
-    request to find out.
-    """
-    for index in range(tier + 1, len(tiers)):
-        body = tiers[index]()
-        if body != current:
-            return index, body
-    return None

--- a/ddev/src/ddev/cli/ci/tests/task_test_runner.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_runner.py
@@ -43,6 +43,7 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
         super().__init__(name)
         self._client = client
         self._options = options
+        self._runs_in_flight: dict[str, int] = {}
         self._logger = logging.getLogger(f"{__name__}.{name}")
 
     async def process_message(self, message: TestBatch):
@@ -59,6 +60,7 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
         )
         run_id = dispatch.data.workflow_run_id
         log_extra["run_id"] = run_id
+        self._runs_in_flight[message.batch_id] = run_id
         self._logger.info("Dispatched batch", extra=log_extra)
 
         run = await self._client.get_workflow_run(self._options.owner, self._options.repo, run_id)
@@ -84,6 +86,10 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
                 run = await self._poll_until_complete(run_id, log_extra)
             else:
                 self._logger.info("Workflow completed", extra=log_extra)
+
+            # Not in the `finally`, which also runs when this task is cancelled with the run still
+            # going, and that is when there is something to cancel.
+            self._runs_in_flight.pop(message.batch_id, None)
 
             raw = run.data.conclusion
             if raw is None:
@@ -122,6 +128,31 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
         if finished is not None:
             self.submit_message(finished)
             self._logger.info("BatchFinished emitted", extra=log_extra)
+
+    async def cancel_dispatched_runs(self) -> None:
+        """Cancel the runs this runner dispatched that have not finished.
+
+        Left running they would keep burning runner minutes long after the run that asked for them is
+        gone. Concurrent, because whatever budget the caller has is shared by all of them.
+        """
+        if not self._runs_in_flight:
+            return
+
+        self._logger.info("Cancelling %s dispatched run(s)", len(self._runs_in_flight))
+        await asyncio.gather(
+            *(self._cancel_run(batch_id, run_id) for batch_id, run_id in tuple(self._runs_in_flight.items()))
+        )
+
+    async def _cancel_run(self, batch_id: str, run_id: int) -> None:
+        """Cancel one run, reporting rather than raising: one that will not cancel must not stop the rest."""
+        log_extra = {"batch_id": batch_id, "run_id": run_id}
+        try:
+            await self._client.cancel_workflow_run(self._options.owner, self._options.repo, run_id)
+        except Exception:
+            self._logger.exception("Failed to cancel dispatched run", extra=log_extra)
+        else:
+            self._runs_in_flight.pop(batch_id, None)
+            self._logger.info("Dispatched run cancelled", extra=log_extra)
 
     async def _poll_until_complete(self, run_id: int, log_extra: dict[str, Any]) -> GitHubResponse[WorkflowRun]:
         while True:

--- a/ddev/src/ddev/cli/ci/tests/task_test_runner.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_runner.py
@@ -17,6 +17,11 @@ from ddev.event_bus.orchestrator import AsyncProcessor
 from ddev.utils.github_async import AsyncGitHubClient, GitHubResponse
 from ddev.utils.github_async.models import CheckRunConclusion, CheckRunStatus, WorkflowJob, WorkflowRun
 
+# A cancelled job has roughly ten seconds before it is killed, and there may be several runs to stop.
+# The retry policy bounds the ladder, not a socket, so a GitHub that accepts the connection and then
+# goes quiet would hold this for the client's default and take every other cancellation with it.
+CANCEL_REQUEST_TIMEOUT = 3.0
+
 
 @dataclass(frozen=True)
 class TestRunnerOptions:
@@ -147,7 +152,9 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
         """Cancel one run, reporting rather than raising: one that will not cancel must not stop the rest."""
         log_extra = {"batch_id": batch_id, "run_id": run_id}
         try:
-            await self._client.cancel_workflow_run(self._options.owner, self._options.repo, run_id)
+            await self._client.cancel_workflow_run(
+                self._options.owner, self._options.repo, run_id, timeout=CANCEL_REQUEST_TIMEOUT
+            )
         except Exception:
             self._logger.exception("Failed to cancel dispatched run", extra=log_extra)
         else:

--- a/ddev/src/ddev/utils/github_async/client.py
+++ b/ddev/src/ddev/utils/github_async/client.py
@@ -65,6 +65,8 @@ DEFAULT_BASE_URL = "https://api.github.com"
 # number; neither the OpenAPI description nor the REST docs state it. Measured in UTF-8 bytes, which is
 # never below the character count GitHub means, so it errs only towards refusing a body it might take.
 COMMENT_BODY_LIMIT = 65_536
+# GitHub answers a cancel with 409 once the run has reached a terminal state, which is what was asked for.
+RUN_ALREADY_TERMINAL_STATUS = 409
 
 # How an expired signed URL presents from the artifact storage host.
 SIGNED_URL_EXPIRED_STATUS = 403
@@ -575,6 +577,42 @@ class AsyncGitHubClient:
             "GET", f"/repos/{owner}/{repo}/actions/runs/{run_id}", timeout=timeout, retry=retry
         )
         return self._parse_response(response, WorkflowRun)
+
+    def relax_rate_limits(self, *, max_wait_seconds: float, max_rate: float) -> None:
+        """Stop pacing our own requests, and cap how long a GitHub pause may block one.
+
+        For a process that will not live long enough to spend the budget being paced: see
+        :meth:`InstrumentedAsyncLimiter.relax`. GitHub's own limits are still honoured, only bounded.
+        """
+        self._rate_limiter.relax(max_wait_seconds=max_wait_seconds, max_rate=max_rate)
+
+    async def cancel_workflow_run(
+        self,
+        owner: str,
+        repo: str,
+        run_id: int,
+        timeout: float | None = None,
+    ) -> None:
+        """
+        Calls the GitHub API to cancel a workflow run.
+
+        GitHub replies 409 when the run already reached a terminal state, which is the outcome asked
+        for, so it is not treated as a failure.
+
+        GitHub API Documentation:
+        https://docs.github.com/en/rest/actions/workflow-runs#cancel-a-workflow-run
+
+        Args:
+            owner: Repository owner (user or organisation).
+            repo: Repository name.
+            run_id: Numeric ID of the workflow run to cancel.
+            timeout: Optional timeout for this specific request. Defaults to the client's default_timeout.
+        """
+        try:
+            await self._request("POST", f"/repos/{owner}/{repo}/actions/runs/{run_id}/cancel", timeout=timeout)
+        except httpx.HTTPStatusError as error:
+            if error.response.status_code != RUN_ALREADY_TERMINAL_STATUS:
+                raise
 
     async def list_workflow_run_artifacts(
         self,

--- a/ddev/src/ddev/utils/github_async/client.py
+++ b/ddev/src/ddev/utils/github_async/client.py
@@ -67,6 +67,8 @@ DEFAULT_BASE_URL = "https://api.github.com"
 COMMENT_BODY_LIMIT = 65_536
 # GitHub answers a cancel with 409 once the run has reached a terminal state, which is what was asked for.
 RUN_ALREADY_TERMINAL_STATUS = 409
+# The caller is a run being cancelled, so the whole ladder has to fit in the seconds it has left.
+CANCEL_RETRY_TIMEOUT = 5.0
 
 # How an expired signed URL presents from the artifact storage host.
 SIGNED_URL_EXPIRED_STATUS = 403
@@ -592,6 +594,8 @@ class AsyncGitHubClient:
         repo: str,
         run_id: int,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> None:
         """
         Calls the GitHub API to cancel a workflow run.
@@ -607,9 +611,16 @@ class AsyncGitHubClient:
             repo: Repository name.
             run_id: Numeric ID of the workflow run to cancel.
             timeout: Optional timeout for this specific request. Defaults to the client's default_timeout.
+            retry: Defaults to the replayable policy, since cancelling twice cancels once. The ladder is
+                shortened because the caller is usually a run being torn down with seconds to spare.
         """
         try:
-            await self._request("POST", f"/repos/{owner}/{repo}/actions/runs/{run_id}/cancel", timeout=timeout)
+            await self._request(
+                "POST",
+                f"/repos/{owner}/{repo}/actions/runs/{run_id}/cancel",
+                timeout=timeout,
+                retry=retry if retry is not None else self._retry_policies.safe.replace(timeout=CANCEL_RETRY_TIMEOUT),
+            )
         except httpx.HTTPStatusError as error:
             if error.response.status_code != RUN_ALREADY_TERMINAL_STATUS:
                 raise

--- a/ddev/src/ddev/utils/rate_limiting.py
+++ b/ddev/src/ddev/utils/rate_limiting.py
@@ -321,6 +321,20 @@ class InstrumentedAsyncLimiter:
         self.budget_governor = budget_governor
         self.name = name
 
+    def relax(self, *, max_wait_seconds: float, max_rate: float) -> None:
+        """Stop pacing ourselves, and cap how long a provider pause may block.
+
+        For a process that will not live long enough to spend the budget being protected: rationing
+        spreads what is left over the window, which is longer than the time remaining. The provider's
+        own pauses are still honoured, but bounded, so a doomed call fails instead of blocking.
+        """
+        self.limiter.max_rate = max_rate
+        if self.budget_governor is None:
+            return
+
+        self.budget_governor.reserve_fraction = 0.0
+        self.budget_governor.max_wait_seconds = max_wait_seconds
+
     async def __aenter__(self) -> InstrumentedAsyncLimiter:
         if self.budget_governor is not None:
             await self.budget_governor.wait()

--- a/ddev/tests/cli/ci/tests/test_dispatcher.py
+++ b/ddev/tests/cli/ci/tests/test_dispatcher.py
@@ -8,11 +8,18 @@ from __future__ import annotations
 import os
 import signal
 import sys
+import time
 from pathlib import Path
 
 import pytest
 
-from ddev.cli.ci.tests.dispatcher import Dispatcher, DispatcherContext, RunContext
+from ddev.cli.ci.tests.dispatcher import (
+    CANCELLED_MAX_RATE,
+    CANCELLED_MAX_WAIT_SECONDS,
+    Dispatcher,
+    DispatcherContext,
+    RunContext,
+)
 from ddev.cli.ci.tests.messages import BatchJob, TestBatch
 from ddev.cli.ci.tests.pr_comment import CANCELLED_HEADING
 from ddev.cli.ci.tests.task_run_reporter import RunReporterOptions, TaskRunReporter
@@ -207,6 +214,12 @@ def test_a_cancelled_run_reports_itself_and_stops_the_work_it_started(client, tm
         pytest.fail("SIGINT reached the interpreter: the run handled no cancellation signal")
 
     assert dispatcher.cancelled
+    # The cleanup competes with a ~10s kill using a bucket the run has been spending all along, so
+    # without this it is paced for a run that still had its whole window ahead of it.
+    assert client.last_call("relax_rate_limits").kwargs == {
+        "max_wait_seconds": CANCELLED_MAX_WAIT_SECONDS,
+        "max_rate": CANCELLED_MAX_RATE,
+    }
     # The initial plan already created the comment, so the cancelled report edits that one.
     assert CANCELLED_HEADING in client.last_call("update_issue_comment").kwargs["body"]
     assert [call.kwargs["run_id"] for call in client.calls_to("cancel_workflow_run")] == [123]
@@ -214,3 +227,39 @@ def test_a_cancelled_run_reports_itself_and_stops_the_work_it_started(client, tm
     assert client.last_call("update_check_run").kwargs["conclusion"] == "cancelled"
     # The run page is rendered from the same report, so it cannot claim the run is still going.
     assert CANCELLED_HEADING.removeprefix("## ") in step_summary.read_text(encoding="utf-8")
+
+
+def test_a_run_still_winds_down_when_the_rate_limiter_cannot_be_relaxed(client, tmp_path):
+    """The signal handler's own failures are invisible: the loop logs them and the next signal, which
+    finds the run already cancelling, returns without retrying. So the stop cannot be left downstream
+    of anything that might raise, or the run waits to be killed instead of winding down.
+    """
+    batch = make_batch(make_job())
+    dispatcher = build_bus(client, tmp_path, [batch])
+    client.mock_response("relax_rate_limits", RuntimeError("the limiter is not what we think it is"))
+    client.mock_response(
+        "get_workflow_run",
+        WorkflowRun(
+            id=123,
+            name="test-batch",
+            status="in_progress",
+            conclusion=None,
+            html_url="https://github.com/DataDog/integrations-core/actions/runs/123",
+        ),
+    )
+    created_check_run = client.create_check_run
+
+    async def cancel_once_the_check_run_exists(*args, **kwargs):
+        response = await created_check_run(*args, **kwargs)
+        os.kill(os.getpid(), signal.SIGINT)
+        return response
+
+    client.create_check_run = cancel_once_the_check_run_exists  # type: ignore[method-assign]
+
+    start = time.perf_counter()
+    dispatcher.run()
+    elapsed = time.perf_counter() - start
+
+    # The bus's own timeout is 30s, so anything near it means the stop never arrived.
+    assert elapsed < 5
+    assert [call.kwargs["run_id"] for call in client.calls_to("cancel_workflow_run")] == [123]

--- a/ddev/tests/cli/ci/tests/test_dispatcher.py
+++ b/ddev/tests/cli/ci/tests/test_dispatcher.py
@@ -176,27 +176,20 @@ def test_the_report_is_written_to_the_run_summary(client, tmp_path, step_summary
     assert jobs_reported(step_summary.read_text(encoding="utf-8")) == 1
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="The Dispatcher only runs on Linux CI runners")
-def test_a_cancelled_run_reports_itself_and_stops_the_work_it_started(client, tmp_path, step_summary):
-    """A cancelled job gets about ten seconds before it is killed, and must not go quietly.
+# Cancellation tests send a real SIGINT to their own process, which needs two things every time.
+# On Windows no handler can be installed, and `os.kill` with a signal other than `CTRL_*` calls
+# `TerminateProcess`, so the pytest process would die rather than the test failing. And an escaped
+# `KeyboardInterrupt` aborts the session, taking every test after it. Both live here so a new
+# cancellation test gets them by construction.
+requires_signals = pytest.mark.skipif(sys.platform == "win32", reason="The Dispatcher only runs on Linux CI runners")
 
-    The signal is sent from inside the run, once the run's own handlers are installed and there is a
-    dispatched run to stop, so the two things only this process can do still happen: say so on the
-    pull request, and cancel the workflow runs it started.
+
+def run_cancelled_by_sigint(dispatcher: Dispatcher, client: FakeAsyncGitHubClient) -> None:
+    """Run *dispatcher* to completion, signalling it once it has a dispatched run to clean up.
+
+    The signal goes out from inside `create_check_run`, so the run's handlers are already installed
+    and there is something in flight for the cleanup to find.
     """
-    batch = make_batch(make_job())
-    dispatcher = build_bus(client, tmp_path, [batch])
-    # Never completes, so the batch is still polling when the signal lands.
-    client.mock_response(
-        "get_workflow_run",
-        WorkflowRun(
-            id=123,
-            name="test-batch",
-            status="in_progress",
-            conclusion=None,
-            html_url="https://github.com/DataDog/integrations-core/actions/runs/123",
-        ),
-    )
     created_check_run = client.create_check_run
 
     async def cancel_once_the_check_run_exists(*args, **kwargs):
@@ -212,6 +205,33 @@ def test_a_cancelled_run_reports_itself_and_stops_the_work_it_started(client, tm
         # Reported rather than left to propagate, which would abort the whole session instead of
         # failing this test.
         pytest.fail("SIGINT reached the interpreter: the run handled no cancellation signal")
+
+
+def a_run_that_never_finishes(client: FakeAsyncGitHubClient) -> None:
+    """Keep every dispatched run `in_progress`, so a batch is still polling when the signal lands."""
+    client.mock_response(
+        "get_workflow_run",
+        WorkflowRun(
+            id=123,
+            name="test-batch",
+            status="in_progress",
+            conclusion=None,
+            html_url="https://github.com/DataDog/integrations-core/actions/runs/123",
+        ),
+    )
+
+
+@requires_signals
+def test_a_cancelled_run_reports_itself_and_stops_the_work_it_started(client, tmp_path, step_summary):
+    """A cancelled job gets about ten seconds before it is killed, and must not go quietly.
+
+    The two things only this process can do still happen: say so on the pull request, and cancel the
+    workflow runs it started.
+    """
+    dispatcher = build_bus(client, tmp_path, [make_batch(make_job())])
+    a_run_that_never_finishes(client)
+
+    run_cancelled_by_sigint(dispatcher, client)
 
     assert dispatcher.cancelled
     # The cleanup competes with a ~10s kill using a bucket the run has been spending all along, so
@@ -229,35 +249,18 @@ def test_a_cancelled_run_reports_itself_and_stops_the_work_it_started(client, tm
     assert CANCELLED_HEADING.removeprefix("## ") in step_summary.read_text(encoding="utf-8")
 
 
+@requires_signals
 def test_a_run_still_winds_down_when_the_rate_limiter_cannot_be_relaxed(client, tmp_path):
     """The signal handler's own failures are invisible: the loop logs them and the next signal, which
     finds the run already cancelling, returns without retrying. So the stop cannot be left downstream
     of anything that might raise, or the run waits to be killed instead of winding down.
     """
-    batch = make_batch(make_job())
-    dispatcher = build_bus(client, tmp_path, [batch])
+    dispatcher = build_bus(client, tmp_path, [make_batch(make_job())])
+    a_run_that_never_finishes(client)
     client.mock_response("relax_rate_limits", RuntimeError("the limiter is not what we think it is"))
-    client.mock_response(
-        "get_workflow_run",
-        WorkflowRun(
-            id=123,
-            name="test-batch",
-            status="in_progress",
-            conclusion=None,
-            html_url="https://github.com/DataDog/integrations-core/actions/runs/123",
-        ),
-    )
-    created_check_run = client.create_check_run
-
-    async def cancel_once_the_check_run_exists(*args, **kwargs):
-        response = await created_check_run(*args, **kwargs)
-        os.kill(os.getpid(), signal.SIGINT)
-        return response
-
-    client.create_check_run = cancel_once_the_check_run_exists  # type: ignore[method-assign]
 
     start = time.perf_counter()
-    dispatcher.run()
+    run_cancelled_by_sigint(dispatcher, client)
     elapsed = time.perf_counter() - start
 
     # The bus's own timeout is 30s, so anything near it means the stop never arrived.

--- a/ddev/tests/cli/ci/tests/test_dispatcher.py
+++ b/ddev/tests/cli/ci/tests/test_dispatcher.py
@@ -5,12 +5,16 @@
 
 from __future__ import annotations
 
+import os
+import signal
+import sys
 from pathlib import Path
 
 import pytest
 
 from ddev.cli.ci.tests.dispatcher import Dispatcher, DispatcherContext, RunContext
 from ddev.cli.ci.tests.messages import BatchJob, TestBatch
+from ddev.cli.ci.tests.pr_comment import CANCELLED_HEADING
 from ddev.cli.ci.tests.task_run_reporter import RunReporterOptions, TaskRunReporter
 from ddev.cli.ci.tests.task_test_gatherer import TaskTestGatherer
 from ddev.cli.ci.tests.task_test_runner import TaskTestRunner, TestRunnerOptions
@@ -163,3 +167,50 @@ def test_the_report_is_written_to_the_run_summary(client, tmp_path, step_summary
 
     client.assert_not_called("create_issue_comment")
     assert jobs_reported(step_summary.read_text(encoding="utf-8")) == 1
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="The Dispatcher only runs on Linux CI runners")
+def test_a_cancelled_run_reports_itself_and_stops_the_work_it_started(client, tmp_path, step_summary):
+    """A cancelled job gets about ten seconds before it is killed, and must not go quietly.
+
+    The signal is sent from inside the run, once the run's own handlers are installed and there is a
+    dispatched run to stop, so the two things only this process can do still happen: say so on the
+    pull request, and cancel the workflow runs it started.
+    """
+    batch = make_batch(make_job())
+    dispatcher = build_bus(client, tmp_path, [batch])
+    # Never completes, so the batch is still polling when the signal lands.
+    client.mock_response(
+        "get_workflow_run",
+        WorkflowRun(
+            id=123,
+            name="test-batch",
+            status="in_progress",
+            conclusion=None,
+            html_url="https://github.com/DataDog/integrations-core/actions/runs/123",
+        ),
+    )
+    created_check_run = client.create_check_run
+
+    async def cancel_once_the_check_run_exists(*args, **kwargs):
+        response = await created_check_run(*args, **kwargs)
+        os.kill(os.getpid(), signal.SIGINT)
+        return response
+
+    client.create_check_run = cancel_once_the_check_run_exists  # type: ignore[method-assign]
+
+    try:
+        dispatcher.run()
+    except KeyboardInterrupt:  # pragma: no cover - only if the run installed no handler
+        # Reported rather than left to propagate, which would abort the whole session instead of
+        # failing this test.
+        pytest.fail("SIGINT reached the interpreter: the run handled no cancellation signal")
+
+    assert dispatcher.cancelled
+    # The initial plan already created the comment, so the cancelled report edits that one.
+    assert CANCELLED_HEADING in client.last_call("update_issue_comment").kwargs["body"]
+    assert [call.kwargs["run_id"] for call in client.calls_to("cancel_workflow_run")] == [123]
+    # Each batch closes its own check run on the way out, so the cleanup does not repeat it.
+    assert client.last_call("update_check_run").kwargs["conclusion"] == "cancelled"
+    # The run page is rendered from the same report, so it cannot claim the run is still going.
+    assert CANCELLED_HEADING.removeprefix("## ") in step_summary.read_text(encoding="utf-8")

--- a/ddev/tests/cli/ci/tests/test_pr_comment.py
+++ b/ddev/tests/cli/ci/tests/test_pr_comment.py
@@ -16,7 +16,10 @@ from collections.abc import Callable
 import pytest
 
 from ddev.cli.ci.tests.pr_comment import (
+    CANCELLED_HEADING,
     COMMENT_MARKER,
+    FOOTER_RUNNING_NOTE,
+    render_cancelled_notice,
     render_comment,
     render_compact_comment,
     render_minimal_comment,
@@ -25,7 +28,14 @@ from ddev.cli.ci.tests.pr_comment import (
 )
 from ddev.cli.ci.tests.progress import DispatcherProgress, ExecutionState, ProgressError
 from ddev.cli.ci.tests.status import Status
-from tests.cli.ci.tests.helpers import attempt, batch_progress, failing_report, job_progress, planned_batch
+from tests.cli.ci.tests.helpers import (
+    attempt,
+    batch_progress,
+    failing_report,
+    job_progress,
+    planned_batch,
+    uniform_progress,
+)
 
 # GitHub's own ceiling, from the 422 it returns: "body is too long (maximum is 65536 characters)".
 # Not imported from the renderer on purpose — a test that reads the same constant it is checking
@@ -843,3 +853,34 @@ def test_the_budget_is_measured_in_bytes_not_characters():
     assert len(body.encode("utf-8")) <= GITHUB_COMMENT_HARD_LIMIT
     # Characters alone would have left room that the bytes do not, which is the bug this rules out.
     assert len(body) < len(body.encode("utf-8"))
+
+
+def test_a_cancelled_run_with_nothing_gathered_still_says_it_ran():
+    """The comment is the only place a reader learns the run existed.
+
+    No comment at all is indistinguishable from a job that hung, and the marker has to be there or
+    the next run creates a second comment instead of editing this one.
+    """
+    body = render_cancelled_notice()
+
+    assert body.startswith(COMMENT_MARKER)
+    assert CANCELLED_HEADING in body
+
+
+def test_a_cancelled_run_keeps_what_it_gathered_without_still_reading_as_running():
+    """A partial report is worth keeping, but every part of it claims the run is still going.
+
+    The heading, the alert and the footer all derive from `done`, so a cancelled report that keeps
+    any of them invites waiting for results that will never arrive.
+    """
+    progress = uniform_progress(done=False, complete=6)
+    assert "Tests are still running" in render_comment(progress)
+
+    body = render_comment(progress, cancelled=True)
+
+    assert CANCELLED_HEADING in body
+    assert "Dispatcher tests · in progress" not in body
+    assert "Tests are still running" not in body
+    assert FOOTER_RUNNING_NOTE not in body
+    # Per-batch rows keep their own last-known state, which the alert explains was cancelled with it.
+    assert "batch-01" in body

--- a/ddev/tests/cli/ci/tests/test_pr_comment.py
+++ b/ddev/tests/cli/ci/tests/test_pr_comment.py
@@ -855,16 +855,22 @@ def test_the_budget_is_measured_in_bytes_not_characters():
     assert len(body) < len(body.encode("utf-8"))
 
 
-def test_a_cancelled_run_with_nothing_gathered_still_says_it_ran():
+def test_a_cancelled_run_with_nothing_gathered_still_says_it_ran(monkeypatch):
     """The comment is the only place a reader learns the run existed.
 
     No comment at all is indistinguishable from a job that hung, and the marker has to be there or
-    the next run creates a second comment instead of editing this one.
+    the next run creates a second comment instead of editing this one. With no results to go on, the
+    footer's link is all a reader has to find out what happened.
     """
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "DataDog/integrations-core")
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+
     body = render_cancelled_notice()
 
     assert body.startswith(COMMENT_MARKER)
     assert CANCELLED_HEADING in body
+    assert "https://github.com/DataDog/integrations-core/actions/runs/12345" in body
 
 
 def test_a_cancelled_run_keeps_what_it_gathered_without_still_reading_as_running():

--- a/ddev/tests/cli/ci/tests/test_task_run_reporter.py
+++ b/ddev/tests/cli/ci/tests/test_task_run_reporter.py
@@ -17,13 +17,14 @@ import pytest
 
 from ddev.cli.ci.tests import pr_comment
 from ddev.cli.ci.tests.messages import UpdatePRComment
-from ddev.cli.ci.tests.pr_comment import COMMENT_MARKER
+from ddev.cli.ci.tests.pr_comment import CANCELLED_HEADING, COMMENT_MARKER
 from ddev.cli.ci.tests.progress import JobAttemptProgress, JobProgress, ProgressError
 from ddev.cli.ci.tests.status import Status
 from ddev.cli.ci.tests.task_run_reporter import RunReporterOptions, TaskRunReporter
 from ddev.utils.github_async.models import IssueComment
 from ddev.utils.github_async.models.workflow import WorkflowJobConclusion
 from ddev.utils.github_errors import GitHubAuthenticationError, GitHubBodyTooLongError
+from ddev.utils.rate_limiting import RateLimitWaitAbandoned
 from tests.cli.ci.tests.helpers import (
     TOTAL_JOBS,
     comment_page,
@@ -712,3 +713,53 @@ def test_the_ladder_lands_when_github_is_stricter_than_our_measurement(monkeypat
     # Full refused, compact refused, minimal accepted: the whole ladder, ending on a write.
     assert attempted == tiers
     assert not reporter.pr_comment_failed
+
+
+async def test_a_cancelled_run_is_reported_even_with_nothing_gathered():
+    """The comment is the only place a reader learns the run happened.
+
+    Posting nothing when a run is cancelled before any batch reports is indistinguishable from a job
+    that hung, which is the state a reader would otherwise keep waiting on.
+    """
+    client = FakeAsyncGitHubClient()
+    reporter = _reporter(client)
+
+    await reporter.publish_cancelled()
+
+    created = client.last_call("create_issue_comment")
+    assert CANCELLED_HEADING in created.kwargs["body"]
+
+
+async def test_a_cancelled_run_reports_what_it_had_gathered():
+    """A partial report is still worth publishing, and the run summary must not contradict it.
+
+    `on_finalize` renders the run summary from `latest_body`, so leaving it at the last in-progress
+    body would have the summary claim the run was still going while the comment says cancelled.
+    """
+    client = FakeAsyncGitHubClient()
+    reporter = _reporter(client)
+    await reporter.process_message(_update(1))
+
+    await reporter.publish_cancelled()
+
+    assert reporter.latest_body is not None
+    assert CANCELLED_HEADING in reporter.latest_body
+    assert CANCELLED_HEADING in client.last_call("update_issue_comment").kwargs["body"]
+
+
+async def test_a_write_that_raises_still_leaves_the_report_behind():
+    """The report is what the run found; whether it reached GitHub is a separate fact.
+
+    `_write` only catches HTTP failures, and `RateLimitWaitAbandoned` is a `TimeoutError`, so it goes
+    straight through. The cancellation path sets a small `max_wait_seconds` to make that happen, which
+    is exactly when the run summary is the only place left to publish from.
+    """
+    client = FakeAsyncGitHubClient()
+    client.mock_response("create_issue_comment", RateLimitWaitAbandoned(waited_seconds=0.0, remaining_seconds=61.0))
+    reporter = _reporter(client)
+
+    with pytest.raises(RateLimitWaitAbandoned):
+        await reporter.process_message(_update(3))
+
+    assert reporter.latest_body is not None
+    assert reporter._latest_revision == 3

--- a/ddev/tests/cli/ci/tests/test_task_run_reporter.py
+++ b/ddev/tests/cli/ci/tests/test_task_run_reporter.py
@@ -17,7 +17,7 @@ import pytest
 
 from ddev.cli.ci.tests import pr_comment
 from ddev.cli.ci.tests.messages import UpdatePRComment
-from ddev.cli.ci.tests.pr_comment import CANCELLED_HEADING, COMMENT_MARKER
+from ddev.cli.ci.tests.pr_comment import CANCELLED_HEADING, CANCELLED_WITHOUT_RESULTS_NOTE, COMMENT_MARKER
 from ddev.cli.ci.tests.progress import JobAttemptProgress, JobProgress, ProgressError
 from ddev.cli.ci.tests.status import Status
 from ddev.cli.ci.tests.task_run_reporter import RunReporterOptions, TaskRunReporter
@@ -770,10 +770,11 @@ async def test_nothing_supersedes_a_cancelled_report():
 
 
 async def test_a_cancelled_run_reports_what_it_had_gathered():
-    """A partial report is still worth publishing, and the run summary must not contradict it.
+    """A partial report is worth keeping, so cancelling renders the snapshot rather than discarding it.
 
-    `on_finalize` renders the run summary from `latest_body`, so leaving it at the last in-progress
-    body would have the summary claim the run was still going while the comment says cancelled.
+    The heading alone cannot tell the two cancelled bodies apart, since the no-results notice carries
+    it too. The job count is what identifies the snapshot behind a body, so that is what says the
+    partial results survived instead of being replaced by the notice.
     """
     client = FakeAsyncGitHubClient()
     reporter = _reporter(client)
@@ -783,7 +784,8 @@ async def test_a_cancelled_run_reports_what_it_had_gathered():
 
     assert reporter.latest_body is not None
     assert CANCELLED_HEADING in reporter.latest_body
-    assert CANCELLED_HEADING in client.last_call("update_issue_comment").kwargs["body"]
+    assert jobs_reported(reporter.latest_body) == 1
+    assert CANCELLED_WITHOUT_RESULTS_NOTE not in reporter.latest_body
 
 
 async def test_a_write_that_raises_still_leaves_the_report_behind():
@@ -801,4 +803,7 @@ async def test_a_write_that_raises_still_leaves_the_report_behind():
         await reporter.process_message(_update(3))
 
     assert reporter.latest_body is not None
-    assert reporter._latest_revision == 3
+    # The revision advanced with the retained body, so the earlier snapshot that follows is refused
+    # and the only write attempted is the one that failed.
+    await reporter.process_message(_update(2))
+    assert len(client.calls_to("create_issue_comment")) == 1

--- a/ddev/tests/cli/ci/tests/test_task_run_reporter.py
+++ b/ddev/tests/cli/ci/tests/test_task_run_reporter.py
@@ -730,6 +730,25 @@ async def test_a_cancelled_run_is_reported_even_with_nothing_gathered():
     assert CANCELLED_HEADING in created.kwargs["body"]
 
 
+async def test_nothing_supersedes_a_cancelled_report():
+    """A batch finishing as the run is cancelled must not put the report back to "still running".
+
+    Batches report concurrently, so a revision can be rendered after the cancellation notice went
+    out. Leaving that to call order would have the last word on the pull request claim the run is
+    still going, on a run that has already been cancelled.
+    """
+    client = FakeAsyncGitHubClient()
+    reporter = _reporter(client)
+    await reporter.process_message(_update(1))
+    await reporter.publish_cancelled()
+
+    await reporter.process_message(_update(2))
+
+    assert reporter.latest_body is not None
+    assert CANCELLED_HEADING in reporter.latest_body
+    assert CANCELLED_HEADING in client.last_call("update_issue_comment").kwargs["body"]
+
+
 async def test_a_cancelled_run_reports_what_it_had_gathered():
     """A partial report is still worth publishing, and the run summary must not contradict it.
 

--- a/ddev/tests/cli/ci/tests/test_task_run_reporter.py
+++ b/ddev/tests/cli/ci/tests/test_task_run_reporter.py
@@ -730,6 +730,26 @@ async def test_a_cancelled_run_is_reported_even_with_nothing_gathered():
     assert CANCELLED_HEADING in created.kwargs["body"]
 
 
+async def test_a_cancelled_report_that_never_landed_says_so_on_the_run_page():
+    """The run page is the only place left to say the pull request was not updated.
+
+    `_report_cancellation` gathers this with `return_exceptions`, so a write that raises is absorbed
+    and never reaches the caller. `RateLimitWaitAbandoned` is the one to expect, because cancelling
+    shortens the limiter's wait so a GitHub pause fails fast instead of outliving the process. With
+    the failure recorded only after the write, the summary would claim the comment was current.
+    """
+    client = FakeAsyncGitHubClient()
+    reporter = _reporter(client)
+    await reporter.process_message(_update(1))
+    for method in ("update_issue_comment", "create_issue_comment", "list_issue_comments"):
+        client.mock_response(method, RateLimitWaitAbandoned(2.0, 58.0))
+
+    with pytest.raises(RateLimitWaitAbandoned):
+        await reporter.publish_cancelled()
+
+    assert reporter.pr_comment_failed
+
+
 async def test_nothing_supersedes_a_cancelled_report():
     """A batch finishing as the run is cancelled must not put the report back to "still running".
 

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any
@@ -690,3 +691,46 @@ async def test_failure_at_submit_message_closes_check_run_as_success(tmp_path: P
     assert len(update_calls) == 1
     assert update_calls[0].kwargs["status"] == "completed"
     assert update_calls[0].kwargs["conclusion"] == "success"
+
+
+async def test_a_run_that_finished_on_its_own_is_not_cancelled(tmp_path: Path):
+    """Nothing to cancel once a run reached a terminal state, and asking wastes a call.
+
+    Under cancellation the budget is a few seconds shared by every cleanup call, so spending one on a
+    run that is already done costs one that is not.
+    """
+    client = FakeAsyncGitHubClient()
+    client.mock_response("get_workflow_run", wrap(make_workflow_run()))
+    mock_artifacts(client, [])
+    mock_jobs(client, [])
+    runner = make_runner(client, tmp_path)
+    runner.bus = RecordingBus()  # type: ignore[assignment]
+
+    await runner.process_message(make_batch(batch_id="batch-1"))
+    await runner.cancel_dispatched_runs()
+
+    assert client.calls_to("cancel_workflow_run") == []
+
+
+async def test_a_run_still_going_when_the_batch_is_cancelled_is_cancelled_too(tmp_path: Path):
+    """A dispatched run outlives the process that asked for it and keeps burning runner minutes.
+
+    The batch's own `finally` runs when its task is cancelled, so anything cleared there would be gone
+    before the cleanup looked, which is exactly when there is something to cancel.
+    """
+    client = FakeAsyncGitHubClient()
+    client.mock_response("get_workflow_run", wrap(make_workflow_run(status="in_progress", conclusion=None)))
+    runner = make_runner(client, tmp_path)
+    runner.bus = RecordingBus()  # type: ignore[assignment]
+
+    task = asyncio.create_task(runner.process_message(make_batch(batch_id="batch-1")))
+    await asyncio.sleep(0)
+    while not client.calls_to("create_check_run"):
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await runner.cancel_dispatched_runs()
+
+    assert [call.kwargs["run_id"] for call in client.calls_to("cancel_workflow_run")] == [123]

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -14,7 +14,7 @@ import pytest
 
 from ddev.cli.ci.tests.messages import BatchFinished, BatchJob, TestBatch
 from ddev.cli.ci.tests.status import Status, conclusion_to_check_run_conclusion, conclusion_to_status
-from ddev.cli.ci.tests.task_test_runner import TaskTestRunner, TestRunnerOptions
+from ddev.cli.ci.tests.task_test_runner import CANCEL_REQUEST_TIMEOUT, TaskTestRunner, TestRunnerOptions
 from ddev.utils.github_async import GitHubResponse
 from ddev.utils.github_async.models import (
     Artifact,
@@ -710,6 +710,31 @@ async def test_a_run_that_finished_on_its_own_is_not_cancelled(tmp_path: Path):
     await runner.cancel_dispatched_runs()
 
     assert client.calls_to("cancel_workflow_run") == []
+
+
+async def test_cancelling_a_run_does_not_wait_out_the_clients_default_timeout(tmp_path: Path):
+    """A GitHub that accepts the connection then stalls must not consume the whole teardown budget.
+
+    The retry policy's timeout bounds the ladder, not an attempt in flight, so without a per-request
+    timeout this inherits the client's 30s default. The process is killed after roughly ten, so one
+    stalled call would mean no run is cancelled at all.
+    """
+    client = FakeAsyncGitHubClient()
+    client.mock_response("get_workflow_run", wrap(make_workflow_run(status="in_progress", conclusion=None)))
+    runner = make_runner(client, tmp_path)
+    runner.bus = RecordingBus()  # type: ignore[assignment]
+
+    task = asyncio.create_task(runner.process_message(make_batch(batch_id="batch-1")))
+    async with asyncio.timeout(5):
+        while not client.calls_to("create_check_run"):
+            await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await runner.cancel_dispatched_runs()
+
+    assert client.last_call("cancel_workflow_run").kwargs["timeout"] == CANCEL_REQUEST_TIMEOUT
 
 
 async def test_a_run_still_going_when_the_batch_is_cancelled_is_cancelled_too(tmp_path: Path):

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -725,8 +725,11 @@ async def test_a_run_still_going_when_the_batch_is_cancelled_is_cancelled_too(tm
 
     task = asyncio.create_task(runner.process_message(make_batch(batch_id="batch-1")))
     await asyncio.sleep(0)
-    while not client.calls_to("create_check_run"):
-        await asyncio.sleep(0)
+    # Bounded, so a regression that never creates the check run fails here instead of spinning until
+    # the CI job's own timeout, which reports nothing useful.
+    async with asyncio.timeout(5):
+        while not client.calls_to("create_check_run"):
+            await asyncio.sleep(0)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task

--- a/ddev/tests/helpers/github_async.py
+++ b/ddev/tests/helpers/github_async.py
@@ -116,6 +116,8 @@ def _default_response_factories() -> dict[str, Callable[[], Any]]:
             headers={},
         ),
         'add_labels_to_issue': lambda: GitHubResponse.model_validate({'data': [], 'headers': {}}),
+        # Cancelling returns nothing, and a run already terminal is the outcome asked for.
+        'cancel_workflow_run': lambda: None,
         'create_issue_comment': lambda: GitHubResponse(
             data=IssueComment(
                 id=DEFAULT_COMMENT_ID,
@@ -428,6 +430,21 @@ class FakeAsyncGitHubClient:
     ) -> GitHubResponse[WorkflowRun]:
         return self._call(
             'get_workflow_run',
+            owner=owner,
+            repo=repo,
+            run_id=run_id,
+            timeout=timeout,
+        )
+
+    async def cancel_workflow_run(
+        self,
+        owner: str,
+        repo: str,
+        run_id: int,
+        timeout: float | None = None,
+    ) -> None:
+        self._call(
+            'cancel_workflow_run',
             owner=owner,
             repo=repo,
             run_id=run_id,

--- a/ddev/tests/helpers/github_async.py
+++ b/ddev/tests/helpers/github_async.py
@@ -51,6 +51,7 @@ from ddev.utils.github_async.models import (
     IssueComment,
     Label,
     PullRequest,
+    PullRequestReviewComment,
     WorkflowDispatchResult,
     WorkflowJobsList,
     WorkflowRun,
@@ -125,6 +126,10 @@ def _default_response_factories() -> dict[str, Callable[[], Any]]:
                 body='',
                 html_url='https://github.com/test/repo/issues/1#issuecomment-1',
             ),
+            headers={},
+        ),
+        'create_pr_review_comment': lambda: GitHubResponse(
+            data=PullRequestReviewComment(id=1, body='', path='file.py', commit_id='abc123'),
             headers={},
         ),
         'update_issue_comment': lambda: GitHubResponse(
@@ -331,6 +336,33 @@ class FakeAsyncGitHubClient:
             repo=repo,
             issue_number=issue_number,
             body=body,
+            timeout=timeout,
+        )
+
+    async def create_pr_review_comment(
+        self,
+        owner: str,
+        repo: str,
+        pull_number: int,
+        body: str,
+        commit_id: str,
+        path: str,
+        position: int | None = None,
+        line: int | None = None,
+        side: Literal['LEFT', 'RIGHT'] | None = None,
+        timeout: float | None = None,
+    ) -> GitHubResponse[PullRequestReviewComment]:
+        return self._call(
+            'create_pr_review_comment',
+            owner=owner,
+            repo=repo,
+            pull_number=pull_number,
+            body=body,
+            commit_id=commit_id,
+            path=path,
+            position=position,
+            line=line,
+            side=side,
             timeout=timeout,
         )
 

--- a/ddev/tests/helpers/github_async.py
+++ b/ddev/tests/helpers/github_async.py
@@ -56,6 +56,7 @@ from ddev.utils.github_async.models import (
     WorkflowJobsList,
     WorkflowRun,
 )
+from ddev.utils.github_async.retry import RetryPolicy
 from ddev.utils.github_errors import GitHubBodyTooLongError, github_body_too_long_message
 
 # Stable URL baked into the default `create_workflow_dispatch` response. Exported so tests
@@ -268,6 +269,8 @@ class FakeAsyncGitHubClient:
         repo: str,
         pull_number: int,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> GitHubResponse[PullRequest]:
         return self._call(
             'get_pull_request',
@@ -286,6 +289,8 @@ class FakeAsyncGitHubClient:
         base: str | None = None,
         per_page: int = 100,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> GitHubResponse[list[PullRequest]]:
         return self._call(
             'list_pull_requests',
@@ -308,6 +313,8 @@ class FakeAsyncGitHubClient:
         body: str = '',
         draft: bool = False,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> GitHubResponse[PullRequest]:
         return self._call(
             'create_pull_request',
@@ -328,6 +335,8 @@ class FakeAsyncGitHubClient:
         issue_number: int,
         body: str,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> GitHubResponse[IssueComment]:
         _ensure_body_fits(body)
         return self._call(
@@ -351,6 +360,8 @@ class FakeAsyncGitHubClient:
         line: int | None = None,
         side: Literal['LEFT', 'RIGHT'] | None = None,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> GitHubResponse[PullRequestReviewComment]:
         return self._call(
             'create_pr_review_comment',
@@ -373,6 +384,8 @@ class FakeAsyncGitHubClient:
         comment_id: int,
         body: str,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> GitHubResponse[IssueComment]:
         _ensure_body_fits(body)
         return self._call(
@@ -391,6 +404,8 @@ class FakeAsyncGitHubClient:
         issue_number: int,
         per_page: int = 100,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> AsyncIterator[GitHubResponse[list[IssueComment]]]:
         """Async-generator mirror.
 
@@ -422,6 +437,8 @@ class FakeAsyncGitHubClient:
         issue_number: int,
         labels: list[str],
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> GitHubResponse[list[Label]]:
         return self._call(
             'add_labels_to_issue',
@@ -441,6 +458,7 @@ class FakeAsyncGitHubClient:
         inputs: dict[str, str] | None = None,
         timeout: float | None = None,
         *,
+        retry: RetryPolicy | None = None,
         return_run_details: bool = False,
     ) -> GitHubResponse[Any]:
         return self._call(
@@ -460,6 +478,8 @@ class FakeAsyncGitHubClient:
         repo: str,
         run_id: int,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> GitHubResponse[WorkflowRun]:
         return self._call(
             'get_workflow_run',
@@ -475,6 +495,8 @@ class FakeAsyncGitHubClient:
         repo: str,
         run_id: int,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> None:
         self._call(
             'cancel_workflow_run',
@@ -497,6 +519,8 @@ class FakeAsyncGitHubClient:
         details_url: str | None = None,
         output: dict[str, Any] | None = None,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> GitHubResponse[CheckRun]:
         return self._call(
             'create_check_run',
@@ -520,6 +544,8 @@ class FakeAsyncGitHubClient:
         details_url: str | None = None,
         output: dict[str, Any] | None = None,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> GitHubResponse[CheckRun]:
         if status == CheckRunStatus.COMPLETED and conclusion is None:
             raise ValueError("A conclusion is required when a check run status is 'completed'.")
@@ -542,6 +568,8 @@ class FakeAsyncGitHubClient:
         run_id: int,
         per_page: int = 30,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> AsyncIterator[GitHubResponse[ArtifactsList]]:
         """Async-generator mirror. A registered response may be a single page or a list of pages."""
         self._record(
@@ -572,6 +600,8 @@ class FakeAsyncGitHubClient:
         run_id: int,
         per_page: int = 30,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> AsyncIterator[GitHubResponse[WorkflowJobsList]]:
         """Async-generator mirror. A registered response may be a single page or a list of pages."""
         self._record(
@@ -600,6 +630,8 @@ class FakeAsyncGitHubClient:
         archive_download_url: str,
         dest_path: Any,
         timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
     ) -> None:
         """Side-effecting mirror that returns ``None``; registered exceptions are raised."""
         self._record(

--- a/ddev/tests/helpers/github_async.py
+++ b/ddev/tests/helpers/github_async.py
@@ -118,6 +118,7 @@ def _default_response_factories() -> dict[str, Callable[[], Any]]:
         'add_labels_to_issue': lambda: GitHubResponse.model_validate({'data': [], 'headers': {}}),
         # Cancelling returns nothing, and a run already terminal is the outcome asked for.
         'cancel_workflow_run': lambda: None,
+        'relax_rate_limits': lambda: None,
         'create_issue_comment': lambda: GitHubResponse(
             data=IssueComment(
                 id=DEFAULT_COMMENT_ID,
@@ -450,6 +451,9 @@ class FakeAsyncGitHubClient:
             run_id=run_id,
             timeout=timeout,
         )
+
+    def relax_rate_limits(self, *, max_wait_seconds: float, max_rate: float) -> None:
+        self._call('relax_rate_limits', max_wait_seconds=max_wait_seconds, max_rate=max_rate)
 
     async def create_check_run(
         self,

--- a/ddev/tests/test_fake_github_async.py
+++ b/ddev/tests/test_fake_github_async.py
@@ -386,6 +386,15 @@ def test_every_mirror_is_in_the_call_table():
     assert {name for name, _, _ in MIRROR_CALLS} == mirrors
 
 
+MIRRORED_METHODS = frozenset(
+    {
+        name
+        for name, member in vars(AsyncGitHubClient).items()
+        if not name.startswith('_') and inspect.isfunction(member) and hasattr(FakeAsyncGitHubClient, name)
+    }
+)
+
+
 def test_every_client_method_has_a_mirror():
     """A client method with no mirror is the one gap the other two checks cannot see.
 
@@ -406,6 +415,21 @@ def test_every_client_method_has_a_mirror():
     }
 
     assert real - NON_MIRRORS <= fake
+
+
+@pytest.mark.parametrize('name', sorted(MIRRORED_METHODS), ids=sorted(MIRRORED_METHODS))
+def test_a_mirror_accepts_what_the_real_method_accepts(name: str):
+    """A mirror missing a parameter fails only in the test that passes it, and never in type checking.
+
+    `mypy-files` is `src/ddev`, so nothing checks a call into the fake. Every mirror went a whole
+    release with no `retry` parameter and nothing noticed, because no test had passed one yet.
+    """
+    real = inspect.signature(getattr(AsyncGitHubClient, name)).parameters
+    fake = inspect.signature(getattr(FakeAsyncGitHubClient, name)).parameters
+
+    assert [p for p in real if p not in fake] == []
+    # The reverse too, or the fake grows arguments no caller can ever pass.
+    assert [p for p in fake if p not in real] == []
 
 
 def test_no_real_client_method_is_excused_from_the_table():

--- a/ddev/tests/test_fake_github_async.py
+++ b/ddev/tests/test_fake_github_async.py
@@ -14,7 +14,7 @@ from typing import Any
 import httpx
 import pytest
 
-from ddev.utils.github_async import GitHubResponse
+from ddev.utils.github_async import AsyncGitHubClient, GitHubResponse
 from ddev.utils.github_async.models import Artifact, ArtifactsList, IssueComment, PullRequest
 from tests.cli.ci.tests.helpers import comment_page
 from tests.helpers.github_async import FakeAsyncGitHubClient
@@ -326,6 +326,11 @@ MIRROR_CALLS = [
     ('get_workflow_run', lambda f, _: f.get_workflow_run('o', 'r', 42), {'run_id': 42}),
     ('cancel_workflow_run', lambda f, _: f.cancel_workflow_run('o', 'r', 42), {'run_id': 42}),
     (
+        'relax_rate_limits',
+        lambda f, _: f.relax_rate_limits(max_wait_seconds=2.0, max_rate=10_000.0),
+        {'max_rate': 10_000.0},
+    ),
+    (
         'create_check_run',
         lambda f, _: f.create_check_run('o', 'r', 'unit', 'abc123', 'in_progress'),
         {'head_sha': 'abc123'},
@@ -345,17 +350,47 @@ MIRROR_CALLS = [
 ]
 
 
+# Helpers the fake adds for tests to assert with. Everything else public on the fake mirrors a real
+# client method and therefore belongs in the call table.
+NON_MIRRORS = frozenset(
+    {
+        'aclose',
+        'assert_all_responses_consumed',
+        'assert_called_once_with',
+        'assert_called_with',
+        'assert_not_called',
+        'calls_to',
+        'last_call',
+        'mock_response',
+    }
+)
+
+
 def test_every_mirror_is_in_the_call_table():
-    """A mirror missing from the table is an untested mirror, so the omission has to fail loudly."""
+    """A mirror missing from the table is an untested mirror, so the omission has to fail loudly.
+
+    Discriminated by name rather than by whether the mirror is a coroutine: the client has sync
+    methods too, and filtering on `iscoroutinefunction` made those invisible to this check.
+    """
     mirrors = {
         name
         for name, member in vars(FakeAsyncGitHubClient).items()
-        if not name.startswith('_')
-        and name != 'aclose'
-        and (inspect.iscoroutinefunction(member) or inspect.isasyncgenfunction(member))
+        if not name.startswith('_') and name not in NON_MIRRORS and inspect.isfunction(member)
     }
 
     assert {name for name, _, _ in MIRROR_CALLS} == mirrors
+
+
+def test_no_real_client_method_is_excused_from_the_table():
+    """`NON_MIRRORS` excuses a name from the check above, so it must only ever name test helpers.
+
+    Without this, adding a client method to `NON_MIRRORS` would silently exempt it from needing a
+    mirror at all. `aclose` is the one legitimate overlap: both classes have it, and the fake's is
+    a no-op with no arguments worth recording.
+    """
+    real = {name for name, member in vars(AsyncGitHubClient).items() if inspect.isfunction(member)}
+
+    assert NON_MIRRORS & real == {'aclose'}
 
 
 @pytest.mark.parametrize(('method', 'call', 'expected'), MIRROR_CALLS, ids=[name for name, _, _ in MIRROR_CALLS])
@@ -368,7 +403,9 @@ async def test_a_mirror_records_the_arguments_it_was_called_with(
 ):
     """Recording happens before the response resolves, so a mirror whose default raises still records."""
     with contextlib.suppress(httpx.HTTPStatusError):
-        await call(fake, tmp_path)
+        # Sync mirrors return nothing to await, so the table can hold both shapes.
+        if inspect.isawaitable(result := call(fake, tmp_path)):
+            await result
 
     recorded = fake.last_call(method).kwargs
     assert expected.items() <= recorded.items()

--- a/ddev/tests/test_fake_github_async.py
+++ b/ddev/tests/test_fake_github_async.py
@@ -324,6 +324,7 @@ MIRROR_CALLS = [
         {'workflow_id': 'wf.yml'},
     ),
     ('get_workflow_run', lambda f, _: f.get_workflow_run('o', 'r', 42), {'run_id': 42}),
+    ('cancel_workflow_run', lambda f, _: f.cancel_workflow_run('o', 'r', 42), {'run_id': 42}),
     (
         'create_check_run',
         lambda f, _: f.create_check_run('o', 'r', 'unit', 'abc123', 'in_progress'),

--- a/ddev/tests/test_fake_github_async.py
+++ b/ddev/tests/test_fake_github_async.py
@@ -326,6 +326,11 @@ MIRROR_CALLS = [
     ('get_workflow_run', lambda f, _: f.get_workflow_run('o', 'r', 42), {'run_id': 42}),
     ('cancel_workflow_run', lambda f, _: f.cancel_workflow_run('o', 'r', 42), {'run_id': 42}),
     (
+        'create_pr_review_comment',
+        lambda f, _: f.create_pr_review_comment('o', 'r', 1, 'body', 'abc123', 'file.py', line=10, side='RIGHT'),
+        {'commit_id': 'abc123', 'line': 10},
+    ),
+    (
         'relax_rate_limits',
         lambda f, _: f.relax_rate_limits(max_wait_seconds=2.0, max_rate=10_000.0),
         {'max_rate': 10_000.0},
@@ -379,6 +384,28 @@ def test_every_mirror_is_in_the_call_table():
     }
 
     assert {name for name, _, _ in MIRROR_CALLS} == mirrors
+
+
+def test_every_client_method_has_a_mirror():
+    """A client method with no mirror is the one gap the other two checks cannot see.
+
+    They compare the fake against the call table and the exemption list against the client, so a
+    method that exists only on the real client is absent from both sides of both. That is how a
+    caller reached a mirror that was never written: the code raised `AttributeError` mid-run and the
+    test around it still passed.
+    """
+    real = {
+        name
+        for name, member in vars(AsyncGitHubClient).items()
+        if not name.startswith('_') and inspect.isfunction(member)
+    }
+    fake = {
+        name
+        for name, member in vars(FakeAsyncGitHubClient).items()
+        if not name.startswith('_') and inspect.isfunction(member)
+    }
+
+    assert real - NON_MIRRORS <= fake
 
 
 def test_no_real_client_method_is_excused_from_the_table():

--- a/ddev/tests/utils/github_async/test_endpoints.py
+++ b/ddev/tests/utils/github_async/test_endpoints.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import nullcontext as does_not_raise
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -651,3 +652,23 @@ async def test_endpoint_forwards_response_headers(case: EndpointCase) -> None:
     client = make_client(httpx.MockTransport(handler))
     result = await case.call(client)
     assert result.headers["x-ratelimit-remaining"] == "42"
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expectation"),
+    [
+        pytest.param(202, does_not_raise(), id="accepted"),
+        pytest.param(409, does_not_raise(), id="already_terminal"),
+        pytest.param(404, pytest.raises(httpx.HTTPStatusError), id="not_found"),
+    ],
+)
+async def test_cancelling_a_run_that_already_finished_is_not_a_failure(status_code: int, expectation) -> None:
+    """GitHub answers 409 once a run is terminal, which is the state the caller asked for.
+
+    Treating it as a failure would have the caller report a cleanup step as broken for doing nothing,
+    and a run finishing between the decision to cancel it and the call is ordinary.
+    """
+    client = make_client(httpx.MockTransport(lambda request: httpx.Response(status_code)))
+
+    with expectation:
+        await client.cancel_workflow_run("DataDog", "integrations-core", 123)

--- a/ddev/tests/utils/github_async/test_retry.py
+++ b/ddev/tests/utils/github_async/test_retry.py
@@ -68,6 +68,24 @@ async def test_a_server_error_is_replayed_only_where_replaying_is_safe(case) -> 
         assert len(calls) == 1
 
 
+async def test_cancelling_a_run_replays_a_server_error() -> None:
+    """Cancelling twice cancels once, so a 503 that may have landed is worth repeating.
+
+    The caller is a run being torn down to stop workflows it started. On the mutating default a
+    transport failure after the POST reached GitHub is not replayed, and the run it meant to cancel
+    keeps consuming runner minutes.
+
+    Not in `ENDPOINT_CALLS` because this endpoint returns nothing, and the registry's
+    header-forwarding case needs a response to read.
+    """
+    transport, calls = recording_transport([httpx.Response(503), httpx.Response(202)])
+    client = AsyncGitHubClient(token=TOKEN, transport=transport)
+
+    await client.cancel_workflow_run("o", "r", 42)
+
+    assert len(calls) == 2
+
+
 @pytest.mark.parametrize("case", ENDPOINT_CALLS, ids=lambda case: case.id)
 async def test_a_request_that_never_left_is_replayed_by_every_endpoint(case) -> None:
     """A refused connection proves GitHub never saw the request, so even a create can safely repeat.

--- a/ddev/tests/utils/test_rate_limiting.py
+++ b/ddev/tests/utils/test_rate_limiting.py
@@ -705,3 +705,38 @@ async def test_instrumented_limiter_does_not_consume_bucket_token_during_governo
 def test_instrumented_limiter_observe_without_governor_does_not_raise():
     limiter = InstrumentedAsyncLimiter(AsyncLimiter(max_rate=1, time_period=1000))
     limiter.observe(make_snapshot(limit=100, remaining=50, reset_at=2000.0))
+
+
+async def test_relaxing_stops_rationing_the_budget(clock: FakeClock, slept: list[float]) -> None:
+    """Pacing spreads what is left of the budget over the window, which outlasts a dying process.
+
+    A cancelled CI job has about ten seconds. Rationing a low budget over a half-hour window puts
+    every request after the first outside that, so the cleanup would land one call and lose the rest.
+    """
+    governor = BudgetGovernor(now=clock, reserve_fraction=0.15)
+    limiter = InstrumentedAsyncLimiter(AsyncLimiter(max_rate=10, time_period=60), budget_governor=governor)
+    governor.observe(make_snapshot(clock=clock, limit=1000, remaining=100, reset_in=1800))
+
+    limiter.relax(max_wait_seconds=2.0, max_rate=10_000)
+    for _ in range(8):
+        async with limiter:
+            pass
+
+    assert slept == []
+
+
+async def test_relaxing_gives_up_on_a_pause_it_cannot_outlast(clock: FakeClock, slept: list[float]) -> None:
+    """A provider pause is real and cannot be skipped, but blocking on it wastes the time left.
+
+    Failing at once lets the caller move to the next thing it wants to say before the kill arrives.
+    """
+    governor = BudgetGovernor(now=clock, reserve_fraction=0.15)
+    limiter = InstrumentedAsyncLimiter(AsyncLimiter(max_rate=10, time_period=60), budget_governor=governor)
+    governor.observe(make_snapshot(retry_after=60))
+
+    limiter.relax(max_wait_seconds=2.0, max_rate=10_000)
+
+    with pytest.raises(RateLimitWaitAbandoned):
+        async with limiter:
+            pass
+    assert slept == []


### PR DESCRIPTION
> **Stack**
>
> 1. ~~#24978 Wait for sync processors and retire the thread pool on shutdown~~ (merged)
> 2. ~~#24980 Abandon gathering when the bus is shutting down~~ (merged)
> 3. #25002 Let a caller ask the event bus to stop
> 4. **#25042 Report and clean up after a cancelled Dispatcher run** :point_left: this PR

### What does this PR do?

Handles SIGINT and SIGTERM in the Dispatcher, and does three things on the way out.

**Relaxes the shared rate limiter, before stopping.** Our own pacing spreads a low budget over the rest of the window, which is far longer than the process has left. Rationing goes off and provider pauses become bounded, so a call that cannot go out fails at once instead of blocking. GitHub's own limits are still honoured; only our pacing is dropped.

**Reports the run as cancelled on the pull request.** Rendered from the newest snapshot rather than edited out of the last body, because "still running" is said in the heading, the alert and the footer, and a report keeping any of them tells the reader to wait for results that are not coming. A run cancelled before any batch reported still comments.

**Cancels the workflow runs it dispatched.** They otherwise keep burning runner minutes after the run that asked for them is gone. Tracked from dispatch, dropped once a run finishes on its own.

Also adds `AsyncGitHubClient.cancel_workflow_run`, which treats GitHub's 409 as success since a run that already finished is the state being asked for.

Check runs are deliberately **not** closed here. Each batch closes its own in a `finally`, and the bus awaits the tasks it cancelled, so those closes complete before this hook runs. Measured on a probe bus: `check run created` -> `check run CLOSED as cancelled` -> `on_finalize ran`. Relaxing the limiter is what makes them land in time.

Two things found while reviewing this, both small and both fixed here rather than deferred:

- **`create_pr_review_comment` had no mirror on the fake client.** The two guards in
  `test_fake_github_async.py` compared the fake against the call table, and the exemption list
  against the client, so a client method missing from the fake entirely was absent from both sides of
  both checks. That is exactly the shape that bit this branch once already: `_cancel` reached a
  mirror nobody had written, raised `AttributeError` mid-run, and the test around it still passed off
  the orchestrator's 30s timeout. There is now a third assertion for that direction, and closing it
  needed the one method it found missing. It has no production caller, only the client's own endpoint
  tests, so the mirror has no behaviour to get wrong.
- **`cancel_workflow_run` was the only endpoint with no `retry`**, because it was written on this
  branch before the retry layer merged. It fell through to the mutating default, which replays only
  failures proving the request never left the process, so a transport error after the POST reached
  GitHub went unretried and the run it meant to cancel kept spending runner minutes. Cancelling twice
  cancels once, so it takes the replayable policy, with the ladder shortened to 5s because the caller
  is a teardown working with seconds.

### Motivation

A cancelled job gets about ten seconds, measured rather than assumed: SIGINT, 7.51s, SIGTERM, ~2.5s, hard kill. Handling the signals also means SIGINT stops arriving as `KeyboardInterrupt`, so shutdown takes one path whichever signal came first.

Rate limiting is the part that decides whether any of it works. With `reserve_fraction=0.15` at 100 of 1000 remaining and 30 minutes to reset, eight concurrent closes are paced to `0, 18, 36, 54, 72, 90, 108, 126` seconds; relaxed, all eight go at `0.0`. Without that, one check run closes and the rest are killed mid-wait.

Signal handling lives on the Dispatcher rather than the bus: the bus is generic ddev infrastructure and the Dispatcher only runs on Linux runners, so a Linux-only concern should not reach every future bus user. Installation tolerates an event loop that cannot do it, because ddev's own tests run on Windows, and the test for the mechanism is skipped there.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


