### PR TITLE
Add missing account_id config field to RingCentral tile

### DIFF
--- a/ringcentral/assets/account_config.json
+++ b/ringcentral/assets/account_config.json
@@ -23,7 +23,7 @@
     {
       "key": "account_id",
       "label": "Account ID",
-      "help": "Your RingCentral account ID (a 9-digit number). Leave as ~ to use the account of the currently authorized user.",
+      "help": "Your RingCentral account ID (a 9-digit number).",
       "required": true,
       "editable": true,
       "text": {}

--- a/ringcentral/assets/account_config.json
+++ b/ringcentral/assets/account_config.json
@@ -21,6 +21,14 @@
   ],
   "additional_config_fields": [
     {
+      "key": "account_id",
+      "label": "Account ID",
+      "help": "Your RingCentral account ID (a 9-digit number). Leave as ~ to use the account of the currently authorized user.",
+      "required": true,
+      "editable": true,
+      "text": {}
+    },
+    {
       "key": "tags",
       "label": "Tags",
       "editable": true,


### PR DESCRIPTION
### What does this PR do?
Adds a required `account_id` text field to `ringcentral/assets/account_config.json`'s `additional_config_fields`.

### Motivation
The RingCentral crawler (crawler-sdk) requires a customer-configured `account_id` at runtime — it's a required field in the crawler's account config since the integration's original commit — but the tile's `account_config.json` never exposed this field to customers. As a result, no customer could ever configure their RingCentral account ID, causing crawls to fail with RingCentral API errors (`CMN-101`/`CMN-102`/`ANL-102`). See [WEBINT-2727](https://datadoghq.atlassian.net/browse/WEBINT-2727).

Companion crawler-sdk change: https://github.com/DataDog/crawler-sdk/pull/1526

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WEBINT-2727]: https://datadoghq.atlassian.net/browse/WEBINT-2727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ