### PR TITLE
[AI-7124] Tell processors when the bus is asked to stop

### DIFF
--- a/ddev/changelog.d/25078.added
+++ b/ddev/changelog.d/25078.added
@@ -1,0 +1,1 @@
+Tell processors when a stop is requested so they can shorten work in flight.

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -85,9 +85,10 @@ class BaseProcessor[T: BaseMessage]:
     def on_stop_requested(self) -> None:
         """React to the bus being asked to wind down, by shortening work already in flight.
 
-        Called once per processor, before the bus acts on the request and possibly from a signal
-        handler, so it must not block or await. Raising is contained: the stop still happens and the
-        other processors are still told.
+        Called once per processor. :attr:`stopping` is already set and the bus may already be acting on
+        it, so this cannot assume anything is still running; shorten what is in flight rather than
+        expecting to run first. May be called from a signal handler, so it must not block or await.
+        Raising is contained: the stop still happens and the other processors are still told.
         """
 
     def submit_message(self, message: BaseMessage) -> None:
@@ -168,7 +169,7 @@ class EventBusOrchestrator(ABC):
         # because the pool's own threads discard from it as they finish.
         self._sync_work: set[Future] = set()
         self._sync_work_lock = threading.Lock()
-        self._stop_lock = threading.Lock()
+        self._stop_claim = threading.Lock()
         self._fail_fast = fail_fast
         self._subscribers: dict[type[BaseMessage], list[Processor]] = {}
         self._processors: list[Processor] = []
@@ -211,16 +212,17 @@ class EventBusOrchestrator(ABC):
         ``on_initialize`` and ``on_message_received`` are abandoned if they are still waiting, since the
         loop awaits them directly and would otherwise be held for as long as they take.
 
-        Every registered processor's :meth:`BaseProcessor.on_stop_requested` runs before this returns; a
-        caller that finds the stop already claimed returns at once.
+        Sets :attr:`stopping`, then runs every registered processor's
+        :meth:`BaseProcessor.on_stop_requested`. A second caller returns at once rather than waiting for
+        those to finish.
         """
-        # Claimed atomically, and before the hooks: two threads may call this, and one that raises must
-        # not leave the bus running. Notifying outside the lock, so a hook cannot hold it.
-        with self._stop_lock:
-            if self.stopping:
-                return
-            self._stopping.set()
+        # A one-shot latch, never released, so the first caller is the one that notifies. Non-blocking
+        # because a signal handler runs on the thread it interrupted: waiting here for a lock that
+        # thread already holds would deadlock it, and the handler is often the one for SIGTERM.
+        if not self._stop_claim.acquire(blocking=False):
+            return
 
+        self._stopping.set()
         self._logger.info("Stop requested; the bus will wind down")
         self._notify_processors_of_stop()
 

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -168,10 +168,9 @@ class EventBusOrchestrator(ABC):
         # because the pool's own threads discard from it as they finish.
         self._sync_work: set[Future] = set()
         self._sync_work_lock = threading.Lock()
+        self._stop_lock = threading.Lock()
         self._fail_fast = fail_fast
         self._subscribers: dict[type[BaseMessage], list[Processor]] = {}
-        # Also kept flat, because `_subscribers` holds a processor once per message type it takes and
-        # lifecycle hooks are owed to each processor once.
         self._processors: list[Processor] = []
         # These will be initialized in the running loop
         self._queue = asyncio.Queue[BaseMessage]()
@@ -212,14 +211,17 @@ class EventBusOrchestrator(ABC):
         ``on_initialize`` and ``on_message_received`` are abandoned if they are still waiting, since the
         loop awaits them directly and would otherwise be held for as long as they take.
 
-        Every registered processor's :meth:`BaseProcessor.on_stop_requested` runs before this returns.
+        Every registered processor's :meth:`BaseProcessor.on_stop_requested` runs before this returns; a
+        caller that finds the stop already claimed returns at once.
         """
-        if self.stopping:
-            return
+        # Claimed atomically, and before the hooks: two threads may call this, and one that raises must
+        # not leave the bus running. Notifying outside the lock, so a hook cannot hold it.
+        with self._stop_lock:
+            if self.stopping:
+                return
+            self._stopping.set()
 
         self._logger.info("Stop requested; the bus will wind down")
-        # Set before the hooks, so one that raises cannot leave the bus running.
-        self._stopping.set()
         self._notify_processors_of_stop()
 
     def _notify_processors_of_stop(self) -> None:

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -170,6 +170,9 @@ class EventBusOrchestrator(ABC):
         self._sync_work_lock = threading.Lock()
         self._fail_fast = fail_fast
         self._subscribers: dict[type[BaseMessage], list[Processor]] = {}
+        # Also kept flat, because `_subscribers` holds a processor once per message type it takes and
+        # lifecycle hooks are owed to each processor once.
+        self._processors: list[Processor] = []
         # These will be initialized in the running loop
         self._queue = asyncio.Queue[BaseMessage]()
         self._running = False
@@ -197,6 +200,9 @@ class EventBusOrchestrator(ABC):
         processor.bus = self
         for msg_type in message_types:
             self._subscribers.setdefault(msg_type, []).append(processor)
+        # By identity: a subclass defining `__eq__` would otherwise drop a distinct processor.
+        if not any(registered is processor for registered in self._processors):
+            self._processors.append(processor)
 
     def request_stop(self) -> None:
         """Ask the bus to wind down, from any thread.
@@ -217,24 +223,13 @@ class EventBusOrchestrator(ABC):
         self._notify_processors_of_stop()
 
     def _notify_processors_of_stop(self) -> None:
-        for processor in self._registered_processors():
+        for processor in self._processors:
             try:
                 processor.on_stop_requested()
             except Exception as e:
                 # Swallowed rather than routed: the caller may be a signal handler, where raising loses
                 # the processors behind this one.
                 self._logger.error("on_stop_requested failed for '%s': %s", processor.name, e, exc_info=e)
-
-    def _registered_processors(self) -> list[Processor]:
-        """Every registered processor, once each, since ``_subscribers`` is keyed by message type.
-
-        Keyed by identity because a subclass defining ``__eq__`` would collide or be unhashable.
-        """
-        unique: dict[int, Processor] = {}
-        for processors in self._subscribers.values():
-            for processor in processors:
-                unique.setdefault(id(processor), processor)
-        return list(unique.values())
 
     def submit_message(self, message: BaseMessage):
         """Adds a message to the queue, from any thread.

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -82,6 +82,14 @@ class BaseProcessor[T: BaseMessage]:
         """
         raise error
 
+    def on_stop_requested(self) -> None:
+        """React to the bus being asked to wind down, by shortening work already in flight.
+
+        Called once per processor, before the bus acts on the request and possibly from a signal
+        handler, so it must not block or await. Raising is contained: the stop still happens and the
+        other processors are still told.
+        """
+
     def submit_message(self, message: BaseMessage) -> None:
         """Put *message* on the bus this processor was registered in, from any thread."""
         if self.bus is None:
@@ -197,12 +205,36 @@ class EventBusOrchestrator(ABC):
         control, such as a cancelled CI job, reaches ``finalize`` without waiting out the grace period.
         ``on_initialize`` and ``on_message_received`` are abandoned if they are still waiting, since the
         loop awaits them directly and would otherwise be held for as long as they take.
+
+        Every registered processor's :meth:`BaseProcessor.on_stop_requested` runs before this returns.
         """
         if self.stopping:
             return
 
         self._logger.info("Stop requested; the bus will wind down")
+        # Set before the hooks, so one that raises cannot leave the bus running.
         self._stopping.set()
+        self._notify_processors_of_stop()
+
+    def _notify_processors_of_stop(self) -> None:
+        for processor in self._registered_processors():
+            try:
+                processor.on_stop_requested()
+            except Exception as e:
+                # Swallowed rather than routed: the caller may be a signal handler, where raising loses
+                # the processors behind this one.
+                self._logger.error("on_stop_requested failed for '%s': %s", processor.name, e, exc_info=e)
+
+    def _registered_processors(self) -> list[Processor]:
+        """Every registered processor, once each, since ``_subscribers`` is keyed by message type.
+
+        Keyed by identity because a subclass defining ``__eq__`` would collide or be unhashable.
+        """
+        unique: dict[int, Processor] = {}
+        for processors in self._subscribers.values():
+            for processor in processors:
+                unique.setdefault(id(processor), processor)
+        return list(unique.values())
 
     def submit_message(self, message: BaseMessage):
         """Adds a message to the queue, from any thread.

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -1255,33 +1255,15 @@ def test_a_processor_is_told_once_however_often_it_subscribed(registrations: lis
     assert watcher.stop_notifications == 1
 
 
-def test_two_threads_asking_to_stop_at_once_notify_each_processor_once(monkeypatch: pytest.MonkeyPatch):
-    """`request_stop` is documented as callable from any thread, and a `SyncProcessor` runs in one.
-
-    Driven through the log call because that sits between the guard and the flag unless the claim is
-    atomic, which is the window a second thread gets through.
-    """
+def test_asking_to_stop_again_notifies_nobody_and_does_not_block():
+    """The claim is a latch that is never released, so a second call must test it rather than wait."""
     watcher = StopWatcher("watcher")
-    orchestrator = MockOrchestrator(logging.getLogger("test_stop_hook_race"), max_timeout=30, grace_period=1)
+    orchestrator = MockOrchestrator(logging.getLogger("test_stop_repeat"), max_timeout=30, grace_period=1)
     orchestrator.register_processor(watcher, [TaskAssignment])
-    seam_fired = False
-    original_info = orchestrator._logger.info
-
-    def info_then_stop_from_another_thread(*args, **kwargs):
-        nonlocal seam_fired
-        original_info(*args, **kwargs)
-        if seam_fired:
-            return
-        seam_fired = True
-        second = threading.Thread(target=orchestrator.request_stop)
-        second.start()
-        second.join()
-
-    monkeypatch.setattr(orchestrator._logger, "info", info_then_stop_from_another_thread)
 
     orchestrator.request_stop()
+    orchestrator.request_stop()
 
-    assert seam_fired, "the second thread never ran, so this test proves nothing"
     assert watcher.stop_notifications == 1
 
 

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -1255,6 +1255,36 @@ def test_a_processor_is_told_once_however_often_it_subscribed(registrations: lis
     assert watcher.stop_notifications == 1
 
 
+def test_two_threads_asking_to_stop_at_once_notify_each_processor_once(monkeypatch: pytest.MonkeyPatch):
+    """`request_stop` is documented as callable from any thread, and a `SyncProcessor` runs in one.
+
+    Driven through the log call because that sits between the guard and the flag unless the claim is
+    atomic, which is the window a second thread gets through.
+    """
+    watcher = StopWatcher("watcher")
+    orchestrator = MockOrchestrator(logging.getLogger("test_stop_hook_race"), max_timeout=30, grace_period=1)
+    orchestrator.register_processor(watcher, [TaskAssignment])
+    seam_fired = False
+    original_info = orchestrator._logger.info
+
+    def info_then_stop_from_another_thread(*args, **kwargs):
+        nonlocal seam_fired
+        original_info(*args, **kwargs)
+        if seam_fired:
+            return
+        seam_fired = True
+        second = threading.Thread(target=orchestrator.request_stop)
+        second.start()
+        second.join()
+
+    monkeypatch.setattr(orchestrator._logger, "info", info_then_stop_from_another_thread)
+
+    orchestrator.request_stop()
+
+    assert seam_fired, "the second thread never ran, so this test proves nothing"
+    assert watcher.stop_notifications == 1
+
+
 def test_a_stop_is_not_derailed_by_a_processor_that_fails_to_wind_down():
     """A signal handler is a valid caller, and there an escaping exception loses the stop itself."""
     failing = StopWatcher("failing", fail=True)

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -1236,11 +1236,19 @@ class StopWatcher(AsyncProcessor[TaskAssignment | Announcement]):
             raise RuntimeError("this processor cannot wind down")
 
 
-def test_a_processor_is_told_once_however_often_it_subscribed():
+@pytest.mark.parametrize(
+    "registrations",
+    [
+        pytest.param([[TaskAssignment, Announcement]], id="one-call-two-types"),
+        pytest.param([[TaskAssignment], [Announcement]], id="two-calls"),
+    ],
+)
+def test_a_processor_is_told_once_however_often_it_subscribed(registrations: list[list[type[BaseMessage]]]):
     """Subscriptions are per message type, so notifying per subscription would repeat the hook."""
     watcher = StopWatcher("watcher")
     orchestrator = MockOrchestrator(logging.getLogger("test_stop_hook_once"), max_timeout=30, grace_period=1)
-    orchestrator.register_processor(watcher, [TaskAssignment, Announcement])
+    for message_types in registrations:
+        orchestrator.register_processor(watcher, message_types)
 
     orchestrator.request_stop()
 

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -1221,6 +1221,46 @@ class StopRequester(AsyncProcessor[Memo]):
         self.submit_message(Memo("after_stop", subject="late"))
 
 
+class StopWatcher(AsyncProcessor[TaskAssignment | Announcement]):
+    def __init__(self, name: str, *, fail: bool = False):
+        super().__init__(name)
+        self.stop_notifications = 0
+        self._fail = fail
+
+    async def process_message(self, message: TaskAssignment | Announcement):
+        pass
+
+    def on_stop_requested(self):
+        self.stop_notifications += 1
+        if self._fail:
+            raise RuntimeError("this processor cannot wind down")
+
+
+def test_a_processor_is_told_once_however_often_it_subscribed():
+    """Subscriptions are per message type, so notifying per subscription would repeat the hook."""
+    watcher = StopWatcher("watcher")
+    orchestrator = MockOrchestrator(logging.getLogger("test_stop_hook_once"), max_timeout=30, grace_period=1)
+    orchestrator.register_processor(watcher, [TaskAssignment, Announcement])
+
+    orchestrator.request_stop()
+
+    assert watcher.stop_notifications == 1
+
+
+def test_a_stop_is_not_derailed_by_a_processor_that_fails_to_wind_down():
+    """A signal handler is a valid caller, and there an escaping exception loses the stop itself."""
+    failing = StopWatcher("failing", fail=True)
+    watcher = StopWatcher("watcher")
+    orchestrator = MockOrchestrator(logging.getLogger("test_stop_hook_failure"), max_timeout=30, grace_period=1)
+    orchestrator.register_processor(failing, [TaskAssignment])
+    orchestrator.register_processor(watcher, [Announcement])
+
+    orchestrator.request_stop()
+
+    assert orchestrator.stopping
+    assert watcher.stop_notifications == 1
+
+
 def test_a_requested_stop_ends_an_idle_bus_without_waiting_out_the_grace_period(
     secretary: Secretary, caplog: pytest.LogCaptureFixture
 ):


### PR DESCRIPTION
> 1. ~~[#25076](https://github.com/DataDog/integrations-core/pull/25076) client shutdown mode~~ (merged)
> 2. **this PR** processors are told when a stop is requested
> 3. *(to come)* signal handling moves into the bus

### What does this PR do?

Adds `BaseProcessor.on_stop_requested()`, called by `request_stop()` on every registered processor.

- **sync**, because the caller can be a signal handler, where scheduling a task can lose it and reorders unpredictably against the stop
- **once per processor**, not once per subscription. `_subscribers` is keyed by message type, so a processor registered for two types appears in two lists; the notification dedupes by identity
- **the event is set first**, so a hook that raises cannot leave the bus running
- **a raising hook is logged and contained**, so it neither stops the other processors being told nor derails the stop

No production processor overrides it yet, and the Dispatcher's cancellation path is unchanged. That is deliberate: see below.

### Motivation

Second of three items from [AI-7124](https://datadoghq.atlassian.net/browse/AI-7124).

`stopping` is poll-only, so a processor finds out about a stop when it next thinks to look. Of the Dispatcher's three processors, only the gatherer ever looks:

```
task_test_gatherer.py:90    if self.stopping:
task_test_gatherer.py:108   if self.stopping:
```

Meanwhile `on_error` is already a push hook. That asymmetry is the gap this closes: state changes that matter get pushed to processors, except this one.

**Why nothing overrides it yet.** The gatherer's polls are correct as they are: it is a `SyncProcessor` running in a thread, and a hook cannot interrupt a thread, so a push would not improve it. The runner and reporter both hold the shared client, but the Dispatcher already puts that client into shutdown mode once in `_cancel`, and moving that into two processors would mean two calls into shared state with the rate-limit decision duplicated in both. So the honest position is that this PR is the contract, and item 3 is what makes it load-bearing: once the bus itself owns the signal handlers, notifying processors is how anything downstream of the bus learns a signal arrived.

The once-per-processor guarantee is worth stating explicitly because nothing in the Dispatcher would catch getting it wrong: all three of its processors register for exactly one message type, so a per-subscription notification would look correct today and misbehave for whoever first registers for two.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7124]: https://datadoghq.atlassian.net/browse/AI-7124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
