### PR TITLE
Pass commit hash for integrations core pin to agent build

### DIFF
--- a/.gitlab/build_agent.yaml
+++ b/.gitlab/build_agent.yaml
@@ -6,7 +6,7 @@
     RELEASE_VERSION_7: "nightly-a7"
     BUCKET_BRANCH: "dev"
     DEPLOY_AGENT: "false"
-    INTEGRATIONS_CORE_VERSION: ${CI_COMMIT_REF_NAME}
+    INTEGRATIONS_CORE_VERSION: ${CI_COMMIT_SHA}
     INTEGRATIONS_WHEELS_STORAGE: "dev"
     RUN_E2E_TESTS: "on"
     # disable kitchen tests


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Change how we pass the pin for integrations-core repo to the agent build job.

### Motivation
<!-- What inspired you to submit this pull request? -->
Agent doesn't accept branches/tags anymore.

