### PR TITLE
AI-7139 Resolve a pull request's changed files through the GitHub API

### DIFF
--- a/ddev/changelog.d/25095.fixed
+++ b/ddev/changelog.d/25095.fixed
@@ -1,1 +1,1 @@
-Resolve a pull request's changed files through the GitHub API instead of local git.
+Resolve a pull request's changed files through the GitHub API instead of local git, and split the pull request endpoints into the two schemas GitHub returns, so a listed pull request can no longer stand in for a full one.

--- a/ddev/changelog.d/25095.fixed
+++ b/ddev/changelog.d/25095.fixed
@@ -1,0 +1,1 @@
+Resolve a pull request's changed files through the GitHub API instead of local git.

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import click
@@ -15,7 +16,8 @@ if TYPE_CHECKING:
     from ddev.cli.ci.tests.dispatcher import DispatcherContext, RunContext
     from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
     from ddev.cli.ci.tests.messages import TestBatch
-    from ddev.utils.github_async.models import PullRequest
+    from ddev.utils.git import ChangedFile
+    from ddev.utils.github_async import AsyncGitHubClient
 
 DEFAULT_OUTPUT_DIRECTORY = ".dispatcher"
 
@@ -27,19 +29,19 @@ DEFAULT_OUTPUT_DIRECTORY = ".dispatcher"
     'pull_request',
     metavar='PR_NUMBER_OR_URL',
     default=None,
-    help='Pull request to test, as a number or a URL. Its branch, commits and target branch are read from GitHub.',
+    help='Pull request to test, as a number or a URL. Everything else about the run is read from GitHub.',
 )
-@click.option('--pr-number', type=int, default=None, help='Pull request number, when not using `--pr`.')
-@click.option('--checkout-sha', default=None, help='Ref the test workflow checks out. Defaults to the base commit.')
-@click.option('--base-sha', default=None, help='Commit the run reports against. Defaults to the local HEAD.')
-@click.option('--branch', default=None, help='Branch being tested. Defaults to the current branch.')
-@click.option('--target-branch', default=None, help='Target branch of the pull request, used as the comparison base.')
 @click.option(
-    '--context',
-    'run_context',
-    type=click.Choice(['pr', 'master', 'agent-test', 'release']),
+    '--pr-head-sha',
     default=None,
-    help='Kind of run. Defaults to `pr` when a pull request is known, `master` otherwise.',
+    metavar='SHA',
+    help='Head commit of the pull request to test, resolved to its pull request. What `workflow_run` provides.',
+)
+@click.option(
+    '--commit',
+    default=None,
+    metavar='SHA',
+    help='Commit on the default branch to test, compared with its first parent. Defaults to the local HEAD.',
 )
 @click.option('--repo', 'repository', default=None, metavar='OWNER/NAME', help='Repository to dispatch against.')
 @click.option('--all', 'all_targets', is_flag=True, help='Test every eligible target instead of the affected ones.')
@@ -59,12 +61,8 @@ DEFAULT_OUTPUT_DIRECTORY = ".dispatcher"
 def dispatch_tests(
     app: Application,
     pull_request: str | None,
-    pr_number: int | None,
-    checkout_sha: str | None,
-    base_sha: str | None,
-    branch: str | None,
-    target_branch: str | None,
-    run_context: str | None,
+    pr_head_sha: str | None,
+    commit: str | None,
     repository: str | None,
     all_targets: bool,
     minimum_base_package: bool,
@@ -76,24 +74,23 @@ def dispatch_tests(
     """Plan the tests a commit requires, run them as parallel batches of GitHub Actions jobs, and
     report the result to the pull request and to the run summary.
 
-    Every input can be passed explicitly, which is how a workflow calls it. Locally, `--pr` reads
-    the branch, commits and target branch from GitHub so only the pull request has to be named.
+    Which commit to test is the only thing that has to be said. `--pr` and `--pr-head-sha` name a
+    pull request, whose branch, commits and diff are then read from GitHub; `--commit` names a
+    commit on the default branch, compared with its first parent using local git.
     """
     import logging
     from pathlib import Path
 
     from ddev.cli.ci.tests.batching.build import HatchEnvironmentProvider
-    from ddev.cli.ci.tests.dispatcher import DispatcherContext, RunContext, build_dispatcher
+    from ddev.cli.ci.tests.dispatcher import DispatcherContext, build_dispatcher
     from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
     from ddev.utils.github import resolve_owner_repo
 
     requested_pr, token = validate_options(
         app,
         pull_request=pull_request,
-        pr_number=pr_number,
-        branch=branch,
-        base_sha=base_sha,
-        target_branch=target_branch,
+        pr_head_sha=pr_head_sha,
+        commit=commit,
         dry_run=dry_run,
     )
 
@@ -103,27 +100,23 @@ def dispatch_tests(
     config = DispatcherConfig.from_repo_config(app.repo.config)
     owner, repo = resolve_owner_repo(app, repository)
 
-    resolved_number = resolved_branch = resolved_sha = resolved_target = None
-    if requested_pr is not None:
-        resolved = fetch_pull_request(app, owner, repo, requested_pr, token)
-        if resolved.head is None or resolved.base is None:
-            app.abort(f'Pull request {resolved.number} reports no branch references.')
-        resolved_number = resolved.number
-        resolved_branch, resolved_sha, resolved_target = resolved.head.ref, resolved.head.sha, resolved.base.ref
-
-    pr_number = pr_number if pr_number is not None else resolved_number
-    branch = branch or resolved_branch or app.repo.git.current_branch()
-    base_sha = base_sha or resolved_sha or app.repo.git.latest_commit().sha
-    target_branch = target_branch or resolved_target
-    checkout_sha = checkout_sha or (f'refs/pull/{pr_number}/merge' if pr_number is not None else base_sha)
-    resolved_context = RunContext(run_context) if run_context else (RunContext.PR if pr_number else RunContext.MASTER)
+    run = resolve_run(
+        app,
+        owner=owner,
+        repo=repo,
+        requested_pr=requested_pr,
+        pr_head_sha=pr_head_sha,
+        commit=commit,
+        token=token,
+        all_targets=all_targets,
+    )
+    if run is None:
+        return
 
     batches = build_plan(
         app,
         config=config,
-        base_sha=base_sha,
-        run_context=resolved_context,
-        target_branch=target_branch,
+        changed_files=run.changed_files,
         all_targets=all_targets,
         minimum_base_package=minimum_base_package,
         environment_provider=HatchEnvironmentProvider(app.platform, config.default_python_version),
@@ -135,14 +128,14 @@ def dispatch_tests(
     context = DispatcherContext(
         owner=owner,
         repo=repo,
-        run_context=resolved_context,
-        checkout_sha=checkout_sha,
-        base_sha=base_sha,
-        branch=branch,
+        run_context=run.run_context,
+        checkout_sha=run.checkout_sha,
+        base_sha=run.base_sha,
+        branch=run.branch,
         workflow=workflow or config.workflow,
         workflow_ref=workflow_ref or config.workflow_ref,
-        target_branch=target_branch,
-        pr_number=pr_number,
+        target_branch=run.target_branch,
+        pr_number=run.pr_number,
     )
 
     display_plan(app, context, batches)
@@ -178,112 +171,205 @@ def validate_options(
     app: Application,
     *,
     pull_request: str | None,
-    pr_number: int | None,
-    branch: str | None,
-    base_sha: str | None,
-    target_branch: str | None,
+    pr_head_sha: str | None,
+    commit: str | None,
     dry_run: bool,
 ) -> tuple[int | None, str]:
     """Check every input before the run does any work, and return what checking them resolved.
 
     That is the pull request ``--pr`` names, if any, and the GitHub token, empty when the run needs
-    none: a dry run planning from local git talks to nobody. Reading a pull request needs a token
-    even for a dry run, because the API client refuses to be built without one.
+    none. Only a dry run of a commit on the default branch needs none: it plans from local git and
+    talks to nobody. A pull request needs one even for a dry run, because both its own fields and
+    its diff are read from the API.
     """
     from ddev.utils.github import parse_pull_request_reference
 
+    named = [name for name, value in (('`--pr`', pull_request), ('`--pr-head-sha`', pr_head_sha)) if value is not None]
+    if commit is not None:
+        named.append('`--commit`')
+    if len(named) > 1:
+        app.abort(f'{", ".join(named)} name different runs, so only one can be passed.')
+
     requested_pr = None
     if pull_request is not None:
-        resolved_by_pr = [
-            name
-            for name, value in (
-                ('`--pr-number`', pr_number),
-                ('`--branch`', branch),
-                ('`--base-sha`', base_sha),
-                ('`--target-branch`', target_branch),
-            )
-            if value is not None
-        ]
-        if resolved_by_pr:
-            app.abort(f'{", ".join(resolved_by_pr)} cannot be passed with `--pr`, which reads them from GitHub.')
-
         requested_pr = parse_pull_request_reference(pull_request)
         if requested_pr is None:
             app.abort(f'`{pull_request}` is neither a pull request number nor a pull request URL.')
 
+    tests_a_pull_request = pull_request is not None or pr_head_sha is not None
     token = app.config.github.token
-    if not token and (pull_request is not None or not dry_run):
+    if not token and (tests_a_pull_request or not dry_run):
         app.abort('A GitHub token is required. Set `github.token` in your ddev config.')
 
     return requested_pr, token
 
 
-def fetch_pull_request(app: Application, owner: str, repo: str, number: int, token: str) -> PullRequest:
-    """Read pull request *number* from the GitHub API."""
+@dataclass(frozen=True)
+class ResolvedRun:
+    """What the run is testing, and the changes it is responsible for.
+
+    ``changed_files`` is None when the plan does not come from a comparison, which is `--all`.
+    """
+
+    run_context: RunContext
+    base_sha: str
+    checkout_sha: str
+    branch: str
+    changed_files: list[ChangedFile] | None
+    pr_number: int | None = None
+    target_branch: str | None = None
+
+
+def resolve_run(
+    app: Application,
+    *,
+    owner: str,
+    repo: str,
+    requested_pr: int | None,
+    pr_head_sha: str | None,
+    commit: str | None,
+    token: str,
+    all_targets: bool,
+) -> ResolvedRun | None:
+    """Resolve what to test, or None when there is nothing to do.
+
+    A pull request that is no longer open is the one such case: nothing to test at that point, and
+    no open pull request to report to either.
+    """
+    from ddev.cli.ci.tests.dispatcher import RunContext
+
+    if requested_pr is not None or pr_head_sha is not None:
+        return resolve_pull_request_run(
+            app,
+            owner=owner,
+            repo=repo,
+            requested_pr=requested_pr,
+            pr_head_sha=pr_head_sha,
+            token=token,
+            all_targets=all_targets,
+        )
+
+    tested_commit = commit or app.repo.git.latest_commit().sha
+    changed_files = None
+    if not all_targets:
+        from ddev.cli.ci.tests.changes import ChangeResolutionError, changes_in_commit
+
+        try:
+            changed_files = changes_in_commit(app.repo.git, tested_commit)
+        except ChangeResolutionError as error:
+            app.abort(str(error))
+
+    return ResolvedRun(
+        run_context=RunContext.MASTER,
+        base_sha=tested_commit,
+        checkout_sha=tested_commit,
+        branch=app.repo.git.current_branch(),
+        changed_files=changed_files,
+    )
+
+
+def resolve_pull_request_run(
+    app: Application,
+    *,
+    owner: str,
+    repo: str,
+    requested_pr: int | None,
+    pr_head_sha: str | None,
+    token: str,
+    all_targets: bool,
+) -> ResolvedRun | None:
+    """Read the pull request and its changed files from the API, in one client session."""
     import asyncio
 
     import httpx
     from pydantic import ValidationError
 
+    from ddev.cli.ci.tests.changes import ChangeResolutionError, changes_in_pull_request
+    from ddev.cli.ci.tests.dispatcher import RunContext
     from ddev.utils.github_async import async_github_client
+    from ddev.utils.github_async.models import PullRequestState
     from ddev.utils.github_errors import GitHubAuthenticationError
 
-    async def fetch() -> PullRequest:
+    async def resolve() -> ResolvedRun | None:
         async with async_github_client(token=token) as client:
-            response = await client.get_pull_request(owner, repo, number)
-            return response.data
+            number = requested_pr
+            if number is None:
+                assert pr_head_sha is not None
+                number = await resolve_pull_request_number(client, owner, repo, pr_head_sha)
+                if number is None:
+                    app.display_info(f'{pr_head_sha} belongs to no open pull request, so there is nothing to test.')
+                    return None
+
+            pull = (await client.get_pull_request(owner, repo, number)).data
+            if pull.head is None or pull.base is None:
+                app.abort(f'Pull request {pull.number} reports no branch references.')
+            if pull.state is not PullRequestState.OPEN:
+                app.display_info(f'Pull request {pull.number} is not open, so there is nothing to test.')
+                return None
+
+            changed_files = None
+            if not all_targets:
+                changed_files = await changes_in_pull_request(client, owner, repo, pull.number, pull.changed_files)
+
+            return ResolvedRun(
+                run_context=RunContext.PR,
+                base_sha=pull.head.sha,
+                checkout_sha=f'refs/pull/{pull.number}/merge',
+                branch=pull.head.ref,
+                changed_files=changed_files,
+                pr_number=pull.number,
+                target_branch=pull.base.ref,
+            )
 
     try:
-        return asyncio.run(fetch())
+        return asyncio.run(resolve())
     except GitHubAuthenticationError as error:
         app.abort(str(error))
+    except ChangeResolutionError as error:
+        app.abort(str(error))
     except (httpx.HTTPError, ValidationError) as error:
-        app.abort(f'Could not read pull request {number}: {error}')
+        app.abort(f'Could not read the pull request to test: {error}')
+
+
+async def resolve_pull_request_number(client: AsyncGitHubClient, owner: str, repo: str, head_sha: str) -> int | None:
+    """Return the open pull request whose head is *head_sha*, or None when there is none.
+
+    A `workflow_run` event carries the head commit but not reliably a number, and a fork's head
+    resolves here because the base repository keeps it as `refs/pull/<n>/head`.
+    """
+    from ddev.utils.github_async.models import PullRequestState
+
+    async for page in client.list_commit_pulls(owner, repo, head_sha):
+        for pull in page.data:
+            if pull.state is PullRequestState.OPEN:
+                return pull.number
+
+    return None
 
 
 def build_plan(
     app: Application,
     *,
     config: DispatcherConfig,
-    base_sha: str,
-    run_context: RunContext,
-    target_branch: str | None,
+    changed_files: list[ChangedFile] | None,
     all_targets: bool,
     minimum_base_package: bool,
     environment_provider: EnvironmentProvider,
 ) -> list[TestBatch]:
     """Build the batches this run must execute, aborting with a readable message on a bad plan.
 
-    `--all` skips the comparison entirely: what changed is not what decides which targets run.
+    `--all` plans every eligible target, so it needs no comparison and `changed_files` is None.
     """
     from ddev.cli.ci.tests.batching.build import build_test_batches
     from ddev.cli.ci.tests.batching.exceptions import PlanningError
     from ddev.cli.ci.tests.batching.targets import all_target_rules
-    from ddev.cli.ci.tests.changes import CIContext, get_changed_files
-    from ddev.cli.ci.tests.dispatcher import RunContext
 
-    changed_files = []
-    rules = None
-    if all_targets:
-        rules = all_target_rules()
-    else:
-        ci_context = CIContext.PULL_REQUEST if run_context is RunContext.PR else CIContext.DEFAULT_BRANCH
-        try:
-            changed_files = get_changed_files(app.repo.git, base_sha, context=ci_context, target_branch=target_branch)
-        except ValueError as error:
-            app.abort(str(error))
-        except OSError as error:
-            # `GitRepository` reports a failed git invocation as OSError, and the usual cause is a
-            # commit the local clone has never fetched.
-            app.abort(
-                f'Could not compare {base_sha} against {target_branch or "its parent"} locally: {error}\n'
-                'Fetch the commit first, or pass `--all` to plan every target.'
-            )
+    rules = all_target_rules() if all_targets else None
 
     try:
         batches = build_test_batches(
             app.repo,
-            changed_files,
+            changed_files or [],
             environment_provider=environment_provider,
             config=config.batching,
             rules=rules,

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -13,7 +13,7 @@ import click
 if TYPE_CHECKING:
     from ddev.cli.application import Application
     from ddev.cli.ci.tests.batching.units import EnvironmentProvider
-    from ddev.cli.ci.tests.dispatcher import DispatcherContext, RunContext
+    from ddev.cli.ci.tests.dispatcher import DispatcherContext
     from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
     from ddev.cli.ci.tests.messages import TestBatch
     from ddev.utils.git import ChangedFile
@@ -44,11 +44,10 @@ DEFAULT_OUTPUT_DIRECTORY = ".dispatcher"
     help='Commit on the default branch to test, compared with its first parent. Defaults to the local HEAD.',
 )
 @click.option(
-    '--context',
-    'run_context',
-    type=click.Choice(['pr', 'master', 'agent-test', 'release']),
+    '--tags',
     default=None,
-    help='Kind of run, reported as a monitoring tag. Defaults to `pr` when testing a pull request, `master` otherwise.',
+    metavar='"KEY:VALUE ..."',
+    help='Tags the run reports itself under, separated by spaces. Their meaning is the caller\'s to decide.',
 )
 @click.option('--repo', 'repository', default=None, metavar='OWNER/NAME', help='Repository to dispatch against.')
 @click.option('--all', 'all_targets', is_flag=True, help='Test every eligible target instead of the affected ones.')
@@ -70,7 +69,7 @@ def dispatch_tests(
     pull_request: str | None,
     pr_head_sha: str | None,
     commit: str | None,
-    run_context: str | None,
+    tags: str | None,
     repository: str | None,
     all_targets: bool,
     minimum_base_package: bool,
@@ -90,7 +89,7 @@ def dispatch_tests(
     from pathlib import Path
 
     from ddev.cli.ci.tests.batching.build import HatchEnvironmentProvider
-    from ddev.cli.ci.tests.dispatcher import DispatcherContext, RunContext, build_dispatcher
+    from ddev.cli.ci.tests.dispatcher import DispatcherContext, build_dispatcher
     from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
     from ddev.utils.github import resolve_owner_repo
 
@@ -117,7 +116,6 @@ def dispatch_tests(
         commit=commit,
         token=token,
         all_targets=all_targets,
-        run_context=RunContext(run_context) if run_context else None,
     )
     if run is None:
         return
@@ -137,7 +135,7 @@ def dispatch_tests(
     context = DispatcherContext(
         owner=owner,
         repo=repo,
-        run_context=run.run_context,
+        tags=tuple(tags.split()) if tags else (),
         checkout_sha=run.checkout_sha,
         base_sha=run.base_sha,
         branch=run.branch,
@@ -220,7 +218,6 @@ class ResolvedRun:
     ``changed_files`` is None when the plan does not come from a comparison, which is `--all`.
     """
 
-    run_context: RunContext
     base_sha: str
     checkout_sha: str
     branch: str
@@ -239,18 +236,12 @@ def resolve_run(
     commit: str | None,
     token: str,
     all_targets: bool,
-    run_context: RunContext | None,
 ) -> ResolvedRun | None:
     """Resolve what to test, or None when there is nothing to do.
 
     A pull request that is no longer open is the one such case: nothing to test at that point, and
     no open pull request to report to either.
-
-    `run_context` only labels the run. What is compared, and against what, follows from which input
-    named the run, so the two cannot contradict each other.
     """
-    from ddev.cli.ci.tests.dispatcher import RunContext
-
     if requested_pr is not None or pr_head_sha is not None:
         return resolve_pull_request_run(
             app,
@@ -260,7 +251,6 @@ def resolve_run(
             pr_head_sha=pr_head_sha,
             token=token,
             all_targets=all_targets,
-            run_context=run_context or RunContext.PR,
         )
 
     tested_commit = commit or app.repo.git.latest_commit().sha
@@ -274,7 +264,6 @@ def resolve_run(
             app.abort(str(error))
 
     return ResolvedRun(
-        run_context=run_context or RunContext.MASTER,
         base_sha=tested_commit,
         checkout_sha=tested_commit,
         branch=app.repo.git.current_branch(),
@@ -291,7 +280,6 @@ def resolve_pull_request_run(
     pr_head_sha: str | None,
     token: str,
     all_targets: bool,
-    run_context: RunContext,
 ) -> ResolvedRun | None:
     """Read the pull request and its changed files from the API, in one client session."""
     import asyncio
@@ -331,7 +319,6 @@ def resolve_pull_request_run(
                 changed_files = await changes_in_pull_request(client, owner, repo, pull.number, pull.changed_files)
 
             return ResolvedRun(
-                run_context=run_context,
                 base_sha=pull.head.sha,
                 checkout_sha=f'refs/pull/{pull.number}/merge',
                 branch=pull.head.ref,
@@ -403,7 +390,6 @@ def build_plan(
 def display_plan(app: Application, context: DispatcherContext, batches: list[TestBatch]) -> None:
     app.display_header('Dispatcher plan')
     app.display_pair('Repository', f'{context.owner}/{context.repo}')
-    app.display_pair('Context', context.run_context.value)
     app.display_pair('Branch', context.branch)
     app.display_pair('Base commit', context.base_sha)
     app.display_pair('Checkout ref', context.checkout_sha)
@@ -411,6 +397,8 @@ def display_plan(app: Application, context: DispatcherContext, batches: list[Tes
         app.display_pair('Pull request', str(context.pr_number))
     if context.target_branch is not None:
         app.display_pair('Target branch', context.target_branch)
+    if context.tags:
+        app.display_pair('Tags', ' '.join(context.tags))
     app.display_pair('Workflow', f'{context.workflow} @ {context.workflow_ref}')
 
     total = sum(batch.jobs_count for batch in batches)

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -38,6 +38,12 @@ DEFAULT_OUTPUT_DIRECTORY = ".dispatcher"
     help='Head commit of the pull request to test, resolved to its pull request. What `workflow_run` provides.',
 )
 @click.option(
+    '--pr-base-ref',
+    default=None,
+    metavar='BRANCH',
+    help='Base branch of the pull request, when a head commit heads more than one.',
+)
+@click.option(
     '--commit',
     default=None,
     metavar='SHA',
@@ -68,6 +74,7 @@ def dispatch_tests(
     app: Application,
     pull_request: str | None,
     pr_head_sha: str | None,
+    pr_base_ref: str | None,
     commit: str | None,
     tags: str | None,
     repository: str | None,
@@ -97,6 +104,7 @@ def dispatch_tests(
         app,
         pull_request=pull_request,
         pr_head_sha=pr_head_sha,
+        pr_base_ref=pr_base_ref,
         commit=commit,
         dry_run=dry_run,
     )
@@ -113,6 +121,7 @@ def dispatch_tests(
         repo=repo,
         requested_pr=requested_pr,
         pr_head_sha=pr_head_sha,
+        pr_base_ref=pr_base_ref,
         commit=commit,
         token=token,
         all_targets=all_targets,
@@ -179,6 +188,7 @@ def validate_options(
     *,
     pull_request: str | None,
     pr_head_sha: str | None,
+    pr_base_ref: str | None,
     commit: str | None,
     dry_run: bool,
 ) -> tuple[int | None, str]:
@@ -196,6 +206,9 @@ def validate_options(
         named.append('`--commit`')
     if len(named) > 1:
         app.abort(f'{", ".join(named)} name different runs, so only one can be passed.')
+
+    if pr_base_ref is not None and pr_head_sha is None:
+        app.abort('`--pr-base-ref` only narrows which pull request `--pr-head-sha` resolves to.')
 
     requested_pr = None
     if pull_request is not None:
@@ -233,6 +246,7 @@ def resolve_run(
     repo: str,
     requested_pr: int | None,
     pr_head_sha: str | None,
+    pr_base_ref: str | None,
     commit: str | None,
     token: str,
     all_targets: bool,
@@ -247,6 +261,7 @@ def resolve_run(
             repo=repo,
             requested_pr=requested_pr,
             pr_head_sha=pr_head_sha,
+            pr_base_ref=pr_base_ref,
             token=token,
             all_targets=all_targets,
         )
@@ -276,6 +291,7 @@ def resolve_pull_request_run(
     repo: str,
     requested_pr: int | None,
     pr_head_sha: str | None,
+    pr_base_ref: str | None,
     token: str,
     all_targets: bool,
 ) -> ResolvedRun | None:
@@ -298,10 +314,21 @@ def resolve_pull_request_run(
                     'A pull request run needs either a number or a head commit, and this run reported '
                     'neither. `resolve_run` dispatched to the wrong resolver.'
                 )
-                number = await resolve_pull_request_number(client, owner, repo, pr_head_sha)
-                if number is None:
-                    app.display_info(f'{pr_head_sha} belongs to no open pull request, so there is nothing to test.')
+                numbers = await resolve_pull_requests_headed_by(client, owner, repo, pr_head_sha, pr_base_ref)
+                if not numbers:
+                    app.display_info(
+                        f'{pr_head_sha} heads no open pull request, so there is nothing to test. A commit that '
+                        'later commits have superseded reports here too, since testing it would plan the newer '
+                        'revision against the older one.'
+                    )
                     return None
+                if len(numbers) > 1:
+                    listed = ', '.join(f'#{number}' for number in sorted(numbers))
+                    app.abort(
+                        f'{pr_head_sha} heads {len(numbers)} open pull requests ({listed}), so which one this run '
+                        'is testing is ambiguous. Pass `--pr-base-ref` to name the base branch.'
+                    )
+                number = numbers[0]
 
             pull = (await client.get_pull_request(owner, repo, number)).data
             if pull.head is None or pull.base is None:
@@ -333,19 +360,30 @@ def resolve_pull_request_run(
         app.abort(f'Could not read the pull request to test: {error}')
 
 
-async def resolve_pull_request_number(client: AsyncGitHubClient, owner: str, repo: str, head_sha: str) -> int | None:
-    """Return the open pull request whose head is *head_sha*, or None when there is none.
+async def resolve_pull_requests_headed_by(
+    client: AsyncGitHubClient, owner: str, repo: str, head_sha: str, base_ref: str | None
+) -> list[int]:
+    """Return the open pull requests whose head *is* `head_sha`, narrowed to `base_ref` when given.
 
-    A fork's head resolves too, because the base repository keeps it as `refs/pull/<n>/head`.
+    A commit stays associated with its pull request after later commits land on the branch, so a
+    pull request whose head has moved on is not a match: testing it would plan the newer revision
+    while reporting against the older one. A fork's head resolves too, because the base repository
+    keeps it as `refs/pull/<n>/head`.
     """
     from ddev.utils.github_async.models import PullRequestState
 
+    matches = []
     async for page in client.list_commit_pulls(owner, repo, head_sha):
         for pull in page.data:
-            if pull.state is PullRequestState.OPEN:
-                return pull.number
+            if pull.state is not PullRequestState.OPEN or pull.head is None or pull.base is None:
+                continue
+            if not pull.head.sha.startswith(head_sha):
+                continue
+            if base_ref is not None and pull.base.ref != base_ref:
+                continue
+            matches.append(pull.number)
 
-    return None
+    return matches
 
 
 def build_plan(

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -43,6 +43,13 @@ DEFAULT_OUTPUT_DIRECTORY = ".dispatcher"
     metavar='SHA',
     help='Commit on the default branch to test, compared with its first parent. Defaults to the local HEAD.',
 )
+@click.option(
+    '--context',
+    'run_context',
+    type=click.Choice(['pr', 'master', 'agent-test', 'release']),
+    default=None,
+    help='Kind of run, reported as a monitoring tag. Defaults to `pr` when testing a pull request, `master` otherwise.',
+)
 @click.option('--repo', 'repository', default=None, metavar='OWNER/NAME', help='Repository to dispatch against.')
 @click.option('--all', 'all_targets', is_flag=True, help='Test every eligible target instead of the affected ones.')
 @click.option(
@@ -63,6 +70,7 @@ def dispatch_tests(
     pull_request: str | None,
     pr_head_sha: str | None,
     commit: str | None,
+    run_context: str | None,
     repository: str | None,
     all_targets: bool,
     minimum_base_package: bool,
@@ -82,7 +90,7 @@ def dispatch_tests(
     from pathlib import Path
 
     from ddev.cli.ci.tests.batching.build import HatchEnvironmentProvider
-    from ddev.cli.ci.tests.dispatcher import DispatcherContext, build_dispatcher
+    from ddev.cli.ci.tests.dispatcher import DispatcherContext, RunContext, build_dispatcher
     from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
     from ddev.utils.github import resolve_owner_repo
 
@@ -109,6 +117,7 @@ def dispatch_tests(
         commit=commit,
         token=token,
         all_targets=all_targets,
+        run_context=RunContext(run_context) if run_context else None,
     )
     if run is None:
         return
@@ -230,11 +239,15 @@ def resolve_run(
     commit: str | None,
     token: str,
     all_targets: bool,
+    run_context: RunContext | None,
 ) -> ResolvedRun | None:
     """Resolve what to test, or None when there is nothing to do.
 
     A pull request that is no longer open is the one such case: nothing to test at that point, and
     no open pull request to report to either.
+
+    `run_context` only labels the run. What is compared, and against what, follows from which input
+    named the run, so the two cannot contradict each other.
     """
     from ddev.cli.ci.tests.dispatcher import RunContext
 
@@ -247,6 +260,7 @@ def resolve_run(
             pr_head_sha=pr_head_sha,
             token=token,
             all_targets=all_targets,
+            run_context=run_context or RunContext.PR,
         )
 
     tested_commit = commit or app.repo.git.latest_commit().sha
@@ -260,7 +274,7 @@ def resolve_run(
             app.abort(str(error))
 
     return ResolvedRun(
-        run_context=RunContext.MASTER,
+        run_context=run_context or RunContext.MASTER,
         base_sha=tested_commit,
         checkout_sha=tested_commit,
         branch=app.repo.git.current_branch(),
@@ -277,6 +291,7 @@ def resolve_pull_request_run(
     pr_head_sha: str | None,
     token: str,
     all_targets: bool,
+    run_context: RunContext,
 ) -> ResolvedRun | None:
     """Read the pull request and its changed files from the API, in one client session."""
     import asyncio
@@ -285,7 +300,6 @@ def resolve_pull_request_run(
     from pydantic import ValidationError
 
     from ddev.cli.ci.tests.changes import ChangeResolutionError, changes_in_pull_request
-    from ddev.cli.ci.tests.dispatcher import RunContext
     from ddev.utils.github_async import async_github_client
     from ddev.utils.github_async.models import PullRequestState
     from ddev.utils.github_errors import GitHubAuthenticationError
@@ -294,7 +308,12 @@ def resolve_pull_request_run(
         async with async_github_client(token=token) as client:
             number = requested_pr
             if number is None:
-                assert pr_head_sha is not None
+                # `resolve_run` only comes here when one of the two was given, and `validate_options`
+                # has already refused both at once.
+                assert pr_head_sha is not None, (
+                    'A pull request run needs either a number or a head commit, and this run reported '
+                    'neither. `resolve_run` dispatched to the wrong resolver.'
+                )
                 number = await resolve_pull_request_number(client, owner, repo, pr_head_sha)
                 if number is None:
                     app.display_info(f'{pr_head_sha} belongs to no open pull request, so there is nothing to test.')
@@ -312,7 +331,7 @@ def resolve_pull_request_run(
                 changed_files = await changes_in_pull_request(client, owner, repo, pull.number, pull.changed_files)
 
             return ResolvedRun(
-                run_context=RunContext.PR,
+                run_context=run_context,
                 base_sha=pull.head.sha,
                 checkout_sha=f'refs/pull/{pull.number}/merge',
                 branch=pull.head.ref,

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -336,6 +336,14 @@ def resolve_pull_request_run(
             if pull.state is not PullRequestState.OPEN:
                 app.display_info(f'Pull request {pull.number} is not open, so there is nothing to test.')
                 return None
+            # A commit pushed between resolving the number and reading the pull request would leave
+            # this describing a newer revision than the one asked for.
+            if pr_head_sha is not None and not pull.head.sha.startswith(pr_head_sha):
+                app.display_info(
+                    f'Pull request {pull.number} has moved on from {pr_head_sha} to {pull.head.sha}, so there is '
+                    'nothing to test: the run for the newer commit covers it.'
+                )
+                return None
 
             changed_files = None
             if not all_targets:

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -237,10 +237,8 @@ def resolve_run(
     token: str,
     all_targets: bool,
 ) -> ResolvedRun | None:
-    """Resolve what to test, or None when there is nothing to do.
-
-    A pull request that is no longer open is the one such case: nothing to test at that point, and
-    no open pull request to report to either.
+    """Resolve what to test, or None when a pull request is no longer open and there is nothing
+    left to test or report to.
     """
     if requested_pr is not None or pr_head_sha is not None:
         return resolve_pull_request_run(
@@ -296,8 +294,6 @@ def resolve_pull_request_run(
         async with async_github_client(token=token) as client:
             number = requested_pr
             if number is None:
-                # `resolve_run` only comes here when one of the two was given, and `validate_options`
-                # has already refused both at once.
                 assert pr_head_sha is not None, (
                     'A pull request run needs either a number or a head commit, and this run reported '
                     'neither. `resolve_run` dispatched to the wrong resolver.'
@@ -340,8 +336,7 @@ def resolve_pull_request_run(
 async def resolve_pull_request_number(client: AsyncGitHubClient, owner: str, repo: str, head_sha: str) -> int | None:
     """Return the open pull request whose head is *head_sha*, or None when there is none.
 
-    A `workflow_run` event carries the head commit but not reliably a number, and a fork's head
-    resolves here because the base repository keeps it as `refs/pull/<n>/head`.
+    A fork's head resolves too, because the base repository keeps it as `refs/pull/<n>/head`.
     """
     from ddev.utils.github_async.models import PullRequestState
 

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -255,8 +255,10 @@ def resolve_run(
     token: str,
     all_targets: bool,
 ) -> ResolvedRun | None:
-    """Resolve what to test, or None when a pull request is no longer open and there is nothing
-    left to test or report to.
+    """Resolve what to test, or None when there is nothing left to test or report to.
+
+    Every such outcome says which one it was before returning, since from the outside a run that
+    resolved to nothing and a run that was never asked for anything look the same.
     """
     if requested_pr is not None or pr_head_sha is not None:
         return resolve_pull_request_run(
@@ -351,6 +353,11 @@ def resolve_pull_request_run(
 
             changed_files = None
             if not all_targets:
+                # Listing the files of an empty diff would meet a count of 0 and read it as the
+                # truncation the count exists to catch.
+                if pull.changed_files == 0:
+                    app.display_info(f'Pull request {pull.number} changes no file, so there is nothing to test.')
+                    return None
                 changed_files = await changes_in_pull_request(client, owner, repo, pull.number, pull.changed_files)
 
             return ResolvedRun(

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -198,6 +198,10 @@ def validate_options(
     none. Only a dry run of a commit on the default branch needs none: it plans from local git and
     talks to nobody. A pull request needs one even for a dry run, because both its own fields and
     its diff are read from the API.
+
+    A malformed invocation raises `UsageError` (exit code 2), so a caller can tell it from a run
+    that started and failed. A missing token is not one: the options were right, the environment
+    is not.
     """
     from ddev.utils.github import parse_pull_request_reference
 
@@ -205,16 +209,16 @@ def validate_options(
     if commit is not None:
         named.append('`--commit`')
     if len(named) > 1:
-        app.abort(f'{", ".join(named)} name different runs, so only one can be passed.')
+        raise click.UsageError(f'{", ".join(named)} name different runs, so only one can be passed.')
 
     if pr_base_ref is not None and pr_head_sha is None:
-        app.abort('`--pr-base-ref` only narrows which pull request `--pr-head-sha` resolves to.')
+        raise click.UsageError('`--pr-base-ref` only narrows which pull request `--pr-head-sha` resolves to.')
 
     requested_pr = None
     if pull_request is not None:
         requested_pr = parse_pull_request_reference(pull_request)
         if requested_pr is None:
-            app.abort(f'`{pull_request}` is neither a pull request number nor a pull request URL.')
+            raise click.UsageError(f'`{pull_request}` is neither a pull request number nor a pull request URL.')
 
     tests_a_pull_request = pull_request is not None or pr_head_sha is not None
     token = app.config.github.token

--- a/ddev/src/ddev/cli/ci/tests/changes.py
+++ b/ddev/src/ddev/cli/ci/tests/changes.py
@@ -1,42 +1,82 @@
 # (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-"""Selection of the commits a CI run compares to find what it must test."""
+"""Where a CI run gets the changes it must test.
+
+The source depends on the trigger, because the objects each one leaves in the checkout differ. A
+push compares against the commit's first parent, which is one object away on the branch already
+checked out. A pull request needs the merge base of two diverged histories, and the checkout it runs
+in has neither the target branch as a local ref nor, under `workflow_run`, the head commit at all,
+so it reads the diff from the API instead.
+"""
 
 from __future__ import annotations
 
-import enum
 from typing import TYPE_CHECKING
 
+from ddev.utils.git import ChangedFile, ChangeType
+
 if TYPE_CHECKING:
-    from ddev.utils.git import ChangedFile, GitRepository
+    from ddev.utils.git import GitRepository
+    from ddev.utils.github_async import AsyncGitHubClient
+    from ddev.utils.github_async.models import PullRequestFile
 
 
-class CIContext(enum.Enum):
-    """The comparison context that determines which revisions are diffed."""
-
-    PULL_REQUEST = enum.auto()
-    DEFAULT_BRANCH = enum.auto()
+class ChangeResolutionError(Exception):
+    """Raised when the changes a run is responsible for cannot be established."""
 
 
-def get_changed_files(
-    git: GitRepository,
-    tested_commit: str,
-    *,
-    context: CIContext,
-    target_branch: str | None = None,
-) -> list[ChangedFile]:
-    """Return the changes the tested commit is responsible for.
+# `unchanged` is reachable only on a paginated diff GitHub truncated, and a type change reads as a
+# modification, so both fall back to MODIFIED rather than dropping the path.
+CHANGE_TYPES = {
+    "added": ChangeType.ADDED,
+    "removed": ChangeType.DELETED,
+    "modified": ChangeType.MODIFIED,
+    "renamed": ChangeType.RENAMED,
+    "copied": ChangeType.COPIED,
+    "changed": ChangeType.MODIFIED,
+    "unchanged": ChangeType.MODIFIED,
+}
 
-    A pull request is compared with the merge base of its target branch, so unrelated commits
-    landing on that branch meanwhile do not count as changes. On the default branch the comparison
-    is against the tested commit's first parent, which is the commit's own contribution.
+
+def changes_in_commit(git: GitRepository, commit: str) -> list[ChangedFile]:
+    """Return what *commit* itself contributed, comparing it with its first parent.
+
+    Only the parent is needed, so a checkout two commits deep is enough and no request is made.
     """
-    if context is CIContext.PULL_REQUEST:
-        if not target_branch:
-            raise ValueError("A target branch is required to compare a pull request against its merge base")
-        base = target_branch
-    else:
-        base = f"{tested_commit}^1"
+    try:
+        return git.changed_files(f"{commit}^1", commit)
+    except OSError as error:
+        raise ChangeResolutionError(
+            f"Could not compare {commit} with its parent: {error}\n"
+            "The checkout needs the parent commit, which `fetch-depth: 2` provides."
+        ) from error
 
-    return git.changed_files(base, tested_commit)
+
+async def changes_in_pull_request(
+    client: AsyncGitHubClient, owner: str, repo: str, pull_number: int, expected_total: int | None
+) -> list[ChangedFile]:
+    """Return the files a pull request changes, read from the API.
+
+    `expected_total` is `changed_files` on the pull request. The endpoint stops at 3000 files
+    without saying so, and a short list plans a subset of the targets and still reports success, so
+    a count that disagrees aborts the run instead.
+    """
+    files: list[PullRequestFile] = []
+    async for page in client.list_pull_request_files(owner, repo, pull_number):
+        files.extend(page.data)
+
+    if expected_total is not None and len(files) != expected_total:
+        raise ChangeResolutionError(
+            f"Pull request {pull_number} reports {expected_total} changed files but the API listed "
+            f"{len(files)}. Planning from an incomplete list would leave part of the change untested."
+        )
+
+    return [
+        ChangedFile(
+            change_type=CHANGE_TYPES.get(changed.status, ChangeType.MODIFIED),
+            path=changed.filename,
+            previous_path=changed.previous_filename,
+        )
+        for changed in files
+    ]

--- a/ddev/src/ddev/cli/ci/tests/changes.py
+++ b/ddev/src/ddev/cli/ci/tests/changes.py
@@ -44,6 +44,8 @@ def changes_in_commit(git: GitRepository, commit: str) -> list[ChangedFile]:
             f"Could not compare {commit} with its parent: {error}\n"
             "The checkout needs the parent commit, which `fetch-depth: 2` provides."
         ) from error
+    except ValueError as error:
+        raise ChangeResolutionError(f"Could not read the diff of {commit}: {error}") from error
 
 
 async def changes_in_pull_request(

--- a/ddev/src/ddev/cli/ci/tests/changes.py
+++ b/ddev/src/ddev/cli/ci/tests/changes.py
@@ -3,11 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 """Where a CI run gets the changes it must test.
 
-The source depends on the trigger, because the objects each one leaves in the checkout differ. A
-push compares against the commit's first parent, which is one object away on the branch already
-checked out. A pull request needs the merge base of two diverged histories, and the checkout it runs
-in has neither the target branch as a local ref nor, under `workflow_run`, the head commit at all,
-so it reads the diff from the API instead.
+A pull request reads its diff from the API because the merge base it would need locally is not in
+the checkout: the target branch has no local ref, and under `workflow_run` the head commit is
+absent too.
 """
 
 from __future__ import annotations
@@ -26,8 +24,6 @@ class ChangeResolutionError(Exception):
     """Raised when the changes a run is responsible for cannot be established."""
 
 
-# `unchanged` is reachable only on a paginated diff GitHub truncated, and a type change reads as a
-# modification, so both fall back to MODIFIED rather than dropping the path.
 CHANGE_TYPES = {
     "added": ChangeType.ADDED,
     "removed": ChangeType.DELETED,
@@ -40,10 +36,7 @@ CHANGE_TYPES = {
 
 
 def changes_in_commit(git: GitRepository, commit: str) -> list[ChangedFile]:
-    """Return what *commit* itself contributed, comparing it with its first parent.
-
-    Only the parent is needed, so a checkout two commits deep is enough and no request is made.
-    """
+    """Return what *commit* itself contributed, comparing it with its first parent."""
     try:
         return git.changed_files(f"{commit}^1", commit)
     except OSError as error:
@@ -58,9 +51,8 @@ async def changes_in_pull_request(
 ) -> list[ChangedFile]:
     """Return the files a pull request changes, read from the API.
 
-    `expected_total` is `changed_files` on the pull request. The endpoint stops at 3000 files
-    without saying so, and a short list plans a subset of the targets and still reports success, so
-    a count that disagrees aborts the run instead.
+    The endpoint stops at 3000 files without reporting that it did, so a total that disagrees with
+    `expected_total` (`changed_files` on the pull request) aborts rather than planning a subset.
     """
     files: list[PullRequestFile] = []
     async for page in client.list_pull_request_files(owner, repo, pull_number):

--- a/ddev/src/ddev/cli/ci/tests/changes.py
+++ b/ddev/src/ddev/cli/ci/tests/changes.py
@@ -49,18 +49,19 @@ def changes_in_commit(git: GitRepository, commit: str) -> list[ChangedFile]:
 
 
 async def changes_in_pull_request(
-    client: AsyncGitHubClient, owner: str, repo: str, pull_number: int, expected_total: int | None
+    client: AsyncGitHubClient, owner: str, repo: str, pull_number: int, expected_total: int
 ) -> list[ChangedFile]:
     """Return the files a pull request changes, read from the API.
 
     The endpoint stops at 3000 files without reporting that it did, so a total that disagrees with
     `expected_total` (`changed_files` on the pull request) aborts rather than planning a subset.
+    A run with nothing to compare never reaches here, so the total is always a count to check.
     """
     files: list[PullRequestFile] = []
     async for page in client.list_pull_request_files(owner, repo, pull_number):
         files.extend(page.data)
 
-    if expected_total is not None and len(files) != expected_total:
+    if len(files) != expected_total:
         raise ChangeResolutionError(
             f"Pull request {pull_number} reports {expected_total} changed files but the API listed "
             f"{len(files)}. Planning from an incomplete list would leave part of the change untested."

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -55,8 +55,6 @@ class DispatcherContext:
     workflow_ref: str
     target_branch: str | None = None
     pr_number: int | None = None
-    # Free-form `key:value` tags the run reports itself under. What they mean is the caller's to
-    # decide, so nothing here reads them.
     tags: tuple[str, ...] = ()
 
 

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -9,7 +9,6 @@ import asyncio
 import logging
 import signal
 from dataclasses import dataclass
-from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from ddev.cli.ci.tests.messages import BatchFinished, TestBatch, UpdatePRComment
@@ -37,15 +36,6 @@ logger = logging.getLogger(__name__)
 CANCELLED_RATE_LIMITS = RelaxedRateLimits(max_wait_seconds=2.0, max_rate=10_000.0)
 
 
-class RunContext(StrEnum):
-    """What kind of run the Dispatcher is testing, reported as a monitoring tag."""
-
-    PR = "pr"
-    MASTER = "master"
-    AGENT_TEST = "agent-test"
-    RELEASE = "release"
-
-
 @dataclass(frozen=True)
 class DispatcherContext:
     """The run being tested. `build_dispatcher` consumes part of it; the rest describes the run
@@ -58,7 +48,6 @@ class DispatcherContext:
 
     owner: str
     repo: str
-    run_context: RunContext
     checkout_sha: str
     base_sha: str
     branch: str
@@ -66,6 +55,9 @@ class DispatcherContext:
     workflow_ref: str
     target_branch: str | None = None
     pr_number: int | None = None
+    # Free-form `key:value` tags the run reports itself under. What they mean is the caller's to
+    # decide, so nothing here reads them.
+    tags: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/ddev/src/ddev/utils/github_async/client.py
+++ b/ddev/src/ddev/utils/github_async/client.py
@@ -46,6 +46,7 @@ from .models import (
     PullRequest,
     PullRequestFile,
     PullRequestReviewComment,
+    PullRequestSimple,
     WorkflowDispatchResult,
     WorkflowJobsList,
     WorkflowRun,
@@ -900,7 +901,7 @@ class AsyncGitHubClient:
         timeout: float | None = None,
         *,
         retry: RetryPolicy | None = None,
-    ) -> AsyncIterator[GitHubResponse[list[PullRequest]]]:
+    ) -> AsyncIterator[GitHubResponse[list[PullRequestSimple]]]:
         """
         Calls the GitHub API to list the pull requests associated with a commit (paginated).
 
@@ -920,16 +921,18 @@ class AsyncGitHubClient:
             retry: Applies per page. Defaults to the client's policy for replayable requests.
 
         Returns:
-            AsyncIterator[GitHubResponse[list[PullRequest]]]: One page of pull requests per iteration.
-            The endpoint returns the abbreviated form, so ``changed_files`` is unset on each.
+            AsyncIterator[GitHubResponse[list[PullRequestSimple]]]: One page of pull requests per
+            iteration, in the abbreviated form the list endpoints return.
         """
         # The response body is a bare JSON array, so there is no wrapper model to validate against.
         endpoint = f"/repos/{owner}/{repo}/commits/{commit_sha}/pulls"
         async for response in self._paginated_request(
             "GET", endpoint, timeout=timeout, retry=retry, params={"per_page": per_page}
         ):
-            pulls = [PullRequest.model_validate(item) for item in response.json()]
-            yield GitHubResponse[list[PullRequest]].model_validate({"data": pulls, "headers": dict(response.headers)})
+            pulls = [PullRequestSimple.model_validate(item) for item in response.json()]
+            yield GitHubResponse[list[PullRequestSimple]].model_validate(
+                {"data": pulls, "headers": dict(response.headers)}
+            )
 
     async def list_pull_request_files(
         self,
@@ -985,7 +988,7 @@ class AsyncGitHubClient:
         timeout: float | None = None,
         *,
         retry: RetryPolicy | None = None,
-    ) -> GitHubResponse[list[PullRequest]]:
+    ) -> GitHubResponse[list[PullRequestSimple]]:
         """
         Calls the GitHub API to list pull requests in a repository.
 
@@ -1005,7 +1008,8 @@ class AsyncGitHubClient:
             retry: Defaults to the client's policy for replayable requests.
 
         Returns:
-            GitHubResponse[list[PullRequest]]: The validated pull requests on the first result page.
+            GitHubResponse[list[PullRequestSimple]]: The validated pull requests on the first result
+            page, in the abbreviated form the list endpoints return.
 
         Raises:
             ValueError: If `per_page` is outside 1..`MAX_PER_PAGE`.
@@ -1019,8 +1023,10 @@ class AsyncGitHubClient:
         response = await self._request(
             "GET", f"/repos/{owner}/{repo}/pulls", timeout=timeout, retry=retry, params=params
         )
-        pulls = [PullRequest.model_validate(item) for item in response.json()]
-        return GitHubResponse[list[PullRequest]].model_validate({"data": pulls, "headers": dict(response.headers)})
+        pulls = [PullRequestSimple.model_validate(item) for item in response.json()]
+        return GitHubResponse[list[PullRequestSimple]].model_validate(
+            {"data": pulls, "headers": dict(response.headers)}
+        )
 
     async def create_pull_request(
         self,

--- a/ddev/src/ddev/utils/github_async/models/__init__.py
+++ b/ddev/src/ddev/utils/github_async/models/__init__.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from .pull_request import PullRequestFile as PullRequestFile
     from .pull_request import PullRequestFileStatus as PullRequestFileStatus
     from .pull_request import PullRequestRef as PullRequestRef
+    from .pull_request import PullRequestSimple as PullRequestSimple
     from .pull_request import PullRequestState as PullRequestState
     from .user import GitHubUser as GitHubUser
     from .workflow import Artifact as Artifact
@@ -66,6 +67,7 @@ MODULE_BY_NAME: dict[str, str] = {
     'PullRequestFileStatus': 'pull_request',
     'PullRequestRef': 'pull_request',
     'PullRequestReviewComment': 'comment',
+    'PullRequestSimple': 'pull_request',
     'PullRequestState': 'pull_request',
     'WorkflowDispatchResult': 'workflow',
     'WorkflowJob': 'workflow',

--- a/ddev/src/ddev/utils/github_async/models/pull_request.py
+++ b/ddev/src/ddev/utils/github_async/models/pull_request.py
@@ -75,11 +75,17 @@ class PullRequestRef(BaseModel):
     label: str | None = None  # e.g. 'octocat:new-topic'
 
 
-class PullRequest(BaseModel):
-    """A GitHub pull request.
+class PullRequestSimple(BaseModel):
+    """A GitHub pull request as the list endpoints return it.
 
-    Field reference:
-    https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
+    GitHub has two pull request schemas. `pull-request-simple` is what the list endpoints return,
+    and it is a strict subset of `pull-request`: it omits the diff totals and the merge state,
+    without marking them null. Whether those fields are available is therefore a property of the
+    endpoint that was called, not of the pull request, which is why the two are modelled
+    separately rather than as one class with everything optional. `PullRequest` adds them.
+
+    Field reference (the `pull-request-simple` schema):
+    https://docs.github.com/en/rest/pulls/pulls#list-pull-requests
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -102,7 +108,6 @@ class PullRequest(BaseModel):
     # State
     state: PullRequestState | None = None
     draft: bool = False
-    merged: bool | None = None
     locked: bool = False
     merge_commit_sha: str | None = None
 
@@ -128,7 +133,22 @@ class PullRequest(BaseModel):
     head: PullRequestRef | None = None
     base: PullRequestRef | None = None
 
-    # Diff totals. Required by the `pull-request` schema but absent from `pull-request-simple`,
-    # which is what the list endpoints return, so this stays optional. A caller listing a pull
-    # request's files needs it to tell a complete file list from a truncated one.
-    changed_files: int | None = None
+
+class PullRequest(PullRequestSimple):
+    """A GitHub pull request as the single-object endpoints return it.
+
+    Adds the fields `pull-request` declares and `pull-request-simple` omits. `changed_files` is
+    required: the schema declares it as a required integer, and a caller listing a pull request's
+    files needs it to tell a complete list from a silently truncated one. Validation failing is
+    the point, since the alternative is reading a missing count as an empty diff and testing
+    nothing.
+
+    Field reference (the `pull-request` schema):
+    https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
+    """
+
+    changed_files: int
+
+    # Also full-only, but left optional: `port-commit` reads it as a boolean and the schema's other
+    # additions (`additions`, `deletions`, `commits`, `mergeable`, ...) are not modelled at all.
+    merged: bool | None = None

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import pytest
 
+from ddev.cli.ci.tests.dispatcher import RunContext
 from ddev.utils.github_async import GitHubResponse
 from ddev.utils.github_async.models import PullRequest, PullRequestFile
 from tests.cli.ci.tests.helpers import make_batch, make_job
@@ -214,3 +215,44 @@ def test_all_targets_plans_without_reading_a_diff(ddev, github, planned):
     assert result.exit_code == 0, result.output
     github.assert_not_called('list_pull_request_files')
     assert planned.call_args.kwargs['changed_files'] is None
+
+
+@pytest.mark.parametrize('run_context', list(RunContext), ids=lambda member: member.value)
+def test_every_run_context_is_accepted(ddev, github, planned, run_context: RunContext):
+    """`--context` restates its choices as literals, because `RunContext` lives in a module too
+    heavy to import while building the decorator. Parameterizing over the enum catches a member
+    added there and never wired up.
+    """
+    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--context', run_context.value, '--dry-run')
+
+    assert result.exit_code == 0, result.output
+    assert f'Context -> {run_context.value}' in result.output
+
+
+@pytest.mark.parametrize(
+    ('options', 'expected'),
+    [
+        (['--pr', str(PR_NUMBER)], RunContext.PR),
+        (['--commit', 'a-sha'], RunContext.MASTER),
+    ],
+    ids=['pull-request', 'commit'],
+)
+def test_the_kind_of_run_defaults_to_what_named_it(
+    ddev, github, planned, local_changes, options: list[str], expected: RunContext
+):
+    result = ddev('ci', 'dispatch-tests', *options, '--dry-run')
+
+    assert result.exit_code == 0, result.output
+    assert f'Context -> {expected.value}' in result.output
+
+
+def test_a_pull_request_can_be_reported_under_another_kind_of_run(ddev, github, planned):
+    """An agent test or a release run still tests a pull request, so the label is set apart from
+    what the run compares.
+    """
+    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--context', 'agent-test', '--dry-run')
+
+    assert result.exit_code == 0, result.output
+    assert 'Context -> agent-test' in result.output
+    # The label does not change where the diff came from.
+    assert github.last_call('list_pull_request_files').kwargs['pull_number'] == PR_NUMBER

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -96,7 +96,6 @@ def test_a_head_sha_resolves_to_its_pull_request(ddev, github, planned):
 
 
 def test_a_head_sha_belonging_to_no_open_pull_request_dispatches_nothing(ddev, github, planned):
-    """A closed pull request resolves to nothing, and there is nothing to test or report to."""
     github.mock_response('list_commit_pulls', pulls_page())
 
     result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA)
@@ -108,7 +107,7 @@ def test_a_head_sha_belonging_to_no_open_pull_request_dispatches_nothing(ddev, g
 
 
 def test_a_pull_request_that_is_no_longer_open_dispatches_nothing(ddev, github, planned):
-    """Nothing to test once it is closed, and no open pull request to comment on either."""
+    """Nothing to test at that point, and no open pull request to report to either."""
     github.mock_response('get_pull_request', pull_request(state='closed'))
 
     result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER))
@@ -160,7 +159,7 @@ def test_a_run_that_dispatches_needs_a_token_before_it_plans(ddev, planned, mock
 
 
 def test_a_dry_run_of_a_commit_needs_no_token(ddev, planned, local_changes, mocker):
-    """The only run that talks to nobody: a commit is compared with its parent by local git."""
+    """The only run that talks to nobody, since git answers the comparison."""
     mocker.patch.dict('os.environ', {'DD_GITHUB_TOKEN': '', 'GH_TOKEN': '', 'GITHUB_TOKEN': ''})
 
     result = ddev('ci', 'dispatch-tests', '--commit', 'a-sha', '--dry-run')
@@ -170,7 +169,7 @@ def test_a_dry_run_of_a_commit_needs_no_token(ddev, planned, local_changes, mock
 
 
 def test_a_dry_run_of_a_pull_request_needs_a_token(ddev, planned, mocker):
-    """Its branch, commits and diff all come from the API, so there is no offline pull request run."""
+    """Its branch, commits and diff all come from the API, so there is no offline version of it."""
     mocker.patch.dict('os.environ', {'DD_GITHUB_TOKEN': '', 'GH_TOKEN': '', 'GITHUB_TOKEN': ''})
 
     result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--dry-run')
@@ -208,7 +207,6 @@ def test_an_empty_plan_is_not_dispatched(ddev, fake_async_github, local_changes,
 
 
 def test_all_targets_plans_without_reading_a_diff(ddev, github, planned):
-    """`--all` decides which targets run without a comparison, so it reads no files."""
     result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--all', '--dry-run')
 
     assert result.exit_code == 0, result.output
@@ -217,9 +215,7 @@ def test_all_targets_plans_without_reading_a_diff(ddev, github, planned):
 
 
 def test_tags_are_separated_on_spaces(ddev, github, planned, mocker):
-    """One tag per space-separated word. What each means is the caller's to decide, so the only
-    thing this command can get wrong is where one tag ends and the next begins.
-    """
+    """Where one tag ends and the next begins is the only thing the command decides about them."""
     displayed = mocker.patch('ddev.cli.ci.dispatch_tests.display_plan')
 
     result = ddev(

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import pytest
 
-from ddev.cli.ci.tests.dispatcher import RunContext
 from ddev.utils.github_async import GitHubResponse
 from ddev.utils.github_async.models import PullRequest, PullRequestFile
 from tests.cli.ci.tests.helpers import make_batch, make_job
@@ -217,42 +216,15 @@ def test_all_targets_plans_without_reading_a_diff(ddev, github, planned):
     assert planned.call_args.kwargs['changed_files'] is None
 
 
-@pytest.mark.parametrize('run_context', list(RunContext), ids=lambda member: member.value)
-def test_every_run_context_is_accepted(ddev, github, planned, run_context: RunContext):
-    """`--context` restates its choices as literals, because `RunContext` lives in a module too
-    heavy to import while building the decorator. Parameterizing over the enum catches a member
-    added there and never wired up.
+def test_tags_are_separated_on_spaces(ddev, github, planned, mocker):
+    """One tag per space-separated word. What each means is the caller's to decide, so the only
+    thing this command can get wrong is where one tag ends and the next begins.
     """
-    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--context', run_context.value, '--dry-run')
+    displayed = mocker.patch('ddev.cli.ci.dispatch_tests.display_plan')
+
+    result = ddev(
+        'ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--tags', 'kind:agent-test team:agent-integrations', '--dry-run'
+    )
 
     assert result.exit_code == 0, result.output
-    assert f'Context -> {run_context.value}' in result.output
-
-
-@pytest.mark.parametrize(
-    ('options', 'expected'),
-    [
-        (['--pr', str(PR_NUMBER)], RunContext.PR),
-        (['--commit', 'a-sha'], RunContext.MASTER),
-    ],
-    ids=['pull-request', 'commit'],
-)
-def test_the_kind_of_run_defaults_to_what_named_it(
-    ddev, github, planned, local_changes, options: list[str], expected: RunContext
-):
-    result = ddev('ci', 'dispatch-tests', *options, '--dry-run')
-
-    assert result.exit_code == 0, result.output
-    assert f'Context -> {expected.value}' in result.output
-
-
-def test_a_pull_request_can_be_reported_under_another_kind_of_run(ddev, github, planned):
-    """An agent test or a release run still tests a pull request, so the label is set apart from
-    what the run compares.
-    """
-    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--context', 'agent-test', '--dry-run')
-
-    assert result.exit_code == 0, result.output
-    assert 'Context -> agent-test' in result.output
-    # The label does not change where the diff came from.
-    assert github.last_call('list_pull_request_files').kwargs['pull_number'] == PR_NUMBER
+    assert displayed.call_args.args[1].tags == ('kind:agent-test', 'team:agent-integrations')

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -15,13 +15,19 @@ PR_NUMBER = 4242
 HEAD_SHA = 'head-sha-aaa'
 
 
-def pull_request(state: str = 'open', changed_files: int | None = 1) -> PullRequest:
+def pull_request(
+    state: str = 'open',
+    changed_files: int | None = 1,
+    number: int = PR_NUMBER,
+    head_sha: str = HEAD_SHA,
+    base_ref: str = 'a-target-branch',
+) -> PullRequest:
     return PullRequest(
-        number=PR_NUMBER,
-        html_url=f'https://github.com/DataDog/integrations-core/pull/{PR_NUMBER}',
+        number=number,
+        html_url=f'https://github.com/DataDog/integrations-core/pull/{number}',
         state=state,
-        head={'ref': 'hs/a-branch', 'sha': HEAD_SHA},
-        base={'ref': 'a-target-branch', 'sha': 'base-sha-bbb'},
+        head={'ref': 'hs/a-branch', 'sha': head_sha},
+        base={'ref': base_ref, 'sha': 'base-sha-bbb'},
         changed_files=changed_files,
     )
 
@@ -101,9 +107,63 @@ def test_a_head_sha_belonging_to_no_open_pull_request_dispatches_nothing(ddev, g
     result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA)
 
     assert result.exit_code == 0, result.output
-    assert 'belongs to no open pull request' in result.output
+    assert 'heads no open pull request' in result.output
     planned.assert_not_called()
     github.assert_not_called('create_workflow_dispatch')
+
+
+def test_a_commit_that_is_no_longer_the_head_dispatches_nothing(ddev, github, planned):
+    """A commit stays associated with its pull request once later commits land on the branch.
+
+    Testing it anyway would read the newer head and diff while reporting against the older commit,
+    so the run would test one revision and attribute it to another.
+    """
+    github.mock_response('list_commit_pulls', pulls_page(pull_request(head_sha='a-newer-sha')))
+
+    result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA)
+
+    assert result.exit_code == 0, result.output
+    assert 'heads no open pull request' in result.output
+    planned.assert_not_called()
+    github.assert_not_called('create_workflow_dispatch')
+
+
+def test_a_head_sha_heading_several_pull_requests_is_refused(ddev, github, planned):
+    """Choosing one would plan against its base and comment on it, so a run that cannot say which
+    pull request it is testing must not run.
+    """
+    github.mock_response(
+        'list_commit_pulls',
+        pulls_page(pull_request(number=1), pull_request(number=2, base_ref='7.62.x')),
+    )
+
+    result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA)
+
+    assert result.exit_code == 1
+    assert 'heads 2 open pull requests (#1, #2)' in result.output
+    planned.assert_not_called()
+    github.assert_not_called('create_workflow_dispatch')
+
+
+def test_a_base_ref_narrows_an_ambiguous_head_sha(ddev, github, planned):
+    github.mock_response(
+        'list_commit_pulls',
+        pulls_page(pull_request(number=1), pull_request(number=2, base_ref='7.62.x')),
+    )
+    github.mock_response('get_pull_request', pull_request(number=2, base_ref='7.62.x'))
+
+    result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA, '--pr-base-ref', '7.62.x', '--dry-run')
+
+    assert result.exit_code == 0, result.output
+    assert github.last_call('get_pull_request').kwargs['pull_number'] == 2
+
+
+def test_a_base_ref_without_a_head_sha_is_refused(ddev, github, planned):
+    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--pr-base-ref', 'master', '--dry-run')
+
+    assert result.exit_code == 1
+    assert 'only narrows which pull request' in result.output
+    planned.assert_not_called()
 
 
 def test_a_pull_request_that_is_no_longer_open_dispatches_nothing(ddev, github, planned):

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -128,6 +128,23 @@ def test_a_commit_that_is_no_longer_the_head_dispatches_nothing(ddev, github, pl
     github.assert_not_called('create_workflow_dispatch')
 
 
+def test_a_head_that_moves_while_the_pull_request_is_read_dispatches_nothing(ddev, github, planned):
+    """The number is resolved from one response and the pull request read from another.
+
+    A commit pushed in between leaves the second describing a newer revision, whose diff and head
+    would then be tested and reported against the commit this run was asked for.
+    """
+    github.mock_response('list_commit_pulls', pulls_page(pull_request()))
+    github.mock_response('get_pull_request', pull_request(head_sha='a-newer-sha'))
+
+    result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA)
+
+    assert result.exit_code == 0, result.output
+    assert f'has moved on from {HEAD_SHA}' in result.output
+    planned.assert_not_called()
+    github.assert_not_called('create_workflow_dispatch')
+
+
 def test_a_head_sha_heading_several_pull_requests_is_refused(ddev, github, planned):
     """Choosing one would plan against its base and comment on it, so a run that cannot say which
     pull request it is testing must not run.
@@ -272,15 +289,3 @@ def test_all_targets_plans_without_reading_a_diff(ddev, github, planned):
     assert result.exit_code == 0, result.output
     github.assert_not_called('list_pull_request_files')
     assert planned.call_args.kwargs['changed_files'] is None
-
-
-def test_tags_are_separated_on_spaces(ddev, github, planned, mocker):
-    """Where one tag ends and the next begins is the only thing the command decides about them."""
-    displayed = mocker.patch('ddev.cli.ci.dispatch_tests.display_plan')
-
-    result = ddev(
-        'ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--tags', 'kind:agent-test team:agent-integrations', '--dry-run'
-    )
-
-    assert result.exit_code == 0, result.output
-    assert displayed.call_args.args[1].tags == ('kind:agent-test', 'team:agent-integrations')

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -7,17 +7,31 @@ from __future__ import annotations
 
 import pytest
 
-from ddev.cli.ci.tests.dispatcher import RunContext
-from ddev.utils.github_async.models import PullRequest
+from ddev.utils.github_async import GitHubResponse
+from ddev.utils.github_async.models import PullRequest, PullRequestFile
 from tests.cli.ci.tests.helpers import make_batch, make_job
 
 PR_NUMBER = 4242
-PR_PAYLOAD = PullRequest(
-    number=PR_NUMBER,
-    html_url=f'https://github.com/DataDog/integrations-core/pull/{PR_NUMBER}',
-    head={'ref': 'hs/a-branch', 'sha': 'head-sha-aaa'},
-    base={'ref': 'a-target-branch', 'sha': 'base-sha-bbb'},
-)
+HEAD_SHA = 'head-sha-aaa'
+
+
+def pull_request(state: str = 'open', changed_files: int | None = 1) -> PullRequest:
+    return PullRequest(
+        number=PR_NUMBER,
+        html_url=f'https://github.com/DataDog/integrations-core/pull/{PR_NUMBER}',
+        state=state,
+        head={'ref': 'hs/a-branch', 'sha': HEAD_SHA},
+        base={'ref': 'a-target-branch', 'sha': 'base-sha-bbb'},
+        changed_files=changed_files,
+    )
+
+
+def files_page(*files: PullRequestFile) -> GitHubResponse[list[PullRequestFile]]:
+    return GitHubResponse[list[PullRequestFile]].model_validate({'data': list(files), 'headers': {}})
+
+
+def pulls_page(*pulls: PullRequest) -> GitHubResponse[list[PullRequest]]:
+    return GitHubResponse[list[PullRequest]].model_validate({'data': list(pulls), 'headers': {}})
 
 
 @pytest.fixture
@@ -28,9 +42,28 @@ def planned(mocker):
 
 
 @pytest.fixture
+def local_changes(mocker):
+    """Stand in for the git comparison, so a test about anything else needs no real commit.
+
+    `changes_in_commit` is imported inside the function that calls it, so the patch lands on the
+    defining module.
+    """
+    from ddev.utils.git import ChangedFile, ChangeType
+
+    return mocker.patch(
+        'ddev.cli.ci.tests.changes.changes_in_commit',
+        return_value=[ChangedFile(ChangeType.MODIFIED, 'ntp/datadog_checks/ntp/ntp.py')],
+    )
+
+
+@pytest.fixture
 def github(fake_async_github):
-    """A GitHub that answers `get_pull_request` with `PR_PAYLOAD`."""
-    fake_async_github.mock_response('get_pull_request', PR_PAYLOAD)
+    """A GitHub answering with one open pull request that changed one file."""
+    fake_async_github.mock_response('get_pull_request', pull_request())
+    fake_async_github.mock_response(
+        'list_pull_request_files',
+        files_page(PullRequestFile(filename='ntp/datadog_checks/ntp/ntp.py', status='modified')),
+    )
     return fake_async_github
 
 
@@ -39,28 +72,79 @@ def github(fake_async_github):
     [PR_NUMBER, f'https://github.com/DataDog/integrations-core/pull/{PR_NUMBER}'],
     ids=['number', 'url'],
 )
-def test_a_pull_request_supplies_the_run_context(ddev, github, planned, reference):
-    """`--pr` is the only input a local run should need: everything else comes from the API."""
+def test_a_pull_request_supplies_the_whole_run_context(ddev, github, planned, reference):
+    """`--pr` is the only input a pull request run should need: everything else comes from the API."""
     result = ddev('ci', 'dispatch-tests', '--pr', str(reference), '--dry-run')
 
     assert result.exit_code == 0, result.output
     assert 'hs/a-branch' in result.output
-    assert 'head-sha-aaa' in result.output
+    assert HEAD_SHA in result.output
     assert 'a-target-branch' in result.output
     # A pull request is tested at its merge commit, not at its head.
     assert f'refs/pull/{PR_NUMBER}/merge' in result.output
 
 
-@pytest.mark.parametrize(
-    'option, value',
-    [('--pr-number', '77'), ('--branch', 'a-branch'), ('--base-sha', 'a-sha'), ('--target-branch', 'a-target')],
-)
-def test_what_a_pull_request_resolves_cannot_also_be_passed(ddev, github, planned, option, value):
-    """Taking one and ignoring the other would run one pull request's branch against another's diff."""
-    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), option, value, '--dry-run')
+def test_a_head_sha_resolves_to_its_pull_request(ddev, github, planned):
+    """`workflow_run` carries the head commit, not reliably a number, so the run resolves it."""
+    github.mock_response('list_commit_pulls', pulls_page(pull_request()))
+
+    result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA, '--dry-run')
+
+    assert result.exit_code == 0, result.output
+    assert str(PR_NUMBER) in result.output
+    assert github.last_call('list_commit_pulls').kwargs['commit_sha'] == HEAD_SHA
+
+
+def test_a_head_sha_belonging_to_no_open_pull_request_dispatches_nothing(ddev, github, planned):
+    """A closed pull request resolves to nothing, and there is nothing to test or report to."""
+    github.mock_response('list_commit_pulls', pulls_page())
+
+    result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA)
+
+    assert result.exit_code == 0, result.output
+    assert 'belongs to no open pull request' in result.output
+    planned.assert_not_called()
+    github.assert_not_called('create_workflow_dispatch')
+
+
+def test_a_pull_request_that_is_no_longer_open_dispatches_nothing(ddev, github, planned):
+    """Nothing to test once it is closed, and no open pull request to comment on either."""
+    github.mock_response('get_pull_request', pull_request(state='closed'))
+
+    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER))
+
+    assert result.exit_code == 0, result.output
+    assert 'is not open' in result.output
+    planned.assert_not_called()
+    github.assert_not_called('create_workflow_dispatch')
+
+
+def test_an_incomplete_diff_aborts_rather_than_testing_part_of_the_change(ddev, github, planned):
+    """The files endpoint truncates silently, so a count that disagrees has to stop the run."""
+    github.mock_response('get_pull_request', pull_request(changed_files=97))
+
+    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--dry-run')
 
     assert result.exit_code == 1
-    assert f'`{option}` cannot be passed with `--pr`' in result.output
+    assert 'reports 97 changed files but the API listed 1' in result.output
+    planned.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    'options',
+    [
+        ['--pr', str(PR_NUMBER), '--pr-head-sha', HEAD_SHA],
+        ['--pr', str(PR_NUMBER), '--commit', 'a-sha'],
+        ['--pr-head-sha', HEAD_SHA, '--commit', 'a-sha'],
+    ],
+    ids=['pr-and-head-sha', 'pr-and-commit', 'head-sha-and-commit'],
+)
+def test_only_one_run_can_be_named(ddev, github, planned, options: list[str]):
+    """Taking one and ignoring the rest would test one commit and report against another."""
+    result = ddev('ci', 'dispatch-tests', *options, '--dry-run')
+
+    assert result.exit_code == 1
+    assert 'name different runs' in result.output
     planned.assert_not_called()
 
 
@@ -68,21 +152,32 @@ def test_a_run_that_dispatches_needs_a_token_before_it_plans(ddev, planned, mock
     """Planning shells out to git and Hatch for every target, so a missing token must stop it first."""
     mocker.patch.dict('os.environ', {'DD_GITHUB_TOKEN': '', 'GH_TOKEN': '', 'GITHUB_TOKEN': ''})
 
-    result = ddev('ci', 'dispatch-tests', '--base-sha', 'a-sha')
+    result = ddev('ci', 'dispatch-tests', '--commit', 'a-sha')
 
     assert result.exit_code == 1
     assert 'A GitHub token is required' in result.output
     planned.assert_not_called()
 
 
-def test_a_dry_run_reading_no_pull_request_needs_no_token(ddev, planned, mocker):
-    """The only run that talks to nobody, so it is the one exception to needing a token."""
+def test_a_dry_run_of_a_commit_needs_no_token(ddev, planned, local_changes, mocker):
+    """The only run that talks to nobody: a commit is compared with its parent by local git."""
     mocker.patch.dict('os.environ', {'DD_GITHUB_TOKEN': '', 'GH_TOKEN': '', 'GITHUB_TOKEN': ''})
 
-    result = ddev('ci', 'dispatch-tests', '--base-sha', 'a-sha', '--dry-run')
+    result = ddev('ci', 'dispatch-tests', '--commit', 'a-sha', '--dry-run')
 
     assert result.exit_code == 0, result.output
     assert 'Dry run: nothing was dispatched.' in result.output
+
+
+def test_a_dry_run_of_a_pull_request_needs_a_token(ddev, planned, mocker):
+    """Its branch, commits and diff all come from the API, so there is no offline pull request run."""
+    mocker.patch.dict('os.environ', {'DD_GITHUB_TOKEN': '', 'GH_TOKEN': '', 'GITHUB_TOKEN': ''})
+
+    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--dry-run')
+
+    assert result.exit_code == 1
+    assert 'A GitHub token is required' in result.output
+    planned.assert_not_called()
 
 
 def test_a_dry_run_dispatches_nothing(ddev, github, planned):
@@ -101,24 +196,21 @@ def test_a_reference_that_is_neither_a_number_nor_a_url_is_refused(ddev, planned
     planned.assert_not_called()
 
 
-def test_an_empty_plan_is_not_dispatched(ddev, fake_async_github, mocker):
+def test_an_empty_plan_is_not_dispatched(ddev, fake_async_github, local_changes, mocker):
     """Nothing to test is a clean outcome, not a failure and not an empty comment."""
     mocker.patch('ddev.cli.ci.dispatch_tests.build_plan', return_value=[])
 
-    result = ddev('ci', 'dispatch-tests', '--base-sha', 'a-sha')
+    result = ddev('ci', 'dispatch-tests', '--commit', 'a-sha')
 
     assert result.exit_code == 0, result.output
     assert 'No affected target to test.' in result.output
     fake_async_github.assert_not_called('create_workflow_dispatch')
 
 
-@pytest.mark.parametrize('run_context', list(RunContext), ids=lambda member: member.value)
-def test_every_run_context_is_accepted(ddev, github, planned, run_context):
-    """`--context` restates its choices as literals, because `RunContext` lives in a module too
-    heavy to import while building the decorator. Parameterizing over the enum catches a member
-    added there and never wired up.
-    """
-    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--context', run_context.value, '--dry-run')
+def test_all_targets_plans_without_reading_a_diff(ddev, github, planned):
+    """`--all` decides which targets run without a comparison, so it reads no files."""
+    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--all', '--dry-run')
 
     assert result.exit_code == 0, result.output
-    assert f'Context -> {run_context.value}' in result.output
+    github.assert_not_called('list_pull_request_files')
+    assert planned.call_args.kwargs['changed_files'] is None

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import pytest
 
 from ddev.utils.github_async import GitHubResponse
-from ddev.utils.github_async.models import PullRequest, PullRequestFile
+from ddev.utils.github_async.models import PullRequest, PullRequestFile, PullRequestSimple
 from tests.cli.ci.tests.helpers import make_batch, make_job
 
 PR_NUMBER = 4242
@@ -17,7 +17,7 @@ HEAD_SHA = 'head-sha-aaa'
 
 def pull_request(
     state: str = 'open',
-    changed_files: int | None = 1,
+    changed_files: int = 1,
     number: int = PR_NUMBER,
     head_sha: str = HEAD_SHA,
     base_ref: str = 'a-target-branch',
@@ -32,12 +32,28 @@ def pull_request(
     )
 
 
+def listed_pull_request(
+    number: int = PR_NUMBER,
+    head_sha: str = HEAD_SHA,
+    base_ref: str = 'a-target-branch',
+    state: str = 'open',
+) -> PullRequestSimple:
+    """What `list_commit_pulls` returns: no diff totals, so it cannot stand in for the full form."""
+    return PullRequestSimple(
+        number=number,
+        html_url=f'https://github.com/DataDog/integrations-core/pull/{number}',
+        state=state,
+        head={'ref': 'hs/a-branch', 'sha': head_sha},
+        base={'ref': base_ref, 'sha': 'base-sha-bbb'},
+    )
+
+
 def files_page(*files: PullRequestFile) -> GitHubResponse[list[PullRequestFile]]:
     return GitHubResponse[list[PullRequestFile]].model_validate({'data': list(files), 'headers': {}})
 
 
-def pulls_page(*pulls: PullRequest) -> GitHubResponse[list[PullRequest]]:
-    return GitHubResponse[list[PullRequest]].model_validate({'data': list(pulls), 'headers': {}})
+def pulls_page(*pulls: PullRequestSimple) -> GitHubResponse[list[PullRequestSimple]]:
+    return GitHubResponse[list[PullRequestSimple]].model_validate({'data': list(pulls), 'headers': {}})
 
 
 @pytest.fixture
@@ -92,7 +108,7 @@ def test_a_pull_request_supplies_the_whole_run_context(ddev, github, planned, re
 
 def test_a_head_sha_resolves_to_its_pull_request(ddev, github, planned):
     """`workflow_run` carries the head commit, not reliably a number, so the run resolves it."""
-    github.mock_response('list_commit_pulls', pulls_page(pull_request()))
+    github.mock_response('list_commit_pulls', pulls_page(listed_pull_request()))
 
     result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA, '--dry-run')
 
@@ -118,7 +134,7 @@ def test_a_commit_that_is_no_longer_the_head_dispatches_nothing(ddev, github, pl
     Testing it anyway would read the newer head and diff while reporting against the older commit,
     so the run would test one revision and attribute it to another.
     """
-    github.mock_response('list_commit_pulls', pulls_page(pull_request(head_sha='a-newer-sha')))
+    github.mock_response('list_commit_pulls', pulls_page(listed_pull_request(head_sha='a-newer-sha')))
 
     result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA)
 
@@ -134,7 +150,7 @@ def test_a_head_that_moves_while_the_pull_request_is_read_dispatches_nothing(dde
     A commit pushed in between leaves the second describing a newer revision, whose diff and head
     would then be tested and reported against the commit this run was asked for.
     """
-    github.mock_response('list_commit_pulls', pulls_page(pull_request()))
+    github.mock_response('list_commit_pulls', pulls_page(listed_pull_request()))
     github.mock_response('get_pull_request', pull_request(head_sha='a-newer-sha'))
 
     result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA)
@@ -151,7 +167,7 @@ def test_a_head_sha_heading_several_pull_requests_is_refused(ddev, github, plann
     """
     github.mock_response(
         'list_commit_pulls',
-        pulls_page(pull_request(number=1), pull_request(number=2, base_ref='7.62.x')),
+        pulls_page(listed_pull_request(number=1), listed_pull_request(number=2, base_ref='7.62.x')),
     )
 
     result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA)
@@ -165,7 +181,7 @@ def test_a_head_sha_heading_several_pull_requests_is_refused(ddev, github, plann
 def test_a_base_ref_narrows_an_ambiguous_head_sha(ddev, github, planned):
     github.mock_response(
         'list_commit_pulls',
-        pulls_page(pull_request(number=1), pull_request(number=2, base_ref='7.62.x')),
+        pulls_page(listed_pull_request(number=1), listed_pull_request(number=2, base_ref='7.62.x')),
     )
     github.mock_response('get_pull_request', pull_request(number=2, base_ref='7.62.x'))
 

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -178,7 +178,7 @@ def test_a_base_ref_narrows_an_ambiguous_head_sha(ddev, github, planned):
 def test_a_base_ref_without_a_head_sha_is_refused(ddev, github, planned):
     result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--pr-base-ref', 'master', '--dry-run')
 
-    assert result.exit_code == 1
+    assert result.exit_code == 2
     assert 'only narrows which pull request' in result.output
     planned.assert_not_called()
 
@@ -219,7 +219,7 @@ def test_only_one_run_can_be_named(ddev, github, planned, options: list[str]):
     """Taking one and ignoring the rest would test one commit and report against another."""
     result = ddev('ci', 'dispatch-tests', *options, '--dry-run')
 
-    assert result.exit_code == 1
+    assert result.exit_code == 2
     assert 'name different runs' in result.output
     planned.assert_not_called()
 
@@ -267,7 +267,7 @@ def test_a_dry_run_dispatches_nothing(ddev, github, planned):
 def test_a_reference_that_is_neither_a_number_nor_a_url_is_refused(ddev, planned):
     result = ddev('ci', 'dispatch-tests', '--pr', 'not-a-pull-request', '--dry-run')
 
-    assert result.exit_code == 1
+    assert result.exit_code == 2
     assert 'neither a pull request number nor a pull request URL' in result.output
     planned.assert_not_called()
 

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -222,6 +222,19 @@ def test_an_incomplete_diff_aborts_rather_than_testing_part_of_the_change(ddev, 
     planned.assert_not_called()
 
 
+def test_a_pull_request_that_changes_no_file_dispatches_nothing(ddev, github, planned):
+    """Listing the files of an empty diff would meet a count of 0 and read that as truncation."""
+    github.mock_response('get_pull_request', pull_request(changed_files=0))
+
+    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER))
+
+    assert result.exit_code == 0, result.output
+    assert 'changes no file' in result.output
+    github.assert_not_called('list_pull_request_files')
+    planned.assert_not_called()
+    github.assert_not_called('create_workflow_dispatch')
+
+
 @pytest.mark.parametrize(
     'options',
     [

--- a/ddev/tests/cli/ci/tests/test_changes.py
+++ b/ddev/tests/cli/ci/tests/test_changes.py
@@ -1,45 +1,99 @@
 # (C) Datadog, Inc. 2026-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-"""Tests for the comparison a CI run diffs to find what it must test."""
+"""Tests for where a CI run gets the changes it must test."""
 
 from __future__ import annotations
 
 import pytest
 
-from ddev.cli.ci.tests.changes import CIContext, get_changed_files
+from ddev.cli.ci.tests.changes import ChangeResolutionError, changes_in_commit, changes_in_pull_request
 from ddev.utils.git import ChangedFile, ChangeType
+from ddev.utils.github_async import GitHubResponse
+from ddev.utils.github_async.models import PullRequestFile
 
 
 class RecordingGit:
     """Stand-in for `GitRepository` that records the comparison it was asked for."""
 
-    def __init__(self, changed=()):
+    def __init__(self, changed: tuple[ChangedFile, ...] = (), error: OSError | None = None):
         self.changed = list(changed)
+        self.error = error
         self.calls: list[tuple[str, str | None]] = []
 
-    def changed_files(self, base="origin/master", head=None):
+    def changed_files(self, base: str = "origin/master", head: str | None = None) -> list[ChangedFile]:
         self.calls.append((base, head))
+        if self.error is not None:
+            raise self.error
         return list(self.changed)
 
 
-@pytest.mark.parametrize(
-    ("context", "target_branch", "expected_call"),
-    [
-        pytest.param(CIContext.PULL_REQUEST, "origin/master", ("origin/master", "abc123"), id="pull-request"),
-        pytest.param(CIContext.DEFAULT_BRANCH, None, ("abc123^1", "abc123"), id="default-branch"),
-    ],
-)
-def test_get_changed_files_uses_the_right_comparison(context, target_branch, expected_call):
+def file_page(*files: PullRequestFile) -> GitHubResponse[list[PullRequestFile]]:
+    return GitHubResponse[list[PullRequestFile]].model_validate({"data": list(files), "headers": {}})
+
+
+class FakeFilesClient:
+    """Stand-in for the client, yielding the pages it was built with."""
+
+    def __init__(self, *pages: GitHubResponse[list[PullRequestFile]]):
+        self.pages = pages
+        self.calls: list[tuple[str, str, int]] = []
+
+    async def list_pull_request_files(self, owner: str, repo: str, pull_number: int):
+        self.calls.append((owner, repo, pull_number))
+        for page in self.pages:
+            yield page
+
+
+def test_a_commit_is_compared_with_its_first_parent():
+    """The comparison a push needs, and the only one a two-commit checkout can answer."""
     changed_file = ChangedFile(ChangeType.MODIFIED, "foo/bar.py")
-    git = RecordingGit([changed_file])
+    git = RecordingGit((changed_file,))
 
-    changed = get_changed_files(git, "abc123", context=context, target_branch=target_branch)
-
-    assert git.calls == [expected_call]
-    assert changed == [changed_file]
+    assert changes_in_commit(git, "abc123") == [changed_file]
+    assert git.calls == [("abc123^1", "abc123")]
 
 
-def test_get_changed_files_pull_request_requires_target_branch():
-    with pytest.raises(ValueError, match="target branch is required"):
-        get_changed_files(RecordingGit(), "abc123", context=CIContext.PULL_REQUEST, target_branch=None)
+def test_a_commit_whose_parent_is_missing_says_what_would_fix_it():
+    """A depth-1 checkout has no parent to compare with, and the message has to name the fix."""
+    git = RecordingGit(error=OSError("fatal: ambiguous argument 'abc123^1'"))
+
+    with pytest.raises(ChangeResolutionError, match="fetch-depth: 2"):
+        changes_in_commit(git, "abc123")
+
+
+async def test_a_pull_request_reads_every_page_of_its_diff():
+    """Stopping early would plan a subset of the targets and still report success."""
+    client = FakeFilesClient(
+        file_page(PullRequestFile(filename="first.py", status="modified")),
+        file_page(PullRequestFile(filename="second.py", status="added")),
+    )
+
+    changed = await changes_in_pull_request(client, "DataDog", "integrations-core", 25082, 2)
+
+    assert [file.path for file in changed] == ["first.py", "second.py"]
+    assert [file.change_type for file in changed] == [ChangeType.MODIFIED, ChangeType.ADDED]
+    assert client.calls == [("DataDog", "integrations-core", 25082)]
+
+
+async def test_a_truncated_diff_aborts_rather_than_planning_a_subset():
+    """`pulls/{n}/files` stops at 3000 files without saying so, so the count is the only guard."""
+    client = FakeFilesClient(file_page(PullRequestFile(filename="only.py", status="modified")))
+
+    with pytest.raises(ChangeResolutionError, match="reports 2 changed files but the API listed 1"):
+        await changes_in_pull_request(client, "DataDog", "integrations-core", 25082, 2)
+
+
+async def test_a_rename_selects_the_target_it_moved_away_from():
+    """`affected_paths` only returns the source for a RENAMED change, so a rename mapped to anything
+    else silently stops selecting the target that used to own the file.
+    """
+    client = FakeFilesClient(
+        file_page(
+            PullRequestFile(filename="disk/new.py", status="renamed", previous_filename="postgres/old.py"),
+        )
+    )
+
+    changed = await changes_in_pull_request(client, "DataDog", "integrations-core", 1, 1)
+
+    assert changed[0].affected_paths == ("disk/new.py", "postgres/old.py")

--- a/ddev/tests/cli/ci/tests/test_changes.py
+++ b/ddev/tests/cli/ci/tests/test_changes.py
@@ -16,7 +16,7 @@ from ddev.utils.github_async.models import PullRequestFile
 class RecordingGit:
     """Stand-in for `GitRepository` that records the comparison it was asked for."""
 
-    def __init__(self, changed: tuple[ChangedFile, ...] = (), error: OSError | None = None):
+    def __init__(self, changed: tuple[ChangedFile, ...] = (), error: Exception | None = None):
         self.changed = list(changed)
         self.error = error
         self.calls: list[tuple[str, str | None]] = []
@@ -53,11 +53,20 @@ def test_a_commit_is_compared_with_its_first_parent():
     assert git.calls == [("abc123^1", "abc123")]
 
 
-def test_a_commit_whose_parent_is_missing_says_what_would_fix_it():
-    """The usual cause is a depth-1 checkout, which the message has to be able to point at."""
-    git = RecordingGit(error=OSError("fatal: ambiguous argument 'abc123^1'"))
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        pytest.param(OSError("fatal: ambiguous argument 'abc123^1'"), "fetch-depth: 2", id="parent-missing"),
+        pytest.param(ValueError("Malformed diff line: 'M'"), "Could not read the diff", id="unparsable-diff"),
+    ],
+)
+def test_a_comparison_git_cannot_answer_is_reported_as_a_change_resolution_failure(error: Exception, expected: str):
+    """Both reach the CLI as a message: the depth-1 checkout that causes the first is the common
+    case and the message has to point at it, and neither should surface as a traceback.
+    """
+    git = RecordingGit(error=error)
 
-    with pytest.raises(ChangeResolutionError, match="fetch-depth: 2"):
+    with pytest.raises(ChangeResolutionError, match=expected):
         changes_in_commit(git, "abc123")
 
 

--- a/ddev/tests/cli/ci/tests/test_changes.py
+++ b/ddev/tests/cli/ci/tests/test_changes.py
@@ -46,7 +46,6 @@ class FakeFilesClient:
 
 
 def test_a_commit_is_compared_with_its_first_parent():
-    """The comparison a push needs, and the only one a two-commit checkout can answer."""
     changed_file = ChangedFile(ChangeType.MODIFIED, "foo/bar.py")
     git = RecordingGit((changed_file,))
 
@@ -55,7 +54,7 @@ def test_a_commit_is_compared_with_its_first_parent():
 
 
 def test_a_commit_whose_parent_is_missing_says_what_would_fix_it():
-    """A depth-1 checkout has no parent to compare with, and the message has to name the fix."""
+    """The usual cause is a depth-1 checkout, which the message has to be able to point at."""
     git = RecordingGit(error=OSError("fatal: ambiguous argument 'abc123^1'"))
 
     with pytest.raises(ChangeResolutionError, match="fetch-depth: 2"):
@@ -77,7 +76,7 @@ async def test_a_pull_request_reads_every_page_of_its_diff():
 
 
 async def test_a_truncated_diff_aborts_rather_than_planning_a_subset():
-    """`pulls/{n}/files` stops at 3000 files without saying so, so the count is the only guard."""
+    """The endpoint truncates without saying so, so the count is the only thing that can catch it."""
     client = FakeFilesClient(file_page(PullRequestFile(filename="only.py", status="modified")))
 
     with pytest.raises(ChangeResolutionError, match="reports 2 changed files but the API listed 1"):
@@ -85,8 +84,8 @@ async def test_a_truncated_diff_aborts_rather_than_planning_a_subset():
 
 
 async def test_a_rename_selects_the_target_it_moved_away_from():
-    """`affected_paths` only returns the source for a RENAMED change, so a rename mapped to anything
-    else silently stops selecting the target that used to own the file.
+    """`affected_paths` returns the source only for a RENAMED change, so mapping a rename to
+    anything else stops selecting the target that used to own the file.
     """
     client = FakeFilesClient(
         file_page(

--- a/ddev/tests/cli/ci/tests/test_dispatcher.py
+++ b/ddev/tests/cli/ci/tests/test_dispatcher.py
@@ -17,7 +17,6 @@ from ddev.cli.ci.tests.dispatcher import (
     CANCELLED_RATE_LIMITS,
     Dispatcher,
     DispatcherContext,
-    RunContext,
 )
 from ddev.cli.ci.tests.messages import BatchJob, TestBatch
 from ddev.cli.ci.tests.pr_comment import CANCELLED_HEADING
@@ -35,7 +34,6 @@ pytestmark = pytest.mark.usefixtures("step_summary")
 CONTEXT = DispatcherContext(
     owner="DataDog",
     repo="integrations-core",
-    run_context=RunContext.PR,
     checkout_sha="refs/pull/42/merge",
     base_sha="head-sha",
     branch="a-branch",

--- a/ddev/tests/cli/release/test_port_commit.py
+++ b/ddev/tests/cli/release/test_port_commit.py
@@ -336,7 +336,7 @@ def test_create_pull_request_step(app_mock: MagicMock, fake_async_github: FakeAs
     app_mock.config.github.token = 'ghp_test'
     fake_async_github.mock_response(
         'create_pull_request',
-        PullRequest(number=7, html_url='https://github.com/x/pr/1'),
+        PullRequest(number=7, html_url='https://github.com/x/pr/1', changed_files=1),
     )
 
     step = CreatePullRequestStep(
@@ -448,6 +448,7 @@ def _merged_pr(number=23703, merge_commit_sha=None, backport_bases=(), extra_lab
         merged=True,
         merge_commit_sha=merge_commit_sha or FULL_SHA_FOR_TESTS,
         labels=labels,
+        changed_files=1,
     )
 
 
@@ -455,7 +456,7 @@ def test_command_happy_path(ddev: CliRunner, mocker: MockerFixture, fake_async_g
     run_mock = _setup_command_mocks(mocker)
     fake_async_github.mock_response(
         'create_pull_request',
-        PullRequest(number=1, html_url='https://github.com/x/pr/1'),
+        PullRequest(number=1, html_url='https://github.com/x/pr/1', changed_files=1),
     )
     mocker.patch('click.confirm', return_value=True)
     mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
@@ -500,7 +501,7 @@ def test_command_lowercases_branch_name(
     run_mock = _setup_command_mocks(mocker)
     fake_async_github.mock_response(
         'create_pull_request',
-        PullRequest(number=1, html_url='https://github.com/x/pr/1'),
+        PullRequest(number=1, html_url='https://github.com/x/pr/1', changed_files=1),
     )
     mocker.patch('click.confirm', return_value=True)
     mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'AAraKKe'})
@@ -560,7 +561,7 @@ def test_create_pull_request_step_propagates_authentication_failure_when_labelin
     app_mock.config.github.token = 'ghp_test'
     fake_async_github.mock_response(
         'create_pull_request',
-        PullRequest(number=7, html_url='https://github.com/x/pr/7'),
+        PullRequest(number=7, html_url='https://github.com/x/pr/7', changed_files=1),
     )
     fake_async_github.mock_response(
         'add_labels_to_issue',
@@ -602,7 +603,7 @@ def test_command_uses_central_handler_on_label_authentication_failure(
     _setup_command_mocks(mocker)
     fake_async_github.mock_response(
         'create_pull_request',
-        PullRequest(number=1, html_url='https://github.com/x/pr/1'),
+        PullRequest(number=1, html_url='https://github.com/x/pr/1', changed_files=1),
     )
     fake_async_github.mock_response(
         'add_labels_to_issue',
@@ -781,7 +782,7 @@ def test_command_fetches_commit_when_not_local(
     )
     fake_async_github.mock_response(
         'create_pull_request',
-        PullRequest(number=1, html_url='https://github.com/x/pr/1'),
+        PullRequest(number=1, html_url='https://github.com/x/pr/1', changed_files=1),
     )
     mocker.patch('click.confirm', return_value=True)
     mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
@@ -829,7 +830,7 @@ def test_command_resolves_pr_input(
     fake_async_github.mock_response('get_pull_request', _merged_pr(number=23703))
     fake_async_github.mock_response(
         'create_pull_request',
-        PullRequest(number=1, html_url='https://github.com/x/pr/1'),
+        PullRequest(number=1, html_url='https://github.com/x/pr/1', changed_files=1),
     )
     mocker.patch('click.confirm', return_value=True)
     mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
@@ -854,6 +855,7 @@ def test_command_aborts_when_pr_not_merged(
             html_url='https://github.com/DataDog/integrations-core/pull/23703',
             merged=False,
             merge_commit_sha=None,
+            changed_files=1,
         ),
     )
     mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
@@ -947,7 +949,7 @@ def test_command_falls_back_to_commit_on_pr_not_found(
     mocker.patch('ddev.utils.git.GitRepository.log', return_value=[{'hash': full_sha, 'subject': 'Fix bug'}])
     fake_async_github.mock_response(
         'create_pull_request',
-        PullRequest(number=1, html_url='https://github.com/x/pr/1'),
+        PullRequest(number=1, html_url='https://github.com/x/pr/1', changed_files=1),
     )
     mocker.patch('click.confirm', return_value=True)
     mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
@@ -1012,7 +1014,7 @@ def test_command_non_interactive_skips_confirmation(
     _setup_command_mocks(mocker)
     fake_async_github.mock_response(
         'create_pull_request',
-        PullRequest(number=1, html_url='https://github.com/x/pr/1'),
+        PullRequest(number=1, html_url='https://github.com/x/pr/1', changed_files=1),
     )
     confirm = mocker.patch('click.confirm', return_value=False)
     mocker.patch.dict('os.environ', {'DD_GITHUB_USER': 'alice'})
@@ -1070,6 +1072,7 @@ def test_derive_backport_bases(label_names: list[str], expected: list[str]) -> N
         number=1,
         html_url='https://github.com/DataDog/integrations-core/pull/1',
         labels=[Label(id=idx, name=name) for idx, name in enumerate(label_names, start=1)],
+        changed_files=1,
     )
     assert derive_backport_bases(pr) == expected
 

--- a/ddev/tests/helpers/github_async.py
+++ b/ddev/tests/helpers/github_async.py
@@ -14,7 +14,7 @@ Quick reference:
         # Sticky default for all matching calls
         fake_async_github.mock_response(
             'create_pull_request',
-            PullRequest(number=5, html_url='https://github.com/x/pr/5'),
+            PullRequest(number=5, html_url='https://github.com/x/pr/5', changed_files=1),
         )
 
         # Partial match: only PR #5 gets the override
@@ -116,7 +116,7 @@ def _default_response_factories() -> dict[str, Callable[[], Any]]:
     """Built-in default responses used when no `mock_response` matches a call."""
     return {
         'create_pull_request': lambda: GitHubResponse(
-            data=PullRequest(number=1, html_url='https://github.com/test/repo/pull/1'),
+            data=PullRequest(number=1, html_url='https://github.com/test/repo/pull/1', changed_files=1),
             headers={},
         ),
         'add_labels_to_issue': lambda: GitHubResponse.model_validate({'data': [], 'headers': {}}),

--- a/ddev/tests/test_fake_github_async.py
+++ b/ddev/tests/test_fake_github_async.py
@@ -22,6 +22,11 @@ from tests.helpers.github_async import FakeAsyncGitHubClient
 from tests.utils.github_async.helpers import first_page
 
 
+def a_pull_request(number: int) -> PullRequest:
+    """A payload for the fake to hand back. These tests are about the fake's dispatch, not the model."""
+    return PullRequest(number=number, html_url=f'https://x/{number}', changed_files=1)
+
+
 @pytest.fixture
 def fake() -> FakeAsyncGitHubClient:
     return FakeAsyncGitHubClient()
@@ -39,7 +44,7 @@ def test_unknown_method_without_default_raises(fake: FakeAsyncGitHubClient) -> N
 
 
 async def test_sticky_mock_with_inner_data_is_auto_wrapped(fake: FakeAsyncGitHubClient) -> None:
-    fake.mock_response('create_pull_request', PullRequest(number=42, html_url='https://x/42'))
+    fake.mock_response('create_pull_request', a_pull_request(42))
 
     response = await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
 
@@ -48,9 +53,7 @@ async def test_sticky_mock_with_inner_data_is_auto_wrapped(fake: FakeAsyncGitHub
 
 
 async def test_sticky_mock_with_full_response_passes_through(fake: FakeAsyncGitHubClient) -> None:
-    full = GitHubResponse.model_validate(
-        {'data': PullRequest(number=99, html_url='https://x/99'), 'headers': {'x-rate-limit': '5'}}
-    )
+    full = GitHubResponse.model_validate({'data': a_pull_request(99), 'headers': {'x-rate-limit': '5'}})
     fake.mock_response('create_pull_request', full)
 
     response = await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
@@ -60,7 +63,7 @@ async def test_sticky_mock_with_full_response_passes_through(fake: FakeAsyncGitH
 
 
 async def test_sticky_mock_partial_match_only_fires_for_matching_call(fake: FakeAsyncGitHubClient) -> None:
-    fake.mock_response('create_pull_request', PullRequest(number=7, html_url='https://x/7'), draft=True)
+    fake.mock_response('create_pull_request', a_pull_request(7), draft=True)
 
     # Default fires for non-matching calls.
     default = await fake.create_pull_request('o', 'r', 'T', 'h', 'b', draft=False)
@@ -72,8 +75,8 @@ async def test_sticky_mock_partial_match_only_fires_for_matching_call(fake: Fake
 
 
 async def test_most_recent_sticky_mock_wins(fake: FakeAsyncGitHubClient) -> None:
-    fake.mock_response('create_pull_request', PullRequest(number=1, html_url='https://x/1'))
-    fake.mock_response('create_pull_request', PullRequest(number=2, html_url='https://x/2'))
+    fake.mock_response('create_pull_request', a_pull_request(1))
+    fake.mock_response('create_pull_request', a_pull_request(2))
 
     response = await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
 
@@ -89,8 +92,8 @@ async def test_exception_response_raises(fake: FakeAsyncGitHubClient) -> None:
 
 
 async def test_one_shot_consumed_then_falls_through_to_sticky(fake: FakeAsyncGitHubClient) -> None:
-    fake.mock_response('create_pull_request', PullRequest(number=10, html_url='https://x/10'), once=True)
-    fake.mock_response('create_pull_request', PullRequest(number=99, html_url='https://x/99'))  # sticky
+    fake.mock_response('create_pull_request', a_pull_request(10), once=True)
+    fake.mock_response('create_pull_request', a_pull_request(99))  # sticky
 
     first = await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
     second = await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
@@ -105,7 +108,7 @@ async def test_multiple_one_shots_fire_in_registration_order(fake: FakeAsyncGitH
     """The retry pattern: first call errors, second succeeds."""
     err = httpx.HTTPStatusError('try again', request=httpx.Request('POST', 'https://x'), response=httpx.Response(500))
     fake.mock_response('create_pull_request', err, once=True)
-    fake.mock_response('create_pull_request', PullRequest(number=5, html_url='https://x/5'), once=True)
+    fake.mock_response('create_pull_request', a_pull_request(5), once=True)
 
     with pytest.raises(httpx.HTTPStatusError):
         await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
@@ -117,7 +120,7 @@ async def test_multiple_one_shots_fire_in_registration_order(fake: FakeAsyncGitH
 async def test_one_shot_with_match_kwargs_only_consumed_when_match(fake: FakeAsyncGitHubClient) -> None:
     fake.mock_response(
         'create_pull_request',
-        PullRequest(number=7, html_url='https://x/7'),
+        a_pull_request(7),
         once=True,
         draft=True,
     )
@@ -136,15 +139,15 @@ async def test_one_shot_with_match_kwargs_only_consumed_when_match(fake: FakeAsy
 
 
 async def test_assert_all_responses_consumed_passes_when_empty(fake: FakeAsyncGitHubClient) -> None:
-    fake.mock_response('create_pull_request', PullRequest(number=5, html_url='https://x/5'), once=True)
+    fake.mock_response('create_pull_request', a_pull_request(5), once=True)
     await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
 
     fake.assert_all_responses_consumed()  # must not raise
 
 
 async def test_assert_all_responses_consumed_fails_with_pending(fake: FakeAsyncGitHubClient) -> None:
-    fake.mock_response('create_pull_request', PullRequest(number=1, html_url='https://x/1'), once=True)
-    fake.mock_response('create_pull_request', PullRequest(number=2, html_url='https://x/2'), once=True)
+    fake.mock_response('create_pull_request', a_pull_request(1), once=True)
+    fake.mock_response('create_pull_request', a_pull_request(2), once=True)
 
     await fake.create_pull_request('o', 'r', 'T', 'h', 'b')
 
@@ -295,7 +298,7 @@ async def test_assert_not_called_fails_when_method_was_called(fake: FakeAsyncGit
 async def test_calls_are_recorded_regardless_of_response(fake: FakeAsyncGitHubClient) -> None:
     err = httpx.HTTPStatusError('boom', request=httpx.Request('POST', 'https://x'), response=httpx.Response(500))
     fake.mock_response('create_pull_request', err, once=True)
-    fake.mock_response('create_pull_request', PullRequest(number=5, html_url='https://x/5'))
+    fake.mock_response('create_pull_request', a_pull_request(5))
 
     with pytest.raises(httpx.HTTPStatusError):
         await fake.create_pull_request('o', 'r', 'T', 'h', 'b', draft=True)

--- a/ddev/tests/utils/github_async/helpers.py
+++ b/ddev/tests/utils/github_async/helpers.py
@@ -188,7 +188,7 @@ ENDPOINT_CALLS = [
     EndpointCase(
         "create_pull_request",
         lambda c: c.create_pull_request("o", "r", "t", "h", "b"),
-        lambda: json_response(pull_request_payload(number=1), status_code=201),
+        lambda: json_response(full_pull_request_payload(number=1), status_code=201),
         default_retry="mutating",
     ),
     EndpointCase(

--- a/ddev/tests/utils/github_async/payloads.py
+++ b/ddev/tests/utils/github_async/payloads.py
@@ -129,6 +129,11 @@ def pull_request_file_payload(
 
 
 def pull_request_payload(number: int = 1, html_url: str | None = None, **extra: Any) -> dict[str, Any]:
+    """A minimal `pull-request-simple` payload, which is what the list endpoints return.
+
+    It carries no diff totals, so it validates as `PullRequestSimple` but not as `PullRequest`.
+    Use `full_pull_request_payload` for an endpoint that returns the full schema.
+    """
     return {
         "number": number,
         "html_url": html_url if html_url is not None else f"https://github.com/owner/repo/pull/{number}",
@@ -156,9 +161,14 @@ def full_pull_request_payload(
     labels: list[dict[str, Any]] | None = None,
     head: dict[str, Any] | None = None,
     base: dict[str, Any] | None = None,
+    changed_files: int = 1,
     **extra: Any,
 ) -> dict[str, Any]:
-    """A richer PR payload exercising sub-models (user, labels, head/base)."""
+    """A `pull-request` payload exercising sub-models (user, labels, head/base).
+
+    This is the full schema the single-object endpoints return, so it carries the diff totals the
+    abbreviated form omits.
+    """
     return {
         "id": 9000 + number,
         "number": number,
@@ -195,6 +205,7 @@ def full_pull_request_payload(
         if head is not None
         else {"ref": "alice/fix", "sha": "1234567890abcdef00", "label": "alice:alice/fix"},
         "base": base if base is not None else {"ref": "master", "sha": "cafebabe00", "label": "owner:master"},
+        "changed_files": changed_files,
         **extra,
     }
 

--- a/ddev/tests/utils/github_async/test_endpoints.py
+++ b/ddev/tests/utils/github_async/test_endpoints.py
@@ -25,6 +25,7 @@ from ddev.utils.github_async.models import (
     PullRequestFile,
     PullRequestFileStatus,
     PullRequestReviewComment,
+    PullRequestSimple,
     PullRequestState,
     WorkflowDispatchResult,
     WorkflowJob,
@@ -493,7 +494,7 @@ async def test_create_pull_request_success() -> None:
             "body": "Fix description",
             "draft": False,
         }
-        return json_response(pull_request_payload(number=42), status_code=201)
+        return json_response(full_pull_request_payload(number=42), status_code=201)
 
     client = make_client(httpx.MockTransport(handler))
     result = await client.create_pull_request("owner", "repo", "Fix bug", "alice/fix", "master", "Fix description")
@@ -506,7 +507,7 @@ async def test_create_pull_request_draft_true_forwarded() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content)
         assert body["draft"] is True
-        return json_response(pull_request_payload(number=7), status_code=201)
+        return json_response(full_pull_request_payload(number=7), status_code=201)
 
     client = make_client(httpx.MockTransport(handler))
     result = await client.create_pull_request("o", "r", "T", "h", "b", draft=True)
@@ -543,15 +544,15 @@ async def test_list_pull_requests_success():
         assert request.url.params.get("head") == "owner:alice/backport-123-to-7.62.x"
         return json_response(
             [
-                full_pull_request_payload(number=5, state="closed", merged=True),
-                full_pull_request_payload(number=6, state="closed", merged=True),
+                pull_request_payload(number=5, state="closed"),
+                pull_request_payload(number=6, state="closed"),
             ]
         )
 
     client = make_client(httpx.MockTransport(handler))
     result = await client.list_pull_requests("owner", "repo", state="all", head="owner:alice/backport-123-to-7.62.x")
     assert [pr.number for pr in result.data] == [5, 6]
-    assert all(isinstance(pr, PullRequest) for pr in result.data)
+    assert all(isinstance(pr, PullRequestSimple) for pr in result.data)
 
 
 async def test_list_pull_requests_empty_result():


### PR DESCRIPTION
### What does this PR do?

Splits where the Dispatcher gets its diff, and reshapes the command's inputs around that.

A push keeps using git, comparing the commit with its first parent. A pull request reads its changed files from `pulls/{n}/files`, and the file count on the pull request object is checked against what came back, so a truncated list aborts instead of planning a subset.

Reshaping the inputs is most of the diff. The command took the parts of a run separately, and the one that mattered, `--target-branch`, existed only to feed `git merge-base`, which is the call that cannot work under any CI trigger. It now takes the run itself:

```
ddev ci dispatch-tests --pr 25082            # local, or anything holding a number
ddev ci dispatch-tests --pr-head-sha <sha>   # what workflow_run has
ddev ci dispatch-tests --commit <sha>        # push to the default branch
```

`--pr-number`, `--base-sha`, `--branch`, `--target-branch` and `--checkout-sha` are gone; all five are derived from the pull request or the commit.

`--context` is replaced by `--tags "key:value key:value"`, and `RunContext` is deleted. It used to do two jobs, and the one that mattered was choosing the comparison: `--context release` on a pull request silently switched the diff to `<sha>^1`. Once the comparison follows from which input named the run, what was left was a closed enum of four values whose only job was to label a run, two of which (`agent-test`, `release`) were set by nobody. Tags cover that without the command having an opinion on what a label may say. Fifteen options down to eleven.

`--pr-head-sha` resolves through `commits/{sha}/pulls` rather than reading `workflow_run.pull_requests`, because that array is empty for 33 of 100 sampled runs on this repository. A pull request that is no longer open now dispatches nothing and exits cleanly: nothing to test, and no open pull request to report to.

### Motivation

Three trigger-dependent failures, all reproduced:

```
trigger        compares              needs                     checkout gives            result
pull_request   merge-base(tgt,head)  local ref for the target  detached at pull/N/merge  fatal: Not a valid
                                                               no local branches         object name master
workflow_run   merge-base(tgt,head)  the pull request head     master tip only           head absent
push           the first parent      the parent commit         fetch-depth 1             fatal: ambiguous
                                                                                         argument HEAD^1
```

The first was hit for real on the dispatch proof of concept, in [run 33621704293](https://github.com/DataDog/integrations-core/actions/runs/33621704293). Passing `origin/master` works around that one, and fetching the tested commit into a shallow clone is still not enough: `merge-base` then exits 1 with no output, and only full history resolves it.

The truncation check is the part worth reviewing. `pulls/{n}/files` stops at 3000 files and does not report that it did, so a short list would plan a subset of the targets and still report success. Comparing against `changed_files` is the only way to notice, which is why that field went in with the client work.

Verified against the live API on this branch:

```
--pr on an open PR (25082)      state=open  base=master  changed_files=9  resolved=9   complete
--pr-head-sha (same head)       67023409b4 -> PR 25082
--pr-head-sha, closed PR        e905723e   -> none, exits cleanly
--pr-head-sha, a fork's head    c4cb1caca0 -> none (that PR is closed too)
truncation guard, wrong count   aborted: "reports 9999 changed files but the API listed 9"
large PR across pages (22711)   changed_files=397  resolved=397  complete
```

The push path is unchanged in behaviour and still needs no request; it does need `fetch-depth: 2`, which lands with the workflows in [AI-7129](https://datadoghq.atlassian.net/browse/AI-7129).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7129]: https://datadoghq.atlassian.net/browse/AI-7129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ