### PR TITLE
Validate per_page against GitHub's maximum in the async client

### DIFF
--- a/ddev/changelog.d/25100.fixed
+++ b/ddev/changelog.d/25100.fixed
@@ -1,0 +1,1 @@
+Reject a `per_page` outside GitHub's accepted range of 1..100 in the async GitHub client.

--- a/ddev/src/ddev/utils/github_async/AGENTS.md
+++ b/ddev/src/ddev/utils/github_async/AGENTS.md
@@ -136,6 +136,13 @@ the `stamina` logger, so retries are visible even with no logger injected. That 
 disabling it would also silence the unrelated `stamina.retry` in `ddev/e2e/agent/docker.py`, so it is
 left alone here rather than reached into from this package.
 
+## Reject a page size GitHub would not honour
+
+Every endpoint method taking `per_page` must call `_ensure_per_page_valid` before its request.
+GitHub's shared `per-page` parameter is documented as "max 100" but carries no maximum in its schema,
+and a larger value is not refused: the API silently serves 100. Without the check, a method that only
+reads the first page returns fewer results than the caller asked for and nothing says why.
+
 ## Never follow a redirect
 
 The client does not follow redirects, because the `Authorization` header would travel to whatever

--- a/ddev/src/ddev/utils/github_async/__init__.py
+++ b/ddev/src/ddev/utils/github_async/__init__.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from .client import COMMENT_BODY_LIMIT as COMMENT_BODY_LIMIT
     from .client import DEFAULT_BASE_URL as DEFAULT_BASE_URL
     from .client import GITHUB_API_VERSION as GITHUB_API_VERSION
+    from .client import MAX_PER_PAGE as MAX_PER_PAGE
     from .client import AsyncGitHubClient as AsyncGitHubClient
     from .client import GitHubResponse as GitHubResponse
     from .client import PaginationData as PaginationData
@@ -45,6 +46,7 @@ MODULE_BY_NAME: dict[str, str] = {
     'GITHUB_API_VERSION': 'client',
     'DEFAULT_BASE_URL': 'client',
     'COMMENT_BODY_LIMIT': 'client',
+    'MAX_PER_PAGE': 'client',
     'GitHubResponse': 'client',
     'PaginationData': 'client',
     'RetryPolicy': 'retry',

--- a/ddev/src/ddev/utils/github_async/client.py
+++ b/ddev/src/ddev/utils/github_async/client.py
@@ -66,6 +66,10 @@ DEFAULT_BASE_URL = "https://api.github.com"
 # number; neither the OpenAPI description nor the REST docs state it. Measured in UTF-8 bytes, which is
 # never below the character count GitHub means, so it errs only towards refusing a body it might take.
 COMMENT_BODY_LIMIT = 65_536
+# Every paginated endpoint this client calls takes the shared `per-page` parameter, described as
+# "The number of results per page (max 100)". The cap is not in the parameter's schema and GitHub does
+# not reject a larger value, it silently serves 100, so nothing but this check surfaces the mistake.
+MAX_PER_PAGE = 100
 # GitHub answers a cancel with 409 once the run has reached a terminal state, which is what was asked for.
 RUN_ALREADY_TERMINAL_STATUS = 409
 # The caller is a run being cancelled, so the whole ladder has to fit in the seconds it has left.
@@ -80,6 +84,16 @@ SIGNED_URL_EXPIRED_STATUS = 403
 QUERY_MASK = "***"  # noqa: S105
 
 _LINK_RE = re.compile(r'<([^>]+)>;\s*rel="([^"]+)"')
+
+
+def _ensure_per_page_valid(per_page: int):
+    """Refuse a page size GitHub would not honour, before spending a request on it.
+
+    Raises:
+        ValueError: If *per_page* is outside 1..`MAX_PER_PAGE`.
+    """
+    if not 1 <= per_page <= MAX_PER_PAGE:
+        raise ValueError(f"per_page must be between 1 and {MAX_PER_PAGE}, got {per_page}")
 
 
 def _ensure_body_fits(body: str):
@@ -659,7 +673,11 @@ class AsyncGitHubClient:
 
         Returns:
             AsyncIterator[GitHubResponse[ArtifactsList]]: One page of artifacts per iteration.
+
+        Raises:
+            ValueError: If `per_page` is outside 1..`MAX_PER_PAGE`.
         """
+        _ensure_per_page_valid(per_page)
         endpoint = f"/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts"
         async for response in self._paginated_request(
             "GET", endpoint, timeout=timeout, retry=retry, params={"per_page": per_page}
@@ -692,7 +710,11 @@ class AsyncGitHubClient:
 
         Returns:
             AsyncIterator[GitHubResponse[WorkflowJobsList]]: One page of jobs per iteration.
+
+        Raises:
+            ValueError: If `per_page` is outside 1..`MAX_PER_PAGE`.
         """
+        _ensure_per_page_valid(per_page)
         endpoint = f"/repos/{owner}/{repo}/actions/runs/{run_id}/jobs"
         async for response in self._paginated_request(
             "GET", endpoint, timeout=timeout, retry=retry, params={"per_page": per_page}
@@ -822,7 +844,11 @@ class AsyncGitHubClient:
         Returns:
             AsyncIterator[GitHubResponse[list[IssueComment]]]: One page of comments per iteration,
             following Link headers until exhausted.
+
+        Raises:
+            ValueError: If `per_page` is outside 1..`MAX_PER_PAGE`.
         """
+        _ensure_per_page_valid(per_page)
         # The response body is a bare JSON array, so there is no wrapper model to validate against
         # (unlike ``WorkflowJobsList``); each item is validated individually.
         endpoint = f"/repos/{owner}/{repo}/issues/{issue_number}/comments"
@@ -896,7 +922,11 @@ class AsyncGitHubClient:
 
         Returns:
             GitHubResponse[list[PullRequest]]: The validated pull requests on the first result page.
+
+        Raises:
+            ValueError: If `per_page` is outside 1..`MAX_PER_PAGE`.
         """
+        _ensure_per_page_valid(per_page)
         params: dict[str, Any] = {"state": state, "per_page": per_page}
         if head is not None:
             params["head"] = head

--- a/ddev/tests/utils/github_async/test_endpoints.py
+++ b/ddev/tests/utils/github_async/test_endpoints.py
@@ -32,7 +32,7 @@ from ddev.utils.github_async.models import (
     WorkflowRun,
 )
 from ddev.utils.github_errors import GitHubAuthenticationError, GitHubBodyTooLongError
-from tests.utils.github_async.helpers import ENDPOINT_CALLS, json_response, make_client
+from tests.utils.github_async.helpers import ENDPOINT_CALLS, first_page, json_response, make_client
 from tests.utils.github_async.payloads import (
     artifact,
     check_run_payload,
@@ -327,6 +327,60 @@ async def test_a_non_validation_status_is_never_read_as_too_long():
 
     assert not isinstance(exc_info.value, GitHubBodyTooLongError)
     assert exc_info.value.response.status_code == 500
+
+
+# Deliberately a literal rather than `MAX_PER_PAGE`, for the same reason as the comment-body limit.
+GITHUB_PAGE_SIZE_LIMIT = 100
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(
+            lambda client, size: first_page(client.list_workflow_run_artifacts("o", "r", 1, per_page=size)),
+            id="list_workflow_run_artifacts",
+        ),
+        pytest.param(
+            lambda client, size: first_page(client.list_workflow_jobs("o", "r", 42, per_page=size)),
+            id="list_workflow_jobs",
+        ),
+        pytest.param(
+            lambda client, size: first_page(client.list_issue_comments("o", "r", 7, per_page=size)),
+            id="list_issue_comments",
+        ),
+        pytest.param(lambda client, size: client.list_pull_requests("o", "r", per_page=size), id="list_pull_requests"),
+    ],
+)
+async def test_an_out_of_range_page_size_is_refused_before_the_request(call):
+    """GitHub serves 100 for a larger value instead of failing, so only this guard surfaces the mistake."""
+    requested = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal requested
+        requested = True
+        return json_response([])
+
+    client = make_client(httpx.MockTransport(handler))
+    with pytest.raises(ValueError, match="per_page"):
+        await call(client, GITHUB_PAGE_SIZE_LIMIT + 1)
+
+    assert requested is False
+
+
+@pytest.mark.parametrize(
+    ("per_page", "expectation"),
+    [
+        pytest.param(0, pytest.raises(ValueError), id="below-range"),
+        pytest.param(1, does_not_raise(), id="smallest-page"),
+        pytest.param(GITHUB_PAGE_SIZE_LIMIT, does_not_raise(), id="largest-page"),
+        pytest.param(GITHUB_PAGE_SIZE_LIMIT + 1, pytest.raises(ValueError), id="above-range"),
+    ],
+)
+async def test_the_accepted_page_sizes_are_one_to_githubs_maximum(per_page, expectation):
+    """A page size GitHub ignores, 0 included, is a caller mistake worth naming rather than silently sending."""
+    client = make_client(httpx.MockTransport(lambda request: json_response([])))
+    with expectation:
+        await client.list_pull_requests("o", "r", per_page=per_page)
 
 
 async def test_an_unreadable_validation_response_is_not_assumed_to_be_about_length():


### PR DESCRIPTION
### What does this PR do?

Adds a `per_page` range check to the async GitHub client. Every endpoint method taking `per_page` now calls `_ensure_per_page_valid`, which raises `ValueError` for anything outside 1..100 before the request is sent. Covers `list_workflow_run_artifacts`, `list_workflow_jobs`, `list_issue_comments` and `list_pull_requests`.

### Motivation

Follow up to a review comment on [#25082](https://github.com/DataDog/integrations-core/pull/25082): the docstrings say GitHub caps `per_page` at 100, but nothing enforced it.

The cap holds for every endpoint this client calls. All of them reference the shared `per-page` parameter in the OpenAPI description for `2022-11-28`, described as "The number of results per page (max 100)". The cap lives only in that prose, the parameter's schema carries no `maximum`, and GitHub does not reject a larger value:

```
per_page=100  -> 100 results
per_page=150  -> 100
per_page=1000 -> 100
per_page=0    -> 30 (the default)
```

So an out-of-range value never surfaces as an API error. For `list_pull_requests`, which reads only the first page, a caller asking for 500 quietly gets 100 and no signal that the rest exist. The guard is per method rather than central, so `ddev/src/ddev/utils/github_async/AGENTS.md` gains a short section requiring new endpoints to call it.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
