### PR TITLE
AI-7129 Grant the Dispatcher POC statuses:write in place of checks:write

### DIFF
--- a/.github/chainguard/self.dispatch-poc.pull-request.sts.yaml
+++ b/.github/chainguard/self.dispatch-poc.pull-request.sts.yaml
@@ -21,9 +21,15 @@
 #
 # Permissions granted:
 #   - actions: write       - Dispatch the batch workflow, then read its runs, jobs, and artifacts.
-#   - checks: write        - One check run per batch, opened before the dispatch and closed after.
+#   - statuses: write      - The run's aggregate result, one per run whatever the batch count.
 #   - pull_requests: write - The run's summary comment.
 #   - contents: read       - Check out the repository and read the pull request's diff.
+#
+# `checks: write` is deliberately absent. Each batch opens and closes its own check run from within
+# `test-batch.yml`, on that workflow's own token, so the Dispatcher writes no check run at all. The
+# aggregate is a commit status rather than a check run because a check run's `details_url` is
+# overwritten when it is created from inside a workflow, which leaves `Details` pointing at a page
+# that only says the check started.
 #
 # Usage in workflows:
 #   - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
@@ -42,6 +48,6 @@ claim_pattern:
 
 permissions:
   actions: write
-  checks: write
+  statuses: write
   pull_requests: write
   contents: read


### PR DESCRIPTION
### What does this PR do?

Swaps `checks: write` for `statuses: write` on `self.dispatch-poc.pull-request`, the octo-sts policy the Dispatcher POC uses.

| Permission | Before | After | Why |
| --- | --- | --- | --- |
| `actions: write` | ✅ | ✅ | Dispatch the batch workflow, then read its runs, jobs and artifacts |
| `checks: write` | ✅ | ❌ | Each batch opens and closes its own check run inside `test-batch.yml`, on that workflow's own token. The Dispatcher writes none |
| `statuses: write` | ❌ | ✅ | The run's aggregate result |
| `pull_requests: write` | ✅ | ✅ | The run's summary comment |
| `contents: read` | ✅ | ✅ | Checkout and the pull request's diff |

### Motivation

Two things changed under the policy since it was written in [#25113](https://github.com/DataDog/integrations-core/pull/25113).

**The Dispatcher stopped writing check runs.** [#25115](https://github.com/DataDog/integrations-core/pull/25115) moved the per-batch check into `test-batch.yml`'s own `setup`/`teardown` jobs, so `checks: write` grants something the Dispatcher no longer does.

**The aggregate is a commit status, not a check run.** A check run's `details_url` is overwritten when the run is created from inside a workflow, so `Details` landed on the check's own page, which says only that the check started. Observed on the POC's own commit:

```
name=test-batch/batch-01
  details_url=https://github.com/DataDog/integrations-core/runs/101043429428
  html_url   =https://github.com/DataDog/integrations-core/runs/101043429428
```

The run URL passed to the API is gone; GitHub replaced it with the check's page. This is reported upstream in [checks-action#18](https://github.com/LouisBrunner/checks-action/issues/18) and [#21](https://github.com/LouisBrunner/checks-action/issues/21), noting it happens specifically when the check run is created in the context of a GitHub workflow.

A commit status's `target_url` is honoured, which the POC confirms:

```
zz-dispatch-poc/tests  state=pending  desc=Planning and dispatching batches
  target_url=https://github.com/DataDog/integrations-core/actions/runs/33879753245
```

`Details` on that lands on the dispatcher run in one click.

The status is also what can eventually be required, which is the point of having it: one per run whatever the batch count. A batch's own check cannot be required, because `batch-03` only exists on a diff large enough to plan three, and a required check that never reports leaves a small pull request blocked forever.

The POC currently posts the status on the ambient `GITHUB_TOKEN` because the policy does not grant `statuses: write`. Once this merges it moves onto the octo-sts token, so the credential exchange covers everything the run does.

The production `test-dispatch` policy, written in AI-7129 proper, takes the same shape.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
