### PR TITLE
Stop passing --explicit-package-bases when type checking ddev

### DIFF
--- a/ddev/changelog.d/25051.fixed
+++ b/ddev/changelog.d/25051.fixed
@@ -1,0 +1,1 @@
+Stop passing ``--explicit-package-bases`` when type checking ddev, so mypy resolves first-party imports instead of silently treating them as ``Any``.

--- a/ddev/src/ddev/cli/ci/tests/task_run_reporter.py
+++ b/ddev/src/ddev/cli/ci/tests/task_run_reporter.py
@@ -105,7 +105,7 @@ class TaskRunReporter(AsyncProcessor["UpdatePRComment"]):
     async def process_message(self, message: UpdatePRComment):
         # Rendering is pure, so it happens outside the lock.
         body = render_comment(message.progress)
-        log_extra = {"revision": message.revision, "done": message.progress.done}
+        log_extra: dict[str, object] = {"revision": message.revision, "done": message.progress.done}
 
         # The lock spans revision validation, the write and the retained report, all of which may
         # only move forwards. Batches finish concurrently, so without this a slow early revision

--- a/ddev/src/ddev/cli/create/_scaffold.py
+++ b/ddev/src/ddev/cli/create/_scaffold.py
@@ -452,6 +452,7 @@ def _write_files_with_cleanup_hint(
 def _display_tree(app: Application, root: Path, files: list[TemplateFile]) -> None:
     tree: defaultdict = defaultdict(dict)
     for f in files:
+        rel: _StdPath
         try:
             rel = f.target_path.relative_to(root)
         except ValueError:

--- a/ddev/src/ddev/plugin/external/hatch/environment_collector.py
+++ b/ddev/src/ddev/plugin/external/hatch/environment_collector.py
@@ -72,9 +72,10 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
 
     @cached_property
     def mypy_args(self):
-        return (
-            ['--explicit-package-bases'] + self.config.get('mypy-args', []) + ['--install-types', '--non-interactive']
-        )
+        # Excluded for ddev: its `src` layout infers module names correctly, unlike the namespace
+        # packages the integrations use, and the flag would name every module `src.ddev.*`.
+        base_args = [] if self.is_dev_package else ['--explicit-package-bases']
+        return base_args + self.config.get('mypy-args', []) + ['--install-types', '--non-interactive']
 
     @cached_property
     def mypy_files(self):

--- a/ddev/tests/plugin/external/hatch/test_environment_collector.py
+++ b/ddev/tests/plugin/external/hatch/test_environment_collector.py
@@ -161,6 +161,30 @@ def test_format_base_package_double_quotes_local_path_on_windows(monkeypatch):
 
 
 @pytest.mark.parametrize(
+    'package_name, expects_flag',
+    [
+        pytest.param(None, True, id='integration_uses_explicit_package_bases'),
+        pytest.param('ddev', False, id='ddev_infers_its_own_package_bases'),
+    ],
+)
+def test_explicit_package_bases_is_only_used_for_the_namespace_packaged_integrations(
+    fake_checkout, package_name, expects_flag
+):
+    """ddev's `src` layout resolves its own module names; the flag would name every module `src.ddev.*`.
+
+    A `from ddev...` import then resolves to nothing and `ignore_missing_imports` turns it into `Any`,
+    so mypy reports success while checking nothing that crosses a module boundary.
+    """
+    integrations_core, integration_root = fake_checkout(*([package_name] if package_name else []))
+    package_root = integrations_core / package_name if package_name else integration_root
+
+    collector = DatadogChecksEnvironmentCollector(package_root, {'check-types': True})
+    [command] = collector.get_initial_config()['lint']['scripts']['typing']
+
+    assert ('--explicit-package-bases' in tokenize(command)) is expects_flag
+
+
+@pytest.mark.parametrize(
     'script_name, config_flag',
     [
         pytest.param('style', '--config', id='ruff_style'),


### PR DESCRIPTION
### What does this PR do?

Derives `--explicit-package-bases` from the package layout in the hatch environment collector instead of passing it unconditionally, so `ddev` no longer gets it:

```python
base_args = [] if self.is_dev_package else ['--explicit-package-bases']
```

Turning it off surfaced two real type errors that were previously invisible, both fixed here:

- `task_run_reporter.py` — `log_extra` inferred as `dict[str, int]` (`bool` is an `int`), passed to a `dict[str, object]` parameter. Annotated at the assignment. Same fix as #25042, which touches this line too.
- `_scaffold.py` — `rel` inferred from `Path.relative_to` as `ddev.utils.fs.Path`, then reassigned a `pathlib.Path` in the `except` branch. Annotated as `_StdPath`, which is sound because `ddev.utils.fs.Path` subclasses `pathlib.PosixPath`/`WindowsPath` and only `.parts` is used after.

### Motivation

`ddev test --lint ddev` reported `Success: no issues found in 217 source files` while mypy was resolving every first-party import to `Any`. Nothing that crossed a module boundary in `ddev/src` was being checked.

`--explicit-package-bases` makes mypy derive module names from the working directory rather than by walking up while `__init__.py` exists. The integrations need it: `datadog_checks/` is a namespace package, so inference would root a module at `<integration>.check` instead of `datadog_checks.<integration>.check`. `ddev` is a plain `src` layout where inference is already correct, and there the flag is actively wrong. Module names taken from mypy's own cache:

```
WITH the flag      src/ddev/utils/fs.meta.ff   ->  module src.ddev.utils.fs   ❌
WITHOUT it             ddev/utils/fs.meta.ff   ->  module ddev.utils.fs       ✅
```

Because the files are filed under `src.ddev.*`, a `from ddev.utils.fs import Path` elsewhere resolves to nothing, and `ignore_missing_imports = true` in the root `[tool.mypy]` turns that into `Any` with no diagnostic. Two files in the same package, and mypy could not connect them. Confirmed with `reveal_type(self._client)` on a `TaskTestRunner` attribute typed `AsyncGitHubClient`:

```
# with the flag
src/ddev/cli/ci/tests/task_test_runner.py:49:21: note: Revealed type is "Any"
# without it
src/ddev/cli/ci/tests/task_test_runner.py:49:21: note: Revealed type is "ddev.utils.github_async.client.AsyncGitHubClient"
```

Same 218 files either way, so this is not a discovery change:

```
$ hatch run lint:mypy --config-file=$ROOT/pyproject.toml --explicit-package-bases src/ddev
Success: no issues found in 218 source files

$ hatch run lint:mypy --config-file=$ROOT/pyproject.toml src/ddev
Found 2 errors in 2 files (checked 218 source files)
```

Both errors are cross-module argument/assignment mismatches, which is exactly the blind spot. After the fixes in this PR, mypy is clean again, this time having actually checked.

The generated commands, from the collector in this branch:

```
ddev       -> --install-types --non-interactive src/ddev
prefect    -> --explicit-package-bases --install-types --non-interactive datadog_checks/prefect
```

`is_dev_package` was chosen over a `hatch.toml` knob because the collector already special-cases ddev's layout two properties above this one (`package_directory` returns `src/ddev`), and a knob would have exactly one non-default user while letting any future `src`-layout package silently inherit the wrong default.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
