### PR TITLE
Bump minimum datadog-checks-base for openmetrics and cilium to 38.3.0

### DIFF
--- a/cilium/changelog.d/25109.changed
+++ b/cilium/changelog.d/25109.changed
@@ -1,1 +1,1 @@
-Raise the minimum required ``datadog-checks-base`` version to ``38.3.0``, which introduces the Agent Health issue reporting this check relies on.
+Raise the minimum required datadog-checks-base version to 38.3.0.

--- a/cilium/changelog.d/25109.changed
+++ b/cilium/changelog.d/25109.changed
@@ -1,0 +1,1 @@
+Raise the minimum required ``datadog-checks-base`` version to ``38.3.0``, which introduces the Agent Health issue reporting this check relies on.

--- a/cilium/pyproject.toml
+++ b/cilium/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=38.3.0",
 ]
 dynamic = [
     "version",

--- a/openmetrics/changelog.d/25109.changed
+++ b/openmetrics/changelog.d/25109.changed
@@ -1,1 +1,1 @@
-Raise the minimum required ``datadog-checks-base`` version to ``38.3.0``, which introduces the Agent Health issue reporting this check relies on.
+Raise the minimum required datadog-checks-base version to 38.3.0.

--- a/openmetrics/changelog.d/25109.changed
+++ b/openmetrics/changelog.d/25109.changed
@@ -1,0 +1,1 @@
+Raise the minimum required ``datadog-checks-base`` version to ``38.3.0``, which introduces the Agent Health issue reporting this check relies on.

--- a/openmetrics/pyproject.toml
+++ b/openmetrics/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=37.33.0",
+    "datadog-checks-base>=38.3.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
## Summary
- Nightly minimum-base-package test failed for both `openmetrics` and `cilium`: https://github.com/DataDog/integrations-core/actions/runs/33720104723
- `openmetrics`: `ModuleNotFoundError: No module named 'datadog_checks.base.checks.openmetrics.metric_limit_issue'`
- `cilium`: `AttributeError: 'CiliumCheckV2' object has no attribute '_on_metric_limit_state'`
- Both checks' OpenMetrics base classes (`base_check.py`, `v2/base.py`) import `metric_limit_issue`, added in `datadog-checks-base` 38.3.0 by #24819. Their declared minimum (`>=37.33.0`) predates that release, so the nightly job installs a base package too old to satisfy it.
- Bumps `datadog-checks-base` minimum to `>=38.3.0` in both checks' `pyproject.toml`.

## Test plan
- [ ] Re-run the "Nightly minimum base package test" workflow (or the `OpenMetrics` and `Cilium` jobs specifically) and confirm they pass