### PR TITLE
[AI-7124] Give the async GitHub client a shutdown mode

### DIFF
--- a/ddev/changelog.d/25076.added
+++ b/ddev/changelog.d/25076.added
@@ -1,0 +1,1 @@
+Add a shutdown mode to the async GitHub client that caps request timeouts and stops retrying.

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -38,8 +38,7 @@ logger = logging.getLogger(__name__)
 CANCELLATION_SIGNALS = (signal.SIGINT, signal.SIGTERM)
 
 # A call that cannot go out within this is one the process will not live to see answered.
-# A cancelled run abandons its own pacing: the budget it was rationing outlives the process, and the
-# few seconds left are better spent closing check runs than waiting for a slot.
+# A cancelled run abandons its pacing: the budget it was rationing outlives the process.
 CANCELLED_RATE_LIMITS = RelaxedRateLimits(max_wait_seconds=2.0, max_rate=10_000.0)
 
 
@@ -182,10 +181,8 @@ class Dispatcher(EventBusOrchestrator):
 
         self._cancelled = True
         self._logger.warning("Received %s: cancelling the run", received.name)
-        # Stop first: this runs as a signal-handler callback, so anything raised here goes to the
-        # loop's exception handler, and the second signal would find `_cancelled` already set and
-        # return without retrying. Shutdown mode still lands in time, because the stop only sets an
-        # event the loop acts on later, and it is what makes each batch close its check run.
+        # Stop first: anything raised here goes to the loop's exception handler, and the second signal
+        # returns early on `_cancelled`. The stop is what makes each batch close its check run.
         self.request_stop()
         self._client.enter_shutdown_mode(rate_limits=CANCELLED_RATE_LIMITS)
 

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -22,6 +22,7 @@ from ddev.cli.ci.tests.task_test_gatherer import TaskTestGatherer
 from ddev.cli.ci.tests.task_test_runner import TaskTestRunner, TestRunnerOptions
 from ddev.event_bus.orchestrator import BaseMessage, EventBusOrchestrator
 from ddev.utils.github_actions import write_step_summary
+from ddev.utils.rate_limiting import RelaxedRateLimits
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -37,8 +38,9 @@ logger = logging.getLogger(__name__)
 CANCELLATION_SIGNALS = (signal.SIGINT, signal.SIGTERM)
 
 # A call that cannot go out within this is one the process will not live to see answered.
-CANCELLED_MAX_WAIT_SECONDS = 2.0
-CANCELLED_MAX_RATE = 10_000.0
+# A cancelled run abandons its own pacing: the budget it was rationing outlives the process, and the
+# few seconds left are better spent closing check runs than waiting for a slot.
+CANCELLED_RATE_LIMITS = RelaxedRateLimits(max_wait_seconds=2.0, max_rate=10_000.0)
 
 
 class RunContext(StrEnum):
@@ -169,7 +171,7 @@ class Dispatcher(EventBusOrchestrator):
                 loop.remove_signal_handler(received)
 
     def _cancel(self, received: signal.Signals) -> None:
-        """Start winding down, and let the cleanup outrun the pacing built for a whole run.
+        """Start winding down, and size what is left for the seconds the process still has.
 
         Idempotent because both signals arrive on a cancelled job, seconds apart, and the second must
         not restart anything the first began.
@@ -182,10 +184,10 @@ class Dispatcher(EventBusOrchestrator):
         self._logger.warning("Received %s: cancelling the run", received.name)
         # Stop first: this runs as a signal-handler callback, so anything raised here goes to the
         # loop's exception handler, and the second signal would find `_cancelled` already set and
-        # return without retrying. Relaxing still lands in time, because the stop only sets an event
-        # the loop acts on later, and it is what makes each batch close its check run.
+        # return without retrying. Shutdown mode still lands in time, because the stop only sets an
+        # event the loop acts on later, and it is what makes each batch close its check run.
         self.request_stop()
-        self._client.relax_rate_limits(max_wait_seconds=CANCELLED_MAX_WAIT_SECONDS, max_rate=CANCELLED_MAX_RATE)
+        self._client.enter_shutdown_mode(rate_limits=CANCELLED_RATE_LIMITS)
 
     async def on_message_received(self, message: BaseMessage):
         self._logger.debug("Message received: %s(%s)", type(message).__name__, message.id)

--- a/ddev/src/ddev/utils/github_async/client.py
+++ b/ddev/src/ddev/utils/github_async/client.py
@@ -70,8 +70,7 @@ COMMENT_BODY_LIMIT = 65_536
 RUN_ALREADY_TERMINAL_STATUS = 409
 # The caller is a run being cancelled, so the whole ladder has to fit in the seconds it has left.
 CANCEL_RETRY_TIMEOUT = 5.0
-# Shutdown mode caps each request well inside the few seconds a killed process has left; the point is
-# to fail and move on to the next cleanup call, not to see this one through.
+# Inside the few seconds a killed process has left, so a stalled call fails and the next one still runs.
 SHUTDOWN_REQUEST_TIMEOUT = 3.0
 
 # How an expired signed URL presents from the artifact storage host.
@@ -287,20 +286,12 @@ class AsyncGitHubClient:
     # ------------------------------------------------------------------
 
     def _effective_timeout(self, timeout: float | None) -> float:
-        """The per-request timeout to use, capped once shutting down.
-
-        An explicit timeout is still capped: a caller that asked for longer than the process has left
-        would spend the whole window on one request.
-        """
+        """The per-request timeout, capped once shutting down even when the caller asked for longer."""
         requested = timeout if timeout is not None else self._default_timeout
         return min(requested, SHUTDOWN_REQUEST_TIMEOUT) if self._shutting_down else requested
 
     def _effective_retry(self, policy: RetryPolicy) -> RetryPolicy:
-        """`policy`, collapsed to a single attempt once shutting down.
-
-        A ladder spends the remaining time re-asking a question that will not be answered before the
-        process dies, and every attempt it schedules is one the next cleanup call does not get.
-        """
+        """`policy`, collapsed to a single attempt once shutting down."""
         return policy.replace(attempts=1) if self._shutting_down else policy
 
     def _retry_cause(self, policy: RetryPolicy) -> RetryCause:
@@ -395,18 +386,9 @@ class AsyncGitHubClient:
         **kwargs: Any,
     ) -> httpx.Response:
         effective_timeout = self._effective_timeout(timeout)
-        # Rate-limit-aware retry lives here, not in _execute_request: re-entering the limiter IS the
-        # backoff. The failed response's headers were observed inside _execute_request before the
-        # exception propagated, so the governor already holds the pause this very 403 armed;
-        # re-acquiring waits it out exactly (retry-after plus buffer for secondary limits, until
-        # reset for an exhausted window). Hence no sleeps or backoff math. A loop inside
-        # _execute_request would be wrong: it would retry while still holding the acquisition,
-        # without re-consulting the governor. Concurrent retries also serialize behind the same
-        # shared pause instead of stampeding, which is what GitHub's secondary-limit guidance asks
-        # for. RateLimitWaitAbandoned raised while (re-)acquiring propagates untouched from here: it
-        # is the caller-configured killswitch, and counting it as an attempt would defeat it.
-        # Re-acquiring the limiter is this layer's backoff, so its retries are a wait like any other
-        # and shutting down means not taking them.
+        # Re-acquiring the limiter is the backoff: the governor already holds the pause this 403 armed,
+        # observed in _execute_request before it raised. Never add a sleep here. RateLimitWaitAbandoned
+        # from the acquisition is the caller's killswitch, so it must not count as an attempt.
         rate_limit_retries = 0 if self._shutting_down else self._max_rate_limit_retries
         for attempt in range(rate_limit_retries + 1):
             async with self._rate_limiter:
@@ -415,11 +397,8 @@ class AsyncGitHubClient:
                         method, endpoint, effective_timeout, expect_redirect=expect_redirect, **kwargs
                     )
                 except httpx.HTTPStatusError as exc:
-                    # A rate-limit 403/429 is safe to retry for every endpoint, including
-                    # non-idempotent POSTs, precisely because GitHub rejected it without performing
-                    # the action. (Transport errors are never retried, and are not caught here: after
-                    # one we cannot know whether the action executed.) Give up on the last attempt or
-                    # on a non-rate-limit status, which waiting cannot fix.
+                    # Safe to replay even for non-idempotent endpoints: GitHub rejected the request
+                    # without performing the action.
                     is_rate_limit_response = self._is_rate_limit_response(exc.response)
                     if is_rate_limit_response:
                         if attempt == rate_limit_retries:
@@ -605,14 +584,12 @@ class AsyncGitHubClient:
     def enter_shutdown_mode(self, *, rate_limits: RelaxedRateLimits | None = None) -> None:
         """Size every subsequent request for a process that is about to be killed.
 
-        Caps each request at :data:`SHUTDOWN_REQUEST_TIMEOUT` and takes a single attempt at it, so
-        cleanup calls fail fast and the next one still gets a turn. Idempotent, because the signals
-        that lead here arrive more than once.
+        Caps each request at :data:`SHUTDOWN_REQUEST_TIMEOUT` and takes a single attempt at it.
+        Idempotent, because the signals that lead here arrive more than once.
 
-        Rate limiting is left alone unless `rate_limits` says otherwise: pacing protects a budget
-        shared with everything else using the token, and abandoning it is a decision only the caller
-        can make. Note that this means an acquisition can still block longer than the request itself;
-        pass `rate_limits` to bound that too. See :meth:`InstrumentedAsyncLimiter.relax`.
+        Pacing is left alone unless `rate_limits` says otherwise, since the budget it protects is
+        shared with everything else using the token. Without it an acquisition can still outlast the
+        request. See :meth:`InstrumentedAsyncLimiter.relax`.
         """
         self._shutting_down = True
         if rate_limits is not None:

--- a/ddev/src/ddev/utils/github_async/client.py
+++ b/ddev/src/ddev/utils/github_async/client.py
@@ -585,7 +585,8 @@ class AsyncGitHubClient:
         """Size every subsequent request for a process that is about to be killed.
 
         Caps each request at :data:`SHUTDOWN_REQUEST_TIMEOUT` and takes a single attempt at it.
-        Idempotent, because the signals that lead here arrive more than once.
+        Idempotent, because the signals that lead here arrive more than once. One request, so an
+        operation spanning several stays the caller's to bound.
 
         Pacing is left alone unless `rate_limits` says otherwise, since the budget it protects is
         shared with everything else using the token. Without it an acquisition can still outlast the

--- a/ddev/src/ddev/utils/github_async/client.py
+++ b/ddev/src/ddev/utils/github_async/client.py
@@ -32,6 +32,7 @@ from ddev.utils.rate_limiting import (
     BudgetSnapshot,
     InstrumentedAsyncLimiter,
     RateLimitWaitAbandoned,
+    RelaxedRateLimits,
 )
 
 from .defaults import default_github_rate_limiter, log_rate_limit_events
@@ -69,6 +70,9 @@ COMMENT_BODY_LIMIT = 65_536
 RUN_ALREADY_TERMINAL_STATUS = 409
 # The caller is a run being cancelled, so the whole ladder has to fit in the seconds it has left.
 CANCEL_RETRY_TIMEOUT = 5.0
+# Shutdown mode caps each request well inside the few seconds a killed process has left; the point is
+# to fail and move on to the next cleanup call, not to see this one through.
+SHUTDOWN_REQUEST_TIMEOUT = 3.0
 
 # How an expired signed URL presents from the artifact storage host.
 SIGNED_URL_EXPIRED_STATUS = 403
@@ -256,6 +260,7 @@ class AsyncGitHubClient:
             else default_github_rate_limiter(on_event=log_rate_limit_events(logger) if logger is not None else None)
         )
         self._default_timeout = default_timeout
+        self._shutting_down = False
         self._max_rate_limit_retries = max_rate_limit_retries
         self._retry_policies = retry_policies if retry_policies is not None else DEFAULT_RETRY_POLICIES
         # A 403 from GitHub itself arrives as GitHubAuthenticationError, which the guard refuses, so
@@ -282,7 +287,21 @@ class AsyncGitHubClient:
     # ------------------------------------------------------------------
 
     def _effective_timeout(self, timeout: float | None) -> float:
-        return timeout if timeout is not None else self._default_timeout
+        """The per-request timeout to use, capped once shutting down.
+
+        An explicit timeout is still capped: a caller that asked for longer than the process has left
+        would spend the whole window on one request.
+        """
+        requested = timeout if timeout is not None else self._default_timeout
+        return min(requested, SHUTDOWN_REQUEST_TIMEOUT) if self._shutting_down else requested
+
+    def _effective_retry(self, policy: RetryPolicy) -> RetryPolicy:
+        """`policy`, collapsed to a single attempt once shutting down.
+
+        A ladder spends the remaining time re-asking a question that will not be answered before the
+        process dies, and every attempt it schedules is one the next cleanup call does not get.
+        """
+        return policy.replace(attempts=1) if self._shutting_down else policy
 
     def _retry_cause(self, policy: RetryPolicy) -> RetryCause:
         """The predicate for one operation: what `policy` accepts, minus what this client refuses."""
@@ -386,7 +405,10 @@ class AsyncGitHubClient:
         # shared pause instead of stampeding, which is what GitHub's secondary-limit guidance asks
         # for. RateLimitWaitAbandoned raised while (re-)acquiring propagates untouched from here: it
         # is the caller-configured killswitch, and counting it as an attempt would defeat it.
-        for attempt in range(self._max_rate_limit_retries + 1):
+        # Re-acquiring the limiter is this layer's backoff, so its retries are a wait like any other
+        # and shutting down means not taking them.
+        rate_limit_retries = 0 if self._shutting_down else self._max_rate_limit_retries
+        for attempt in range(rate_limit_retries + 1):
             async with self._rate_limiter:
                 try:
                     return await self._execute_request(
@@ -400,7 +422,7 @@ class AsyncGitHubClient:
                     # on a non-rate-limit status, which waiting cannot fix.
                     is_rate_limit_response = self._is_rate_limit_response(exc.response)
                     if is_rate_limit_response:
-                        if attempt == self._max_rate_limit_retries:
+                        if attempt == rate_limit_retries:
                             raise
                         continue
                     if exc.response.status_code in GITHUB_AUTHENTICATION_STATUS_CODES:
@@ -423,7 +445,7 @@ class AsyncGitHubClient:
         Wraps the rate-limit layer rather than living inside it, so every attempt re-acquires the
         limiter and waits out any pause the governor holds.
         """
-        policy = retry if retry is not None else self._retry_policies.for_method(method)
+        policy = self._effective_retry(retry if retry is not None else self._retry_policies.for_method(method))
         cause = self._retry_cause(policy)
         async for attempt in retry_attempts(policy, cause):
             with attempt:
@@ -580,13 +602,21 @@ class AsyncGitHubClient:
         )
         return self._parse_response(response, WorkflowRun)
 
-    def relax_rate_limits(self, *, max_wait_seconds: float, max_rate: float) -> None:
-        """Stop pacing our own requests, and cap how long a GitHub pause may block one.
+    def enter_shutdown_mode(self, *, rate_limits: RelaxedRateLimits | None = None) -> None:
+        """Size every subsequent request for a process that is about to be killed.
 
-        For a process that will not live long enough to spend the budget being paced: see
-        :meth:`InstrumentedAsyncLimiter.relax`. GitHub's own limits are still honoured, only bounded.
+        Caps each request at :data:`SHUTDOWN_REQUEST_TIMEOUT` and takes a single attempt at it, so
+        cleanup calls fail fast and the next one still gets a turn. Idempotent, because the signals
+        that lead here arrive more than once.
+
+        Rate limiting is left alone unless `rate_limits` says otherwise: pacing protects a budget
+        shared with everything else using the token, and abandoning it is a decision only the caller
+        can make. Note that this means an acquisition can still block longer than the request itself;
+        pass `rate_limits` to bound that too. See :meth:`InstrumentedAsyncLimiter.relax`.
         """
-        self._rate_limiter.relax(max_wait_seconds=max_wait_seconds, max_rate=max_rate)
+        self._shutting_down = True
+        if rate_limits is not None:
+            self._rate_limiter.relax(max_wait_seconds=rate_limits.max_wait_seconds, max_rate=rate_limits.max_rate)
 
     async def cancel_workflow_run(
         self,

--- a/ddev/src/ddev/utils/rate_limiting.py
+++ b/ddev/src/ddev/utils/rate_limiting.py
@@ -305,8 +305,8 @@ class BudgetGovernor:
 class RelaxedRateLimits:
     """How far to relax pacing for a process that will not live long enough to spend its budget.
 
-    Both values are needed together, so they travel as one argument: a rate with no wait cap still
-    blocks on a provider pause, and a cap with no rate still waits for a slot it need not have.
+    Paired because neither works alone: a rate with no wait cap still blocks on a provider pause, and
+    a cap with no rate still waits for a slot.
     """
 
     max_wait_seconds: float

--- a/ddev/src/ddev/utils/rate_limiting.py
+++ b/ddev/src/ddev/utils/rate_limiting.py
@@ -301,6 +301,24 @@ class BudgetGovernor:
         )
 
 
+@dataclasses.dataclass(frozen=True)
+class RelaxedRateLimits:
+    """How far to relax pacing for a process that will not live long enough to spend its budget.
+
+    Both values are needed together, so they travel as one argument: a rate with no wait cap still
+    blocks on a provider pause, and a cap with no rate still waits for a slot it need not have.
+    """
+
+    max_wait_seconds: float
+    max_rate: float
+
+    def __post_init__(self) -> None:
+        if self.max_wait_seconds < 0:
+            raise ValueError(f"max_wait_seconds must be zero or greater, got {self.max_wait_seconds}")
+        if self.max_rate <= 0:
+            raise ValueError(f"max_rate must be greater than zero, got {self.max_rate}")
+
+
 class InstrumentedAsyncLimiter:
     """Thin async context manager wrapper around AsyncLimiter.
 

--- a/ddev/tests/cli/ci/tests/test_dispatcher.py
+++ b/ddev/tests/cli/ci/tests/test_dispatcher.py
@@ -14,8 +14,7 @@ from pathlib import Path
 import pytest
 
 from ddev.cli.ci.tests.dispatcher import (
-    CANCELLED_MAX_RATE,
-    CANCELLED_MAX_WAIT_SECONDS,
+    CANCELLED_RATE_LIMITS,
     Dispatcher,
     DispatcherContext,
     RunContext,
@@ -236,10 +235,7 @@ def test_a_cancelled_run_reports_itself_and_stops_the_work_it_started(client, tm
     assert dispatcher.cancelled
     # The cleanup competes with a ~10s kill using a bucket the run has been spending all along, so
     # without this it is paced for a run that still had its whole window ahead of it.
-    assert client.last_call("relax_rate_limits").kwargs == {
-        "max_wait_seconds": CANCELLED_MAX_WAIT_SECONDS,
-        "max_rate": CANCELLED_MAX_RATE,
-    }
+    assert client.last_call("enter_shutdown_mode").kwargs == {"rate_limits": CANCELLED_RATE_LIMITS}
     # The initial plan already created the comment, so the cancelled report edits that one.
     assert CANCELLED_HEADING in client.last_call("update_issue_comment").kwargs["body"]
     assert [call.kwargs["run_id"] for call in client.calls_to("cancel_workflow_run")] == [123]
@@ -250,14 +246,14 @@ def test_a_cancelled_run_reports_itself_and_stops_the_work_it_started(client, tm
 
 
 @requires_signals
-def test_a_run_still_winds_down_when_the_rate_limiter_cannot_be_relaxed(client, tmp_path):
+def test_a_run_still_winds_down_when_shutdown_mode_cannot_be_entered(client, tmp_path):
     """The signal handler's own failures are invisible: the loop logs them and the next signal, which
     finds the run already cancelling, returns without retrying. So the stop cannot be left downstream
     of anything that might raise, or the run waits to be killed instead of winding down.
     """
     dispatcher = build_bus(client, tmp_path, [make_batch(make_job())])
     a_run_that_never_finishes(client)
-    client.mock_response("relax_rate_limits", RuntimeError("the limiter is not what we think it is"))
+    client.mock_response("enter_shutdown_mode", RuntimeError("the limiter is not what we think it is"))
 
     start = time.perf_counter()
     run_cancelled_by_sigint(dispatcher, client)

--- a/ddev/tests/helpers/github_async.py
+++ b/ddev/tests/helpers/github_async.py
@@ -58,6 +58,7 @@ from ddev.utils.github_async.models import (
 )
 from ddev.utils.github_async.retry import RetryPolicy
 from ddev.utils.github_errors import GitHubBodyTooLongError, github_body_too_long_message
+from ddev.utils.rate_limiting import RelaxedRateLimits
 
 # Stable URL baked into the default `create_workflow_dispatch` response. Exported so tests
 # that assert on the URL can reference the helper rather than duplicating the literal.
@@ -120,7 +121,7 @@ def _default_response_factories() -> dict[str, Callable[[], Any]]:
         'add_labels_to_issue': lambda: GitHubResponse.model_validate({'data': [], 'headers': {}}),
         # Cancelling returns nothing, and a run already terminal is the outcome asked for.
         'cancel_workflow_run': lambda: None,
-        'relax_rate_limits': lambda: None,
+        'enter_shutdown_mode': lambda: None,
         'create_issue_comment': lambda: GitHubResponse(
             data=IssueComment(
                 id=DEFAULT_COMMENT_ID,
@@ -506,8 +507,8 @@ class FakeAsyncGitHubClient:
             timeout=timeout,
         )
 
-    def relax_rate_limits(self, *, max_wait_seconds: float, max_rate: float) -> None:
-        self._call('relax_rate_limits', max_wait_seconds=max_wait_seconds, max_rate=max_rate)
+    def enter_shutdown_mode(self, *, rate_limits: RelaxedRateLimits | None = None) -> None:
+        self._call('enter_shutdown_mode', rate_limits=rate_limits)
 
     async def create_check_run(
         self,

--- a/ddev/tests/test_fake_github_async.py
+++ b/ddev/tests/test_fake_github_async.py
@@ -16,6 +16,7 @@ import pytest
 
 from ddev.utils.github_async import AsyncGitHubClient, GitHubResponse
 from ddev.utils.github_async.models import Artifact, ArtifactsList, IssueComment, PullRequest
+from ddev.utils.rate_limiting import RelaxedRateLimits
 from tests.cli.ci.tests.helpers import comment_page
 from tests.helpers.github_async import FakeAsyncGitHubClient
 from tests.utils.github_async.helpers import first_page
@@ -306,6 +307,8 @@ async def test_calls_are_recorded_regardless_of_response(fake: FakeAsyncGitHubCl
 # One call per mirror, paired with an argument the recording must carry back. Every mirror belongs
 # here: `test_every_mirror_is_in_the_call_table` fails when one is added without being registered,
 # which is the case a hand-written test per method cannot catch.
+SHUTDOWN_RATE_LIMITS = RelaxedRateLimits(max_wait_seconds=2.0, max_rate=10_000.0)
+
 MIRROR_CALLS = [
     ('get_pull_request', lambda f, _: f.get_pull_request('o', 'r', 5), {'pull_number': 5}),
     ('list_pull_requests', lambda f, _: f.list_pull_requests('o', 'r', head='o:branch'), {'head': 'o:branch'}),
@@ -331,9 +334,9 @@ MIRROR_CALLS = [
         {'commit_id': 'abc123', 'line': 10},
     ),
     (
-        'relax_rate_limits',
-        lambda f, _: f.relax_rate_limits(max_wait_seconds=2.0, max_rate=10_000.0),
-        {'max_rate': 10_000.0},
+        'enter_shutdown_mode',
+        lambda f, _: f.enter_shutdown_mode(rate_limits=SHUTDOWN_RATE_LIMITS),
+        {'rate_limits': SHUTDOWN_RATE_LIMITS},
     ),
     (
         'create_check_run',

--- a/ddev/tests/utils/github_async/test_client_core.py
+++ b/ddev/tests/utils/github_async/test_client_core.py
@@ -109,11 +109,7 @@ async def test_request_timeout_forwarded_to_transport(call_kwargs: dict[str, flo
     ],
 )
 async def test_shutting_down_caps_how_long_one_request_may_take(call_kwargs: dict[str, float], expected: float) -> None:
-    """A cleanup call has to fail in time for the next one to be tried at all.
-
-    The cap applies to an explicit timeout too: a caller asking for longer than the process has left
-    would spend the whole window on one request.
-    """
+    """A cleanup call has to fail in time for the next one to be tried at all."""
     captured: dict[str, Any] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:

--- a/ddev/tests/utils/github_async/test_client_core.py
+++ b/ddev/tests/utils/github_async/test_client_core.py
@@ -89,7 +89,12 @@ async def test_context_manager_closes_on_exit() -> None:
         # for the next one to be tried at all.
         pytest.param({}, True, SHUTDOWN_REQUEST_TIMEOUT, id="shutdown-caps-the-default"),
         pytest.param({"timeout": 60.0}, True, SHUTDOWN_REQUEST_TIMEOUT, id="shutdown-caps-a-longer-timeout"),
-        pytest.param({"timeout": 0.5}, True, 0.5, id="shutdown-keeps-a-shorter-timeout"),
+        pytest.param(
+            {"timeout": SHUTDOWN_REQUEST_TIMEOUT / 2},
+            True,
+            SHUTDOWN_REQUEST_TIMEOUT / 2,
+            id="shutdown-keeps-a-shorter-timeout",
+        ),
     ],
 )
 async def test_request_timeout_forwarded_to_transport(

--- a/ddev/tests/utils/github_async/test_client_core.py
+++ b/ddev/tests/utils/github_async/test_client_core.py
@@ -81,13 +81,20 @@ async def test_context_manager_closes_on_exit() -> None:
 
 
 @pytest.mark.parametrize(
-    ("call_kwargs", "expected"),
+    ("call_kwargs", "shutting_down", "expected"),
     [
-        pytest.param({"timeout": 2.0}, 2.0, id="per-request-override"),
-        pytest.param({}, 5.0, id="constructor-default"),
+        pytest.param({"timeout": 2.0}, False, 2.0, id="per-request-override"),
+        pytest.param({}, False, 5.0, id="constructor-default"),
+        # Shutting down caps whatever the caller asked for, so a stalled cleanup call fails in time
+        # for the next one to be tried at all.
+        pytest.param({}, True, SHUTDOWN_REQUEST_TIMEOUT, id="shutdown-caps-the-default"),
+        pytest.param({"timeout": 60.0}, True, SHUTDOWN_REQUEST_TIMEOUT, id="shutdown-caps-a-longer-timeout"),
+        pytest.param({"timeout": 0.5}, True, 0.5, id="shutdown-keeps-a-shorter-timeout"),
     ],
 )
-async def test_request_timeout_forwarded_to_transport(call_kwargs: dict[str, float], expected: float) -> None:
+async def test_request_timeout_forwarded_to_transport(
+    call_kwargs: dict[str, float], shutting_down: bool, expected: float
+) -> None:
     captured: dict[str, Any] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -95,30 +102,8 @@ async def test_request_timeout_forwarded_to_transport(call_kwargs: dict[str, flo
         return json_response(workflow_run_payload())
 
     client = AsyncGitHubClient(token=TOKEN, default_timeout=5.0, transport=httpx.MockTransport(handler))
-    await client.get_workflow_run("o", "r", 42, **call_kwargs)
-
-    assert captured["timeout"] == dict.fromkeys(("connect", "read", "write", "pool"), expected)
-
-
-@pytest.mark.parametrize(
-    ("call_kwargs", "expected"),
-    [
-        pytest.param({}, SHUTDOWN_REQUEST_TIMEOUT, id="caps-the-default"),
-        pytest.param({"timeout": 60.0}, SHUTDOWN_REQUEST_TIMEOUT, id="caps-a-longer-explicit-timeout"),
-        pytest.param({"timeout": 0.5}, 0.5, id="keeps-a-shorter-explicit-timeout"),
-    ],
-)
-async def test_shutting_down_caps_how_long_one_request_may_take(call_kwargs: dict[str, float], expected: float) -> None:
-    """A cleanup call has to fail in time for the next one to be tried at all."""
-    captured: dict[str, Any] = {}
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        captured["timeout"] = request.extensions["timeout"]
-        return json_response(workflow_run_payload())
-
-    client = AsyncGitHubClient(token=TOKEN, default_timeout=30.0, transport=httpx.MockTransport(handler))
-    client.enter_shutdown_mode()
-
+    if shutting_down:
+        client.enter_shutdown_mode()
     await client.get_workflow_run("o", "r", 42, **call_kwargs)
 
     assert captured["timeout"] == dict.fromkeys(("connect", "read", "write", "pool"), expected)

--- a/ddev/tests/utils/github_async/test_client_core.py
+++ b/ddev/tests/utils/github_async/test_client_core.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 
 from ddev.utils.github_async import GITHUB_API_VERSION, AsyncGitHubClient, PaginationData, async_github_client
-from ddev.utils.github_async.client import QUERY_MASK, failure_reason, with_query_masked
+from ddev.utils.github_async.client import QUERY_MASK, SHUTDOWN_REQUEST_TIMEOUT, failure_reason, with_query_masked
 from ddev.utils.github_async.retry import NO_RETRY
 from tests.utils.github_async.helpers import TOKEN, json_response, make_client
 from tests.utils.github_async.payloads import artifact, workflow_run_payload
@@ -95,6 +95,34 @@ async def test_request_timeout_forwarded_to_transport(call_kwargs: dict[str, flo
         return json_response(workflow_run_payload())
 
     client = AsyncGitHubClient(token=TOKEN, default_timeout=5.0, transport=httpx.MockTransport(handler))
+    await client.get_workflow_run("o", "r", 42, **call_kwargs)
+
+    assert captured["timeout"] == dict.fromkeys(("connect", "read", "write", "pool"), expected)
+
+
+@pytest.mark.parametrize(
+    ("call_kwargs", "expected"),
+    [
+        pytest.param({}, SHUTDOWN_REQUEST_TIMEOUT, id="caps-the-default"),
+        pytest.param({"timeout": 60.0}, SHUTDOWN_REQUEST_TIMEOUT, id="caps-a-longer-explicit-timeout"),
+        pytest.param({"timeout": 0.5}, 0.5, id="keeps-a-shorter-explicit-timeout"),
+    ],
+)
+async def test_shutting_down_caps_how_long_one_request_may_take(call_kwargs: dict[str, float], expected: float) -> None:
+    """A cleanup call has to fail in time for the next one to be tried at all.
+
+    The cap applies to an explicit timeout too: a caller asking for longer than the process has left
+    would spend the whole window on one request.
+    """
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["timeout"] = request.extensions["timeout"]
+        return json_response(workflow_run_payload())
+
+    client = AsyncGitHubClient(token=TOKEN, default_timeout=30.0, transport=httpx.MockTransport(handler))
+    client.enter_shutdown_mode()
+
     await client.get_workflow_run("o", "r", 42, **call_kwargs)
 
     assert captured["timeout"] == dict.fromkeys(("connect", "read", "write", "pool"), expected)

--- a/ddev/tests/utils/github_async/test_rate_limiting.py
+++ b/ddev/tests/utils/github_async/test_rate_limiting.py
@@ -22,6 +22,7 @@ from ddev.utils.rate_limiting import (
     PacingEvent,
     PacingReason,
     RateLimitEvent,
+    RelaxedRateLimits,
     SecondaryLimitEvent,
 )
 from tests.helpers.clock import FakeClock, advance_clock_on_sleep
@@ -236,6 +237,59 @@ async def test_retries_exhausted_raises_after_max(monkeypatch: pytest.MonkeyPatc
 
     assert len(calls) == 2
     assert type(exc_info.value) is httpx.HTTPStatusError
+
+
+async def test_shutting_down_does_not_wait_out_a_rate_limit_pause(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-acquiring the limiter is this layer's backoff, so its retries are a wait like any other.
+
+    Waiting out a reset spends a window the process does not have on one call, when the point of
+    shutting down is to give every remaining cleanup call a turn.
+    """
+    clock = FakeClock()
+    advance_clock_on_sleep(clock, monkeypatch)
+    transport, calls = recording_transport([httpx.Response(403, headers={"retry-after": "5"})])
+    client = governed_client(clock, transport, max_rate_limit_retries=2)
+    client.enter_shutdown_mode()
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client._rate_limited_request("GET", "/x")
+
+    assert len(calls) == 1
+
+
+async def test_shutting_down_leaves_pacing_alone_unless_asked() -> None:
+    """Pacing protects a budget shared with everything else using the token, so abandoning it is the
+    caller's call to make and not a side effect of shutting down.
+    """
+    limiter = InstrumentedAsyncLimiter(
+        AsyncLimiter(max_rate=1, time_period=1000), budget_governor=BudgetGovernor(), name="github"
+    )
+    client = AsyncGitHubClient(
+        token=TOKEN, rate_limiter=limiter, transport=httpx.MockTransport(lambda _: httpx.Response(200))
+    )
+
+    client.enter_shutdown_mode()
+
+    assert limiter.limiter.max_rate == 1
+    assert limiter.budget_governor is not None
+    assert limiter.budget_governor.reserve_fraction != 0.0
+
+
+async def test_shutting_down_relaxes_pacing_when_the_caller_asks() -> None:
+    """A caller that knows the budget outlives the process can spend what is left on cleanup."""
+    limiter = InstrumentedAsyncLimiter(
+        AsyncLimiter(max_rate=1, time_period=1000), budget_governor=BudgetGovernor(), name="github"
+    )
+    client = AsyncGitHubClient(
+        token=TOKEN, rate_limiter=limiter, transport=httpx.MockTransport(lambda _: httpx.Response(200))
+    )
+
+    client.enter_shutdown_mode(rate_limits=RelaxedRateLimits(max_wait_seconds=2.0, max_rate=10_000.0))
+
+    assert limiter.limiter.max_rate == 10_000.0
+    assert limiter.budget_governor is not None
+    assert limiter.budget_governor.max_wait_seconds == 2.0
+    assert limiter.budget_governor.reserve_fraction == 0.0
 
 
 async def test_download_redirect_302_is_not_retried(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:

--- a/ddev/tests/utils/github_async/test_rate_limiting.py
+++ b/ddev/tests/utils/github_async/test_rate_limiting.py
@@ -240,10 +240,8 @@ async def test_retries_exhausted_raises_after_max(monkeypatch: pytest.MonkeyPatc
 
 
 async def test_shutting_down_does_not_wait_out_a_rate_limit_pause(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Re-acquiring the limiter is this layer's backoff, so its retries are a wait like any other.
-
-    Waiting out a reset spends a window the process does not have on one call, when the point of
-    shutting down is to give every remaining cleanup call a turn.
+    """Re-acquiring the limiter is this layer's backoff, so waiting out a reset spends the window on
+    one call.
     """
     clock = FakeClock()
     advance_clock_on_sleep(clock, monkeypatch)
@@ -258,8 +256,8 @@ async def test_shutting_down_does_not_wait_out_a_rate_limit_pause(monkeypatch: p
 
 
 async def test_shutting_down_leaves_pacing_alone_unless_asked() -> None:
-    """Pacing protects a budget shared with everything else using the token, so abandoning it is the
-    caller's call to make and not a side effect of shutting down.
+    """The budget is shared with everything else using the token, so abandoning it is the caller's
+    decision rather than a side effect of shutting down.
     """
     limiter = InstrumentedAsyncLimiter(
         AsyncLimiter(max_rate=1, time_period=1000), budget_governor=BudgetGovernor(), name="github"

--- a/ddev/tests/utils/github_async/test_rate_limiting.py
+++ b/ddev/tests/utils/github_async/test_rate_limiting.py
@@ -223,71 +223,52 @@ async def test_the_rate_limit_layer_does_not_retry_a_transport_error() -> None:
     assert len(calls) == 1
 
 
-async def test_retries_exhausted_raises_after_max(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Two consecutive rate-limit responses with max_rate_limit_retries=1 raise after exactly two calls."""
-    clock = FakeClock()
-    advance_clock_on_sleep(clock, monkeypatch)
-    transport, calls = recording_transport(
-        [httpx.Response(403, headers={"retry-after": "5"}), httpx.Response(403, headers={"retry-after": "5"})]
-    )
-    client = governed_client(clock, transport, max_rate_limit_retries=1)
+@pytest.mark.parametrize(
+    ("retries", "shutting_down", "expected_calls"),
+    [
+        pytest.param(1, False, 2, id="stops-after-max-retries"),
+        pytest.param(2, True, 1, id="shutting-down-does-not-retry"),
+    ],
+)
+async def test_the_rate_limit_layer_stops_re_acquiring_when_it_is_out_of_attempts(
+    monkeypatch: pytest.MonkeyPatch, retries: int, shutting_down: bool, expected_calls: int
+) -> None:
+    """Re-acquiring the limiter is this layer's backoff, so an attempt here is a wait.
 
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        await client._rate_limited_request("GET", "/x")
-
-    assert len(calls) == 2
-    assert type(exc_info.value) is httpx.HTTPStatusError
-
-
-async def test_shutting_down_does_not_wait_out_a_rate_limit_pause(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Re-acquiring the limiter is this layer's backoff, so waiting out a reset spends the window on
-    one call.
+    Shutting down takes none of them: waiting out a reset would spend the whole window on one call.
     """
     clock = FakeClock()
     advance_clock_on_sleep(clock, monkeypatch)
-    transport, calls = recording_transport([httpx.Response(403, headers={"retry-after": "5"})])
-    client = governed_client(clock, transport, max_rate_limit_retries=2)
-    client.enter_shutdown_mode()
+    rate_limited = httpx.Response(403, headers={"retry-after": "5"})
+    transport, calls = recording_transport([rate_limited, rate_limited])
+    client = governed_client(clock, transport, max_rate_limit_retries=retries)
+    if shutting_down:
+        client.enter_shutdown_mode()
 
     with pytest.raises(httpx.HTTPStatusError):
         await client._rate_limited_request("GET", "/x")
 
-    assert len(calls) == 1
+    assert len(calls) == expected_calls
 
 
-async def test_shutting_down_leaves_pacing_alone_unless_asked() -> None:
-    """The budget is shared with everything else using the token, so abandoning it is the caller's
-    decision rather than a side effect of shutting down.
+async def test_shutting_down_relaxes_pacing_only_when_the_caller_asks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The budget is shared with everything else using the token, so only the caller can abandon it.
+
+    What relaxing then does to the limiter is the limiter's own contract, covered in its suite; this is
+    only about whether the client forwards the request.
     """
-    limiter = InstrumentedAsyncLimiter(
-        AsyncLimiter(max_rate=1, time_period=1000), budget_governor=BudgetGovernor(), name="github"
-    )
+    relaxed: list[dict[str, float]] = []
+    limiter = InstrumentedAsyncLimiter(AsyncLimiter(max_rate=5000, time_period=3600), name="github")
+    monkeypatch.setattr(limiter, "relax", lambda **kwargs: relaxed.append(kwargs), raising=True)
     client = AsyncGitHubClient(
         token=TOKEN, rate_limiter=limiter, transport=httpx.MockTransport(lambda _: httpx.Response(200))
     )
 
     client.enter_shutdown_mode()
-
-    assert limiter.limiter.max_rate == 1
-    assert limiter.budget_governor is not None
-    assert limiter.budget_governor.reserve_fraction != 0.0
-
-
-async def test_shutting_down_relaxes_pacing_when_the_caller_asks() -> None:
-    """A caller that knows the budget outlives the process can spend what is left on cleanup."""
-    limiter = InstrumentedAsyncLimiter(
-        AsyncLimiter(max_rate=1, time_period=1000), budget_governor=BudgetGovernor(), name="github"
-    )
-    client = AsyncGitHubClient(
-        token=TOKEN, rate_limiter=limiter, transport=httpx.MockTransport(lambda _: httpx.Response(200))
-    )
+    assert relaxed == []
 
     client.enter_shutdown_mode(rate_limits=RelaxedRateLimits(max_wait_seconds=2.0, max_rate=10_000.0))
-
-    assert limiter.limiter.max_rate == 10_000.0
-    assert limiter.budget_governor is not None
-    assert limiter.budget_governor.max_wait_seconds == 2.0
-    assert limiter.budget_governor.reserve_fraction == 0.0
+    assert relaxed == [{"max_wait_seconds": 2.0, "max_rate": 10_000.0}]
 
 
 async def test_download_redirect_302_is_not_retried(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:

--- a/ddev/tests/utils/github_async/test_retry.py
+++ b/ddev/tests/utils/github_async/test_retry.py
@@ -128,12 +128,23 @@ async def test_a_mutation_does_not_replay_a_request_that_may_have_landed(error: 
 # ---------------------------------------------------------------------------
 
 
-async def test_a_caller_can_turn_retrying_off_for_one_call() -> None:
+@pytest.mark.parametrize(
+    ("call_kwargs", "shutting_down"),
+    [
+        pytest.param({"retry": NO_RETRY}, False, id="per-call-policy"),
+        # The ladder outlives the process, and every attempt it schedules is time the next cleanup
+        # call does not get.
+        pytest.param({}, True, id="shutting-down"),
+    ],
+)
+async def test_retrying_can_be_turned_off(call_kwargs: dict[str, object], shutting_down: bool) -> None:
     transport, calls = recording_transport([httpx.Response(503), json_response(workflow_run_payload())])
     client = AsyncGitHubClient(token=TOKEN, transport=transport)
+    if shutting_down:
+        client.enter_shutdown_mode()
 
     with pytest.raises(httpx.HTTPStatusError):
-        await client.get_workflow_run("o", "r", 42, retry=NO_RETRY)
+        await client.get_workflow_run("o", "r", 42, **call_kwargs)
 
     assert len(calls) == 1
 
@@ -318,18 +329,6 @@ def test_tuning_a_policy_leaves_the_shared_default_alone() -> None:
 
     assert tuned.attempts == 1
     assert SAFE_RETRY.attempts == DEFAULT_ATTEMPTS
-
-
-async def test_shutting_down_takes_one_attempt_and_gives_up() -> None:
-    """The ladder outlives the process, and a 503 is what the widest policy would otherwise replay."""
-    transport, calls = recording_transport([httpx.Response(503), json_response(workflow_run_payload())])
-    client = AsyncGitHubClient(token=TOKEN, transport=transport)
-    client.enter_shutdown_mode()
-
-    with pytest.raises(httpx.HTTPStatusError):
-        await client.get_workflow_run("o", "r", 42)
-
-    assert len(calls) == 1
 
 
 @pytest.mark.parametrize(

--- a/ddev/tests/utils/github_async/test_retry.py
+++ b/ddev/tests/utils/github_async/test_retry.py
@@ -321,11 +321,7 @@ def test_tuning_a_policy_leaves_the_shared_default_alone() -> None:
 
 
 async def test_shutting_down_takes_one_attempt_and_gives_up() -> None:
-    """The ladder outlives the process, and every attempt it schedules is time the next call loses.
-
-    A 503 is what the widest policy would replay, so it is the failure that proves the ladder is gone
-    rather than merely unreachable.
-    """
+    """The ladder outlives the process, and a 503 is what the widest policy would otherwise replay."""
     transport, calls = recording_transport([httpx.Response(503), json_response(workflow_run_payload())])
     client = AsyncGitHubClient(token=TOKEN, transport=transport)
     client.enter_shutdown_mode()

--- a/ddev/tests/utils/github_async/test_retry.py
+++ b/ddev/tests/utils/github_async/test_retry.py
@@ -320,6 +320,22 @@ def test_tuning_a_policy_leaves_the_shared_default_alone() -> None:
     assert SAFE_RETRY.attempts == DEFAULT_ATTEMPTS
 
 
+async def test_shutting_down_takes_one_attempt_and_gives_up() -> None:
+    """The ladder outlives the process, and every attempt it schedules is time the next call loses.
+
+    A 503 is what the widest policy would replay, so it is the failure that proves the ladder is gone
+    rather than merely unreachable.
+    """
+    transport, calls = recording_transport([httpx.Response(503), json_response(workflow_run_payload())])
+    client = AsyncGitHubClient(token=TOKEN, transport=transport)
+    client.enter_shutdown_mode()
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.get_workflow_run("o", "r", 42)
+
+    assert len(calls) == 1
+
+
 @pytest.mark.parametrize(
     ("limits", "message"),
     [

--- a/ddev/tests/utils/test_rate_limiting.py
+++ b/ddev/tests/utils/test_rate_limiting.py
@@ -716,11 +716,7 @@ def test_instrumented_limiter_observe_without_governor_does_not_raise():
     ],
 )
 def test_relaxed_limits_that_would_block_forever_are_rejected(limits: dict[str, float], message: str) -> None:
-    """Relaxing exists to stop blocking, so values that block instead defeat the point of asking.
-
-    A rate of zero hands out no slots at all, which is the opposite of what a caller relaxing pacing
-    is asking for, and it would surface as a hang rather than an error.
-    """
+    """A rate of zero hands out no slots, so it would surface as a hang rather than an error."""
     with pytest.raises(ValueError, match=message):
         RelaxedRateLimits(**limits)
 

--- a/ddev/tests/utils/test_rate_limiting.py
+++ b/ddev/tests/utils/test_rate_limiting.py
@@ -23,6 +23,7 @@ from ddev.utils.rate_limiting import (
     PacingReason,
     RateLimitEvent,
     RateLimitWaitAbandoned,
+    RelaxedRateLimits,
     SecondaryLimitEvent,
 )
 from tests.helpers.assertions import assert_blocks
@@ -705,6 +706,23 @@ async def test_instrumented_limiter_does_not_consume_bucket_token_during_governo
 def test_instrumented_limiter_observe_without_governor_does_not_raise():
     limiter = InstrumentedAsyncLimiter(AsyncLimiter(max_rate=1, time_period=1000))
     limiter.observe(make_snapshot(limit=100, remaining=50, reset_at=2000.0))
+
+
+@pytest.mark.parametrize(
+    ("limits", "message"),
+    [
+        pytest.param({"max_wait_seconds": -1.0, "max_rate": 10.0}, "max_wait_seconds must be zero", id="negative_wait"),
+        pytest.param({"max_wait_seconds": 2.0, "max_rate": 0.0}, "max_rate must be greater", id="zero_rate"),
+    ],
+)
+def test_relaxed_limits_that_would_block_forever_are_rejected(limits: dict[str, float], message: str) -> None:
+    """Relaxing exists to stop blocking, so values that block instead defeat the point of asking.
+
+    A rate of zero hands out no slots at all, which is the opposite of what a caller relaxing pacing
+    is asking for, and it would surface as a hang rather than an error.
+    """
+    with pytest.raises(ValueError, match=message):
+        RelaxedRateLimits(**limits)
 
 
 async def test_relaxing_stops_rationing_the_budget(clock: FakeClock, slept: list[float]) -> None:


### PR DESCRIPTION
### What does this PR do?

Adds `AsyncGitHubClient.enter_shutdown_mode()`, which sizes every subsequent request for a process that is about to be killed:

- caps each request at `SHUTDOWN_REQUEST_TIMEOUT` (3s), including an explicit `timeout=` that asks for longer
- takes a single attempt, in **both** retry layers: the strategy's ladder, and the rate-limit layer's re-acquisition (re-acquiring the limiter *is* that layer's backoff, so its retries are a wait like any other)

Rate limiting is left alone unless the caller passes `rate_limits`. This replaces `relax_rate_limits`, whose two arguments now travel together as `RelaxedRateLimits` since neither is any use alone: a rate with no wait cap still blocks on a provider pause, and a cap with no rate still waits for a slot it need not have.

The Dispatcher opts in, so its behaviour on cancellation is unchanged.

### Motivation

First of three items from [AI-7124](https://datadoghq.atlassian.net/browse/AI-7124). The issue was originally filed as a single timeout around the shutdown phase; that turned out to be the wrong tool, because a stopwatch does not make anything faster, it just stops us listening. Where the time actually goes is the retry ladder.

Measured on a check-run close against a socket that reads the request and then holds the connection open with no reply. `update_check_run` is replayable, so it carries the widest policy, and closing a check run is the cleanup a cancelled batch most needs to land:

```
normal (today)   ReadTimeout   after  60.56s
shutdown mode    ReadTimeout   after   3.00s

budget: SIGTERM lands ~7.5s after SIGINT, hard kill ~10s
```

For comparison, the per-call `timeout=3.0` fix considered earlier reached 11.88s, still past the kill, because the ladder still took three attempts.

Rate limiting stays on by default because pacing protects a budget shared with everything else using the token. One consequence worth knowing, and called out in the docstring: an acquisition can still block longer than the request itself, so a caller that needs that bounded too has to pass `rate_limits`. The Dispatcher does.

The remaining two items (a processor `on_stop_requested` hook the bus calls, and moving signal handling into the bus behind an overridable method) are follow-ups.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7124]: https://datadoghq.atlassian.net/browse/AI-7124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ