### PR TITLE
Fix Vagrant E2E Agents not receiving their environment variables

### DIFF
--- a/ddev/changelog.d/25068.fixed
+++ b/ddev/changelog.d/25068.fixed
@@ -1,0 +1,1 @@
+Fix Vagrant E2E Agents not receiving their environment variables; they are now persisted in the Agent systemd service ``EnvironmentFile``.

--- a/ddev/src/ddev/e2e/agent/Vagrantfile.template
+++ b/ddev/src/ddev/e2e/agent/Vagrantfile.template
@@ -27,6 +27,7 @@ Vagrant.configure("2") do |config|
     node.vm.provision "shell", inline: <<-SHELL, run: "always"
       sudo apt update
       {{ agent_install_env_vars_str }} bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+{{ systemd_env_vars_str }}
       sudo service datadog-agent start && echo "Agent started successfully"
       echo "VM {{ vm_hostname }} is ready"
     SHELL

--- a/ddev/src/ddev/e2e/agent/Vagrantfile.template
+++ b/ddev/src/ddev/e2e/agent/Vagrantfile.template
@@ -1,7 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-$set_environment_variables = <<SCRIPT
+# The quoted heredoc delimiters (<<'...') keep Ruby from interpolating the rendered
+# content, so values like $HOME or #{...} reach the provisioning shell literally.
+$set_environment_variables = <<-'SCRIPT'
 tee "/etc/profile.d/myvars.sh" > "/dev/null" <<EOF
 
 export LOCAL_IP=$(hostname -I | cut -d ' ' -f 1)
@@ -24,11 +26,11 @@ Vagrant.configure("2") do |config|
 
     node.vm.provision "shell", inline: $set_environment_variables, run: "always"
 
-    node.vm.provision "shell", inline: <<-SHELL, run: "always"
+    node.vm.provision "shell", inline: <<-'SHELL', run: "always"
       sudo apt update
       {{ agent_install_env_vars_str }} bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
 {{ systemd_env_vars_str }}
-      sudo service datadog-agent start && echo "Agent started successfully"
+      sudo service datadog-agent restart && echo "Agent restarted successfully"
       echo "VM {{ vm_hostname }} is ready"
     SHELL
   end

--- a/ddev/src/ddev/e2e/agent/vagrant.py
+++ b/ddev/src/ddev/e2e/agent/vagrant.py
@@ -176,6 +176,15 @@ class VagrantAgent(AgentInterface):
             else ""
         )
 
+        # The Agent runs as a systemd service, which does not source login-shell profile scripts,
+        # so persist the env vars in the service's EnvironmentFile to make sure the Agent receives them.
+        # The heredoc terminators must stay at the start of the line.
+        systemd_env_vars_str = ""
+        if exported_env_vars and not self._is_windows_vm:
+            systemd_env_vars_str = "sudo tee /etc/datadog-agent/environment > /dev/null <<EOF\n"
+            systemd_env_vars_str += "\n".join(f"{key}={value}" for key, value in sorted(exported_env_vars.items()))
+            systemd_env_vars_str += "\nEOF\nsudo chmod 600 /etc/datadog-agent/environment"
+
         vm_hostname = self._vm_name  # Already sanitized and unique
         vagrant_box = self.metadata.get("vagrant_box", "net9/ubuntu-24.04-arm64")  # Default box
 
@@ -198,6 +207,7 @@ class VagrantAgent(AgentInterface):
 
         return template.render(
             exported_env_vars_str=exported_env_vars_str,
+            systemd_env_vars_str=systemd_env_vars_str,
             vagrant_box=vagrant_box,
             synced_folders_str=synced_folders_str,
             vm_hostname=vm_hostname,

--- a/ddev/src/ddev/e2e/agent/vagrant.py
+++ b/ddev/src/ddev/e2e/agent/vagrant.py
@@ -35,6 +35,15 @@ if TYPE_CHECKING:
     from ddev.utils.fs import Path
 
 
+def _encode_environment_file_value(value: str) -> str:
+    """Quote and escape a value for a systemd EnvironmentFile (``KEY="<value>"`` lines).
+
+    A systemd EnvironmentFile does not perform variable expansion, so a value is preserved
+    literally as long as double quotes and backslashes are escaped per systemd syntax.
+    """
+    return value.replace('\\', '\\\\').replace('"', '\\"')
+
+
 @contextmanager
 def disable_integration_before_install(config_file: Path):
     """
@@ -178,11 +187,15 @@ class VagrantAgent(AgentInterface):
 
         # The Agent runs as a systemd service, which does not source login-shell profile scripts,
         # so persist the env vars in the service's EnvironmentFile to make sure the Agent receives them.
+        # The quoted heredoc keeps the provisioning shell from expanding the values, and each value is
+        # quoted and escaped per systemd EnvironmentFile syntax.
         # The heredoc terminators must stay at the start of the line.
         systemd_env_vars_str = ""
         if exported_env_vars and not self._is_windows_vm:
-            systemd_env_vars_str = "sudo tee /etc/datadog-agent/environment > /dev/null <<EOF\n"
-            systemd_env_vars_str += "\n".join(f"{key}={value}" for key, value in sorted(exported_env_vars.items()))
+            systemd_env_vars_str = "sudo tee /etc/datadog-agent/environment > /dev/null <<'EOF'\n"
+            systemd_env_vars_str += "\n".join(
+                f'{key}="{_encode_environment_file_value(value)}"' for key, value in sorted(exported_env_vars.items())
+            )
             systemd_env_vars_str += "\nEOF\nsudo chmod 600 /etc/datadog-agent/environment"
 
         vm_hostname = self._vm_name  # Already sanitized and unique

--- a/ddev/tests/e2e/agent/test_vagrant.py
+++ b/ddev/tests/e2e/agent/test_vagrant.py
@@ -351,16 +351,51 @@ class TestStart:
         mock_vagrantfile_template.render.assert_called_once()
         render_kwargs = mock_vagrantfile_template.render.call_args.kwargs
         systemd_env_vars_str = render_kwargs['systemd_env_vars_str']
-        assert systemd_env_vars_str.startswith('sudo tee /etc/datadog-agent/environment > /dev/null <<EOF\n')
-        assert 'DD_LOGS_ENABLED=true' in systemd_env_vars_str
-        assert 'DD_APM_ENABLED=false' in systemd_env_vars_str
-        assert 'DD_API_KEY=' in systemd_env_vars_str
+        assert systemd_env_vars_str.startswith("sudo tee /etc/datadog-agent/environment > /dev/null <<'EOF'\n")
+        assert 'DD_LOGS_ENABLED="true"' in systemd_env_vars_str
+        assert 'DD_APM_ENABLED="false"' in systemd_env_vars_str
+        assert 'DD_API_KEY="' in systemd_env_vars_str
         assert systemd_env_vars_str.endswith('\nEOF\nsudo chmod 600 /etc/datadog-agent/environment')
+
+    def test_systemd_environment_file_preserves_literal_values(
+        self,
+        app,
+        temp_dir,
+        get_integration,
+        mocker,
+        mock_env_data_storage,
+        mock_vagrantfile_template,
+        mock_platform_run,
+        vagrant_env_cleanup,
+    ):
+        config_file = temp_dir / 'config' / 'config.yaml'
+        config_file.parent.mkdir()
+        config_file.touch()
+
+        integration = 'glusterfs'
+        environment = 'py3.12'
+        metadata = {}
+
+        agent = VagrantAgent(app, get_integration(integration), environment, metadata, config_file)
+        agent.start(
+            agent_build='',
+            local_packages={},
+            # Values that a shell would expand or that break systemd EnvironmentFile parsing if unescaped
+            env_vars={'DD_TEST': 'a $HOME $(pwd) `pwd` "quoted" back\\slash'},
+        )
+
+        mock_vagrantfile_template.render.assert_called_once()
+        render_kwargs = mock_vagrantfile_template.render.call_args.kwargs
+        systemd_env_vars_str = render_kwargs['systemd_env_vars_str']
+        # The quoted heredoc keeps the provisioning shell from expanding the value…
+        assert "<<'EOF'" in systemd_env_vars_str
+        # …and the value is quoted and escaped per systemd EnvironmentFile syntax
+        assert 'DD_TEST="a $HOME $(pwd) `pwd` \\"quoted\\" back\\\\slash"' in systemd_env_vars_str
 
     @pytest.mark.parametrize(
         'guest_os, expected_systemd_env_vars_str',
         [
-            pytest.param(None, 'sudo tee /etc/datadog-agent/environment > /dev/null <<EOF\n', id='linux'),
+            pytest.param(None, "sudo tee /etc/datadog-agent/environment > /dev/null <<'EOF'\n", id='linux'),
             pytest.param('windows', '', id='windows'),
         ],
     )

--- a/ddev/tests/e2e/agent/test_vagrant.py
+++ b/ddev/tests/e2e/agent/test_vagrant.py
@@ -324,6 +324,74 @@ class TestStart:
         assert 'export DD_PROXY_HTTP="http://localhost:8080"' in exported_env_vars_str
         assert 'export DD_PROXY_HTTPS="https://localhost:4443"' in exported_env_vars_str
 
+    def test_persists_env_vars_in_agent_service_environment_file(
+        self,
+        app,
+        temp_dir,
+        get_integration,
+        mocker,
+        mock_env_data_storage,
+        mock_vagrantfile_template,
+        mock_platform_run,
+        vagrant_env_cleanup,
+    ):
+        config_file = temp_dir / 'config' / 'config.yaml'
+        config_file.parent.mkdir()
+        config_file.touch()
+
+        integration = 'glusterfs'
+        environment = 'py3.12'
+        metadata = {}
+
+        agent = VagrantAgent(app, get_integration(integration), environment, metadata, config_file)
+        agent.start(agent_build='', local_packages={}, env_vars={'DD_LOGS_ENABLED': 'true'})
+
+        # The Agent runs as a systemd service, which does not source login-shell profile scripts,
+        # so the env vars must be persisted in the service's EnvironmentFile.
+        mock_vagrantfile_template.render.assert_called_once()
+        render_kwargs = mock_vagrantfile_template.render.call_args.kwargs
+        systemd_env_vars_str = render_kwargs['systemd_env_vars_str']
+        assert systemd_env_vars_str.startswith('sudo tee /etc/datadog-agent/environment > /dev/null <<EOF\n')
+        assert 'DD_LOGS_ENABLED=true' in systemd_env_vars_str
+        assert 'DD_APM_ENABLED=false' in systemd_env_vars_str
+        assert 'DD_API_KEY=' in systemd_env_vars_str
+        assert systemd_env_vars_str.endswith('\nEOF\nsudo chmod 600 /etc/datadog-agent/environment')
+
+    @pytest.mark.parametrize(
+        'guest_os, expected_systemd_env_vars_str',
+        [
+            pytest.param(None, 'sudo tee /etc/datadog-agent/environment > /dev/null <<EOF\n', id='linux'),
+            pytest.param('windows', '', id='windows'),
+        ],
+    )
+    def test_systemd_environment_file_by_guest_os(
+        self,
+        app,
+        temp_dir,
+        get_integration,
+        mocker,
+        mock_env_data_storage,
+        mock_vagrantfile_template,
+        mock_platform_run,
+        vagrant_env_cleanup,
+        guest_os,
+        expected_systemd_env_vars_str,
+    ):
+        config_file = temp_dir / 'config' / 'config.yaml'
+        config_file.parent.mkdir()
+        config_file.touch()
+
+        integration = 'glusterfs'
+        environment = 'py3.12'
+        metadata = {'vagrant_guest_os': guest_os} if guest_os else {}
+
+        agent = VagrantAgent(app, get_integration(integration), environment, metadata, config_file)
+        agent.start(agent_build='', local_packages={}, env_vars={})
+
+        mock_vagrantfile_template.render.assert_called_once()
+        render_kwargs = mock_vagrantfile_template.render.call_args.kwargs
+        assert render_kwargs['systemd_env_vars_str'].startswith(expected_systemd_env_vars_str)
+
     def test_executes_start_commands_after_vagrant_up(
         self,
         app,

--- a/ddev/tests/e2e/agent/test_vagrant.py
+++ b/ddev/tests/e2e/agent/test_vagrant.py
@@ -392,6 +392,38 @@ class TestStart:
         # …and the value is quoted and escaped per systemd EnvironmentFile syntax
         assert 'DD_TEST="a $HOME $(pwd) `pwd` \\"quoted\\" back\\\\slash"' in systemd_env_vars_str
 
+    def test_rendered_vagrantfile_preserves_literal_values(
+        self,
+        app,
+        temp_dir,
+        get_integration,
+        mock_env_data_storage,
+        mock_platform_run,
+        vagrant_env_cleanup,
+    ):
+        config_file = temp_dir / 'config' / 'config.yaml'
+        config_file.parent.mkdir()
+        config_file.touch()
+
+        # Uses the real template (no mock), so the assertions run against the
+        # actual Vagrantfile content and cover the Jinja and Ruby heredoc layers.
+        agent = VagrantAgent(app, get_integration('glusterfs'), 'py3.12', {}, config_file)
+        agent.start(
+            agent_build='',
+            local_packages={},
+            env_vars={'DD_TEST': 'a $HOME $(pwd) `pwd` "quoted" back\\slash'},
+        )
+
+        vagrantfile = (temp_dir / 'vagrant' / 'dd-vagrant-glusterfs-py3.12' / 'Vagrantfile').read_text()
+        # Non-interpolating Ruby heredocs keep the values from being expanded by Ruby
+        assert "<<-'SHELL'" in vagrantfile
+        assert "<<-'SCRIPT'" in vagrantfile
+        # …and the value is quoted and escaped per systemd EnvironmentFile syntax
+        assert 'DD_TEST="a $HOME $(pwd) `pwd` \\"quoted\\" back\\\\slash"' in vagrantfile
+        # The service is restarted after the EnvironmentFile is written so a process
+        # already started by the install script also receives the variables
+        assert 'sudo service datadog-agent restart' in vagrantfile
+
     @pytest.mark.parametrize(
         'guest_os, expected_systemd_env_vars_str',
         [


### PR DESCRIPTION
### What does this PR do?

Fixes a pre-existing bug in the Vagrant E2E Agent backend: the environment variables prepared by `VagrantAgent._prepare_exported_env_vars` (`DD_API_KEY`, `DD_APM_ENABLED`, `DD_TELEMETRY_ENABLED`, `DD_EXPVAR_PORT`, proxy settings, and any user-provided env vars) were only rendered into `/etc/profile.d/myvars.sh` by `Vagrantfile.template`. The Agent, however, is started as a systemd service, and systemd services do not source login-shell profile scripts, so the Agent process never received any of them.

The variables are now also persisted in `/etc/datadog-agent/environment` — the `EnvironmentFile` shipped with the `datadog-agent` systemd unit — and the service is explicitly restarted after the file is written (the install script may already have started the Agent, and `service start` on an active unit is a no-op). Values are preserved literally through every rendering layer: the provisioning heredocs use non-interpolating Ruby delimiters, the shell heredoc is quoted, and each value is quoted and escaped per systemd `EnvironmentFile` syntax. The file is only generated for Linux guests, since Windows guests have no systemd.

### Motivation

Spotted while reviewing #25050: that PR disables agent telemetry by setting `DD_AGENT_TELEMETRY_ENABLED` for E2E agents, but for the Vagrant backend the variable would silently have no effect for the same reason. Since the propagation bug is pre-existing and affects every exported variable, the fix is extracted into this separate PR; #25050 can drop its copy of this hunk and rebase.

Note that a few variables were previously masked: the Agent install script is invoked in a shell that sources `myvars.sh`, and `install_script_agent7.sh` translates `DD_API_KEY`, `DD_HOSTNAME`, and `DD_SITE` into `datadog.yaml`. Everything else (e.g. `DD_LOGS_ENABLED`, `DD_APM_ENABLED`, `DD_TELEMETRY_ENABLED`, `DD_EXPVAR_PORT`, `DD_DD_URL` — the script only reads `DD_URL` — and arbitrary user-provided variables) was silently dropped.

Verified end to end on a real Vagrant E2E environment (`ddev env start` with `agent_type: vagrant` for `tcp_check`), on both the default path and `--dev`:

- Before the fix, the Agent process environment (`/proc/<pid>/environ`) contained none of the exported variables: passing `-e DD_LOGS_ENABLED=true` still resulted in `logs-agent disabled`.
- After the fix, the Agent process environment contains all exported variables; `-e DD_LOGS_ENABLED=true` starts the logs agent; and a value containing shell/quote syntax (`a $HOME $(pwd) `pwd` "quoted" back\slash`) reaches the Agent process environment byte-for-byte through the Jinja render, the Ruby heredoc, the shell heredoc, and systemd `EnvironmentFile` parsing.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

---

Note: this PR description was generated by GLM-5.3 (Z.ai).
