### PR TITLE
Fix SQL Server deadlock signatures

### DIFF
--- a/sqlserver/changelog.d/25062.fixed
+++ b/sqlserver/changelog.d/25062.fixed
@@ -1,0 +1,1 @@
+Fix query signature extraction from SQL Server deadlock events.

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -94,6 +94,7 @@ class Deadlocks(DBMAsyncJob):
         if process_list is None:
             raise Exception("process-list element not found. The deadlock XML is in an unexpected format.")
         query_signatures = []
+        seen_spids = set()
         for process in process_list.findall('process'):
             spid = process.get('spid')
             if spid is not None:
@@ -102,8 +103,9 @@ class Deadlocks(DBMAsyncJob):
                 except ValueError:
                     self._log.error("spid not an integer. Skipping query signature computation.")
                     continue
-                if spid in query_signatures:
+                if spid in seen_spids:
                     continue
+                seen_spids.add(spid)
             else:
                 self._log.error("spid not found in process element. Skipping query signature computation.")
 
@@ -112,7 +114,7 @@ class Deadlocks(DBMAsyncJob):
             for frame in process.findall('.//frame'):
                 if frame.text is not None and frame.text != "unknown":
                     frame.text = self.obfuscate_no_except_wrapper(frame.text)
-                    if signature is not None and frame.text != OBFUSCATION_ERROR:
+                    if signature is None and frame.text != OBFUSCATION_ERROR:
                         signature = compute_sql_signature(frame.text)
 
             for inputbuf in process.findall('.//inputbuf'):

--- a/sqlserver/tests/test_deadlocks.py
+++ b/sqlserver/tests/test_deadlocks.py
@@ -366,6 +366,54 @@ def test_deadlock_calls_obfuscator(deadlocks_collection_instance):
         assert expected_xml_string == result_string
 
 
+def test_deadlock_signature_uses_first_stack_frame(deadlocks_collection_instance):
+    root = ET.fromstring(
+        """
+        <deadlock>
+          <process-list>
+            <process spid="51">
+              <executionStack>
+                <frame>SELECT * FROM orders WHERE id = 1</frame>
+                <frame>SELECT * FROM customers WHERE id = 2</frame>
+              </executionStack>
+            </process>
+          </process-list>
+        </deadlock>
+        """
+    )
+    deadlocks_obj = _get_deadlock_obj(deadlocks_collection_instance)
+
+    with (
+        patch.object(deadlocks_obj, 'obfuscate_no_except_wrapper', side_effect=lambda sql: sql.strip()),
+        patch('datadog_checks.sqlserver.deadlocks.compute_sql_signature', side_effect=lambda sql: f'sig:{sql}'),
+    ):
+        signatures = deadlocks_obj._obfuscate_xml(root)
+
+    assert signatures == [{'spid': 51, 'signature': 'sig:SELECT * FROM orders WHERE id = 1'}]
+
+
+def test_deadlock_signatures_deduplicate_spids(deadlocks_collection_instance):
+    root = ET.fromstring(
+        """
+        <deadlock>
+          <process-list>
+            <process spid="51"><inputbuf>SELECT 1</inputbuf></process>
+            <process spid="51"><inputbuf>SELECT 2</inputbuf></process>
+          </process-list>
+        </deadlock>
+        """
+    )
+    deadlocks_obj = _get_deadlock_obj(deadlocks_collection_instance)
+
+    with (
+        patch.object(deadlocks_obj, 'obfuscate_no_except_wrapper', side_effect=lambda sql: sql.strip()),
+        patch('datadog_checks.sqlserver.deadlocks.compute_sql_signature', side_effect=lambda sql: f'sig:{sql}'),
+    ):
+        signatures = deadlocks_obj._obfuscate_xml(root)
+
+    assert signatures == [{'spid': 51, 'signature': 'sig:SELECT 1'}]
+
+
 @pytest.mark.unit
 def test_collect_deadlocks_config(dbm_instance):
     dbm_instance['collect_deadlocks'] = {"enabled": True, 'collection_interval': 0.2}


### PR DESCRIPTION
### What does this PR do?

Uses the first valid deadlock stack frame for the query signature and suppresses duplicate signatures for the same SPID. Adds focused XML regression tests for both behaviors.

### Motivation

The frame condition was reversed, so stack frames never populated an empty signature. Duplicate detection compared an integer SPID with dictionaries and never matched.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
