### PR TITLE
Redact SQL Server health connection strings

### DIFF
--- a/sqlserver/changelog.d/25066.security
+++ b/sqlserver/changelog.d/25066.security
@@ -1,1 +1,1 @@
-Redact connection strings from DBM initialization health events.
+Redact credentials in connection strings included in DBM initialization health events.

--- a/sqlserver/changelog.d/25066.security
+++ b/sqlserver/changelog.d/25066.security
@@ -1,0 +1,1 @@
+Redact connection strings from DBM initialization health events.

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -10,6 +10,7 @@ from datadog_checks.base import ConfigurationError, is_affirmative
 from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.utils import get_agent_host_tags
 from datadog_checks.sqlserver.config_models.instance import DataObservability
+from datadog_checks.sqlserver.connection import sanitize_connection_string
 from datadog_checks.sqlserver.const import (
     DEFAULT_AUTODISCOVERY_INTERVAL,
     DEFAULT_LONG_METRICS_COLLECTION_INTERVAL,
@@ -317,5 +318,7 @@ def sanitize(config: dict) -> dict:
     """
     sanitized = copy.deepcopy(config)
     sanitized['password'] = '***' if sanitized.get('password') else None
-    sanitized['connection_string'] = '***' if sanitized.get('connection_string') else None
+    sanitized['connection_string'] = (
+        sanitize_connection_string(sanitized['connection_string']) if sanitized.get('connection_string') else None
+    )
     return sanitized

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -317,4 +317,5 @@ def sanitize(config: dict) -> dict:
     """
     sanitized = copy.deepcopy(config)
     sanitized['password'] = '***' if sanitized.get('password') else None
+    sanitized['connection_string'] = '***' if sanitized.get('connection_string') else None
     return sanitized

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -65,19 +65,22 @@ def split_sqlserver_host_port(host):
 # we're only including the bare minimum set of special characters required to parse the connection string while
 # supporting escaping using braces, letting the client library or the database ultimately decide what's valid
 CONNECTION_STRING_SPECIAL_CHARACTERS = set('=;{}')
+SENSITIVE_CONNECTION_STRING_KEYS = frozenset({'clientkey', 'extendedproperties', 'providerstring', 'pwd'})
+SENSITIVE_CONNECTION_STRING_KEY_PARTS = ('connectionstring', 'credential', 'password', 'secret', 'token')
 
 
 def parse_connection_string_properties(cs):
     """
     Parses the properties portion of a SQL Server connection string (i.e. "key1=value1;key2=value2;...") into a map of
     {key -> value}. The string must contain *properties only*, meaning the subprotocol, serverName, instanceName and
-    portNumber are not included in the string.
+    portNumber are not included in the string. Values may use ODBC brace escaping or ADO double-quote escaping.
     See https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url
     """
     cs = cs.strip()
     params = {}
     i = 0
     escaping = False
+    quoting = False
     key, parsed, key_done = "", "", False
     while i < len(cs):
         if escaping:
@@ -92,8 +95,24 @@ def parse_connection_string_properties(cs):
             parsed += cs[i]
             i += 1
             continue
+        if quoting:
+            if cs[i : i + 2] == '""':
+                parsed += '"'
+                i += 2
+                continue
+            if cs[i] == '"':
+                quoting = False
+                i += 1
+                continue
+            parsed += cs[i]
+            i += 1
+            continue
         if cs[i] == '{':
             escaping = True
+            i += 1
+            continue
+        if key_done and not parsed and cs[i] == '"':
+            quoting = True
             i += 1
             continue
         # ignore leading whitespace, i.e. between two keys "A=B;  C=D"
@@ -128,6 +147,10 @@ def parse_connection_string_properties(cs):
         raise ConfigurationError(
             "Invalid connection string: did not find expected matching closing brace '}}': {}".format(cs)
         )
+    if quoting:
+        raise ConfigurationError(
+            "Invalid connection string: did not find expected matching closing quote '\"': {}".format(cs)
+        )
     if key:
         if not parsed:
             raise ConfigurationError(
@@ -148,6 +171,42 @@ def _escape_odbc_connection_string_value(value: str) -> str:
     # Sources: https://learn.microsoft.com/en-us/sql/relational-databases/security/strong-passwords
     # https://sqlprotocoldoc.z19.web.core.windows.net/MS-ODBCSTR/%5BMS-ODBCSTR%5D-100604.pdf
     return '{{{}}}'.format(value.replace('}', '}}'))
+
+
+def sanitize_connection_string(connection_string: str) -> str:
+    """Redact credential-bearing properties while preserving diagnostic connection properties."""
+    try:
+        properties = parse_connection_string_properties(connection_string)
+    except ConfigurationError:
+        return '***'
+
+    if (not properties and connection_string.strip()) or any(not key.strip() for key in properties):
+        return '***'
+
+    sensitive_keys = set()
+    for key in properties:
+        normalized_key = ''.join(character for character in key.casefold() if character.isalnum())
+        if (
+            normalized_key in SENSITIVE_CONNECTION_STRING_KEYS
+            or normalized_key.startswith('pwd')
+            or normalized_key.endswith('key')
+            or any(part in normalized_key for part in SENSITIVE_CONNECTION_STRING_KEY_PARTS)
+        ):
+            sensitive_keys.add(key)
+
+    if not sensitive_keys:
+        return connection_string
+
+    sanitized_properties = []
+    for key, value in properties.items():
+        if key in sensitive_keys:
+            value = '***'
+        elif value != value.strip() or any(character in CONNECTION_STRING_SPECIAL_CHARACTERS for character in value):
+            value = _escape_odbc_connection_string_value(value)
+        sanitized_properties.append('{}={}'.format(key, value))
+
+    trailing_delimiter = ';' if connection_string.rstrip().endswith(';') else ''
+    return ';'.join(sanitized_properties) + trailing_delimiter
 
 
 def _escape_legacy_freetds_odbc_connection_string_value(value: str) -> str:

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -16,6 +16,7 @@ from datadog_checks.sqlserver.connection import (
     Connection,
     SQLConnectionError,
     parse_connection_string_properties,
+    sanitize_connection_string,
 )
 from datadog_checks.sqlserver.connection_errors import (
     ConnectionErrorCode,
@@ -49,8 +50,14 @@ SPECIAL_CHARACTERS_PASSWORD = 'Pa;ss}"word123!'
         pytest.param('A=B C;', {"A": "B C"}, id="spaces allowed inside a value"),
         pytest.param('A=C ;', {"A": "C "}, id="spaces allowed after a value"),
         pytest.param('A=B ;C=D', {"A": "B ", "C": 'D'}, id="spaces allowed after a value, they become part of it"),
+        pytest.param(
+            'User ID=datadog;Password="Pa;ss""word";',
+            {'User ID': 'datadog', 'Password': 'Pa;ss"word'},
+            id='quoted value with escaped quote',
+        ),
         pytest.param('host=foo;password={pass";{}word}', None, id="escape too early then invalid character"),
         pytest.param('host=foo;password={incomplete_escape;', None, id="incomplete escape"),
+        pytest.param('host=foo;password="incomplete_quote;', None, id="incomplete quote"),
         pytest.param('host=foo;password=;', None, id="empty value"),
         pytest.param('host=foo;=hello;', None, id="empty key"),
         pytest.param('host=foo;;', None, id="empty both"),
@@ -63,6 +70,58 @@ def test_parse_connection_string_properties(cs, parsed):
         return
     with pytest.raises(ConfigurationError):
         parse_connection_string_properties(cs)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'connection_string, expected',
+    [
+        pytest.param(
+            'ApplicationIntent=ReadOnly;TrustServerCertificate=yes',
+            'ApplicationIntent=ReadOnly;TrustServerCertificate=yes',
+            id='safe-properties-unchanged',
+        ),
+        pytest.param(
+            'UID=datadog;PWD=connection-secret;TrustServerCertificate=yes',
+            'UID=datadog;PWD=***;TrustServerCertificate=yes',
+            id='odbc-password',
+        ),
+        pytest.param(
+            'User ID=datadog;Password={pa;ss}}word};Application Name={dbm;check};',
+            'User ID=datadog;Password=***;Application Name={dbm;check};',
+            id='braced-password-and-safe-value',
+        ),
+        pytest.param(
+            'Access Token=access-secret;Server=database.example.com',
+            'Access Token=***;Server=database.example.com',
+            id='access-token',
+        ),
+        pytest.param(
+            'User ID=datadog;Password="Pa;ss""word";Encrypt=yes',
+            'User ID=datadog;Password=***;Encrypt=yes',
+            id='ado-quoted-password',
+        ),
+        pytest.param(
+            'KeystorePrincipalId=client-id;KeystoreSecret=client-secret',
+            'KeystorePrincipalId=client-id;KeystoreSecret=***',
+            id='keystore-secret',
+        ),
+        pytest.param(
+            'ClientCertificate=/etc/sqlserver/client.pem;ClientKey=/etc/sqlserver/client-key.pem',
+            'ClientCertificate=/etc/sqlserver/client.pem;ClientKey=***',
+            id='client-key',
+        ),
+        pytest.param(
+            'Provider String={Server=database.example.com;Password=nested-secret};Encrypt=yes',
+            'Provider String=***;Encrypt=yes',
+            id='nested-provider-string',
+        ),
+        pytest.param('PWD={incomplete;', '***', id='invalid-connection-string'),
+        pytest.param('not-a-property', '***', id='missing-key-value-separator'),
+    ],
+)
+def test_sanitize_connection_string(connection_string, expected):
+    assert sanitize_connection_string(connection_string) == expected
 
 
 @pytest.mark.unit

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -61,7 +61,7 @@ except ImportError:
 pytestmark = pytest.mark.unit
 
 
-def test_sanitize_config_redacts_connection_string():
+def test_sanitize_config_redacts_connection_string_credentials():
     config = {
         'password': 'top-secret',
         'connection_string': 'UID=datadog;PWD=connection-secret;TrustServerCertificate=yes',
@@ -69,7 +69,10 @@ def test_sanitize_config_redacts_connection_string():
 
     sanitized = sanitize(config)
 
-    assert sanitized == {'password': '***', 'connection_string': '***'}
+    assert sanitized == {
+        'password': '***',
+        'connection_string': 'UID=datadog;PWD=***;TrustServerCertificate=yes',
+    }
     assert config['connection_string'] == 'UID=datadog;PWD=connection-secret;TrustServerCertificate=yes'
 
 

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -18,6 +18,7 @@ from datadog_checks.base.stubs.datadog_agent import datadog_agent
 from datadog_checks.base.utils.db import QueryManager
 from datadog_checks.dev import EnvVars
 from datadog_checks.sqlserver import SQLServer
+from datadog_checks.sqlserver.config import sanitize
 from datadog_checks.sqlserver.connection import split_sqlserver_host_port
 from datadog_checks.sqlserver.const import (
     ENGINE_EDITION_AZURE_MANAGED_INSTANCE,
@@ -58,6 +59,18 @@ except ImportError:
 
 # mark the whole module
 pytestmark = pytest.mark.unit
+
+
+def test_sanitize_config_redacts_connection_string():
+    config = {
+        'password': 'top-secret',
+        'connection_string': 'UID=datadog;PWD=connection-secret;TrustServerCertificate=yes',
+    }
+
+    sanitized = sanitize(config)
+
+    assert sanitized == {'password': '***', 'connection_string': '***'}
+    assert config['connection_string'] == 'UID=datadog;PWD=connection-secret;TrustServerCertificate=yes'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

Redacts credential-bearing connection-string properties from the SQL Server configuration copied into DBM initialization health events while preserving non-sensitive diagnostics. Supports ODBC braced values and ADO quoted values, and masks the entire string when parsing fails. Adds regression coverage without mutating the source configuration.

### Motivation

SQL Server connection strings can embed passwords, access tokens, client keys, keystore secrets, and nested provider strings. The existing sanitizer masked `password` but left `connection_string` unchanged.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
