### PR TITLE
[AI-7124] Let the event bus own the shutdown signals

### DIFF
--- a/ddev/changelog.d/25088.added
+++ b/ddev/changelog.d/25088.added
@@ -1,0 +1,1 @@
+Handle the shutdown signals in the event bus so every orchestrator winds down cleanly.

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -113,7 +113,14 @@ class Dispatcher(EventBusOrchestrator):
         grace_period: float,
         run_logger: logging.Logger | None = None,
     ):
-        super().__init__(run_logger or logger, max_timeout=max_timeout, grace_period=grace_period)
+        super().__init__(
+            run_logger or logger,
+            max_timeout=max_timeout,
+            grace_period=grace_period,
+            # A cancelled run reports itself, on the pull request and in the run summary, and the caller
+            # reads that outcome once this returns. Raising instead would skip it.
+            propagate_keyboard_interrupt=False,
+        )
         self._batches = batches
         self._client = client
         self._runner = runner

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -113,14 +113,7 @@ class Dispatcher(EventBusOrchestrator):
         grace_period: float,
         run_logger: logging.Logger | None = None,
     ):
-        super().__init__(
-            run_logger or logger,
-            max_timeout=max_timeout,
-            grace_period=grace_period,
-            # A cancelled run reports itself, on the pull request and in the run summary, and the caller
-            # reads that outcome once this returns. Raising instead would skip it.
-            propagate_keyboard_interrupt=False,
-        )
+        super().__init__(run_logger or logger, max_timeout=max_timeout, grace_period=grace_period)
         self._batches = batches
         self._client = client
         self._runner = runner

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import signal
 from dataclasses import dataclass
@@ -33,12 +32,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Signals a cancelled GitHub Actions job sends: SIGINT first, SIGTERM about 7.5s later, then a hard
-# kill about 2.5s after that.
-CANCELLATION_SIGNALS = (signal.SIGINT, signal.SIGTERM)
-
-# A call that cannot go out within this is one the process will not live to see answered.
-# A cancelled run abandons its pacing: the budget it was rationing outlives the process.
+# A cancelled job gets SIGINT, SIGTERM about 7.5s later, then a hard kill about 2.5s after that, so a
+# cancelled run abandons its pacing: the budget it was rationing outlives the process.
 CANCELLED_RATE_LIMITS = RelaxedRateLimits(max_wait_seconds=2.0, max_rate=10_000.0)
 
 
@@ -142,48 +137,25 @@ class Dispatcher(EventBusOrchestrator):
         return self._cancelled
 
     async def on_initialize(self):
-        self._listen_for_cancellation()
         self.submit_message(self._gatherer.build_initial_update())
         for batch in self._batches:
             self.submit_message(batch)
         self._logger.info("Dispatched %s batches", len(self._batches))
 
-    def _listen_for_cancellation(self) -> None:
-        """Handle the cancellation signals, so the run winds down instead of being killed mid-flight.
+    def on_shutdown_signal(self, received: signal.Signals) -> None:
+        """Record that the run was cancelled, then size what is left for the seconds it has.
 
-        Handling SIGINT here also means it no longer arrives as `KeyboardInterrupt`, so shutdown takes
-        the same path whichever signal came first.
-        """
-        loop = asyncio.get_running_loop()
-        for received in CANCELLATION_SIGNALS:
-            # Only Unix event loops can do this. The Dispatcher runs on Linux runners, but ddev's own
-            # tests run on Windows too, where a run simply cannot be cancelled cleanly.
-            try:
-                loop.add_signal_handler(received, self._cancel, received)
-            except NotImplementedError:
-                self._logger.debug("This event loop cannot handle %s; cancellation will not be clean", received.name)
-
-    def _stop_listening_for_cancellation(self) -> None:
-        loop = asyncio.get_running_loop()
-        for received in CANCELLATION_SIGNALS:
-            with contextlib.suppress(NotImplementedError, RuntimeError):
-                loop.remove_signal_handler(received)
-
-    def _cancel(self, received: signal.Signals) -> None:
-        """Start winding down, and size what is left for the seconds the process still has.
-
-        Idempotent because both signals arrive on a cancelled job, seconds apart, and the second must
-        not restart anything the first began.
+        Both signals arrive on a cancelled job, seconds apart, so the second must not restart what the
+        first began.
         """
         if self._cancelled:
             self._logger.info("Already cancelling; ignoring %s", received.name)
             return
 
         self._cancelled = True
-        self._logger.warning("Received %s: cancelling the run", received.name)
-        # Stop first: anything raised here goes to the loop's exception handler, and the second signal
-        # returns early on `_cancelled`. The stop is what makes each batch close its check run.
-        self.request_stop()
+        # Recorded and stopped before anything that can raise: this runs as a loop callback, so a
+        # failure here goes to the loop's exception handler and the second signal returns early.
+        super().on_shutdown_signal(received)
         self._client.enter_shutdown_mode(rate_limits=CANCELLED_RATE_LIMITS)
 
     async def on_message_received(self, message: BaseMessage):
@@ -202,7 +174,6 @@ class Dispatcher(EventBusOrchestrator):
             if (body := self._reporter.latest_body) is not None:
                 write_step_summary(render_run_summary(body, pr_comment_failed=self._reporter.pr_comment_failed))
         finally:
-            self._stop_listening_for_cancellation()
             await self._client.aclose()
 
     async def _report_cancellation(self) -> None:

--- a/ddev/src/ddev/cli/validate/all/orchestrator.py
+++ b/ddev/src/ddev/cli/validate/all/orchestrator.py
@@ -212,6 +212,14 @@ class ValidationOrchestrator(EventBusOrchestrator):
             [ValidationMessage],
         )
 
+    def install_signal_handlers(self) -> None:
+        """Left to the default handling, which is what interrupts the validations.
+
+        Each one runs as a subprocess from a pool thread, and a requested stop cannot interrupt either;
+        it would be noticed only once the subprocess returned or timed out. Winding down cleanly needs
+        the children terminated first, so until that exists the default remains the quicker way out.
+        """
+
     async def on_initialize(self) -> None:
         for name in self._validations:
             config = VALIDATIONS.get(name, ValidationConfig())

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -142,6 +142,7 @@ class EventBusOrchestrator(ABC):
         logger: logging.Logger,
         max_timeout: float | None = DEFAULT_ORCHESTRATOR_MAX_TIMEOUT,
         grace_period: float = 10,
+        propagate_keyboard_interrupt: bool = True,
         executor: Executor | None = None,
         fail_fast: bool = False,
     ):
@@ -157,6 +158,10 @@ class EventBusOrchestrator(ABC):
                 or killing the process) will stop it.
             grace_period: The timeout in seconds to wait for a new message to be submitted after all
                 messages have been processed.
+            propagate_keyboard_interrupt: Whether ``run`` re-raises ``KeyboardInterrupt`` once a run
+                interrupted by SIGINT has finished winding down. Handling the signal is what stops the
+                interpreter raising it, and with it whatever the caller does about one, such as Click's
+                abort. Turn it off where the bus reports the outcome itself.
             executor: The executor to use for running sync processors.
                       The default will be a ThreadpoolExecutor with 4 workers.
             fail_fast: If True, any exception that escapes an ``on_error`` handler stops
@@ -187,6 +192,8 @@ class EventBusOrchestrator(ABC):
         self._loop: asyncio.AbstractEventLoop | None = None
         self._stopping = threading.Event()
         self._displaced_signal_handlers: dict[signal.Signals, SignalHandler] = {}
+        self._propagate_keyboard_interrupt = propagate_keyboard_interrupt
+        self._interrupted = False
 
     def __validate_parameters(self, max_timeout: float, grace_period: float):
         """
@@ -261,6 +268,7 @@ class EventBusOrchestrator(ABC):
         raises reaches the loop's exception handler, and a second signal will not retry it, so put what
         must happen first. Override to add to this, calling ``super()``.
         """
+        self._interrupted = self._interrupted or received == signal.SIGINT
         self._logger.warning("Received %s: the bus will wind down", received.name)
         self.request_stop()
 
@@ -325,8 +333,14 @@ class EventBusOrchestrator(ABC):
           - [hook] on_message_received(message)
         - finalize()
           - [hook] on_finalize(exc_info)
+
+        Re-raises ``KeyboardInterrupt`` after all of that when a SIGINT arrived and
+        ``propagate_keyboard_interrupt`` is set, so an interrupted run does not report success to
+        whatever launched it. A caller that reads state off the bus afterwards wants it off.
         """
         asyncio.run(self._entry_point())
+        if self._interrupted and self._propagate_keyboard_interrupt:
+            raise KeyboardInterrupt
 
     async def _entry_point(self):
         exception = None

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -142,7 +142,6 @@ class EventBusOrchestrator(ABC):
         logger: logging.Logger,
         max_timeout: float | None = DEFAULT_ORCHESTRATOR_MAX_TIMEOUT,
         grace_period: float = 10,
-        propagate_keyboard_interrupt: bool = True,
         executor: Executor | None = None,
         fail_fast: bool = False,
     ):
@@ -158,10 +157,6 @@ class EventBusOrchestrator(ABC):
                 or killing the process) will stop it.
             grace_period: The timeout in seconds to wait for a new message to be submitted after all
                 messages have been processed.
-            propagate_keyboard_interrupt: Whether ``run`` re-raises ``KeyboardInterrupt`` once a run
-                interrupted by SIGINT has finished winding down. Handling the signal is what stops the
-                interpreter raising it, and with it whatever the caller does about one, such as Click's
-                abort. Turn it off where the bus reports the outcome itself.
             executor: The executor to use for running sync processors.
                       The default will be a ThreadpoolExecutor with 4 workers.
             fail_fast: If True, any exception that escapes an ``on_error`` handler stops
@@ -192,7 +187,6 @@ class EventBusOrchestrator(ABC):
         self._loop: asyncio.AbstractEventLoop | None = None
         self._stopping = threading.Event()
         self._displaced_signal_handlers: dict[signal.Signals, SignalHandler] = {}
-        self._propagate_keyboard_interrupt = propagate_keyboard_interrupt
         self._interrupted = False
 
     def __validate_parameters(self, max_timeout: float, grace_period: float):
@@ -320,7 +314,7 @@ class EventBusOrchestrator(ABC):
         else:
             self._queue.put_nowait(message)
 
-    def run(self):
+    def run(self, *, propagate_keyboard_interrupt: bool = False):
         """
         Launch the orchestrator and start consuming messages from the message queue.
 
@@ -334,12 +328,15 @@ class EventBusOrchestrator(ABC):
         - finalize()
           - [hook] on_finalize(exc_info)
 
-        Re-raises ``KeyboardInterrupt`` after all of that when a SIGINT arrived and
-        ``propagate_keyboard_interrupt`` is set, so an interrupted run does not report success to
-        whatever launched it. A caller that reads state off the bus afterwards wants it off.
+        Args:
+            propagate_keyboard_interrupt: Re-raise ``KeyboardInterrupt`` after a run interrupted by
+                SIGINT has wound down. Handling the signal is what stops the interpreter raising it, and
+                with it whatever the caller does about one, such as Click's abort. Off by default: a bus
+                that wound down cleanly has not failed. Callers that read state off the bus afterwards,
+                or report the outcome themselves, want it off.
         """
         asyncio.run(self._entry_point())
-        if self._interrupted and self._propagate_keyboard_interrupt:
+        if self._interrupted and propagate_keyboard_interrupt:
             raise KeyboardInterrupt
 
     async def _entry_point(self):

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -214,8 +214,10 @@ class EventBusOrchestrator(ABC):
         Called by :meth:`initialize`. Override to handle a different set, or to do nothing where the
         process has another owner for them.
 
-        Handling SIGINT here also means it stops arriving as ``KeyboardInterrupt``, so shutdown takes
-        the same path whichever signal comes first.
+        One handler per signal, despite the name: this replaces whatever was installed rather than
+        chaining onto it, so two buses in a process would leave only the second one hearing anything.
+        For SIGINT what it replaces is the handler that raises ``KeyboardInterrupt``, which is what
+        makes shutdown take the same path whichever signal comes first.
         """
         loop = asyncio.get_running_loop()
         for received in SHUTDOWN_SIGNALS:

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -14,6 +14,7 @@ from collections.abc import Awaitable, Callable
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from concurrent.futures import wait as wait_for_futures
 from dataclasses import dataclass
+from types import FrameType
 from typing import assert_never, cast
 
 from .exceptions import (
@@ -27,6 +28,9 @@ from .exceptions import (
 )
 
 type ErrorHandler[E: Exception] = Callable[[E], Awaitable[None]]
+# What `signal.getsignal` hands back: a Python callable, one of the `SIG_*` constants, or None for a
+# handler installed outside Python.
+type SignalHandler = Callable[[int, FrameType | None], object] | int | signal.Handlers | None
 
 DEFAULT_ORCHESTRATOR_MAX_TIMEOUT = 300.0
 # How long the loop may block before re-reading the timeout and the stop flag.
@@ -182,6 +186,7 @@ class EventBusOrchestrator(ABC):
         self._running = False
         self._loop: asyncio.AbstractEventLoop | None = None
         self._stopping = threading.Event()
+        self._displaced_signal_handlers: dict[signal.Signals, SignalHandler] = {}
 
     def __validate_parameters(self, max_timeout: float, grace_period: float):
         """
@@ -217,23 +222,37 @@ class EventBusOrchestrator(ABC):
         One handler per signal, despite the name: this replaces whatever was installed rather than
         chaining onto it, so two buses in a process would leave only the second one hearing anything.
         For SIGINT what it replaces is the handler that raises ``KeyboardInterrupt``, which is what
-        makes shutdown take the same path whichever signal comes first.
+        makes shutdown take the same path whichever signal comes first. Whatever is displaced is put
+        back by :meth:`remove_signal_handlers`.
         """
         loop = asyncio.get_running_loop()
         for received in SHUTDOWN_SIGNALS:
+            displaced = signal.getsignal(received)
             try:
                 loop.add_signal_handler(received, self.on_shutdown_signal, received)
             except (NotImplementedError, RuntimeError) as e:
                 # Windows loops cannot do this at all, and no loop can off the main thread. Neither is
                 # worth failing a run over: the bus still stops, just not on a signal.
                 self._logger.debug("Not handling %s: %s", received.name, e)
+            else:
+                # Recorded only once installed, so a partial install cannot have teardown write back a
+                # handler this never displaced.
+                self._displaced_signal_handlers[received] = displaced
 
     def remove_signal_handlers(self) -> None:
-        """Undo :meth:`install_signal_handlers`. Called by :meth:`finalize`."""
+        """Undo :meth:`install_signal_handlers`. Called by :meth:`finalize`.
+
+        ``remove_signal_handler`` restores the interpreter default rather than what was displaced, so a
+        run would otherwise leave a caller that had its own handler without one.
+        """
         loop = asyncio.get_running_loop()
-        for received in SHUTDOWN_SIGNALS:
+        while self._displaced_signal_handlers:
+            received, displaced = self._displaced_signal_handlers.popitem()
             with contextlib.suppress(NotImplementedError, RuntimeError):
                 loop.remove_signal_handler(received)
+            # None means the handler was not installed from Python, which `signal` refuses to take back.
+            if displaced is not None:
+                signal.signal(received, displaced)
 
     def on_shutdown_signal(self, received: signal.Signals) -> None:
         """React to a shutdown signal by winding the bus down.

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -7,6 +7,7 @@ import asyncio
 import contextlib
 import logging
 import math
+import signal
 import threading
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
@@ -30,6 +31,9 @@ type ErrorHandler[E: Exception] = Callable[[E], Awaitable[None]]
 DEFAULT_ORCHESTRATOR_MAX_TIMEOUT = 300.0
 # How long the loop may block before re-reading the timeout and the stop flag.
 STOP_CHECK_INTERVAL = 1.0
+# What a process is asked to stop with: SIGINT from an interactive interrupt, SIGTERM from a scheduler
+# or CI runner cancelling the job.
+SHUTDOWN_SIGNALS = (signal.SIGINT, signal.SIGTERM)
 
 
 class OrchestratorTimeout(Exception):
@@ -204,6 +208,41 @@ class EventBusOrchestrator(ABC):
         if not any(registered is processor for registered in self._processors):
             self._processors.append(processor)
 
+    def install_signal_handlers(self) -> None:
+        """Route :data:`SHUTDOWN_SIGNALS` to :meth:`on_shutdown_signal` for the life of the run.
+
+        Called by :meth:`initialize`. Override to handle a different set, or to do nothing where the
+        process has another owner for them.
+
+        Handling SIGINT here also means it stops arriving as ``KeyboardInterrupt``, so shutdown takes
+        the same path whichever signal comes first.
+        """
+        loop = asyncio.get_running_loop()
+        for received in SHUTDOWN_SIGNALS:
+            try:
+                loop.add_signal_handler(received, self.on_shutdown_signal, received)
+            except (NotImplementedError, RuntimeError) as e:
+                # Windows loops cannot do this at all, and no loop can off the main thread. Neither is
+                # worth failing a run over: the bus still stops, just not on a signal.
+                self._logger.debug("Not handling %s: %s", received.name, e)
+
+    def remove_signal_handlers(self) -> None:
+        """Undo :meth:`install_signal_handlers`. Called by :meth:`finalize`."""
+        loop = asyncio.get_running_loop()
+        for received in SHUTDOWN_SIGNALS:
+            with contextlib.suppress(NotImplementedError, RuntimeError):
+                loop.remove_signal_handler(received)
+
+    def on_shutdown_signal(self, received: signal.Signals) -> None:
+        """React to a shutdown signal by winding the bus down.
+
+        Runs as a loop callback rather than in signal context, so it may not block or await. Anything it
+        raises reaches the loop's exception handler, and a second signal will not retry it, so put what
+        must happen first. Override to add to this, calling ``super()``.
+        """
+        self._logger.warning("Received %s: the bus will wind down", received.name)
+        self.request_stop()
+
     def request_stop(self) -> None:
         """Ask the bus to wind down, from any thread.
 
@@ -284,6 +323,8 @@ class EventBusOrchestrator(ABC):
         Initializes the orchestrator.
         """
         self._running = True
+        # Before the hook, so a signal arriving during it winds the bus down rather than killing it.
+        self.install_signal_handlers()
         try:
             await self._bounded_by_stop(self.on_initialize(), HookName.ON_INITIALIZE)
         except (FatalProcessingError, asyncio.CancelledError):
@@ -329,6 +370,10 @@ class EventBusOrchestrator(ABC):
                 OrchestratorHookError(HookName.ON_FINALIZE, e),
                 self.on_error,
             )
+        finally:
+            # A handler outlives the loop it was installed on, so leaving it behind would have a later
+            # bus in the same process deliver signals to this dead one.
+            self.remove_signal_handlers()
 
     async def _run_in_worker[T: BaseMessage](self, work: Callable[[T], None], message: T) -> None:
         """Run blocking work on the processor pool, tracked until it finishes.

--- a/ddev/tests/cli/validate/all/test_orchestrator.py
+++ b/ddev/tests/cli/validate/all/test_orchestrator.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import asyncio
+import signal
 import subprocess
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -108,6 +109,23 @@ class CapturingOrchestrator(ValidationOrchestrator):
         self.submitted.append(message)
 
 
+def test_signals_are_left_to_the_default_handling(mock_app: MagicMock):
+    """A validation is a subprocess run from a pool thread, so a requested stop cannot interrupt it and
+    the command would stay alive until the subprocess timeout instead of terminating.
+    """
+    orch = ValidationOrchestrator(app=mock_app, target=None, validations=["models"])
+    installed: list[signal.Signals] = []
+
+    async def install_with_a_live_loop() -> None:
+        loop = asyncio.get_running_loop()
+        with patch.object(loop, "add_signal_handler", side_effect=lambda sig, *_: installed.append(sig)):
+            orch.install_signal_handlers()
+
+    asyncio.run(install_with_a_live_loop())
+
+    assert installed == []
+
+
 @pytest.mark.parametrize(
     "validation, target, expect_args",
     [
@@ -118,23 +136,6 @@ class CapturingOrchestrator(ValidationOrchestrator):
         ("ci", None, []),
     ],
 )
-def test_signals_are_left_to_the_default_handling(mock_app):
-    """A validation is a subprocess run from a pool thread, so a requested stop cannot interrupt it and
-    the command would stay alive until the subprocess timeout instead of terminating.
-    """
-    orch = ValidationOrchestrator(app=mock_app, target=None, validations=["models"])
-    installed = []
-
-    async def install_with_a_live_loop():
-        loop = asyncio.get_running_loop()
-        with patch.object(loop, "add_signal_handler", side_effect=lambda sig, *_: installed.append(sig)):
-            orch.install_signal_handlers()
-
-    asyncio.run(install_with_a_live_loop())
-
-    assert installed == []
-
-
 def test_on_initialize_message_args(mock_app, validation: str, target: str | None, expect_args: list[str]):
     orch = CapturingOrchestrator(app=mock_app, validations=[validation], target=target)
     asyncio.run(orch.on_initialize())

--- a/ddev/tests/cli/validate/all/test_orchestrator.py
+++ b/ddev/tests/cli/validate/all/test_orchestrator.py
@@ -118,6 +118,23 @@ class CapturingOrchestrator(ValidationOrchestrator):
         ("ci", None, []),
     ],
 )
+def test_signals_are_left_to_the_default_handling(mock_app):
+    """A validation is a subprocess run from a pool thread, so a requested stop cannot interrupt it and
+    the command would stay alive until the subprocess timeout instead of terminating.
+    """
+    orch = ValidationOrchestrator(app=mock_app, target=None, validations=["models"])
+    installed = []
+
+    async def install_with_a_live_loop():
+        loop = asyncio.get_running_loop()
+        with patch.object(loop, "add_signal_handler", side_effect=lambda sig, *_: installed.append(sig)):
+            orch.install_signal_handlers()
+
+    asyncio.run(install_with_a_live_loop())
+
+    assert installed == []
+
+
 def test_on_initialize_message_args(mock_app, validation: str, target: str | None, expect_args: list[str]):
     orch = CapturingOrchestrator(app=mock_app, validations=[validation], target=target)
     asyncio.run(orch.on_initialize())

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -16,6 +16,7 @@ from concurrent.futures import Executor, ThreadPoolExecutor
 from contextlib import AbstractContextManager, contextmanager, suppress
 from contextlib import nullcontext as does_not_raise
 from dataclasses import dataclass
+from types import FrameType
 
 import pytest
 from pytest_mock import MockerFixture
@@ -1299,6 +1300,28 @@ def caught_rather_than_fatal(sent: signal.Signals) -> Generator[list[signal.Sign
     previous = signal.signal(sent, lambda *_: reached_the_process.append(sent))
     try:
         yield reached_the_process
+    finally:
+        signal.signal(sent, previous)
+
+
+@requires_signals
+@pytest.mark.parametrize("sent", [signal.SIGINT, signal.SIGTERM], ids=lambda s: s.name)
+def test_a_run_gives_back_the_handler_it_displaced(sent: signal.Signals):
+    """Nothing says the bus owns the process: a caller may have its own handler and outlive the run.
+
+    `remove_signal_handler` restores the interpreter default rather than what was displaced, so without
+    putting it back the caller silently loses its handler to a run that ended normally.
+    """
+
+    def caller_handler(signum: int, frame: FrameType | None) -> None: ...
+
+    orchestrator = MockOrchestrator(logging.getLogger("test_signal_restore"), max_timeout=30, grace_period=0)
+    orchestrator.register_processor(Secretary("secretary"), [Memo])
+    previous = signal.signal(sent, caller_handler)
+    try:
+        orchestrator.run()
+
+        assert signal.getsignal(sent) is caller_handler
     finally:
         signal.signal(sent, previous)
 

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -32,7 +32,6 @@ from ddev.event_bus.exceptions import (
 )
 from ddev.event_bus.orchestrator import (
     DEFAULT_ORCHESTRATOR_MAX_TIMEOUT,
-    SHUTDOWN_SIGNALS,
     AsyncProcessor,
     BaseMessage,
     EventBusOrchestrator,
@@ -1226,14 +1225,15 @@ class StopRequester(AsyncProcessor[Memo]):
 
 
 class Signaller(AsyncProcessor[Memo]):
-    """Sends the process a real SIGINT while the bus is running."""
+    """Sends the process a real signal while the bus is running."""
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, send: signal.Signals):
         super().__init__(name)
+        self._send = send
         self.stop_notifications = 0
 
     async def process_message(self, message: Memo):
-        os.kill(os.getpid(), signal.SIGINT)
+        os.kill(os.getpid(), self._send)
 
     def on_stop_requested(self):
         self.stop_notifications += 1
@@ -1288,35 +1288,44 @@ def test_asking_to_stop_again_notifies_nobody_and_does_not_block():
 requires_signals = pytest.mark.skipif(sys.platform == "win32", reason="Windows loops cannot install these")
 
 
+@contextmanager
+def caught_rather_than_fatal(sent: signal.Signals) -> Generator[list[signal.Signals]]:
+    """Record *sent* instead of letting its default action end the process.
+
+    A bus that stopped installing handlers would otherwise kill the test session rather than fail a
+    test: SIGTERM's default is death, and nothing can catch that.
+    """
+    reached_the_process: list[signal.Signals] = []
+    previous = signal.signal(sent, lambda *_: reached_the_process.append(sent))
+    try:
+        yield reached_the_process
+    finally:
+        signal.signal(sent, previous)
+
+
 @requires_signals
-def test_a_signal_winds_the_bus_down_instead_of_killing_it():
-    """Handling SIGINT is also what stops it arriving as `KeyboardInterrupt` mid-run."""
-    signaller = Signaller("signaller")
+@pytest.mark.parametrize("sent", [signal.SIGINT, signal.SIGTERM], ids=lambda s: s.name)
+def test_a_signal_winds_the_bus_down_instead_of_killing_the_process(sent: signal.Signals):
+    """Installing a handler is what replaces the default that would end the process.
+
+    Both defaults are fatal to a run, differently: SIGINT raises `KeyboardInterrupt` and SIGTERM kills
+    outright, so the fallback below keeps a regression reportable. The bus having handled the signal is
+    what leaves that fallback untouched.
+    """
+    signaller = Signaller("signaller", sent)
     orchestrator = MockOrchestrator(logging.getLogger("test_signal_stop"), max_timeout=30, grace_period=1)
     orchestrator.register_processor(signaller, [Memo])
     orchestrator.submit_message(Memo("memo1"))
 
-    try:
-        orchestrator.run()
-    except KeyboardInterrupt:  # pragma: no cover
-        pytest.fail("SIGINT reached the interpreter instead of the bus")
+    with caught_rather_than_fatal(sent) as reached_the_process:
+        try:
+            orchestrator.run()
+        except KeyboardInterrupt:  # pragma: no cover
+            pytest.fail(f"{sent.name} reached the interpreter instead of the bus")
 
+    assert reached_the_process == []
     assert orchestrator.stopping
     assert signaller.stop_notifications == 1
-
-
-@requires_signals
-def test_handlers_do_not_outlive_the_run_that_installed_them():
-    """Installing is process-wide, so a bus that left its handlers behind would have the next one's
-    signals delivered to a loop that is already closed, and nothing would wind down.
-    """
-    before = {received: signal.getsignal(received) for received in SHUTDOWN_SIGNALS}
-    orchestrator = MockOrchestrator(logging.getLogger("test_signal_teardown"), max_timeout=30, grace_period=0)
-    orchestrator.register_processor(Secretary("secretary"), [Memo])
-
-    orchestrator.run()
-
-    assert {received: signal.getsignal(received) for received in SHUTDOWN_SIGNALS} == before
 
 
 def test_a_stop_is_not_derailed_by_a_processor_that_fails_to_wind_down():

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -156,7 +156,6 @@ class MockOrchestrator(EventBusOrchestrator):
         grace_period: float = 10,
         fail_fast: bool = False,
         executor: Executor | None = None,
-        propagate_keyboard_interrupt: bool = True,
     ):
         super().__init__(
             logger=logger,
@@ -164,7 +163,6 @@ class MockOrchestrator(EventBusOrchestrator):
             grace_period=grace_period,
             fail_fast=fail_fast,
             executor=executor,
-            propagate_keyboard_interrupt=propagate_keyboard_interrupt,
         )
         self.events: list[str] = []
         self.received_messages: list[BaseMessage] = []
@@ -1320,23 +1318,18 @@ def test_an_interrupted_run_hands_the_interrupt_back_once_it_has_wound_down(
     sent: signal.Signals, propagate: bool, expectation: AbstractContextManager
 ):
     """Handling SIGINT is what stops `KeyboardInterrupt` reaching the caller, and with it whatever the
-    caller does about one: Click turns it into `Aborted!` and exit 1, so without this an interrupted
-    command would report success.
+    caller does about one: Click turns it into `Aborted!` and exit 1, so a caller that wants that back
+    asks for it here.
 
     Raised after the wind-down rather than instead of it, so the cleanup still happens first.
     """
     signaller = Signaller("signaller", sent)
-    orchestrator = MockOrchestrator(
-        logging.getLogger("test_interrupt_propagation"),
-        max_timeout=30,
-        grace_period=1,
-        propagate_keyboard_interrupt=propagate,
-    )
+    orchestrator = MockOrchestrator(logging.getLogger("test_interrupt_propagation"), max_timeout=30, grace_period=1)
     orchestrator.register_processor(signaller, [Memo])
     orchestrator.submit_message(Memo("memo1"))
 
     with caught_rather_than_fatal(sent), expectation:
-        orchestrator.run()
+        orchestrator.run(propagate_keyboard_interrupt=propagate)
 
     # Whatever the caller sees, the bus wound down first rather than being cut short.
     assert orchestrator.stopping
@@ -1374,9 +1367,7 @@ def test_a_signal_reaches_the_bus_rather_than_the_process(sent: signal.Signals):
     The bus having handled the signal is what leaves that fallback untouched.
     """
     signaller = Signaller("signaller", sent)
-    orchestrator = MockOrchestrator(
-        logging.getLogger("test_signal_stop"), max_timeout=30, grace_period=1, propagate_keyboard_interrupt=False
-    )
+    orchestrator = MockOrchestrator(logging.getLogger("test_signal_stop"), max_timeout=30, grace_period=1)
     orchestrator.register_processor(signaller, [Memo])
     orchestrator.submit_message(Memo("memo1"))
 

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+import os
+import signal
+import sys
 import threading
 import time
 from collections.abc import Generator
@@ -29,6 +32,7 @@ from ddev.event_bus.exceptions import (
 )
 from ddev.event_bus.orchestrator import (
     DEFAULT_ORCHESTRATOR_MAX_TIMEOUT,
+    SHUTDOWN_SIGNALS,
     AsyncProcessor,
     BaseMessage,
     EventBusOrchestrator,
@@ -1221,6 +1225,20 @@ class StopRequester(AsyncProcessor[Memo]):
         self.submit_message(Memo("after_stop", subject="late"))
 
 
+class Signaller(AsyncProcessor[Memo]):
+    """Sends the process a real SIGINT while the bus is running."""
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.stop_notifications = 0
+
+    async def process_message(self, message: Memo):
+        os.kill(os.getpid(), signal.SIGINT)
+
+    def on_stop_requested(self):
+        self.stop_notifications += 1
+
+
 class StopWatcher(AsyncProcessor[TaskAssignment | Announcement]):
     def __init__(self, name: str, *, fail: bool = False):
         super().__init__(name)
@@ -1265,6 +1283,40 @@ def test_asking_to_stop_again_notifies_nobody_and_does_not_block():
     orchestrator.request_stop()
 
     assert watcher.stop_notifications == 1
+
+
+requires_signals = pytest.mark.skipif(sys.platform == "win32", reason="Windows loops cannot install these")
+
+
+@requires_signals
+def test_a_signal_winds_the_bus_down_instead_of_killing_it():
+    """Handling SIGINT is also what stops it arriving as `KeyboardInterrupt` mid-run."""
+    signaller = Signaller("signaller")
+    orchestrator = MockOrchestrator(logging.getLogger("test_signal_stop"), max_timeout=30, grace_period=1)
+    orchestrator.register_processor(signaller, [Memo])
+    orchestrator.submit_message(Memo("memo1"))
+
+    try:
+        orchestrator.run()
+    except KeyboardInterrupt:  # pragma: no cover
+        pytest.fail("SIGINT reached the interpreter instead of the bus")
+
+    assert orchestrator.stopping
+    assert signaller.stop_notifications == 1
+
+
+@requires_signals
+def test_handlers_do_not_outlive_the_run_that_installed_them():
+    """Installing is process-wide, so a bus that left its handlers behind would have the next one's
+    signals delivered to a loop that is already closed, and nothing would wind down.
+    """
+    before = {received: signal.getsignal(received) for received in SHUTDOWN_SIGNALS}
+    orchestrator = MockOrchestrator(logging.getLogger("test_signal_teardown"), max_timeout=30, grace_period=0)
+    orchestrator.register_processor(Secretary("secretary"), [Memo])
+
+    orchestrator.run()
+
+    assert {received: signal.getsignal(received) for received in SHUTDOWN_SIGNALS} == before
 
 
 def test_a_stop_is_not_derailed_by_a_processor_that_fails_to_wind_down():

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -156,6 +156,7 @@ class MockOrchestrator(EventBusOrchestrator):
         grace_period: float = 10,
         fail_fast: bool = False,
         executor: Executor | None = None,
+        propagate_keyboard_interrupt: bool = True,
     ):
         super().__init__(
             logger=logger,
@@ -163,6 +164,7 @@ class MockOrchestrator(EventBusOrchestrator):
             grace_period=grace_period,
             fail_fast=fail_fast,
             executor=executor,
+            propagate_keyboard_interrupt=propagate_keyboard_interrupt,
         )
         self.events: list[str] = []
         self.received_messages: list[BaseMessage] = []
@@ -1305,6 +1307,43 @@ def caught_rather_than_fatal(sent: signal.Signals) -> Generator[list[signal.Sign
 
 
 @requires_signals
+@pytest.mark.parametrize(
+    ("sent", "propagate", "expectation"),
+    [
+        pytest.param(signal.SIGINT, True, pytest.raises(KeyboardInterrupt), id="sigint-propagates"),
+        pytest.param(signal.SIGINT, False, does_not_raise(), id="sigint-suppressed"),
+        # Nothing in the interpreter raises for SIGTERM, so there is nothing to hand back.
+        pytest.param(signal.SIGTERM, True, does_not_raise(), id="sigterm-has-no-exception"),
+    ],
+)
+def test_an_interrupted_run_hands_the_interrupt_back_once_it_has_wound_down(
+    sent: signal.Signals, propagate: bool, expectation: AbstractContextManager
+):
+    """Handling SIGINT is what stops `KeyboardInterrupt` reaching the caller, and with it whatever the
+    caller does about one: Click turns it into `Aborted!` and exit 1, so without this an interrupted
+    command would report success.
+
+    Raised after the wind-down rather than instead of it, so the cleanup still happens first.
+    """
+    signaller = Signaller("signaller", sent)
+    orchestrator = MockOrchestrator(
+        logging.getLogger("test_interrupt_propagation"),
+        max_timeout=30,
+        grace_period=1,
+        propagate_keyboard_interrupt=propagate,
+    )
+    orchestrator.register_processor(signaller, [Memo])
+    orchestrator.submit_message(Memo("memo1"))
+
+    with caught_rather_than_fatal(sent), expectation:
+        orchestrator.run()
+
+    # Whatever the caller sees, the bus wound down first rather than being cut short.
+    assert orchestrator.stopping
+    assert signaller.stop_notifications == 1
+
+
+@requires_signals
 @pytest.mark.parametrize("sent", [signal.SIGINT, signal.SIGTERM], ids=lambda s: s.name)
 def test_a_run_gives_back_the_handler_it_displaced(sent: signal.Signals):
     """Nothing says the bus owns the process: a caller may have its own handler and outlive the run.
@@ -1328,23 +1367,21 @@ def test_a_run_gives_back_the_handler_it_displaced(sent: signal.Signals):
 
 @requires_signals
 @pytest.mark.parametrize("sent", [signal.SIGINT, signal.SIGTERM], ids=lambda s: s.name)
-def test_a_signal_winds_the_bus_down_instead_of_killing_the_process(sent: signal.Signals):
-    """Installing a handler is what replaces the default that would end the process.
+def test_a_signal_reaches_the_bus_rather_than_the_process(sent: signal.Signals):
+    """Both defaults end a run, differently: SIGINT raises `KeyboardInterrupt` where it lands and
+    SIGTERM kills outright, so the fallback keeps a regression reportable rather than fatal.
 
-    Both defaults are fatal to a run, differently: SIGINT raises `KeyboardInterrupt` and SIGTERM kills
-    outright, so the fallback below keeps a regression reportable. The bus having handled the signal is
-    what leaves that fallback untouched.
+    The bus having handled the signal is what leaves that fallback untouched.
     """
     signaller = Signaller("signaller", sent)
-    orchestrator = MockOrchestrator(logging.getLogger("test_signal_stop"), max_timeout=30, grace_period=1)
+    orchestrator = MockOrchestrator(
+        logging.getLogger("test_signal_stop"), max_timeout=30, grace_period=1, propagate_keyboard_interrupt=False
+    )
     orchestrator.register_processor(signaller, [Memo])
     orchestrator.submit_message(Memo("memo1"))
 
     with caught_rather_than_fatal(sent) as reached_the_process:
-        try:
-            orchestrator.run()
-        except KeyboardInterrupt:  # pragma: no cover
-            pytest.fail(f"{sent.name} reached the interpreter instead of the bus")
+        orchestrator.run()
 
     assert reached_the_process == []
     assert orchestrator.stopping


### PR DESCRIPTION
> Last of three from [AI-7124](https://datadoghq.atlassian.net/browse/AI-7124).
>
> 1. ~~[#25076](https://github.com/DataDog/integrations-core/pull/25076) client shutdown mode~~ (merged)
> 2. ~~[#25078](https://github.com/DataDog/integrations-core/pull/25078) processors are told when a stop is requested~~ (merged)
> 3. **this PR** signal handling moves into the bus

### What does this PR do?

Moves shutdown-signal handling from the Dispatcher into the event bus, as three overridable methods:

- `install_signal_handlers()`, called by `initialize()`, routes `SHUTDOWN_SIGNALS` (SIGINT, SIGTERM) to the handler. Override to take a different set, or to do nothing where the process has another owner for them.
- `remove_signal_handlers()`, called by `finalize()` in a `finally`.
- `on_shutdown_signal(received)` logs and calls `request_stop()`, which since #25078 tells every processor.

The Dispatcher overrides only `on_shutdown_signal`, to record the cancellation and put the client into shutdown mode. It loses 40 lines for 12, and its three private signal methods along with `CANCELLATION_SIGNALS` are gone.

### Motivation

The behaviour was right but it lived in the wrong place: the registration, the Windows guard and the teardown were all the Dispatcher's, so a second orchestrator would have had to repeat them to get a clean shutdown. Making it the default the bus provides, overridable rather than opt-in, means most orchestrators get it for free and anything with a different need says so explicitly.

**One bug found on the way.** The install guard caught only `NotImplementedError`, which is what a Windows loop raises. A loop off the main thread raises something else:

```
main thread:   installed OK
worker thread: RuntimeError: set_wakeup_fd only works in main thread of the main interpreter
```

Harmless for the Dispatcher, which runs under `asyncio.run` on the main thread, but not for a base class every orchestrator inherits. It now catches both.

**Teardown carries more weight here than it did.** With this in the base class, every bus in the suite installs real process-wide handlers, and `ddev`'s event bus tests call `run()` 42 times in one process. A leaked handler would deliver a later run's signal to a closed loop, so `finalize` removing them is covered by its own test.

The Dispatcher's existing cancellation tests are untouched and still pass, which is the evidence this is behaviour-preserving.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7124]: https://datadoghq.atlassian.net/browse/AI-7124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ