### PR TITLE
Add AMS health probe to incident.io

### DIFF
--- a/incident_io/assets/account_config.json
+++ b/incident_io/assets/account_config.json
@@ -23,7 +23,7 @@
   ],
   "health_probe": {
     "http_method": "GET",
-    "path": "/v2/actions",
+    "path": "/v1/identity",
     "http_headers": [
       {
         "name": "Accept",

--- a/incident_io/assets/account_config.json
+++ b/incident_io/assets/account_config.json
@@ -12,5 +12,23 @@
         }
       }
     }
-  ]
+  ],
+  "supported_connection_methods": [
+    {
+      "name": "incident.io",
+      "fixed": {
+        "fixed_base_url": "https://api.incident.io"
+      }
+    }
+  ],
+  "health_probe": {
+    "http_method": "GET",
+    "path": "/v2/actions",
+    "http_headers": [
+      {
+        "name": "Accept",
+        "value": "application/json"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Impact
* If the connection checking feature works and the credentials are bad, the save still succeeds but the user gets a status/error message indicating that the credentials do not work
* If the connection checking feature works and the credentials are good, the save succeeds with no additional information
* If the connection checking feature itself is broken there will be no impact to users — they save the credentials (good or bad) with no feedback.

## What this does

Adds an AMS health probe to the incident.io integration's `assets/account_config.json` so the account service can verify the API key when a user saves an account.

The probe only runs when all three of `supported_auth_methods`, `supported_connection_methods`, and `health_probe` are present. The existing `bearer_token` auth method is unchanged; this change declares the other two:

- **`supported_connection_methods`** — a fixed base URL of `https://api.incident.io`.
- **`health_probe`** — a `GET` to `/v2/actions` with an `Accept: application/json` header. With the bearer token attached, a 2xx means the credentials are valid; a 401 means they are not.

## Backward compatibility

No field was added, renamed, or dropped. The existing `bearer_token` auth method and its `api_token` field are unchanged. This change only adds two new top-level sections.

## Testing

- [ ] The probe needs to be validated in staging before it goes to production. Specifically, `GET /v2/actions` with a valid bearer token must return a **2xx**, and with an invalid token a **401**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
