### PR TITLE
AI-7129 Scope test-dispatch tokens for master and POC validation

### DIFF
--- a/.github/chainguard/self.dispatch-poc.pull-request.sts.yaml
+++ b/.github/chainguard/self.dispatch-poc.pull-request.sts.yaml
@@ -1,53 +1,15 @@
-# Policy for: .github/workflows/zz-dispatch-poc.yml in DataDog/integrations-core
-#
-# Temporary, and deliberately narrower than the Dispatcher will eventually need. It exists so the
-# POC round trip runs on a real octo-sts token rather than the ambient GITHUB_TOKEN, which is the
-# one part of the production path the POC cannot otherwise exercise. Deleted together with
-# zz-dispatch-poc.yml; the production policy is AI-7129.
-#
-# Naming convention:
-#   self:          Only this repository (DataDog/integrations-core) can use this policy
-#   dispatch-poc:  The Dispatcher POC workflow
-#   pull-request:  Triggered by pull_request events
-#
-# Security model:
-#   - job_workflow_ref pins the policy to zz-dispatch-poc.yml, so no other workflow can mint it.
-#   - The ref is left open, because a pull_request run resolves it to refs/pull/<n>/merge and the
-#     POC is iterated on across pull requests. Reaching this policy therefore requires push access
-#     to this repository: a fork pull request is never granted id-token: write, so it cannot obtain
-#     the OIDC token the exchange starts from.
-#   - Nothing here is granted that the workflow's own `permissions:` block does not already hold,
-#     so the token is a swap of credential, not an escalation.
-#
-# Permissions granted:
-#   - actions: write       - Dispatch the batch workflow, then read its runs, jobs, and artifacts.
-#   - statuses: write      - The run's aggregate result, one per run whatever the batch count.
-#   - pull_requests: write - The run's summary comment.
-#   - contents: read       - Check out the repository and read the pull request's diff.
-#
-# `checks: write` is deliberately absent. Each batch opens and closes its own check run from within
-# `test-batch.yml`, on that workflow's own token, so the Dispatcher writes no check run at all. The
-# aggregate is a commit status rather than a check run because a check run's `details_url` is
-# overwritten when it is created from inside a workflow, which leaves `Details` pointing at a page
-# that only says the check started.
-#
-# Usage in workflows:
-#   - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
-#     with:
-#       scope: DataDog/integrations-core
-#       policy: self.dispatch-poc.pull-request
-
+# Temporary exception for PR #25081; remove when test-dispatch switches to its production triggers.
 issuer: https://token.actions.githubusercontent.com
 
-subject_pattern: repo:DataDog/integrations-core:pull_request
+subject: repo:DataDog/integrations-core:pull_request
 
 claim_pattern:
-  event_name: pull_request
-  job_workflow_ref: DataDog/integrations-core/\.github/workflows/zz-dispatch-poc\.yml@.*
-  repository: DataDog/integrations-core
+  event_name: ^pull_request$
+  ref: ^refs/pull/25081/merge$
+  job_workflow_ref: ^DataDog/integrations-core/\.github/workflows/test-dispatch\.yml@refs/pull/25081/merge$
+  repository: ^DataDog/integrations-core$
 
 permissions:
   actions: write
-  statuses: write
   pull_requests: write
-  contents: read
+  statuses: write

--- a/.github/chainguard/self.dispatch-poc.pull-request.sts.yaml
+++ b/.github/chainguard/self.dispatch-poc.pull-request.sts.yaml
@@ -6,6 +6,7 @@ subject: repo:DataDog/integrations-core:pull_request
 claim_pattern:
   event_name: ^pull_request$
   ref: ^refs/pull/25081/merge$
+  ref_type: ^branch$
   job_workflow_ref: ^DataDog/integrations-core/\.github/workflows/test-dispatch\.yml@refs/pull/25081/merge$
   repository: ^DataDog/integrations-core$
 

--- a/.github/chainguard/self.test-dispatch.sts.yaml
+++ b/.github/chainguard/self.test-dispatch.sts.yaml
@@ -1,3 +1,4 @@
+# Allows test-dispatch on master to run test batches and report their results.
 issuer: https://token.actions.githubusercontent.com
 
 subject: repo:DataDog/integrations-core:ref:refs/heads/master
@@ -10,6 +11,6 @@ claim_pattern:
   repository: ^DataDog/integrations-core$
 
 permissions:
-  actions: write
-  pull_requests: write
-  statuses: write
+  actions: write # Dispatch/cancel batches and read runs, jobs, and artifacts.
+  pull_requests: write # Resolve the PR and post its test report.
+  statuses: write # Publish the aggregate result on the tested commit.

--- a/.github/chainguard/self.test-dispatch.sts.yaml
+++ b/.github/chainguard/self.test-dispatch.sts.yaml
@@ -1,0 +1,15 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/integrations-core:ref:refs/heads/master
+
+claim_pattern:
+  event_name: ^(push|workflow_dispatch|workflow_run)$
+  ref: ^refs/heads/master$
+  ref_protected: "^true$"
+  job_workflow_ref: ^DataDog/integrations-core/\.github/workflows/test-dispatch\.yml@refs/heads/master$
+  repository: ^DataDog/integrations-core$
+
+permissions:
+  actions: write
+  pull_requests: write
+  statuses: write

--- a/.github/chainguard/self.test-dispatch.sts.yaml
+++ b/.github/chainguard/self.test-dispatch.sts.yaml
@@ -5,7 +5,7 @@ subject: repo:DataDog/integrations-core:ref:refs/heads/master
 claim_pattern:
   event_name: ^(push|workflow_dispatch|workflow_run)$
   ref: ^refs/heads/master$
-  ref_protected: "^true$"
+  ref_type: ^branch$
   job_workflow_ref: ^DataDog/integrations-core/\.github/workflows/test-dispatch\.yml@refs/heads/master$
   repository: ^DataDog/integrations-core$
 


### PR DESCRIPTION
### What does this PR do?

Adds the master-only octo-sts policy for `test-dispatch.yml`, with `actions: write`, `pull_requests: write`, and `statuses: write`.

Restricts the existing POC policy to `test-dispatch.yml` at `refs/pull/25081/merge`. The checkout uses the ambient token, so the POC policy no longer needs `contents: read`.

### Motivation

[AI-7129](https://datadoghq.atlassian.net/browse/AI-7129). Policies must be on master before octo-sts can use them. This lets [#25081](https://github.com/DataDog/integrations-core/pull/25081) validate the real workflow before it merges, without allowing PR refs through the production policy. The temporary exception will be removed when the workflow switches to its production triggers.

Both policies require `ref_type: branch`, without relying on `ref_protected`, following the [ID token verification guidance](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/6222446815).

Validated YAML and 14 local claim-matching scenarios, including other PRs, workflows, repositories, and tag refs. The actual token exchange will be checked after merge.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7129]: https://datadoghq.atlassian.net/browse/AI-7129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
