### PR TITLE
Add AMS health probe to sanity

### DIFF
--- a/sanity/assets/account_config.json
+++ b/sanity/assets/account_config.json
@@ -1,0 +1,40 @@
+{
+  "supported_auth_methods": [
+    {
+      "auth_name": "API Token",
+      "bearer_token": {
+        "password_setting": {
+          "key": "api_token",
+          "label": "API Token",
+          "help": "API token for your Sanity project.",
+          "editable": true,
+          "required": true,
+          "password": {}
+        }
+      }
+    }
+  ],
+  "supported_connection_methods": [
+    {
+      "name": "Sanity",
+      "fixed": {
+        "fixed_base_url": "https://api.sanity.io"
+      }
+    }
+  ],
+  "dataflow_config": [
+    {
+      "dataflow_id": "sanity-logs"
+    }
+  ],
+  "health_probe": {
+    "http_method": "GET",
+    "path": "/v2021-02-01/activity",
+    "http_headers": [
+      {
+        "name": "Accept",
+        "value": "application/json"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Impact
* If the connection checking feature works and the credentials are bad, the save still succeeds but the user gets a status/error message indicating that the credentials do not work
* If the connection checking feature works and the credentials are good, the save succeeds with no additional information
* If the connection checking feature itself is broken there will be no impact to users — they save the credentials (good or bad) with no feedback.

## What this does

Adds an AMS health probe to the sanity integration's `assets/account_config.json` so the account service can verify credentials when a user saves an account.

The probe only runs when all three of `supported_auth_methods`, `supported_connection_methods`, and `health_probe` are present. This change declares all three:

- **`supported_auth_methods`** — bearer token auth.
- **`supported_connection_methods`** — a fixed base URL of `https://api.sanity.io`.
- **`health_probe`** — a `GET` to `/v2021-02-01/activity` with an `Accept: application/json` header. With the auth attached, a 2xx means the credentials are valid; a 401 means they are not.

## Backward compatibility

This integration previously had no `account_config.json`; the credential fields were declared in crawler-sdk's `account_config_fields()`. The field `key` values here match exactly what the crawler reads, so existing accounts keep working unchanged.

## Testing

- [ ] The probe needs to be validated in staging before it goes to production. Specifically, `GET /v2021-02-01/activity` with valid credentials must return a **2xx**, and with invalid credentials a **401**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
