### PR TITLE
Make agent-integrations the owner of .github/actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -834,6 +834,7 @@ plaid/assets/logs/                                                  @DataDog/saa
 /datadog_checks_downloader/                                           @DataDog/agent-integrations
 docs/developer/process/integration-release.md                         @DataDog/agent-integrations
 # As well as the pipelines.
+/.github/actions/                                                     @DataDog/agent-integrations
 /.github/chainguard/                                                  @DataDog/agent-integrations
 /.github/chainguard/agentrelease-worker.*                             @DataDog/agent-delivery
 /.github/workflows/                                                   @DataDog/agent-integrations


### PR DESCRIPTION
### What does this PR do?

Adds `/.github/actions/` to CODEOWNERS, owned by `@DataDog/agent-integrations`.

The directory had no entry at all, so the composite actions in it were unowned and a PR touching only those files got no review request. `/.github/workflows/` is already owned by the same team, so this just makes the two match.

### Motivation

Came up while adding `.github/actions/run-test-job` in [#25115](https://github.com/DataDog/integrations-core/pull/25115), which lands a new action in an unowned directory.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged