### PR TITLE
[TXP-333] Add data types for NDM integrations

### DIFF
--- a/cisco_aci/assets/dataflows.yaml
+++ b/cisco_aci/assets/dataflows.yaml
@@ -1,5 +1,7 @@
 provides:
   - id: cisco-aci-network-device-metrics
+    data_type: metrics
     always_on: false
   - id: cisco-aci-network-event-logs
+    data_type: logs
     always_on: false

--- a/versa/assets/dataflows.yaml
+++ b/versa/assets/dataflows.yaml
@@ -1,3 +1,4 @@
 provides:
   - id: versa-network-device-metrics
+    data_type: metrics
     always_on: false


### PR DESCRIPTION
Set `data_type` for the missing NDM integrations dataflows. We will soon be making this a required field; but looking to make sure all existing dataflows define a "data_type". 

Initially gathered alignment through this spreadsheet - https://docs.google.com/spreadsheets/d/1AGbEs1TBfdH_Y3QqFACiS74LwZ08YZEaHJ1vhSDJh50/edit?pli=1&gid=992123986#gid=992123986

This PR modifies:
* cisco_aci
* versa