### PR TITLE
Isolate the GitHub Actions job summary in ddev tests

### DIFF
--- a/ddev/tests/cli/ci/tests/test_dispatcher.py
+++ b/ddev/tests/cli/ci/tests/test_dispatcher.py
@@ -18,6 +18,10 @@ from ddev.utils.github_async.models import ArtifactsList, WorkflowJob, WorkflowJ
 from tests.cli.ci.tests.helpers import jobs_reported, make_batch, make_job
 from tests.helpers.github_async import FakeAsyncGitHubClient
 
+# Every test here runs a Dispatcher to completion, and `on_finalize` writes the run summary. Without
+# this the reports land in the real job summary whenever the suite runs inside a workflow.
+pytestmark = pytest.mark.usefixtures("step_summary")
+
 CONTEXT = DispatcherContext(
     owner="DataDog",
     repo="integrations-core",
@@ -149,10 +153,8 @@ def test_a_failed_batch_makes_the_run_unsuccessful(client, tmp_path):
     assert outcome.progress.failed == 1
 
 
-def test_the_report_is_written_to_the_run_summary(client, tmp_path, monkeypatch):
+def test_the_report_is_written_to_the_run_summary(client, tmp_path, step_summary):
     """A run with no pull request has the run summary as its only report."""
-    summary = tmp_path / "summary.md"
-    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
     job = make_job()
     mock_job_result(client, job, "success")
     dispatcher = build_bus(client, tmp_path, [make_batch(job)], pr_number=None)
@@ -160,4 +162,4 @@ def test_the_report_is_written_to_the_run_summary(client, tmp_path, monkeypatch)
     dispatcher.run()
 
     client.assert_not_called("create_issue_comment")
-    assert jobs_reported(summary.read_text(encoding="utf-8")) == 1
+    assert jobs_reported(step_summary.read_text(encoding="utf-8")) == 1

--- a/ddev/tests/cli/validate/all/test_orchestrator.py
+++ b/ddev/tests/cli/validate/all/test_orchestrator.py
@@ -189,10 +189,7 @@ def test_on_finalize_logs_exception(mock_app):
 # --- on_finalize PR comment + step summary ---
 
 
-def test_on_finalize_writes_step_summary(mock_app, tmp_path, monkeypatch):
-    summary_file = tmp_path / "summary.md"
-    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
-
+def test_on_finalize_writes_step_summary(mock_app, step_summary):
     mock_app.config.github.token = ""
     orch = ValidationOrchestrator(app=mock_app, validations=["config"], target=None)
     orch._results = {
@@ -200,7 +197,7 @@ def test_on_finalize_writes_step_summary(mock_app, tmp_path, monkeypatch):
     }
     asyncio.run(orch.on_finalize(exception=None))
 
-    content = summary_file.read_text(encoding="utf-8")
+    content = step_summary.read_text(encoding="utf-8")
     assert "Validation Report" in content
     assert "| Validation | Description | Status |" in content
     assert "| `config` |" in content
@@ -239,10 +236,7 @@ def test_on_finalize_pr_comment_omits_run_link_when_env_missing(mock_app, monkey
     assert "[View full run]" not in body
 
 
-def test_on_finalize_step_summary_does_not_include_run_link(mock_app, tmp_path, monkeypatch):
-    summary_file = tmp_path / "summary.md"
-    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
-
+def test_on_finalize_step_summary_does_not_include_run_link(mock_app, step_summary):
     mock_app.config.github.token = "fake-token"
     orch = ValidationOrchestrator(app=mock_app, validations=["config"], target=None, pr_number=42)
     orch._results = {
@@ -250,7 +244,7 @@ def test_on_finalize_step_summary_does_not_include_run_link(mock_app, tmp_path, 
     }
     asyncio.run(orch.on_finalize(exception=None))
 
-    content = summary_file.read_text(encoding="utf-8")
+    content = step_summary.read_text(encoding="utf-8")
     assert "[View full run]" not in content
 
 
@@ -289,9 +283,7 @@ def test_on_finalize_deletes_previous_validation_comments(mock_app):
     mock_app.github.post_pull_request_comment.assert_called_once()
 
 
-def test_on_finalize_includes_pr_warning_in_summary(mock_app, tmp_path, monkeypatch):
-    summary_file = tmp_path / "summary.md"
-    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+def test_on_finalize_includes_pr_warning_in_summary(mock_app, step_summary, monkeypatch):
     monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
 
     mock_app.config.github.token = ""
@@ -301,7 +293,7 @@ def test_on_finalize_includes_pr_warning_in_summary(mock_app, tmp_path, monkeypa
     }
     asyncio.run(orch.on_finalize(exception=None))
 
-    content = summary_file.read_text(encoding="utf-8")
+    content = step_summary.read_text(encoding="utf-8")
     assert "could not determine PR number" in content
 
 

--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -160,6 +160,25 @@ def temp_dir(tmp_path) -> Path:
     return path
 
 
+@pytest.fixture
+def step_summary(tmp_path, monkeypatch) -> Path:
+    """Redirect the GitHub Actions job summary to a temporary file and return it.
+
+    Request this in any test that reaches code calling `write_step_summary`. Without it, such a test
+    inherits the real `GITHUB_STEP_SUMMARY` when the suite runs inside a workflow and appends its
+    output to the job's own summary panel.
+    """
+    summary_file = Path(tmp_path, 'step-summary.md')
+    monkeypatch.setenv('GITHUB_STEP_SUMMARY', str(summary_file))
+    return summary_file
+
+
+@pytest.fixture
+def without_step_summary(monkeypatch) -> None:
+    """Unset `GITHUB_STEP_SUMMARY`, for tests covering the no-summary-available path."""
+    monkeypatch.delenv('GITHUB_STEP_SUMMARY', raising=False)
+
+
 @pytest.fixture(scope='session', autouse=True)
 def isolation() -> Generator[Path, None, None]:
     from unittest.mock import patch

--- a/ddev/tests/utils/test_github_actions.py
+++ b/ddev/tests/utils/test_github_actions.py
@@ -10,8 +10,11 @@ from ddev.utils.github_actions import get_workflow_run_url, write_step_summary
 
 @pytest.fixture(autouse=True)
 def _github_actions_env(monkeypatch):
-    """A consistent GitHub Actions environment, so a real one cannot leak into these tests."""
-    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    """A consistent GitHub Actions environment, so a real one cannot leak into these tests.
+
+    `GITHUB_STEP_SUMMARY` is not set here: every test below picks either `step_summary` or
+    `without_step_summary`, and a default would just be a third source of truth for the same variable.
+    """
     monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
     monkeypatch.setenv("GITHUB_REPOSITORY", "DataDog/integrations-core")
     monkeypatch.setenv("GITHUB_RUN_ID", "12345")
@@ -33,26 +36,20 @@ def test_get_workflow_run_url_returns_none_when_env_missing(monkeypatch, missing
 # --- write_step_summary ---
 
 
-def test_write_step_summary_writes_to_file(tmp_path, monkeypatch):
-    summary_file = tmp_path / "summary.md"
-    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
-
+def test_write_step_summary_writes_to_file(step_summary):
     write_step_summary("## Report\nAll good")
-    assert summary_file.read_text(encoding="utf-8") == "## Report\nAll good\n"
+    assert step_summary.read_text(encoding="utf-8") == "## Report\nAll good\n"
 
 
-def test_write_step_summary_appends(tmp_path, monkeypatch):
-    summary_file = tmp_path / "summary.md"
-    summary_file.write_text("existing\n", encoding="utf-8")
-    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
+def test_write_step_summary_appends(step_summary):
+    step_summary.write_text("existing\n", encoding="utf-8")
 
     write_step_summary("new content")
-    assert "existing\n" in summary_file.read_text(encoding="utf-8")
-    assert "new content\n" in summary_file.read_text(encoding="utf-8")
+    assert "existing\n" in step_summary.read_text(encoding="utf-8")
+    assert "new content\n" in step_summary.read_text(encoding="utf-8")
 
 
-def test_write_step_summary_noop_without_env(monkeypatch):
-    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+def test_write_step_summary_noop_without_env(without_step_summary):
     write_step_summary("should not error")
 
 
@@ -62,16 +59,13 @@ def test_write_step_summary_survives_an_unwritable_summary_file(tmp_path, monkey
     write_step_summary("should not error")
 
 
-def test_the_step_summary_is_written_as_utf8_whatever_the_locale(tmp_path, monkeypatch):
+def test_the_step_summary_is_written_as_utf8_whatever_the_locale(step_summary):
     """The Dispatcher report is emoji-dense, so the encoding is part of the contract.
 
     Asserted in bytes, because reading it back as text would use the locale encoding and agree with
     whatever was written. Only fails where it matters — Windows CI, or ``LC_ALL=C PYTHONUTF8=0``.
     """
-    summary_file = tmp_path / "summary.md"
-    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_file))
-
     write_step_summary("## ✅ passed · ❌ failed")
 
     # The trailing newline is excluded deliberately: text mode translates it to CRLF on Windows.
-    assert summary_file.read_bytes().startswith("## ✅ passed · ❌ failed".encode())
+    assert step_summary.read_bytes().startswith("## ✅ passed · ❌ failed".encode())


### PR DESCRIPTION
### What does this PR do?

Adds two fixtures to `ddev/tests/conftest.py` for the GitHub Actions job summary, and uses them wherever a test reaches code that writes one:

- `step_summary` redirects `GITHUB_STEP_SUMMARY` to a `tmp_path` file and returns it, so a test can assert on what was written
- `without_step_summary` unsets the variable, for the no-summary-available path

`test_dispatcher.py` gets a module-level `pytestmark = pytest.mark.usefixtures("step_summary")`, since every test in it runs a Dispatcher to completion and `on_finalize` writes the summary. `test_github_actions.py` and the three summary tests in `validate/all/test_orchestrator.py` drop their hand-rolled `tmp_path` + `monkeypatch.setenv` pairs for the fixture.

No source changes.

### Motivation

The Dispatcher tests build a real `Dispatcher` and call `run()`, so `on_finalize` ran for real and read `GITHUB_STEP_SUMMARY` from the ambient environment, which is always set inside a GH Actions job. Two of them appended their fake reports to the ddev job's actual summary panel. That is where the dispatcher sections on master runs like [33182606881](https://github.com/DataDog/integrations-core/actions/runs/33182606881) came from, even though the dispatcher is not the test engine yet.

Reproduced by pointing the variable at a file the way CI does:

```
$ GITHUB_STEP_SUMMARY=/tmp/leak.md ddev --no-interactive test ddev -- -q -p no:randomly
2083 passed, 18 skipped in 294.04s
$ wc -c /tmp/leak.md
1571 /tmp/leak.md
$ grep '^## ' /tmp/leak.md
## ❌ Dispatcher tests · failed
## ⚠️ Dispatcher tests · results incomplete
```

`test_a_batch_travels_from_dispatch_to_the_pull_request_comment` wrote 750 bytes and `test_a_failed_batch_makes_the_run_unsuccessful` 821. `test_the_report_is_written_to_the_run_summary` was already clean, because it sets the variable to its own file to assert on it, which is the pattern the `step_summary` fixture now generalizes.

The three files were already doing this by hand in six places, so the fixture removes that duplication as well as fixing the leak.

Checked the fixture is actually load-bearing rather than incidentally passing, by dropping the `pytestmark` line and rerunning:

```
# with pytestmark
$ GITHUB_STEP_SUMMARY=/tmp/lk.md ddev --no-interactive test ddev -- -q -p no:randomly \
    tests/cli/ci/tests/test_dispatcher.py tests/utils/test_github_actions.py tests/cli/validate/all/test_orchestrator.py
45 passed in 0.96s
$ wc -c /tmp/lk.md
0 /tmp/lk.md

# same run, pytestmark removed
$ wc -c /tmp/lk2.md
1571 /tmp/lk2.md
```

The autouse `_clean_github_env` in `validate/all/conftest.py` keeps its `GITHUB_STEP_SUMMARY` `delenv`: it is the default for the tests there that do not request `step_summary`, and it orders before the fixture's `setenv` for the three that do.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
