### PR TITLE
AI-7126 Send a batch's job list as gzip and base64

### DIFF
--- a/ddev/changelog.d/25096.fixed
+++ b/ddev/changelog.d/25096.fixed
@@ -1,0 +1,1 @@
+Send a batch's job list to the test workflow as gzip and base64.

--- a/ddev/src/ddev/cli/ci/tests/task_test_runner.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_runner.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import dataclasses
+import gzip
 import json
 import logging
 from dataclasses import dataclass
@@ -21,6 +23,36 @@ from ddev.utils.github_async.models import CheckRunConclusion, CheckRunStatus, W
 # The retry policy bounds the ladder, not a socket, so a GitHub that accepts the connection and then
 # goes quiet would hold this for the client's default and take every other cancellation with it.
 CANCEL_REQUEST_TIMEOUT = 3.0
+
+# GitHub rejects a workflow dispatch whose whole `inputs` object exceeds this.
+# https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
+WORKFLOW_INPUTS_LIMIT = 65535
+
+
+class JobListTooLargeError(Exception):
+    """Raised when a batch's inputs exceed what a workflow dispatch accepts.
+
+    Dispatching anyway fails the request, so the batch never runs and its jobs are never reported.
+    """
+
+    def __init__(self, batch_id: str, size: int):
+        super().__init__(
+            f"Batch {batch_id} needs {size} characters of workflow inputs, over GitHub's "
+            f"{WORKFLOW_INPUTS_LIMIT}. Lower `max_jobs_per_batch` so the plan splits further."
+        )
+        self.batch_id = batch_id
+        self.size = size
+
+
+def encode_job_list(jobs: list[dict[str, Any]]) -> str:
+    """Encode a batch's jobs for a workflow input, as gzip then base64.
+
+    A repository-wide batch is several times the 65,535-character input limit as plain JSON, and
+    compresses by around 17x. `mtime=0` keeps the result a function of the jobs alone, so the same
+    plan always encodes to the same string.
+    """
+    raw = json.dumps(jobs, separators=(",", ":")).encode()
+    return base64.b64encode(gzip.compress(raw, mtime=0)).decode()
 
 
 @dataclass(frozen=True)
@@ -180,12 +212,17 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
         return jobs
 
     def _build_inputs(self, message: TestBatch) -> dict[str, str]:
-        return {
+        inputs = {
             "batch_id": message.batch_id,
             "checkout_sha": self._options.checkout_sha,
             "integrations": json.dumps(message.integrations),
-            "job_list": json.dumps([self._job_input(job) for job in message.job_list]),
+            "job_list": encode_job_list([self._job_input(job) for job in message.job_list]),
         }
+        size = sum(len(value) for value in inputs.values())
+        if size > WORKFLOW_INPUTS_LIMIT:
+            raise JobListTooLargeError(message.batch_id, size)
+
+        return inputs
 
     @staticmethod
     def _job_input(job: BatchJob) -> dict[str, Any]:

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -6,7 +6,11 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import gzip
 import json
+import secrets
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -14,7 +18,13 @@ import pytest
 
 from ddev.cli.ci.tests.messages import BatchFinished, BatchJob, TestBatch
 from ddev.cli.ci.tests.status import Status, conclusion_to_check_run_conclusion, conclusion_to_status
-from ddev.cli.ci.tests.task_test_runner import CANCEL_REQUEST_TIMEOUT, TaskTestRunner, TestRunnerOptions
+from ddev.cli.ci.tests.task_test_runner import (
+    CANCEL_REQUEST_TIMEOUT,
+    WORKFLOW_INPUTS_LIMIT,
+    JobListTooLargeError,
+    TaskTestRunner,
+    TestRunnerOptions,
+)
 from ddev.utils.github_async import GitHubResponse
 from ddev.utils.github_async.models import (
     Artifact,
@@ -34,6 +44,10 @@ from tests.helpers.github_async import FakeAsyncGitHubClient
 
 def wrap(data: Any) -> GitHubResponse[Any]:
     return GitHubResponse(data=data, headers={})
+
+
+def decode_job_list(encoded: str) -> list[dict[str, Any]]:
+    return json.loads(gzip.decompress(base64.b64decode(encoded)).decode())
 
 
 DEFAULT_URL = object()
@@ -190,51 +204,100 @@ async def test_dispatches_workflow_with_job_list_payload(tmp_path: Path):
 
     dispatch_calls = fake.calls_to("create_workflow_dispatch")
     assert len(dispatch_calls) == 1
-    assert dispatch_calls[0].kwargs == {
+    kwargs = dispatch_calls[0].kwargs
+    assert {key: value for key, value in kwargs.items() if key != "inputs"} == {
         "owner": "DataDog",
         "repo": "integrations-core",
         "workflow_id": "test-batch.yaml",
         "ref": "master",
         "timeout": None,
         "return_run_details": True,
-        "inputs": {
-            "batch_id": "batch-1",
-            "checkout_sha": "merge-sha-bbb",
-            "integrations": json.dumps(["ntp", "kafka"]),
-            "job_list": json.dumps(
-                [
-                    {
-                        "name": "j1",
-                        "target": "ntp",
-                        "runner_labels": ["ubuntu-22.04"],
-                        "environment": "py3.13",
-                        "platform": "linux",
-                        "python_version": "3.13",
-                        "unit_tests": True,
-                        "e2e_tests": False,
-                        "agent_image": None,
-                        "minimum_base_package": False,
-                        "coverage": True,
-                        "artifact_name": "ntp_py3.13_linux",
-                    },
-                    {
-                        "name": "j2",
-                        "target": "ntp",
-                        "runner_labels": ["ubuntu-22.04"],
-                        "environment": "py3.13",
-                        "platform": "linux",
-                        "python_version": "3.13",
-                        "unit_tests": True,
-                        "e2e_tests": False,
-                        "agent_image": None,
-                        "minimum_base_package": False,
-                        "coverage": True,
-                        "artifact_name": "ntp_py3.13_linux",
-                    },
-                ]
-            ),
-        },
     }
+    assert kwargs["inputs"]["batch_id"] == "batch-1"
+    assert kwargs["inputs"]["checkout_sha"] == "merge-sha-bbb"
+    assert kwargs["inputs"]["integrations"] == json.dumps(["ntp", "kafka"])
+    assert decode_job_list(kwargs["inputs"]["job_list"]) == [
+        {
+            "name": "j1",
+            "target": "ntp",
+            "runner_labels": ["ubuntu-22.04"],
+            "environment": "py3.13",
+            "platform": "linux",
+            "python_version": "3.13",
+            "unit_tests": True,
+            "e2e_tests": False,
+            "agent_image": None,
+            "minimum_base_package": False,
+            "coverage": True,
+            "artifact_name": "ntp_py3.13_linux",
+        },
+        {
+            "name": "j2",
+            "target": "ntp",
+            "runner_labels": ["ubuntu-22.04"],
+            "environment": "py3.13",
+            "platform": "linux",
+            "python_version": "3.13",
+            "unit_tests": True,
+            "e2e_tests": False,
+            "agent_image": None,
+            "minimum_base_package": False,
+            "coverage": True,
+            "artifact_name": "ntp_py3.13_linux",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_job_list_decodes_with_the_pipeline_the_workflow_runs(tmp_path: Path):
+    """`test-batch` decodes the input in shell, as `base64 -d | gzip -dc`.
+
+    Any other compression round-trips in Python and leaves the workflow unable to read its own
+    matrix, which fails at expand time with the batch already dispatched.
+    """
+    fake, _ = await run_happy_path(tmp_path)
+    encoded = fake.calls_to("create_workflow_dispatch")[0].kwargs["inputs"]["job_list"]
+
+    decoded = subprocess.run(  # noqa: S602
+        "base64 -d | gzip -dc",
+        shell=True,
+        input=encoded.encode(),
+        capture_output=True,
+        check=True,
+    )
+
+    assert [job["name"] for job in json.loads(decoded.stdout)] == ["j1", "j2"]
+
+
+@pytest.mark.asyncio
+async def test_a_batch_too_large_to_dispatch_is_refused(tmp_path: Path):
+    """GitHub rejects the dispatch itself, so the batch would never run and never be reported.
+
+    Names are random rather than repetitive, so they survive compression and the batch really does
+    exceed the limit.
+    """
+    jobs = [make_job(secrets.token_hex(150)) for _ in range(300)]
+    batch = TestBatch(id="big", batch_id="batch-big", job_list=jobs, jobs_count=len(jobs), integrations=["ntp"])
+    fake = FakeAsyncGitHubClient()
+    runner = TaskTestRunner(
+        "runner",
+        fake,
+        TestRunnerOptions(
+            owner="DataDog",
+            repo="integrations-core",
+            workflow_id="test-batch.yaml",
+            ref="master",
+            base_sha="base-sha-aaa",
+            checkout_sha="merge-sha-bbb",
+            artifacts_base_path=tmp_path,
+            poll_interval_seconds=0.0,
+        ),
+    )
+
+    with pytest.raises(JobListTooLargeError, match=str(WORKFLOW_INPUTS_LIMIT)):
+        runner._build_inputs(batch)
+
+    fake.assert_not_called("create_workflow_dispatch")
 
 
 @pytest.mark.asyncio

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -270,8 +270,9 @@ async def test_the_job_list_decodes_with_the_pipeline_the_workflow_runs(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_a_batch_too_large_to_dispatch_is_refused(tmp_path: Path):
-    """GitHub rejects the dispatch itself, so the batch would never run and never be reported.
+async def test_a_batch_too_large_to_dispatch_is_refused_before_dispatching(tmp_path: Path):
+    """GitHub rejects an oversized dispatch, and a rejected one still opens a check run that
+    nothing will ever close, so the batch has to be refused before the request is made.
 
     Names are random rather than repetitive, so they survive compression and the batch really does
     exceed the limit.
@@ -279,25 +280,13 @@ async def test_a_batch_too_large_to_dispatch_is_refused(tmp_path: Path):
     jobs = [make_job(secrets.token_hex(150)) for _ in range(300)]
     batch = TestBatch(id="big", batch_id="batch-big", job_list=jobs, jobs_count=len(jobs), integrations=["ntp"])
     fake = FakeAsyncGitHubClient()
-    runner = TaskTestRunner(
-        "runner",
-        fake,
-        TestRunnerOptions(
-            owner="DataDog",
-            repo="integrations-core",
-            workflow_id="test-batch.yaml",
-            ref="master",
-            base_sha="base-sha-aaa",
-            checkout_sha="merge-sha-bbb",
-            artifacts_base_path=tmp_path,
-            poll_interval_seconds=0.0,
-        ),
-    )
+    runner = make_runner(fake, tmp_path)
 
     with pytest.raises(JobListTooLargeError, match=str(WORKFLOW_INPUTS_LIMIT)):
-        runner._build_inputs(batch)
+        await runner.process_message(batch)
 
     fake.assert_not_called("create_workflow_dispatch")
+    fake.assert_not_called("create_check_run")
 
 
 @pytest.mark.asyncio

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -10,7 +10,6 @@ import base64
 import gzip
 import json
 import secrets
-import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -246,27 +245,6 @@ async def test_dispatches_workflow_with_job_list_payload(tmp_path: Path):
             "artifact_name": "ntp_py3.13_linux",
         },
     ]
-
-
-@pytest.mark.asyncio
-async def test_the_job_list_decodes_with_the_pipeline_the_workflow_runs(tmp_path: Path):
-    """`test-batch` decodes the input in shell, as `base64 -d | gzip -dc`.
-
-    Any other compression round-trips in Python and leaves the workflow unable to read its own
-    matrix, which fails at expand time with the batch already dispatched.
-    """
-    fake, _ = await run_happy_path(tmp_path)
-    encoded = fake.calls_to("create_workflow_dispatch")[0].kwargs["inputs"]["job_list"]
-
-    decoded = subprocess.run(  # noqa: S602
-        "base64 -d | gzip -dc",
-        shell=True,
-        input=encoded.encode(),
-        capture_output=True,
-        check=True,
-    )
-
-    assert [job["name"] for job in json.loads(decoded.stdout)] == ["j1", "j2"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What does this PR do?

Encodes a batch's `job_list` as gzip then base64 before it goes out as a workflow input, and refuses a batch whose inputs still would not fit rather than dispatching it.

This is the first of two PRs for [AI-7126](https://datadoghq.atlassian.net/browse/AI-7126). The run-wide options (`--pytest-args`) come next; they land in the same lines [#25095](https://github.com/DataDog/integrations-core/pull/25095) is rewriting, so they wait for it. The ticket's other option, `--context`, is already done differently: [#25095](https://github.com/DataDog/integrations-core/pull/25095) replaced it with `--tags`.

No workflow change is needed. `zz-test-batch-poc.yml` already accepts both encodings, so it reads this as-is.

### Motivation

GitHub caps the whole `inputs` object of a workflow dispatch at 65,535 characters. Measured against the real registry on this branch, with `--all`:

```
--minimum-base-package=False   2 batches, 431 jobs
  batch       jobs      raw   gz+b64   ratio   raw fits?
  batch-01     232    84681     6396   13.2x   OVER
  batch-02     199    74755     5176   14.4x   OVER

--minimum-base-package=True    4 batches, 853 jobs
  batch-01     240    87908     5192   16.9x   OVER
  batch-02     215    79424     4516   17.6x   OVER
  batch-03     220    81020     4336   18.7x   OVER
  batch-04     178    69354     3832   18.1x   OVER
```

Every batch is over the limit today, so a repository-wide dispatch fails at the request. The ticket said only `batch-01` was over and `batch-02` passed by 531 characters; that stopped being true when [AI-7125](https://datadoghq.atlassian.net/browse/AI-7125) added the replicas, and I have corrected the ticket.

After encoding, the worst batch is 5,192 characters, under 8% of the cap, so there is room for the plan to grow by more than an order of magnitude.

The size guard is checked against the sum of all inputs, not just the job list, since that is what GitHub limits. It raises before the dispatch: a rejected request would leave a check run open that nothing closes, and the batch would never run or report.

`mtime=0` keeps the output a function of the jobs alone, so the same plan always encodes to the same string.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7126]: https://datadoghq.atlassian.net/browse/AI-7126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-7125]: https://datadoghq.atlassian.net/browse/AI-7125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ