### PR TITLE
Move secrets to vars in slapr workflow

### DIFF
--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: DataDog/slapr@4b5efe2ce585e45898bb88c4fa303e226e8199e4 # 1.0.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        SLACK_CHANNEL_ID: "${{ vars.[matrix.slack_channel_variable] }}"
+        SLACK_CHANNEL_ID: "${{ vars[matrix.slack_channel_variable] }}"
         SLACK_API_TOKEN: "${{ secrets.SLACK_API_TOKEN }}"
         SLAPR_BOT_USER_ID: "${{ vars.SLAPR_BOT_USER_ID }}"
         SLAPR_EMOJI_REVIEW_STARTED: "review_started"

--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -19,9 +19,9 @@ jobs:
     - uses: DataDog/slapr@4b5efe2ce585e45898bb88c4fa303e226e8199e4 # 1.0.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        SLACK_CHANNEL_ID: "${{ secrets[matrix.slack_channel_variable] }}"
+        SLACK_CHANNEL_ID: "${{ vars.[matrix.slack_channel_variable] }}"
         SLACK_API_TOKEN: "${{ secrets.SLACK_API_TOKEN }}"
-        SLAPR_BOT_USER_ID: "${{ secrets.SLAPR_BOT_USER_ID }}"
+        SLAPR_BOT_USER_ID: "${{ vars.SLAPR_BOT_USER_ID }}"
         SLAPR_EMOJI_REVIEW_STARTED: "review_started"
         SLAPR_EMOJI_APPROVED: "approved2"
         SLAPR_EMOJI_CHANGES_REQUESTED: "changes_requested"


### PR DESCRIPTION
### What does this PR do?
Moves secrets to vars in slapr workflow to remove unprotected secrets. The variables are already created in github so once this is merged we can delete the secrets.

### Motivation
These secrets don't need to be secrets, so we're moving them to variables to minimize our unprotected secrets
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
