### PR TITLE
Skip the OpenMetrics metric-limit issue test on old base packages

### DIFF
--- a/openmetrics/tests/test_metric_limit_issue.py
+++ b/openmetrics/tests/test_metric_limit_issue.py
@@ -5,9 +5,16 @@ from typing import Any
 
 import pytest
 
-from datadog_checks.base.checks.openmetrics.metric_limit_issue import ISSUE_NAME
 from datadog_checks.openmetrics import OpenMetricsCheck
 
+# `metric_limit_issue` landed after the minimum supported datadog-checks-base
+# version (>=37.33.0), so skip cleanly when it is not available, e.g. during the
+# minimum base package nightlies.
+metric_limit_issue = pytest.importorskip(
+    'datadog_checks.base.checks.openmetrics.metric_limit_issue',
+    reason='requires a datadog-checks-base version that supports the OpenMetrics metric limit issue',
+)
+ISSUE_NAME = metric_limit_issue.ISSUE_NAME
 ISSUE_ID = 'openmetrics-dropped-config:40c8930ce3bf6455'
 ENDPOINT = 'http://localhost:10249/metrics'
 


### PR DESCRIPTION
## What is this?

Fixes the OpenMetrics job in the nightly minimum base package run:
https://github.com/DataDog/integrations-core/actions/runs/33720104723/job/100537339967

**Stacked on #25075** (that PR already resolves the sibling Cilium failure by moving the failing test into `datadog_checks_base`).

## Why?

PR #24819 added `datadog_checks.base.checks.openmetrics.metric_limit_issue` and an `openmetrics` test that imports it unconditionally. The nightly minimum base package workflow installs the oldest supported released `datadog-checks-base` (currently `37.33.0`), where that module does not exist (it is not in any released version yet), so pytest fails at collection:

```
openmetrics/tests/test_metric_limit_issue.py:8
from datadog_checks.base.checks.openmetrics.metric_limit_issue import ISSUE_NAME
E   ModuleNotFoundError: No module named 'datadog_checks.base.checks.openmetrics.metric_limit_issue'
```

## How?

Replace the hard import with `pytest.importorskip(...)`, following the existing repo pattern (`pytest.importorskip` is already used in `datadog_checks_base`/`gearmand` tests). When the installed base package does not provide the module, the whole test module skips cleanly with a clear reason; with a newer base package the tests run unchanged.

## Validation

Reproduced both scenarios in a scratch venv against this branch:

- `datadog-checks-base[deps]==37.33.0` + `datadog-checks-dev==40.0.1` + this `openmetrics` (editable):
  - `pytest tests --collect-only -q` → `11 tests collected` (previously: `11 items / 1 error`, exit 2)
  - `pytest tests/test_metric_limit_issue.py -rs` → module-level `SKIPPED ... requires a datadog-checks-base version that supports the OpenMetrics metric limit issue`
- local `datadog_checks_base` (with the module) installed editable:
  - `pytest tests/test_metric_limit_issue.py -v` → `2 passed`
- `ddev test --lint openmetrics` and `ruff format`/`ruff check` on the changed file pass.

Once a `datadog-checks-base` release ships the module, the nightly simply runs the tests again (no floor bump needed).
