### PR TITLE
Drop tests of framework mechanics in the ci/tests suite

### DIFF
--- a/ddev/tests/cli/ci/tests/test_messages.py
+++ b/ddev/tests/cli/ci/tests/test_messages.py
@@ -12,11 +12,8 @@ import pytest
 from ddev.cli.ci.tests.messages import (
     ARTIFACT_NAME_DISALLOWED,
     BatchJobResult,
-    JobResult,
-    UpdatePRComment,
     WorkflowStatus,
 )
-from ddev.cli.ci.tests.progress import DispatcherProgress
 from ddev.cli.ci.tests.status import Status
 from ddev.utils.github_async.models import WorkflowJob
 from ddev.utils.platform import PlatformName
@@ -94,10 +91,6 @@ def test_correlate_ignores_artifact_dir_missing_on_disk(tmp_path: Path):
     assert result.artifact_name_path is None
 
 
-def _job(integration: str, status: Status) -> JobResult:
-    return JobResult(integration=integration, environment="py3.13", platform=PlatformName.LINUX, status=status)
-
-
 def _workflow(batch_id: str, run_id: int, success: int, failed: int, skipped: int, results: list) -> WorkflowStatus:
     return WorkflowStatus(
         batch_id=batch_id,
@@ -116,14 +109,3 @@ def test_workflow_status_label():
     assert _workflow("b3", 3, 0, 0, 2, []).status == Status.SKIPPED
     # A batch with passes and skips (no failures) reads as success.
     assert _workflow("b4", 4, 3, 0, 1, []).status == Status.SUCCESS
-
-
-def test_update_pr_comment_carries_only_the_revision_and_the_snapshot() -> None:
-    # Ordering metadata plus the aggregate: no second copy of the counts or the done flag.
-    progress = DispatcherProgress(batches=(), done=False)
-    update = UpdatePRComment(id="m1", revision=0, progress=progress)
-
-    assert (update.id, update.revision) == ("m1", 0)
-    assert update.progress is progress
-    assert not hasattr(update, "workflows")
-    assert not hasattr(update, "done")

--- a/ddev/tests/cli/ci/tests/test_progress.py
+++ b/ddev/tests/cli/ci/tests/test_progress.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 import dataclasses
 
-import pytest
-
 from ddev.cli.ci.tests.messages import BatchJob
 from ddev.cli.ci.tests.progress import (
     BatchProgress,
@@ -206,28 +204,3 @@ def test_an_execution_missing_its_artifacts_still_counts() -> None:
 def test_empty_progress_counts_zero() -> None:
     progress = DispatcherProgress(batches=(), done=False)
     assert (progress.passed, progress.failed, progress.skipped, progress.complete, progress.total) == (0, 0, 0, 0, 0)
-
-
-# ---------------------------------------------------------------------------
-# Immutability and defaults
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    ("instance", "field_name", "value"),
-    [
-        (_attempt(), "status", Status.FAILURE),
-        (_job(), "attempts", ()),
-        (_batch(), "state", ExecutionState.PLANNED),
-        (DispatcherProgress(batches=(), done=False), "done", True),
-    ],
-    ids=["attempt", "job", "batch", "dispatcher"],
-)
-def test_progress_objects_are_immutable(instance: object, field_name: str, value: object) -> None:
-    with pytest.raises(dataclasses.FrozenInstanceError):
-        setattr(instance, field_name, value)
-
-
-def test_error_defaults_to_none() -> None:
-    assert _attempt().error is None
-    assert _batch().error is None

--- a/ddev/tests/cli/ci/tests/test_rate_limiting.py
+++ b/ddev/tests/cli/ci/tests/test_rate_limiting.py
@@ -14,34 +14,31 @@ from ddev.cli.ci.tests.rate_limiting import RateLimiterConfig, RateLimiterFactor
 # ---------------------------------------------------------------------------
 
 
-def test_rate_limiter_config_rejects_zero_max_rate():
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"max_rate": 0}, id="zero-max-rate"),
+        pytest.param({"max_rate": -1.0}, id="negative-max-rate"),
+        pytest.param({"max_rate": 10.0, "time_period": 0}, id="zero-time-period"),
+        pytest.param({"max_rate": 10.0, "time_period": -1.0}, id="negative-time-period"),
+    ],
+)
+def test_rate_limiter_config_rejects_a_non_positive_rate(kwargs: dict):
     with pytest.raises(ValidationError, match="greater than 0"):
-        RateLimiterConfig(max_rate=0)
+        RateLimiterConfig(**kwargs)
 
 
-def test_rate_limiter_config_rejects_negative_max_rate():
-    with pytest.raises(ValidationError, match="greater than 0"):
-        RateLimiterConfig(max_rate=-1.0)
-
-
-def test_rate_limiter_config_rejects_zero_time_period():
-    with pytest.raises(ValidationError, match="greater than 0"):
-        RateLimiterConfig(max_rate=10.0, time_period=0)
-
-
-def test_rate_limiter_config_rejects_negative_time_period():
-    with pytest.raises(ValidationError, match="greater than 0"):
-        RateLimiterConfig(max_rate=10.0, time_period=-1.0)
-
-
-def test_rate_limiter_config_hourly_rate_with_default_period():
-    # 360 tokens per 3600s = 360 req/hr
-    assert RateLimiterConfig(max_rate=360.0).hourly_rate == pytest.approx(360.0)
-
-
-def test_rate_limiter_config_hourly_rate_with_custom_period():
-    # 6 tokens per 60s = 360 req/hr
-    assert RateLimiterConfig(max_rate=6.0, time_period=60.0).hourly_rate == pytest.approx(360.0)
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # 360 tokens per 3600s and 6 per 60s are the same hourly budget, which is the unit the
+        # combined-rate check compares against.
+        pytest.param({"max_rate": 360.0}, id="default-period"),
+        pytest.param({"max_rate": 6.0, "time_period": 60.0}, id="custom-period"),
+    ],
+)
+def test_rate_limiter_config_normalizes_its_rate_to_an_hourly_one(kwargs: dict):
+    assert RateLimiterConfig(**kwargs).hourly_rate == pytest.approx(360.0)
 
 
 # ---------------------------------------------------------------------------
@@ -69,6 +66,7 @@ def test_factory_config_raises_when_combined_rate_exceeds_total_mixed_periods():
 
 
 def test_factory_config_accepts_combined_rate_at_limit():
+    """The boundary is inclusive, so a config that exactly spends the budget is legal."""
     assert RateLimiterFactoryConfig(
         default=RateLimiterConfig(max_rate=750.0),
         slow=RateLimiterConfig(max_rate=750.0),
@@ -76,26 +74,14 @@ def test_factory_config_accepts_combined_rate_at_limit():
     )
 
 
-def test_factory_config_default_is_within_bounds():
+def test_factory_config_defaults_satisfy_their_own_combined_rate_check():
+    """The shipped defaults must not be a config the validator would reject."""
     assert RateLimiterFactoryConfig()
 
 
 def test_factory_config_rejects_negative_total_hourly_max_rate():
     with pytest.raises(ValidationError, match="greater than 0"):
         RateLimiterFactoryConfig(total_hourly_max_rate=-1.0)
-
-
-# ---------------------------------------------------------------------------
-# RateLimiterFactory construction
-# ---------------------------------------------------------------------------
-
-
-def test_factory_default_config_is_within_bounds():
-    assert RateLimiterFactory() is not None
-
-
-def test_factory_with_logger_does_not_raise():
-    assert RateLimiterFactory(logger=logging.getLogger("test")) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -155,10 +141,3 @@ def test_factory_shares_on_event_across_governor_and_both_limiters():
 
     assert factory.default.on_event is factory.slow.on_event
     assert factory.default.on_event is factory.default.budget_governor.on_event
-
-
-def test_factory_uses_distinct_names_for_default_and_slow_limiters():
-    factory = RateLimiterFactory()
-
-    assert factory.default.name == "default"
-    assert factory.slow.name == "slow"


### PR DESCRIPTION
### What does this PR do?

Removes tests in `ddev/tests/cli/ci/tests/` that assert framework mechanics or removed fields, and parameterizes near-identical variants. 34 tests across the three files become 43-minus-the-deletions; no behaviour loses coverage.

`test_messages.py`
- Drops `test_update_pr_comment_carries_only_the_revision_and_the_snapshot`. It asserted `not hasattr(update, "workflows")` and `not hasattr(update, "done")`, which only mean something if you remember the iteration that had those fields. The rest of it was constructor assignment. `UpdatePRComment`'s real contract is covered in `test_task_run_reporter.py`.
- Removes the `_job`/`JobResult` helper that test was the only user of.

`test_rate_limiting.py`
- Drops `test_factory_default_config_is_within_bounds` and `test_factory_with_logger_does_not_raise`, both of which asserted `RateLimiterFactory(...) is not None`.
- Drops `test_factory_uses_distinct_names_for_default_and_slow_limiters`, which asserted the two name literals the limiters are declared with.
- Folds the four `rejects_zero/negative` cases into one parameterized test, and the two `hourly_rate` cases into one.
- Renames the surviving `RateLimiterFactoryConfig()` test to say what it is for: the shipped defaults must not be a config the combined-rate validator rejects.

`test_progress.py`
- Drops `test_progress_objects_are_immutable` (asserts `FrozenInstanceError`, i.e. `@dataclass(frozen=True)` working) and `test_error_defaults_to_none` (asserts a declared default).

The derived-rule tests in these files are untouched: `latest`, `retry_count` over a sparse attempt history, counters using only the latest attempt, the tier-selection and shared-limiter tests that enforce the global rate cap.

### Motivation

Drive-by cleanup spotted while tracking down a job-summary leak in the same package (#25044, independent of this PR). These are the patterns [AGENTS.md](https://github.com/DataDog/integrations-core/blob/master/AGENTS.md#writing-tests) rules out: asserting the code no longer does what an earlier iteration did, and testing that a constructor assigned its arguments or that an enum has its declared values. They cost CI time on every run and break on harmless refactors without protecting anything.

Ran the three touched files:

```
$ ddev --no-interactive test ddev -- -q tests/cli/ci/tests/test_messages.py tests/cli/ci/tests/test_rate_limiting.py tests/cli/ci/tests/test_progress.py
43 passed in 0.27s
```

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
