### PR TITLE
Fix SQL Server activity column logging

### DIFF
--- a/sqlserver/changelog.d/25067.fixed
+++ b/sqlserver/changelog.d/25067.fixed
@@ -1,0 +1,1 @@
+Fix activity collection diagnostics when expected request DMV columns are unavailable.

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -365,8 +365,8 @@ class SqlserverActivity(DBMAsyncJob):
         available_columns = [c for c in all_expected_columns if c in all_columns]
         missing_columns = set(all_expected_columns) - set(available_columns)
         if missing_columns:
-            self._log.info("missing the following expected columns from sys.dm_exec_requests: %s", missing_columns)
-        self._log.debug("found available sys.dm_exec_requests columns: %s", available_columns)
+            self.log.info("missing the following expected columns from sys.dm_exec_requests: %s", missing_columns)
+        self.log.debug("found available sys.dm_exec_requests columns: %s", available_columns)
         return available_columns
 
     @staticmethod

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -540,25 +540,6 @@ def very_old_time():
     return datetime.datetime(2021, 9, 20, 23, 21, 21, 669330).isoformat()
 
 
-@pytest.mark.unit
-def test_get_available_requests_columns_logs_missing_columns(dbm_instance):
-    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    cursor = mock.Mock()
-    cursor.description = [('session_id',), ('status',)]
-    check.activity.log = mock.Mock()
-    check.activity._log = mock.Mock()
-
-    available_columns = check.activity._get_available_requests_columns(
-        cursor, ['session_id', 'status', 'page_resource']
-    )
-
-    assert available_columns == ['session_id', 'status']
-    check.activity.log.info.assert_called_once_with(
-        'missing the following expected columns from sys.dm_exec_requests: %s', {'page_resource'}
-    )
-    check.activity._log.info.assert_not_called()
-
-
 @pytest.mark.parametrize(
     "rows,expected_len,expected_users",
     [

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -540,6 +540,25 @@ def very_old_time():
     return datetime.datetime(2021, 9, 20, 23, 21, 21, 669330).isoformat()
 
 
+@pytest.mark.unit
+def test_get_available_requests_columns_logs_missing_columns(dbm_instance):
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+    cursor = mock.Mock()
+    cursor.description = [('session_id',), ('status',)]
+    check.activity.log = mock.Mock()
+    check.activity._log = mock.Mock()
+
+    available_columns = check.activity._get_available_requests_columns(
+        cursor, ['session_id', 'status', 'page_resource']
+    )
+
+    assert available_columns == ['session_id', 'status']
+    check.activity.log.info.assert_called_once_with(
+        'missing the following expected columns from sys.dm_exec_requests: %s', {'page_resource'}
+    )
+    check.activity._log.info.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "rows,expected_len,expected_users",
     [


### PR DESCRIPTION
### What does this PR do?

Routes SQL Server activity DMV compatibility diagnostics through the integration logger.

### Motivation

`SqlserverActivity` stores the integration logger as `self.log`, but the missing-column fallback used the base async job logger. This made that path inconsistent with the rest of activity collection.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
