### PR TITLE
Type check-run status and conclusion as the enums they are

### DIFF
--- a/ddev/changelog.d/25046.fixed
+++ b/ddev/changelog.d/25046.fixed
@@ -1,0 +1,1 @@
+Send check-run status and conclusion as the enums the GitHub API declares.

--- a/ddev/src/ddev/cli/ci/tests/status.py
+++ b/ddev/src/ddev/cli/ci/tests/status.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from enum import StrEnum, auto
 
+from ddev.utils.github_async.models.check_run import CheckRunConclusion
 from ddev.utils.github_async.models.workflow import WorkflowJobConclusion
 
 
@@ -36,3 +37,25 @@ def conclusion_to_status(conclusion: str | None) -> Status:
     if conclusion == WorkflowJobConclusion.SKIPPED:
         return Status.SKIPPED
     return Status.FAILURE
+
+
+def conclusion_to_check_run_conclusion(conclusion: str | None) -> CheckRunConclusion:
+    """Map a GitHub Actions conclusion to the one a check run can report.
+
+    The two sets are not the same. ``workflow-run.conclusion`` is a nullable string with no declared
+    enum, so it can carry values a check run has no member for; ``startup_failure`` is the known one
+    (https://github.com/github/rest-api-description/issues/1989). A check run accepts only the eight
+    its request schema declares
+    (https://docs.github.com/en/rest/checks/runs#update-a-check-run).
+
+    Anything unrecognised reports as a failure rather than being passed through, which GitHub would
+    reject. ``None`` reports as neutral, matching :func:`conclusion_to_status`'s note that the check UI
+    prefers an explicit badge where the internal status prefers a binary outcome.
+    """
+    if conclusion is None:
+        return CheckRunConclusion.NEUTRAL
+
+    try:
+        return CheckRunConclusion(conclusion)
+    except ValueError:
+        return CheckRunConclusion.FAILURE

--- a/ddev/src/ddev/cli/ci/tests/task_test_runner.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_runner.py
@@ -12,10 +12,10 @@ from pathlib import Path
 from typing import Any
 
 from ddev.cli.ci.tests.messages import BatchFinished, BatchJob, BatchJobResult, TestBatch
-from ddev.cli.ci.tests.status import conclusion_to_status
+from ddev.cli.ci.tests.status import conclusion_to_check_run_conclusion, conclusion_to_status
 from ddev.event_bus.orchestrator import AsyncProcessor
 from ddev.utils.github_async import AsyncGitHubClient, GitHubResponse
-from ddev.utils.github_async.models import WorkflowJob, WorkflowRun
+from ddev.utils.github_async.models import CheckRunConclusion, CheckRunStatus, WorkflowJob, WorkflowRun
 
 
 @dataclass(frozen=True)
@@ -70,14 +70,14 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
             self._options.repo,
             name=f"test-batch/{message.batch_id}",
             head_sha=self._options.base_sha,
-            status="in_progress",
+            status=CheckRunStatus.IN_PROGRESS,
             details_url=workflow_url,
         )
         check_run_id = check.data.id
         log_extra["check_run_id"] = check_run_id
         self._logger.info("Check run created", extra=log_extra)
 
-        final_conclusion: str = "cancelled"
+        final_conclusion = CheckRunConclusion.CANCELLED
         finished: BatchFinished | None = None
         try:
             if run.data.status != "completed":
@@ -88,7 +88,7 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
             raw = run.data.conclusion
             if raw is None:
                 self._logger.warning("Workflow completed with null conclusion", extra=log_extra)
-            final_conclusion = raw or "neutral"
+            final_conclusion = conclusion_to_check_run_conclusion(raw)
 
             artifact_dirs = await self._download_artifacts(run_id, log_extra)
             self._logger.info("Artifacts downloaded", extra=log_extra)
@@ -111,7 +111,7 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
                     self._options.owner,
                     self._options.repo,
                     check_run_id,
-                    status="completed",
+                    status=CheckRunStatus.COMPLETED,
                     conclusion=final_conclusion,
                     details_url=workflow_url,
                 )

--- a/ddev/src/ddev/utils/github_async/client.py
+++ b/ddev/src/ddev/utils/github_async/client.py
@@ -39,6 +39,7 @@ from .models import (
     ArtifactsList,
     CheckRun,
     CheckRunConclusion,
+    CheckRunStatus,
     IssueComment,
     Label,
     PullRequest,
@@ -993,7 +994,7 @@ class AsyncGitHubClient:
         repo: str,
         name: str,
         head_sha: str,
-        status: Literal["queued", "in_progress", "completed"],
+        status: CheckRunStatus,
         details_url: str | None = None,
         output: dict[str, Any] | None = None,
         timeout: float | None = None,
@@ -1011,7 +1012,8 @@ class AsyncGitHubClient:
             repo: Repository name.
             name: Display name of the check.
             head_sha: SHA of the commit the check is attached to.
-            status: Initial status of the check.
+            status: Initial status of the check. Only GitHub Actions can set `waiting`, `pending` or
+                `requested`; every other caller is limited to `queued`, `in_progress` and `completed`.
             details_url: Optional URL the check title links to.
             output: Optional structured output (title, summary, ...).
             timeout: Optional timeout for this specific request. Defaults to the client's default_timeout.
@@ -1039,7 +1041,7 @@ class AsyncGitHubClient:
         owner: str,
         repo: str,
         check_run_id: int,
-        status: Literal["queued", "in_progress", "completed"] | None = None,
+        status: CheckRunStatus | None = None,
         conclusion: CheckRunConclusion | None = None,
         details_url: str | None = None,
         output: dict[str, Any] | None = None,
@@ -1057,8 +1059,10 @@ class AsyncGitHubClient:
             owner: Repository owner (user or organisation).
             repo: Repository name.
             check_run_id: Numeric ID of the check run to update.
-            status: New status (``"queued"`` | ``"in_progress"`` | ``"completed"``).
-            conclusion: Final conclusion. Required when ``status="completed"``.
+            status: New status. Only GitHub Actions can set `waiting`, `pending` or `requested`; every
+                other caller is limited to `queued`, `in_progress` and `completed`.
+            conclusion: Final conclusion. Required when `status` is `completed`, and providing one
+                sets that status. `stale` is rejected: only GitHub can conclude a check run as stale.
             details_url: Optional URL the check title links to.
             output: Optional structured output (title, summary, ...).
             timeout: Optional timeout for this specific request. Defaults to the client's default_timeout.

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -12,12 +12,13 @@ from typing import Any
 import pytest
 
 from ddev.cli.ci.tests.messages import BatchFinished, BatchJob, TestBatch
-from ddev.cli.ci.tests.status import Status, conclusion_to_status
+from ddev.cli.ci.tests.status import Status, conclusion_to_check_run_conclusion, conclusion_to_status
 from ddev.cli.ci.tests.task_test_runner import TaskTestRunner, TestRunnerOptions
 from ddev.utils.github_async import GitHubResponse
 from ddev.utils.github_async.models import (
     Artifact,
     ArtifactsList,
+    CheckRunConclusion,
     WorkflowJob,
     WorkflowJobsList,
     WorkflowRun,
@@ -157,6 +158,24 @@ def test_conclusion_to_status(conclusion: str | None, expected: Status):
     result = conclusion_to_status(conclusion)
     assert result is expected
     assert isinstance(result, Status)
+
+
+@pytest.mark.parametrize(
+    ("conclusion", "expected"),
+    [
+        ("success", CheckRunConclusion.SUCCESS),
+        ("timed_out", CheckRunConclusion.TIMED_OUT),
+        (None, CheckRunConclusion.NEUTRAL),
+        ("startup_failure", CheckRunConclusion.FAILURE),
+    ],
+)
+def test_conclusion_to_check_run_conclusion(conclusion: str | None, expected: CheckRunConclusion):
+    """A workflow run's conclusion is a free-form string, a check run's is a closed set of eight.
+
+    `startup_failure` is a real workflow conclusion with no check-run member, so passing it through
+    would have GitHub reject the request that closes the check run.
+    """
+    assert conclusion_to_check_run_conclusion(conclusion) is expected
 
 
 # ---------------------------------------------------------------------------

--- a/ddev/tests/helpers/github_async.py
+++ b/ddev/tests/helpers/github_async.py
@@ -46,6 +46,8 @@ from ddev.utils.github_async import COMMENT_BODY_LIMIT, GitHubResponse
 from ddev.utils.github_async.models import (
     ArtifactsList,
     CheckRun,
+    CheckRunConclusion,
+    CheckRunStatus,
     IssueComment,
     Label,
     PullRequest,
@@ -438,7 +440,7 @@ class FakeAsyncGitHubClient:
         repo: str,
         name: str,
         head_sha: str,
-        status: str,
+        status: CheckRunStatus,
         details_url: str | None = None,
         output: dict[str, Any] | None = None,
         timeout: float | None = None,
@@ -460,13 +462,13 @@ class FakeAsyncGitHubClient:
         owner: str,
         repo: str,
         check_run_id: int,
-        status: str | None = None,
-        conclusion: str | None = None,
+        status: CheckRunStatus | None = None,
+        conclusion: CheckRunConclusion | None = None,
         details_url: str | None = None,
         output: dict[str, Any] | None = None,
         timeout: float | None = None,
     ) -> GitHubResponse[CheckRun]:
-        if status == 'completed' and conclusion is None:
+        if status == CheckRunStatus.COMPLETED and conclusion is None:
             raise ValueError("A conclusion is required when a check run status is 'completed'.")
         return self._call(
             'update_check_run',


### PR DESCRIPTION
### What does this PR do?

`create_check_run` and `update_check_run` typed `status` as `Literal["queued", "in_progress", "completed"]`. The request schema for both endpoints declares all six values the response schema does, so the parameter now takes the existing `CheckRunStatus`.

`TaskTestRunner` passed plain strings for both `status` and `conclusion`, so neither enum was reaching the API. It now passes `CheckRunStatus` members, and its conclusion goes through a new `conclusion_to_check_run_conclusion` in `status.py`, next to the existing `conclusion_to_status`.

That conclusion needs a mapping rather than a cast. `workflow-run.conclusion` is a nullable string with **no** declared enum, and it carries values a check run has no member for; `startup_failure` is the known one ([rest-api-description#1989](https://github.com/github/rest-api-description/issues/1989)). Previously that string was forwarded as-is for GitHub to reject. Now an unrecognised conclusion reports as `failure`, and `None` still reports as `neutral`, matching the note already on `conclusion_to_status`.

The fake client mirrors the real signatures so tests cannot pass something the client would reject.

### Motivation

The repository rule is that a field the OpenAPI description declares as an `enum` must not be typed as a plain string, and that a `StrEnum` must list every declared value rather than a guessed subset. The three-value `Literal` was exactly that guessed subset, and the runner bypassed the enums entirely.

Checked against the description pinned by `GITHUB_API_VERSION` (`2022-11-28`) rather than the rendered docs:

```
create/update check run request:  status     enum [queued, in_progress, completed, waiting, requested, pending]
                                  conclusion enum [action_required, cancelled, failure, neutral, success, skipped, stale, timed_out]
workflow-run response:            status     {"type": "string", "nullable": true}
                                  conclusion {"type": "string", "nullable": true}
```

The docs note that only GitHub Actions can set `waiting`, `pending` and `requested`. That restricts who may use those values, not what the parameter accepts, the same way the request enum includes a `stale` conclusion only GitHub can set. `WorkflowRun` keeps `str | None` for both fields, which the description confirms is correct.

Worth knowing for review: mypy does not currently catch this class of mistake. `ddev test --lint` resolves every `ddev.*` import to `Any`, because `ddev/src` is not on the mypy path and `ignore_missing_imports` is on, so `reveal_type(self._client)` is `Any` and no argument to a client method is checked. Adding `MYPYPATH=src` makes the runner error appear, and it is gone with this change. That gap is a separate piece of work.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged