### PR TITLE
Add azure_sys to default ignore_databases for Postgres

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -253,6 +253,7 @@ files:
           - 'template1'
           - rdsadmin
           - azure_maintenance
+          - azure_sys
           - cloudsqladmin
           - alloydbadmin
           - alloydbmetadata
@@ -261,6 +262,7 @@ files:
           - 'template1'
           - rdsadmin
           - azure_maintenance
+          - azure_sys
           - cloudsqladmin
           - alloydbadmin
           - alloydbmetadata

--- a/postgres/changelog.d/25054.fixed
+++ b/postgres/changelog.d/25054.fixed
@@ -1,0 +1,1 @@
+Add ``azure_sys`` to the default list of ignored databases so it is excluded from query metrics and samples on Azure.

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -102,6 +102,7 @@ def instance_ignore_databases():
         'template1',
         'rdsadmin',
         'azure_maintenance',
+        'azure_sys',
         'cloudsqladmin',
         'alloydbadmin',
         'alloydbmetadata',

--- a/postgres/datadog_checks/postgres/config_models/dict_defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/dict_defaults.py
@@ -15,6 +15,7 @@ DEFAULT_EXCLUDED_DATABASES = [
     "template1",
     "rdsadmin",
     "azure_maintenance",
+    "azure_sys",
     "cloudsqladmin",
     "alloydbadmin",
     "alloydbmetadata",

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -172,7 +172,7 @@ instances:
     #
     # reported_hostname: <REPORTED_HOSTNAME>
 
-    ## @param ignore_databases - list of strings - optional - default: ['template0', 'template1', 'rdsadmin', 'azure_maintenance', 'cloudsqladmin', 'alloydbadmin', 'alloydbmetadata']
+    ## @param ignore_databases - list of strings - optional - default: ['template0', 'template1', 'rdsadmin', 'azure_maintenance', 'azure_sys', 'cloudsqladmin', 'alloydbadmin', 'alloydbmetadata']
     ## A list of databases to ignore. No metrics or statement samples will be collected for these databases.
     ## Each value can be a plain string or a Postgres pattern. If you want to ignore the postgres database,
     ## set collect_default_database to false in addition to adding it to this array.
@@ -185,6 +185,7 @@ instances:
     #   - template1
     #   - rdsadmin
     #   - azure_maintenance
+    #   - azure_sys
     #   - cloudsqladmin
     #   - alloydbadmin
     #   - alloydbmetadata


### PR DESCRIPTION
### What does this PR do?

Adds `azure_sys` to the default `ignore_databases` list for the Postgres integration.

### Motivation

`azure_sys` is the internal system database that Azure Database for PostgreSQL Flexible Server uses for its Query Store / autonomous-tuning feature ([Microsoft docs](https://learn.microsoft.com/en-us/azure/postgresql/monitor/concepts-query-store)). It stores Azure's own query-store data — not user data — so we don't want query metrics or samples from it. The check connecting to it also produces recurring errors (e.g. `explain_statement` fails there with `schema "datadog" does not exist`).

This just adds it to the existing default exclusion list alongside the other cloud-provider system databases (`azure_maintenance`, `rdsadmin`, `cloudsqladmin`, ...). No behavior change for anyone not on Azure.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
