### PR TITLE
[CAP-3944] Add container health to Kubernetes Pods dashboard

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -342,7 +342,7 @@
                                     "query": {
                                         "data_source": "infrastructure",
                                         "resource_type": "pod",
-                                        "query_string": "$scope $cluster $namespace $deployment $statefulset $daemonset $job $cronjob ((field#metadata.creationTimestamp:>=1hr AND NOT kube_condition_ready:true) OR pod_phase:failed)"
+                                        "query_string": "$scope $cluster $namespace $deployment $statefulset $daemonset $job $cronjob ((field#metadata.creationTimestamp:>=1hr AND NOT kube_condition_ready:true AND NOT pod_phase:succeeded) OR pod_phase:failed)"
                                     },
                                     "columns": [
                                         {
@@ -627,12 +627,27 @@
                                             "data_source": "metrics",
                                             "name": "usage",
                                             "query": "sum:kubernetes.memory.usage{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob}"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "working_set",
+                                            "query": "sum:kubernetes.memory.working_set{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob}"
                                         }
                                     ],
                                     "formulas": [
                                         {
                                             "formula": "usage",
                                             "alias": "Usage",
+                                            "number_format": {
+                                                "unit": {
+                                                    "type": "canonical_unit",
+                                                    "unit_name": "byte_in_binary_bytes_family"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "formula": "working_set",
+                                            "alias": "Working Set",
                                             "number_format": {
                                                 "unit": {
                                                     "type": "canonical_unit",
@@ -1073,6 +1088,217 @@
                 "y": 13,
                 "width": 12,
                 "height": 9
+            }
+        },
+        {
+            "id": 2768845919270966,
+            "definition": {
+                "title": "Containers",
+                "title_align": "center",
+                "background_color": "pink",
+                "show_title": true,
+                "type": "group",
+                "layout_type": "ordered",
+                "widgets": [
+                    {
+                        "id": 5129512503162770,
+                        "definition": {
+                            "title": "Container states and readiness",
+                            "title_size": "16",
+                            "title_align": "left",
+                            "show_legend": true,
+                            "legend_layout": "auto",
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "type": "timeseries",
+                            "requests": [
+                                {
+                                    "response_format": "timeseries",
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "running",
+                                            "query": "sum:kubernetes_state.container.running{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob}",
+                                            "semantic_mode": "combined"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "waiting",
+                                            "query": "sum:kubernetes_state.container.status_report.count.waiting{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob}.fill(zero)",
+                                            "semantic_mode": "combined"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "terminated",
+                                            "query": "sum:kubernetes_state.container.terminated{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob}",
+                                            "semantic_mode": "combined"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "ready",
+                                            "query": "sum:kubernetes_state.container.ready{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob}",
+                                            "semantic_mode": "combined"
+                                        }
+                                    ],
+                                    "formulas": [
+                                        {
+                                            "formula": "running",
+                                            "alias": "Running"
+                                        },
+                                        {
+                                            "formula": "waiting",
+                                            "alias": "Waiting"
+                                        },
+                                        {
+                                            "formula": "terminated",
+                                            "alias": "Terminated"
+                                        },
+                                        {
+                                            "formula": "ready",
+                                            "alias": "Ready"
+                                        }
+                                    ],
+                                    "style": {
+                                        "palette": "purple",
+                                        "line_type": "solid",
+                                        "line_width": "normal"
+                                    },
+                                    "display_type": "line"
+                                }
+                            ],
+                            "yaxis": {
+                                "include_zero": true
+                            }
+                        },
+                        "layout": {
+                            "x": 0,
+                            "y": 0,
+                            "width": 12,
+                            "height": 3
+                        }
+                    },
+                    {
+                        "id": 935123463493438,
+                        "definition": {
+                            "title": "Pods with OOMKilled containers",
+                            "title_size": "16",
+                            "title_align": "left",
+                            "time": {
+                                "live_span": "10m"
+                            },
+                            "type": "toplist",
+                            "requests": [
+                                {
+                                    "response_format": "scalar",
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "oom_state",
+                                            "query": "sum:kubernetes.containers.state.terminated{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob,reason:oomkilled} by {kube_cluster_name,kube_namespace,pod_name}",
+                                            "aggregator": "max",
+                                            "semantic_mode": "combined"
+                                        }
+                                    ],
+                                    "formulas": [
+                                        {
+                                            "formula": "oom_state",
+                                            "alias": "Containers"
+                                        }
+                                    ],
+                                    "sort": {
+                                        "count": 100,
+                                        "order_by": [
+                                            {
+                                                "type": "formula",
+                                                "index": 0,
+                                                "order": "desc"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ],
+                            "custom_links": [],
+                            "style": {
+                                "display": {
+                                    "type": "flat"
+                                },
+                                "palette": "red"
+                            }
+                        },
+                        "layout": {
+                            "x": 0,
+                            "y": 3,
+                            "width": 6,
+                            "height": 3
+                        }
+                    },
+                    {
+                        "id": 656508063035940,
+                        "definition": {
+                            "title": "Pods with CrashLoopBackOff containers",
+                            "title_size": "16",
+                            "title_align": "left",
+                            "time": {
+                                "live_span": "10m"
+                            },
+                            "type": "toplist",
+                            "requests": [
+                                {
+                                    "response_format": "scalar",
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "crashloop",
+                                            "query": "sum:kubernetes_state.container.status_report.count.waiting{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob,reason:crashloopbackoff} by {kube_cluster_name,kube_namespace,pod_name}",
+                                            "aggregator": "max",
+                                            "semantic_mode": "combined"
+                                        }
+                                    ],
+                                    "formulas": [
+                                        {
+                                            "formula": "crashloop",
+                                            "alias": "Waiting containers"
+                                        }
+                                    ],
+                                    "sort": {
+                                        "count": 100,
+                                        "order_by": [
+                                            {
+                                                "type": "formula",
+                                                "index": 0,
+                                                "order": "desc"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ],
+                            "custom_links": [],
+                            "style": {
+                                "display": {
+                                    "type": "flat"
+                                },
+                                "palette": "orange"
+                            }
+                        },
+                        "layout": {
+                            "x": 6,
+                            "y": 3,
+                            "width": 6,
+                            "height": 3
+                        }
+                    }
+                ]
+            },
+            "layout": {
+                "x": 0,
+                "y": 22,
+                "width": 12,
+                "height": 7
             }
         }
     ],


### PR DESCRIPTION
### What does this PR do?
Restores the **Containers** group in the Kubernetes Pods Overview dashboard with three widgets:

- **Container states and readiness**: aggregate counts of running, waiting, terminated, and ready containers.
- **Pods with OOMKilled containers**: top 100 pods with containers observed in an OOMKilled termination state.
- **Pods with CrashLoopBackOff containers**: top 100 pods with containers observed in a CrashLoopBackOff waiting state.

The two toplists use `max` over a fixed ten-minute window and group by `kube_cluster_name`, `kube_namespace`, and `pod_name`. This keeps the results bounded and captures recently observed states. These values are states, not event counts.

The **Pods requiring attention** query now excludes pods in the `Succeeded` phase.

The widget **Memory Usage** also shows memory working set.

Validated with `ddev validate dashboards kubernetes` and live metric data.

| Before | After |
| --- | --- |
| (new) | <img width="1222" height="607" alt="Screenshot 2026-09-07 at 15 03 02" src="https://github.com/user-attachments/assets/b883c2ae-13a0-43b3-865b-875805db29a4" /> |
| <img width="585" height="171" alt="Screenshot 2026-09-07 at 15 17 09" src="https://github.com/user-attachments/assets/85a7a70e-1c81-42a0-9553-473fac9cd034" /> | <img width="587" height="176" alt="Screenshot 2026-09-07 at 15 16 34" src="https://github.com/user-attachments/assets/11228ee0-fb3d-4821-980c-bd13486eeda5" /> |

### Motivation
Restore the container troubleshooting workflow requested in [CAP-3944](https://datadoghq.atlassian.net/browse/CAP-3944) without reintroducing the high-cardinality queries investigated in [CAP-3888](https://datadoghq.atlassian.net/browse/CAP-3888).

### QA
[Open the updated dashboard](https://app.datadoghq.com/dashboard/ppr-9yk-uc6/kubernetes-pods-overview) and compare it with [the previous version](https://app.datadoghq.com/dash/integration/30322/kubernetes-pods-overview).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

[CAP-3944]: https://datadoghq.atlassian.net/browse/CAP-3944
[CAP-3888]: https://datadoghq.atlassian.net/browse/CAP-3888