### PR TITLE
AI-7128 Add the Dispatcher batch workflow

### DIFF
--- a/.github/actions/run-test-job/action.yml
+++ b/.github/actions/run-test-job/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: "Test context, reported to CI Visibility and used to pick the E2E flags"
     required: false
     default: "standard"
+  is_fork:
+    description: "Whether the code under test comes from a fork. Turns off anything needing a credential"
+    required: false
+    default: "false"
   dd_api_key:
     description: "Datadog API key, for CI Visibility. Telemetry only"
     required: false
@@ -118,9 +122,9 @@ runs:
         INPUT_TEST_PY2: "false"
         INPUT_TEST_PY3: "true"
         INPUT_REPO: core
-        # A fork's code only ever reaches a runner through a merge ref the caller resolved, so there
-        # is no fork-owned execution to downgrade here.
-        INPUT_IS_FORK: "false"
+        # Read by both run scripts to decide whether to trace. A fork holds no API key, so claiming
+        # otherwise would have them trace with nothing to send to.
+        INPUT_IS_FORK: ${{ inputs.is_fork }}
         DD_API_KEY_SECRET: ${{ inputs.dd_api_key }}
         SETUP_ENV_VARS: ""
         DOCKER_USERNAME: ${{ inputs.docker_username }}

--- a/.github/actions/run-test-job/action.yml
+++ b/.github/actions/run-test-job/action.yml
@@ -1,0 +1,170 @@
+name: "Run test job"
+description: "Runs one target's tests on a runner that already has Python and ddev installed"
+
+# Holds the logic to run tests, not the logic to decide where they run. The caller owns `runs-on`,
+# `permissions`, `concurrency`, `timeout-minutes`, and which secrets exist at all; this action owns
+# what gets tested and how.
+#
+# `runner_labels` therefore never appears here. `platform` does, but only as test configuration: it
+# tags the run and turns off tracing for sqlserver-on-Windows. It does not pick the Agent image,
+# which the caller resolves per job and passes in, and it does not pick the runner.
+#
+# Composite actions cannot read the `secrets` context, so every credential is an explicit input, as
+# `tag-job` already does with `dd_api_key`. All of them are optional and no-op when absent, so a
+# caller that does not have one simply does not pass it.
+
+inputs:
+  target:
+    description: "Integration to test"
+    required: true
+  job_name:
+    description: "Name of the calling job, used to name the results directory"
+    required: true
+  platform:
+    description: "linux, windows or macos. Test configuration only, not runner selection"
+    required: true
+  environment:
+    description: "Target environment, empty for a target that defines none"
+    required: false
+    default: ""
+  python_version:
+    description: "Python version already set up on the runner"
+    required: false
+    default: "3.13"
+  unit_tests:
+    description: "Run unit and integration tests"
+    required: false
+    default: "false"
+  e2e_tests:
+    description: "Run E2E tests"
+    required: false
+    default: "false"
+  agent_image:
+    description: "Agent image for E2E, resolved by the caller. Empty when e2e_tests is false"
+    required: false
+    default: ""
+  minimum_base_package:
+    description: "Test against the oldest supported datadog-checks-base"
+    required: false
+    default: "false"
+  pytest_args:
+    description: 'Arguments appended to pytest, as one string, e.g. -m "not flaky"'
+    required: false
+    default: ""
+  context:
+    description: "Test context, reported to CI Visibility and used to pick the E2E flags"
+    required: false
+    default: "standard"
+  dd_api_key:
+    description: "Datadog API key, for CI Visibility. Telemetry only"
+    required: false
+    default: ""
+  github_token:
+    description: "Token used to lift the api.github.com rate limit during ddev validate licenses"
+    required: false
+    default: ""
+  docker_username:
+    description: "Docker Hub user, needed only by the sap_hana and weblogic setup scripts"
+    required: false
+    default: ""
+  docker_token:
+    description: "Docker Hub token, needed only by the sap_hana and weblogic setup scripts"
+    required: false
+    default: ""
+  oracle_docker_username:
+    description: "Oracle registry user, needed only by the weblogic setup script"
+    required: false
+    default: ""
+  oracle_docker_password:
+    description: "Oracle registry password, needed only by the weblogic setup script"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    # uv's default hardlink mode on Windows breaks the `hatch env remove` that `ddev test --compat`
+    # runs at the end of a minimum-base-package job. See test-target.yml for the full explanation.
+    - name: Configure uv link mode (Windows minimum-base-package)
+      if: runner.os == 'Windows' && inputs.minimum_base_package == 'true'
+      shell: bash
+      run: echo "UV_LINK_MODE=copy" >> "$GITHUB_ENV"
+
+    - name: Install workflow scripts
+      uses: ./.github/actions/setup-test-target-scripts
+
+    # Sets FORCE_COLOR, DDEV_E2E_AGENT, the DD_* CI Visibility variables, TEST_RESULTS_DIR, DD_TAGS,
+    # and the INPUT_* variables the two run scripts read. It runs under `set -u`, so every variable
+    # it dereferences is passed, including the Python 2 images it reads unconditionally.
+    - name: Set environment variables
+      shell: bash
+      run: bash .github/workflows/scripts/setup-test-env.sh
+      env:
+        INPUT_TARGET: ${{ inputs.target }}
+        INPUT_TARGET_ENV: ${{ inputs.environment }}
+        INPUT_PLATFORM: ${{ inputs.platform }}
+        INPUT_PYTHON_VERSION: ${{ inputs.python_version }}
+        INPUT_MINIMUM_BASE_PACKAGE: ${{ inputs.minimum_base_package }}
+        INPUT_JOB_NAME: ${{ inputs.job_name }}
+        INPUT_PYTEST_ARGS: ${{ inputs.pytest_args }}
+        INPUT_CONTEXT: ${{ inputs.context }}
+        # The caller resolved the image, so the script's platform branch is given the same value on
+        # both sides and cannot pick a different one.
+        INPUT_AGENT_IMAGE: ${{ inputs.agent_image }}
+        INPUT_AGENT_IMAGE_WINDOWS: ${{ inputs.agent_image }}
+        # Python 2 is not supported here, but the script reads both variables unconditionally.
+        INPUT_AGENT_IMAGE_PY2: ""
+        INPUT_AGENT_IMAGE_WINDOWS_PY2: ""
+        INPUT_TEST_PY2: "false"
+        INPUT_TEST_PY3: "true"
+        INPUT_REPO: core
+        # A fork's code only ever reaches a runner through a merge ref the caller resolved, so there
+        # is no fork-owned execution to downgrade here.
+        INPUT_IS_FORK: "false"
+        DD_API_KEY_SECRET: ${{ inputs.dd_api_key }}
+        SETUP_ENV_VARS: ""
+        DOCKER_USERNAME: ${{ inputs.docker_username }}
+        DOCKER_ACCESS_TOKEN: ${{ inputs.docker_token }}
+        ORACLE_DOCKER_USERNAME: ${{ inputs.oracle_docker_username }}
+        ORACLE_DOCKER_PASSWORD: ${{ inputs.oracle_docker_password }}
+        DD_GITHUB_USER: ${{ github.actor }}
+        DD_GITHUB_TOKEN: ${{ inputs.github_token }}
+
+    - name: Tag job for CI Visibility
+      if: inputs.dd_api_key != ''
+      uses: ./.github/actions/tag-job
+      with:
+        tags: ${{ env.DD_TAGS }}
+        dd_api_key: ${{ inputs.dd_api_key }}
+        dd_site: ${{ env.DD_SITE }}
+
+    - name: Lint
+      shell: bash
+      env:
+        TARGET: ${{ inputs.target }}
+      run: |
+        ddev test --lint "$TARGET" || {
+          echo "::error::Lint failed!"
+          echo "::error::Run 'ddev test --fmt $TARGET' to fix formatting issues."
+          exit 1
+        }
+
+    - name: Prepare for testing
+      shell: bash
+      run: ddev ci setup "$INPUT_TARGET_STR"
+
+    - name: Ensure Docker is running
+      shell: bash
+      run: bash .github/workflows/scripts/ensure-docker.sh
+
+    - name: Run Unit & Integration tests
+      if: inputs.unit_tests == 'true'
+      shell: bash
+      run: bash .github/workflows/scripts/run-unit-integration-tests.sh
+
+    - name: Run E2E tests
+      if: inputs.e2e_tests == 'true'
+      shell: bash
+      run: bash .github/workflows/scripts/run-e2e-tests.sh
+      env:
+        INPUT_SESSION_NAME: e2e-tests

--- a/.github/workflows/test-batch.yml
+++ b/.github/workflows/test-batch.yml
@@ -166,11 +166,23 @@ jobs:
           HEAD_SHA: ${{ inputs.head_sha }}
           BRANCH: ${{ inputs.branch }}
         run: |
+          set -euo pipefail
+
+          # The author identity is attacker-controlled, and a value carrying a newline would define
+          # further variables in GITHUB_ENV rather than just itself. git's ident parser cannot
+          # produce one today (it strips them on the way in and yields an empty string for an object
+          # malformed enough to contain one), so this is a guard against that changing, not a fix for
+          # a live hole. Dropped rather than escaped: an unattributed result beats a decorated one.
+          author_email=$(git log -1 --format=%ae)
+          case $author_email in
+            *[!a-zA-Z0-9.@_+-]*) author_email='' ;;
+          esac
+
           {
             echo "DD_GIT_COMMIT_SHA=${HEAD_SHA}"
             echo "DD_GIT_BRANCH=${BRANCH}"
             echo "DD_GIT_REPOSITORY_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
-            echo "DD_GIT_COMMIT_AUTHOR_EMAIL=$(git log -1 --format=%ae)"
+            echo "DD_GIT_COMMIT_AUTHOR_EMAIL=${author_email}"
           } >> "$GITHUB_ENV"
 
       - name: Get Datadog credentials

--- a/.github/workflows/test-batch.yml
+++ b/.github/workflows/test-batch.yml
@@ -42,7 +42,7 @@ on:
         required: true
         type: string
       head_sha:
-        description: "Commit the results belong to, full 40 characters. The pull request's head"
+        description: "Commit the results belong to. The pull request's head"
         required: true
         type: string
       branch:
@@ -76,10 +76,14 @@ on:
 
 permissions: {}
 
-# The Dispatcher has no way to cancel a run, so without this a second push leaves every batch of the
-# previous one running with nothing to reap it.
+# A new revision of a pull request dispatches the same batch ids against the same
+# refs/pull/<n>/merge, so its batches land in the previous revision's groups and cancel them.
+# `head_sha` would give every revision a group of its own and cancel nothing; a commit run keys on
+# its own SHA, so master never cancels itself. What the group cannot see, the Dispatcher's
+# `cancel_dispatched_runs` reaps: a cancellation or a closed pull request with no follow-up push,
+# and a plan that shrank, whose old higher-numbered batches have no successor here.
 concurrency:
-  group: test-batch-${{ inputs.head_sha }}-${{ inputs.batch_id }}
+  group: test-batch-${{ inputs.checkout_sha }}-${{ inputs.batch_id }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/test-batch.yml
+++ b/.github/workflows/test-batch.yml
@@ -1,0 +1,249 @@
+# Runs one Dispatcher batch: a set of test jobs planned by `ddev ci dispatch-tests` and sent here as
+# a single workflow input.
+#
+# The Dispatcher decides *what* runs and this workflow decides *how*, so the split against
+# `test-target.yml` is deliberate: that one is a reusable workflow a caller invokes per target and is
+# also consumed by integrations-extras and marketplace, while this one is dispatched once per batch
+# and expands the batch itself. Both drive the same scripts from
+# `.github/actions/setup-test-target-scripts`, which is where the test recipe actually lives, so
+# neither is a copy of the other.
+#
+# Two parts of the contract fail silently when broken, both consumed by the Dispatcher:
+#   - the matrix job name must be `BatchJob.name` verbatim, because the gatherer joins workflow jobs
+#     to planned jobs by exact name and raises when a planned job has none.
+#   - each job uploads exactly one artifact named `BatchJob.artifact_name()`, holding its JUnit and
+#     coverage XML. Any other name reads as a lost artifact and the batch reports empty results.
+#
+# `workflow_dispatch` requires the file to exist on the default branch, so changes here only take
+# effect once merged.
+name: Test Batch
+
+on:
+  workflow_dispatch:
+    inputs:
+      batch_id:
+        description: "Logical batch identity, e.g. batch-01"
+        required: true
+        type: string
+      checkout_sha:
+        description: "Ref the batch tests, refs/pull/<n>/merge for a pull request"
+        required: true
+        type: string
+      job_list:
+        description: "The batch's jobs, as gzip+base64 of the plan's JSON"
+        required: true
+        type: string
+      integrations:
+        description: "JSON array of the target names in this batch"
+        required: false
+        default: "[]"
+        type: string
+      pytest_args:
+        description: 'Arguments every job appends to pytest, e.g. -m "not flaky"'
+        required: false
+        default: ""
+        type: string
+      context:
+        description: "Test context, reported to CI Visibility and used to pick the E2E flags"
+        required: false
+        default: "standard"
+        type: string
+
+# The test job runs a pull request's code, so it gets nothing. Job-level grants are added where they
+# are needed rather than here.
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  expand:
+    name: expand
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.decode.outputs.matrix }}
+    steps:
+      - name: Decode the job list
+        id: decode
+        env:
+          JOB_LIST: ${{ inputs.job_list }}
+          BATCH_ID: ${{ inputs.batch_id }}
+          INTEGRATIONS: ${{ inputs.integrations }}
+        run: |
+          set -euo pipefail
+
+          # A repository-wide batch is several times GitHub's 65,535-character input limit as plain
+          # JSON, so the Dispatcher always compresses. A decode failure means a malformed input and
+          # must stop the batch rather than produce an empty matrix.
+          printf '%s' "$JOB_LIST" | base64 -d | gzip -dc > jobs.json
+
+          count=$(python3 -c 'import json; print(len(json.load(open("jobs.json"))))')
+          if [[ "$count" -eq 0 ]]; then
+            echo "::error::The batch carries no jobs."
+            exit 1
+          fi
+
+          echo "matrix=$(cat jobs.json)" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### ${BATCH_ID}"
+            echo
+            echo "- jobs: ${count}"
+            echo "- targets: $(python3 -c 'import json,os; print(", ".join(json.loads(os.environ["INTEGRATIONS"])) or "-")')"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  test:
+    needs: expand
+    # Correlated by exact name, so this must stay `matrix.name` alone: a prefix or a suffix here
+    # leaves every job in the batch unmatched.
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner_labels }}
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      id-token: write # dd-sts, for the CI Visibility API key
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.expand.outputs.matrix) }}
+    steps:
+      - name: Set up Windows
+        if: runner.os == 'Windows'
+        run: diskperf -y
+
+      # uv's default hardlink mode on Windows breaks the `hatch env remove` that `ddev test --compat`
+      # runs at the end of a minimum-base-package job. See test-target.yml for the full explanation.
+      - name: Configure uv link mode (Windows minimum-base-package)
+        if: runner.os == 'Windows' && matrix.minimum_base_package
+        run: echo "UV_LINK_MODE=copy" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout_sha }}
+
+      - name: Get Datadog credentials
+        id: dd-sts
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+        with:
+          policy: integrations-test-target-api-key
+
+      - name: Install workflow scripts
+        uses: ./.github/actions/setup-test-target-scripts
+
+      # Sets FORCE_COLOR, PYTHON_VERSION, DDEV_E2E_AGENT, the DD_* CI Visibility variables,
+      # TEST_RESULTS_DIR, and the INPUT_* variables the two run scripts read. Every variable it
+      # dereferences must be set here: it runs under `set -u`.
+      - name: Set environment variables
+        run: bash .github/workflows/scripts/setup-test-env.sh
+        env:
+          INPUT_TARGET: ${{ matrix.target }}
+          INPUT_TARGET_ENV: ${{ matrix.environment }}
+          INPUT_PLATFORM: ${{ matrix.platform }}
+          INPUT_PYTHON_VERSION: ${{ matrix.python_version }}
+          INPUT_MINIMUM_BASE_PACKAGE: ${{ matrix.minimum_base_package }}
+          INPUT_JOB_NAME: ${{ matrix.name }}
+          INPUT_PYTEST_ARGS: ${{ inputs.pytest_args }}
+          INPUT_CONTEXT: ${{ inputs.context }}
+          # The planner resolves the agent image per job and leaves it unset for a job that runs no
+          # E2E tests, where the value is never read.
+          INPUT_AGENT_IMAGE: ${{ matrix.agent_image || 'registry.datadoghq.com/agent-dev:master-py3' }}
+          INPUT_AGENT_IMAGE_WINDOWS: ${{ matrix.agent_image || 'registry.datadoghq.com/agent:7-rc-servercore' }}
+          # Python 2 is not dispatched, but the script reads both variables unconditionally.
+          INPUT_AGENT_IMAGE_PY2: ""
+          INPUT_AGENT_IMAGE_WINDOWS_PY2: ""
+          INPUT_TEST_PY2: "false"
+          INPUT_TEST_PY3: "true"
+          # Only integrations-core is dispatched, and a dispatch never carries fork code: the ref is
+          # this repository's merge ref, resolved by the Dispatcher.
+          INPUT_REPO: core
+          INPUT_IS_FORK: "false"
+          DD_API_KEY_SECRET: ${{ steps.dd-sts.outputs.api_key }}
+          SETUP_ENV_VARS: ""
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+          ORACLE_DOCKER_USERNAME: ${{ secrets.ORACLE_DOCKER_USERNAME }}
+          ORACLE_DOCKER_PASSWORD: ${{ secrets.ORACLE_DOCKER_PASSWORD }}
+          DD_GITHUB_USER: ${{ github.actor }}
+          DD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag job for CI Visibility
+        uses: ./.github/actions/tag-job
+        with:
+          tags: ${{ env.DD_TAGS }}
+          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
+          dd_site: ${{ env.DD_SITE }}
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - uses: ./.github/actions/setup-ddev
+        with:
+          install-mode: local
+          cache-profile: local-ddev-base
+
+      - name: Configure ddev
+        run: |
+          ddev config set upgrade_check false
+          ddev config set repos.core .
+          ddev config set repo core
+
+      - name: Lint
+        timeout-minutes: 60
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          ddev test --lint "$TARGET" || {
+            echo "::error::Lint failed!"
+            echo "::error::Run 'ddev test --fmt $TARGET' to fix formatting issues."
+            exit 1
+          }
+
+      - name: Prepare for testing
+        timeout-minutes: 60
+        run: ddev ci setup "$INPUT_TARGET_STR"
+
+      - name: Ensure Docker is running
+        run: bash .github/workflows/scripts/ensure-docker.sh
+
+      - name: Run Unit & Integration tests
+        if: matrix.unit_tests
+        timeout-minutes: 60
+        run: bash .github/workflows/scripts/run-unit-integration-tests.sh
+
+      - name: Run E2E tests
+        if: matrix.e2e_tests
+        timeout-minutes: 60
+        run: bash .github/workflows/scripts/run-e2e-tests.sh
+        env:
+          INPUT_SESSION_NAME: e2e-tests
+
+      # One flat directory per job, uploaded under the job's `artifact_name`. The gatherer rglobs
+      # `test-*.xml` and `coverage*.xml` inside it, which is what `ddev test --junit` and `--cov`
+      # already produce; nothing here renames them.
+      - name: Collect the job's reports
+        if: always()
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          mkdir -p reports
+          if [[ -d "$TARGET/junit" ]]; then
+            find "$TARGET/junit" -name 'test-*.xml' -exec cp {} reports/ \;
+          fi
+          # Absent for a minimum-base-package job, which runs without `--cov`.
+          if [[ -f "$TARGET/coverage.xml" ]]; then
+            cp "$TARGET/coverage.xml" reports/
+          fi
+          ls -la reports
+
+      - name: Upload the job's reports
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: reports
+          if-no-files-found: warn

--- a/.github/workflows/test-batch.yml
+++ b/.github/workflows/test-batch.yml
@@ -1,18 +1,23 @@
-# Runs one Dispatcher batch: a set of test jobs planned by `ddev ci dispatch-tests` and sent here as
-# a single workflow input.
+# Runs one Dispatcher batch: the set of test jobs `ddev ci dispatch-tests` planned and sent here as a
+# single workflow input.
 #
-# The Dispatcher decides *what* runs and this workflow decides *how*, so the split against
-# `test-target.yml` is deliberate: that one is a reusable workflow a caller invokes per target and is
-# also consumed by integrations-extras and marketplace, while this one is dispatched once per batch
-# and expands the batch itself. Both drive the same scripts from
-# `.github/actions/setup-test-target-scripts`, which is where the test recipe actually lives, so
-# neither is a copy of the other.
+# The batch owns its own check run, opened in `setup` and closed in `teardown`. That is deliberately
+# not the Dispatcher's job: a step guarded by `if: always()` gets GitHub's server-side cancellation
+# window, whereas the Dispatcher process is signalled and then killed, so a cancelled run would leave
+# a check open forever if the Dispatcher were the one closing it.
 #
-# Two parts of the contract fail silently when broken, both consumed by the Dispatcher:
-#   - the matrix job name must be `BatchJob.name` verbatim, because the gatherer joins workflow jobs
-#     to planned jobs by exact name and raises when a planned job has none.
-#   - each job uploads exactly one artifact named `BatchJob.artifact_name()`, holding its JUnit and
-#     coverage XML. Any other name reads as a lost artifact and the batch reports empty results.
+# Test execution lives in `.github/actions/run-test-job`, which this workflow calls once per job. The
+# workflow decides where a job runs and what it may touch; the action decides what gets tested.
+#
+# Three parts of the contract fail silently when broken, all read straight off the matrix so nothing
+# here reconstructs them:
+#   - the job name must be `BatchJob.name` verbatim, because the gatherer joins workflow jobs to
+#     planned jobs by exact name and raises when a planned job has none.
+#   - each job uploads exactly one artifact named `BatchJob.artifact_name()`. Any other name reads as
+#     a lost artifact and the batch reports empty results.
+#   - `DD_GIT_*` must point at the tested commit. This workflow is dispatched at `ref: master`, so
+#     its ambient `GITHUB_SHA` is master's tip and every result would otherwise be attributed to
+#     master, including on pull requests.
 #
 # `workflow_dispatch` requires the file to exist on the default branch, so changes here only take
 # effect once merged.
@@ -27,6 +32,14 @@ on:
         type: string
       checkout_sha:
         description: "Ref the batch tests, refs/pull/<n>/merge for a pull request"
+        required: true
+        type: string
+      head_sha:
+        description: "Commit the results belong to, full 40 characters. The pull request's head"
+        required: true
+        type: string
+      branch:
+        description: "Branch the results belong to"
         required: true
         type: string
       job_list:
@@ -49,21 +62,28 @@ on:
         default: "standard"
         type: string
 
-# The test job runs a pull request's code, so it gets nothing. Job-level grants are added where they
-# are needed rather than here.
 permissions: {}
+
+# The Dispatcher has no way to cancel a run, so without this a second push leaves every batch of the
+# previous one running with nothing to reap it.
+concurrency:
+  group: test-batch-${{ inputs.head_sha }}-${{ inputs.batch_id }}
+  cancel-in-progress: true
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  expand:
-    name: expand
+  setup:
+    name: setup
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    permissions:
+      checks: write
     outputs:
       matrix: ${{ steps.decode.outputs.matrix }}
+      check_run_id: ${{ steps.check.outputs.id }}
     steps:
       - name: Decode the job list
         id: decode
@@ -75,8 +95,8 @@ jobs:
           set -euo pipefail
 
           # A repository-wide batch is several times GitHub's 65,535-character input limit as plain
-          # JSON, so the Dispatcher always compresses. A decode failure means a malformed input and
-          # must stop the batch rather than produce an empty matrix.
+          # JSON, so the Dispatcher always compresses. A decode failure is a malformed input and must
+          # stop the batch rather than produce an empty matrix.
           printf '%s' "$JOB_LIST" | base64 -d | gzip -dc > jobs.json
 
           count=$(python3 -c 'import json; print(len(json.load(open("jobs.json"))))')
@@ -94,34 +114,64 @@ jobs:
             echo "- targets: $(python3 -c 'import json,os; print(", ".join(json.loads(os.environ["INTEGRATIONS"])) or "-")')"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Open the batch's check run
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BATCH_ID: ${{ inputs.batch_id }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          id=$(gh api "repos/${GITHUB_REPOSITORY}/check-runs" \
+            -f "name=test-batch/${BATCH_ID}" \
+            -f "head_sha=${HEAD_SHA}" \
+            -f "status=in_progress" \
+            -f "details_url=${RUN_URL}" \
+            --jq '.id')
+          echo "id=${id}" >> "$GITHUB_OUTPUT"
+
   test:
-    needs: expand
+    needs: setup
     # Correlated by exact name, so this must stay `matrix.name` alone: a prefix or a suffix here
     # leaves every job in the batch unmatched.
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner_labels }}
+    # Hardcoded rather than an input: a hung job would otherwise hold a runner for the 6h default,
+    # long after the Dispatcher's own ceiling has passed.
     timeout-minutes: 120
+    # This job runs the tested commit's code. It gets no write scope, and the workflow is read from
+    # the default branch under workflow_dispatch, so a pull request cannot widen this.
     permissions:
       contents: read
       id-token: write # dd-sts, for the CI Visibility API key
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.expand.outputs.matrix) }}
+        include: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
       - name: Set up Windows
         if: runner.os == 'Windows'
         run: diskperf -y
 
-      # uv's default hardlink mode on Windows breaks the `hatch env remove` that `ddev test --compat`
-      # runs at the end of a minimum-base-package job. See test-target.yml for the full explanation.
-      - name: Configure uv link mode (Windows minimum-base-package)
-        if: runner.os == 'Windows' && matrix.minimum_base_package
-        run: echo "UV_LINK_MODE=copy" >> "$GITHUB_ENV"
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout_sha }}
+
+      # Datadog's git variables take precedence over the CI provider's, which is the only way to stop
+      # this run being attributed to master. `head_sha` and not `checkout_sha`: the latter is
+      # refs/pull/<n>/merge, which is not a SHA.
+      - name: Attribute results to the tested commit
+        env:
+          HEAD_SHA: ${{ inputs.head_sha }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          {
+            echo "DD_GIT_COMMIT_SHA=${HEAD_SHA}"
+            echo "DD_GIT_BRANCH=${BRANCH}"
+            echo "DD_GIT_REPOSITORY_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
+            echo "DD_GIT_COMMIT_AUTHOR_EMAIL=$(git log -1 --format=%ae)"
+          } >> "$GITHUB_ENV"
 
       - name: Get Datadog credentials
         id: dd-sts
@@ -129,101 +179,51 @@ jobs:
         with:
           policy: integrations-test-target-api-key
 
-      - name: Install workflow scripts
-        uses: ./.github/actions/setup-test-target-scripts
-
-      # Sets FORCE_COLOR, PYTHON_VERSION, DDEV_E2E_AGENT, the DD_* CI Visibility variables,
-      # TEST_RESULTS_DIR, and the INPUT_* variables the two run scripts read. Every variable it
-      # dereferences must be set here: it runs under `set -u`.
-      - name: Set environment variables
-        run: bash .github/workflows/scripts/setup-test-env.sh
-        env:
-          INPUT_TARGET: ${{ matrix.target }}
-          INPUT_TARGET_ENV: ${{ matrix.environment }}
-          INPUT_PLATFORM: ${{ matrix.platform }}
-          INPUT_PYTHON_VERSION: ${{ matrix.python_version }}
-          INPUT_MINIMUM_BASE_PACKAGE: ${{ matrix.minimum_base_package }}
-          INPUT_JOB_NAME: ${{ matrix.name }}
-          INPUT_PYTEST_ARGS: ${{ inputs.pytest_args }}
-          INPUT_CONTEXT: ${{ inputs.context }}
-          # The planner resolves the agent image per job and leaves it unset for a job that runs no
-          # E2E tests, where the value is never read.
-          INPUT_AGENT_IMAGE: ${{ matrix.agent_image || 'registry.datadoghq.com/agent-dev:master-py3' }}
-          INPUT_AGENT_IMAGE_WINDOWS: ${{ matrix.agent_image || 'registry.datadoghq.com/agent:7-rc-servercore' }}
-          # Python 2 is not dispatched, but the script reads both variables unconditionally.
-          INPUT_AGENT_IMAGE_PY2: ""
-          INPUT_AGENT_IMAGE_WINDOWS_PY2: ""
-          INPUT_TEST_PY2: "false"
-          INPUT_TEST_PY3: "true"
-          # Only integrations-core is dispatched, and a dispatch never carries fork code: the ref is
-          # this repository's merge ref, resolved by the Dispatcher.
-          INPUT_REPO: core
-          INPUT_IS_FORK: "false"
-          DD_API_KEY_SECRET: ${{ steps.dd-sts.outputs.api_key }}
-          SETUP_ENV_VARS: ""
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_ACCESS_TOKEN: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-          ORACLE_DOCKER_USERNAME: ${{ secrets.ORACLE_DOCKER_USERNAME }}
-          ORACLE_DOCKER_PASSWORD: ${{ secrets.ORACLE_DOCKER_PASSWORD }}
-          DD_GITHUB_USER: ${{ github.actor }}
-          DD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Tag job for CI Visibility
-        uses: ./.github/actions/tag-job
-        with:
-          tags: ${{ env.DD_TAGS }}
-          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
-          dd_site: ${{ env.DD_SITE }}
-
-      - name: Set up Python ${{ env.PYTHON_VERSION }}
+      - name: Set up Python ${{ matrix.python_version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python_version }}
 
+      # The planner fans a change in ddev's test-planning code out to every eligible target precisely
+      # to find out whether it breaks running the integrations' tests, so the jobs have to run the
+      # checkout's ddev. From PyPI they would all exercise the released one and the fan-out would be
+      # guaranteed to tell us nothing.
       - uses: ./.github/actions/setup-ddev
         with:
           install-mode: local
           cache-profile: local-ddev-base
 
       - name: Configure ddev
-        run: |
-          ddev config set upgrade_check false
-          ddev config set repos.core .
-          ddev config set repo core
+        run: ddev config override
 
-      - name: Lint
-        timeout-minutes: 60
-        env:
-          TARGET: ${{ matrix.target }}
-        run: |
-          ddev test --lint "$TARGET" || {
-            echo "::error::Lint failed!"
-            echo "::error::Run 'ddev test --fmt $TARGET' to fix formatting issues."
-            exit 1
-          }
-
-      - name: Prepare for testing
-        timeout-minutes: 60
-        run: ddev ci setup "$INPUT_TARGET_STR"
-
-      - name: Ensure Docker is running
-        run: bash .github/workflows/scripts/ensure-docker.sh
-
-      - name: Run Unit & Integration tests
-        if: matrix.unit_tests
-        timeout-minutes: 60
-        run: bash .github/workflows/scripts/run-unit-integration-tests.sh
-
-      - name: Run E2E tests
-        if: matrix.e2e_tests
-        timeout-minutes: 60
-        run: bash .github/workflows/scripts/run-e2e-tests.sh
-        env:
-          INPUT_SESSION_NAME: e2e-tests
+      - name: Run the tests
+        uses: ./.github/actions/run-test-job
+        with:
+          target: ${{ matrix.target }}
+          job_name: ${{ matrix.name }}
+          platform: ${{ matrix.platform }}
+          environment: ${{ matrix.environment }}
+          python_version: ${{ matrix.python_version }}
+          unit_tests: ${{ matrix.unit_tests }}
+          e2e_tests: ${{ matrix.e2e_tests }}
+          agent_image: ${{ matrix.agent_image }}
+          minimum_base_package: ${{ matrix.minimum_base_package }}
+          pytest_args: ${{ inputs.pytest_args }}
+          context: ${{ inputs.context }}
+          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
+          # A rate-limit lift for the ~70 api.github.com calls `ddev validate licenses` makes, not an
+          # authorization requirement, so the ambient token is enough.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Read only by the sap_hana and weblogic setup scripts, so every other job runs without
+          # them rather than seeing credentials it has no use for.
+          docker_username: ${{ (matrix.target == 'sap_hana' || matrix.target == 'weblogic') && secrets.DOCKER_USERNAME || '' }}
+          docker_token: ${{ (matrix.target == 'sap_hana' || matrix.target == 'weblogic') && secrets.DOCKER_ACCESS_TOKEN || '' }}
+          oracle_docker_username: ${{ matrix.target == 'weblogic' && secrets.ORACLE_DOCKER_USERNAME || '' }}
+          oracle_docker_password: ${{ matrix.target == 'weblogic' && secrets.ORACLE_DOCKER_PASSWORD || '' }}
 
       # One flat directory per job, uploaded under the job's `artifact_name`. The gatherer rglobs
       # `test-*.xml` and `coverage*.xml` inside it, which is what `ddev test --junit` and `--cov`
-      # already produce; nothing here renames them.
+      # already write, so nothing is renamed here.
       - name: Collect the job's reports
         if: always()
         env:
@@ -247,3 +247,37 @@ jobs:
           name: ${{ matrix.artifact_name }}
           path: reports
           if-no-files-found: warn
+
+  teardown:
+    needs:
+      - setup
+      - test
+    if: always() && needs.setup.result == 'success'
+    name: teardown
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      checks: write
+    steps:
+      # From the test job's result rather than this job's status, so a cancelled or skipped batch
+      # closes as what it was instead of as a success.
+      - name: Close the batch's check run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHECK_RUN_ID: ${{ needs.setup.outputs.check_run_id }}
+          TEST_RESULT: ${{ needs.test.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          case "$TEST_RESULT" in
+            success)   conclusion=success ;;
+            cancelled) conclusion=cancelled ;;
+            skipped)   conclusion=skipped ;;
+            *)         conclusion=failure ;;
+          esac
+
+          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/check-runs/${CHECK_RUN_ID}" \
+            -f "status=completed" \
+            -f "conclusion=${conclusion}" \
+            -f "details_url=${RUN_URL}" \
+            --jq '.conclusion'

--- a/.github/workflows/test-batch.yml
+++ b/.github/workflows/test-batch.yml
@@ -9,9 +9,12 @@
 # Test execution lives in `.github/actions/run-test-job`, which this workflow calls once per job. The
 # workflow decides where a job runs and what it may touch; the action decides what gets tested.
 #
-# Every input is chosen by whoever dispatched the batch, so `setup` validates all of them and
-# resolves fork status from the API rather than trusting `inputs.is_fork`. `setup` and `teardown`
-# never check out, so they only ever run code that comes from the default branch.
+# Trust model. The Dispatcher runs from `test-dispatch.yml` in master context, and the OIDC policy
+# issues the dispatch credential only to a master-context run, so every input here was produced by
+# master's ddev. What a pull request does influence is plan content, because the planner reads
+# `.ddev/config.toml` and each target's `hatch.toml` from the tree it is given; `validate_batches`
+# bounds that Dispatcher-side. A repository maintainer can hand-dispatch anything, and this workflow
+# does not defend against its own maintainers.
 #
 # Three parts of the contract fail silently when broken, all read straight off the matrix so nothing
 # here reconstructs them:
@@ -66,7 +69,7 @@ on:
         default: "standard"
         type: string
       is_fork:
-        description: "What the dispatcher believes about the tested commit. Cross-checked in setup"
+        description: "Whether the tested commit comes from a fork. Withholds every credential when true"
         required: false
         default: "false"
         type: string
@@ -74,8 +77,7 @@ on:
 permissions: {}
 
 # The Dispatcher has no way to cancel a run, so without this a second push leaves every batch of the
-# previous one running with nothing to reap it. Evaluated before any job starts, so it sits outside
-# the input validation `setup` does.
+# previous one running with nothing to reap it.
 concurrency:
   group: test-batch-${{ inputs.head_sha }}-${{ inputs.batch_id }}
   cancel-in-progress: true
@@ -91,16 +93,11 @@ jobs:
     timeout-minutes: 5
     permissions:
       checks: write
-      # Read-only, for the pull request lookup and the ancestor check below. This job never
-      # checks out.
-      contents: read
-      pull-requests: read
     outputs:
       matrix: ${{ steps.decode.outputs.matrix }}
-      is_fork: ${{ steps.resolve.outputs.is_fork }}
       check_run_id: ${{ steps.check.outputs.id }}
     steps:
-      - name: Decode and validate the job list
+      - name: Decode the job list
         id: decode
         env:
           JOB_LIST: ${{ inputs.job_list }}
@@ -109,210 +106,30 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Becomes the check run name and the concurrency group.
-          if [[ ! "$BATCH_ID" =~ ^[A-Za-z0-9._-]+$ ]]; then
-            echo "::error::batch_id is not a plain identifier."
-            exit 1
-          fi
-
           # A repository-wide batch is several times GitHub's 65,535-character input limit as plain
           # JSON, so the Dispatcher always compresses. A decode failure is a malformed input and must
           # stop the batch rather than produce an empty matrix.
           printf '%s' "$JOB_LIST" | base64 -d | gzip -dc > jobs.json
 
-          python3 <<'PY' > matrix.json
-          import json
-          import re
+          count=$(python3 -c 'import json; print(len(json.load(open("jobs.json"))))')
+          if [[ "$count" -eq 0 ]]; then
+            echo "::error::The batch carries no jobs."
+            exit 1
+          fi
 
-          # Where a batch's code gets scheduled, fork-authored code included, so a self-hosted label
-          # must never appear here. A label added to `.ddev/config.toml` needs adding here too.
-          ALLOWED_RUNNER_LABELS = {"ubuntu-22.04", "windows-2022", "macos-14-large"}
-
-          # matrix-keys-begin
-          EXPECTED_KEYS = {
-              "name",
-              "target",
-              "runner_labels",
-              "environment",
-              "platform",
-              "python_version",
-              "unit_tests",
-              "e2e_tests",
-              "agent_image",
-              "minimum_base_package",
-              "coverage",
-              "artifact_name",
-          }
-          # matrix-keys-end
-
-          PLATFORMS = {"linux", "windows", "macos"}
-          TARGET = re.compile(r"^[A-Za-z0-9._-]+$")
-          ENVIRONMENT = re.compile(r"^[A-Za-z0-9._-]*$")
-          PYTHON_VERSION = re.compile(r"^[0-9]+\.[0-9]+$")
-          AGENT_IMAGE = re.compile(r"^[A-Za-z0-9./:_@-]+$")
-          # `ARTIFACT_NAME_DISALLOWED` in ddev's `messages.py`. Reaching upload-artifact with one of
-          # these loses the job's reports instead of failing the batch.
-          ARTIFACT_DISALLOWED = re.compile(r'["\:<>|*?\\/\r\n]')
-
-          errors = []
-
-          def displayable(value):
-              # Built from an integration's display name, which `normalize_job_name` only strips
-              # `<>:"/\|?*` from, so the character set is open. Bound what breaks the matrix.
-              return (
-                  isinstance(value, str)
-                  and 0 < len(value) <= 120
-                  and value == value.strip()
-                  and not any(ord(char) < 0x20 or ord(char) == 0x7F for char in value)
-              )
-
-          def matches(pattern, value):
-              return isinstance(value, str) and pattern.fullmatch(value) is not None
-
-          with open("jobs.json") as stream:
-              jobs = json.load(stream)
-          if not isinstance(jobs, list) or not jobs:
-              raise SystemExit("::error::The batch carries no jobs.")
-
-          for index, job in enumerate(jobs):
-              def bad(field, why, index=index):
-                  errors.append(f"::error::job {index}, {field}: {why}")
-
-              if not isinstance(job, dict):
-                  bad("<job>", "not an object")
-                  continue
-
-              keys = set(job)
-              if keys != EXPECTED_KEYS:
-                  missing = ", ".join(sorted(EXPECTED_KEYS - keys)) or "none"
-                  unknown = ", ".join(sorted(keys - EXPECTED_KEYS)) or "none"
-                  bad("<keys>", f"missing {missing}, unknown {unknown}")
-                  continue
-
-              labels = job["runner_labels"]
-              if not isinstance(labels, list) or not labels:
-                  bad("runner_labels", "not a non-empty list")
-              else:
-                  for label in labels:
-                      if label not in ALLOWED_RUNNER_LABELS:
-                          bad("runner_labels", f"{label!r} is not an allowed runner")
-
-              if not displayable(job["name"]):
-                  bad("name", "empty, padded, over-long or carrying a control character")
-              if not displayable(job["artifact_name"]) or ARTIFACT_DISALLOWED.search(str(job["artifact_name"])):
-                  bad("artifact_name", "not a name upload-artifact accepts")
-              if not matches(TARGET, job["target"]):
-                  bad("target", "not a plain identifier")
-              if not matches(ENVIRONMENT, job["environment"]):
-                  bad("environment", "not a plain identifier")
-              if job["platform"] not in PLATFORMS:
-                  bad("platform", f"{job['platform']!r} is not a known platform")
-              if not matches(PYTHON_VERSION, job["python_version"]):
-                  bad("python_version", "not major.minor")
-              if job["agent_image"] is not None and not matches(AGENT_IMAGE, job["agent_image"]):
-                  bad("agent_image", "not an image reference")
-              for field in ("unit_tests", "e2e_tests", "minimum_base_package", "coverage"):
-                  if not isinstance(job[field], bool):
-                      bad(field, "not a boolean")
-
-          # A repeated artifact name makes the second upload fail, which reads as a lost result
-          # rather than as a broken batch. A repeated job name leaves the gatherer's join ambiguous.
-          for field in ("name", "artifact_name"):
-              seen = set()
-              for index, job in enumerate(jobs):
-                  value = job.get(field) if isinstance(job, dict) else None
-                  if isinstance(value, str):
-                      if value in seen:
-                          errors.append(f"::error::job {index}, {field}: {value!r} is not unique")
-                      seen.add(value)
-
-          if errors:
-              raise SystemExit("\n".join(errors))
-
-          print(json.dumps(jobs, separators=(",", ":")), end="")
-          PY
-
-          compact=$(cat matrix.json)
           {
             echo "matrix<<__MATRIX__"
-            echo "$compact"
+            cat jobs.json
+            echo
             echo "__MATRIX__"
           } >> "$GITHUB_OUTPUT"
 
           {
             echo "### ${BATCH_ID}"
             echo
-            echo "- jobs: $(python3 -c 'import json; print(len(json.load(open("matrix.json"))))')"
+            echo "- jobs: ${count}"
             echo "- targets: $(python3 -c 'import json,os; print(", ".join(json.loads(os.environ["INTEGRATIONS"])) or "-")')"
           } >> "$GITHUB_STEP_SUMMARY"
-
-      # `inputs.is_fork` is the Dispatcher's claim, and the Dispatcher may itself be running code
-      # from the commit under test. Resolving it here keeps the gate right when that claim is not.
-      - name: Resolve what this batch is testing
-        id: resolve
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CHECKOUT_SHA: ${{ inputs.checkout_sha }}
-          HEAD_SHA: ${{ inputs.head_sha }}
-          BRANCH: ${{ inputs.branch }}
-          CLAIMED_FORK: ${{ inputs.is_fork }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: |
-          set -euo pipefail
-
-          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::head_sha is not a commit SHA."
-            exit 1
-          fi
-
-          # An unreadable answer withholds credentials rather than stopping the batch, so one retry
-          # keeps a transient error from silently costing a trusted batch its CI Visibility.
-          retry() { "$@" || { sleep 5; "$@"; }; }
-
-          is_fork=true
-          if [[ "$CHECKOUT_SHA" =~ ^refs/pull/([0-9]+)/merge$ ]]; then
-            number="${BASH_REMATCH[1]}"
-            if pull=$(retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}"); then
-              head_repo=$(jq -r '.head.repo.full_name // ""' <<<"$pull")
-              head_sha=$(jq -r '.head.sha' <<<"$pull")
-              head_ref=$(jq -r '.head.ref' <<<"$pull")
-              # Without this the batch could attach its check run to any commit it named, including
-              # another pull request's head.
-              if [[ "$head_sha" != "$HEAD_SHA" || "$head_ref" != "$BRANCH" ]]; then
-                echo "::error::Batch reports ${HEAD_SHA} on ${BRANCH}, #${number} heads ${head_sha} on ${head_ref}."
-                exit 1
-              fi
-              if [[ "${head_repo,,}" == "${GITHUB_REPOSITORY,,}" ]]; then
-                is_fork=false
-              fi
-            else
-              echo "::warning::Could not read #${number}, so the batch runs without credentials."
-            fi
-          elif [[ "$CHECKOUT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            # A fork's commits are reachable here under refs/pull/<n>/head, so a bare SHA is trusted
-            # only once it is known to be on the default branch.
-            if [[ "$CHECKOUT_SHA" != "$HEAD_SHA" ]]; then
-              echo "::error::A commit batch must report the commit it checks out."
-              exit 1
-            fi
-            if status=$(retry gh api "repos/${GITHUB_REPOSITORY}/compare/${DEFAULT_BRANCH}...${CHECKOUT_SHA}" --jq '.status'); then
-              case "$status" in
-                identical|behind) is_fork=false ;;
-                *) echo "::warning::${CHECKOUT_SHA} is not on ${DEFAULT_BRANCH}, so the batch runs without credentials." ;;
-              esac
-            else
-              echo "::warning::Could not place ${CHECKOUT_SHA} on ${DEFAULT_BRANCH}, so the batch runs without credentials."
-            fi
-          else
-            echo "::error::checkout_sha must be refs/pull/<n>/merge or a commit SHA."
-            exit 1
-          fi
-
-          echo "is_fork=${is_fork}" >> "$GITHUB_OUTPUT"
-          if [[ "$is_fork" != "$CLAIMED_FORK" ]]; then
-            echo "::warning::The dispatcher reported is_fork=${CLAIMED_FORK}, this batch resolved ${is_fork}."
-          fi
-          echo "- fork: ${is_fork}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Open the batch's check run
         id: check
@@ -337,7 +154,7 @@ jobs:
   # credentials.
   test:
     needs: setup
-    if: needs.setup.outputs.is_fork != 'true'
+    if: inputs.is_fork != 'true'
     # Correlated by exact name, so this must stay `matrix.name` alone: a prefix or a suffix here
     # leaves every job in the batch unmatched.
     name: ${{ matrix.name }}
@@ -374,14 +191,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          # A newline in either would define further variables in GITHUB_ENV. The branch guard
-          # asserts a git ref invariant rather than fixing a live hole.
+          # Attacker-controlled, and a newline in it would define further variables in GITHUB_ENV.
           author_email=$(git log -1 --format=%ae)
           case $author_email in
             *[!a-zA-Z0-9.@_+-]*) author_email='' ;;
-          esac
-          case $BRANCH in
-            *[!a-zA-Z0-9._/+-]*) BRANCH='' ;;
           esac
 
           {
@@ -474,7 +287,7 @@ jobs:
   # Each of those is optional in the action and no-ops when absent, so the tests still run.
   test_fork:
     needs: setup
-    if: needs.setup.outputs.is_fork == 'true'
+    if: inputs.is_fork == 'true'
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner_labels }}
     timeout-minutes: 120
@@ -504,9 +317,6 @@ jobs:
           author_email=$(git log -1 --format=%ae)
           case $author_email in
             *[!a-zA-Z0-9.@_+-]*) author_email='' ;;
-          esac
-          case $BRANCH in
-            *[!a-zA-Z0-9._/+-]*) BRANCH='' ;;
           esac
 
           {
@@ -589,7 +399,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHECK_RUN_ID: ${{ needs.setup.outputs.check_run_id }}
-          TEST_RESULT: ${{ needs.setup.outputs.is_fork == 'true' && needs.test_fork.result || needs.test.result }}
+          TEST_RESULT: ${{ inputs.is_fork == 'true' && needs.test_fork.result || needs.test.result }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail

--- a/.github/workflows/test-batch.yml
+++ b/.github/workflows/test-batch.yml
@@ -9,6 +9,10 @@
 # Test execution lives in `.github/actions/run-test-job`, which this workflow calls once per job. The
 # workflow decides where a job runs and what it may touch; the action decides what gets tested.
 #
+# Every input is chosen by whoever dispatched the batch, so `setup` validates all of them and
+# resolves fork status from the API rather than trusting `inputs.is_fork`. `setup` and `teardown`
+# never check out, so they only ever run code that comes from the default branch.
+#
 # Three parts of the contract fail silently when broken, all read straight off the matrix so nothing
 # here reconstructs them:
 #   - the job name must be `BatchJob.name` verbatim, because the gatherer joins workflow jobs to
@@ -62,7 +66,7 @@ on:
         default: "standard"
         type: string
       is_fork:
-        description: "Whether the tested commit comes from a fork. Withholds every credential when true"
+        description: "What the dispatcher believes about the tested commit. Cross-checked in setup"
         required: false
         default: "false"
         type: string
@@ -70,7 +74,8 @@ on:
 permissions: {}
 
 # The Dispatcher has no way to cancel a run, so without this a second push leaves every batch of the
-# previous one running with nothing to reap it.
+# previous one running with nothing to reap it. Evaluated before any job starts, so it sits outside
+# the input validation `setup` does.
 concurrency:
   group: test-batch-${{ inputs.head_sha }}-${{ inputs.batch_id }}
   cancel-in-progress: true
@@ -86,11 +91,16 @@ jobs:
     timeout-minutes: 5
     permissions:
       checks: write
+      # Read-only, for the pull request lookup and the ancestor check below. This job never
+      # checks out.
+      contents: read
+      pull-requests: read
     outputs:
       matrix: ${{ steps.decode.outputs.matrix }}
+      is_fork: ${{ steps.resolve.outputs.is_fork }}
       check_run_id: ${{ steps.check.outputs.id }}
     steps:
-      - name: Decode the job list
+      - name: Decode and validate the job list
         id: decode
         env:
           JOB_LIST: ${{ inputs.job_list }}
@@ -99,25 +109,210 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Becomes the check run name and the concurrency group.
+          if [[ ! "$BATCH_ID" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::batch_id is not a plain identifier."
+            exit 1
+          fi
+
           # A repository-wide batch is several times GitHub's 65,535-character input limit as plain
           # JSON, so the Dispatcher always compresses. A decode failure is a malformed input and must
           # stop the batch rather than produce an empty matrix.
           printf '%s' "$JOB_LIST" | base64 -d | gzip -dc > jobs.json
 
-          count=$(python3 -c 'import json; print(len(json.load(open("jobs.json"))))')
-          if [[ "$count" -eq 0 ]]; then
-            echo "::error::The batch carries no jobs."
-            exit 1
-          fi
+          python3 <<'PY' > matrix.json
+          import json
+          import re
 
-          echo "matrix=$(cat jobs.json)" >> "$GITHUB_OUTPUT"
+          # Where a batch's code gets scheduled, fork-authored code included, so a self-hosted label
+          # must never appear here. A label added to `.ddev/config.toml` needs adding here too.
+          ALLOWED_RUNNER_LABELS = {"ubuntu-22.04", "windows-2022", "macos-14-large"}
+
+          # matrix-keys-begin
+          EXPECTED_KEYS = {
+              "name",
+              "target",
+              "runner_labels",
+              "environment",
+              "platform",
+              "python_version",
+              "unit_tests",
+              "e2e_tests",
+              "agent_image",
+              "minimum_base_package",
+              "coverage",
+              "artifact_name",
+          }
+          # matrix-keys-end
+
+          PLATFORMS = {"linux", "windows", "macos"}
+          TARGET = re.compile(r"^[A-Za-z0-9._-]+$")
+          ENVIRONMENT = re.compile(r"^[A-Za-z0-9._-]*$")
+          PYTHON_VERSION = re.compile(r"^[0-9]+\.[0-9]+$")
+          AGENT_IMAGE = re.compile(r"^[A-Za-z0-9./:_@-]+$")
+          # `ARTIFACT_NAME_DISALLOWED` in ddev's `messages.py`. Reaching upload-artifact with one of
+          # these loses the job's reports instead of failing the batch.
+          ARTIFACT_DISALLOWED = re.compile(r'["\:<>|*?\\/\r\n]')
+
+          errors = []
+
+          def displayable(value):
+              # Built from an integration's display name, which `normalize_job_name` only strips
+              # `<>:"/\|?*` from, so the character set is open. Bound what breaks the matrix.
+              return (
+                  isinstance(value, str)
+                  and 0 < len(value) <= 120
+                  and value == value.strip()
+                  and not any(ord(char) < 0x20 or ord(char) == 0x7F for char in value)
+              )
+
+          def matches(pattern, value):
+              return isinstance(value, str) and pattern.fullmatch(value) is not None
+
+          with open("jobs.json") as stream:
+              jobs = json.load(stream)
+          if not isinstance(jobs, list) or not jobs:
+              raise SystemExit("::error::The batch carries no jobs.")
+
+          for index, job in enumerate(jobs):
+              def bad(field, why, index=index):
+                  errors.append(f"::error::job {index}, {field}: {why}")
+
+              if not isinstance(job, dict):
+                  bad("<job>", "not an object")
+                  continue
+
+              keys = set(job)
+              if keys != EXPECTED_KEYS:
+                  missing = ", ".join(sorted(EXPECTED_KEYS - keys)) or "none"
+                  unknown = ", ".join(sorted(keys - EXPECTED_KEYS)) or "none"
+                  bad("<keys>", f"missing {missing}, unknown {unknown}")
+                  continue
+
+              labels = job["runner_labels"]
+              if not isinstance(labels, list) or not labels:
+                  bad("runner_labels", "not a non-empty list")
+              else:
+                  for label in labels:
+                      if label not in ALLOWED_RUNNER_LABELS:
+                          bad("runner_labels", f"{label!r} is not an allowed runner")
+
+              if not displayable(job["name"]):
+                  bad("name", "empty, padded, over-long or carrying a control character")
+              if not displayable(job["artifact_name"]) or ARTIFACT_DISALLOWED.search(str(job["artifact_name"])):
+                  bad("artifact_name", "not a name upload-artifact accepts")
+              if not matches(TARGET, job["target"]):
+                  bad("target", "not a plain identifier")
+              if not matches(ENVIRONMENT, job["environment"]):
+                  bad("environment", "not a plain identifier")
+              if job["platform"] not in PLATFORMS:
+                  bad("platform", f"{job['platform']!r} is not a known platform")
+              if not matches(PYTHON_VERSION, job["python_version"]):
+                  bad("python_version", "not major.minor")
+              if job["agent_image"] is not None and not matches(AGENT_IMAGE, job["agent_image"]):
+                  bad("agent_image", "not an image reference")
+              for field in ("unit_tests", "e2e_tests", "minimum_base_package", "coverage"):
+                  if not isinstance(job[field], bool):
+                      bad(field, "not a boolean")
+
+          # A repeated artifact name makes the second upload fail, which reads as a lost result
+          # rather than as a broken batch. A repeated job name leaves the gatherer's join ambiguous.
+          for field in ("name", "artifact_name"):
+              seen = set()
+              for index, job in enumerate(jobs):
+                  value = job.get(field) if isinstance(job, dict) else None
+                  if isinstance(value, str):
+                      if value in seen:
+                          errors.append(f"::error::job {index}, {field}: {value!r} is not unique")
+                      seen.add(value)
+
+          if errors:
+              raise SystemExit("\n".join(errors))
+
+          print(json.dumps(jobs, separators=(",", ":")), end="")
+          PY
+
+          compact=$(cat matrix.json)
+          {
+            echo "matrix<<__MATRIX__"
+            echo "$compact"
+            echo "__MATRIX__"
+          } >> "$GITHUB_OUTPUT"
 
           {
             echo "### ${BATCH_ID}"
             echo
-            echo "- jobs: ${count}"
+            echo "- jobs: $(python3 -c 'import json; print(len(json.load(open("matrix.json"))))')"
             echo "- targets: $(python3 -c 'import json,os; print(", ".join(json.loads(os.environ["INTEGRATIONS"])) or "-")')"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # `inputs.is_fork` is the Dispatcher's claim, and the Dispatcher may itself be running code
+      # from the commit under test. Resolving it here keeps the gate right when that claim is not.
+      - name: Resolve what this batch is testing
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHECKOUT_SHA: ${{ inputs.checkout_sha }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          BRANCH: ${{ inputs.branch }}
+          CLAIMED_FORK: ${{ inputs.is_fork }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::head_sha is not a commit SHA."
+            exit 1
+          fi
+
+          # An unreadable answer withholds credentials rather than stopping the batch, so one retry
+          # keeps a transient error from silently costing a trusted batch its CI Visibility.
+          retry() { "$@" || { sleep 5; "$@"; }; }
+
+          is_fork=true
+          if [[ "$CHECKOUT_SHA" =~ ^refs/pull/([0-9]+)/merge$ ]]; then
+            number="${BASH_REMATCH[1]}"
+            if pull=$(retry gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}"); then
+              head_repo=$(jq -r '.head.repo.full_name // ""' <<<"$pull")
+              head_sha=$(jq -r '.head.sha' <<<"$pull")
+              head_ref=$(jq -r '.head.ref' <<<"$pull")
+              # Without this the batch could attach its check run to any commit it named, including
+              # another pull request's head.
+              if [[ "$head_sha" != "$HEAD_SHA" || "$head_ref" != "$BRANCH" ]]; then
+                echo "::error::Batch reports ${HEAD_SHA} on ${BRANCH}, #${number} heads ${head_sha} on ${head_ref}."
+                exit 1
+              fi
+              if [[ "${head_repo,,}" == "${GITHUB_REPOSITORY,,}" ]]; then
+                is_fork=false
+              fi
+            else
+              echo "::warning::Could not read #${number}, so the batch runs without credentials."
+            fi
+          elif [[ "$CHECKOUT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            # A fork's commits are reachable here under refs/pull/<n>/head, so a bare SHA is trusted
+            # only once it is known to be on the default branch.
+            if [[ "$CHECKOUT_SHA" != "$HEAD_SHA" ]]; then
+              echo "::error::A commit batch must report the commit it checks out."
+              exit 1
+            fi
+            if status=$(retry gh api "repos/${GITHUB_REPOSITORY}/compare/${DEFAULT_BRANCH}...${CHECKOUT_SHA}" --jq '.status'); then
+              case "$status" in
+                identical|behind) is_fork=false ;;
+                *) echo "::warning::${CHECKOUT_SHA} is not on ${DEFAULT_BRANCH}, so the batch runs without credentials." ;;
+              esac
+            else
+              echo "::warning::Could not place ${CHECKOUT_SHA} on ${DEFAULT_BRANCH}, so the batch runs without credentials."
+            fi
+          else
+            echo "::error::checkout_sha must be refs/pull/<n>/merge or a commit SHA."
+            exit 1
+          fi
+
+          echo "is_fork=${is_fork}" >> "$GITHUB_OUTPUT"
+          if [[ "$is_fork" != "$CLAIMED_FORK" ]]; then
+            echo "::warning::The dispatcher reported is_fork=${CLAIMED_FORK}, this batch resolved ${is_fork}."
+          fi
+          echo "- fork: ${is_fork}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Open the batch's check run
         id: check
@@ -136,8 +331,13 @@ jobs:
             --jq '.id')
           echo "id=${id}" >> "$GITHUB_OUTPUT"
 
+  # Twin of `test_fork`, which runs the same steps with no OIDC and no credentials. `permissions`
+  # takes no expression, so the gate has to be two jobs, and a reusable workflow would rename them to
+  # `<caller> / <called>` and break the exact-name join. Keep the step lists identical apart from the
+  # credentials.
   test:
     needs: setup
+    if: needs.setup.outputs.is_fork != 'true'
     # Correlated by exact name, so this must stay `matrix.name` alone: a prefix or a suffix here
     # leaves every job in the batch unmatched.
     name: ${{ matrix.name }}
@@ -145,8 +345,8 @@ jobs:
     # Hardcoded rather than an input: a hung job would otherwise hold a runner for the 6h default,
     # long after the Dispatcher's own ceiling has passed.
     timeout-minutes: 120
-    # This job runs the tested commit's code. It gets no write scope, and the workflow is read from
-    # the default branch under workflow_dispatch, so a pull request cannot widen this.
+    # Permissions come from the default branch and a pull request cannot widen them, but every step
+    # after the checkout runs the tested commit's code, so what this job holds is what it can take.
     permissions:
       contents: read
       id-token: write # dd-sts, for the CI Visibility API key
@@ -162,6 +362,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout_sha }}
+          persist-credentials: false
 
       # Datadog's git variables take precedence over the CI provider's, which is the only way to stop
       # this run being attributed to master. `head_sha` and not `checkout_sha`: the latter is
@@ -173,10 +374,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Attacker-controlled, and a newline in it would define further variables in GITHUB_ENV.
+          # A newline in either would define further variables in GITHUB_ENV. The branch guard
+          # asserts a git ref invariant rather than fixing a live hole.
           author_email=$(git log -1 --format=%ae)
           case $author_email in
             *[!a-zA-Z0-9.@_+-]*) author_email='' ;;
+          esac
+          case $BRANCH in
+            *[!a-zA-Z0-9._/+-]*) BRANCH='' ;;
           esac
 
           {
@@ -186,10 +391,7 @@ jobs:
             echo "DD_GIT_COMMIT_AUTHOR_EMAIL=${author_email}"
           } >> "$GITHUB_ENV"
 
-      # Skipped for a fork, so its code never runs in a job holding the key. The cost is no CI
-      # Visibility for fork pull requests, which is what `test-target` does today.
       - name: Get Datadog credentials
-        if: inputs.is_fork != 'true'
         id: dd-sts
         uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
         with:
@@ -228,19 +430,17 @@ jobs:
           minimum_base_package: ${{ matrix.minimum_base_package }}
           pytest_args: ${{ inputs.pytest_args }}
           context: ${{ inputs.context }}
-          is_fork: ${{ inputs.is_fork }}
-          # Every credential below is withheld from a fork. Each is optional in the action and
-          # no-ops when absent, so a fork batch runs the tests and skips what needs a secret.
+          is_fork: "false"
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
           # A rate-limit lift for the ~70 api.github.com calls `ddev validate licenses` makes, not an
           # authorization requirement, so the ambient token is enough.
-          github_token: ${{ inputs.is_fork != 'true' && secrets.GITHUB_TOKEN || '' }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Read only by the sap_hana and weblogic setup scripts, so every other job runs without
           # them rather than seeing credentials it has no use for.
-          docker_username: ${{ inputs.is_fork != 'true' && (matrix.target == 'sap_hana' || matrix.target == 'weblogic') && secrets.DOCKER_USERNAME || '' }}
-          docker_token: ${{ inputs.is_fork != 'true' && (matrix.target == 'sap_hana' || matrix.target == 'weblogic') && secrets.DOCKER_ACCESS_TOKEN || '' }}
-          oracle_docker_username: ${{ inputs.is_fork != 'true' && matrix.target == 'weblogic' && secrets.ORACLE_DOCKER_USERNAME || '' }}
-          oracle_docker_password: ${{ inputs.is_fork != 'true' && matrix.target == 'weblogic' && secrets.ORACLE_DOCKER_PASSWORD || '' }}
+          docker_username: ${{ (matrix.target == 'sap_hana' || matrix.target == 'weblogic') && secrets.DOCKER_USERNAME || '' }}
+          docker_token: ${{ (matrix.target == 'sap_hana' || matrix.target == 'weblogic') && secrets.DOCKER_ACCESS_TOKEN || '' }}
+          oracle_docker_username: ${{ matrix.target == 'weblogic' && secrets.ORACLE_DOCKER_USERNAME || '' }}
+          oracle_docker_password: ${{ matrix.target == 'weblogic' && secrets.ORACLE_DOCKER_PASSWORD || '' }}
 
       # One flat directory per job, uploaded under the job's `artifact_name`. The gatherer rglobs
       # `test-*.xml` and `coverage*.xml` inside it, which is what `ddev test --junit` and `--cov`
@@ -269,10 +469,112 @@ jobs:
           path: reports
           if-no-files-found: warn
 
+  # Twin of `test`, for a commit this repository does not control. No `id-token`, so the tested code
+  # cannot mint an OIDC token whose claims name the default branch, and no credential inputs at all.
+  # Each of those is optional in the action and no-ops when absent, so the tests still run.
+  test_fork:
+    needs: setup
+    if: needs.setup.outputs.is_fork == 'true'
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner_labels }}
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.setup.outputs.matrix) }}
+    steps:
+      - name: Set up Windows
+        if: runner.os == 'Windows'
+        run: diskperf -y
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout_sha }}
+          persist-credentials: false
+
+      - name: Attribute results to the tested commit
+        env:
+          HEAD_SHA: ${{ inputs.head_sha }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+
+          author_email=$(git log -1 --format=%ae)
+          case $author_email in
+            *[!a-zA-Z0-9.@_+-]*) author_email='' ;;
+          esac
+          case $BRANCH in
+            *[!a-zA-Z0-9._/+-]*) BRANCH='' ;;
+          esac
+
+          {
+            echo "DD_GIT_COMMIT_SHA=${HEAD_SHA}"
+            echo "DD_GIT_BRANCH=${BRANCH}"
+            echo "DD_GIT_REPOSITORY_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
+            echo "DD_GIT_COMMIT_AUTHOR_EMAIL=${author_email}"
+          } >> "$GITHUB_ENV"
+
+      - name: Set up Python ${{ matrix.python_version }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - uses: ./.github/actions/setup-ddev
+        with:
+          install-mode: local
+          cache-profile: local-ddev-base
+
+      - name: Configure ddev
+        run: |
+          ddev config set upgrade_check false
+          ddev config override
+
+      - name: Run the tests
+        uses: ./.github/actions/run-test-job
+        with:
+          target: ${{ matrix.target }}
+          job_name: ${{ matrix.name }}
+          platform: ${{ matrix.platform }}
+          environment: ${{ matrix.environment }}
+          python_version: ${{ matrix.python_version }}
+          unit_tests: ${{ matrix.unit_tests }}
+          e2e_tests: ${{ matrix.e2e_tests }}
+          agent_image: ${{ matrix.agent_image }}
+          minimum_base_package: ${{ matrix.minimum_base_package }}
+          pytest_args: ${{ inputs.pytest_args }}
+          context: ${{ inputs.context }}
+          is_fork: "true"
+
+      - name: Collect the job's reports
+        if: always()
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          mkdir -p reports
+          if [[ -d "$TARGET/junit" ]]; then
+            find "$TARGET/junit" -name 'test-*.xml' -exec cp {} reports/ \;
+          fi
+          if [[ -f "$TARGET/coverage.xml" ]]; then
+            cp "$TARGET/coverage.xml" reports/
+          fi
+          ls -la reports
+
+      - name: Upload the job's reports
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: reports
+          if-no-files-found: warn
+
   teardown:
     needs:
       - setup
       - test
+      - test_fork
     if: always() && needs.setup.result == 'success'
     name: teardown
     runs-on: ubuntu-22.04
@@ -281,12 +583,13 @@ jobs:
       checks: write
     steps:
       # From the test job's result rather than this job's status, so a cancelled or skipped batch
-      # closes as what it was instead of as a success.
+      # closes as what it was instead of as a success. The twin that did not run reports `skipped`,
+      # so which one to read is selected on the value that chose it.
       - name: Close the batch's check run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHECK_RUN_ID: ${{ needs.setup.outputs.check_run_id }}
-          TEST_RESULT: ${{ needs.test.result }}
+          TEST_RESULT: ${{ needs.setup.outputs.is_fork == 'true' && needs.test_fork.result || needs.test.result }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail

--- a/.github/workflows/test-batch.yml
+++ b/.github/workflows/test-batch.yml
@@ -168,11 +168,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # The author identity is attacker-controlled, and a value carrying a newline would define
-          # further variables in GITHUB_ENV rather than just itself. git's ident parser cannot
-          # produce one today (it strips them on the way in and yields an empty string for an object
-          # malformed enough to contain one), so this is a guard against that changing, not a fix for
-          # a live hole. Dropped rather than escaped: an unattributed result beats a decorated one.
+          # Attacker-controlled, and a newline in it would define further variables in GITHUB_ENV.
           author_email=$(git log -1 --format=%ae)
           case $author_email in
             *[!a-zA-Z0-9.@_+-]*) author_email='' ;;
@@ -206,7 +202,9 @@ jobs:
           cache-profile: local-ddev-base
 
       - name: Configure ddev
-        run: ddev config override
+        run: |
+          ddev config set upgrade_check false
+          ddev config override
 
       - name: Run the tests
         uses: ./.github/actions/run-test-job

--- a/.github/workflows/test-batch.yml
+++ b/.github/workflows/test-batch.yml
@@ -61,6 +61,11 @@ on:
         required: false
         default: "standard"
         type: string
+      is_fork:
+        description: "Whether the tested commit comes from a fork. Withholds every credential when true"
+        required: false
+        default: "false"
+        type: string
 
 permissions: {}
 
@@ -181,7 +186,10 @@ jobs:
             echo "DD_GIT_COMMIT_AUTHOR_EMAIL=${author_email}"
           } >> "$GITHUB_ENV"
 
+      # Skipped for a fork, so its code never runs in a job holding the key. The cost is no CI
+      # Visibility for fork pull requests, which is what `test-target` does today.
       - name: Get Datadog credentials
+        if: inputs.is_fork != 'true'
         id: dd-sts
         uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
         with:
@@ -220,16 +228,19 @@ jobs:
           minimum_base_package: ${{ matrix.minimum_base_package }}
           pytest_args: ${{ inputs.pytest_args }}
           context: ${{ inputs.context }}
+          is_fork: ${{ inputs.is_fork }}
+          # Every credential below is withheld from a fork. Each is optional in the action and
+          # no-ops when absent, so a fork batch runs the tests and skips what needs a secret.
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
           # A rate-limit lift for the ~70 api.github.com calls `ddev validate licenses` makes, not an
           # authorization requirement, so the ambient token is enough.
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ inputs.is_fork != 'true' && secrets.GITHUB_TOKEN || '' }}
           # Read only by the sap_hana and weblogic setup scripts, so every other job runs without
           # them rather than seeing credentials it has no use for.
-          docker_username: ${{ (matrix.target == 'sap_hana' || matrix.target == 'weblogic') && secrets.DOCKER_USERNAME || '' }}
-          docker_token: ${{ (matrix.target == 'sap_hana' || matrix.target == 'weblogic') && secrets.DOCKER_ACCESS_TOKEN || '' }}
-          oracle_docker_username: ${{ matrix.target == 'weblogic' && secrets.ORACLE_DOCKER_USERNAME || '' }}
-          oracle_docker_password: ${{ matrix.target == 'weblogic' && secrets.ORACLE_DOCKER_PASSWORD || '' }}
+          docker_username: ${{ inputs.is_fork != 'true' && (matrix.target == 'sap_hana' || matrix.target == 'weblogic') && secrets.DOCKER_USERNAME || '' }}
+          docker_token: ${{ inputs.is_fork != 'true' && (matrix.target == 'sap_hana' || matrix.target == 'weblogic') && secrets.DOCKER_ACCESS_TOKEN || '' }}
+          oracle_docker_username: ${{ inputs.is_fork != 'true' && matrix.target == 'weblogic' && secrets.ORACLE_DOCKER_USERNAME || '' }}
+          oracle_docker_password: ${{ inputs.is_fork != 'true' && matrix.target == 'weblogic' && secrets.ORACLE_DOCKER_PASSWORD || '' }}
 
       # One flat directory per job, uploaded under the job's `artifact_name`. The gatherer rglobs
       # `test-*.xml` and `coverage*.xml` inside it, which is what `ddev test --junit` and `--cov`

--- a/ddev/changelog.d/25115.added
+++ b/ddev/changelog.d/25115.added
@@ -1,1 +1,0 @@
-Add the ``test-batch`` workflow and the ``run-test-job`` action, and move the per-batch check run out of the dispatcher into the workflow that owns it.

--- a/ddev/changelog.d/25115.added
+++ b/ddev/changelog.d/25115.added
@@ -1,0 +1,1 @@
+Add the ``test-batch`` workflow and the ``run-test-job`` action, and move the per-batch check run out of the dispatcher into the workflow that owns it.

--- a/ddev/changelog.d/25115.fixed
+++ b/ddev/changelog.d/25115.fixed
@@ -1,0 +1,1 @@
+``ddev ci dispatch-tests`` sends each batch the commit and branch its results belong to and whether the tested head lives in a fork, no longer opens the batch's check run itself, and rejects a plan naming an unknown runner.

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from ddev.cli.ci.tests.messages import TestBatch
     from ddev.utils.git import ChangedFile
     from ddev.utils.github_async import AsyncGitHubClient
+    from ddev.utils.github_async.models import PullRequestRef
 
 DEFAULT_OUTPUT_DIRECTORY = ".dispatcher"
 
@@ -156,6 +157,7 @@ def dispatch_tests(
         checkout_sha=run.checkout_sha,
         base_sha=run.base_sha,
         branch=run.branch,
+        is_fork=run.is_fork,
         workflow=workflow or config.workflow,
         workflow_ref=workflow_ref or config.workflow_ref,
         target_branch=run.target_branch,
@@ -248,6 +250,7 @@ class ResolvedRun:
     changed_files: list[ChangedFile] | None
     pr_number: int | None = None
     target_branch: str | None = None
+    is_fork: bool = False
 
 
 def resolve_run(
@@ -294,6 +297,17 @@ def resolve_run(
         branch=app.repo.git.current_branch(),
         changed_files=changed_files,
     )
+
+
+def head_is_fork(head: PullRequestRef, *, owner: str, repo: str) -> bool:
+    """Whether a pull request's head branch lives outside the repository being tested.
+
+    A deleted head repository reads as a fork: the value decides whether credentials are withheld, so
+    the unknown case is the restrictive one.
+    """
+    if head.repo is None:
+        return True
+    return head.repo.full_name.casefold() != f"{owner}/{repo}".casefold()
 
 
 def resolve_pull_request_run(
@@ -373,6 +387,7 @@ def resolve_pull_request_run(
                 changed_files=changed_files,
                 pr_number=pull.number,
                 target_branch=pull.base.ref,
+                is_fork=head_is_fork(pull.head, owner=owner, repo=repo),
             )
 
     try:

--- a/ddev/src/ddev/cli/ci/tests/batching/units.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/units.py
@@ -35,6 +35,11 @@ PLATFORMS: dict[PlatformName, PlatformSpec] = {
     PlatformName.MACOS: PlatformSpec("macOS", "macos-14-large"),
 }
 
+# The runners a plan may schedule on. Plan content follows the tested tree's `.ddev/config.toml` and
+# `hatch.toml`, so this is the set of places that influence can put a job, and the reason a
+# self-hosted label never goes in it. A `runners` override needs its label adding here.
+ALLOWED_RUNNER_LABELS = frozenset({"ubuntu-22.04", "windows-2022", "macos-14-large"})
+
 # Targets rendered before everything else, in this order.
 DISPLAY_ORDER_OVERRIDE: dict[str, int] = {
     name: index

--- a/ddev/src/ddev/cli/ci/tests/batching/units.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/units.py
@@ -37,7 +37,8 @@ PLATFORMS: dict[PlatformName, PlatformSpec] = {
 
 # The runners a plan may schedule on. Plan content follows the tested tree's `.ddev/config.toml` and
 # `hatch.toml`, so this is the set of places that influence can put a job, and the reason a
-# self-hosted label never goes in it. A `runners` override needs its label adding here.
+# self-hosted label never goes in it. A `runners` override needs its label adding here. One label
+# per job: `runs-on` with an array is conjunctive, so a hosted image is only schedulable alone.
 ALLOWED_RUNNER_LABELS = frozenset({"ubuntu-22.04", "windows-2022", "macos-14-large"})
 
 # Targets rendered before everything else, in this order.

--- a/ddev/src/ddev/cli/ci/tests/batching/validation.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/validation.py
@@ -9,6 +9,7 @@ from collections import Counter
 from typing import TYPE_CHECKING
 
 from ddev.cli.ci.tests.batching.exceptions import BatchValidationError
+from ddev.cli.ci.tests.batching.units import ALLOWED_RUNNER_LABELS
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -26,8 +27,8 @@ def validate_batches(
     """Enforce the batch-execution contract, so no strategy can emit an unrunnable plan.
 
     Rejects empty or over-capacity batches, duplicate job names or artifact identities within a
-    batch, any deviation from exact once-per-job coverage of `jobs`, and unjustified integration
-    splitting.
+    batch, a runner label outside `ALLOWED_RUNNER_LABELS`, any deviation from exact once-per-job
+    coverage of `jobs`, and unjustified integration splitting.
 
     Artifact identity is checked as well as the display name because sanitization can collapse two
     differently named jobs onto one artifact, whose files would then overwrite each other.
@@ -44,6 +45,10 @@ def validate_batches(
         artifact_names = [job.artifact_name() for job in group]
         if len(artifact_names) != len(set(artifact_names)):
             raise BatchValidationError(f"Batch at index {index} has duplicate artifact identities.")
+        for job in group:
+            unknown = sorted(set(job.runner_labels) - ALLOWED_RUNNER_LABELS)
+            if unknown:
+                raise BatchValidationError(f"Job {job.name!r} runs on unknown runners: {', '.join(unknown)}.")
 
     _validate_coverage(job_groups, jobs)
     _validate_splitting(job_groups, jobs, capacity=capacity, config=config)

--- a/ddev/src/ddev/cli/ci/tests/batching/validation.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/validation.py
@@ -27,8 +27,8 @@ def validate_batches(
     """Enforce the batch-execution contract, so no strategy can emit an unrunnable plan.
 
     Rejects empty or over-capacity batches, duplicate job names or artifact identities within a
-    batch, a runner label outside `ALLOWED_RUNNER_LABELS`, any deviation from exact once-per-job
-    coverage of `jobs`, and unjustified integration splitting.
+    batch, anything but a single runner from `ALLOWED_RUNNER_LABELS`, any deviation from exact
+    once-per-job coverage of `jobs`, and unjustified integration splitting.
 
     Artifact identity is checked as well as the display name because sanitization can collapse two
     differently named jobs onto one artifact, whose files would then overwrite each other.
@@ -46,9 +46,8 @@ def validate_batches(
         if len(artifact_names) != len(set(artifact_names)):
             raise BatchValidationError(f"Batch at index {index} has duplicate artifact identities.")
         for job in group:
-            unknown = sorted(set(job.runner_labels) - ALLOWED_RUNNER_LABELS)
-            if unknown:
-                raise BatchValidationError(f"Job {job.name!r} runs on unknown runners: {', '.join(unknown)}.")
+            if len(job.runner_labels) != 1 or job.runner_labels[0] not in ALLOWED_RUNNER_LABELS:
+                raise BatchValidationError(f"Job {job.name!r} runs on {list(job.runner_labels)}, not one known runner.")
 
     _validate_coverage(job_groups, jobs)
     _validate_splitting(job_groups, jobs, capacity=capacity, config=config)

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -228,6 +228,7 @@ def build_dispatcher(
             base_sha=context.base_sha,
             checkout_sha=context.checkout_sha,
             artifacts_base_path=artifacts_path,
+            branch=context.branch,
             poll_interval_seconds=config.poll_interval_seconds,
             pytest_args=context.pytest_args,
         ),

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -57,6 +57,7 @@ class DispatcherContext:
     pr_number: int | None = None
     tags: tuple[str, ...] = ()
     pytest_args: str = ''
+    is_fork: bool = False
 
 
 @dataclass(frozen=True)
@@ -229,6 +230,7 @@ def build_dispatcher(
             checkout_sha=context.checkout_sha,
             artifacts_base_path=artifacts_path,
             branch=context.branch,
+            is_fork=context.is_fork,
             poll_interval_seconds=config.poll_interval_seconds,
             pytest_args=context.pytest_args,
         ),

--- a/ddev/src/ddev/cli/ci/tests/status.py
+++ b/ddev/src/ddev/cli/ci/tests/status.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 from enum import StrEnum, auto
 
-from ddev.utils.github_async.models.check_run import CheckRunConclusion
 from ddev.utils.github_async.models.workflow import WorkflowJobConclusion
 
 
@@ -28,34 +27,10 @@ class Status(StrEnum):
 def conclusion_to_status(conclusion: str | None) -> Status:
     """Map a GitHub Actions conclusion to the internal :class:`Status`.
 
-    Note: ``None`` maps to ``Status.FAILURE`` here while a check run reports ``"neutral"``
-    for the same input. The asymmetry is intentional — status consumers want a binary
-    outcome, the check UI prefers an explicit ``"neutral"`` badge.
+    ``None`` maps to ``Status.FAILURE``: a run that finished without saying how did not succeed.
     """
     if conclusion == WorkflowJobConclusion.SUCCESS:
         return Status.SUCCESS
     if conclusion == WorkflowJobConclusion.SKIPPED:
         return Status.SKIPPED
     return Status.FAILURE
-
-
-def conclusion_to_check_run_conclusion(conclusion: str | None) -> CheckRunConclusion:
-    """Map a GitHub Actions conclusion to the one a check run can report.
-
-    The two sets are not the same. ``workflow-run.conclusion`` is a nullable string with no declared
-    enum, so it can carry values a check run has no member for; ``startup_failure`` is the known one
-    (https://github.com/github/rest-api-description/issues/1989). A check run accepts only the eight
-    its request schema declares
-    (https://docs.github.com/en/rest/checks/runs#update-a-check-run).
-
-    Anything unrecognised reports as a failure rather than being passed through, which GitHub would
-    reject. ``None`` reports as neutral, matching :func:`conclusion_to_status`'s note that the check UI
-    prefers an explicit badge where the internal status prefers a binary outcome.
-    """
-    if conclusion is None:
-        return CheckRunConclusion.NEUTRAL
-
-    try:
-        return CheckRunConclusion(conclusion)
-    except ValueError:
-        return CheckRunConclusion.FAILURE

--- a/ddev/src/ddev/cli/ci/tests/task_test_runner.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_runner.py
@@ -67,6 +67,7 @@ class TestRunnerOptions:
     checkout_sha: str
     artifacts_base_path: Path
     branch: str = ''
+    is_fork: bool = False
     poll_interval_seconds: float = 30.0
     pytest_args: str = ''
 
@@ -191,6 +192,9 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
             # These two say which commit the results belong to, for CI Visibility and the check run.
             "head_sha": self._options.base_sha,
             "branch": self._options.branch,
+            # The batch withholds every credential when this is true, so it is sent on every dispatch
+            # rather than only when set: an absent input would default the workflow to trusting it.
+            "is_fork": str(self._options.is_fork).lower(),
             "integrations": json.dumps(message.integrations),
             "job_list": encode_job_list([self._job_input(job) for job in message.job_list]),
         }

--- a/ddev/src/ddev/cli/ci/tests/task_test_runner.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_runner.py
@@ -142,8 +142,11 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
     async def cancel_dispatched_runs(self) -> None:
         """Cancel the runs this runner dispatched that have not finished.
 
-        Left running they would keep burning runner minutes long after the run that asked for them is
-        gone. Concurrent, because whatever budget the caller has is shared by all of them.
+        The batch workflow's concurrency group already cancels a superseded revision's batches. This
+        covers what the group cannot see: a cancellation or a closed pull request with no follow-up
+        push, a plan that shrank, and the minutes between this process being killed and the next
+        batches being dispatched. Concurrent, because whatever budget the caller has is shared by
+        all of them.
         """
         if not self._runs_in_flight:
             return

--- a/ddev/src/ddev/cli/ci/tests/task_test_runner.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_runner.py
@@ -14,10 +14,10 @@ from pathlib import Path
 from typing import Any
 
 from ddev.cli.ci.tests.messages import BatchFinished, BatchJob, BatchJobResult, TestBatch
-from ddev.cli.ci.tests.status import conclusion_to_check_run_conclusion, conclusion_to_status
+from ddev.cli.ci.tests.status import conclusion_to_status
 from ddev.event_bus.orchestrator import AsyncProcessor
 from ddev.utils.github_async import AsyncGitHubClient, GitHubResponse
-from ddev.utils.github_async.models import CheckRunConclusion, CheckRunStatus, WorkflowJob, WorkflowRun
+from ddev.utils.github_async.models import WorkflowJob, WorkflowRun
 
 # A cancelled job has roughly ten seconds before it is killed, and there may be several runs to stop.
 # The retry policy bounds the ladder, not a socket, so a GitHub that accepts the connection and then
@@ -66,6 +66,7 @@ class TestRunnerOptions:
     base_sha: str
     checkout_sha: str
     artifacts_base_path: Path
+    branch: str = ''
     poll_interval_seconds: float = 30.0
     pytest_args: str = ''
 
@@ -105,42 +106,27 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
         workflow_url = run.data.html_url
         log_extra["workflow_url"] = workflow_url
 
-        check = await self._client.create_check_run(
-            self._options.owner,
-            self._options.repo,
-            name=f"test-batch/{message.batch_id}",
-            head_sha=self._options.base_sha,
-            status=CheckRunStatus.IN_PROGRESS,
-            details_url=workflow_url,
-        )
-        check_run_id = check.data.id
-        log_extra["check_run_id"] = check_run_id
-        self._logger.info("Check run created", extra=log_extra)
+        if run.data.status != "completed":
+            run = await self._poll_until_complete(run_id, log_extra)
+        else:
+            self._logger.info("Workflow completed", extra=log_extra)
 
-        final_conclusion = CheckRunConclusion.CANCELLED
-        finished: BatchFinished | None = None
-        try:
-            if run.data.status != "completed":
-                run = await self._poll_until_complete(run_id, log_extra)
-            else:
-                self._logger.info("Workflow completed", extra=log_extra)
+        # Popped only once the run is known to be over: while it is in flight it is what
+        # `cancel_dispatched_runs` has to reap.
+        self._runs_in_flight.pop(message.batch_id, None)
 
-            # Not in the `finally`, which also runs when this task is cancelled with the run still
-            # going, and that is when there is something to cancel.
-            self._runs_in_flight.pop(message.batch_id, None)
+        raw = run.data.conclusion
+        if raw is None:
+            self._logger.warning("Workflow completed with null conclusion", extra=log_extra)
 
-            raw = run.data.conclusion
-            if raw is None:
-                self._logger.warning("Workflow completed with null conclusion", extra=log_extra)
-            final_conclusion = conclusion_to_check_run_conclusion(raw)
+        artifact_dirs = await self._download_artifacts(run_id, log_extra)
+        self._logger.info("Artifacts downloaded", extra=log_extra)
 
-            artifact_dirs = await self._download_artifacts(run_id, log_extra)
-            self._logger.info("Artifacts downloaded", extra=log_extra)
+        jobs = await self._list_jobs(run_id, log_extra)
+        batch_jobs = BatchJobResult.correlate(message.job_list, jobs, artifact_dirs)
 
-            jobs = await self._list_jobs(run_id, log_extra)
-            batch_jobs = BatchJobResult.correlate(message.job_list, jobs, artifact_dirs)
-
-            finished = BatchFinished(
+        self.submit_message(
+            BatchFinished(
                 id=message.id,
                 batch_id=message.batch_id,
                 status=conclusion_to_status(raw),
@@ -149,23 +135,8 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
                 artifacts_path=str(self._options.artifacts_base_path),
                 batch_jobs=batch_jobs,
             )
-        finally:
-            try:
-                await self._client.update_check_run(
-                    self._options.owner,
-                    self._options.repo,
-                    check_run_id,
-                    status=CheckRunStatus.COMPLETED,
-                    conclusion=final_conclusion,
-                    details_url=workflow_url,
-                )
-                self._logger.info("Check run closed", extra={**log_extra, "conclusion": final_conclusion})
-            except Exception:
-                self._logger.exception("Failed to close check run", extra={**log_extra, "conclusion": final_conclusion})
-
-        if finished is not None:
-            self.submit_message(finished)
-            self._logger.info("BatchFinished emitted", extra=log_extra)
+        )
+        self._logger.info("BatchFinished emitted", extra=log_extra)
 
     async def cancel_dispatched_runs(self) -> None:
         """Cancel the runs this runner dispatched that have not finished.
@@ -216,6 +187,10 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
         inputs = {
             "batch_id": message.batch_id,
             "checkout_sha": self._options.checkout_sha,
+            # The batch is dispatched at the default branch, so its own context describes master.
+            # These two say which commit the results belong to, for CI Visibility and the check run.
+            "head_sha": self._options.base_sha,
+            "branch": self._options.branch,
             "integrations": json.dumps(message.integrations),
             "job_list": encode_job_list([self._job_input(job) for job in message.job_list]),
         }

--- a/ddev/src/ddev/utils/github_async/models/__init__.py
+++ b/ddev/src/ddev/utils/github_async/models/__init__.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from .pull_request import PullRequestFile as PullRequestFile
     from .pull_request import PullRequestFileStatus as PullRequestFileStatus
     from .pull_request import PullRequestRef as PullRequestRef
+    from .pull_request import PullRequestRepo as PullRequestRepo
     from .pull_request import PullRequestSimple as PullRequestSimple
     from .pull_request import PullRequestState as PullRequestState
     from .user import GitHubUser as GitHubUser
@@ -66,6 +67,7 @@ MODULE_BY_NAME: dict[str, str] = {
     'PullRequestFile': 'pull_request',
     'PullRequestFileStatus': 'pull_request',
     'PullRequestRef': 'pull_request',
+    'PullRequestRepo': 'pull_request',
     'PullRequestReviewComment': 'comment',
     'PullRequestSimple': 'pull_request',
     'PullRequestState': 'pull_request',

--- a/ddev/src/ddev/utils/github_async/models/pull_request.py
+++ b/ddev/src/ddev/utils/github_async/models/pull_request.py
@@ -61,6 +61,14 @@ class PullRequestFile(BaseModel):
     previous_filename: str | None = None
 
 
+class PullRequestRepo(BaseModel):
+    """The repository a pull request's head or base branch lives in."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    full_name: str  # e.g. 'DataDog/integrations-core'
+
+
 class PullRequestRef(BaseModel):
     """A head or base branch reference on a pull request.
 
@@ -73,6 +81,8 @@ class PullRequestRef(BaseModel):
     ref: str
     sha: str
     label: str | None = None  # e.g. 'octocat:new-topic'
+    # Null once the head repository is deleted, which GitHub allows while the pull request survives.
+    repo: PullRequestRepo | None = None
 
 
 class PullRequestSimple(BaseModel):

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import pytest
 
+from ddev.cli.ci.dispatch_tests import head_is_fork
 from ddev.utils.github_async import GitHubResponse
 from ddev.utils.github_async.models import PullRequest, PullRequestFile, PullRequestSimple
 from tests.cli.ci.tests.helpers import make_batch, make_job
@@ -21,12 +22,17 @@ def pull_request(
     number: int = PR_NUMBER,
     head_sha: str = HEAD_SHA,
     base_ref: str = 'a-target-branch',
+    head_repo: str | None = 'DataDog/integrations-core',
 ) -> PullRequest:
     return PullRequest(
         number=number,
         html_url=f'https://github.com/DataDog/integrations-core/pull/{number}',
         state=state,
-        head={'ref': 'hs/a-branch', 'sha': head_sha},
+        head={
+            'ref': 'hs/a-branch',
+            'sha': head_sha,
+            'repo': {'full_name': head_repo} if head_repo is not None else None,
+        },
         base={'ref': base_ref, 'sha': 'base-sha-bbb'},
         changed_files=changed_files,
     )
@@ -310,6 +316,25 @@ def test_an_empty_plan_is_not_dispatched(ddev, fake_async_github, local_changes,
     assert result.exit_code == 0, result.output
     assert 'No affected target to test.' in result.output
     fake_async_github.assert_not_called('create_workflow_dispatch')
+
+
+@pytest.mark.parametrize(
+    ('head_repo', 'expected'),
+    [
+        pytest.param('DataDog/integrations-core', False, id='same-repository'),
+        pytest.param('datadog/Integrations-Core', False, id='same-repository-other-casing'),
+        pytest.param('attacker/integrations-core', True, id='fork'),
+        pytest.param('DataDog/integrations-core-evil', True, id='name-that-only-starts-the-same'),
+        pytest.param(None, True, id='deleted-head-repository'),
+    ],
+)
+def test_head_is_fork(head_repo: str | None, expected: bool):
+    """This decides whether the batch is given credentials, so reading a fork as the repository itself
+    hands a fork's code the Datadog key and the Docker credentials.
+    """
+    head = pull_request(head_repo=head_repo).head
+    assert head is not None
+    assert head_is_fork(head, owner='DataDog', repo='integrations-core') is expected
 
 
 def test_pytest_args_are_shown_in_the_plan(ddev, github, planned):

--- a/ddev/tests/cli/ci/tests/batching/test_validation.py
+++ b/ddev/tests/cli/ci/tests/batching/test_validation.py
@@ -100,10 +100,19 @@ def test_validate_allows_oversized_split_when_enabled():
     validate_batches(groups, all_jobs, config=config(allow_integration_splitting=True))  # no raise
 
 
-def test_validate_rejects_a_runner_the_batch_workflow_will_not_schedule_on():
+@pytest.mark.parametrize(
+    "runner_labels",
+    [
+        pytest.param(("self-hosted",), id="outside the allowlist"),
+        pytest.param((), id="no runner at all"),
+        pytest.param(("ubuntu-22.04", "windows-2022"), id="two allowed labels"),
+    ],
+)
+def test_validate_rejects_a_runner_the_batch_workflow_will_not_schedule_on(runner_labels):
     """A `runners` override travels with the tested tree, so a pull request can name any label it
-    likes. Scheduling on one would put unreviewed code on a runner nobody chose for it.
+    likes. `runs-on` with an array is conjunctive, so two labels and none are equally unschedulable
+    and the batch would hang rather than fail.
     """
-    job = make_job("weird", runner_labels=("self-hosted", "gpu"))
-    with pytest.raises(BatchValidationError, match="unknown runners: gpu, self-hosted"):
+    job = make_job("weird", runner_labels=runner_labels)
+    with pytest.raises(BatchValidationError, match="not one known runner"):
         validate_batches([[job]], [job], config=config())

--- a/ddev/tests/cli/ci/tests/batching/test_validation.py
+++ b/ddev/tests/cli/ci/tests/batching/test_validation.py
@@ -98,3 +98,12 @@ def test_validate_allows_oversized_split_when_enabled():
     all_jobs = jobs("huge", 400)
     groups = default_strategy(all_jobs, config=config(allow_integration_splitting=True))
     validate_batches(groups, all_jobs, config=config(allow_integration_splitting=True))  # no raise
+
+
+def test_validate_rejects_a_runner_the_batch_workflow_will_not_schedule_on():
+    """A `runners` override travels with the tested tree, so a pull request can name any label it
+    likes. Scheduling on one would put unreviewed code on a runner nobody chose for it.
+    """
+    job = make_job("weird", runner_labels=("self-hosted", "gpu"))
+    with pytest.raises(BatchValidationError, match="unknown runners: gpu, self-hosted"):
+        validate_batches([[job]], [job], config=config())

--- a/ddev/tests/cli/ci/tests/test_dispatcher.py
+++ b/ddev/tests/cli/ci/tests/test_dispatcher.py
@@ -184,17 +184,18 @@ requires_signals = pytest.mark.skipif(sys.platform == "win32", reason="The Dispa
 def run_cancelled_by_sigint(dispatcher: Dispatcher, client: FakeAsyncGitHubClient) -> None:
     """Run *dispatcher* to completion, signalling it once it has a dispatched run to clean up.
 
-    The signal goes out from inside `create_check_run`, so the run's handlers are already installed
-    and there is something in flight for the cleanup to find.
+    The signal goes out from inside `get_workflow_run`, the first call after a run is recorded in
+    flight, so the run's handlers are already installed and there is something for the cleanup to
+    find.
     """
-    created_check_run = client.create_check_run
+    got_workflow_run = client.get_workflow_run
 
-    async def cancel_once_the_check_run_exists(*args, **kwargs):
-        response = await created_check_run(*args, **kwargs)
+    async def cancel_once_a_run_is_in_flight(*args, **kwargs):
+        response = await got_workflow_run(*args, **kwargs)
         os.kill(os.getpid(), signal.SIGINT)
         return response
 
-    client.create_check_run = cancel_once_the_check_run_exists  # type: ignore[method-assign]
+    client.get_workflow_run = cancel_once_a_run_is_in_flight  # type: ignore[method-assign]
 
     try:
         dispatcher.run()
@@ -237,8 +238,6 @@ def test_a_cancelled_run_reports_itself_and_stops_the_work_it_started(client, tm
     # The initial plan already created the comment, so the cancelled report edits that one.
     assert CANCELLED_HEADING in client.last_call("update_issue_comment").kwargs["body"]
     assert [call.kwargs["run_id"] for call in client.calls_to("cancel_workflow_run")] == [123]
-    # Each batch closes its own check run on the way out, so the cleanup does not repeat it.
-    assert client.last_call("update_check_run").kwargs["conclusion"] == "cancelled"
     # The run page is rendered from the same report, so it cannot claim the run is still going.
     assert CANCELLED_HEADING.removeprefix("## ") in step_summary.read_text(encoding="utf-8")
 

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -9,6 +9,7 @@ import asyncio
 import base64
 import gzip
 import json
+import re
 import secrets
 from pathlib import Path
 from typing import Any
@@ -704,3 +705,17 @@ async def test_a_run_still_going_when_the_batch_is_cancelled_is_cancelled_too(tm
     await runner.cancel_dispatched_runs()
 
     assert [call.kwargs["run_id"] for call in client.calls_to("cancel_workflow_run")] == [123]
+
+
+def test_a_dispatched_job_carries_exactly_the_keys_the_workflow_accepts():
+    """`test-batch.yml` fails a batch whose jobs do not carry exactly these keys, so a new `BatchJob`
+    field that is not added there stops every batch in `setup` rather than reaching a runner.
+
+    The key list is read out of the workflow so the two cannot drift apart silently.
+    """
+    workflow = Path(__file__).parents[5] / ".github" / "workflows" / "test-batch.yml"
+    block = re.search(r"# matrix-keys-begin\n(.*?)# matrix-keys-end", workflow.read_text(encoding="utf-8"), re.DOTALL)
+    assert block is not None, "the key list markers are gone from test-batch.yml"
+    expected = set(re.findall(r'"([a-z0-9_]+)"', block.group(1)))
+
+    assert set(TaskTestRunner._job_input(make_job())) == expected

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -16,7 +16,7 @@ from typing import Any
 import pytest
 
 from ddev.cli.ci.tests.messages import BatchFinished, BatchJob, TestBatch
-from ddev.cli.ci.tests.status import Status, conclusion_to_check_run_conclusion, conclusion_to_status
+from ddev.cli.ci.tests.status import Status, conclusion_to_status
 from ddev.cli.ci.tests.task_test_runner import (
     CANCEL_REQUEST_TIMEOUT,
     WORKFLOW_INPUTS_LIMIT,
@@ -25,14 +25,7 @@ from ddev.cli.ci.tests.task_test_runner import (
     TestRunnerOptions,
 )
 from ddev.utils.github_async import GitHubResponse
-from ddev.utils.github_async.models import (
-    Artifact,
-    ArtifactsList,
-    CheckRunConclusion,
-    WorkflowJob,
-    WorkflowJobsList,
-    WorkflowRun,
-)
+from ddev.utils.github_async.models import Artifact, ArtifactsList, WorkflowJob, WorkflowJobsList, WorkflowRun
 from tests.cli.ci.tests.helpers import RecordingBus, drain_queue, make_job
 from tests.helpers.github_async import FakeAsyncGitHubClient
 
@@ -175,24 +168,6 @@ def test_conclusion_to_status(conclusion: str | None, expected: Status):
     assert isinstance(result, Status)
 
 
-@pytest.mark.parametrize(
-    ("conclusion", "expected"),
-    [
-        ("success", CheckRunConclusion.SUCCESS),
-        ("timed_out", CheckRunConclusion.TIMED_OUT),
-        (None, CheckRunConclusion.NEUTRAL),
-        ("startup_failure", CheckRunConclusion.FAILURE),
-    ],
-)
-def test_conclusion_to_check_run_conclusion(conclusion: str | None, expected: CheckRunConclusion):
-    """A workflow run's conclusion is a free-form string, a check run's is a closed set of eight.
-
-    `startup_failure` is a real workflow conclusion with no check-run member, so passing it through
-    would have GitHub reject the request that closes the check run.
-    """
-    assert conclusion_to_check_run_conclusion(conclusion) is expected
-
-
 # ---------------------------------------------------------------------------
 # process_message — happy path (one concern per test)
 # ---------------------------------------------------------------------------
@@ -286,20 +261,6 @@ async def test_a_batch_too_large_to_dispatch_is_refused_before_dispatching(tmp_p
         await runner.process_message(batch)
 
     fake.assert_not_called("create_workflow_dispatch")
-    fake.assert_not_called("create_check_run")
-
-
-@pytest.mark.asyncio
-async def test_opens_check_run_with_head_sha_and_details_url(tmp_path: Path):
-    fake, _ = await run_happy_path(tmp_path)
-
-    create_calls = fake.calls_to("create_check_run")
-    assert len(create_calls) == 1
-    cr = create_calls[0].kwargs
-    assert cr["head_sha"] == "base-sha-aaa"
-    assert cr["status"] == "in_progress"
-    assert cr["name"] == "test-batch/batch-1"
-    assert cr["details_url"] == "https://github.com/o/r/actions/runs/123"
 
 
 @pytest.mark.asyncio
@@ -351,8 +312,8 @@ async def test_batch_finished_records_unmatched_correlation_when_no_match(tmp_pa
 
 @pytest.mark.asyncio
 async def test_uses_batch_id_not_message_id_for_correlation(tmp_path: Path):
-    # The logical batch identity comes from batch_id; the message id is a separate identity and
-    # must not be used for the check-run name, the workflow inputs, or the emitted BatchFinished.
+    # The logical batch identity comes from batch_id; the message id is a separate identity and must
+    # not be used for the workflow inputs or the emitted BatchFinished.
     fake = FakeAsyncGitHubClient()
     fake.mock_response("get_workflow_run", make_workflow_run("completed", "success"))
     mock_artifacts(fake, [])
@@ -361,25 +322,12 @@ async def test_uses_batch_id_not_message_id_for_correlation(tmp_path: Path):
     batch = TestBatch(id="msg-uuid-xyz", batch_id="batch-07", job_list=[make_job()], jobs_count=1, integrations=["ntp"])
     await runner.process_message(batch)
 
-    assert fake.calls_to("create_check_run")[0].kwargs["name"] == "test-batch/batch-07"
     assert fake.calls_to("create_workflow_dispatch")[0].kwargs["inputs"]["batch_id"] == "batch-07"
 
     finished = drain_queue(runner.bus.queue)[0]
     assert isinstance(finished, BatchFinished)
     assert finished.id == "msg-uuid-xyz"
     assert finished.batch_id == "batch-07"
-
-
-@pytest.mark.asyncio
-async def test_closes_check_run_with_workflow_conclusion(tmp_path: Path):
-    fake, _ = await run_happy_path(tmp_path)
-
-    update_calls = fake.calls_to("update_check_run")
-    assert len(update_calls) == 1
-    upd = update_calls[0].kwargs
-    assert upd["check_run_id"] == 999
-    assert upd["status"] == "completed"
-    assert upd["conclusion"] == "success"
 
 
 # ---------------------------------------------------------------------------
@@ -504,11 +452,6 @@ async def test_process_message_failure_path(tmp_path: Path):
     assert isinstance(finished, BatchFinished)
     assert finished.status == "failure"
 
-    update_calls = fake.calls_to("update_check_run")
-    assert len(update_calls) == 1
-    assert update_calls[0].kwargs["status"] == "completed"
-    assert update_calls[0].kwargs["conclusion"] == "failure"
-
 
 @pytest.mark.asyncio
 async def test_process_message_skipped_conclusion(tmp_path: Path):
@@ -519,16 +462,11 @@ async def test_process_message_skipped_conclusion(tmp_path: Path):
 
     await runner.process_message(make_batch())
 
-    # A "skipped" GitHub conclusion maps to a "skipped" BatchFinished and a "skipped" check run.
     submitted = drain_queue(runner.bus.queue)
     assert len(submitted) == 1
     finished = submitted[0]
     assert isinstance(finished, BatchFinished)
     assert finished.status == "skipped"
-
-    update_calls = fake.calls_to("update_check_run")
-    assert len(update_calls) == 1
-    assert update_calls[0].kwargs["conclusion"] == "skipped"
 
 
 @pytest.mark.asyncio
@@ -591,10 +529,6 @@ async def test_process_message_null_conclusion(tmp_path: Path):
     assert isinstance(finished, BatchFinished)
     assert finished.status == "failure"
 
-    update_calls = fake.calls_to("update_check_run")
-    assert len(update_calls) == 1
-    assert update_calls[0].kwargs["conclusion"] == "neutral"
-
 
 @pytest.mark.asyncio
 async def test_process_message_emits_batch_finished_when_listing_artifacts_fails(tmp_path: Path):
@@ -603,37 +537,15 @@ async def test_process_message_emits_batch_finished_when_listing_artifacts_fails
     fake.mock_response("list_workflow_run_artifacts", RuntimeError("boom-list-artifacts"))
     runner = make_runner(fake, tmp_path)
 
-    # A failure listing artifacts must not abort the batch: the check run is still closed
-    # and exactly one BatchFinished is emitted with the workflow's real conclusion.
+    # A failure listing artifacts must not abort the batch: exactly one BatchFinished is still
+    # emitted, with the workflow's real conclusion.
     await runner.process_message(make_batch())
-
-    update_calls = fake.calls_to("update_check_run")
-    assert len(update_calls) == 1
-    assert update_calls[0].kwargs["conclusion"] == "success"
 
     submitted = drain_queue(runner.bus.queue)
     assert len(submitted) == 1
     finished = submitted[0]
     assert isinstance(finished, BatchFinished)
     assert finished.status == "success"
-
-
-@pytest.mark.asyncio
-async def test_process_message_swallows_check_run_close_failure(tmp_path: Path):
-    fake = FakeAsyncGitHubClient()
-    fake.mock_response("get_workflow_run", make_workflow_run("completed", "success"))
-    mock_artifacts(fake, [make_artifact(1)])
-    fake.mock_response("update_check_run", RuntimeError("boom-close"))
-    runner = make_runner(fake, tmp_path)
-
-    # A failure closing the check run must not propagate or suppress the BatchFinished.
-    await runner.process_message(make_batch())
-
-    assert len(fake.calls_to("update_check_run")) == 1
-    submitted = drain_queue(runner.bus.queue)
-    assert len(submitted) == 1
-    assert isinstance(submitted[0], BatchFinished)
-    assert submitted[0].status == "success"
 
 
 @pytest.mark.asyncio
@@ -661,92 +573,44 @@ async def test_download_failure_for_one_artifact_does_not_abort_others(tmp_path:
     assert len(submitted) == 1
     assert isinstance(submitted[0], BatchFinished)
     assert submitted[0].status == "success"
-    assert fake.calls_to("update_check_run")[0].kwargs["conclusion"] == "success"
 
 
 # ---------------------------------------------------------------------------
-# Error paths — try/finally always closes the check run that was opened
+# Error paths
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("failure_point", ["create_workflow_dispatch", "get_workflow_run_initial"])
+@pytest.mark.parametrize("failure_point", ["create_workflow_dispatch", "get_workflow_run"])
 @pytest.mark.asyncio
-async def test_failure_before_check_run_opens_does_not_create_check_run(tmp_path: Path, failure_point: str):
-    boom = RuntimeError(f"boom-{failure_point}")
+async def test_a_batch_that_failed_before_finishing_emits_nothing(tmp_path: Path, failure_point: str):
+    """A half-run batch must not reach the gatherer: a `BatchFinished` here would report jobs that
+    never ran as absent results.
+    """
     fake = FakeAsyncGitHubClient()
-    if failure_point == "create_workflow_dispatch":
-        fake.mock_response("create_workflow_dispatch", boom)
-    else:
-        fake.mock_response("get_workflow_run", boom)
+    fake.mock_response(failure_point, RuntimeError(f"boom-{failure_point}"))
     runner = make_runner(fake, tmp_path)
 
     with pytest.raises(RuntimeError, match=f"boom-{failure_point}"):
         await runner.process_message(make_batch())
 
-    # The check run is never opened, so there is nothing to close.
-    fake.assert_not_called("create_check_run")
-    fake.assert_not_called("update_check_run")
+    assert drain_queue(runner.bus.queue) == []
 
 
 @pytest.mark.asyncio
-async def test_failure_mid_poll_closes_check_run_as_cancelled(tmp_path: Path):
-    boom = RuntimeError("boom-mid-poll")
+async def test_a_batch_that_failed_mid_poll_stays_cancellable(tmp_path: Path):
+    """The run is still going when the poll dies, so it has to stay in flight: dropping it here
+    leaves a few hundred jobs burning runner minutes with nothing left to reap them.
+    """
     fake = FakeAsyncGitHubClient()
-    # Initial get succeeds (still running), the first poll raises.
     fake.mock_response("get_workflow_run", make_workflow_run("queued"), once=True)
-    fake.mock_response("get_workflow_run", boom, once=True)
+    fake.mock_response("get_workflow_run", RuntimeError("boom-mid-poll"), once=True)
     runner = make_runner(fake, tmp_path)
 
     with pytest.raises(RuntimeError, match="boom-mid-poll"):
         await runner.process_message(make_batch())
 
-    # The check run was opened and the finally closed it as cancelled.
-    assert len(fake.calls_to("create_check_run")) == 1
-    update_calls = fake.calls_to("update_check_run")
-    assert len(update_calls) == 1
-    assert update_calls[0].kwargs["status"] == "completed"
-    assert update_calls[0].kwargs["conclusion"] == "cancelled"
-
-
-@pytest.mark.asyncio
-async def test_failure_at_create_check_run_does_not_close_check_run(tmp_path: Path):
-    boom = RuntimeError("boom-create-check-run")
-    fake = FakeAsyncGitHubClient()
-    fake.mock_response("get_workflow_run", make_workflow_run("completed", "success"))
-    fake.mock_response("create_check_run", boom)
-    runner = make_runner(fake, tmp_path)
-
-    with pytest.raises(RuntimeError, match="boom-create-check-run"):
-        await runner.process_message(make_batch())
-
-    # The open was attempted but failed before the try/finally, so there is no check run to close.
-    assert len(fake.calls_to("create_check_run")) == 1
-    fake.assert_not_called("update_check_run")
-
-
-@pytest.mark.asyncio
-async def test_failure_at_submit_message_closes_check_run_as_success(tmp_path: Path):
-    boom = RuntimeError("boom-submit-message")
-    fake = FakeAsyncGitHubClient()
-    fake.mock_response("get_workflow_run", make_workflow_run("completed", "success"))
-    mock_artifacts(fake, [make_artifact(1)])
-    runner = make_runner(fake, tmp_path)
-
-    class _BoomBus:
-        def submit_message(self, _: Any):
-            raise boom
-
-    runner.bus = _BoomBus()  # type: ignore[assignment]
-
-    with pytest.raises(RuntimeError, match="boom-submit-message"):
-        await runner.process_message(make_batch())
-
-    # Workflow completed cleanly; the finally closed the check run as success before submit raised.
-    assert len(fake.calls_to("create_check_run")) == 1
-    update_calls = fake.calls_to("update_check_run")
-    assert len(update_calls) == 1
-    assert update_calls[0].kwargs["status"] == "completed"
-    assert update_calls[0].kwargs["conclusion"] == "success"
+    await runner.cancel_dispatched_runs()
+    assert [call.kwargs["run_id"] for call in fake.calls_to("cancel_workflow_run")] == [123]
 
 
 async def test_a_run_that_finished_on_its_own_is_not_cancelled(tmp_path: Path):
@@ -781,8 +645,10 @@ async def test_cancelling_a_run_does_not_wait_out_the_clients_default_timeout(tm
     runner.bus = RecordingBus()  # type: ignore[assignment]
 
     task = asyncio.create_task(runner.process_message(make_batch(batch_id="batch-1")))
+    # `get_workflow_run` is the first call after the run is recorded in flight, so it is the point
+    # from which there is something for the cleanup to cancel.
     async with asyncio.timeout(5):
-        while not client.calls_to("create_check_run"):
+        while not client.calls_to("get_workflow_run"):
             await asyncio.sleep(0)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -796,8 +662,8 @@ async def test_cancelling_a_run_does_not_wait_out_the_clients_default_timeout(tm
 async def test_a_run_still_going_when_the_batch_is_cancelled_is_cancelled_too(tmp_path: Path):
     """A dispatched run outlives the process that asked for it and keeps burning runner minutes.
 
-    The batch's own `finally` runs when its task is cancelled, so anything cleared there would be gone
-    before the cleanup looked, which is exactly when there is something to cancel.
+    The run is dropped from the in-flight set only once it is known to have finished, so a batch
+    cancelled mid-flight is still there for the cleanup to find.
     """
     client = FakeAsyncGitHubClient()
     client.mock_response("get_workflow_run", wrap(make_workflow_run(status="in_progress", conclusion=None)))
@@ -806,10 +672,10 @@ async def test_a_run_still_going_when_the_batch_is_cancelled_is_cancelled_too(tm
 
     task = asyncio.create_task(runner.process_message(make_batch(batch_id="batch-1")))
     await asyncio.sleep(0)
-    # Bounded, so a regression that never creates the check run fails here instead of spinning until
-    # the CI job's own timeout, which reports nothing useful.
+    # Bounded, so a regression that never reaches the in-flight state fails here instead of spinning
+    # until the CI job's own timeout, which reports nothing useful.
     async with asyncio.timeout(5):
-        while not client.calls_to("create_check_run"):
+        while not client.calls_to("get_workflow_run"):
             await asyncio.sleep(0)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -9,7 +9,6 @@ import asyncio
 import base64
 import gzip
 import json
-import re
 import secrets
 from pathlib import Path
 from typing import Any
@@ -705,17 +704,3 @@ async def test_a_run_still_going_when_the_batch_is_cancelled_is_cancelled_too(tm
     await runner.cancel_dispatched_runs()
 
     assert [call.kwargs["run_id"] for call in client.calls_to("cancel_workflow_run")] == [123]
-
-
-def test_a_dispatched_job_carries_exactly_the_keys_the_workflow_accepts():
-    """`test-batch.yml` fails a batch whose jobs do not carry exactly these keys, so a new `BatchJob`
-    field that is not added there stops every batch in `setup` rather than reaching a runner.
-
-    The key list is read out of the workflow so the two cannot drift apart silently.
-    """
-    workflow = Path(__file__).parents[5] / ".github" / "workflows" / "test-batch.yml"
-    block = re.search(r"# matrix-keys-begin\n(.*?)# matrix-keys-end", workflow.read_text(encoding="utf-8"), re.DOTALL)
-    assert block is not None, "the key list markers are gone from test-batch.yml"
-    expected = set(re.findall(r'"([a-z0-9_]+)"', block.group(1)))
-
-    assert set(TaskTestRunner._job_input(make_job())) == expected

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -89,7 +89,9 @@ def mock_jobs(fake: FakeAsyncGitHubClient, jobs: list[WorkflowJob]):
     fake.mock_response("list_workflow_jobs", wrap(WorkflowJobsList(total_count=len(jobs), jobs=list(jobs))))
 
 
-def make_runner(client: FakeAsyncGitHubClient, tmp_path: Path, pytest_args: str = "") -> TaskTestRunner:
+def make_runner(
+    client: FakeAsyncGitHubClient, tmp_path: Path, pytest_args: str = "", is_fork: bool = False
+) -> TaskTestRunner:
     options = TestRunnerOptions(
         owner="DataDog",
         repo="integrations-core",
@@ -100,6 +102,7 @@ def make_runner(client: FakeAsyncGitHubClient, tmp_path: Path, pytest_args: str 
         artifacts_base_path=tmp_path,
         poll_interval_seconds=0.0,
         pytest_args=pytest_args,
+        is_fork=is_fork,
     )
     runner = TaskTestRunner(
         name="task-test-runner",
@@ -242,6 +245,23 @@ async def test_pytest_args_reach_the_batch_workflow(tmp_path: Path, pytest_args:
 
     inputs = fake.calls_to("create_workflow_dispatch")[0].kwargs["inputs"]
     assert inputs.get("pytest_args") == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("is_fork", "expected"), [(True, "true"), (False, "false")])
+async def test_the_batch_is_told_whether_it_is_testing_a_fork(tmp_path: Path, is_fork: bool, expected: str):
+    """The batch withholds every credential on this input, so a fork dispatched without it hands a
+    fork's code the Datadog key and the Docker credentials. Sent either way, because an absent input
+    leaves the workflow on its own default of trusting the commit.
+    """
+    fake = FakeAsyncGitHubClient()
+    fake.mock_response("get_workflow_run", make_workflow_run("completed", "success"))
+    mock_artifacts(fake, [])
+    runner = make_runner(fake, tmp_path, is_fork=is_fork)
+
+    await runner.process_message(make_batch("batch-1"))
+
+    assert fake.calls_to("create_workflow_dispatch")[0].kwargs["inputs"]["is_fork"] == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What does this PR do?

Adds `.github/workflows/test-batch.yml`, the workflow `ddev ci dispatch-tests` dispatches once per batch, and `.github/actions/run-test-job`, the action it calls once per job. The batch also owns its check run now: `setup` opens it, `teardown` closes it, which moves that responsibility out of the Dispatcher.

Four jobs. `setup` decodes the job list into a matrix and opens the check run. `test` and `test_fork` are twins that run the same steps with different privilege, selected on `is_fork`. `teardown` closes the check run on whichever twin ran.

It is its own workflow, not a caller of `test-target.yml`, but it is not a copy of it either: the test recipe lives in `.github/actions/setup-test-target-scripts`, and this workflow drives the same four scripts (`setup-test-env.sh`, `run-unit-integration-tests.sh`, `run-e2e-tests.sh`, `ensure-docker.sh`). `test-target.yml` stays as it is, reusable per target and consumed by integrations-extras and marketplace.

Two parts of the contract belong to the Dispatcher and are read straight off the matrix, so this workflow never reconstructs either:

| What | Where it comes from | Consumed by |
| --- | --- | --- |
| `matrix.name` | `BatchJob.name` | `BatchJobResult.correlate`, exact-match join on job name |
| `matrix.artifact_name` | `BatchJob.artifact_name()`, put on the matrix by `_job_input` | the runner's artifact-name to path map |

Both are fixed when the batch is planned, so what a job will be called and what its artifact will be called are known at dispatch time:

```
matrix.name matrix.artifact_name
j-ntp      ntp_py3.13_linux
j-pg       postgres_py3.13-17.0-C_linux
j-mbp      minimum-base-package-disk_py3.13_linux

Same plan encoded twice is byte-identical: True
artifact_name recomputed from the job matches the matrix: True
```

Scope follows what a `BatchJob` can express, so Python 2, `latest`, benchmarks, `setup-env-vars` and non-core repositories are absent rather than stubbed. `setup-test-env.sh` runs under `set -euo pipefail` and dereferences 23 variables without defaults, so all of them are passed, including the two Python 2 agent images it reads unconditionally.

### Security

The Dispatcher runs from `test-dispatch.yml` in master context, and the OIDC policy issues the dispatch credential only to a master-context run, so a batch's inputs are always produced by master's ddev. What a pull request influences is plan content, since the planner reads `.ddev/config.toml` and each target's `hatch.toml` from the tree it is given, and `validate_batches` bounds that by restricting `runner_labels` to the runners the planner can emit. Fork code is kept away from anything worth taking by the job split: `test_fork` holds no `id-token` and is passed no credential, because `permissions` takes no expression and a reusable workflow would rename the jobs and break the exact-name join.

Adding a hosted image to a `runners` override in `.ddev/config.toml` fails every batch until `ALLOWED_RUNNER_LABELS` in `batching/units.py` lists it too. That coupling is the point, but it is not obvious from the override site.

One note for OIDC trust policies: tokens minted on the trusted path carry `ref: refs/heads/master`, so a policy for this repository keyed on `ref` alone must also key on the workflow name.

### Motivation

AI-7128. The Dispatcher currently dispatches `zz-test-batch-poc.yml`, which writes placeholder reports and runs no tests. This is the workflow that actually runs them.

The POC was not wasted: it validated on real runs the three constructs this depends on. From run [33622636661](https://github.com/DataDog/integrations-core/actions/runs/33622636661):

```
expand                     [success]  runner=ubuntu-22.04
Disk on Windows (py3.13)   [success]  runner=windows-2022
Disk on Linux (py3.13)     [success]  runner=ubuntu-22.04

artifacts: disk_py3.13_windows, disk_py3.13_linux
```

That is `runs-on: ${{ matrix.runner_labels }}` resolving a JSON array to a real label, `strategy.matrix.include` from `fromJson`, job names coming out as bare `matrix.name` with no caller prefix, and artifacts landing on `matrix.artifact_name`.

On `context`: it is an input defaulting to `standard` rather than hardcoded, because `run-e2e-tests.sh` reads `INPUT_CONTEXT` to pick the E2E flags (`test-agent*` selects `--new-env`), so it is behaviour and not only a CI Visibility tag. The Dispatcher does not send it yet; [#25095](https://github.com/DataDog/integrations-core/pull/25095) replaced `--context` with `--tags` and tags do not reach a batch.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
