### PR TITLE
AI-7126 Add --pytest-args to dispatch-tests

### DIFF
--- a/ddev/changelog.d/25112.added
+++ b/ddev/changelog.d/25112.added
@@ -1,0 +1,1 @@
+Add ``--pytest-args`` to ``ddev ci dispatch-tests``, forwarded to each batch workflow.

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -55,6 +55,12 @@ DEFAULT_OUTPUT_DIRECTORY = ".dispatcher"
     metavar='"KEY:VALUE ..."',
     help='Tags the run reports itself under, separated by spaces. Their meaning is the caller\'s to decide.',
 )
+@click.option(
+    '--pytest-args',
+    default=None,
+    metavar='ARGS',
+    help='Arguments every job appends to pytest, as one string. For example: -m "not flaky".',
+)
 @click.option('--repo', 'repository', default=None, metavar='OWNER/NAME', help='Repository to dispatch against.')
 @click.option('--all', 'all_targets', is_flag=True, help='Test every eligible target instead of the affected ones.')
 @click.option(
@@ -77,6 +83,7 @@ def dispatch_tests(
     pr_base_ref: str | None,
     commit: str | None,
     tags: str | None,
+    pytest_args: str | None,
     repository: str | None,
     all_targets: bool,
     minimum_base_package: bool,
@@ -145,6 +152,7 @@ def dispatch_tests(
         owner=owner,
         repo=repo,
         tags=tuple(tags.split()) if tags else (),
+        pytest_args=pytest_args or '',
         checkout_sha=run.checkout_sha,
         base_sha=run.base_sha,
         branch=run.branch,
@@ -451,6 +459,8 @@ def display_plan(app: Application, context: DispatcherContext, batches: list[Tes
         app.display_pair('Target branch', context.target_branch)
     if context.tags:
         app.display_pair('Tags', ' '.join(context.tags))
+    if context.pytest_args:
+        app.display_pair('Pytest args', context.pytest_args)
     app.display_pair('Workflow', f'{context.workflow} @ {context.workflow_ref}')
 
     total = sum(batch.jobs_count for batch in batches)

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -208,8 +208,7 @@ def validate_options(
     its diff are read from the API.
 
     A malformed invocation raises `UsageError` (exit code 2), so a caller can tell it from a run
-    that started and failed. A missing token is not one: the options were right, the environment
-    is not.
+    that started and failed. A missing token is not one: the options were right.
     """
     from ddev.utils.github import parse_pull_request_reference
 
@@ -265,8 +264,7 @@ def resolve_run(
 ) -> ResolvedRun | None:
     """Resolve what to test, or None when there is nothing left to test or report to.
 
-    Every such outcome says which one it was before returning, since from the outside a run that
-    resolved to nothing and a run that was never asked for anything look the same.
+    Every None outcome says which one it was before returning.
     """
     if requested_pr is not None or pr_head_sha is not None:
         return resolve_pull_request_run(

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -56,6 +56,13 @@ class DispatcherContext:
     target_branch: str | None = None
     pr_number: int | None = None
     tags: tuple[str, ...] = ()
+    pytest_args: str = ''
+    """Extra arguments every job passes to pytest, as one unparsed string.
+
+    A property of the run rather than of a job: a run selects tests one way and never mixes kinds.
+    Unparsed because the batch workflow hands it to the shell, which is what makes `-m "not flaky"`
+    survive as a single argument.
+    """
 
 
 @dataclass(frozen=True)
@@ -228,6 +235,7 @@ def build_dispatcher(
             checkout_sha=context.checkout_sha,
             artifacts_base_path=artifacts_path,
             poll_interval_seconds=config.poll_interval_seconds,
+            pytest_args=context.pytest_args,
         ),
     )
     gatherer = TaskTestGatherer("test-gatherer", output_path, batches)

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -57,12 +57,6 @@ class DispatcherContext:
     pr_number: int | None = None
     tags: tuple[str, ...] = ()
     pytest_args: str = ''
-    """Extra arguments every job passes to pytest, as one unparsed string.
-
-    A property of the run rather than of a job: a run selects tests one way and never mixes kinds.
-    Unparsed because the batch workflow hands it to the shell, which is what makes `-m "not flaky"`
-    survive as a single argument.
-    """
 
 
 @dataclass(frozen=True)

--- a/ddev/src/ddev/cli/ci/tests/task_test_runner.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_runner.py
@@ -219,8 +219,7 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
             "integrations": json.dumps(message.integrations),
             "job_list": encode_job_list([self._job_input(job) for job in message.job_list]),
         }
-        # Omitted rather than sent empty, so the workflow's own default is what decides how a run
-        # with no pytest arguments behaves.
+        # GitHub rejects inputs the workflow does not declare, so unset means absent, not empty.
         if self._options.pytest_args:
             inputs["pytest_args"] = self._options.pytest_args
         size = sum(len(value) for value in inputs.values())

--- a/ddev/src/ddev/cli/ci/tests/task_test_runner.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_runner.py
@@ -67,6 +67,7 @@ class TestRunnerOptions:
     checkout_sha: str
     artifacts_base_path: Path
     poll_interval_seconds: float = 30.0
+    pytest_args: str = ''
 
 
 class TaskTestRunner(AsyncProcessor[TestBatch]):
@@ -218,6 +219,10 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
             "integrations": json.dumps(message.integrations),
             "job_list": encode_job_list([self._job_input(job) for job in message.job_list]),
         }
+        # Omitted rather than sent empty, so the workflow's own default is what decides how a run
+        # with no pytest arguments behaves.
+        if self._options.pytest_args:
+            inputs["pytest_args"] = self._options.pytest_args
         size = sum(len(value) for value in inputs.values())
         if size > WORKFLOW_INPUTS_LIMIT:
             raise JobListTooLargeError(message.batch_id, size)

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -313,9 +313,7 @@ def test_an_empty_plan_is_not_dispatched(ddev, fake_async_github, local_changes,
 
 
 def test_pytest_args_are_shown_in_the_plan(ddev, github, planned):
-    """An option click accepts but nothing forwards would silently run the tests it was meant to
-    exclude, and the plan is where a run says what it is about to do.
-    """
+    """Catches an option click accepts but nothing forwards."""
     result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--pytest-args', '-m "not flaky"', '--dry-run')
 
     assert result.exit_code == 0, result.output

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -312,6 +312,16 @@ def test_an_empty_plan_is_not_dispatched(ddev, fake_async_github, local_changes,
     fake_async_github.assert_not_called('create_workflow_dispatch')
 
 
+def test_pytest_args_are_shown_in_the_plan(ddev, github, planned):
+    """An option click accepts but nothing forwards would silently run the tests it was meant to
+    exclude, and the plan is where a run says what it is about to do.
+    """
+    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--pytest-args', '-m "not flaky"', '--dry-run')
+
+    assert result.exit_code == 0, result.output
+    assert '-m "not flaky"' in result.output
+
+
 def test_all_targets_plans_without_reading_a_diff(ddev, github, planned):
     result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--all', '--dry-run')
 

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -257,12 +257,7 @@ async def test_dispatches_workflow_with_job_list_payload(tmp_path: Path):
     ],
 )
 async def test_pytest_args_reach_the_batch_workflow(tmp_path: Path, pytest_args: str, expected: str | None):
-    """A run selects tests with these, so losing them runs tests the caller excluded: `master.yml`
-    passes `-m "not flaky"` and would silently run the flaky suite.
-
-    Unset means absent rather than empty, because GitHub rejects a dispatch carrying an input the
-    workflow does not declare (`HTTP 422: Unexpected inputs provided`).
-    """
+    """Losing these runs tests the caller excluded: `master.yml` passes `-m "not flaky"`."""
     fake = FakeAsyncGitHubClient()
     fake.mock_response("get_workflow_run", make_workflow_run("completed", "success"))
     mock_artifacts(fake, [])

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -96,7 +96,7 @@ def mock_jobs(fake: FakeAsyncGitHubClient, jobs: list[WorkflowJob]):
     fake.mock_response("list_workflow_jobs", wrap(WorkflowJobsList(total_count=len(jobs), jobs=list(jobs))))
 
 
-def make_runner(client: FakeAsyncGitHubClient, tmp_path: Path) -> TaskTestRunner:
+def make_runner(client: FakeAsyncGitHubClient, tmp_path: Path, pytest_args: str = "") -> TaskTestRunner:
     options = TestRunnerOptions(
         owner="DataDog",
         repo="integrations-core",
@@ -106,6 +106,7 @@ def make_runner(client: FakeAsyncGitHubClient, tmp_path: Path) -> TaskTestRunner
         checkout_sha="merge-sha-bbb",
         artifacts_base_path=tmp_path,
         poll_interval_seconds=0.0,
+        pytest_args=pytest_args,
     )
     runner = TaskTestRunner(
         name="task-test-runner",
@@ -245,6 +246,32 @@ async def test_dispatches_workflow_with_job_list_payload(tmp_path: Path):
             "artifact_name": "ntp_py3.13_linux",
         },
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("pytest_args", "expected"),
+    [
+        pytest.param('-m "not flaky"', '-m "not flaky"', id="forwarded-with-quoting-intact"),
+        pytest.param("", None, id="omitted-when-unset"),
+    ],
+)
+async def test_pytest_args_reach_the_batch_workflow(tmp_path: Path, pytest_args: str, expected: str | None):
+    """A run selects tests with these, so losing them runs tests the caller excluded: `master.yml`
+    passes `-m "not flaky"` and would silently run the flaky suite.
+
+    Unset means absent rather than empty, because GitHub rejects a dispatch carrying an input the
+    workflow does not declare (`HTTP 422: Unexpected inputs provided`).
+    """
+    fake = FakeAsyncGitHubClient()
+    fake.mock_response("get_workflow_run", make_workflow_run("completed", "success"))
+    mock_artifacts(fake, [])
+    runner = make_runner(fake, tmp_path, pytest_args=pytest_args)
+
+    await runner.process_message(make_batch("batch-1"))
+
+    inputs = fake.calls_to("create_workflow_dispatch")[0].kwargs["inputs"]
+    assert inputs.get("pytest_args") == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What does this PR do?

Adds `--pytest-args` to `ddev ci dispatch-tests`, carries it on `DispatcherContext`, and forwards it to the batch workflow as a scalar input. Part 2 of AI-7126; part 1 (gzip+base64 of the job list) shipped in #25096.

The value stays unparsed. The batch workflow hands it to the shell, which is what makes `-m "not flaky"` survive as a single argument rather than becoming two. When unset the input is omitted instead of sent empty, because GitHub rejects a dispatch carrying an input the workflow does not declare (`HTTP 422: Unexpected inputs provided`), and `test-batch` does not declare it yet.

The run's plan now shows the value, so a dry run says what it is about to pass.

### Motivation

`master.yml` runs `-m "not flaky"` and `flaky-tests.yml` runs `-m flaky`, both through `test-target`'s `pytest-args` input. Neither can move to the Dispatcher without an equivalent. It is a run-wide option rather than a per-job one because a run selects tests one way and never mixes kinds within a single run.

Out of scope, per the ticket: `latest` and `benchmark` (they do not currently do what they are meant to, so the Dispatcher will not support them), `test-py2`, `step-timeout-minutes`, and the four `agent-image*` inputs. `--context` is already covered by `--tags`, added in #25095.

The exit-code-5 tolerance that `flaky-tests.yml` depends on needs nothing here: the batch workflow reuses the existing `run-unit-integration-tests.sh` and `run-e2e-tests.sh`, so that behaviour comes along unchanged.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged