### PR TITLE
AI-7128 Report a batch as a commit status rather than a check run

### DIFF
--- a/.github/workflows/test-batch.yml
+++ b/.github/workflows/test-batch.yml
@@ -135,17 +135,8 @@ jobs:
             echo "- targets: $(python3 -c 'import json,os; print(", ".join(json.loads(os.environ["INTEGRATIONS"])) or "-")')"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # A commit status rather than a check run. A check run has to live in a check suite, and a suite
-      # is keyed on (app, head_sha): this workflow is dispatched at the default branch, so reporting
-      # on the tested commit means GitHub files the check into whichever `github-actions` suite
-      # already exists at that SHA. The batch then appears under an unrelated workflow, and its
-      # `Details` leads there rather than here.
-      #
-      # Statuses are not in suites, so nothing adopts them, and `target_url` is honoured.
-      #
-      # An octo-sts token would also give the check its own suite, but a policy naming this workflow
-      # is reachable from `test`, which runs the tested commit's code and holds `id-token: write` for
-      # `dd-sts`. That code would then be one exchange away from a token this repository trusts.
+      # A status, not a check run: a check run at a SHA this workflow was not dispatched at gets filed
+      # under whichever workflow already has a check suite there.
       - name: Mark the batch pending
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -418,9 +409,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          # A status has only error/failure/pending/success. Anything that did not pass reports
-          # `failure`, described by what actually happened, because leaving it `pending` would hold
-          # the pull request on a batch that is already over.
+          # A status has no `cancelled` or `skipped`, and `pending` would hold the pull request.
           case "$TEST_RESULT" in
             success)   state=success; description="All jobs passed" ;;
             cancelled) state=failure; description="The batch was cancelled" ;;

--- a/.github/workflows/test-batch.yml
+++ b/.github/workflows/test-batch.yml
@@ -1,10 +1,10 @@
 # Runs one Dispatcher batch: the set of test jobs `ddev ci dispatch-tests` planned and sent here as a
 # single workflow input.
 #
-# The batch owns its own check run, opened in `setup` and closed in `teardown`. That is deliberately
+# The batch reports its own result, posted in `setup` and settled in `teardown`. That is deliberately
 # not the Dispatcher's job: a step guarded by `if: always()` gets GitHub's server-side cancellation
 # window, whereas the Dispatcher process is signalled and then killed, so a cancelled run would leave
-# a check open forever if the Dispatcher were the one closing it.
+# the result pending forever if the Dispatcher were the one settling it.
 #
 # Test execution lives in `.github/actions/run-test-job`, which this workflow calls once per job. The
 # workflow decides where a job runs and what it may touch; the action decides what gets tested.
@@ -96,10 +96,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     permissions:
-      checks: write
+      statuses: write
     outputs:
       matrix: ${{ steps.decode.outputs.matrix }}
-      check_run_id: ${{ steps.check.outputs.id }}
     steps:
       - name: Decode the job list
         id: decode
@@ -122,6 +121,7 @@ jobs:
           fi
 
           {
+            echo "count=${count}"
             echo "matrix<<__MATRIX__"
             cat jobs.json
             echo
@@ -135,22 +135,32 @@ jobs:
             echo "- targets: $(python3 -c 'import json,os; print(", ".join(json.loads(os.environ["INTEGRATIONS"])) or "-")')"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Open the batch's check run
-        id: check
+      # A commit status rather than a check run. A check run has to live in a check suite, and a suite
+      # is keyed on (app, head_sha): this workflow is dispatched at the default branch, so reporting
+      # on the tested commit means GitHub files the check into whichever `github-actions` suite
+      # already exists at that SHA. The batch then appears under an unrelated workflow, and its
+      # `Details` leads there rather than here.
+      #
+      # Statuses are not in suites, so nothing adopts them, and `target_url` is honoured.
+      #
+      # An octo-sts token would also give the check its own suite, but a policy naming this workflow
+      # is reachable from `test`, which runs the tested commit's code and holds `id-token: write` for
+      # `dd-sts`. That code would then be one exchange away from a token this repository trusts.
+      - name: Mark the batch pending
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BATCH_ID: ${{ inputs.batch_id }}
           HEAD_SHA: ${{ inputs.head_sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          JOB_COUNT: ${{ steps.decode.outputs.count }}
         run: |
           set -euo pipefail
-          id=$(gh api "repos/${GITHUB_REPOSITORY}/check-runs" \
-            -f "name=test-batch/${BATCH_ID}" \
-            -f "head_sha=${HEAD_SHA}" \
-            -f "status=in_progress" \
-            -f "details_url=${RUN_URL}" \
-            --jq '.id')
-          echo "id=${id}" >> "$GITHUB_OUTPUT"
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f "context=test-batch/${BATCH_ID}" \
+            -f "state=pending" \
+            -f "description=Running ${JOB_COUNT} job(s)" \
+            -f "target_url=${RUN_URL}" \
+            --jq '"posted \(.context) as \(.state)"'
 
   # Twin of `test_fork`, which runs the same steps with no OIDC and no credentials. `permissions`
   # takes no expression, so the gate has to be two jobs, and a reusable workflow would rename them to
@@ -394,28 +404,33 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     permissions:
-      checks: write
+      statuses: write
     steps:
       # From the test job's result rather than this job's status, so a cancelled or skipped batch
-      # closes as what it was instead of as a success. The twin that did not run reports `skipped`,
+      # settles as what it was instead of as a success. The twin that did not run reports `skipped`,
       # so which one to read is selected on the value that chose it.
-      - name: Close the batch's check run
+      - name: Settle the batch's result
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CHECK_RUN_ID: ${{ needs.setup.outputs.check_run_id }}
+          BATCH_ID: ${{ inputs.batch_id }}
+          HEAD_SHA: ${{ inputs.head_sha }}
           TEST_RESULT: ${{ inputs.is_fork == 'true' && needs.test_fork.result || needs.test.result }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
+          # A status has only error/failure/pending/success. Anything that did not pass reports
+          # `failure`, described by what actually happened, because leaving it `pending` would hold
+          # the pull request on a batch that is already over.
           case "$TEST_RESULT" in
-            success)   conclusion=success ;;
-            cancelled) conclusion=cancelled ;;
-            skipped)   conclusion=skipped ;;
-            *)         conclusion=failure ;;
+            success)   state=success; description="All jobs passed" ;;
+            cancelled) state=failure; description="The batch was cancelled" ;;
+            skipped)   state=failure; description="The batch did not run" ;;
+            *)         state=failure; description="A job failed" ;;
           esac
 
-          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/check-runs/${CHECK_RUN_ID}" \
-            -f "status=completed" \
-            -f "conclusion=${conclusion}" \
-            -f "details_url=${RUN_URL}" \
-            --jq '.conclusion'
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f "context=test-batch/${BATCH_ID}" \
+            -f "state=${state}" \
+            -f "description=${description}" \
+            -f "target_url=${RUN_URL}" \
+            --jq '"settled \(.context) as \(.state)"'


### PR DESCRIPTION
### What does this PR do?

Makes a batch report itself as a commit status instead of a check run. `setup` posts `test-batch/<batch_id>` as `pending`, `teardown` settles it from `needs.test.result`. `checks: write` becomes `statuses: write` on both jobs.

### Motivation

The batch's check run was showing up under an unrelated workflow:

```
Resolve Dependencies and Build Wheels / test-batch/batch-01 (push)   Failing after 54s
```

A check run has to live in a check suite, and a suite is keyed on (app, `head_sha`). This workflow is dispatched at the default branch but reports on the tested commit, so the two differ, and GitHub filed the check into whichever `github-actions` suite already existed at that SHA:

```
suite 91815529136 = "Resolve Dependencies and Build Wheels", event=push, head_sha=1c98ce7984
  Check content hashes              [success]
  Run tests                         [skipped]
  Pre-resolve dependency versions   [skipped]
  Publish artifacts and commit...   [skipped]
  test-batch/batch-01               [failure]   <- ours, adopted

Test Batch  run 33878680404  event=workflow_dispatch  head_sha=51b95335f7  suite 91814349851
```

The `(push)` in the title is the adopting suite's event. `Details` on that entry led into that workflow, not to the batch.

Statuses are not in suites, so nothing can adopt them, and `target_url` is honoured rather than replaced, so `Details` lands on the run that holds the jobs.

### Why not give the check its own suite with an octo-sts token

That also fixes the grouping, and it was the first option considered. It is rejected because a trust policy naming `test-batch.yml` is reachable from the `test` job, which runs the tested commit's code and already holds `id-token: write` for `dd-sts`. That code would then be one exchange away from a token this repository trusts. Losing the in-flight spinner is the cheaper trade.

### What changes for a reader

A batch entry is a status rather than a check, so while it runs it reads "Waiting for status to be reported" instead of showing a spinner, and it links straight to the batch's run. Terminal states are unchanged. `cancelled` and `skipped` both settle as `failure`, since a status has only `error`/`failure`/`pending`/`success` and leaving it `pending` would hold the pull request on a batch that is already over; the description says which it was.

The aggregate the Dispatcher posts is a status for the same reason, so a run with three batches reports `test-batch/batch-01`, `-02`, `-03` plus the aggregate, all flat and all linking to what produced them.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
