### PR TITLE
[TXP-333] Add data types for LLM integrations

### DIFF
--- a/anthropic/assets/dataflows.yaml
+++ b/anthropic/assets/dataflows.yaml
@@ -1,4 +1,5 @@
 provides:
   - id: anthropic-llm-completions
     always_on: false
+    data_type: llm_completions
     granular: true


### PR DESCRIPTION
Set `data_type` for the missing LLM integrations dataflows. We will soon be making this a required field; but looking to make sure all existing dataflows define a "data_type". 

Initially gathered alignment through this spreadsheet - https://docs.google.com/spreadsheets/d/1AGbEs1TBfdH_Y3QqFACiS74LwZ08YZEaHJ1vhSDJh50/edit?pli=1&gid=992123986#gid=992123986

This PR modifies:
* anthropic