### PR TITLE
AI-7125 Model minimum-base-package as part of Dispatcher job identity

### DIFF
--- a/ddev/changelog.d/25074.added
+++ b/ddev/changelog.d/25074.added
@@ -1,0 +1,1 @@
+Add a `--minimum-base-package` option to `ddev ci dispatch-tests` that plans a minimum-base-package job alongside each test job.

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -43,6 +43,11 @@ DEFAULT_OUTPUT_DIRECTORY = ".dispatcher"
 )
 @click.option('--repo', 'repository', default=None, metavar='OWNER/NAME', help='Repository to dispatch against.')
 @click.option('--all', 'all_targets', is_flag=True, help='Test every eligible target instead of the affected ones.')
+@click.option(
+    '--minimum-base-package',
+    is_flag=True,
+    help='Also test every job against the oldest supported base package, as a second job per target.',
+)
 @click.option('--workflow', default=None, help='Workflow each batch is dispatched to.')
 @click.option('--workflow-ref', default=None, help='Ref the workflow definition is loaded from.')
 @click.option(
@@ -62,6 +67,7 @@ def dispatch_tests(
     run_context: str | None,
     repository: str | None,
     all_targets: bool,
+    minimum_base_package: bool,
     workflow: str | None,
     workflow_ref: str | None,
     output_dir: str | None,
@@ -119,6 +125,7 @@ def dispatch_tests(
         run_context=resolved_context,
         target_branch=target_branch,
         all_targets=all_targets,
+        minimum_base_package=minimum_base_package,
         environment_provider=HatchEnvironmentProvider(app.platform, config.default_python_version),
     )
     if not batches:
@@ -242,6 +249,7 @@ def build_plan(
     run_context: RunContext,
     target_branch: str | None,
     all_targets: bool,
+    minimum_base_package: bool,
     environment_provider: EnvironmentProvider,
 ) -> list[TestBatch]:
     """Build the batches this run must execute, aborting with a readable message on a bad plan.
@@ -279,6 +287,7 @@ def build_plan(
             environment_provider=environment_provider,
             config=config.batching,
             rules=rules,
+            minimum_base_package=minimum_base_package,
         )
     except PlanningError as error:
         app.abort(f'Could not build a test plan: {error}')

--- a/ddev/src/ddev/cli/ci/tests/batching/build.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/build.py
@@ -94,10 +94,8 @@ def build_test_units(
 def supports_minimum_base_package(integration: Integration) -> bool:
     """Whether testing *integration* against the minimum base package differs from a normal run.
 
-    Mirrors the condition `ddev test --compat` applies before pinning the base package version. The
-    tooling targets (`ddev`, `datadog_checks_base` and friends) are not integrations, and an
-    integration that depends on `datadog-checks-base` without pinning a version has no older version
-    to test against. For all of those `--compat` is a no-op, so a replica would rerun the same suite.
+    Mirrors the condition `ddev test --compat` applies before pinning the base package version, so a
+    target it would not pin is never replicated.
     """
     return (
         integration.is_package and integration.is_integration and integration.minimum_base_package_version is not None

--- a/ddev/src/ddev/cli/ci/tests/batching/build.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/build.py
@@ -84,10 +84,24 @@ def build_test_units(
                 platforms=tuple(platforms),
                 runners=ci_override.get("runners", {}),
                 environments=environments,
+                supports_minimum_base_package=supports_minimum_base_package(integration),
             )
         )
 
     return expand_test_units(definitions)
+
+
+def supports_minimum_base_package(integration: Integration) -> bool:
+    """Whether testing *integration* against the minimum base package differs from a normal run.
+
+    Mirrors the condition `ddev test --compat` applies before pinning the base package version. The
+    tooling targets (`ddev`, `datadog_checks_base` and friends) are not integrations, and an
+    integration that depends on `datadog-checks-base` without pinning a version has no older version
+    to test against. For all of those `--compat` is a no-op, so a replica would rerun the same suite.
+    """
+    return (
+        integration.is_package and integration.is_integration and integration.minimum_base_package_version is not None
+    )
 
 
 def build_test_batches(

--- a/ddev/src/ddev/cli/ci/tests/batching/build.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/build.py
@@ -98,6 +98,7 @@ def build_test_batches(
     config: BatchingConfig,
     strategy: BatchStrategy = default_strategy,
     rules: Sequence[TargetRule] | None = None,
+    minimum_base_package: bool = False,
 ) -> list[TestBatch]:
     """Turn changed files into the complete, ordered list of `TestBatch` messages.
 
@@ -110,7 +111,7 @@ def build_test_batches(
         environment_provider=environment_provider,
         rules=rules,
     )
-    jobs = expand_batch_jobs(units)
+    jobs = expand_batch_jobs(units, minimum_base_package=minimum_base_package)
     job_groups = strategy(jobs, config=config)
     validate_batches(job_groups, jobs, config=config)
     return create_test_batches(job_groups)

--- a/ddev/src/ddev/cli/ci/tests/batching/jobs.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/jobs.py
@@ -37,8 +37,9 @@ def expand_batch_jobs(
     every job ran against. A job with no E2E tests gets no image, so an unresolvable one can only
     fail a plan that would actually have used it.
 
-    With *minimum_base_package*, each unit also yields a replica pinned to the oldest supported base
-    package, so a run that wants that coverage plans it instead of the workflow making a second pass.
+    With *minimum_base_package*, a unit whose target supports it also yields a replica pinned to the
+    oldest supported base package, so a run that wants that coverage plans it instead of the workflow
+    making a second pass.
     """
     jobs: list[BatchJob] = []
     for unit in units:
@@ -55,8 +56,9 @@ def expand_batch_jobs(
             agent_image=_resolve_agent_image(unit, agent_image_resolver),
         )
         jobs.append(job)
-        if minimum_base_package and (replica := _minimum_base_package_replica(job)) is not None:
-            jobs.append(replica)
+        if minimum_base_package and unit.supports_minimum_base_package:
+            if (replica := _minimum_base_package_replica(job)) is not None:
+                jobs.append(replica)
 
     return jobs
 

--- a/ddev/src/ddev/cli/ci/tests/batching/jobs.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/jobs.py
@@ -5,10 +5,11 @@
 
 from __future__ import annotations
 
+import dataclasses
 from typing import TYPE_CHECKING, Protocol
 
 from ddev.cli.ci.tests.batching.exceptions import PlanningError
-from ddev.cli.ci.tests.messages import BatchJob
+from ddev.cli.ci.tests.messages import MINIMUM_BASE_PACKAGE_PREFIX, BatchJob
 from ddev.e2e.agent_images import AgentImageError, get_agent_image
 
 if TYPE_CHECKING:
@@ -28,31 +29,57 @@ def expand_batch_jobs(
     units: Sequence[TestUnit],
     *,
     agent_image_resolver: AgentImageResolver = get_agent_image,
+    minimum_base_package: bool = False,
 ) -> list[BatchJob]:
     """Expand test units into concrete jobs, one per unit, preserving order.
 
     The Agent image is resolved here rather than in the workflow so the recorded plan states what
     every job ran against. A job with no E2E tests gets no image, so an unresolvable one can only
     fail a plan that would actually have used it.
+
+    With *minimum_base_package*, each unit also yields a replica pinned to the oldest supported base
+    package, so a run that wants that coverage plans it instead of the workflow making a second pass.
     """
     jobs: list[BatchJob] = []
     for unit in units:
         environment = unit.environment
-        jobs.append(
-            BatchJob(
-                name=unit.name,
-                target=unit.target,
-                runner_labels=unit.runner_labels,
-                environment=environment.name,
-                platform=unit.platform,
-                python_version=environment.python_version,
-                unit_tests=environment.test_available,
-                e2e_tests=environment.e2e_available,
-                agent_image=_resolve_agent_image(unit, agent_image_resolver),
-            )
+        job = BatchJob(
+            name=unit.name,
+            target=unit.target,
+            runner_labels=unit.runner_labels,
+            environment=environment.name,
+            platform=unit.platform,
+            python_version=environment.python_version,
+            unit_tests=environment.test_available,
+            e2e_tests=environment.e2e_available,
+            agent_image=_resolve_agent_image(unit, agent_image_resolver),
         )
+        jobs.append(job)
+        if minimum_base_package and (replica := _minimum_base_package_replica(job)) is not None:
+            jobs.append(replica)
 
     return jobs
+
+
+def _minimum_base_package_replica(job: BatchJob) -> BatchJob | None:
+    """The minimum-base-package variant of *job*, or `None` when there is nothing for it to run.
+
+    The variant only substitutes the base package the unit tests import, so it runs no E2E tests and
+    needs no Agent image. It also runs without coverage, because measuring an old base package says
+    nothing about the coverage of the code under test. A unit-less job would therefore have no work
+    left at all, so none is planned.
+    """
+    if not job.unit_tests:
+        return None
+
+    return dataclasses.replace(
+        job,
+        name=f"{MINIMUM_BASE_PACKAGE_PREFIX}{job.name}",
+        e2e_tests=False,
+        agent_image=None,
+        minimum_base_package=True,
+        coverage=False,
+    )
 
 
 def _resolve_agent_image(unit: TestUnit, resolver: AgentImageResolver) -> str | None:

--- a/ddev/src/ddev/cli/ci/tests/batching/jobs.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/jobs.py
@@ -38,8 +38,7 @@ def expand_batch_jobs(
     fail a plan that would actually have used it.
 
     With *minimum_base_package*, a unit whose target supports it also yields a replica pinned to the
-    oldest supported base package, so a run that wants that coverage plans it instead of the workflow
-    making a second pass.
+    oldest supported base package.
     """
     jobs: list[BatchJob] = []
     for unit in units:
@@ -64,12 +63,10 @@ def expand_batch_jobs(
 
 
 def _minimum_base_package_replica(job: BatchJob) -> BatchJob | None:
-    """The minimum-base-package variant of *job*, or `None` when there is nothing for it to run.
+    """The minimum-base-package variant of *job*, or `None` when it would have nothing to run.
 
-    The variant only substitutes the base package the unit tests import, so it runs no E2E tests and
-    needs no Agent image. It also runs without coverage, because measuring an old base package says
-    nothing about the coverage of the code under test. A unit-less job would therefore have no work
-    left at all, so none is planned.
+    The variant only substitutes the base package the unit tests import, so it runs neither E2E tests
+    nor coverage, and a job without unit tests yields no variant at all.
     """
     if not job.unit_tests:
         return None

--- a/ddev/src/ddev/cli/ci/tests/batching/units.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/units.py
@@ -102,6 +102,10 @@ class TargetDefinition:
     platforms: tuple[PlatformName, ...] = (PlatformName.LINUX,)
     runners: Mapping[str, Sequence[str]] = field(default_factory=dict)
     environments: tuple[ResolvedEnvironment, ...] = ()
+    # Whether `ddev test --compat` would pin this target's base package. Resolved from the
+    # integration itself, because only a shipped integration that pins a `datadog-checks-base`
+    # version has an older one to test against.
+    supports_minimum_base_package: bool = False
 
 
 @dataclass(frozen=True)
@@ -119,6 +123,7 @@ class TestUnit:
     platform: PlatformName
     runner_labels: tuple[str, ...]
     environment: ResolvedEnvironment
+    supports_minimum_base_package: bool = False
 
 
 def normalize_job_name(job_name: str) -> str:
@@ -218,6 +223,7 @@ def expand_test_units(targets: Sequence[TargetDefinition]) -> list[TestUnit]:
                         platform=platform_id,
                         runner_labels=runner_labels,
                         environment=environment,
+                        supports_minimum_base_package=target.supports_minimum_base_package,
                     )
                 )
 

--- a/ddev/src/ddev/cli/ci/tests/batching/units.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/units.py
@@ -102,9 +102,7 @@ class TargetDefinition:
     platforms: tuple[PlatformName, ...] = (PlatformName.LINUX,)
     runners: Mapping[str, Sequence[str]] = field(default_factory=dict)
     environments: tuple[ResolvedEnvironment, ...] = ()
-    # Whether `ddev test --compat` would pin this target's base package. Resolved from the
-    # integration itself, because only a shipped integration that pins a `datadog-checks-base`
-    # version has an older one to test against.
+    # Whether `ddev test --compat` would pin this target's base package.
     supports_minimum_base_package: bool = False
 
 

--- a/ddev/src/ddev/cli/ci/tests/messages.py
+++ b/ddev/src/ddev/cli/ci/tests/messages.py
@@ -25,6 +25,9 @@ ARTIFACT_NAME_DISALLOWED = re.compile(r'["\:<>|*?\\/\r\n]')
 # Separator between the artifact name's fields. Names are matched by reconstruction, not by
 # splitting, so the separator does not need to be absent from the field values.
 ARTIFACT_NAME_SEPARATOR = "_"
+# Marks the jobs that run against the minimum supported base package. Matches the prefix
+# `test-target` gives those runs today, so artifacts stay recognizable across both paths.
+MINIMUM_BASE_PACKAGE_PREFIX = "minimum-base-package-"
 
 
 @dataclass(frozen=True)
@@ -45,15 +48,24 @@ class BatchJob:
     unit_tests: bool
     e2e_tests: bool
     agent_image: str | None = None  # `None` when the job runs no E2E tests
+    # Run against the oldest supported `datadog-checks-base` instead of the current one. Part of the
+    # job's identity: a plan can hold both variants of the same target/environment/platform, and
+    # they would otherwise share a name and an artifact and silently overwrite each other.
+    minimum_base_package: bool = False
+    # Whether the job is expected to produce a coverage report. The minimum-base-package variant
+    # runs without `--cov`, so the gatherer must not read its missing report as a lost artifact.
+    coverage: bool = True
 
     def artifact_name(self) -> str:
-        """Sanitized, deterministic name built from the job's target, environment, and platform.
+        """Sanitized, deterministic name built from the job's identity.
 
-        Those three fields are the job's identity, so the name is unique within a batch. An
-        environmentless job contributes no segment rather than an empty one.
+        Identity is target, environment, platform, and whether the job runs against the minimum base
+        package, so the name is unique within a batch. An environmentless job contributes no segment
+        rather than an empty one.
         """
         fields = (self.target, self.environment, self.platform)
-        return ARTIFACT_NAME_SEPARATOR.join(ARTIFACT_NAME_DISALLOWED.sub("_", field) for field in fields if field)
+        name = ARTIFACT_NAME_SEPARATOR.join(ARTIFACT_NAME_DISALLOWED.sub("_", field) for field in fields if field)
+        return f"{MINIMUM_BASE_PACKAGE_PREFIX}{name}" if self.minimum_base_package else name
 
 
 @dataclass

--- a/ddev/src/ddev/cli/ci/tests/messages.py
+++ b/ddev/src/ddev/cli/ci/tests/messages.py
@@ -25,8 +25,6 @@ ARTIFACT_NAME_DISALLOWED = re.compile(r'["\:<>|*?\\/\r\n]')
 # Separator between the artifact name's fields. Names are matched by reconstruction, not by
 # splitting, so the separator does not need to be absent from the field values.
 ARTIFACT_NAME_SEPARATOR = "_"
-# Marks the jobs that run against the minimum supported base package. Matches the prefix
-# `test-target` gives those runs today, so artifacts stay recognizable across both paths.
 MINIMUM_BASE_PACKAGE_PREFIX = "minimum-base-package-"
 
 
@@ -48,20 +46,15 @@ class BatchJob:
     unit_tests: bool
     e2e_tests: bool
     agent_image: str | None = None  # `None` when the job runs no E2E tests
-    # Run against the oldest supported `datadog-checks-base` instead of the current one. Part of the
-    # job's identity: a plan can hold both variants of the same target/environment/platform, and
-    # they would otherwise share a name and an artifact and silently overwrite each other.
+    # Runs against the oldest supported `datadog-checks-base` rather than the current one.
     minimum_base_package: bool = False
-    # Whether the job is expected to produce a coverage report. The minimum-base-package variant
-    # runs without `--cov`, so the gatherer must not read its missing report as a lost artifact.
-    coverage: bool = True
+    coverage: bool = True  # `False` for a job that runs without `--cov`
 
     def artifact_name(self) -> str:
         """Sanitized, deterministic name built from the job's identity.
 
-        Identity is target, environment, platform, and whether the job runs against the minimum base
-        package, so the name is unique within a batch. An environmentless job contributes no segment
-        rather than an empty one.
+        Identity is target, environment, platform and the base package variant, so the name is unique
+        within a batch. An environmentless job contributes no segment rather than an empty one.
         """
         fields = (self.target, self.environment, self.platform)
         name = ARTIFACT_NAME_SEPARATOR.join(ARTIFACT_NAME_DISALLOWED.sub("_", field) for field in fields if field)

--- a/ddev/src/ddev/cli/ci/tests/pr_comment.py
+++ b/ddev/src/ddev/cli/ci/tests/pr_comment.py
@@ -493,4 +493,6 @@ def _unavailable_count(progress: DispatcherProgress) -> int:
 
 
 def _job_label(job: JobProgress) -> str:
-    return f"{job.job.target} / {job.job.environment} / {job.job.platform}"
+    label = f"{job.job.target} / {job.job.environment} / {job.job.platform}"
+    # Only the base package variant separates a replica from its ordinary job.
+    return f"{label} / minimum base package" if job.job.minimum_base_package else label

--- a/ddev/tests/cli/ci/tests/batching/test_build.py
+++ b/ddev/tests/cli/ci/tests/batching/test_build.py
@@ -283,9 +283,11 @@ def test_build_batches_end_to_end_split_defaults():
 
 
 def test_build_batches_plans_minimum_base_package_replicas():
-    repo = FakeRepo([FakeIntegration("postgres")])
-    provider = FakeEnvironmentProvider({"postgres": [env("py3.11", unit=True, e2e=True)]})
-    changed = [modified("postgres/tests/test_a.py")]
+    # `ddev` stands in for a target `ddev test --compat` does nothing for: it is not an integration,
+    # so pinning a base package version does not apply and a replica would rerun the same suite.
+    repo = FakeRepo([FakeIntegration("postgres"), FakeIntegration("ddev", is_integration=False)])
+    provider = FakeEnvironmentProvider({"postgres": [env("py3.11", unit=True, e2e=True)], "ddev": [env("py3.11")]})
+    changed = [modified("postgres/tests/test_a.py"), modified("ddev/tests/test_b.py")]
 
     [batch] = build_test_batches(
         repo,
@@ -295,42 +297,15 @@ def test_build_batches_plans_minimum_base_package_replicas():
         minimum_base_package=True,
     )
 
-    # Both variants reach the plan, and the partition validates: the batch contract rejects
-    # duplicate job names and artifact identities, which is what the pair used to produce.
+    # Only the eligible target is replicated, and the partition validates: the batch contract rejects
+    # duplicate job names and artifact identities, which is what a replica pair used to produce.
     assert [(j.name, j.e2e_tests, j.minimum_base_package) for j in batch.job_list] == [
+        ("ddev (py3.11)", False, False),
         ("postgres (py3.11)", True, False),
         ("minimum-base-package-postgres (py3.11)", False, True),
     ]
-    assert batch.jobs_count == 2
-    assert batch.integrations == ["postgres"]
-
-
-@pytest.mark.parametrize(
-    ("attributes", "replicated"),
-    [
-        pytest.param({}, True, id="shipped-integration-with-a-pinned-base-package"),
-        pytest.param({"is_integration": False}, False, id="tooling-target-is-not-an-integration"),
-        pytest.param({"is_package": False}, False, id="tile-ships-no-package"),
-        pytest.param({"minimum_base_package_version": None}, False, id="base-package-not-pinned"),
-    ],
-)
-def test_only_targets_compat_applies_to_are_replicated(attributes, replicated):
-    # The replica exists to run against an older base package. `ddev test --compat` pins one only for
-    # a shipped integration that declares a version, so for anything else the replica would rerun the
-    # identical suite at full cost.
-    repo = FakeRepo([FakeIntegration("postgres", **attributes)])
-    provider = FakeEnvironmentProvider({"postgres": [env("py3.11")]})
-    changed = [modified("postgres/tests/test_a.py")]
-
-    [batch] = build_test_batches(
-        repo,
-        changed,
-        environment_provider=provider,
-        config=BatchingConfig(),
-        minimum_base_package=True,
-    )
-
-    assert [job.minimum_base_package for job in batch.job_list] == ([False, True] if replicated else [False])
+    assert batch.jobs_count == 3
+    assert batch.integrations == ["ddev", "postgres"]
 
 
 def test_build_batches_empty_input_returns_no_batches():

--- a/ddev/tests/cli/ci/tests/batching/test_build.py
+++ b/ddev/tests/cli/ci/tests/batching/test_build.py
@@ -282,6 +282,29 @@ def test_build_batches_end_to_end_split_defaults():
     assert batch.jobs_count == 1
 
 
+def test_build_batches_plans_minimum_base_package_replicas():
+    repo = FakeRepo([FakeIntegration("postgres")])
+    provider = FakeEnvironmentProvider({"postgres": [env("py3.11", unit=True, e2e=True)]})
+    changed = [modified("postgres/tests/test_a.py")]
+
+    [batch] = build_test_batches(
+        repo,
+        changed,
+        environment_provider=provider,
+        config=BatchingConfig(),
+        minimum_base_package=True,
+    )
+
+    # Both variants reach the plan, and the partition validates: the batch contract rejects
+    # duplicate job names and artifact identities, which is what the pair used to produce.
+    assert [(j.name, j.e2e_tests, j.minimum_base_package) for j in batch.job_list] == [
+        ("postgres (py3.11)", True, False),
+        ("minimum-base-package-postgres (py3.11)", False, True),
+    ]
+    assert batch.jobs_count == 2
+    assert batch.integrations == ["postgres"]
+
+
 def test_build_batches_empty_input_returns_no_batches():
     repo = FakeRepo([FakeIntegration("postgres")])
     provider = FakeEnvironmentProvider({"postgres": [env("py3.11")]})

--- a/ddev/tests/cli/ci/tests/batching/test_build.py
+++ b/ddev/tests/cli/ci/tests/batching/test_build.py
@@ -305,6 +305,34 @@ def test_build_batches_plans_minimum_base_package_replicas():
     assert batch.integrations == ["postgres"]
 
 
+@pytest.mark.parametrize(
+    ("attributes", "replicated"),
+    [
+        pytest.param({}, True, id="shipped-integration-with-a-pinned-base-package"),
+        pytest.param({"is_integration": False}, False, id="tooling-target-is-not-an-integration"),
+        pytest.param({"is_package": False}, False, id="tile-ships-no-package"),
+        pytest.param({"minimum_base_package_version": None}, False, id="base-package-not-pinned"),
+    ],
+)
+def test_only_targets_compat_applies_to_are_replicated(attributes, replicated):
+    # The replica exists to run against an older base package. `ddev test --compat` pins one only for
+    # a shipped integration that declares a version, so for anything else the replica would rerun the
+    # identical suite at full cost.
+    repo = FakeRepo([FakeIntegration("postgres", **attributes)])
+    provider = FakeEnvironmentProvider({"postgres": [env("py3.11")]})
+    changed = [modified("postgres/tests/test_a.py")]
+
+    [batch] = build_test_batches(
+        repo,
+        changed,
+        environment_provider=provider,
+        config=BatchingConfig(),
+        minimum_base_package=True,
+    )
+
+    assert [job.minimum_base_package for job in batch.job_list] == ([False, True] if replicated else [False])
+
+
 def test_build_batches_empty_input_returns_no_batches():
     repo = FakeRepo([FakeIntegration("postgres")])
     provider = FakeEnvironmentProvider({"postgres": [env("py3.11")]})

--- a/ddev/tests/cli/ci/tests/batching/test_build.py
+++ b/ddev/tests/cli/ci/tests/batching/test_build.py
@@ -10,6 +10,7 @@ environment provider, so neither Git nor Hatch is ever invoked.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -23,14 +24,20 @@ from ddev.cli.ci.tests.batching.build import (
 from ddev.cli.ci.tests.batching.exceptions import BatchValidationError, PlanningError
 from ddev.cli.ci.tests.dispatcher_config import BatchingConfig
 from ddev.utils.platform import PlatformName
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ddev.cli.ci.tests.batching.units import ResolvedEnvironment
+    from ddev.cli.ci.tests.messages import BatchJob
 from tests.cli.ci.tests.helpers import DEFAULT_PYTHON_VERSION, FakeIntegration, FakeRegistry, env, jobs, modified
 
 
 class FakeConfig:
-    def __init__(self, ci=None):
+    def __init__(self, ci: dict[str, dict] | None = None):
         self._ci = ci or {}
 
-    def get(self, pointer, default=None):
+    def get(self, pointer: str, default: object = None) -> object:
         prefix = "/overrides/ci/"
         if pointer.startswith(prefix):
             return self._ci.get(pointer[len(prefix) :], default)
@@ -38,7 +45,12 @@ class FakeConfig:
 
 
 class FakeRepo:
-    def __init__(self, integrations, ci=None, name="core"):
+    def __init__(
+        self,
+        integrations: Sequence[FakeIntegration],
+        ci: dict[str, dict] | None = None,
+        name: str = "core",
+    ):
         self.name = name
         self.integrations = FakeRegistry(integrations)
         self.config = FakeConfig(ci)
@@ -47,17 +59,25 @@ class FakeRepo:
 class FakeEnvironmentProvider:
     """Returns pre-configured resolved environments per integration; ignores the platforms hint."""
 
-    def __init__(self, environments):
+    def __init__(self, environments: dict[str, list[ResolvedEnvironment]]):
         self._environments = environments
 
-    def __call__(self, integration, platforms):
+    def __call__(self, integration: FakeIntegration, platforms: Sequence[PlatformName]) -> list[ResolvedEnvironment]:
         return list(self._environments.get(integration.name, []))
 
 
 class EnvStub:
     """Minimal stand-in for ddev's Hatch ``Environment`` (no Hatch invocation)."""
 
-    def __init__(self, name, *, test_env=True, e2e_env=False, platforms=(), python=None):
+    def __init__(
+        self,
+        name: str,
+        *,
+        test_env: bool = True,
+        e2e_env: bool = False,
+        platforms: Sequence[str] = (),
+        python: str | None = None,
+    ):
         self.name = name
         self.test_env = test_env
         self.e2e_env = e2e_env
@@ -96,7 +116,7 @@ def test_build_end_to_end_direct_and_broad_overlap():
     ]
 
 
-def test_build_warns_about_a_target_with_no_testable_environment(caplog):
+def test_build_warns_about_a_target_with_no_testable_environment(caplog: pytest.LogCaptureFixture):
     repo = FakeRepo([FakeIntegration("ddev")])
     provider = FakeEnvironmentProvider({})
     changed = [modified("ddev/src/ddev/foo.py")]
@@ -109,7 +129,9 @@ def test_build_warns_about_a_target_with_no_testable_environment(caplog):
     assert "ddev has a hatch.toml but no testable environment" in caplog.text
 
 
-def test_build_plans_nothing_for_a_platform_whose_environments_are_constrained_elsewhere(caplog):
+def test_build_plans_nothing_for_a_platform_whose_environments_are_constrained_elsewhere(
+    caplog: pytest.LogCaptureFixture,
+):
     # A target declaring a platform that every environment is constrained away from is a weaker
     # version of the same contradiction: odd configuration, worth surfacing, not worth failing.
     repo = FakeRepo([FakeIntegration("disk")], ci={"disk": {"platforms": ["linux", "windows"]}})
@@ -174,7 +196,7 @@ def test_resolve_hatch_environments_includes_both_facets_and_excludes_neither():
 
 
 @pytest.mark.parametrize("python", ["3", "3.13t", "/usr/bin/python3.13", "three.thirteen"])
-def test_resolve_hatch_environments_rejects_a_python_that_is_not_major_minor(python):
+def test_resolve_hatch_environments_rejects_a_python_that_is_not_major_minor(python: str):
     # A unit-only environment never reaches the Agent image resolver, so this boundary is the only
     # place its version is checked.
     environments = [EnvStub("unit-only", test_env=True, e2e_env=False, python=python)]
@@ -287,25 +309,18 @@ def test_build_batches_end_to_end_split_defaults():
     ("attributes", "supported"),
     [
         pytest.param({}, True, id="shipped-integration-pinning-a-base-package-version"),
-        # `ddev` and `datadog_checks_base` are marked `is-integration = false` in the repo config.
+        # The tooling targets are `is-integration = false` in the repository configuration.
         pytest.param({"is_integration": False}, False, id="tooling-target"),
-        # A tile ships no package, so there is nothing to install an older base package against.
         pytest.param({"is_package": False}, False, id="tile-without-a-package"),
-        # `lparstats` depends on `datadog-checks-base` with no specifier: no older version to pin.
+        # `lparstats` depends on `datadog-checks-base` without a specifier.
         pytest.param({"minimum_base_package_version": None}, False, id="base-package-not-pinned"),
     ],
 )
-def test_supports_minimum_base_package_matches_what_compat_pins(attributes, supported):
-    # Mirrors the condition `ddev test --compat` applies before setting BASE_PACKAGE_VERSION. Getting
-    # it wrong either replicates targets whose replica reruns the same suite, or silently drops the
-    # replica for every real integration.
+def test_supports_minimum_base_package_matches_what_compat_pins(attributes: dict, supported: bool):
     assert supports_minimum_base_package(FakeIntegration("postgres", **attributes)) is supported
 
 
 def test_build_batches_plans_minimum_base_package_replicas():
-    # Wiring: the flag reaches expansion, eligibility is read off each integration, and the resulting
-    # partition validates. The batch contract rejects duplicate job names and artifact identities,
-    # which is exactly what a replica pair produced before the variant became part of job identity.
     repo = FakeRepo([FakeIntegration("postgres"), FakeIntegration("ddev", is_integration=False)])
     provider = FakeEnvironmentProvider({"postgres": [env("py3.11", unit=True, e2e=True)], "ddev": [env("py3.11")]})
     changed = [modified("postgres/tests/test_a.py"), modified("ddev/tests/test_b.py")]
@@ -348,7 +363,7 @@ def test_build_batches_rejects_invalid_injected_strategy():
     provider = FakeEnvironmentProvider({"postgres": [env("py3.11"), env("py3.12")]})
     changed = [modified("postgres/tests/test_a.py")]
 
-    def dropping_strategy(jobs, *, config):
+    def dropping_strategy(jobs: Sequence[BatchJob], *, config: BatchingConfig) -> list[list[BatchJob]]:
         return [list(jobs[:-1])]  # loses the last job
 
     with pytest.raises(BatchValidationError, match="exactly once"):
@@ -405,7 +420,7 @@ def test_build_only_expands_the_whole_repository_for_the_core_repo():
     provider = FakeEnvironmentProvider({"postgres": [env("py3.11")], "datadog_checks_base": [env("py3.11")]})
     changed = [modified("datadog_checks_base/datadog_checks/base/utils/foo.py")]
 
-    def targets(repo):
+    def targets(repo: FakeRepo) -> set[str]:
         return {u.target for u in build_test_units(repo, changed, environment_provider=provider)}
 
     assert targets(FakeRepo(integrations)) == {"postgres", "datadog_checks_base"}

--- a/ddev/tests/cli/ci/tests/batching/test_build.py
+++ b/ddev/tests/cli/ci/tests/batching/test_build.py
@@ -18,6 +18,7 @@ from ddev.cli.ci.tests.batching.build import (
     build_test_units,
     create_test_batches,
     resolve_hatch_environments,
+    supports_minimum_base_package,
 )
 from ddev.cli.ci.tests.batching.exceptions import BatchValidationError, PlanningError
 from ddev.cli.ci.tests.dispatcher_config import BatchingConfig
@@ -282,9 +283,29 @@ def test_build_batches_end_to_end_split_defaults():
     assert batch.jobs_count == 1
 
 
+@pytest.mark.parametrize(
+    ("attributes", "supported"),
+    [
+        pytest.param({}, True, id="shipped-integration-pinning-a-base-package-version"),
+        # `ddev` and `datadog_checks_base` are marked `is-integration = false` in the repo config.
+        pytest.param({"is_integration": False}, False, id="tooling-target"),
+        # A tile ships no package, so there is nothing to install an older base package against.
+        pytest.param({"is_package": False}, False, id="tile-without-a-package"),
+        # `lparstats` depends on `datadog-checks-base` with no specifier: no older version to pin.
+        pytest.param({"minimum_base_package_version": None}, False, id="base-package-not-pinned"),
+    ],
+)
+def test_supports_minimum_base_package_matches_what_compat_pins(attributes, supported):
+    # Mirrors the condition `ddev test --compat` applies before setting BASE_PACKAGE_VERSION. Getting
+    # it wrong either replicates targets whose replica reruns the same suite, or silently drops the
+    # replica for every real integration.
+    assert supports_minimum_base_package(FakeIntegration("postgres", **attributes)) is supported
+
+
 def test_build_batches_plans_minimum_base_package_replicas():
-    # `ddev` stands in for a target `ddev test --compat` does nothing for: it is not an integration,
-    # so pinning a base package version does not apply and a replica would rerun the same suite.
+    # Wiring: the flag reaches expansion, eligibility is read off each integration, and the resulting
+    # partition validates. The batch contract rejects duplicate job names and artifact identities,
+    # which is exactly what a replica pair produced before the variant became part of job identity.
     repo = FakeRepo([FakeIntegration("postgres"), FakeIntegration("ddev", is_integration=False)])
     provider = FakeEnvironmentProvider({"postgres": [env("py3.11", unit=True, e2e=True)], "ddev": [env("py3.11")]})
     changed = [modified("postgres/tests/test_a.py"), modified("ddev/tests/test_b.py")]
@@ -297,15 +318,12 @@ def test_build_batches_plans_minimum_base_package_replicas():
         minimum_base_package=True,
     )
 
-    # Only the eligible target is replicated, and the partition validates: the batch contract rejects
-    # duplicate job names and artifact identities, which is what a replica pair used to produce.
-    assert [(j.name, j.e2e_tests, j.minimum_base_package) for j in batch.job_list] == [
-        ("ddev (py3.11)", False, False),
-        ("postgres (py3.11)", True, False),
-        ("minimum-base-package-postgres (py3.11)", False, True),
+    assert [(j.name, j.minimum_base_package) for j in batch.job_list] == [
+        ("ddev (py3.11)", False),
+        ("postgres (py3.11)", False),
+        ("minimum-base-package-postgres (py3.11)", True),
     ]
     assert batch.jobs_count == 3
-    assert batch.integrations == ["ddev", "postgres"]
 
 
 def test_build_batches_empty_input_returns_no_batches():

--- a/ddev/tests/cli/ci/tests/batching/test_jobs.py
+++ b/ddev/tests/cli/ci/tests/batching/test_jobs.py
@@ -113,18 +113,9 @@ def test_no_replica_for_a_job_that_runs_no_unit_tests():
     assert len(jobs) == 1
 
 
-def test_no_replica_for_a_target_that_does_not_support_it():
+def test_only_units_whose_target_supports_it_are_replicated():
     # `ddev test --compat` only pins the base package for a shipped integration that declares a
     # version, so replicating anything else (`ddev`, `datadog_checks_base`) reruns the same suite.
-    units = [make_unit("ddev", environment=env("py3.13"), supports_minimum_base_package=False)]
-
-    jobs = expand_batch_jobs(units, agent_image_resolver=fake_resolver, minimum_base_package=True)
-
-    assert len(jobs) == 1
-    assert not jobs[0].minimum_base_package
-
-
-def test_only_supporting_targets_are_replicated_in_a_mixed_plan():
     units = [
         make_unit("postgres", name="postgres", environment=env("py3.13")),
         make_unit("ddev", name="ddev", environment=env("py3.13"), supports_minimum_base_package=False),

--- a/ddev/tests/cli/ci/tests/batching/test_jobs.py
+++ b/ddev/tests/cli/ci/tests/batching/test_jobs.py
@@ -113,6 +113,32 @@ def test_no_replica_for_a_job_that_runs_no_unit_tests():
     assert len(jobs) == 1
 
 
+def test_no_replica_for_a_target_that_does_not_support_it():
+    # `ddev test --compat` only pins the base package for a shipped integration that declares a
+    # version, so replicating anything else (`ddev`, `datadog_checks_base`) reruns the same suite.
+    units = [make_unit("ddev", environment=env("py3.13"), supports_minimum_base_package=False)]
+
+    jobs = expand_batch_jobs(units, agent_image_resolver=fake_resolver, minimum_base_package=True)
+
+    assert len(jobs) == 1
+    assert not jobs[0].minimum_base_package
+
+
+def test_only_supporting_targets_are_replicated_in_a_mixed_plan():
+    units = [
+        make_unit("postgres", name="postgres", environment=env("py3.13")),
+        make_unit("ddev", name="ddev", environment=env("py3.13"), supports_minimum_base_package=False),
+    ]
+
+    jobs = expand_batch_jobs(units, agent_image_resolver=fake_resolver, minimum_base_package=True)
+
+    assert [(job.target, job.minimum_base_package) for job in jobs] == [
+        ("postgres", False),
+        ("postgres", True),
+        ("ddev", False),
+    ]
+
+
 def test_multiple_units_expand_in_order_one_job_each():
     units = [
         make_unit(name="postgres (py3.11)", environment=env("py3.11")),

--- a/ddev/tests/cli/ci/tests/batching/test_jobs.py
+++ b/ddev/tests/cli/ci/tests/batching/test_jobs.py
@@ -94,28 +94,36 @@ def test_minimum_base_package_replica_is_planned_alongside_the_job():
     assert replica.artifact_name() != original.artifact_name()
 
 
-def test_jobs_are_not_replicated_by_default():
-    # A run that does not ask for it pays nothing: testing against a given Agent image, for one, has
-    # a single base package version available and so has no second variant to run.
-    units = [make_unit(environment=env("py3.13"))]
+@pytest.mark.parametrize(
+    ("requested", "supported", "unit", "replicated"),
+    [
+        pytest.param(True, True, True, True, id="requested-and-eligible"),
+        # Nothing asked for it: a run testing against a given Agent image has one base package
+        # version available, so it has no second variant to run and should pay nothing.
+        pytest.param(False, True, True, False, id="not-requested"),
+        # `ddev test --compat` pins the base package only for a shipped integration that declares a
+        # version. For anything else it is a no-op, so the replica would rerun the same suite.
+        pytest.param(True, False, True, False, id="target-does-not-support-it"),
+        # Only unit tests import the base package, so an E2E-only job's replica has no work.
+        pytest.param(True, True, False, False, id="job-runs-no-unit-tests"),
+    ],
+)
+def test_a_replica_is_planned_only_when_requested_and_the_job_can_use_one(requested, supported, unit, replicated):
+    units = [
+        make_unit(
+            environment=env("py3.13", unit=unit, e2e=not unit),
+            supports_minimum_base_package=supported,
+        )
+    ]
 
-    jobs = expand_batch_jobs(units, agent_image_resolver=fake_resolver)
+    jobs = expand_batch_jobs(units, agent_image_resolver=fake_resolver, minimum_base_package=requested)
 
-    assert [job.minimum_base_package for job in jobs] == [False]
-
-
-def test_no_replica_for_a_job_that_runs_no_unit_tests():
-    # Only unit tests import the base package, so an E2E-only job's replica would run nothing.
-    units = [make_unit(environment=env("py3.13", unit=False, e2e=True))]
-
-    jobs = expand_batch_jobs(units, agent_image_resolver=fake_resolver, minimum_base_package=True)
-
-    assert len(jobs) == 1
+    assert [job.minimum_base_package for job in jobs] == ([False, True] if replicated else [False])
 
 
-def test_only_units_whose_target_supports_it_are_replicated():
-    # `ddev test --compat` only pins the base package for a shipped integration that declares a
-    # version, so replicating anything else (`ddev`, `datadog_checks_base`) reruns the same suite.
+def test_a_replica_is_planned_per_eligible_unit_leaving_the_others_alone():
+    # The decision is per unit, so a mixed plan replicates only the eligible ones and keeps every
+    # job's position: the pair is adjacent, and an ineligible target contributes one job.
     units = [
         make_unit("postgres", name="postgres", environment=env("py3.13")),
         make_unit("ddev", name="ddev", environment=env("py3.13"), supports_minimum_base_package=False),

--- a/ddev/tests/cli/ci/tests/batching/test_jobs.py
+++ b/ddev/tests/cli/ci/tests/batching/test_jobs.py
@@ -27,7 +27,7 @@ def fake_resolver(python_version: str, platform: PlatformName) -> str:
         pytest.param("", True, False, id="environmentless"),
     ],
 )
-def test_each_environment_becomes_one_job_carrying_its_facets(environment_name, unit, e2e):
+def test_each_environment_becomes_one_job_carrying_its_facets(environment_name: str, unit: bool, e2e: bool):
     units = [make_unit(environment=env(environment_name, unit=unit, e2e=e2e))]
 
     [job] = expand_batch_jobs(units, agent_image_resolver=fake_resolver)
@@ -82,14 +82,11 @@ def test_runner_labels_and_platform_are_preserved():
 def test_minimum_base_package_replica_is_planned_alongside_the_job():
     units = [make_unit("postgres", name="postgres (py3.13)", environment=env("py3.13", unit=True, e2e=True))]
 
-    jobs = expand_batch_jobs(units, agent_image_resolver=fake_resolver, minimum_base_package=True)
+    original, replica = expand_batch_jobs(units, agent_image_resolver=fake_resolver, minimum_base_package=True)
 
-    original, replica = jobs
-    # The replica substitutes the base package the unit tests import, so it runs unit tests only and
-    # needs no Agent image. Distinct name and artifact identity are what keep the pair's workflow
-    # correlation and downloaded artifacts from collapsing onto each other.
     assert (replica.unit_tests, replica.e2e_tests, replica.agent_image) == (True, False, None)
     assert replica.minimum_base_package and not replica.coverage
+    # A distinct name and artifact keep the pair from colliding in job correlation and on disk.
     assert replica.name != original.name
     assert replica.artifact_name() != original.artifact_name()
 
@@ -98,17 +95,15 @@ def test_minimum_base_package_replica_is_planned_alongside_the_job():
     ("requested", "supported", "unit", "replicated"),
     [
         pytest.param(True, True, True, True, id="requested-and-eligible"),
-        # Nothing asked for it: a run testing against a given Agent image has one base package
-        # version available, so it has no second variant to run and should pay nothing.
         pytest.param(False, True, True, False, id="not-requested"),
-        # `ddev test --compat` pins the base package only for a shipped integration that declares a
-        # version. For anything else it is a no-op, so the replica would rerun the same suite.
         pytest.param(True, False, True, False, id="target-does-not-support-it"),
         # Only unit tests import the base package, so an E2E-only job's replica has no work.
         pytest.param(True, True, False, False, id="job-runs-no-unit-tests"),
     ],
 )
-def test_a_replica_is_planned_only_when_requested_and_the_job_can_use_one(requested, supported, unit, replicated):
+def test_a_replica_is_planned_only_when_requested_and_the_job_can_use_one(
+    requested: bool, supported: bool, unit: bool, replicated: bool
+):
     units = [
         make_unit(
             environment=env("py3.13", unit=unit, e2e=not unit),
@@ -122,8 +117,6 @@ def test_a_replica_is_planned_only_when_requested_and_the_job_can_use_one(reques
 
 
 def test_a_replica_is_planned_per_eligible_unit_leaving_the_others_alone():
-    # The decision is per unit, so a mixed plan replicates only the eligible ones and keeps every
-    # job's position: the pair is adjacent, and an ineligible target contributes one job.
     units = [
         make_unit("postgres", name="postgres", environment=env("py3.13")),
         make_unit("ddev", name="ddev", environment=env("py3.13"), supports_minimum_base_package=False),

--- a/ddev/tests/cli/ci/tests/batching/test_jobs.py
+++ b/ddev/tests/cli/ci/tests/batching/test_jobs.py
@@ -79,6 +79,40 @@ def test_runner_labels_and_platform_are_preserved():
     assert (job.runner_labels, job.platform) == (("windows-2022", "x-large"), PlatformName.WINDOWS)
 
 
+def test_minimum_base_package_replica_is_planned_alongside_the_job():
+    units = [make_unit("postgres", name="postgres (py3.13)", environment=env("py3.13", unit=True, e2e=True))]
+
+    jobs = expand_batch_jobs(units, agent_image_resolver=fake_resolver, minimum_base_package=True)
+
+    original, replica = jobs
+    # The replica substitutes the base package the unit tests import, so it runs unit tests only and
+    # needs no Agent image. Distinct name and artifact identity are what keep the pair's workflow
+    # correlation and downloaded artifacts from collapsing onto each other.
+    assert (replica.unit_tests, replica.e2e_tests, replica.agent_image) == (True, False, None)
+    assert replica.minimum_base_package and not replica.coverage
+    assert replica.name != original.name
+    assert replica.artifact_name() != original.artifact_name()
+
+
+def test_jobs_are_not_replicated_by_default():
+    # A run that does not ask for it pays nothing: testing against a given Agent image, for one, has
+    # a single base package version available and so has no second variant to run.
+    units = [make_unit(environment=env("py3.13"))]
+
+    jobs = expand_batch_jobs(units, agent_image_resolver=fake_resolver)
+
+    assert [job.minimum_base_package for job in jobs] == [False]
+
+
+def test_no_replica_for_a_job_that_runs_no_unit_tests():
+    # Only unit tests import the base package, so an E2E-only job's replica would run nothing.
+    units = [make_unit(environment=env("py3.13", unit=False, e2e=True))]
+
+    jobs = expand_batch_jobs(units, agent_image_resolver=fake_resolver, minimum_base_package=True)
+
+    assert len(jobs) == 1
+
+
 def test_multiple_units_expand_in_order_one_job_each():
     units = [
         make_unit(name="postgres (py3.11)", environment=env("py3.11")),

--- a/ddev/tests/cli/ci/tests/batching/test_units.py
+++ b/ddev/tests/cli/ci/tests/batching/test_units.py
@@ -129,6 +129,27 @@ def test_expand_carries_the_environment_python_version():
     assert expand_test_units(targets)[0].environment.python_version == "3.11"
 
 
+def test_expand_carries_minimum_base_package_support_to_every_unit():
+    # Resolved once per target from its integration, then read per unit when jobs are expanded. If it
+    # were dropped here, no replica would ever be planned and the flag would silently do nothing.
+    targets = [
+        TargetDefinition(
+            "postgres",
+            environments=(env("py3.11"), env("py3.12")),
+            supports_minimum_base_package=True,
+        ),
+        TargetDefinition("ddev", environments=(env("py3.11"),)),
+    ]
+
+    units = expand_test_units(targets)
+
+    assert [(unit.target, unit.supports_minimum_base_package) for unit in units] == [
+        ("ddev", False),
+        ("postgres", True),
+        ("postgres", True),
+    ]
+
+
 def test_expand_multi_label_runner_is_a_single_selection():
     units = expand_test_units(
         [TargetDefinition("postgres", runners={"linux": ["label-a", "label-b"]}, environments=(env("postgres"),))]

--- a/ddev/tests/cli/ci/tests/batching/test_units.py
+++ b/ddev/tests/cli/ci/tests/batching/test_units.py
@@ -26,7 +26,7 @@ from tests.cli.ci.tests.helpers import env
         pytest.param('My Integration', 'My Integration', id="allowed-unchanged"),
     ],
 )
-def test_normalize_job_name(raw, expected):
+def test_normalize_job_name(raw: str, expected: str):
     assert normalize_job_name(raw) == expected
 
 
@@ -43,12 +43,12 @@ def test_normalize_job_name(raw, expected):
         pytest.param([], ["AIX"], [PlatformName.LINUX], id="only-untestable-os-defaults-linux"),
     ],
 )
-def test_resolve_platforms(platform_override, supported_os, expected):
+def test_resolve_platforms(platform_override: list[str], supported_os: list[str], expected: list[PlatformName]):
     assert resolve_platforms(platform_override, supported_os, target="postgres") == expected
 
 
 @pytest.mark.parametrize("value", ["solaris", "Windows Server"])
-def test_resolve_platforms_rejects_an_unknown_platform_in_the_override(value):
+def test_resolve_platforms_rejects_an_unknown_platform_in_the_override(value: list[str]):
     with pytest.raises(PlanningError, match="Unsupported platform for `postgres`"):
         resolve_platforms([value], [], target="postgres")
 
@@ -103,7 +103,7 @@ def test_expand_rejects_a_target_with_no_environments():
         expand_test_units([TargetDefinition("postgres")])
 
 
-def test_expand_warns_and_plans_nothing_for_a_platform_no_environment_covers(caplog):
+def test_expand_warns_and_plans_nothing_for_a_platform_no_environment_covers(caplog: pytest.LogCaptureFixture):
     target = TargetDefinition(
         "sqlserver",
         platforms=(PlatformName.LINUX, PlatformName.WINDOWS),
@@ -130,8 +130,6 @@ def test_expand_carries_the_environment_python_version():
 
 
 def test_expand_carries_minimum_base_package_support_to_every_unit():
-    # Resolved once per target from its integration, then read per unit when jobs are expanded. If it
-    # were dropped here, no replica would ever be planned and the flag would silently do nothing.
     targets = [
         TargetDefinition(
             "postgres",

--- a/ddev/tests/cli/ci/tests/helpers.py
+++ b/ddev/tests/cli/ci/tests/helpers.py
@@ -77,6 +77,8 @@ def make_job(
     unit_tests: bool = True,
     e2e_tests: bool = False,
     agent_image: str | None = None,
+    minimum_base_package: bool = False,
+    coverage: bool = True,
 ) -> BatchJob:
     return BatchJob(
         name=name,
@@ -88,6 +90,8 @@ def make_job(
         unit_tests=unit_tests,
         e2e_tests=e2e_tests,
         agent_image=agent_image,
+        minimum_base_package=minimum_base_package,
+        coverage=coverage,
     )
 
 

--- a/ddev/tests/cli/ci/tests/helpers.py
+++ b/ddev/tests/cli/ci/tests/helpers.py
@@ -56,6 +56,7 @@ def make_unit(
     platform: PlatformName = PlatformName.LINUX,
     runner_labels: tuple[str, ...] = DEFAULT_RUNNER_LABELS,
     environment: ResolvedEnvironment | None = None,
+    supports_minimum_base_package: bool = True,
 ) -> TestUnit:
     return TestUnit(
         target=target,
@@ -63,6 +64,7 @@ def make_unit(
         platform=platform,
         runner_labels=runner_labels,
         environment=environment if environment is not None else env(target, platform),
+        supports_minimum_base_package=supports_minimum_base_package,
     )
 
 
@@ -130,11 +132,17 @@ class FakeIntegration:
         is_testable: bool = True,
         display_name: str | None = None,
         classifier_tags: Sequence[str] = (),
+        is_package: bool = True,
+        is_integration: bool = True,
+        minimum_base_package_version: str | None = "37.0.0",
     ):
         self.name = name
         self.is_testable = is_testable
         self.display_name = display_name or name
         self.manifest = FakeManifest(classifier_tags)
+        self.is_package = is_package
+        self.is_integration = is_integration
+        self.minimum_base_package_version = minimum_base_package_version
 
 
 class FakeRegistry:

--- a/ddev/tests/cli/ci/tests/helpers.py
+++ b/ddev/tests/cli/ci/tests/helpers.py
@@ -118,7 +118,7 @@ class FakeManifest:
     def __init__(self, classifier_tags: Sequence[str] = ()):
         self._classifier_tags = list(classifier_tags)
 
-    def get(self, pointer, default=None):
+    def get(self, pointer: str, default: object = None) -> object:
         if pointer == "/tile/classifier_tags":
             return list(self._classifier_tags)
         return default

--- a/ddev/tests/cli/ci/tests/helpers.py
+++ b/ddev/tests/cli/ci/tests/helpers.py
@@ -208,10 +208,20 @@ TOTAL_JOBS = 10
 
 
 def batch_job(
-    target: str = "redis", environment: str = "py3.12", platform: PlatformName = PlatformName.LINUX
+    target: str = "redis",
+    environment: str = "py3.12",
+    platform: PlatformName = PlatformName.LINUX,
+    *,
+    minimum_base_package: bool = False,
 ) -> BatchJob:
-    """A job as the renderer sees it. Only target, environment and platform reach the output."""
-    return make_job(f"{target}-{environment}-{platform}", target=target, environment=environment, platform=platform)
+    """A job as the renderer sees it: only its identity fields reach the output."""
+    return make_job(
+        f"{target}-{environment}-{platform}",
+        target=target,
+        environment=environment,
+        platform=platform,
+        minimum_base_package=minimum_base_package,
+    )
 
 
 def failing_report(*test_names: str) -> JUnitReport:
@@ -256,8 +266,16 @@ def attempt(
     )
 
 
-def job_progress(*attempts: JobAttemptProgress, target: str = "redis", environment: str = "py3.12") -> JobProgress:
-    return JobProgress(job=batch_job(target=target, environment=environment), attempts=attempts)
+def job_progress(
+    *attempts: JobAttemptProgress,
+    target: str = "redis",
+    environment: str = "py3.12",
+    minimum_base_package: bool = False,
+) -> JobProgress:
+    return JobProgress(
+        job=batch_job(target=target, environment=environment, minimum_base_package=minimum_base_package),
+        attempts=attempts,
+    )
 
 
 def batch_progress(

--- a/ddev/tests/cli/ci/tests/test_messages.py
+++ b/ddev/tests/cli/ci/tests/test_messages.py
@@ -26,9 +26,7 @@ def test_artifact_name_built_from_target_env_platform():
 
 @pytest.mark.parametrize("field", ["name", "runner_labels", "unit_tests", "e2e_tests", "coverage"])
 def test_artifact_name_ignores_non_identifying_fields(field: str):
-    # The artifact identity is target + environment + platform + minimum_base_package; name/runner
-    # and the facet flags are not part of it (a single job carries its facets, so facets never
-    # distinguish two jobs, and coverage follows from the base package variant rather than naming it).
+    # A single job carries both facets, so no facet flag distinguishes two jobs.
     changed = {
         "name": "other-job",
         "runner_labels": ("windows-latest",),
@@ -48,7 +46,7 @@ def test_artifact_name_ignores_non_identifying_fields(field: str):
         ("minimum_base_package", True),
     ],
 )
-def test_artifact_name_varies_with_identifying_fields(field, value):
+def test_artifact_name_varies_with_identifying_fields(field: str, value: str | PlatformName | bool):
     assert make_job(**{field: value}).artifact_name() != make_job().artifact_name()
 
 

--- a/ddev/tests/cli/ci/tests/test_messages.py
+++ b/ddev/tests/cli/ci/tests/test_messages.py
@@ -24,17 +24,29 @@ def test_artifact_name_built_from_target_env_platform():
     assert make_job().artifact_name() == "ntp_py3.13_linux"
 
 
-@pytest.mark.parametrize("field", ["name", "runner_labels", "unit_tests", "e2e_tests"])
+@pytest.mark.parametrize("field", ["name", "runner_labels", "unit_tests", "e2e_tests", "coverage"])
 def test_artifact_name_ignores_non_identifying_fields(field: str):
-    # The artifact identity is target + environment + platform; name/runner/facet flags are not part
-    # of it (a single job carries its facets, so facets never distinguish two jobs).
-    changed = {"name": "other-job", "runner_labels": ("windows-latest",), "unit_tests": False, "e2e_tests": True}[field]
+    # The artifact identity is target + environment + platform + minimum_base_package; name/runner
+    # and the facet flags are not part of it (a single job carries its facets, so facets never
+    # distinguish two jobs, and coverage follows from the base package variant rather than naming it).
+    changed = {
+        "name": "other-job",
+        "runner_labels": ("windows-latest",),
+        "unit_tests": False,
+        "e2e_tests": True,
+        "coverage": False,
+    }[field]
     assert make_job(**{field: changed}).artifact_name() == make_job().artifact_name()
 
 
 @pytest.mark.parametrize(
     ("field", "value"),
-    [("target", "kafka"), ("environment", "py3.12"), ("platform", PlatformName.WINDOWS)],
+    [
+        ("target", "kafka"),
+        ("environment", "py3.12"),
+        ("platform", PlatformName.WINDOWS),
+        ("minimum_base_package", True),
+    ],
 )
 def test_artifact_name_varies_with_identifying_fields(field, value):
     assert make_job(**{field: value}).artifact_name() != make_job().artifact_name()

--- a/ddev/tests/cli/ci/tests/test_pr_comment.py
+++ b/ddev/tests/cli/ci/tests/test_pr_comment.py
@@ -425,6 +425,21 @@ def test_job_level_error_is_reported_against_the_job():
     assert "redis / py3.12 / linux</code> — no artifacts" in body
 
 
+def test_a_replica_is_distinguishable_from_its_ordinary_job():
+    # The pair shares target, environment and platform, so without the variant a reader cannot tell
+    # which of the two failed.
+    ordinary = job_progress(attempt(Status.FAILURE, failed_steps=("Run unit tests",)))
+    replica = job_progress(attempt(Status.FAILURE, failed_steps=("Run unit tests",)), minimum_base_package=True)
+    progress = DispatcherProgress(
+        batches=(batch_progress("batch-01", ordinary, replica, status=Status.FAILURE),), done=True
+    )
+
+    body = render_comment(progress)
+
+    assert "<code> redis / py3.12 / linux </code>" in body
+    assert "<code> redis / py3.12 / linux / minimum base package </code>" in body
+
+
 # ---------------------------------------------------------------------------
 # Safety: escaping, structure, budget, degenerate input
 # ---------------------------------------------------------------------------

--- a/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
@@ -375,11 +375,9 @@ def test_same_integration_different_platforms_do_not_overwrite(tmp_path: Path):
 
 
 def test_minimum_base_package_replica_organizes_beside_its_original(tmp_path: Path):
-    # The pair shares target, environment and platform, so before the variant became part of the
-    # job's identity both wrote the same output files and one silently replaced the other.
+    # The pair shares target, environment and platform, so only the variant separates their output.
     artifacts = tmp_path / "artifacts" / "100"
     original_dir = _make_job_tree(artifacts, "ntp-job", e2e=False)
-    # The replica runs without `--cov`, so its bundle legitimately carries no coverage report.
     replica_dir = _make_job_tree(artifacts, "minimum-base-package-ntp-job", coverage=False, e2e=False)
 
     original = _batch_job("ntp (py3.13)")
@@ -404,8 +402,7 @@ def test_minimum_base_package_replica_organizes_beside_its_original(tmp_path: Pa
     assert (test_results_dir / "ntp_py3.13_linux-test-unit-py3.13.xml").is_file()
     assert (test_results_dir / "minimum-base-package-ntp_py3.13_linux-test-unit-py3.13.xml").is_file()
 
-    # The replica produces no coverage, and its absence is not an error: only the original's file
-    # is published, and both jobs still report a result.
+    # The replica reports no coverage, and its absence is not a lost artifact.
     coverage_files = sorted(path.name for path in (tmp_path / "out" / "coverage").iterdir())
     assert coverage_files == ["ntp_py3.13_linux.xml"]
 

--- a/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
@@ -374,6 +374,45 @@ def test_same_integration_different_platforms_do_not_overwrite(tmp_path: Path):
     assert (coverage_dir / "ntp_py3.13_windows.xml").is_file()
 
 
+def test_minimum_base_package_replica_organizes_beside_its_original(tmp_path: Path):
+    # The pair shares target, environment and platform, so before the variant became part of the
+    # job's identity both wrote the same output files and one silently replaced the other.
+    artifacts = tmp_path / "artifacts" / "100"
+    original_dir = _make_job_tree(artifacts, "ntp-job", e2e=False)
+    # The replica runs without `--cov`, so its bundle legitimately carries no coverage report.
+    replica_dir = _make_job_tree(artifacts, "minimum-base-package-ntp-job", coverage=False, e2e=False)
+
+    original = _batch_job("ntp (py3.13)")
+    replica = make_job(
+        "minimum-base-package-ntp (py3.13)",
+        target="ntp",
+        minimum_base_package=True,
+        coverage=False,
+    )
+    gatherer = _make_gatherer(tmp_path, {"batch-1": [original, replica]})
+    gatherer.process_message(
+        _batch_finished(
+            artifacts,
+            batch_jobs=[
+                _batch_job_result(original, _workflow_job(original.name, "success"), original_dir),
+                _batch_job_result(replica, _workflow_job(replica.name, "success"), replica_dir),
+            ],
+        )
+    )
+
+    test_results_dir = tmp_path / "out" / "test_results"
+    assert (test_results_dir / "ntp_py3.13_linux-test-unit-py3.13.xml").is_file()
+    assert (test_results_dir / "minimum-base-package-ntp_py3.13_linux-test-unit-py3.13.xml").is_file()
+
+    # The replica produces no coverage, and its absence is not an error: only the original's file
+    # is published, and both jobs still report a result.
+    coverage_files = sorted(path.name for path in (tmp_path / "out" / "coverage").iterdir())
+    assert coverage_files == ["ntp_py3.13_linux.xml"]
+
+    [status] = _registry(gatherer)
+    assert (status.success_count, status.failed_count) == (2, 0)
+
+
 def test_combined_job_unit_and_e2e_outputs_coexist(tmp_path: Path):
     # One job carries both facets (unit_tests and e2e_tests). Its bundle holds both a unit and an
     # E2E JUnit report plus coverage; the organized outputs are distinguished by filename within

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -213,6 +213,8 @@ async def test_dispatches_workflow_with_job_list_payload(tmp_path: Path):
                         "unit_tests": True,
                         "e2e_tests": False,
                         "agent_image": None,
+                        "minimum_base_package": False,
+                        "coverage": True,
                         "artifact_name": "ntp_py3.13_linux",
                     },
                     {
@@ -225,6 +227,8 @@ async def test_dispatches_workflow_with_job_list_payload(tmp_path: Path):
                         "unit_tests": True,
                         "e2e_tests": False,
                         "agent_image": None,
+                        "minimum_base_package": False,
+                        "coverage": True,
                         "artifact_name": "ntp_py3.13_linux",
                     },
                 ]


### PR DESCRIPTION
### What does this PR do?

Makes `minimum-base-package` part of the Dispatcher's job identity and adds an opt-in
`--minimum-base-package` flag to `ddev ci dispatch-tests` that plans the replica jobs.

- `BatchJob` gains `minimum_base_package` and `coverage`. The variant is now part of both the job
  name and `artifact_name()`.
- `expand_batch_jobs` replicates each unit when asked, unit-only and without coverage, and skips the
  replica for a job that runs no unit tests.
- The flag is off by default and threads through `build_test_batches`.

### Motivation

The plan had no notion of a minimum-base-package run, but CI does: `pr-test.yml` and
`nightly-base-package*.yml` make a second full matrix pass with `minimum-base-package: true`. The
Dispatcher cannot replace them without planning both variants.

The identity change has to come first. `artifact_name()` was `(target, environment, platform)`, and
a replica pair differs in nothing else, so both jobs produced e.g. `postgres_py3.13-9.6-UTF8_linux`.
That collides twice, silently: `TaskTestRunner._download_artifacts` keys `artifact_dirs` by artifact
name so one job's artifacts overwrite the other's, and `BatchJobResult.correlate` builds
`jobs_by_name` from `job.name` so both replicas resolve to one workflow job. Reverting just the
`artifact_name()` part of this change fails the four new tests, one of them through the existing
batch validation:

```
BatchValidationError: Batch at index 0 has duplicate artifact identities.
AssertionError: assert 'postgres_py3.13_linux' != 'postgres_py3.13_linux'
```

The flag is opt-in rather than always on because not every run has a second variant to run. A
`test-agent` run tests the current integrations against a given Agent image, and the Agent ships one
`datadog-checks-base`, which is the same reason those runs skip E2E.

The replica's semantics are stated in the plan rather than inferred by the workflow from
`test-target`'s `if:` conditions: unit tests only, no Agent image, no coverage. `coverage` is a
separate field because `test-batch` needs to know whether to pass `--cov` without deriving it from
the variant, and because the gatherer must not read the missing report as a lost artifact.

Measured with the real pipeline (`build_test_batches` with `all_target_rules()`) on this branch:

```
--minimum-base-package=False batches=2 jobs= 431 replicas=  0 no-coverage=  0 e2e=394 (24s)
--minimum-base-package=True  batches=4 jobs= 862 replicas=431 no-coverage=431 e2e=394 (24s)

example pair for ('postgres', 'py3.13-9.6-UTF8', linux)
  name='Postgres (py3.13-9.6-UTF8)'
    artifact='postgres_py3.13-9.6-UTF8_linux' e2e=True cov=True image=registry.datadoghq.com/agent-dev:master-py3
  name='minimum-base-package-Postgres (py3.13-9.6-UTF8)'
    artifact='minimum-base-package-postgres_py3.13-9.6-UTF8_linux' e2e=False cov=False image=None
```

The doubling is deliberate and `pr-test.yml` already pays it today, half of it invisibly behind
`ci_matrix.py`'s `JOB_LIMIT = 256`. E2E stays at 394 because replicas add none.

Nothing consumes the flag yet. `test-batch` (AI-7128) is what will read `minimum_base_package` and
`coverage` off the job spec.

Part of AI-7125.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
