### PR TITLE
Build postgres relation query filters once instead of per database

### DIFF
--- a/postgres/changelog.d/25052.fixed
+++ b/postgres/changelog.d/25052.fixed
@@ -1,0 +1,1 @@
+Build and cache relation queries once instead of rebuilding them for each database on every check run.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -692,11 +692,11 @@ class PostgreSql(DatabaseCheck):
                         # if this is a relation-specific query, we need to list all relations last
                         if is_relations:
                             schema_field = get_schema_field(descriptors)
-                            formatted_query = self._relations_manager.filter_relation_query(query, schema_field)
-                            cursor.execute(formatted_query)
+                            query = self._relations_manager.filter_relation_query(query, schema_field)
                         else:
-                            self.log.debug("Running query: %s", str(query))
-                            cursor.execute(query.replace(r'%', r'%%'))
+                            query = query.replace(r'%', r'%%')
+                        self.log.debug("Running query: %s", query)
+                        cursor.execute(query)
 
                         results = cursor.fetchall()
                         if not results:

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -431,10 +431,9 @@ class RelationsManager(object):
         self.config = self._build_relations_config(yamlconfig)
         self.max_relations = max_relations
         self.has_relations = len(self.config) > 0
-        self._filtered_queries_cache = {}
+        self._filtered_queries_cache: dict[tuple[str, str], str] = {}
 
-    def filter_relation_query(self, query, schema_field):
-        # type (str, str) -> str
+    def filter_relation_query(self, query: str, schema_field: str) -> str:
         """
         Get a filtered query from cache, building it if not already cached. The filter comes from the
         relations configuration, which is fixed for the lifetime of the check, so a query only has to
@@ -445,8 +444,7 @@ class RelationsManager(object):
             self._filtered_queries_cache[cache_key] = self._build_filtered_query(query, schema_field)
         return self._filtered_queries_cache[cache_key]
 
-    def _build_filtered_query(self, query, schema_field):
-        # type (str, str) -> str
+    def _build_filtered_query(self, query: str, schema_field: str) -> str:
         """Build a WHERE clause filtering relations based on relations_config and applies it to the given query"""
         relations_filter = []
         for r in self.config:

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -431,8 +431,21 @@ class RelationsManager(object):
         self.config = self._build_relations_config(yamlconfig)
         self.max_relations = max_relations
         self.has_relations = len(self.config) > 0
+        self._filtered_queries_cache = {}
 
     def filter_relation_query(self, query, schema_field):
+        # type (str, str) -> str
+        """
+        Get a filtered query from cache, building it if not already cached. The filter comes from the
+        relations configuration, which is fixed for the lifetime of the check, so a query only has to
+        be built once no matter how many databases it is later run against.
+        """
+        cache_key = (query, schema_field)
+        if cache_key not in self._filtered_queries_cache:
+            self._filtered_queries_cache[cache_key] = self._build_filtered_query(query, schema_field)
+        return self._filtered_queries_cache[cache_key]
+
+    def _build_filtered_query(self, query, schema_field):
         # type (str, str) -> str
         """Build a WHERE clause filtering relations based on relations_config and applies it to the given query"""
         relations_filter = []
@@ -461,7 +474,7 @@ class RelationsManager(object):
         relations_filter = '(' + ' OR '.join(relations_filter) + ')'
         limits_filter = 'LIMIT {}'.format(self.max_relations)
         self.log.debug(
-            "Running query: %s with relations matching: %s, limits %s", str(query), relations_filter, self.max_relations
+            "Built query: %s with relations matching: %s, limits %s", str(query), relations_filter, self.max_relations
         )
         return query.format(relations=relations_filter, limits=limits_filter)
 

--- a/postgres/tests/test_relationsmanager.py
+++ b/postgres/tests/test_relationsmanager.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import mock
 import pytest
 
 from datadog_checks.postgres.relationsmanager import (
@@ -105,6 +106,18 @@ def test_relation_filter_limit():
 
     query_filter = relations.filter_relation_query(query, SCHEMA_NAME)
     assert 'LIMIT 300' in query_filter
+
+
+def test_filtered_query_is_built_once():
+    """A query is filtered once and reused, however many databases it is run against."""
+    query = "Select foo from bar where {relations}"
+    relations = RelationsManager([{'relation_regex': 'ix.*', 'schemas': ['public']}], default_max_relations)
+
+    with mock.patch.object(relations, '_build_filtered_query', wraps=relations._build_filtered_query) as build:
+        queries = {relations.filter_relation_query(query, SCHEMA_NAME) for _ in range(3)}
+
+    assert build.call_count == 1
+    assert queries == {"Select foo from bar where (( relname ~ 'ix.*' AND schemaname = ANY(array['public']::text[]) ))"}
 
 
 def test_relkind_does_not_apply_to_index_metrics():

--- a/postgres/tests/test_relationsmanager.py
+++ b/postgres/tests/test_relationsmanager.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-import mock
 import pytest
 
 from datadog_checks.postgres.relationsmanager import (
@@ -108,22 +107,22 @@ def test_relation_filter_limit():
     assert 'LIMIT 300' in query_filter
 
 
-def test_filtered_query_is_built_once():
-    """A query is filtered once and reused, however many databases it is run against."""
-    query = "Select foo from bar where {relations}"
-    relations = RelationsManager([{'relation_regex': 'ix.*', 'schemas': ['public']}], default_max_relations)
-
-    with mock.patch.object(relations, '_build_filtered_query', wraps=relations._build_filtered_query) as build:
-        queries = {relations.filter_relation_query(query, SCHEMA_NAME) for _ in range(3)}
-
-    assert build.call_count == 1
-    assert queries == {"Select foo from bar where (( relname ~ 'ix.*' AND schemaname = ANY(array['public']::text[]) ))"}
-
-
-def test_relkind_does_not_apply_to_index_metrics():
-    query = IDX_METRICS['query'].replace('{metrics_columns}', 'foo')
-    relations_config = [{'relation_regex': 'b.*', 'schemas': [ALL_SCHEMAS], 'relkind': ['r']}]
+def test_filters_are_not_shared_between_queries():
+    """
+    Filtering one query must not change what another query gets back from the same manager, since the
+    filter depends on both the query text (`relkind` only applies to pg_locks) and the schema field.
+    """
+    relations_config = [{'relation_regex': 'b.*', 'schemas': ['public'], 'relkind': ['r']}]
     relations = RelationsManager(relations_config, default_max_relations)
+    lock_query = LOCK_METRICS['query'].replace('{metrics_columns}', 'foo')
+    index_query = IDX_METRICS['query'].replace('{metrics_columns}', 'foo')
 
-    query_filter = relations.filter_relation_query(query, SCHEMA_NAME)
-    assert "relkind = ANY(array['r'])" not in query_filter
+    lock_filter = relations.filter_relation_query(lock_query, SCHEMA_NAME)
+    index_filter = relations.filter_relation_query(index_query, SCHEMA_NAME)
+    nspname_filter = relations.filter_relation_query(index_query, 'nspname')
+
+    assert "relkind = ANY(array['r'])" in lock_filter
+    assert "relkind = ANY(array['r'])" not in index_filter
+    assert "schemaname = ANY(array['public']::text[])" in index_filter
+    assert "nspname = ANY(array['public']::text[])" in nspname_filter
+    assert relations.filter_relation_query(lock_query, SCHEMA_NAME) == lock_filter


### PR DESCRIPTION
### What does this PR do?
Caches filtered relation queries in `RelationsManager`, keyed by the query and schema field, so a query is filtered once rather than on every `_run_query_scope` call. The existing build logic moves unchanged into `_build_filtered_query` and `filter_relation_query` becomes a cached accessor

### Motivation
The relation filter is derived entirely from the relations configuration, which cannot change while the check is running, but it was rebuilt for every (database, scope) pair on every collection cycle. The dynamic query path already builds its filters once at initialization, so this is mainly about making the `_query_scope` path consistent with it and keeping config-derived work out of a per-database loop.

The cache holds one entry per relation scope, keyed on text that does not vary by database, so it does not grow with the number of databases or tables.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
