### PR TITLE
Stabilize Harbor E2E readiness

### DIFF
--- a/harbor/tests/conftest.py
+++ b/harbor/tests/conftest.py
@@ -8,7 +8,7 @@ import requests
 from mock import patch
 
 from datadog_checks.dev import docker_run
-from datadog_checks.dev.conditions import CheckDockerLogs, WaitFor
+from datadog_checks.dev.conditions import CheckDockerLogs, CheckEndpoints, WaitFor
 from datadog_checks.dev.http import MockResponse
 from datadog_checks.harbor import HarborCheck
 from datadog_checks.harbor.api import HarborAPI
@@ -48,6 +48,7 @@ def dd_environment(e2e_instance):
     expected_log = "http server Running on"
     conditions = [
         CheckDockerLogs(compose_file, expected_log, wait=3, service='core'),
+        CheckEndpoints(PING_URL.format(base_url=URL), wait=5),
         WaitFor(create_simple_user, wait=5),
     ]
     e2e_metadata = {}
@@ -59,7 +60,7 @@ def dd_environment(e2e_instance):
 
 
 def create_simple_user():
-    requests.post(
+    response = requests.post(
         URL + USERS_PATH,
         auth=("admin", "Harbor12345"),
         json={
@@ -70,6 +71,7 @@ def create_simple_user():
         },
         verify=False,
     )
+    response.raise_for_status()
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
<!-- dd-meta {"pullId":"4846978f-0bcf-48d2-95df-f10d766b3bd8","source":"chat","resourceId":"c1377eeb-7663-48e8-b2d2-ea29ced59ca4","workflowId":"23da597e-1fe7-426e-9a8e-52e1cbce6a3f","codeChangeId":"23da597e-1fe7-426e-9a8e-52e1cbce6a3f","sourceType":"assistant"} -->
### What does this PR do?
- Adds a Harbor API readiness check against `/api/ping/` before the E2E setup creates its simple user.
- Makes `create_simple_user` call `raise_for_status()` so transient Harbor startup HTTP errors cause the existing `WaitFor` loop to retry.

### Motivation
Harbor E2E setup only waited for the core container log, so the fixture could attempt user creation before the API stack was ready. Because the POST response was ignored, `WaitFor` treated setup as successful even on 5xx responses, contributing to intermittent Master failures tracked by monitor 259180475.

### Testing
- `ddev --no-interactive test --lint harbor`
- `ddev --no-interactive test harbor -- -k test_api__make_post_request`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required. Expected label: `qa/skip-qa`.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/c1377eeb-7663-48e8-b2d2-ea29ced59ca4)

Comment @datadog to request changes