### PR TITLE
Honor reported hostname in SQL Server XE events

### DIFF
--- a/sqlserver/changelog.d/25064.fixed
+++ b/sqlserver/changelog.d/25064.fixed
@@ -1,0 +1,1 @@
+Honor reported and excluded hostnames in SQL Server XE events.

--- a/sqlserver/datadog_checks/sqlserver/xe_collection/base.py
+++ b/sqlserver/datadog_checks/sqlserver/xe_collection/base.py
@@ -466,7 +466,7 @@ class XESessionBase(DBMAsyncJob):
         }
 
         return {
-            "host": self._check.resolved_hostname,
+            "host": self._check.reported_hostname,
             "database_instance": self._check.database_identifier,
             "ddagentversion": self._check.agent_version,
             "ddsource": "sqlserver",
@@ -597,7 +597,7 @@ class XESessionBase(DBMAsyncJob):
         if all_query_details:
             # Create base payload from the common fields (using the same structure as _create_event_payload)
             batched_payload = {
-                "host": self._check.resolved_hostname,
+                "host": self._check.reported_hostname,
                 "database_instance": self._check.database_identifier,
                 "ddagentversion": self._check.agent_version,
                 "ddsource": "sqlserver",
@@ -795,7 +795,7 @@ class XESessionBase(DBMAsyncJob):
 
         return {
             "timestamp": time() * 1000,
-            "host": self._check.resolved_hostname,
+            "host": self._check.reported_hostname,
             "database_instance": self._check.database_identifier,
             "ddagentversion": self._check.agent_version,
             "ddsource": "sqlserver",

--- a/sqlserver/tests/test_xe_collection.py
+++ b/sqlserver/tests/test_xe_collection.py
@@ -50,7 +50,7 @@ def assert_event_field_values(event, expected_values):
 def validate_common_payload_fields(payload, expected_type):
     """Validate common fields in event payloads"""
     assert 'timestamp' in payload
-    assert payload['host'] == 'test-host'
+    assert payload['host'] == 'reported-host'
     assert payload['ddagentversion'] == '7.30.0'
     assert payload['ddsource'] == 'sqlserver'
     assert payload['dbm_type'] == expected_type
@@ -95,6 +95,7 @@ def mock_check():
 
     check.static_info_cache = {'version': '2019', 'engine_edition': 'Standard Edition'}
     check.resolved_hostname = "test-host"
+    check.reported_hostname = "reported-host"
     check.agent_version = '7.30.0'
     check.tag_manager = TagManager()
     check.tag_manager.set_tag('test', 'tag')
@@ -1172,6 +1173,7 @@ class TestRunJob:
 
             # Now validate the actual payload structure that was going to be serialized
             assert original_payload is not None, "Payload was not captured"
+            assert original_payload['host'] == 'reported-host'
 
             # Check essential payload properties
             assert 'ddsource' in original_payload, "Missing 'ddsource' in payload"


### PR DESCRIPTION
### What does this PR do?

Uses `reported_hostname` for individual, batched, and raw-query-text SQL Server XE events. Updates payload tests to distinguish reported and resolved hostnames.

### Motivation

XE payloads used `resolved_hostname`, so they ignored `reported_hostname` overrides and `exclude_hostname`.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
