### PR TITLE
[DBMON-6900] Group autodiscovery queries against logical databases

### DIFF
--- a/postgres/changelog.d/25061.fixed
+++ b/postgres/changelog.d/25061.fixed
@@ -1,0 +1,1 @@
+Collect per-database autodiscovery metrics in a single pass over the discovered databases to reduce connection pool churn.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -5,6 +5,7 @@ import contextlib
 import copy
 import functools
 import os
+from collections import defaultdict
 from time import time
 
 import psycopg
@@ -832,19 +833,38 @@ class PostgreSql(DatabaseCheck):
 
         self.metrics_cache.table_activity_metrics[db][tablename][metric_name] = value
 
-    def _collect_metric_autodiscovery(self, instance_tags, scopes, scope_type):
+    def _collect_metric_autodiscovery(self, instance_tags, scope_groups: list[tuple[str, list[dict]]]):
+        """
+        Collect metrics for every autodiscovered database, visiting each database once so its
+        connection pool stays warm across all of its queries.
+
+        Each `scope_groups` entry pairs a telemetry scope type with its scopes; time is reported per
+        group. A group that raises for one database does not skip that database's remaining groups.
+        """
         if not self.autodiscovery:
             return
 
-        start_time = time()
+        groups = [(scope_type, scopes) for scope_type, scopes in scope_groups if scopes]
+        if not groups:
+            return
+
+        elapsed_ms_by_scope_type = defaultdict(float)
         databases = self.autodiscovery.get_items()
         for db in databases:
-            try:
-                for scope in scopes:
-                    self._query_scope(scope, instance_tags, False, dbname=db)
-            except Exception as e:
-                self.log.error("Error collecting metrics for database %s %s", db, str(e))
-        elapsed_ms = (time() - start_time) * 1000
+            for scope_type, scopes in groups:
+                start_time = time()
+                try:
+                    for scope in scopes:
+                        self._query_scope(scope, instance_tags, False, dbname=db)
+                except Exception as e:
+                    self.log.error("Error collecting metrics for database %s %s", db, str(e))
+                finally:
+                    elapsed_ms_by_scope_type[scope_type] += (time() - start_time) * 1000
+
+        for scope_type, _ in groups:
+            self._report_autodiscovery_timing(scope_type, elapsed_ms_by_scope_type[scope_type])
+
+    def _report_autodiscovery_timing(self, scope_type: str, elapsed_ms: float) -> None:
         self.histogram(
             f"dd.postgres.{scope_type}.time",
             elapsed_ms,
@@ -914,22 +934,18 @@ class PostgreSql(DatabaseCheck):
             metric_scope.append(SLRU_METRICS)
 
         # Do we need relation-specific metrics?
+        relations_scopes = []
         if self._config.relations:
             relations_scopes = list(RELATION_METRICS)
 
             if self._config.collect_bloat_metrics:
                 relations_scopes.extend([INDEX_BLOAT, TABLE_BLOAT])
 
-            # If autodiscovery is enabled, get relation metrics from all databases found
-            if self.autodiscovery:
-                self._collect_metric_autodiscovery(
-                    instance_tags,
-                    scopes=relations_scopes,
-                    scope_type='_collect_relations_autodiscovery',
-                )
-            # otherwise, continue just with dbname
-            else:
+            # If autodiscovery is enabled, relation metrics are collected from all databases found
+            # in the single autodiscovery pass below. Otherwise, continue just with dbname.
+            if not self.autodiscovery:
                 metric_scope.extend(relations_scopes)
+                relations_scopes = []
 
         replication_metrics = self.metrics_cache.get_replication_metrics(self.version, self.is_aurora)
         if replication_metrics:
@@ -965,17 +981,18 @@ class PostgreSql(DatabaseCheck):
             activity_metrics = self.metrics_cache.get_activity_metrics(self.version)
             self._query_scope(activity_metrics, instance_tags, False)
 
-        if per_database_metric_scope:
-            # if autodiscovery is enabled, get per-database metrics from all databases found
-            if self.autodiscovery:
-                self._collect_metric_autodiscovery(
-                    instance_tags,
-                    scopes=per_database_metric_scope,
-                    scope_type='_collect_stat_autodiscovery',
-                )
-            else:
-                # otherwise, continue just with dbname
-                metric_scope.extend(per_database_metric_scope)
+        # With autodiscovery, every per-database scope is collected in a single pass over the
+        # database list so that each database is visited once. Without it, continue just with dbname.
+        if self.autodiscovery:
+            self._collect_metric_autodiscovery(
+                instance_tags,
+                scope_groups=[
+                    ('_collect_relations_autodiscovery', relations_scopes),
+                    ('_collect_stat_autodiscovery', per_database_metric_scope),
+                ],
+            )
+        elif per_database_metric_scope:
+            metric_scope.extend(per_database_metric_scope)
 
         for scope in list(metric_scope):
             self._query_scope(scope, instance_tags, False)

--- a/postgres/tests/test_discovery.py
+++ b/postgres/tests/test_discovery.py
@@ -231,6 +231,9 @@ def test_autodiscovery_collect_all_metrics(aggregator, integration_check, pg_ins
     aggregator.assert_metric(
         'dd.postgres._collect_relations_autodiscovery.time',
     )
+    aggregator.assert_metric(
+        'dd.postgres._collect_stat_autodiscovery.time',
+    )
     if float(POSTGRES_VERSION) >= 12:
         checksum_metrics_expected_tags = _get_expected_tags(check, pg_instance, with_db=False, enabled="true")
         aggregator.assert_metric('postgresql.checksums.enabled', value=1, tags=checksum_metrics_expected_tags)

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -4,6 +4,8 @@
 import copy
 import gc
 import weakref
+from collections import Counter
+from itertools import groupby
 
 import mock
 import psycopg
@@ -524,22 +526,55 @@ def test_collect_column_statistics_updates_timestamp_on_failure(pg_instance):
     assert after > before
 
 
-def test_autodiscovery_visits_each_database_once_and_isolates_group_failures(pg_instance):
+def _autodiscovery_scope(name):
+    return {'name': name, 'query': 'SELECT {metrics_columns} FROM fake', 'metrics': {}, 'descriptors': []}
+
+
+def test_autodiscovery_groups_connection_acquisitions_by_database(pg_instance):
     """
-    All scope groups are collected in a single pass over the discovered databases, and a group that
-    raises for one database does not stop the remaining groups for that same database.
+    Every scope group for a database is collected while that database's connection pool is the most
+    recently used one, so the pool is acquired in a single contiguous block instead of being
+    re-created once per group when the pool cap evicts it in between.
+    """
+    pg_instance['reported_hostname'] = 'stubbed-host'
+    check = PostgreSql('postgres', {}, [pg_instance])
+    check.version = VersionInfo(14, 0, 0)
+    check.autodiscovery = mock.MagicMock()
+    check.autodiscovery.get_items.return_value = ['db1', 'db2']
+
+    check.db_pool = mock.MagicMock()
+    cursor = check.db_pool.get_connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value
+    cursor.fetchall.return_value = []
+
+    check._collect_metric_autodiscovery(
+        [],
+        scope_groups=[
+            ('_collect_relations_autodiscovery', [_autodiscovery_scope('relation_scope')]),
+            ('_collect_stat_autodiscovery', [_autodiscovery_scope('stat_scope')]),
+        ],
+    )
+
+    acquired = [call.args[0] for call in check.db_pool.get_connection.call_args_list]
+    assert Counter(acquired) == {'db1': 2, 'db2': 2}, "every group should still run against every database"
+    assert [dbname for dbname, _ in groupby(acquired)] == ['db1', 'db2'], "each database should be acquired once"
+
+
+def test_autodiscovery_group_failure_does_not_skip_later_groups(pg_instance):
+    """
+    A group that raises for a database must not abort that database's remaining groups, otherwise
+    one unreadable relation would silently drop the database's stat metrics too.
     """
     pg_instance['reported_hostname'] = 'stubbed-host'
     check = PostgreSql('postgres', {}, [pg_instance])
     check.autodiscovery = mock.MagicMock()
-    check.autodiscovery.get_items.return_value = ['db1', 'db2']
+    check.autodiscovery.get_items.return_value = ['db1']
 
-    relation_scope = {'name': 'relation_scope'}
-    stat_scope = {'name': 'stat_scope'}
+    relation_scope = _autodiscovery_scope('relation_scope')
+    stat_scope = _autodiscovery_scope('stat_scope')
     collected = []
 
     def query_scope(scope, instance_tags, is_custom_metrics, dbname=None):
-        if scope is relation_scope and dbname == 'db1':
+        if scope is relation_scope:
             raise psycopg.errors.InsufficientPrivilege('relation scope failed')
         collected.append((dbname, scope['name']))
 
@@ -552,10 +587,4 @@ def test_autodiscovery_visits_each_database_once_and_isolates_group_failures(pg_
         ],
     )
 
-    # db1's stat scope still runs despite its relation scope failing, and each database is visited
-    # once with every group rather than once per group.
-    assert collected == [
-        ('db1', 'stat_scope'),
-        ('db2', 'relation_scope'),
-        ('db2', 'stat_scope'),
-    ]
+    assert collected == [('db1', 'stat_scope')]

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -522,3 +522,40 @@ def test_collect_column_statistics_updates_timestamp_on_failure(pg_instance):
         after = metadata._last_column_statistics_query_time
 
     assert after > before
+
+
+def test_autodiscovery_visits_each_database_once_and_isolates_group_failures(pg_instance):
+    """
+    All scope groups are collected in a single pass over the discovered databases, and a group that
+    raises for one database does not stop the remaining groups for that same database.
+    """
+    pg_instance['reported_hostname'] = 'stubbed-host'
+    check = PostgreSql('postgres', {}, [pg_instance])
+    check.autodiscovery = mock.MagicMock()
+    check.autodiscovery.get_items.return_value = ['db1', 'db2']
+
+    relation_scope = {'name': 'relation_scope'}
+    stat_scope = {'name': 'stat_scope'}
+    collected = []
+
+    def query_scope(scope, instance_tags, is_custom_metrics, dbname=None):
+        if scope is relation_scope and dbname == 'db1':
+            raise psycopg.errors.InsufficientPrivilege('relation scope failed')
+        collected.append((dbname, scope['name']))
+
+    check._query_scope = query_scope
+    check._collect_metric_autodiscovery(
+        [],
+        scope_groups=[
+            ('_collect_relations_autodiscovery', [relation_scope]),
+            ('_collect_stat_autodiscovery', [stat_scope]),
+        ],
+    )
+
+    # db1's stat scope still runs despite its relation scope failing, and each database is visited
+    # once with every group rather than once per group.
+    assert collected == [
+        ('db1', 'stat_scope'),
+        ('db2', 'relation_scope'),
+        ('db2', 'stat_scope'),
+    ]


### PR DESCRIPTION
### What does this PR do?

Merges the two per-database autodiscovery metric passes — relation scopes and per-database stat
scopes — into a single pass over the discovered database list, so each database is visited once per
check run rather than once per scope group.

The only intentional change is that reported elapsed time is now the sum of per-database slices
rather than whole-pass wall time, so it excludes `get_items()` and loop overhead and reads slightly
lower. These are internal `dd.postgres.*` telemetry metrics, not customer-facing ones.

### Motivation

The connection pool manager caps pools at 30. With more autodiscovered databases than that, the
first pass evicted every pool it created, so the second pass re-created all of them from scratch —
roughly `2 x n_databases` pool creations per check run for these scopes. Sharing one pass means a
database's pool is still warm when the remaining scopes run, halving pool creations and evictions.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged