### PR TITLE
Handle missing SQL Server deadlock sessions

### DIFF
--- a/sqlserver/changelog.d/25065.fixed
+++ b/sqlserver/changelog.d/25065.fixed
@@ -1,0 +1,1 @@
+Handle missing SQL Server deadlock XE sessions without failing collection.

--- a/sqlserver/datadog_checks/sqlserver/deadlocks.py
+++ b/sqlserver/datadog_checks/sqlserver/deadlocks.py
@@ -176,7 +176,7 @@ class Deadlocks(DBMAsyncJob):
                 self._set_xe_session_name()
             except NoXESessionError as e:
                 self._log.error(str(e))
-                return
+                return []
             self._log.info(
                 f'Using XE session [{self._xe_session_name}], target [{self._xe_session_target}] to collect deadlocks'
             )

--- a/sqlserver/tests/test_deadlocks.py
+++ b/sqlserver/tests/test_deadlocks.py
@@ -21,6 +21,7 @@ from datadog_checks.sqlserver.deadlocks import (
     PAYLOAD_QUERY_SIGNATURE,
     PAYLOAD_TIMESTAMP,
     Deadlocks,
+    NoXESessionError,
 )
 from datadog_checks.sqlserver.queries import (
     DEADLOCK_TIMESTAMP_ALIAS,
@@ -265,6 +266,13 @@ def test__create_deadlock_rows(deadlocks_collection_instance):
         first_mapping = query_signatures[0]
         assert "spid" in first_mapping, "Should have spid in query signatures"
         assert isinstance(first_mapping["spid"], int), "spid should be an int"
+
+
+def test_missing_xe_session_returns_no_deadlocks(deadlocks_collection_instance):
+    deadlocks_obj = _get_deadlock_obj(deadlocks_collection_instance)
+
+    with patch.object(deadlocks_obj, '_set_xe_session_name', side_effect=NoXESessionError('missing XE session')):
+        assert deadlocks_obj._create_deadlock_rows() == []
 
 
 def test_deadlock_xml_bad_format(deadlocks_collection_instance):


### PR DESCRIPTION
### What does this PR do?

Returns an empty deadlock result when no usable XE session exists. Adds a regression test for the missing-session path.

### Motivation

The query method returned `None`, which `_create_deadlock_rows` then attempted to iterate and raised `TypeError`.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
