### PR TITLE
[DOCS-15447] Use DO version of Metabase README

### DIFF
--- a/metabase/README.md
+++ b/metabase/README.md
@@ -10,6 +10,8 @@ Integrate Metabase with Datadog for:
 
 **Data Lineage**: View end-to-end lineage across Metabase collections, dashboards, and cards to understand dependencies and downstream impact.
 
+**Note**: Lineage is derived from your data warehouse, so the Metabase integration produces lineage only when at least one [supported data warehouse destination][3] is also connected to Datadog. Log collection has no such requirement.
+
 ## Setup
 
 ### Prerequisites
@@ -53,16 +55,25 @@ Integrate Metabase with Datadog for:
 
 ### Connect your Metabase account to Datadog
 
-1. Add your Metabase instance type, DNS alias or self-hosted domain, and API key.
-    |Parameters|Description|
+1. Navigate to the [Metabase integration tile][5] and enter the following information:
+
+    |Parameter|Description|
     |--------------------|--------------------|
-    |Metabase instance type|The hosting type of your Metabase instance. Valid values are `cloud` or `self-hosted`. Default is `cloud`.|
-    |Metabase DNS alias|The DNS alias of your Metabase cloud instance (required for cloud instances only). Must be at least three characters long and contain only lowercase letters, dashes, and numbers.|
-    |Metabase self-hosted instance domain|The domain of your self-hosted Metabase instance (required for self-hosted instances only). Must be publicly accessible via HTTPS only (e.g., example.com).|
-    |Metabase API key|The API key used to authenticate the API requests.|
+    |Account name|Used to identify this account in Datadog.|
+    |Instance type|The hosting type of your Metabase instance. Valid values are `cloud` or `self-hosted`. Default is `cloud`.|
+    |DNS alias|The DNS alias of your Metabase cloud instance (required for cloud instances only). Must be at least three characters long and contain only lowercase letters, dashes, and numbers.|
+    |Self-hosted instance domain|The domain of your self-hosted Metabase instance (required for self-hosted instances only). Must be publicly accessible through HTTPS only (for example, `example.com`).|
+    |API key|The API key used to authenticate the API requests.|
 
-2. Click the Save button to save your settings.
+2. Click **Save**.
 
+## What's next
+
+When your Metabase account is successfully connected, Datadog syncs and automatically derives lineage from warehouse tables and columns to Metabase cards and dashboards.
+
+Initial syncs may take up to several hours depending on the size of your Metabase deployment.
+
+After syncing, you can explore your Metabase assets and their upstream dependencies in the [Data Observability Catalog][4].
 
 ## Data Collected
 
@@ -84,3 +95,6 @@ For further assistance, contact [Datadog Support][2].
 
 [1]: https://www.metabase.com/
 [2]: https://docs.datadoghq.com/help/
+[3]: https://docs.datadoghq.com/data_observability/quality_monitoring/data_warehouses/
+[4]: /data-obs/catalog
+[5]: /integrations/metabase


### PR DESCRIPTION
Companion to [documentation#39739](https://github.com/DataDog/documentation/pull/39739), which reduces the duplicate Data Observability copy of the Metabase docs to a stub. This PR moves the content that only existed in that copy into the README.

Follows the same pattern as the Hex pair ([internal-core#3918](https://github.com/DataDog/integrations-internal-core/pull/3918) / [documentation#39211](https://github.com/DataDog/documentation/pull/39211)).

- Added a `What's next` section with the sync latency note and a link to the Data Observability Catalog
- Added framing to clarify that lineage requires a data warehouse connected to Datadog. Scoped to lineage, since log collection has no such requirement
- Fixed the account configuration table against the actual tile: added the missing **Account name** row, and dropped the "Metabase" prefix from the other labels so they match the form. This also cleared two Vale warnings (`via` and `e.g.,`)

cc @kevinzenghu

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
