### PR TITLE
Prevent raw SQL in SQL Server collector logs

### DIFF
--- a/sqlserver/changelog.d/25063.security
+++ b/sqlserver/changelog.d/25063.security
@@ -1,0 +1,1 @@
+Prevent raw SQL text from being written to SQL Server DBM logs.

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -421,7 +421,6 @@ class SqlserverActivity(DBMAsyncJob):
             if row.get('procedure_name') and row.get('schema_name'):
                 row['procedure_name'] = f"{row['schema_name']}.{row['procedure_name']}".lower()
         except Exception as e:
-            print(e)
             if self._config.log_unobfuscated_queries:
                 self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", repr(row['statement_text']), e)
             else:

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -222,10 +222,11 @@ class Deadlocks(DBMAsyncJob):
             try:
                 root = ET.fromstring(row[DEADLOCK_XML_ALIAS])
             except Exception as e:
-                self._log.error(
-                    """An error occurred while collecting SQLServer deadlocks.
-                        One of the deadlock XMLs couldn't be parsed. The error: {}. XML: {}""".format(e, row)
-                )
+                error = "An error occurred while collecting SQLServer deadlocks. "
+                error += "One of the deadlock XMLs couldn't be parsed. The error: {}".format(e)
+                if self._config.log_unobfuscated_queries:
+                    error += ". XML: {}".format(row)
+                self._log.error(error)
                 continue
             query_signatures = {}
             try:

--- a/sqlserver/datadog_checks/sqlserver/xe_collection/base.py
+++ b/sqlserver/datadog_checks/sqlserver/xe_collection/base.py
@@ -523,20 +523,6 @@ class XESessionBase(DBMAsyncJob):
             self._last_event_timestamp = events[-1]['timestamp']
             self._log.debug(f"Updated checkpoint to {self._last_event_timestamp}")
 
-        # Log a sample of events (up to max configured limit) for debugging
-        if self._log.isEnabledFor(logging.DEBUG):
-            sample_size = min(self.debug_sample_events, len(events))
-            sample_events = events[:sample_size]
-
-            try:
-                formatted_json = json_module.dumps(sample_events, indent=2, default=str)
-                self._log.debug(
-                    f"Sample events from {self.session_name} session (limit={self.debug_sample_events}):\n"
-                    f"{formatted_json}"
-                )
-            except Exception as e:
-                self._log.error(f"Error formatting events for logging: {e}")
-
         # Determine the key for the batched events array based on session name
         batch_key = (
             "sqlserver_query_errors" if self.session_name == "datadog_query_errors" else "sqlserver_query_completions"
@@ -544,9 +530,6 @@ class XESessionBase(DBMAsyncJob):
 
         # Create a list to collect all query details
         all_query_details = []
-
-        # Track if we've logged an RQT sample for this batch
-        rqt_sample_logged = False
 
         # Process all events and collect them for batching
         for event in events:
@@ -571,15 +554,6 @@ class XESessionBase(DBMAsyncJob):
                     rqt_event = self._create_rqt_event(obfuscated_event, raw_sql_fields, query_details)
 
                     if rqt_event:
-                        # Log the first successful RQT event we encounter in this batch
-                        if not rqt_sample_logged and self._log.isEnabledFor(logging.DEBUG):
-                            try:
-                                rqt_payload_json = json_module.dumps(rqt_event, default=str, indent=2)
-                                self._log.debug(f"Sample {self.session_name} RQT event payload:\n{rqt_payload_json}")
-                                rqt_sample_logged = True
-                            except Exception as e:
-                                self._log.error(f"Error serializing RQT payload for logging: {e}")
-
                         self._log.debug(
                             f"Created RQT event for query_signature={obfuscated_event.get('query_signature')}"
                         )

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -749,6 +749,23 @@ def test_activity_stored_procedure_failed_to_obfuscate(dbm_instance, datadog_age
         assert result_rows[0]['procedure_signature'] == '__procedure_obfuscation_error__'
 
 
+@pytest.mark.unit
+def test_activity_obfuscation_failure_does_not_write_stdout(dbm_instance, datadog_agent, capsys):
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    row = {
+        'statement_text': "SELECT * FROM customers WHERE token = 'activity-secret'",
+        'query_hash': b'\x01',
+        'query_plan_hash': b'\x02',
+    }
+
+    with mock.patch.object(datadog_agent, 'obfuscate_sql', side_effect=Exception('obfuscation failed')):
+        check.activity._obfuscate_and_sanitize_row(row)
+
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    assert captured.err == ''
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(

--- a/sqlserver/tests/test_deadlocks.py
+++ b/sqlserver/tests/test_deadlocks.py
@@ -293,6 +293,21 @@ def test_deadlock_xml_bad_format(deadlocks_collection_instance):
         AssertionError("Should have raised an exception for bad XML format")
 
 
+def test_deadlock_parse_failure_does_not_log_xml(deadlocks_collection_instance):
+    deadlocks_obj = _get_deadlock_obj(deadlocks_collection_instance)
+    raw_xml = "<deadlock><inputbuf>SELECT 'deadlock-secret'</inputbuf>"
+    rows = [{DEADLOCK_TIMESTAMP_ALIAS: "2024-09-20T12:07:16.647000", DEADLOCK_XML_ALIAS: raw_xml}]
+
+    with (
+        patch.object(Deadlocks, '_query_deadlocks', return_value=rows),
+        patch.object(deadlocks_obj._log, 'error') as log_error,
+    ):
+        assert deadlocks_obj._create_deadlock_rows() == []
+
+    logged = ' '.join(str(call) for call in log_error.call_args_list)
+    assert 'deadlock-secret' not in logged
+
+
 def test_deadlock_calls_obfuscator(deadlocks_collection_instance):
     test_xml = """
     <event name="xml_deadlock_report" package="sqlserver" timestamp="2024-08-20T08:30:35.762Z">

--- a/sqlserver/tests/test_xe_collection.py
+++ b/sqlserver/tests/test_xe_collection.py
@@ -1195,6 +1195,42 @@ class TestRunJob:
                 query_details = event["query_details"]
                 assert "xe_type" in query_details, "Missing 'xe_type' in query_details"
 
+    def test_debug_logs_do_not_include_raw_sql(self, query_completion_handler):
+        raw_sql = "SELECT * FROM customers WHERE token = 'xe-secret'"
+        events = [
+            {
+                'event_name': 'sql_batch_completed',
+                'timestamp': '2023-01-01T12:00:00.123Z',
+                'batch_text': raw_sql,
+            }
+        ]
+        obfuscated_event = {
+            'event_name': 'sql_batch_completed',
+            'timestamp': '2023-01-01T12:00:00.123Z',
+            'batch_text': 'SELECT * FROM customers WHERE token = ?',
+            'database_name': 'customers',
+            'query_signature': 'signature',
+        }
+
+        with (
+            patch.object(query_completion_handler, 'session_exists', return_value=True),
+            patch.object(query_completion_handler, '_query_ring_buffer', return_value='<events />'),
+            patch.object(query_completion_handler, '_process_events', return_value=events),
+            patch.object(query_completion_handler._log, 'isEnabledFor', return_value=True),
+            patch.object(query_completion_handler._log, 'debug') as log_debug,
+            patch.object(
+                query_completion_handler,
+                '_obfuscate_sql_fields',
+                return_value=(obfuscated_event, {'batch_text': raw_sql}, 'batch_text'),
+            ),
+            patch('datadog_checks.sqlserver.xe_collection.base.json.dumps', return_value='{}'),
+        ):
+            query_completion_handler._collect_raw_query = False
+            query_completion_handler.run_job()
+
+        logged = ' '.join(str(call) for call in log_debug.call_args_list)
+        assert 'xe-secret' not in logged
+
     def test_no_session(self, query_completion_handler, mock_check, mock_handler_log):
         """Test behavior when session doesn't exist"""
         with patch.object(query_completion_handler, 'session_exists', return_value=False):


### PR DESCRIPTION
### What does this PR do?

Prevents raw SQL from bypassing `log_unobfuscated_queries`. Removes raw XE and RQT debug samples, removes activity obfuscation errors from stdout, and omits malformed deadlock XML unless unobfuscated query logging is enabled. Adds regression tests for all three collectors.

### Motivation

Raw statements can contain sensitive values. These paths exposed them through debug logs, parse-error logs, or stdout even when unobfuscated query logging was disabled.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
