### PR TITLE
AI-7138 Add pull request file and commit pull endpoints to the async GitHub client

### DIFF
--- a/ddev/changelog.d/25082.added
+++ b/ddev/changelog.d/25082.added
@@ -1,0 +1,1 @@
+Add pull request file endpoints to the async GitHub client.

--- a/ddev/src/ddev/utils/github_async/client.py
+++ b/ddev/src/ddev/utils/github_async/client.py
@@ -43,6 +43,7 @@ from .models import (
     IssueComment,
     Label,
     PullRequest,
+    PullRequestFile,
     PullRequestReviewComment,
     WorkflowDispatchResult,
     WorkflowJobsList,
@@ -855,6 +856,49 @@ class AsyncGitHubClient:
             "GET", f"/repos/{owner}/{repo}/pulls/{pull_number}", timeout=timeout, retry=retry
         )
         return self._parse_response(response, PullRequest)
+
+    async def list_pull_request_files(
+        self,
+        owner: str,
+        repo: str,
+        pull_number: int,
+        per_page: int = 100,
+        timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
+    ) -> AsyncIterator[GitHubResponse[list[PullRequestFile]]]:
+        """
+        Calls the GitHub API to list the files a pull request changes (paginated).
+
+        GitHub API Documentation:
+        https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
+
+        The endpoint stops at 3000 files and does not report that it did, so a caller that needs a
+        complete list must compare the number of files it received against ``changed_files`` on the
+        pull request itself.
+
+        Args:
+            owner: Repository owner (user or organisation).
+            repo: Repository name.
+            pull_number: Pull request number.
+            per_page: Number of files per page (default 100, GitHub's maximum).
+            timeout: Optional timeout for this specific request. Defaults to the client's default_timeout.
+            retry: Applies per page. Defaults to the client's policy for replayable requests.
+
+        Returns:
+            AsyncIterator[GitHubResponse[list[PullRequestFile]]]: One page of files per iteration,
+            following Link headers until exhausted.
+        """
+        # The response body is a bare JSON array, so there is no wrapper model to validate against
+        # (unlike ``WorkflowJobsList``); each item is validated individually.
+        endpoint = f"/repos/{owner}/{repo}/pulls/{pull_number}/files"
+        async for response in self._paginated_request(
+            "GET", endpoint, timeout=timeout, retry=retry, params={"per_page": per_page}
+        ):
+            files = [PullRequestFile.model_validate(item) for item in response.json()]
+            yield GitHubResponse[list[PullRequestFile]].model_validate(
+                {"data": files, "headers": dict(response.headers)}
+            )
 
     async def list_pull_requests(
         self,

--- a/ddev/src/ddev/utils/github_async/client.py
+++ b/ddev/src/ddev/utils/github_async/client.py
@@ -857,6 +857,46 @@ class AsyncGitHubClient:
         )
         return self._parse_response(response, PullRequest)
 
+    async def list_commit_pulls(
+        self,
+        owner: str,
+        repo: str,
+        commit_sha: str,
+        per_page: int = 100,
+        timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
+    ) -> AsyncIterator[GitHubResponse[list[PullRequest]]]:
+        """
+        Calls the GitHub API to list the pull requests associated with a commit (paginated).
+
+        GitHub API Documentation:
+        https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit
+
+        The commit only has to be reachable from the repository, not merged into it, so a pull
+        request opened from a fork resolves through the ``refs/pull/<n>/head`` the base repository
+        keeps. A commit whose pull request is closed resolves to nothing.
+
+        Args:
+            owner: Repository owner (user or organisation).
+            repo: Repository name.
+            commit_sha: SHA of the commit to look up.
+            per_page: Number of pull requests per page (default 100, GitHub's maximum).
+            timeout: Optional timeout for this specific request. Defaults to the client's default_timeout.
+            retry: Applies per page. Defaults to the client's policy for replayable requests.
+
+        Returns:
+            AsyncIterator[GitHubResponse[list[PullRequest]]]: One page of pull requests per iteration.
+            The endpoint returns the abbreviated form, so ``changed_files`` is unset on each.
+        """
+        # The response body is a bare JSON array, so there is no wrapper model to validate against.
+        endpoint = f"/repos/{owner}/{repo}/commits/{commit_sha}/pulls"
+        async for response in self._paginated_request(
+            "GET", endpoint, timeout=timeout, retry=retry, params={"per_page": per_page}
+        ):
+            pulls = [PullRequest.model_validate(item) for item in response.json()]
+            yield GitHubResponse[list[PullRequest]].model_validate({"data": pulls, "headers": dict(response.headers)})
+
     async def list_pull_request_files(
         self,
         owner: str,

--- a/ddev/src/ddev/utils/github_async/models/__init__.py
+++ b/ddev/src/ddev/utils/github_async/models/__init__.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
     from .comment import PullRequestReviewComment as PullRequestReviewComment
     from .label import Label as Label
     from .pull_request import PullRequest as PullRequest
+    from .pull_request import PullRequestFile as PullRequestFile
+    from .pull_request import PullRequestFileStatus as PullRequestFileStatus
     from .pull_request import PullRequestRef as PullRequestRef
     from .pull_request import PullRequestState as PullRequestState
     from .user import GitHubUser as GitHubUser
@@ -60,6 +62,8 @@ MODULE_BY_NAME: dict[str, str] = {
     'JobStepStatus': 'workflow',
     'Label': 'label',
     'PullRequest': 'pull_request',
+    'PullRequestFile': 'pull_request',
+    'PullRequestFileStatus': 'pull_request',
     'PullRequestRef': 'pull_request',
     'PullRequestReviewComment': 'comment',
     'PullRequestState': 'pull_request',

--- a/ddev/src/ddev/utils/github_async/models/pull_request.py
+++ b/ddev/src/ddev/utils/github_async/models/pull_request.py
@@ -25,6 +25,42 @@ class PullRequestState(StrEnum):
     CLOSED = auto()
 
 
+class PullRequestFileStatus(StrEnum):
+    """How a file was changed by a pull request.
+
+    The `diff-entry` schema declares `status` as
+    `enum: [added, removed, modified, renamed, copied, changed, unchanged]`.
+    Reference:
+    https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
+    """
+
+    ADDED = auto()
+    REMOVED = auto()
+    MODIFIED = auto()
+    RENAMED = auto()
+    COPIED = auto()
+    CHANGED = auto()
+    UNCHANGED = auto()
+
+
+class PullRequestFile(BaseModel):
+    """One entry of a pull request's file list.
+
+    Only the fields needed to reconstruct a change are modelled; the schema's diff statistics and
+    blob URLs are ignored. `previous_filename` is populated for renames and copies, and is the
+    source path.
+
+    Field reference (the `diff-entry` schema):
+    https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    filename: str
+    status: PullRequestFileStatus
+    previous_filename: str | None = None
+
+
 class PullRequestRef(BaseModel):
     """A head or base branch reference on a pull request.
 
@@ -91,3 +127,8 @@ class PullRequest(BaseModel):
     # Branch references
     head: PullRequestRef | None = None
     base: PullRequestRef | None = None
+
+    # Diff totals. Required by the `pull-request` schema but absent from `pull-request-simple`,
+    # which is what the list endpoints return, so this stays optional. A caller listing a pull
+    # request's files needs it to tell a complete file list from a truncated one.
+    changed_files: int | None = None

--- a/ddev/tests/helpers/github_async.py
+++ b/ddev/tests/helpers/github_async.py
@@ -51,6 +51,7 @@ from ddev.utils.github_async.models import (
     IssueComment,
     Label,
     PullRequest,
+    PullRequestFile,
     PullRequestReviewComment,
     WorkflowDispatchResult,
     WorkflowJobsList,
@@ -149,6 +150,8 @@ def _default_response_factories() -> dict[str, Callable[[], Any]]:
         # Default to "no existing PRs" so the --from-pr idempotency check does not skip a base
         # unless a test explicitly registers an existing backport PR.
         'list_pull_requests': lambda: GitHubResponse.model_validate({'data': [], 'headers': {}}),
+        # An empty page; tests that need changed files register their own list of PullRequestFile.
+        'list_pull_request_files': lambda: GitHubResponse.model_validate({'data': [], 'headers': {}}),
         'create_workflow_dispatch': lambda: GitHubResponse(
             data=WorkflowDispatchResult(
                 workflow_run_id=123,
@@ -423,6 +426,39 @@ class FakeAsyncGitHubClient:
         response = self._resolve_response(
             'list_issue_comments',
             {'owner': owner, 'repo': repo, 'issue_number': issue_number, 'per_page': per_page, 'timeout': timeout},
+        )
+        if isinstance(response, BaseException):
+            raise response
+        pages = response if isinstance(response, list) else [response]
+        for page in pages:
+            yield page
+
+    async def list_pull_request_files(
+        self,
+        owner: str,
+        repo: str,
+        pull_number: int,
+        per_page: int = 100,
+        timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
+    ) -> AsyncIterator[GitHubResponse[list[PullRequestFile]]]:
+        """Async-generator mirror.
+
+        A page is itself a list of files, so pages are registered explicitly: one `GitHubResponse`
+        for one page, a list of them for several.
+        """
+        self._record(
+            'list_pull_request_files',
+            owner=owner,
+            repo=repo,
+            pull_number=pull_number,
+            per_page=per_page,
+            timeout=timeout,
+        )
+        response = self._resolve_response(
+            'list_pull_request_files',
+            {'owner': owner, 'repo': repo, 'pull_number': pull_number, 'per_page': per_page, 'timeout': timeout},
         )
         if isinstance(response, BaseException):
             raise response

--- a/ddev/tests/helpers/github_async.py
+++ b/ddev/tests/helpers/github_async.py
@@ -152,6 +152,8 @@ def _default_response_factories() -> dict[str, Callable[[], Any]]:
         'list_pull_requests': lambda: GitHubResponse.model_validate({'data': [], 'headers': {}}),
         # An empty page; tests that need changed files register their own list of PullRequestFile.
         'list_pull_request_files': lambda: GitHubResponse.model_validate({'data': [], 'headers': {}}),
+        # Default to "this commit belongs to no open pull request", the same shape a closed one gives.
+        'list_commit_pulls': lambda: GitHubResponse.model_validate({'data': [], 'headers': {}}),
         'create_workflow_dispatch': lambda: GitHubResponse(
             data=WorkflowDispatchResult(
                 workflow_run_id=123,
@@ -426,6 +428,39 @@ class FakeAsyncGitHubClient:
         response = self._resolve_response(
             'list_issue_comments',
             {'owner': owner, 'repo': repo, 'issue_number': issue_number, 'per_page': per_page, 'timeout': timeout},
+        )
+        if isinstance(response, BaseException):
+            raise response
+        pages = response if isinstance(response, list) else [response]
+        for page in pages:
+            yield page
+
+    async def list_commit_pulls(
+        self,
+        owner: str,
+        repo: str,
+        commit_sha: str,
+        per_page: int = 100,
+        timeout: float | None = None,
+        *,
+        retry: RetryPolicy | None = None,
+    ) -> AsyncIterator[GitHubResponse[list[PullRequest]]]:
+        """Async-generator mirror.
+
+        A page is itself a list of pull requests, so pages are registered explicitly: one
+        `GitHubResponse` for one page, a list of them for several.
+        """
+        self._record(
+            'list_commit_pulls',
+            owner=owner,
+            repo=repo,
+            commit_sha=commit_sha,
+            per_page=per_page,
+            timeout=timeout,
+        )
+        response = self._resolve_response(
+            'list_commit_pulls',
+            {'owner': owner, 'repo': repo, 'commit_sha': commit_sha, 'per_page': per_page, 'timeout': timeout},
         )
         if isinstance(response, BaseException):
             raise response

--- a/ddev/tests/test_fake_github_async.py
+++ b/ddev/tests/test_fake_github_async.py
@@ -314,6 +314,11 @@ MIRROR_CALLS = [
     ('update_issue_comment', lambda f, _: f.update_issue_comment('o', 'r', 3, 'edited'), {'comment_id': 3}),
     ('list_issue_comments', lambda f, _: first_page(f.list_issue_comments('o', 'r', 7)), {'issue_number': 7}),
     (
+        'list_pull_request_files',
+        lambda f, _: first_page(f.list_pull_request_files('o', 'r', 5)),
+        {'pull_number': 5},
+    ),
+    (
         'add_labels_to_issue',
         lambda f, _: f.add_labels_to_issue('o', 'r', 7, ['qa/skip-qa']),
         {'labels': ['qa/skip-qa']},

--- a/ddev/tests/test_fake_github_async.py
+++ b/ddev/tests/test_fake_github_async.py
@@ -319,6 +319,11 @@ MIRROR_CALLS = [
         {'pull_number': 5},
     ),
     (
+        'list_commit_pulls',
+        lambda f, _: first_page(f.list_commit_pulls('o', 'r', 'abc123')),
+        {'commit_sha': 'abc123'},
+    ),
+    (
         'add_labels_to_issue',
         lambda f, _: f.add_labels_to_issue('o', 'r', 7, ['qa/skip-qa']),
         {'labels': ['qa/skip-qa']},

--- a/ddev/tests/utils/github_async/helpers.py
+++ b/ddev/tests/utils/github_async/helpers.py
@@ -24,6 +24,7 @@ from tests.utils.github_async.payloads import (
     full_pull_request_payload,
     issue_comment_payload,
     pr_review_comment_payload,
+    pull_request_file_payload,
     pull_request_payload,
     workflow_job,
     workflow_run_payload,
@@ -170,6 +171,12 @@ ENDPOINT_CALLS = [
         "list_pull_requests",
         lambda c: c.list_pull_requests("o", "r"),
         lambda: json_response([pull_request_payload(number=1)]),
+        default_retry="safe",
+    ),
+    EndpointCase(
+        "list_pull_request_files",
+        lambda c: first_page(c.list_pull_request_files("o", "r", 5)),
+        lambda: json_response([pull_request_file_payload()]),
         default_retry="safe",
     ),
     EndpointCase(

--- a/ddev/tests/utils/github_async/helpers.py
+++ b/ddev/tests/utils/github_async/helpers.py
@@ -180,6 +180,12 @@ ENDPOINT_CALLS = [
         default_retry="safe",
     ),
     EndpointCase(
+        "list_commit_pulls",
+        lambda c: first_page(c.list_commit_pulls("o", "r", "abc123")),
+        lambda: json_response([pull_request_payload(number=1)]),
+        default_retry="safe",
+    ),
+    EndpointCase(
         "create_pull_request",
         lambda c: c.create_pull_request("o", "r", "t", "h", "b"),
         lambda: json_response(pull_request_payload(number=1), status_code=201),

--- a/ddev/tests/utils/github_async/payloads.py
+++ b/ddev/tests/utils/github_async/payloads.py
@@ -107,6 +107,27 @@ def pr_review_comment_payload(
     }
 
 
+def pull_request_file_payload(
+    filename: str = "datadog_checks_base/setup.py",
+    status: str = "modified",
+    **extra: Any,
+) -> dict[str, Any]:
+    """A `diff-entry` payload, including the diff statistics the model deliberately ignores."""
+    return {
+        "sha": "bbcd538c8e72b8c175046e27cc8f907076331401",
+        "filename": filename,
+        "status": status,
+        "additions": 3,
+        "deletions": 1,
+        "changes": 4,
+        "blob_url": f"https://github.com/owner/repo/blob/abc/{filename}",
+        "raw_url": f"https://github.com/owner/repo/raw/abc/{filename}",
+        "contents_url": f"https://api.github.com/repos/owner/repo/contents/{filename}",
+        "patch": "@@ -1 +1 @@",
+        **extra,
+    }
+
+
 def pull_request_payload(number: int = 1, html_url: str | None = None, **extra: Any) -> dict[str, Any]:
     return {
         "number": number,

--- a/ddev/tests/utils/github_async/test_endpoints.py
+++ b/ddev/tests/utils/github_async/test_endpoints.py
@@ -537,6 +537,11 @@ async def test_list_pull_request_files_success():
             [
                 pull_request_file_payload(filename="disk/tests/test_unit.py"),
                 pull_request_file_payload(filename="disk/removed.py", status="removed"),
+                pull_request_file_payload(
+                    filename="disk/renamed.py",
+                    status="renamed",
+                    previous_filename="disk/original.py",
+                ),
             ]
         )
 
@@ -546,8 +551,18 @@ async def test_list_pull_request_files_success():
     assert len(pages) == 1
     files = pages[0].data
     assert all(isinstance(changed, PullRequestFile) for changed in files)
-    assert [changed.filename for changed in files] == ["disk/tests/test_unit.py", "disk/removed.py"]
-    assert [changed.status for changed in files] == [PullRequestFileStatus.MODIFIED, PullRequestFileStatus.REMOVED]
+    assert [changed.filename for changed in files] == [
+        "disk/tests/test_unit.py",
+        "disk/removed.py",
+        "disk/renamed.py",
+    ]
+    assert [changed.status for changed in files] == [
+        PullRequestFileStatus.MODIFIED,
+        PullRequestFileStatus.REMOVED,
+        PullRequestFileStatus.RENAMED,
+    ]
+    # A rename's source path is a changed path too, so a caller that loses it misses the work.
+    assert [changed.previous_filename for changed in files] == [None, None, "disk/original.py"]
 
 
 async def test_list_pull_request_files_follows_link_header():

--- a/ddev/tests/utils/github_async/test_endpoints.py
+++ b/ddev/tests/utils/github_async/test_endpoints.py
@@ -576,6 +576,20 @@ async def test_list_pull_request_files_success():
     assert [changed.previous_filename for changed in files] == [None, None, "disk/original.py"]
 
 
+async def test_list_commit_pulls_success():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/repos/owner/repo/commits/31014335d4/pulls"
+        assert request.url.params["per_page"] == "100"
+        # The abbreviated `pull-request-simple` form, which is what this endpoint returns.
+        return json_response([pull_request_payload(number=25082)])
+
+    client = make_client(httpx.MockTransport(handler))
+    pages = [page async for page in client.list_commit_pulls("owner", "repo", "31014335d4")]
+
+    assert [pull.number for page in pages for pull in page.data] == [25082]
+
+
 async def test_add_labels_to_issue_success() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "POST"

--- a/ddev/tests/utils/github_async/test_endpoints.py
+++ b/ddev/tests/utils/github_async/test_endpoints.py
@@ -528,28 +528,39 @@ async def test_list_pull_requests_forwards_base_filter():
 
 
 async def test_list_pull_request_files_success():
+    """Spans two pages because stopping at the first would plan a subset of the targets and still
+    report success, so the run would go green having never tested the rest of the change.
+    """
+    second_page_url = "https://api.github.com/repos/owner/repo/pulls/25074/files?page=2"
+
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "GET"
         assert request.url.path == "/repos/owner/repo/pulls/25074/files"
+        if request.url.params.get("page") == "2":
+            return json_response(
+                [
+                    pull_request_file_payload(
+                        filename="disk/renamed.py",
+                        status="renamed",
+                        previous_filename="disk/original.py",
+                    )
+                ]
+            )
         assert request.url.params["per_page"] == "100"
         # The response body is a bare array, not an object with a wrapper key.
         return json_response(
             [
                 pull_request_file_payload(filename="disk/tests/test_unit.py"),
                 pull_request_file_payload(filename="disk/removed.py", status="removed"),
-                pull_request_file_payload(
-                    filename="disk/renamed.py",
-                    status="renamed",
-                    previous_filename="disk/original.py",
-                ),
-            ]
+            ],
+            headers={"link": f'<{second_page_url}>; rel="next"'},
         )
 
     client = make_client(httpx.MockTransport(handler))
     pages = [page async for page in client.list_pull_request_files("owner", "repo", 25074)]
 
-    assert len(pages) == 1
-    files = pages[0].data
+    assert len(pages) == 2
+    files = [changed for page in pages for changed in page.data]
     assert all(isinstance(changed, PullRequestFile) for changed in files)
     assert [changed.filename for changed in files] == [
         "disk/tests/test_unit.py",
@@ -563,28 +574,6 @@ async def test_list_pull_request_files_success():
     ]
     # A rename's source path is a changed path too, so a caller that loses it misses the work.
     assert [changed.previous_filename for changed in files] == [None, None, "disk/original.py"]
-
-
-async def test_list_pull_request_files_follows_link_header():
-    """A pull request larger than one page must yield every file.
-
-    Stopping at the first page selects a subset of the targets to test and still reports success,
-    so the run goes green having never tested the rest of the change.
-    """
-    second_page_url = "https://api.github.com/repos/owner/repo/pulls/25074/files?page=2"
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.params.get("page") == "2":
-            return json_response([pull_request_file_payload(filename="second.py")])
-        return json_response(
-            [pull_request_file_payload(filename="first.py")],
-            headers={"link": f'<{second_page_url}>; rel="next"'},
-        )
-
-    client = make_client(httpx.MockTransport(handler))
-    pages = [page async for page in client.list_pull_request_files("owner", "repo", 25074)]
-
-    assert [changed.filename for page in pages for changed in page.data] == ["first.py", "second.py"]
 
 
 async def test_add_labels_to_issue_success() -> None:

--- a/ddev/tests/utils/github_async/test_endpoints.py
+++ b/ddev/tests/utils/github_async/test_endpoints.py
@@ -22,6 +22,8 @@ from ddev.utils.github_async.models import (
     JobStepStatus,
     Label,
     PullRequest,
+    PullRequestFile,
+    PullRequestFileStatus,
     PullRequestReviewComment,
     PullRequestState,
     WorkflowDispatchResult,
@@ -39,6 +41,7 @@ from tests.utils.github_async.payloads import (
     full_pull_request_payload,
     issue_comment_payload,
     pr_review_comment_payload,
+    pull_request_file_payload,
     pull_request_payload,
     workflow_job,
     workflow_run_payload,
@@ -522,6 +525,51 @@ async def test_list_pull_requests_forwards_base_filter():
     client = make_client(httpx.MockTransport(handler))
     result = await client.list_pull_requests("o", "r", base="7.62.x")
     assert result.data[0].number == 1
+
+
+async def test_list_pull_request_files_success():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/repos/owner/repo/pulls/25074/files"
+        assert request.url.params["per_page"] == "100"
+        # The response body is a bare array, not an object with a wrapper key.
+        return json_response(
+            [
+                pull_request_file_payload(filename="disk/tests/test_unit.py"),
+                pull_request_file_payload(filename="disk/removed.py", status="removed"),
+            ]
+        )
+
+    client = make_client(httpx.MockTransport(handler))
+    pages = [page async for page in client.list_pull_request_files("owner", "repo", 25074)]
+
+    assert len(pages) == 1
+    files = pages[0].data
+    assert all(isinstance(changed, PullRequestFile) for changed in files)
+    assert [changed.filename for changed in files] == ["disk/tests/test_unit.py", "disk/removed.py"]
+    assert [changed.status for changed in files] == [PullRequestFileStatus.MODIFIED, PullRequestFileStatus.REMOVED]
+
+
+async def test_list_pull_request_files_follows_link_header():
+    """A pull request larger than one page must yield every file.
+
+    Stopping at the first page selects a subset of the targets to test and still reports success,
+    so the run goes green having never tested the rest of the change.
+    """
+    second_page_url = "https://api.github.com/repos/owner/repo/pulls/25074/files?page=2"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params.get("page") == "2":
+            return json_response([pull_request_file_payload(filename="second.py")])
+        return json_response(
+            [pull_request_file_payload(filename="first.py")],
+            headers={"link": f'<{second_page_url}>; rel="next"'},
+        )
+
+    client = make_client(httpx.MockTransport(handler))
+    pages = [page async for page in client.list_pull_request_files("owner", "repo", 25074)]
+
+    assert [changed.filename for page in pages for changed in page.data] == ["first.py", "second.py"]
 
 
 async def test_add_labels_to_issue_success() -> None:

--- a/ddev/tests/utils/github_async/test_models.py
+++ b/ddev/tests/utils/github_async/test_models.py
@@ -8,10 +8,16 @@ from ddev.utils.github_async.models import (
     GitHubUser,
     Label,
     PullRequest,
+    PullRequestFile,
+    PullRequestFileStatus,
     PullRequestRef,
     PullRequestState,
 )
-from tests.utils.github_async.payloads import full_pull_request_payload
+from tests.utils.github_async.payloads import (
+    full_pull_request_payload,
+    pull_request_file_payload,
+    pull_request_payload,
+)
 
 
 def test_pull_request_parses_full_response() -> None:
@@ -45,6 +51,31 @@ def test_pull_request_ignores_extra_fields() -> None:
     payload = full_pull_request_payload(mergeable_state="clean", additions=42, unknown_future_field={"nested": True})
     pr = PullRequest.model_validate(payload)
     assert pr.number == 42
+
+
+def test_pull_request_file_keeps_the_source_path_of_a_rename() -> None:
+    """A rename's source path is a changed path too, so losing it hides work that needs testing."""
+    payload = pull_request_file_payload(
+        filename="datadog_checks_base/renamed.py",
+        status="renamed",
+        previous_filename="datadog_checks_base/original.py",
+    )
+
+    changed = PullRequestFile.model_validate(payload)
+
+    assert changed.filename == "datadog_checks_base/renamed.py"
+    assert changed.status is PullRequestFileStatus.RENAMED
+    assert changed.previous_filename == "datadog_checks_base/original.py"
+
+
+def test_pull_request_changed_files_absent_from_abbreviated_payloads() -> None:
+    """The `pull-request-simple` schema the list endpoints return has no `changed_files`.
+
+    It is required by the `pull-request` schema, so modelling it as required would break parsing for
+    every endpoint that returns the abbreviated form.
+    """
+    assert PullRequest.model_validate(pull_request_payload()).changed_files is None
+    assert PullRequest.model_validate(full_pull_request_payload(changed_files=397)).changed_files == 397
 
 
 def test_models_subpackage_unknown_attribute_raises_attribute_error() -> None:

--- a/ddev/tests/utils/github_async/test_models.py
+++ b/ddev/tests/utils/github_async/test_models.py
@@ -8,16 +8,10 @@ from ddev.utils.github_async.models import (
     GitHubUser,
     Label,
     PullRequest,
-    PullRequestFile,
-    PullRequestFileStatus,
     PullRequestRef,
     PullRequestState,
 )
-from tests.utils.github_async.payloads import (
-    full_pull_request_payload,
-    pull_request_file_payload,
-    pull_request_payload,
-)
+from tests.utils.github_async.payloads import full_pull_request_payload
 
 
 def test_pull_request_parses_full_response() -> None:
@@ -51,31 +45,6 @@ def test_pull_request_ignores_extra_fields() -> None:
     payload = full_pull_request_payload(mergeable_state="clean", additions=42, unknown_future_field={"nested": True})
     pr = PullRequest.model_validate(payload)
     assert pr.number == 42
-
-
-def test_pull_request_file_keeps_the_source_path_of_a_rename() -> None:
-    """A rename's source path is a changed path too, so losing it hides work that needs testing."""
-    payload = pull_request_file_payload(
-        filename="datadog_checks_base/renamed.py",
-        status="renamed",
-        previous_filename="datadog_checks_base/original.py",
-    )
-
-    changed = PullRequestFile.model_validate(payload)
-
-    assert changed.filename == "datadog_checks_base/renamed.py"
-    assert changed.status is PullRequestFileStatus.RENAMED
-    assert changed.previous_filename == "datadog_checks_base/original.py"
-
-
-def test_pull_request_changed_files_absent_from_abbreviated_payloads() -> None:
-    """The `pull-request-simple` schema the list endpoints return has no `changed_files`.
-
-    It is required by the `pull-request` schema, so modelling it as required would break parsing for
-    every endpoint that returns the abbreviated form.
-    """
-    assert PullRequest.model_validate(pull_request_payload()).changed_files is None
-    assert PullRequest.model_validate(full_pull_request_payload(changed_files=397)).changed_files == 397
 
 
 def test_models_subpackage_unknown_attribute_raises_attribute_error() -> None:


### PR DESCRIPTION
### What does this PR do?

Adds the client surface for a pull request's changed files, plus resolving a commit to its pull requests:

- `list_pull_request_files`, `PullRequestFile` (`filename`, `status`, `previous_filename`) and `PullRequestFileStatus`.
- `list_commit_pulls`, for `commits/{sha}/pulls`.
- `changed_files` on `PullRequest`.

Nothing calls them yet; the changed-files provider that consumes them is [AI-7139](https://datadoghq.atlassian.net/browse/AI-7139).

Two things worth a look, both from the pinned OpenAPI description rather than the docs page. Both endpoints return a bare array, so there is no wrapper model (`list_issue_comments` is the precedent). And `changed_files` is declared on `pull-request` but not on `pull-request-simple`, which is what `list_pull_requests` and `commits/{sha}/pulls` return; all three parse into the same `PullRequest`, so the field has to stay optional. Also `status` declares seven values, not the four that turn up in practice.

### Motivation

Planning derives changed files from local git. For a pull request the checkout is detached at `refs/remotes/pull/N/merge` with no local branches, so `merge-base` against the target branch fails outright. Moving that case to the API removes the failure.

`changed_files` is the part that carries weight: `pulls/{n}/files` stops at 3000 files and does not say that it did, so the count on the pull request is the only way to tell a complete list from a truncated prefix. `compare` is unusable here, it paginates commits rather than files and caps at 300 with no truncation flag, which is undetectable from the payload.

`list_commit_pulls` is what lets the dispatcher find the pull request under a `workflow_run` trigger, where the event carries a head SHA but not reliably a number. Measured on this repo, `workflow_run.pull_requests` is empty for 33 of 100 sampled runs, so it cannot be the only source.

Checked against the live API. PR 25074 returns 15 files in one page, matching `changed_files` and matching the 15 that `git merge-base` plus `git diff --name-status` produce, per-file status included. PR 22711 returns 397 across 4 pages, again matching `changed_files`. PR 24931 covers a rename and its `previous_filename`.

For `list_commit_pulls`, the three cases that shape how a caller has to use it:

```
fork PR head       c4cb1caca0  ->  #24474 state=closed  changed_files=None
same-repo open PR  4edb88e9    ->  #24957 state=open    changed_files=None
closed PR head     e905723e    ->  (none)
```

A fork's head resolves fine, through the `refs/pull/N/head` the base repository keeps. A commit whose pull request is closed resolves to nothing. And since the endpoint returns the abbreviated form, `changed_files` is unset, so a caller that needs the count or the state still has to call `get_pull_request`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7139]: https://datadoghq.atlassian.net/browse/AI-7139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ