### PR TITLE
Move the cilium metric-limit endpoint test into datadog_checks_base

### DIFF
--- a/cilium/tests/test_unit.py
+++ b/cilium/tests/test_unit.py
@@ -91,30 +91,6 @@ def test_v2_both_endpoints_build_two_scrapers():
     assert endpoints == ["http://agent/metrics", "http://op/metrics"]
 
 
-def test_v2_metric_limit_issue_uses_generated_scraper_endpoints(datadog_agent):
-    agent_endpoint = "http://z-agent/metrics"
-    operator_endpoint = "http://a-operator/metrics"
-    check = CiliumCheckV2(
-        "cilium",
-        {},
-        [{"agent_endpoint": agent_endpoint, "operator_endpoint": operator_endpoint}],
-    )
-    check._parse_config()
-    check.configure_scrapers()
-
-    check._on_metric_limit_state(True, 20, 5)
-
-    [issue] = datadog_agent._sent_reported_issues["cilium"]
-    assert "openmetrics_endpoint" not in check.instance
-    assert issue["id"] == "openmetrics-dropped-config:659a0d48b0fa9caf"
-    assert issue["title"] == "Dropping 15 of 20 OpenMetrics metrics"
-    assert issue["extra"]["endpoints"] == [operator_endpoint, agent_endpoint]
-    assert "2 configured endpoints" in issue["description"]
-    assert "totals cover the complete check run" in issue["description"]
-    assert agent_endpoint in issue["description"]
-    assert operator_endpoint in issue["description"]
-
-
 def test_v2_agent_scraper_uses_agent_metrics_not_operator():
     check = CiliumCheckV2("cilium", {}, [{"agent_endpoint": "http://agent/metrics"}])
     check._parse_config()

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_metric_limit_issue.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_metric_limit_issue.py
@@ -50,6 +50,42 @@ class IsolatedMetricLimitOpenMetricsCheck(MetricLimitOpenMetricsCheck):
             self.gauge('openmetrics.metric', value)
 
 
+class GeneratedScraperEndpointsCheck(OpenMetricsBaseCheckV2):
+    """Builds scrapers from custom endpoint options instead of an instance field.
+
+    Many v2 integrations (e.g. Cilium) synthesize scraper configurations from option
+    keys such as ``agent_endpoint``, so the metric limit hook must derive endpoints
+    from the actual scrapers rather than from a raw instance field.
+    """
+
+    def configure_scrapers(self) -> None:
+        endpoints = (self.instance.get('agent_endpoint'), self.instance.get('operator_endpoint'))
+        self.scrapers = {endpoint: None for endpoint in endpoints if endpoint}
+
+
+def test_metric_limit_issue_uses_generated_scraper_endpoints(datadog_agent: Any) -> None:
+    agent_endpoint = 'http://z-agent/metrics'
+    operator_endpoint = 'http://a-operator/metrics'
+    check = GeneratedScraperEndpointsCheck(
+        'openmetrics_test',
+        {},
+        [{'agent_endpoint': agent_endpoint, 'operator_endpoint': operator_endpoint, 'namespace': 'demo'}],
+    )
+    check.configure_scrapers()
+
+    check._on_metric_limit_state(True, 20, 5)
+
+    [issue] = reported_issues(datadog_agent)
+    assert 'openmetrics_endpoint' not in check.instance
+    assert issue['id'] == _issue_id('stubbed.hostname', 'openmetrics_test', (operator_endpoint, agent_endpoint), 'demo')
+    assert issue['title'] == 'Dropping 15 of 20 OpenMetrics metrics'
+    assert issue['extra']['endpoints'] == [operator_endpoint, agent_endpoint]
+    assert '2 configured endpoints' in issue['description']
+    assert 'totals cover the complete check run' in issue['description']
+    assert agent_endpoint in issue['description']
+    assert operator_endpoint in issue['description']
+
+
 def create_check(limit: int = 5, endpoint: str = ENDPOINT) -> MetricLimitOpenMetricsCheck:
     instance = {
         'openmetrics_endpoint': endpoint,

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_metric_limit_issue.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_metric_limit_issue.py
@@ -63,7 +63,7 @@ class GeneratedScraperEndpointsCheck(OpenMetricsBaseCheckV2):
         self.scrapers = {endpoint: None for endpoint in endpoints if endpoint}
 
 
-def test_metric_limit_issue_uses_generated_scraper_endpoints(datadog_agent: Any) -> None:
+def test_metric_limit_issue_uses_generated_scraper_endpoints(datadog_agent: Any):
     agent_endpoint = 'http://z-agent/metrics'
     operator_endpoint = 'http://a-operator/metrics'
     check = GeneratedScraperEndpointsCheck(


### PR DESCRIPTION
### What does this PR do?

Move the Cilium test that requires a new base check library to the base check. 

### Motivation

Fix the nightly minimum base check [failures](https://github.com/DataDog/integrations-core/actions/runs/33720104723/job/100537327681#step:20:248) for Cilium.

### Validation

- `datadog_checks_base` focused tests: 21 passed
- Cilium unit tests: 29 passed
- `datadog_checks_base` lint: passed
- Cilium lint: passed

No production code or changelog entries are changed.