### PR TITLE
[DBMON-6903] honor the configured schema collection interval

### DIFF
--- a/postgres/changelog.d/25121.fixed
+++ b/postgres/changelog.d/25121.fixed
@@ -1,0 +1,1 @@
+Fix a bug where schemas were collected more often than ``collect_schemas.collection_interval`` when another metadata collection interval was configured lower.

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -235,10 +235,6 @@ class PostgresMetadata(DBMAsyncJob):
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_postgres_schemas(self):
-        # Record the attempt before collecting rather than after. The job loop ticks at the GCD of
-        # every metadata sub-interval, so leaving this unset lets the gate in
-        # report_postgres_metadata pass on every tick, and recording it up front keeps a slow or
-        # failing collection from retrying in a tight loop.
         self._last_schemas_query_time = time.time()
         self._schema_collector.collect_schemas()
 

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -235,10 +235,12 @@ class PostgresMetadata(DBMAsyncJob):
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_postgres_schemas(self):
-        started = self._schema_collector.collect_schemas()
-        if not started:
-            # TODO: Emit health event for over-long collection
-            self._log.warning("Previous schema collection still in progress, skipping this collection")
+        # Record the attempt before collecting rather than after. The job loop ticks at the GCD of
+        # every metadata sub-interval, so leaving this unset lets the gate in
+        # report_postgres_metadata pass on every tick, and recording it up front keeps a slow or
+        # failing collection from retrying in a tight loop.
+        self._last_schemas_query_time = time.time()
+        self._schema_collector.collect_schemas()
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_postgres_settings(self):

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -4,6 +4,7 @@
 import json
 from concurrent.futures.thread import ThreadPoolExecutor
 from typing import List
+from unittest import mock
 
 import pytest
 
@@ -463,6 +464,69 @@ def test_collect_schemas_multiple_payloads(integration_check, dbm_instance, aggr
     assert collection_payloads_count == len(schema_events)
     for schema_event in schema_events[:-1]:
         assert 'collection_payloads_count' not in schema_event
+
+
+def test_metadata_collectors_honor_their_own_collection_intervals(integration_check, dbm_instance):
+    """
+    Each metadata sub-collector collects only once its own interval has elapsed. The intervals are
+    deliberately distinct so a collector that gates on a sibling's timestamp or interval fails here
+    instead of passing on coincidentally equal values.
+    """
+    # Extensions has no interval of its own; it shares collect_settings.collection_interval.
+    settings_interval, schemas_interval, column_statistics_interval = 600, 700, 800
+    dbm_instance['collect_settings'] = {
+        'enabled': True,
+        'run_sync': True,
+        'collection_interval': settings_interval,
+    }
+    dbm_instance['collect_schemas'] = {'enabled': True, 'collection_interval': schemas_interval}
+    dbm_instance['collect_column_statistics'] = {
+        'enabled': True,
+        'collection_interval': column_statistics_interval,
+    }
+
+    check = integration_check(dbm_instance)
+    # The first run establishes the connection and server version the collectors need, and takes the
+    # one collection each interval allows. Leave the job uncancelled so it can keep running below.
+    run_one_check(check, cancel=False)
+
+    metadata = check.metadata_samples
+
+    # wraps= leaves the real method in place, so each collector still stamps its own timestamp.
+    def spy_on(method_name):
+        return mock.patch.object(metadata, method_name, wraps=getattr(metadata, method_name))
+
+    with (
+        spy_on('_collect_postgres_settings') as settings,
+        spy_on('_collect_postgres_extensions') as extensions,
+        spy_on('_collect_postgres_schemas') as schemas,
+        spy_on('_collect_column_statistics') as column_statistics,
+    ):
+
+        def counts_after_ticks(ticks=1):
+            for _ in range(ticks):
+                metadata.run_job()
+            return {
+                'settings': settings.call_count,
+                'extensions': extensions.call_count,
+                'schemas': schemas.call_count,
+                'column_statistics': column_statistics.call_count,
+            }
+
+        # The first run stamped every collector, so no number of ticks collects anything.
+        assert counts_after_ticks(3) == {'settings': 0, 'extensions': 0, 'schemas': 0, 'column_statistics': 0}
+
+        # Retire one timestamp at a time; only the collector that owns it may become due.
+        metadata._last_schemas_query_time -= schemas_interval + 1
+        assert counts_after_ticks() == {'settings': 0, 'extensions': 0, 'schemas': 1, 'column_statistics': 0}
+
+        metadata._last_column_statistics_query_time -= column_statistics_interval + 1
+        assert counts_after_ticks() == {'settings': 0, 'extensions': 0, 'schemas': 1, 'column_statistics': 1}
+
+        # Settings and extensions share one interval, so they come due together.
+        metadata._time_since_last_settings_query -= settings_interval + 1
+        metadata._time_since_last_extension_query -= settings_interval + 1
+        assert counts_after_ticks() == {'settings': 1, 'extensions': 1, 'schemas': 1, 'column_statistics': 1}
 
 
 def assert_fields(keys: List[str], fields: List[str]):

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -526,6 +526,34 @@ def test_collect_column_statistics_updates_timestamp_on_failure(pg_instance):
     assert after > before
 
 
+def test_report_postgres_metadata_honors_schemas_collection_interval(pg_instance):
+    """
+    The metadata job loop ticks at the GCD of its sub-intervals, so each sub-collector has to gate
+    itself. Schema collection stopped doing that in #21727, which dropped the only assignment to
+    _last_schemas_query_time and left collect_schemas.collection_interval inert: schemas were
+    collected on every tick no matter how high the interval was set.
+    """
+    pg_instance['dbm'] = True
+    pg_instance['collect_schemas'] = {'enabled': True, 'collection_interval': 600}
+    pg_instance['collect_settings'] = {'enabled': False}
+
+    check = PostgreSql('postgres', {}, [pg_instance])
+    metadata = check.metadata_samples
+    metadata._tags_no_db = []
+
+    with mock.patch.object(metadata._schema_collector, 'collect_schemas') as collect_schemas:
+        for _ in range(3):
+            metadata.report_postgres_metadata()
+
+        assert collect_schemas.call_count == 1
+
+        # Collection resumes once the configured interval has elapsed.
+        metadata._last_schemas_query_time -= 601
+        metadata.report_postgres_metadata()
+
+        assert collect_schemas.call_count == 2
+
+
 def _autodiscovery_scope(name):
     return {'name': name, 'query': 'SELECT {metrics_columns} FROM fake', 'metrics': {}, 'descriptors': []}
 

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -263,6 +263,24 @@ def test_collection_interval_gcd(intervals, expected):
 
 
 @pytest.mark.unit
+def test_metadata_job_ticks_at_gcd_of_all_sub_intervals(pg_instance):
+    """
+    Each metadata sub-collector gates itself on its own interval, which only yields the configured
+    cadence if the loop ticks at the GCD of every sub-interval. A tick coarser than that -- because
+    the GCD is computed over only some of the intervals, or not at all -- silently delays whichever
+    collector has the shortest interval.
+    """
+    pg_instance['dbm'] = True
+    pg_instance['collect_settings'] = {'enabled': True, 'collection_interval': 600}
+    pg_instance['collect_schemas'] = {'enabled': True, 'collection_interval': 700}
+    pg_instance['collect_column_statistics'] = {'enabled': True, 'collection_interval': 800}
+
+    check = PostgreSql('postgres', {}, [pg_instance])
+
+    assert check.metadata_samples.collection_interval == 100
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     'exclude_hostname, expected_hostname',
     [
@@ -524,34 +542,6 @@ def test_collect_column_statistics_updates_timestamp_on_failure(pg_instance):
         after = metadata._last_column_statistics_query_time
 
     assert after > before
-
-
-def test_report_postgres_metadata_honors_schemas_collection_interval(pg_instance):
-    """
-    The metadata job loop ticks at the GCD of its sub-intervals, so each sub-collector has to gate
-    itself. Schema collection stopped doing that in #21727, which dropped the only assignment to
-    _last_schemas_query_time and left collect_schemas.collection_interval inert: schemas were
-    collected on every tick no matter how high the interval was set.
-    """
-    pg_instance['dbm'] = True
-    pg_instance['collect_schemas'] = {'enabled': True, 'collection_interval': 600}
-    pg_instance['collect_settings'] = {'enabled': False}
-
-    check = PostgreSql('postgres', {}, [pg_instance])
-    metadata = check.metadata_samples
-    metadata._tags_no_db = []
-
-    with mock.patch.object(metadata._schema_collector, 'collect_schemas') as collect_schemas:
-        for _ in range(3):
-            metadata.report_postgres_metadata()
-
-        assert collect_schemas.call_count == 1
-
-        # Collection resumes once the configured interval has elapsed.
-        metadata._last_schemas_query_time -= 601
-        metadata.report_postgres_metadata()
-
-        assert collect_schemas.call_count == 2
 
 
 def _autodiscovery_scope(name):


### PR DESCRIPTION
### What does this PR do?

Records the time of each schema collection so that `collect_schemas.collection_interval` is
actually enforced.

Also drops an unreachable branch in `_collect_postgres_schemas`. `SchemaCollector.collect_schemas()`
ends in a single unconditional `return True` and only runs on the same thread, so the "previous schema collection still in progress" warning could never fire.

Two tests cover the gating:

- `test_metadata_collectors_honor_their_own_collection_intervals` (integration) drives the real
  collectors against Postgres and retires one timestamp at a time, so every collector has to gate on
  its own timestamp and its own interval rather than a sibling's.
- `test_metadata_job_ticks_at_gcd_of_all_sub_intervals` (unit) pins the loop's tick to the GCD of all
  four sub-intervals, which is what makes the per-collector gating add up to the configured cadence.

### Motivation

With default intervals the GCD happens to equal the schemas interval (600s), which is why this went
unnoticed. It surfaces as soon as any other sub-interval is lowered: with
`collect_settings.collection_interval: 15` and `collect_schemas.collection_interval: 600` the loop
ticks every 15s and schemas are collected on every tick. A local-dev run measured 38 schema
collections in 540 seconds where 1 was expected.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged