### PR TITLE
Update current_milestone to 7.85.0

### DIFF
--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-	"current_milestone": "7.83.0"
+	"current_milestone": "7.85.0"
 }


### PR DESCRIPTION
Updates `current_milestone` in `release.json` to `7.85.0` after cutting the `7.84.x` release branch.