### PR TITLE
AI-7127 Discover Dispatcher environments without running Hatch

### DIFF
--- a/ddev/changelog.d/25129.fixed
+++ b/ddev/changelog.d/25129.fixed
@@ -1,0 +1,1 @@
+Discover Dispatcher test environments from ``hatch.toml`` without executing Hatch.

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -143,7 +143,7 @@ def dispatch_tests(
         changed_files=run.changed_files,
         all_targets=all_targets,
         minimum_base_package=minimum_base_package,
-        environment_provider=HatchEnvironmentProvider(app.platform, config.default_python_version),
+        environment_provider=HatchEnvironmentProvider(default_python_version=config.default_python_version),
     )
     if not batches:
         app.display_info('No affected target to test.')

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -103,7 +103,7 @@ def dispatch_tests(
     import logging
     from pathlib import Path
 
-    from ddev.cli.ci.tests.batching.build import HatchEnvironmentProvider
+    from ddev.cli.ci.tests.batching.hatch_environments import HatchEnvironmentProvider
     from ddev.cli.ci.tests.dispatcher import DispatcherContext, build_dispatcher
     from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
     from ddev.utils.github import resolve_owner_repo

--- a/ddev/src/ddev/cli/ci/tests/batching/AGENTS.md
+++ b/ddev/src/ddev/cli/ci/tests/batching/AGENTS.md
@@ -22,6 +22,7 @@ them from git, and `../changes.py` decides which two commits a CI run compares.
 | Module | Role |
 | --- | --- |
 | `build.py` | Composes the stages and adapts concrete `Repository`/`Integration` objects to them. The package's public entry point. |
+| `hatch_environments.py` | Reads and validates static Hatch environment settings and expands candidate environments. |
 | `targets.py` | Maps changed files to affected target names through ordered, independent rules. `AllTargetsRule` is the exception: it ignores the change set, for a run that tests everything. |
 | `units.py` | Expands targets into `TestUnit` values: one target, one platform, one environment. |
 | `jobs.py` | Turns each unit into the concrete `BatchJob` the workflow runs. |
@@ -41,13 +42,14 @@ Some values are duplicated between them on purpose: `ci_matrix.py` must run stan
 dependencies, so it cannot import from this package. `PLATFORMS` and the path patterns are the
 copies that matter. Change one and change the other.
 
-Environment discovery uses an injected `EnvironmentProvider`. `HatchEnvironmentProvider` reads
-`hatch.toml` without invoking Hatch or loading project plugins. It expands default matrices, Python
-versions, literal platform restrictions, and the `os` matrix convention, including literal
-`matrix.os.platforms` mappings. It does not evaluate general overrides or inheritance. Unsupported
-constructs that affect discovery raise `PlanningError`. Default `test-env` must remain true and
-cannot be overridden: `ddev test` does not filter explicitly selected unit-test environments.
-Conditional E2E availability stays enabled for the worker to resolve at runtime.
+Environment discovery uses an injected `EnvironmentProvider` defined in `units.py`.
+The `HatchEnvironmentProvider` in `hatch_environments.py` reads `hatch.toml` without invoking Hatch
+or loading project plugins. It expands default matrices, Python versions, literal platform
+restrictions, and the `os` matrix convention, including literal `matrix.os.platforms` mappings.
+It does not evaluate general overrides or inheritance. Unsupported constructs that affect discovery
+raise `PlanningError`. Default `test-env` must remain true and cannot be overridden: `ddev test`
+does not filter explicitly selected unit-test environments. Conditional E2E availability stays
+enabled for the worker to resolve at runtime.
 
 ## Rules
 

--- a/ddev/src/ddev/cli/ci/tests/batching/AGENTS.md
+++ b/ddev/src/ddev/cli/ci/tests/batching/AGENTS.md
@@ -45,8 +45,9 @@ Environment discovery uses an injected `EnvironmentProvider`. `HatchEnvironmentP
 `hatch.toml` without invoking Hatch or loading project plugins. It expands default matrices, Python
 versions, literal platform restrictions, and the `os` matrix convention, including literal
 `matrix.os.platforms` mappings. It does not evaluate general overrides or inheritance. Unsupported
-constructs that affect discovery raise `PlanningError`; conditional test availability stays enabled
-for the worker to resolve at runtime.
+constructs that affect discovery raise `PlanningError`. Default `test-env` must remain true and
+cannot be overridden: `ddev test` does not filter explicitly selected unit-test environments.
+Conditional E2E availability stays enabled for the worker to resolve at runtime.
 
 ## Rules
 

--- a/ddev/src/ddev/cli/ci/tests/batching/AGENTS.md
+++ b/ddev/src/ddev/cli/ci/tests/batching/AGENTS.md
@@ -41,11 +41,12 @@ Some values are duplicated between them on purpose: `ci_matrix.py` must run stan
 dependencies, so it cannot import from this package. `PLATFORMS` and the path patterns are the
 copies that matter. Change one and change the other.
 
-Environment discovery is the one place they deliberately differ. This package asks Hatch through an
-injected `EnvironmentProvider`, where `ci_matrix.py` reads the `hatch.toml` matrix directly. Asking
-Hatch is accurate but costs one subprocess per target, and the repository-wide rule selects every testable
-target, so a `datadog_checks_base` change means hundreds of serial subprocesses. That needs
-concurrency or a `hatch.toml`-reading provider before this runs on real pull requests.
+Environment discovery uses an injected `EnvironmentProvider`. `HatchEnvironmentProvider` reads
+`hatch.toml` without invoking Hatch or loading project plugins. It expands default matrices, Python
+versions, literal platform restrictions, and the `os` matrix convention, including literal
+`matrix.os.platforms` mappings. It does not evaluate general overrides or inheritance. Unsupported
+constructs that affect discovery raise `PlanningError`; conditional test availability stays enabled
+for the worker to resolve at runtime.
 
 ## Rules
 

--- a/ddev/src/ddev/cli/ci/tests/batching/build.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/build.py
@@ -6,11 +6,8 @@
 from __future__ import annotations
 
 import logging
-import re
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from ddev.cli.ci.tests.batching.exceptions import PlanningError
 from ddev.cli.ci.tests.batching.jobs import expand_batch_jobs
 from ddev.cli.ci.tests.batching.strategy import BatchStrategy, default_strategy
 from ddev.cli.ci.tests.batching.targets import (
@@ -19,7 +16,6 @@ from ddev.cli.ci.tests.batching.targets import (
     find_affected_targets,
 )
 from ddev.cli.ci.tests.batching.units import (
-    ResolvedEnvironment,
     TargetDefinition,
     TestUnit,
     expand_test_units,
@@ -27,11 +23,9 @@ from ddev.cli.ci.tests.batching.units import (
 )
 from ddev.cli.ci.tests.batching.validation import validate_batches
 from ddev.cli.ci.tests.messages import TestBatch
-from ddev.e2e.agent_images import PYTHON_VERSION_PATTERN
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Sequence
-    from typing import Any
+    from collections.abc import Sequence
 
     from ddev.cli.ci.tests.batching.targets import TargetRule
     from ddev.cli.ci.tests.batching.units import EnvironmentProvider
@@ -40,23 +34,8 @@ if TYPE_CHECKING:
     from ddev.integration.core import Integration
     from ddev.repo.core import Repository
     from ddev.utils.git import ChangedFile
-    from ddev.utils.platform import PlatformName
 
 logger = logging.getLogger(__name__)
-
-ENVIRONMENT_NAME_PATTERN = re.compile(r"[A-Za-z0-9._-]+")
-SUPPORTED_ENVIRONMENT_COLLECTORS = frozenset({"default", "datadog-checks"})
-SUPPORTED_OVERRIDE_SCOPES = frozenset({"platform", "env", "matrix", "name"})
-UNSUPPORTED_ENVIRONMENT_FIELDS = {
-    "default": ("template", "matrix-name-format", "matrix-exclude", "matrix-include"),
-    "named": ("template",),
-}
-UNSUPPORTED_OVERRIDE_FIELDS = frozenset({"python", "platforms", "matrix", "template", "matrix-name-format", "test-env"})
-OS_PLATFORM_OVERRIDE = ("matrix", "os", "platforms")
-PLATFORM_MAPPING_FIELDS = frozenset({"value", "if"})
-
-# The datadog-checks collector enables both stages on the default environment.
-TEST_STAGE_DEFAULTS = {"test-env": True, "e2e-env": True}
 
 
 def build_test_units(
@@ -175,208 +154,3 @@ def _supported_os(integration: Integration) -> list[str]:
         if key == "Supported OS":
             supported_os.append(value)
     return supported_os
-
-
-@dataclass(frozen=True, eq=False)
-class HatchEnvironmentProvider:
-    """Read candidate environments from Hatch configuration without evaluating project code.
-
-    Parse hatch.toml with tomllib and expand each default matrix into the
-    Cartesian product of its axes, with Python first in environment names.
-    For example, python = ["3.12", "3.13"] and version = ["1", "2"] produce
-    py3.12-1, py3.12-2, py3.13-1, and py3.13-2.
-
-    Each combination produces a candidate per compatible requested platform.
-    Without a matrix, use the default environment.
-
-    The test-env flag defaults to true and cannot be disabled or overridden.
-    E2E availability uses its literal value (true by default); an e2e-env
-    override keeps E2E enabled for the worker to decide.
-    Only literal matrix.os.platforms mappings are resolved during planning.
-    Unsupported discovery overrides raise a planning error; runtime-only
-    settings are ignored.
-    """
-
-    default_python_version: str
-
-    def __call__(self, integration: Integration, platforms: Sequence[PlatformName]) -> list[ResolvedEnvironment]:
-        import tomllib
-
-        try:
-            with open(integration.path / "hatch.toml", "rb") as stream:
-                config = tomllib.load(stream)
-            return self._resolve(config, platforms)
-        except (OSError, ValueError) as error:
-            raise PlanningError(f"{integration.name}/hatch.toml: {error}") from error
-
-    def _resolve(self, config: dict[str, Any], platforms: Sequence[PlatformName]) -> list[ResolvedEnvironment]:
-        default = _default_environment(config)
-        python = _python_version(default.get("python", self.default_python_version), "envs.default.python")
-        restrictions = _strings(default.get("platforms", []), "envs.default.platforms")
-        availability, os_platforms = _execution_settings(default)
-        if os_platforms is not None and restrictions:
-            raise ValueError(
-                "envs.default.platforms: combining literal and matrix platform restrictions is unsupported"
-            )
-
-        result: list[ResolvedEnvironment] = []
-        names: set[str] = set()
-        for field, variables in _matrix_combinations(default.get("matrix", [])):
-            version = _python_version(variables.get("python", python), f"{field}.python")
-            name = _environment_name(variables, field)
-            if name in names:
-                raise ValueError(f"{field}: duplicate environment name {name!r}")
-            names.add(name)
-
-            candidates = _environment_platforms(platforms, variables.get("os"), restrictions, os_platforms, field)
-            result.extend(
-                ResolvedEnvironment(
-                    name=name,
-                    platform=platform,
-                    python_version=version,
-                    test_available=availability["test-env"],
-                    e2e_available=availability["e2e-env"],
-                )
-                for platform in candidates
-            )
-        return result
-
-
-def _default_environment(config: dict[str, Any]) -> dict[str, Any]:
-    env = _table(config.get("env", {}), "env")
-    collectors = _table(env.get("collectors", {}), "env.collectors")
-    if unknown := collectors.keys() - SUPPORTED_ENVIRONMENT_COLLECTORS:
-        raise ValueError(f"env.collectors: unsupported collectors {sorted(unknown)}")
-
-    envs = _table(config.get("envs", {}), "envs")
-    for name, value in envs.items():
-        if name == "default":
-            continue
-        named = _table(value, f"envs.{name}")
-        for field in UNSUPPORTED_ENVIRONMENT_FIELDS["named"]:
-            if field in named:
-                raise ValueError(f"envs.{name}.{field}: unsupported for static discovery")
-        if any(named.get(field, False) for field in TEST_STAGE_DEFAULTS):
-            raise ValueError(f"envs.{name}: test environments outside envs.default are unsupported")
-        for _, _, settings in _overrides(named.get("overrides", {}), f"envs.{name}.overrides"):
-            if settings.keys() & TEST_STAGE_DEFAULTS.keys():
-                raise ValueError(f"envs.{name}.overrides: conditional named test environments are unsupported")
-
-    default = _table(envs.get("default", {}), "envs.default")
-    for field in UNSUPPORTED_ENVIRONMENT_FIELDS["default"]:
-        if field in default:
-            raise ValueError(f"envs.default.{field}: unsupported for static discovery")
-    if default.get("type", "virtual") != "virtual":
-        raise ValueError("envs.default.type: only virtual environments support static discovery")
-    return default
-
-
-def _execution_settings(default: dict[str, Any]) -> tuple[dict[str, bool], dict[str, list[str]] | None]:
-    availability = {}
-    for field, fallback in TEST_STAGE_DEFAULTS.items():
-        value = default.get(field, fallback)
-        if not isinstance(value, bool):
-            raise ValueError(f"envs.default.{field}: expected a boolean")
-        availability[field] = value
-    if not availability["test-env"]:
-        raise ValueError("envs.default.test-env: disabling unit tests is unsupported for static discovery")
-
-    os_platforms = None
-    for scope, selector, settings in _overrides(default.get("overrides", {}), "envs.default.overrides"):
-        for field, value in settings.items():
-            location = f"envs.default.overrides.{scope}.{selector}.{field}"
-            if (scope, selector, field) == OS_PLATFORM_OVERRIDE:
-                os_platforms = _os_platform_mapping(value, location)
-            elif field in UNSUPPORTED_OVERRIDE_FIELDS:
-                raise ValueError(f"{location}: unsupported for static discovery")
-            elif field == "e2e-env":
-                # ddev env test evaluates E2E availability on the worker.
-                availability[field] = True
-    return availability, os_platforms
-
-
-def _matrix_combinations(value: object) -> Iterator[tuple[str, dict[str, str]]]:
-    from itertools import product
-
-    if not isinstance(value, list):
-        raise ValueError("envs.default.matrix: expected an array of tables")
-    for index, entry in enumerate(value or [{}]):
-        field = f"envs.default.matrix[{index}]"
-        matrix = _table(entry, field)
-        if value and not matrix:
-            raise ValueError(f"{field}: expected at least one matrix variable")
-        # Hatch places Python first in environment names, regardless of TOML key order.
-        axes = sorted(matrix, key=lambda key: key != "python")
-        values = [_strings(matrix[axis], f"{field}.{axis}", nonempty=True) for axis in axes]
-        for combination in product(*values):
-            yield field, dict(zip(axes, combination, strict=True))
-
-
-def _environment_name(variables: dict[str, str], field: str) -> str:
-    name = "-".join(f"py{value}" if key == "python" else value for key, value in variables.items()) or "default"
-    if not ENVIRONMENT_NAME_PATTERN.fullmatch(name):
-        raise ValueError(f"{field}: invalid environment name {name!r}")
-    return name
-
-
-def _environment_platforms(
-    platforms: Sequence[PlatformName],
-    os_name: str | None,
-    restrictions: list[str],
-    os_platforms: dict[str, list[str]] | None,
-    field: str,
-) -> list[PlatformName]:
-    allowed = restrictions
-    if os_name is not None:
-        if os_platforms is None:
-            if restrictions and os_name not in restrictions:
-                return []
-            allowed = [os_name]
-        elif os_name not in os_platforms:
-            raise ValueError(f"{field}.os: no platform mapping for {os_name!r}")
-        else:
-            allowed = os_platforms[os_name]
-    elif os_platforms is not None:
-        raise ValueError(f"{field}: matrix.os.platforms requires an os variable")
-    return [platform for platform in platforms if not allowed or str(platform) in allowed]
-
-
-def _table(value: object, field: str) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        raise ValueError(f"{field}: expected a table")
-    return value
-
-
-def _strings(value: object, field: str, *, nonempty: bool = False) -> list[str]:
-    if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
-        raise ValueError(f"{field}: expected an array of nonempty strings")
-    if nonempty and not value:
-        raise ValueError(f"{field}: expected at least one value")
-    return value
-
-
-def _python_version(value: object, field: str) -> str:
-    if not isinstance(value, str) or not PYTHON_VERSION_PATTERN.fullmatch(value):
-        raise ValueError(f"{field}: expected a `major.minor` Python version, got {value!r}")
-    return value
-
-
-def _overrides(value: object, field: str) -> Iterator[tuple[str, str, dict[str, Any]]]:
-    for scope, selectors in _table(value, field).items():
-        if scope not in SUPPORTED_OVERRIDE_SCOPES:
-            continue
-        for selector, settings in _table(selectors, f"{field}.{scope}").items():
-            yield scope, selector, _table(settings, f"{field}.{scope}.{selector}")
-
-
-def _os_platform_mapping(value: object, field: str) -> dict[str, list[str]]:
-    if not isinstance(value, list) or not value:
-        raise ValueError(f"{field}: expected literal value/if mappings")
-    platforms: dict[str, list[str]] = {}
-    for item in value:
-        mapping = _table(item, field)
-        if mapping.keys() != PLATFORM_MAPPING_FIELDS or not isinstance(mapping["value"], str) or not mapping["value"]:
-            raise ValueError(f"{field}: only literal value/if mappings are supported")
-        for os_name in _strings(mapping["if"], f"{field}.if", nonempty=True):
-            platforms.setdefault(os_name, []).append(mapping["value"])
-    return platforms

--- a/ddev/src/ddev/cli/ci/tests/batching/build.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/build.py
@@ -47,7 +47,10 @@ logger = logging.getLogger(__name__)
 ENVIRONMENT_NAME_PATTERN = re.compile(r"[A-Za-z0-9._-]+")
 SUPPORTED_ENVIRONMENT_COLLECTORS = frozenset({"default", "datadog-checks"})
 SUPPORTED_OVERRIDE_SCOPES = frozenset({"platform", "env", "matrix", "name"})
-UNSUPPORTED_ENVIRONMENT_FIELDS = ("template", "matrix-name-format", "matrix-exclude", "matrix-include")
+UNSUPPORTED_ENVIRONMENT_FIELDS = {
+    "default": ("template", "matrix-name-format", "matrix-exclude", "matrix-include"),
+    "named": ("template",),
+}
 UNSUPPORTED_OVERRIDE_FIELDS = frozenset({"python", "platforms", "matrix", "template", "matrix-name-format"})
 OS_PLATFORM_OVERRIDE = ("matrix", "os", "platforms")
 PLATFORM_MAPPING_FIELDS = frozenset({"value", "if"})
@@ -236,6 +239,9 @@ def _default_environment(config: dict[str, Any]) -> dict[str, Any]:
         if name == "default":
             continue
         named = _table(value, f"envs.{name}")
+        for field in UNSUPPORTED_ENVIRONMENT_FIELDS["named"]:
+            if field in named:
+                raise ValueError(f"envs.{name}.{field}: unsupported for static discovery")
         if any(named.get(field, False) for field in TEST_STAGE_DEFAULTS):
             raise ValueError(f"envs.{name}: test environments outside envs.default are unsupported")
         for _, _, settings in _overrides(named.get("overrides", {}), f"envs.{name}.overrides"):
@@ -243,7 +249,7 @@ def _default_environment(config: dict[str, Any]) -> dict[str, Any]:
                 raise ValueError(f"envs.{name}.overrides: conditional named test environments are unsupported")
 
     default = _table(envs.get("default", {}), "envs.default")
-    for field in UNSUPPORTED_ENVIRONMENT_FIELDS:
+    for field in UNSUPPORTED_ENVIRONMENT_FIELDS["default"]:
         if field in default:
             raise ValueError(f"envs.default.{field}: unsupported for static discovery")
     if default.get("type", "virtual") != "virtual":

--- a/ddev/src/ddev/cli/ci/tests/batching/build.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/build.py
@@ -43,7 +43,17 @@ if TYPE_CHECKING:
     from ddev.utils.platform import PlatformName
 
 logger = logging.getLogger(__name__)
+
 ENVIRONMENT_NAME_PATTERN = re.compile(r"[A-Za-z0-9._-]+")
+SUPPORTED_ENVIRONMENT_COLLECTORS = frozenset({"default", "datadog-checks"})
+SUPPORTED_OVERRIDE_SCOPES = frozenset({"platform", "env", "matrix", "name"})
+UNSUPPORTED_ENVIRONMENT_FIELDS = ("template", "matrix-name-format", "matrix-exclude", "matrix-include")
+UNSUPPORTED_OVERRIDE_FIELDS = frozenset({"python", "platforms", "matrix", "template", "matrix-name-format"})
+OS_PLATFORM_OVERRIDE = ("matrix", "os", "platforms")
+PLATFORM_MAPPING_FIELDS = frozenset({"value", "if"})
+
+# The datadog-checks collector enables both stages on the default environment.
+TEST_STAGE_DEFAULTS = {"test-env": True, "e2e-env": True}
 
 
 def build_test_units(
@@ -181,110 +191,132 @@ class HatchEnvironmentProvider:
             raise PlanningError(f"{integration.name}/hatch.toml: {error}") from error
 
     def _resolve(self, config: dict[str, Any], platforms: Sequence[PlatformName]) -> list[ResolvedEnvironment]:
-        from itertools import product
-
-        env = _table(config.get("env", {}), "env")
-        collectors = _table(env.get("collectors", {}), "env.collectors")
-        if unknown := collectors.keys() - {"default", "datadog-checks"}:
-            raise ValueError(f"env.collectors: unsupported collectors {sorted(unknown)}")
-
-        envs = _table(config.get("envs", {}), "envs")
-        for name, value in envs.items():
-            if name == "default":
-                continue
-            named = _table(value, f"envs.{name}")
-            if named.get("test-env", False) or named.get("e2e-env", False):
-                raise ValueError(f"envs.{name}: test environments outside envs.default are unsupported")
-            for _, _, settings in _overrides(named.get("overrides", {}), f"envs.{name}.overrides"):
-                if settings.keys() & {"test-env", "e2e-env"}:
-                    raise ValueError(f"envs.{name}.overrides: conditional named test environments are unsupported")
-
-        default = _table(envs.get("default", {}), "envs.default")
-        for field in ("template", "matrix-name-format", "matrix-exclude", "matrix-include"):
-            if field in default:
-                raise ValueError(f"envs.default.{field}: unsupported for static discovery")
-        if default.get("type", "virtual") != "virtual":
-            raise ValueError("envs.default.type: only virtual environments support static discovery")
-
+        default = _default_environment(config)
         python = _python_version(default.get("python", self.default_python_version), "envs.default.python")
         restrictions = _strings(default.get("platforms", []), "envs.default.platforms")
-        availability = {}
-        for field in ("test-env", "e2e-env"):
-            value = default.get(field, True)
-            if not isinstance(value, bool):
-                raise ValueError(f"envs.default.{field}: expected a boolean")
-            availability[field] = value
-
-        os_platforms = None
-        for scope, selector, settings in _overrides(default.get("overrides", {}), "envs.default.overrides"):
-            for field, value in settings.items():
-                location = f"envs.default.overrides.{scope}.{selector}.{field}"
-                if (scope, selector, field) == ("matrix", "os", "platforms"):
-                    os_platforms = _os_platform_mapping(value, location)
-                elif field in {"python", "platforms", "matrix", "template", "matrix-name-format"}:
-                    raise ValueError(f"{location}: unsupported for static discovery")
-                elif field in availability:
-                    # The worker evaluates these conditions; false here would prevent it from doing so.
-                    availability[field] = True
-
+        availability, os_platforms = _execution_settings(default)
         if os_platforms is not None and restrictions:
             raise ValueError(
                 "envs.default.platforms: combining literal and matrix platform restrictions is unsupported"
             )
 
-        matrices = default.get("matrix", [])
-        if not isinstance(matrices, list):
-            raise ValueError("envs.default.matrix: expected an array of tables")
-
-        result = []
+        result: list[ResolvedEnvironment] = []
         names: set[str] = set()
-        for index, value in enumerate(matrices or [{}]):
-            field = f"envs.default.matrix[{index}]"
-            matrix = _table(value, field)
-            if matrices and not matrix:
-                raise ValueError(f"{field}: expected at least one matrix variable")
-            # Hatch places Python first in environment names, regardless of TOML key order.
-            axes = sorted(matrix, key=lambda key: key != "python")
-            values = [_strings(matrix[axis], f"{field}.{axis}", nonempty=True) for axis in axes]
-            for combination in product(*values):
-                variables = dict(zip(axes, combination, strict=True))
-                version = _python_version(variables.get("python", python), f"{field}.python")
-                name = "-".join(f"py{v}" if k == "python" else v for k, v in variables.items()) or "default"
-                if not ENVIRONMENT_NAME_PATTERN.fullmatch(name):
-                    raise ValueError(f"{field}: invalid environment name {name!r}")
-                if name in names:
-                    raise ValueError(f"{field}: duplicate environment name {name!r}")
-                names.add(name)
+        for field, variables in _matrix_combinations(default.get("matrix", [])):
+            version = _python_version(variables.get("python", python), f"{field}.python")
+            name = _environment_name(variables, field)
+            if name in names:
+                raise ValueError(f"{field}: duplicate environment name {name!r}")
+            names.add(name)
 
-                allowed = restrictions
-                if "os" in variables:
-                    os_name = variables["os"]
-                    if os_platforms is None:
-                        allowed = [os_name] if not restrictions or os_name in restrictions else []
-                        if not allowed:
-                            continue
-                    elif os_name not in os_platforms:
-                        raise ValueError(f"{field}.os: no platform mapping for {os_name!r}")
-                    else:
-                        allowed = os_platforms[os_name]
-                elif os_platforms is not None:
-                    raise ValueError(f"{field}: matrix.os.platforms requires an os variable")
-
-                if not any(availability.values()):
-                    continue
-                for platform in platforms:
-                    if allowed and str(platform) not in allowed:
-                        continue
-                    result.append(
-                        ResolvedEnvironment(
-                            name=name,
-                            platform=platform,
-                            python_version=version,
-                            test_available=availability["test-env"],
-                            e2e_available=availability["e2e-env"],
-                        )
-                    )
+            candidates = _environment_platforms(platforms, variables.get("os"), restrictions, os_platforms, field)
+            if not any(availability.values()):
+                continue
+            result.extend(
+                ResolvedEnvironment(
+                    name=name,
+                    platform=platform,
+                    python_version=version,
+                    test_available=availability["test-env"],
+                    e2e_available=availability["e2e-env"],
+                )
+                for platform in candidates
+            )
         return result
+
+
+def _default_environment(config: dict[str, Any]) -> dict[str, Any]:
+    env = _table(config.get("env", {}), "env")
+    collectors = _table(env.get("collectors", {}), "env.collectors")
+    if unknown := collectors.keys() - SUPPORTED_ENVIRONMENT_COLLECTORS:
+        raise ValueError(f"env.collectors: unsupported collectors {sorted(unknown)}")
+
+    envs = _table(config.get("envs", {}), "envs")
+    for name, value in envs.items():
+        if name == "default":
+            continue
+        named = _table(value, f"envs.{name}")
+        if any(named.get(field, False) for field in TEST_STAGE_DEFAULTS):
+            raise ValueError(f"envs.{name}: test environments outside envs.default are unsupported")
+        for _, _, settings in _overrides(named.get("overrides", {}), f"envs.{name}.overrides"):
+            if settings.keys() & TEST_STAGE_DEFAULTS.keys():
+                raise ValueError(f"envs.{name}.overrides: conditional named test environments are unsupported")
+
+    default = _table(envs.get("default", {}), "envs.default")
+    for field in UNSUPPORTED_ENVIRONMENT_FIELDS:
+        if field in default:
+            raise ValueError(f"envs.default.{field}: unsupported for static discovery")
+    if default.get("type", "virtual") != "virtual":
+        raise ValueError("envs.default.type: only virtual environments support static discovery")
+    return default
+
+
+def _execution_settings(default: dict[str, Any]) -> tuple[dict[str, bool], dict[str, list[str]] | None]:
+    availability = {}
+    for field, fallback in TEST_STAGE_DEFAULTS.items():
+        value = default.get(field, fallback)
+        if not isinstance(value, bool):
+            raise ValueError(f"envs.default.{field}: expected a boolean")
+        availability[field] = value
+
+    os_platforms = None
+    for scope, selector, settings in _overrides(default.get("overrides", {}), "envs.default.overrides"):
+        for field, value in settings.items():
+            location = f"envs.default.overrides.{scope}.{selector}.{field}"
+            if (scope, selector, field) == OS_PLATFORM_OVERRIDE:
+                os_platforms = _os_platform_mapping(value, location)
+            elif field in UNSUPPORTED_OVERRIDE_FIELDS:
+                raise ValueError(f"{location}: unsupported for static discovery")
+            elif field in availability:
+                # The worker evaluates these conditions; false here would prevent it from doing so.
+                availability[field] = True
+    return availability, os_platforms
+
+
+def _matrix_combinations(value: object) -> Iterator[tuple[str, dict[str, str]]]:
+    from itertools import product
+
+    if not isinstance(value, list):
+        raise ValueError("envs.default.matrix: expected an array of tables")
+    for index, entry in enumerate(value or [{}]):
+        field = f"envs.default.matrix[{index}]"
+        matrix = _table(entry, field)
+        if value and not matrix:
+            raise ValueError(f"{field}: expected at least one matrix variable")
+        # Hatch places Python first in environment names, regardless of TOML key order.
+        axes = sorted(matrix, key=lambda key: key != "python")
+        values = [_strings(matrix[axis], f"{field}.{axis}", nonempty=True) for axis in axes]
+        for combination in product(*values):
+            yield field, dict(zip(axes, combination, strict=True))
+
+
+def _environment_name(variables: dict[str, str], field: str) -> str:
+    name = "-".join(f"py{value}" if key == "python" else value for key, value in variables.items()) or "default"
+    if not ENVIRONMENT_NAME_PATTERN.fullmatch(name):
+        raise ValueError(f"{field}: invalid environment name {name!r}")
+    return name
+
+
+def _environment_platforms(
+    platforms: Sequence[PlatformName],
+    os_name: str | None,
+    restrictions: list[str],
+    os_platforms: dict[str, list[str]] | None,
+    field: str,
+) -> list[PlatformName]:
+    allowed = restrictions
+    if os_name is not None:
+        if os_platforms is None:
+            if restrictions and os_name not in restrictions:
+                return []
+            allowed = [os_name]
+        elif os_name not in os_platforms:
+            raise ValueError(f"{field}.os: no platform mapping for {os_name!r}")
+        else:
+            allowed = os_platforms[os_name]
+    elif os_platforms is not None:
+        raise ValueError(f"{field}: matrix.os.platforms requires an os variable")
+    return [platform for platform in platforms if not allowed or str(platform) in allowed]
 
 
 def _table(value: object, field: str) -> dict[str, Any]:
@@ -309,7 +341,7 @@ def _python_version(value: object, field: str) -> str:
 
 def _overrides(value: object, field: str) -> Iterator[tuple[str, str, dict[str, Any]]]:
     for scope, selectors in _table(value, field).items():
-        if scope not in {"platform", "env", "matrix", "name"}:
+        if scope not in SUPPORTED_OVERRIDE_SCOPES:
             continue
         for selector, settings in _table(selectors, f"{field}.{scope}").items():
             yield scope, selector, _table(settings, f"{field}.{scope}.{selector}")
@@ -321,7 +353,7 @@ def _os_platform_mapping(value: object, field: str) -> dict[str, list[str]]:
     platforms: dict[str, list[str]] = {}
     for item in value:
         mapping = _table(item, field)
-        if mapping.keys() != {"value", "if"} or not isinstance(mapping["value"], str) or not mapping["value"]:
+        if mapping.keys() != PLATFORM_MAPPING_FIELDS or not isinstance(mapping["value"], str) or not mapping["value"]:
             raise ValueError(f"{field}: only literal value/if mappings are supported")
         for os_name in _strings(mapping["if"], f"{field}.if", nonempty=True):
             platforms.setdefault(os_name, []).append(mapping["value"])

--- a/ddev/src/ddev/cli/ci/tests/batching/build.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/build.py
@@ -179,7 +179,22 @@ def _supported_os(integration: Integration) -> list[str]:
 
 @dataclass(frozen=True, eq=False)
 class HatchEnvironmentProvider:
-    """Read candidate environments from Hatch configuration without evaluating project code."""
+    """Read candidate environments from Hatch configuration without evaluating project code.
+
+    Parse hatch.toml with tomllib and expand each default matrix into the
+    Cartesian product of its axes, with Python first in environment names.
+    For example, python = ["3.12", "3.13"] and version = ["1", "2"] produce
+    py3.12-1, py3.12-2, py3.13-1, and py3.13-2.
+
+    Each combination produces a candidate per compatible requested platform.
+    Without a matrix, use the default environment.
+
+    Only literal matrix.os.platforms mappings are resolved during planning.
+    An override mentioning test-env or e2e-env keeps that specific stage
+    enabled for the worker to decide. Otherwise each flag uses its literal
+    value, defaulting to true. Unsupported discovery overrides raise a
+    planning error; runtime-only settings are ignored.
+    """
 
     default_python_version: str
 

--- a/ddev/src/ddev/cli/ci/tests/batching/build.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/build.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -29,7 +30,8 @@ from ddev.cli.ci.tests.messages import TestBatch
 from ddev.e2e.agent_images import PYTHON_VERSION_PATTERN
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
+    from typing import Any
 
     from ddev.cli.ci.tests.batching.targets import TargetRule
     from ddev.cli.ci.tests.batching.units import EnvironmentProvider
@@ -38,10 +40,10 @@ if TYPE_CHECKING:
     from ddev.integration.core import Integration
     from ddev.repo.core import Repository
     from ddev.utils.git import ChangedFile
-    from ddev.utils.hatch import Environment
-    from ddev.utils.platform import Platform, PlatformName
+    from ddev.utils.platform import PlatformName
 
 logger = logging.getLogger(__name__)
+ENVIRONMENT_NAME_PATTERN = re.compile(r"[A-Za-z0-9._-]+")
 
 
 def build_test_units(
@@ -164,66 +166,163 @@ def _supported_os(integration: Integration) -> list[str]:
 
 @dataclass(frozen=True, eq=False)
 class HatchEnvironmentProvider:
-    """An `EnvironmentProvider` backed by ddev's Hatch integration."""
+    """Read candidate environments from Hatch configuration without evaluating project code."""
 
-    platform: Platform
     default_python_version: str
 
     def __call__(self, integration: Integration, platforms: Sequence[PlatformName]) -> list[ResolvedEnvironment]:
-        from ddev.utils.hatch import list_environments
+        import tomllib
 
-        return resolve_hatch_environments(
-            list_environments(self.platform, integration),
-            platforms,
-            default_python_version=self.default_python_version,
-        )
+        try:
+            with open(integration.path / "hatch.toml", "rb") as stream:
+                config = tomllib.load(stream)
+            return self._resolve(config, platforms)
+        except (OSError, ValueError) as error:
+            raise PlanningError(f"{integration.name}/hatch.toml: {error}") from error
+
+    def _resolve(self, config: dict[str, Any], platforms: Sequence[PlatformName]) -> list[ResolvedEnvironment]:
+        from itertools import product
+
+        env = _table(config.get("env", {}), "env")
+        collectors = _table(env.get("collectors", {}), "env.collectors")
+        if unknown := collectors.keys() - {"default", "datadog-checks"}:
+            raise ValueError(f"env.collectors: unsupported collectors {sorted(unknown)}")
+
+        envs = _table(config.get("envs", {}), "envs")
+        for name, value in envs.items():
+            if name == "default":
+                continue
+            named = _table(value, f"envs.{name}")
+            if named.get("test-env", False) or named.get("e2e-env", False):
+                raise ValueError(f"envs.{name}: test environments outside envs.default are unsupported")
+            for _, _, settings in _overrides(named.get("overrides", {}), f"envs.{name}.overrides"):
+                if settings.keys() & {"test-env", "e2e-env"}:
+                    raise ValueError(f"envs.{name}.overrides: conditional named test environments are unsupported")
+
+        default = _table(envs.get("default", {}), "envs.default")
+        for field in ("template", "matrix-name-format", "matrix-exclude", "matrix-include"):
+            if field in default:
+                raise ValueError(f"envs.default.{field}: unsupported for static discovery")
+        if default.get("type", "virtual") != "virtual":
+            raise ValueError("envs.default.type: only virtual environments support static discovery")
+
+        python = _python_version(default.get("python", self.default_python_version), "envs.default.python")
+        restrictions = _strings(default.get("platforms", []), "envs.default.platforms")
+        availability = {}
+        for field in ("test-env", "e2e-env"):
+            value = default.get(field, True)
+            if not isinstance(value, bool):
+                raise ValueError(f"envs.default.{field}: expected a boolean")
+            availability[field] = value
+
+        os_platforms = None
+        for scope, selector, settings in _overrides(default.get("overrides", {}), "envs.default.overrides"):
+            for field, value in settings.items():
+                location = f"envs.default.overrides.{scope}.{selector}.{field}"
+                if (scope, selector, field) == ("matrix", "os", "platforms"):
+                    os_platforms = _os_platform_mapping(value, location)
+                elif field in {"python", "platforms", "matrix", "template", "matrix-name-format"}:
+                    raise ValueError(f"{location}: unsupported for static discovery")
+                elif field in availability:
+                    # The worker evaluates these conditions; false here would prevent it from doing so.
+                    availability[field] = True
+
+        if os_platforms is not None and restrictions:
+            raise ValueError(
+                "envs.default.platforms: combining literal and matrix platform restrictions is unsupported"
+            )
+
+        matrices = default.get("matrix", [])
+        if not isinstance(matrices, list):
+            raise ValueError("envs.default.matrix: expected an array of tables")
+
+        result = []
+        names: set[str] = set()
+        for index, value in enumerate(matrices or [{}]):
+            field = f"envs.default.matrix[{index}]"
+            matrix = _table(value, field)
+            if matrices and not matrix:
+                raise ValueError(f"{field}: expected at least one matrix variable")
+            # Hatch places Python first in environment names, regardless of TOML key order.
+            axes = sorted(matrix, key=lambda key: key != "python")
+            values = [_strings(matrix[axis], f"{field}.{axis}", nonempty=True) for axis in axes]
+            for combination in product(*values):
+                variables = dict(zip(axes, combination, strict=True))
+                version = _python_version(variables.get("python", python), f"{field}.python")
+                name = "-".join(f"py{v}" if k == "python" else v for k, v in variables.items()) or "default"
+                if not ENVIRONMENT_NAME_PATTERN.fullmatch(name):
+                    raise ValueError(f"{field}: invalid environment name {name!r}")
+                if name in names:
+                    raise ValueError(f"{field}: duplicate environment name {name!r}")
+                names.add(name)
+
+                allowed = restrictions
+                if "os" in variables:
+                    os_name = variables["os"]
+                    if os_platforms is None:
+                        allowed = [os_name] if not restrictions or os_name in restrictions else []
+                        if not allowed:
+                            continue
+                    elif os_name not in os_platforms:
+                        raise ValueError(f"{field}.os: no platform mapping for {os_name!r}")
+                    else:
+                        allowed = os_platforms[os_name]
+                elif os_platforms is not None:
+                    raise ValueError(f"{field}: matrix.os.platforms requires an os variable")
+
+                if not any(availability.values()):
+                    continue
+                for platform in platforms:
+                    if allowed and str(platform) not in allowed:
+                        continue
+                    result.append(
+                        ResolvedEnvironment(
+                            name=name,
+                            platform=platform,
+                            python_version=version,
+                            test_available=availability["test-env"],
+                            e2e_available=availability["e2e-env"],
+                        )
+                    )
+        return result
 
 
-def resolve_hatch_environments(
-    environments: Sequence[Environment],
-    platforms: Sequence[PlatformName],
-    *,
-    default_python_version: str,
-) -> list[ResolvedEnvironment]:
-    """Map ddev `Environment` values onto target platforms, keeping environments that test anything.
+def _table(value: object, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field}: expected a table")
+    return value
 
-    An environment constrained to specific platforms is routed only to those the target also runs
-    on; an unconstrained one runs on every platform the target runs on.
 
-    The Python version comes from Hatch's own `python` value, never from the environment name,
-    which only encodes it by convention.
-    """
-    if not platforms:
-        return []
+def _strings(value: object, field: str, *, nonempty: bool = False) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
+        raise ValueError(f"{field}: expected an array of nonempty strings")
+    if nonempty and not value:
+        raise ValueError(f"{field}: expected at least one value")
+    return value
 
-    by_name = {str(platform): platform for platform in platforms}
-    resolved: list[ResolvedEnvironment] = []
-    for environment in environments:
-        if not (environment.test_env or environment.e2e_env):
+
+def _python_version(value: object, field: str) -> str:
+    if not isinstance(value, str) or not PYTHON_VERSION_PATTERN.fullmatch(value):
+        raise ValueError(f"{field}: expected a `major.minor` Python version, got {value!r}")
+    return value
+
+
+def _overrides(value: object, field: str) -> Iterator[tuple[str, str, dict[str, Any]]]:
+    for scope, selectors in _table(value, field).items():
+        if scope not in {"platform", "env", "matrix", "name"}:
             continue
+        for selector, settings in _table(selectors, f"{field}.{scope}").items():
+            yield scope, selector, _table(settings, f"{field}.{scope}.{selector}")
 
-        if environment.platforms:
-            # Raw configuration, so a platform ddev does not target drops out of the intersection
-            # instead of failing the plan.
-            candidate_platforms = [by_name[name] for name in environment.platforms if name in by_name]
-        else:
-            candidate_platforms = list(platforms)
 
-        python_version = environment.python or default_python_version
-        if not PYTHON_VERSION_PATTERN.match(python_version):
-            raise PlanningError(
-                f'Environment {environment.name!r} reports Python {python_version!r}; '
-                f'expected a `major.minor` version such as `3.13`'
-            )
-
-        for platform in candidate_platforms:
-            resolved.append(
-                ResolvedEnvironment(
-                    name=environment.name,
-                    platform=platform,
-                    python_version=python_version,
-                    test_available=environment.test_env,
-                    e2e_available=environment.e2e_env,
-                )
-            )
-    return resolved
+def _os_platform_mapping(value: object, field: str) -> dict[str, list[str]]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{field}: expected literal value/if mappings")
+    platforms: dict[str, list[str]] = {}
+    for item in value:
+        mapping = _table(item, field)
+        if mapping.keys() != {"value", "if"} or not isinstance(mapping["value"], str) or not mapping["value"]:
+            raise ValueError(f"{field}: only literal value/if mappings are supported")
+        for os_name in _strings(mapping["if"], f"{field}.if", nonempty=True):
+            platforms.setdefault(os_name, []).append(mapping["value"])
+    return platforms

--- a/ddev/src/ddev/cli/ci/tests/batching/build.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/build.py
@@ -51,7 +51,7 @@ UNSUPPORTED_ENVIRONMENT_FIELDS = {
     "default": ("template", "matrix-name-format", "matrix-exclude", "matrix-include"),
     "named": ("template",),
 }
-UNSUPPORTED_OVERRIDE_FIELDS = frozenset({"python", "platforms", "matrix", "template", "matrix-name-format"})
+UNSUPPORTED_OVERRIDE_FIELDS = frozenset({"python", "platforms", "matrix", "template", "matrix-name-format", "test-env"})
 OS_PLATFORM_OVERRIDE = ("matrix", "os", "platforms")
 PLATFORM_MAPPING_FIELDS = frozenset({"value", "if"})
 
@@ -189,11 +189,12 @@ class HatchEnvironmentProvider:
     Each combination produces a candidate per compatible requested platform.
     Without a matrix, use the default environment.
 
+    The test-env flag defaults to true and cannot be disabled or overridden.
+    E2E availability uses its literal value (true by default); an e2e-env
+    override keeps E2E enabled for the worker to decide.
     Only literal matrix.os.platforms mappings are resolved during planning.
-    An override mentioning test-env or e2e-env keeps that specific stage
-    enabled for the worker to decide. Otherwise each flag uses its literal
-    value, defaulting to true. Unsupported discovery overrides raise a
-    planning error; runtime-only settings are ignored.
+    Unsupported discovery overrides raise a planning error; runtime-only
+    settings are ignored.
     """
 
     default_python_version: str
@@ -228,8 +229,6 @@ class HatchEnvironmentProvider:
             names.add(name)
 
             candidates = _environment_platforms(platforms, variables.get("os"), restrictions, os_platforms, field)
-            if not any(availability.values()):
-                continue
             result.extend(
                 ResolvedEnvironment(
                     name=name,
@@ -279,6 +278,8 @@ def _execution_settings(default: dict[str, Any]) -> tuple[dict[str, bool], dict[
         if not isinstance(value, bool):
             raise ValueError(f"envs.default.{field}: expected a boolean")
         availability[field] = value
+    if not availability["test-env"]:
+        raise ValueError("envs.default.test-env: disabling unit tests is unsupported for static discovery")
 
     os_platforms = None
     for scope, selector, settings in _overrides(default.get("overrides", {}), "envs.default.overrides"):
@@ -288,8 +289,8 @@ def _execution_settings(default: dict[str, Any]) -> tuple[dict[str, bool], dict[
                 os_platforms = _os_platform_mapping(value, location)
             elif field in UNSUPPORTED_OVERRIDE_FIELDS:
                 raise ValueError(f"{location}: unsupported for static discovery")
-            elif field in availability:
-                # The worker evaluates these conditions; false here would prevent it from doing so.
+            elif field == "e2e-env":
+                # ddev env test evaluates E2E availability on the worker.
                 availability[field] = True
     return availability, os_platforms
 

--- a/ddev/src/ddev/cli/ci/tests/batching/hatch_environments.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/hatch_environments.py
@@ -1,0 +1,241 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Static Hatch environment discovery for Dispatcher planning."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from ddev.cli.ci.tests.batching.exceptions import PlanningError
+from ddev.cli.ci.tests.batching.units import ResolvedEnvironment
+from ddev.e2e.agent_images import PYTHON_VERSION_PATTERN
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+    from typing import Any
+
+    from ddev.integration.core import Integration
+    from ddev.utils.platform import PlatformName
+
+ENVIRONMENT_NAME_PATTERN = re.compile(r"[A-Za-z0-9._-]+")
+SUPPORTED_ENVIRONMENT_COLLECTORS = frozenset({"default", "datadog-checks"})
+SUPPORTED_OVERRIDE_SCOPES = frozenset({"platform", "env", "matrix", "name"})
+UNSUPPORTED_ENVIRONMENT_FIELDS = {
+    "default": ("template", "matrix-name-format", "matrix-exclude", "matrix-include"),
+    "named": ("template",),
+}
+UNSUPPORTED_OVERRIDE_FIELDS = frozenset({"python", "platforms", "matrix", "template", "matrix-name-format", "test-env"})
+OS_PLATFORM_OVERRIDE = ("matrix", "os", "platforms")
+PLATFORM_MAPPING_FIELDS = frozenset({"value", "if"})
+
+# The datadog-checks collector enables both stages on the default environment.
+TEST_STAGE_DEFAULTS = {"test-env": True, "e2e-env": True}
+
+
+@dataclass(frozen=True)
+class HatchEnvironmentSettings:
+    e2e_available: bool
+    platform_restrictions: list[str]
+    # Matrix `os` value -> eligible execution platforms; None means no explicit mapping.
+    os_platforms: dict[str, list[str]] | None
+
+    def platforms_for(self, platforms: Sequence[PlatformName], os_name: str | None, field: str) -> list[PlatformName]:
+        allowed = self.platform_restrictions
+        if os_name is not None:
+            if self.os_platforms is None:
+                if allowed and os_name not in allowed:
+                    return []
+                allowed = [os_name]
+            elif os_name not in self.os_platforms:
+                raise ValueError(f"{field}.os: no platform mapping for {os_name!r}")
+            else:
+                allowed = self.os_platforms[os_name]
+        elif self.os_platforms is not None:
+            raise ValueError(f"{field}: matrix.os.platforms requires an os variable")
+        return [platform for platform in platforms if not allowed or str(platform) in allowed]
+
+
+@dataclass(frozen=True, eq=False)
+class HatchEnvironmentProvider:
+    """Read candidate environments from Hatch configuration without evaluating project code.
+
+    Parse hatch.toml with tomllib and expand each default matrix into the
+    Cartesian product of its axes, with Python first in environment names.
+    For example, python = ["3.12", "3.13"] and version = ["1", "2"] produce
+    py3.12-1, py3.12-2, py3.13-1, and py3.13-2.
+
+    Each combination produces a candidate per compatible requested platform.
+    Without a matrix, use the default environment.
+
+    The test-env flag defaults to true and cannot be disabled or overridden.
+    E2E availability uses its literal value (true by default); an e2e-env
+    override keeps E2E enabled for the worker to decide.
+    Only literal matrix.os.platforms mappings are resolved during planning.
+    Unsupported discovery overrides raise a planning error; runtime-only
+    settings are ignored.
+    """
+
+    default_python_version: str
+
+    def __call__(self, integration: Integration, platforms: Sequence[PlatformName]) -> list[ResolvedEnvironment]:
+        import tomllib
+
+        try:
+            with open(integration.path / "hatch.toml", "rb") as stream:
+                config = tomllib.load(stream)
+            return self._resolve(config, platforms)
+        except (OSError, ValueError) as error:
+            raise PlanningError(f"{integration.name}/hatch.toml: {error}") from error
+
+    def _resolve(self, config: dict[str, Any], platforms: Sequence[PlatformName]) -> list[ResolvedEnvironment]:
+        default = _default_environment(config)
+        python = _python_version(default.get("python", self.default_python_version), "envs.default.python")
+        settings = _execution_settings(default)
+
+        result: list[ResolvedEnvironment] = []
+        names: set[str] = set()
+        for field, variables in _matrix_combinations(default.get("matrix", [])):
+            version = _python_version(variables.get("python", python), f"{field}.python")
+            name = _environment_name(variables, field)
+            if name in names:
+                raise ValueError(f"{field}: duplicate environment name {name!r}")
+            names.add(name)
+
+            result.extend(
+                ResolvedEnvironment(
+                    name=name,
+                    platform=platform,
+                    python_version=version,
+                    test_available=True,
+                    e2e_available=settings.e2e_available,
+                )
+                for platform in settings.platforms_for(platforms, variables.get("os"), field)
+            )
+        return result
+
+
+def _default_environment(config: dict[str, Any]) -> dict[str, Any]:
+    env = _table(config.get("env", {}), "env")
+    collectors = _table(env.get("collectors", {}), "env.collectors")
+    if unknown := collectors.keys() - SUPPORTED_ENVIRONMENT_COLLECTORS:
+        raise ValueError(f"env.collectors: unsupported collectors {sorted(unknown)}")
+
+    envs = _table(config.get("envs", {}), "envs")
+    for name, value in envs.items():
+        if name == "default":
+            continue
+        named = _table(value, f"envs.{name}")
+        for field in UNSUPPORTED_ENVIRONMENT_FIELDS["named"]:
+            if field in named:
+                raise ValueError(f"envs.{name}.{field}: unsupported for static discovery")
+        if any(named.get(field, False) for field in TEST_STAGE_DEFAULTS):
+            raise ValueError(f"envs.{name}: test environments outside envs.default are unsupported")
+        for _, _, settings in _overrides(named.get("overrides", {}), f"envs.{name}.overrides"):
+            if settings.keys() & TEST_STAGE_DEFAULTS.keys():
+                raise ValueError(f"envs.{name}.overrides: conditional named test environments are unsupported")
+
+    default = _table(envs.get("default", {}), "envs.default")
+    for field in UNSUPPORTED_ENVIRONMENT_FIELDS["default"]:
+        if field in default:
+            raise ValueError(f"envs.default.{field}: unsupported for static discovery")
+    if default.get("type", "virtual") != "virtual":
+        raise ValueError("envs.default.type: only virtual environments support static discovery")
+    return default
+
+
+def _execution_settings(default: dict[str, Any]) -> HatchEnvironmentSettings:
+    restrictions = _strings(default.get("platforms", []), "envs.default.platforms")
+    availability = {}
+    for field, fallback in TEST_STAGE_DEFAULTS.items():
+        value = default.get(field, fallback)
+        if not isinstance(value, bool):
+            raise ValueError(f"envs.default.{field}: expected a boolean")
+        availability[field] = value
+    if not availability["test-env"]:
+        raise ValueError("envs.default.test-env: disabling unit tests is unsupported for static discovery")
+
+    os_platforms = None
+    for scope, selector, settings in _overrides(default.get("overrides", {}), "envs.default.overrides"):
+        for field, value in settings.items():
+            location = f"envs.default.overrides.{scope}.{selector}.{field}"
+            if (scope, selector, field) == OS_PLATFORM_OVERRIDE:
+                os_platforms = _os_platform_mapping(value, location)
+            elif field in UNSUPPORTED_OVERRIDE_FIELDS:
+                raise ValueError(f"{location}: unsupported for static discovery")
+            elif field == "e2e-env":
+                # ddev env test evaluates E2E availability on the worker.
+                availability[field] = True
+
+    if os_platforms is not None and restrictions:
+        raise ValueError("envs.default.platforms: combining literal and matrix platform restrictions is unsupported")
+    return HatchEnvironmentSettings(
+        e2e_available=availability["e2e-env"], platform_restrictions=restrictions, os_platforms=os_platforms
+    )
+
+
+def _matrix_combinations(value: object) -> Iterator[tuple[str, dict[str, str]]]:
+    from itertools import product
+
+    if not isinstance(value, list):
+        raise ValueError("envs.default.matrix: expected an array of tables")
+    for index, entry in enumerate(value or [{}]):
+        field = f"envs.default.matrix[{index}]"
+        matrix = _table(entry, field)
+        if value and not matrix:
+            raise ValueError(f"{field}: expected at least one matrix variable")
+        # Hatch places Python first in environment names, regardless of TOML key order.
+        axes = sorted(matrix, key=lambda key: key != "python")
+        values = [_strings(matrix[axis], f"{field}.{axis}", nonempty=True) for axis in axes]
+        for combination in product(*values):
+            yield field, dict(zip(axes, combination, strict=True))
+
+
+def _environment_name(variables: dict[str, str], field: str) -> str:
+    name = "-".join(f"py{value}" if key == "python" else value for key, value in variables.items()) or "default"
+    if not ENVIRONMENT_NAME_PATTERN.fullmatch(name):
+        raise ValueError(f"{field}: invalid environment name {name!r}")
+    return name
+
+
+def _table(value: object, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field}: expected a table")
+    return value
+
+
+def _strings(value: object, field: str, *, nonempty: bool = False) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
+        raise ValueError(f"{field}: expected an array of nonempty strings")
+    if nonempty and not value:
+        raise ValueError(f"{field}: expected at least one value")
+    return value
+
+
+def _python_version(value: object, field: str) -> str:
+    if not isinstance(value, str) or not PYTHON_VERSION_PATTERN.fullmatch(value):
+        raise ValueError(f"{field}: expected a `major.minor` Python version, got {value!r}")
+    return value
+
+
+def _overrides(value: object, field: str) -> Iterator[tuple[str, str, dict[str, Any]]]:
+    for scope, selectors in _table(value, field).items():
+        if scope not in SUPPORTED_OVERRIDE_SCOPES:
+            continue
+        for selector, settings in _table(selectors, f"{field}.{scope}").items():
+            yield scope, selector, _table(settings, f"{field}.{scope}.{selector}")
+
+
+def _os_platform_mapping(value: object, field: str) -> dict[str, list[str]]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{field}: expected literal value/if mappings")
+    platforms: dict[str, list[str]] = {}
+    for item in value:
+        mapping = _table(item, field)
+        if mapping.keys() != PLATFORM_MAPPING_FIELDS or not isinstance(mapping["value"], str) or not mapping["value"]:
+            raise ValueError(f"{field}: only literal value/if mappings are supported")
+        for os_name in _strings(mapping["if"], f"{field}.if", nonempty=True):
+            platforms.setdefault(os_name, []).append(mapping["value"])
+    return platforms

--- a/ddev/src/ddev/cli/ci/tests/batching/units.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/units.py
@@ -66,8 +66,8 @@ logger = logging.getLogger(__name__)
 class ResolvedEnvironment:
     """A candidate environment routed onto a platform.
 
-    Availability flags request test stages, not guaranteed work. Conditional availability stays
-    enabled here so the worker can resolve it against its own platform and environment.
+    Availability flags request test stages, not guaranteed work. Conditional E2E availability
+    stays enabled here so the worker can resolve it against its own platform and environment.
     """
 
     name: str

--- a/ddev/src/ddev/cli/ci/tests/batching/units.py
+++ b/ddev/src/ddev/cli/ci/tests/batching/units.py
@@ -64,31 +64,16 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class ResolvedEnvironment:
-    """One environment a target runs, already routed onto a platform.
+    """A candidate environment routed onto a platform.
 
-    The two availability flags carry intent rather than a decision. They exist so a later change can
-    split unit and E2E work into separate jobs per environment and platform, which is why they are
-    per-environment here instead of per-target. Nothing splits on them yet: the workflow runs both
-    kinds of test and each works out at runtime whether it has anything to do, which is how CI
-    behaves today.
-
-    Splitting is deferred because Hatch cannot answer the question at planning time. It resolves
-    `platform.*` overrides against the machine it runs on, so `platform.windows.e2e-env = false`
-    (ibm_mq, ibm_ace, network, sqlserver) is invisible when planning on Linux, and it resolves
-    `env.*` overrides against the ambient environment, so azure_iot_edge's E2E availability depends
-    on a secret the planner does not have. Neither is knowable from one host. Note the `env.*` case
-    fails toward reporting no E2E work, so it drops coverage rather than wasting compute once
-    anything gates on these flags. The per-integration tooling configuration that replaces
-    `manifest.json` and `.ddev/config.toml` is where each environment will declare this
-    deterministically, and that is what these flags should be driven from.
+    Availability flags request test stages, not guaranteed work. Conditional availability stays
+    enabled here so the worker can resolve it against its own platform and environment.
     """
 
     name: str
     platform: PlatformName
     python_version: str  # `major.minor`, picks both the runner Python and the E2E Agent image
-    # TODO(manifest): drive these from the per-integration tooling configuration planned to replace
-    # `manifest.json`, which can declare them per platform deterministically, and split unit and
-    # E2E work into separate jobs once it can.
+    # TODO(manifest): use explicit per-platform availability before splitting unit and E2E jobs.
     test_available: bool = True  # ddev's `test_env`
     e2e_available: bool = False  # ddev's `e2e_env`
 

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -5,12 +5,22 @@
 
 from __future__ import annotations
 
+import subprocess
+from typing import TYPE_CHECKING
+
 import pytest
 
 from ddev.cli.ci.dispatch_tests import head_is_fork
 from ddev.utils.github_async import GitHubResponse
 from ddev.utils.github_async.models import PullRequest, PullRequestFile, PullRequestSimple
 from tests.cli.ci.tests.helpers import make_batch, make_job
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ddev.config.file import ConfigFileWithOverrides
+    from tests.helpers.github_async import FakeAsyncGitHubClient
+    from tests.helpers.runner import CliRunner
 
 PR_NUMBER = 4242
 HEAD_SHA = 'head-sha-aaa'
@@ -64,7 +74,7 @@ def pulls_page(*pulls: PullRequestSimple) -> GitHubResponse[list[PullRequestSimp
 
 @pytest.fixture
 def planned(mocker):
-    """Stand in for the planning layer, which has its own tests and costs a Hatch call per target."""
+    """Keep PR-resolution tests independent of the planning layer."""
     batches = [make_batch(make_job(target='ntp'))]
     return mocker.patch('ddev.cli.ci.dispatch_tests.build_plan', return_value=batches)
 
@@ -110,6 +120,27 @@ def test_a_pull_request_supplies_the_whole_run_context(ddev, github, planned, re
     assert 'a-target-branch' in result.output
     # A pull request is tested at its merge commit, not at its head.
     assert f'refs/pull/{PR_NUMBER}/merge' in result.output
+
+
+def test_dispatch_tests_plans_from_hatch_toml(
+    ddev: CliRunner, github: FakeAsyncGitHubClient, config_file: ConfigFileWithOverrides, tmp_path: Path
+):
+    root = tmp_path / 'repo'
+    (root / '.ddev').mkdir(parents=True)
+    (root / '.ddev' / 'config.toml').write_text('')
+    subprocess.run(['git', 'init', '--quiet', str(root)], check=True)
+    (root / 'ntp').mkdir()
+    (root / 'ntp' / 'hatch.toml').write_text(
+        '[envs.default]\ne2e-env = false\n[[envs.default.matrix]]\npython = ["3.13"]\nversion = ["1", "2"]\n'
+    )
+    config_file.global_model.repos['core'] = str(root)
+    config_file.save()
+
+    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--repo', 'DataDog/integrations-core', '--dry-run')
+
+    assert result.exit_code == 0, result.output
+    assert 'Batches -> 1 (2 jobs)' in result.output
+    assert '\n    ntp\n' in result.output
 
 
 def test_a_head_sha_resolves_to_its_pull_request(ddev, github, planned):

--- a/ddev/tests/cli/ci/tests/batching/test_build.py
+++ b/ddev/tests/cli/ci/tests/batching/test_build.py
@@ -18,10 +18,9 @@ from ddev.cli.ci.tests.batching.build import (
     build_test_batches,
     build_test_units,
     create_test_batches,
-    resolve_hatch_environments,
     supports_minimum_base_package,
 )
-from ddev.cli.ci.tests.batching.exceptions import BatchValidationError, PlanningError
+from ddev.cli.ci.tests.batching.exceptions import BatchValidationError
 from ddev.cli.ci.tests.dispatcher_config import BatchingConfig
 from ddev.utils.platform import PlatformName
 
@@ -30,7 +29,7 @@ if TYPE_CHECKING:
 
     from ddev.cli.ci.tests.batching.units import ResolvedEnvironment
     from ddev.cli.ci.tests.messages import BatchJob
-from tests.cli.ci.tests.helpers import DEFAULT_PYTHON_VERSION, FakeIntegration, FakeRegistry, env, jobs, modified
+from tests.cli.ci.tests.helpers import FakeIntegration, FakeRegistry, env, jobs, modified
 
 
 class FakeConfig:
@@ -64,25 +63,6 @@ class FakeEnvironmentProvider:
 
     def __call__(self, integration: FakeIntegration, platforms: Sequence[PlatformName]) -> list[ResolvedEnvironment]:
         return list(self._environments.get(integration.name, []))
-
-
-class EnvStub:
-    """Minimal stand-in for ddev's Hatch ``Environment`` (no Hatch invocation)."""
-
-    def __init__(
-        self,
-        name: str,
-        *,
-        test_env: bool = True,
-        e2e_env: bool = False,
-        platforms: Sequence[str] = (),
-        python: str | None = None,
-    ):
-        self.name = name
-        self.test_env = test_env
-        self.e2e_env = e2e_env
-        self.platforms = list(platforms)
-        self.python = python
 
 
 def test_build_end_to_end_direct_and_broad_overlap():
@@ -174,112 +154,6 @@ def test_build_applies_platform_and_runner_overrides():
         (PlatformName.WINDOWS, ("windows-2022",)),
         (PlatformName.LINUX, ("ubuntu-22.04",)),
     ]
-
-
-def test_resolve_hatch_environments_includes_both_facets_and_excludes_neither():
-    environments = [
-        EnvStub("unit-only", test_env=True, e2e_env=False),
-        EnvStub("e2e-only", test_env=False, e2e_env=True),
-        EnvStub("both", test_env=True, e2e_env=True),
-        EnvStub("neither", test_env=False, e2e_env=False),
-    ]
-
-    resolved = resolve_hatch_environments(
-        environments, default_python_version=DEFAULT_PYTHON_VERSION, platforms=[PlatformName.LINUX]
-    )
-
-    assert [(r.name, r.test_available, r.e2e_available) for r in resolved] == [
-        ("unit-only", True, False),
-        ("e2e-only", False, True),
-        ("both", True, True),
-    ]
-
-
-@pytest.mark.parametrize("python", ["3", "3.13t", "/usr/bin/python3.13", "three.thirteen"])
-def test_resolve_hatch_environments_rejects_a_python_that_is_not_major_minor(python: str):
-    # A unit-only environment never reaches the Agent image resolver, so this boundary is the only
-    # place its version is checked.
-    environments = [EnvStub("unit-only", test_env=True, e2e_env=False, python=python)]
-
-    with pytest.raises(PlanningError, match="expected a `major.minor` version"):
-        resolve_hatch_environments(
-            environments, default_python_version=DEFAULT_PYTHON_VERSION, platforms=[PlatformName.LINUX]
-        )
-
-
-def test_resolve_hatch_environments_routes_constrained_platforms_without_crossing():
-    # Mirrors sqlserver: os matrix surfaces as Environment.platforms via overrides.matrix.os.platforms.
-    environments = [
-        EnvStub("py3.13-linux", platforms=["linux", "macos"]),
-        EnvStub("py3.13-windows", platforms=["windows"]),
-    ]
-
-    resolved = resolve_hatch_environments(
-        environments,
-        default_python_version=DEFAULT_PYTHON_VERSION,
-        platforms=[PlatformName.WINDOWS, PlatformName.LINUX],
-    )
-
-    # Each environment lands only on its declared platform (intersected with the target's);
-    # the Linux env never duplicates onto Windows and vice versa, and macos is dropped.
-    assert [(r.name, r.platform) for r in resolved] == [
-        ("py3.13-linux", PlatformName.LINUX),
-        ("py3.13-windows", PlatformName.WINDOWS),
-    ]
-
-
-def test_resolve_hatch_environments_unconstrained_runs_on_every_platform():
-    environments = [EnvStub("py3.11", platforms=[])]
-
-    resolved = resolve_hatch_environments(
-        environments,
-        default_python_version=DEFAULT_PYTHON_VERSION,
-        platforms=[PlatformName.LINUX, PlatformName.WINDOWS],
-    )
-
-    # An environment that names no platform belongs to all of them, so the platform a target
-    # happens to list first carries no meaning.
-    assert [(r.name, r.platform) for r in resolved] == [
-        ("py3.11", PlatformName.LINUX),
-        ("py3.11", PlatformName.WINDOWS),
-    ]
-
-
-def test_resolve_hatch_environments_carries_facets_and_python_to_every_platform():
-    # Regression: the second platform used to fall through to a synthesised environment that
-    # claimed the default Python and no E2E, silently dropping Windows E2E for targets like disk.
-    environments = [EnvStub("py3.11", test_env=True, e2e_env=True, python="3.11")]
-
-    resolved = resolve_hatch_environments(
-        environments,
-        default_python_version=DEFAULT_PYTHON_VERSION,
-        platforms=[PlatformName.LINUX, PlatformName.WINDOWS],
-    )
-
-    assert [(r.platform, r.python_version, r.test_available, r.e2e_available) for r in resolved] == [
-        (PlatformName.LINUX, "3.11", True, True),
-        (PlatformName.WINDOWS, "3.11", True, True),
-    ]
-
-
-def test_resolve_hatch_environments_reads_the_python_version_from_hatch():
-    environments = [EnvStub("py3.11-1.23", python="3.11")]
-
-    resolved = resolve_hatch_environments(
-        environments, default_python_version=DEFAULT_PYTHON_VERSION, platforms=[PlatformName.LINUX]
-    )
-
-    assert resolved[0].python_version == "3.11"
-
-
-def test_resolve_hatch_environments_falls_back_when_hatch_declares_no_python():
-    # Hatch omits `python` when the environment does not pin one; the name is not parsed as a
-    # substitute because it only encodes the version by convention.
-    environments = [EnvStub("py3.11-1.23", python=None)]
-
-    resolved = resolve_hatch_environments(environments, default_python_version="3.9", platforms=[PlatformName.LINUX])
-
-    assert resolved[0].python_version == "3.9"
 
 
 def test_build_batches_end_to_end_split_defaults():

--- a/ddev/tests/cli/ci/tests/batching/test_hatch_environments.py
+++ b/ddev/tests/cli/ci/tests/batching/test_hatch_environments.py
@@ -126,9 +126,8 @@ def test_hatch_environments_route_platforms(tmp_path: Path, config: str, expecte
     ("config", "expected"),
     [
         pytest.param('[envs.default]', [(True, True)], id="standard-stages"),
+        pytest.param('[envs.default]\ntest-env = true', [(True, True)], id="explicit-unit-tests"),
         pytest.param('[envs.default]\ne2e-env = false', [(True, False)], id="unit-only"),
-        pytest.param('[envs.default]\ntest-env = false', [(False, True)], id="e2e-only"),
-        pytest.param('[envs.default]\ntest-env = false\ne2e-env = false', [], id="disabled"),
         pytest.param(
             '''
             [envs.default]
@@ -149,7 +148,7 @@ def test_hatch_environments_route_platforms(tmp_path: Path, config: str, expecte
         ),
     ],
 )
-def test_hatch_environments_keep_conditional_stages_for_the_worker(
+def test_hatch_environments_resolve_stages_and_defer_conditional_e2e(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config: str, expected: list[tuple[bool, bool]]
 ):
     integration = integration_with_config(tmp_path, config)
@@ -164,6 +163,17 @@ def test_hatch_environments_keep_conditional_stages_for_the_worker(
 @pytest.mark.parametrize(
     ("config", "field"),
     [
+        pytest.param('[envs.default]\ntest-env = false', "envs.default.test-env", id="disabled-unit-tests"),
+        pytest.param(
+            '[envs.default.overrides]\nenv.RUN_UNIT.test-env = { value = true }',
+            "envs.default.overrides.env.RUN_UNIT.test-env",
+            id="unit-test-enablement-override",
+        ),
+        pytest.param(
+            '[envs.default.overrides]\nplatform.windows.test-env = { value = false }',
+            "envs.default.overrides.platform.windows.test-env",
+            id="unit-test-disablement-override",
+        ),
         pytest.param('[envs.default]\npython = "3.13t"', "envs.default.python", id="unsupported-python"),
         pytest.param('[envs.default]\nplatforms = "linux"', "envs.default.platforms", id="invalid-platform-list"),
         pytest.param('[[envs.default.matrix]]\npython = []', "envs.default.matrix[0].python", id="empty-axis"),

--- a/ddev/tests/cli/ci/tests/batching/test_hatch_environments.py
+++ b/ddev/tests/cli/ci/tests/batching/test_hatch_environments.py
@@ -9,8 +9,8 @@ from textwrap import dedent
 
 import pytest
 
-from ddev.cli.ci.tests.batching.build import HatchEnvironmentProvider
 from ddev.cli.ci.tests.batching.exceptions import PlanningError
+from ddev.cli.ci.tests.batching.hatch_environments import HatchEnvironmentProvider
 from ddev.integration.core import Integration
 from ddev.repo.config import RepositoryConfig
 from ddev.utils.fs import Path as DdevPath

--- a/ddev/tests/cli/ci/tests/batching/test_hatch_environments.py
+++ b/ddev/tests/cli/ci/tests/batching/test_hatch_environments.py
@@ -183,6 +183,19 @@ def test_hatch_environments_keep_conditional_stages_for_the_worker(
         pytest.param('[env.collectors.custom]\npath = "hatch_plugin.py"', "env.collectors", id="custom-collector"),
         pytest.param('[envs.extra]\ntest-env = true', "envs.extra", id="named-test-environment"),
         pytest.param(
+            '''
+            [env.collectors.default]
+            [envs.default]
+            python = "3.13"
+            test-env = true
+            e2e-env = false
+            [envs.extra]
+            template = "default"
+            ''',
+            "envs.extra.template",
+            id="named-inheritance",
+        ),
+        pytest.param(
             '[envs.default.overrides]\nenv.PYTHON.python = { value = "3.11" }',
             "envs.default.overrides.env.PYTHON.python",
             id="dynamic-python",

--- a/ddev/tests/cli/ci/tests/batching/test_hatch_environments.py
+++ b/ddev/tests/cli/ci/tests/batching/test_hatch_environments.py
@@ -1,0 +1,204 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from ddev.cli.ci.tests.batching.build import HatchEnvironmentProvider
+from ddev.cli.ci.tests.batching.exceptions import PlanningError
+from ddev.integration.core import Integration
+from ddev.repo.config import RepositoryConfig
+from ddev.utils.fs import Path as DdevPath
+from ddev.utils.platform import PlatformName
+
+
+def integration_with_config(tmp_path: Path, content: str) -> Integration:
+    path = DdevPath(tmp_path, "sample")
+    path.mkdir()
+    (path / "hatch.toml").write_text(dedent(content), encoding="utf-8")
+    return Integration(path, DdevPath(tmp_path), RepositoryConfig(DdevPath(tmp_path, "config.toml")))
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        pytest.param('[envs.default]\npython = "3.11"', [("default", "3.11")], id="default-only"),
+        pytest.param('[envs.default]', [("default", "3.13")], id="default-python"),
+        pytest.param(
+            '''
+            [envs.default]
+            python = "3.12"
+            [[envs.default.matrix]]
+            version = ["1", "2"]
+            ''',
+            [("1", "3.12"), ("2", "3.12")],
+            id="python-outside-matrix",
+        ),
+        pytest.param(
+            '''
+            [[envs.default.matrix]]
+            version = ["9", "10"]
+            python = ["3.11", "3.13"]
+            [[envs.default.matrix]]
+            python = ["3.13"]
+            version = ["9"]
+            setup = ["cluster"]
+            [envs.default.overrides]
+            matrix.version.env-vars = "VERSION"
+            GITLAB_IMAGE = "gitlab/gitlab-ce"
+            [envs.bench]
+            detached = true
+            ''',
+            [
+                ("py3.11-9", "3.11"),
+                ("py3.11-10", "3.11"),
+                ("py3.13-9", "3.13"),
+                ("py3.13-10", "3.13"),
+                ("py3.13-9-cluster", "3.13"),
+            ],
+            id="multiple-matrices",
+        ),
+    ],
+)
+def test_hatch_environments_expand_names_and_python_on_each_platform(
+    tmp_path: Path, config: str, expected: list[tuple[str, str]]
+):
+    integration = integration_with_config(tmp_path, config)
+    platforms = [PlatformName.LINUX, PlatformName.WINDOWS]
+
+    environments = HatchEnvironmentProvider("3.13")(integration, platforms)
+
+    assert [(e.name, e.python_version, e.platform) for e in environments] == [
+        (name, python, platform) for name, python in expected for platform in platforms
+    ]
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        pytest.param(
+            '[envs.default]\nplatforms = ["windows"]',
+            [("default", PlatformName.WINDOWS)],
+            id="literal-platforms",
+        ),
+        pytest.param(
+            '[[envs.default.matrix]]\npython = ["3.13"]\nos = ["linux", "windows"]',
+            [("py3.13-linux", PlatformName.LINUX), ("py3.13-windows", PlatformName.WINDOWS)],
+            id="os-convention",
+        ),
+        pytest.param(
+            '''
+            [[envs.default.matrix]]
+            python = ["3.13"]
+            os = ["linux", "windows"]
+            [envs.default.overrides]
+            matrix.os.platforms = [
+              { value = "windows", if = ["windows"] },
+              { value = "linux", if = ["linux"] },
+              { value = "macos", if = ["linux"] },
+            ]
+            ''',
+            [
+                ("py3.13-linux", PlatformName.LINUX),
+                ("py3.13-linux", PlatformName.MACOS),
+                ("py3.13-windows", PlatformName.WINDOWS),
+            ],
+            id="sqlserver-platform-map",
+        ),
+    ],
+)
+def test_hatch_environments_route_platforms(tmp_path: Path, config: str, expected: list[tuple[str, PlatformName]]):
+    integration = integration_with_config(tmp_path, config)
+
+    environments = HatchEnvironmentProvider("3.13")(
+        integration, [PlatformName.LINUX, PlatformName.MACOS, PlatformName.WINDOWS]
+    )
+
+    assert [(e.name, e.platform) for e in environments] == expected
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        pytest.param('[envs.default]', [(True, True)], id="standard-stages"),
+        pytest.param('[envs.default]\ne2e-env = false', [(True, False)], id="unit-only"),
+        pytest.param('[envs.default]\ntest-env = false', [(False, True)], id="e2e-only"),
+        pytest.param('[envs.default]\ntest-env = false\ne2e-env = false', [], id="disabled"),
+        pytest.param(
+            '''
+            [envs.default]
+            e2e-env = false
+            [envs.default.overrides]
+            env.IOT_EDGE_CONNSTR.e2e-env = { value = true }
+            ''',
+            [(True, True)],
+            id="runtime-enablement",
+        ),
+        pytest.param(
+            '''
+            [envs.default.overrides]
+            platform.windows.e2e-env = { value = false }
+            ''',
+            [(True, True)],
+            id="runtime-disablement",
+        ),
+    ],
+)
+def test_hatch_environments_keep_conditional_stages_for_the_worker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config: str, expected: list[tuple[bool, bool]]
+):
+    integration = integration_with_config(tmp_path, config)
+    provider = HatchEnvironmentProvider("3.13")
+
+    monkeypatch.delenv("IOT_EDGE_CONNSTR", raising=False)
+    environments = provider(integration, [PlatformName.WINDOWS])
+
+    assert [(e.test_available, e.e2e_available) for e in environments] == expected
+
+
+@pytest.mark.parametrize(
+    ("config", "field"),
+    [
+        pytest.param('[envs.default]\npython = "3.13t"', "envs.default.python", id="unsupported-python"),
+        pytest.param('[envs.default]\nplatforms = "linux"', "envs.default.platforms", id="invalid-platform-list"),
+        pytest.param('[[envs.default.matrix]]\npython = []', "envs.default.matrix[0].python", id="empty-axis"),
+        pytest.param('[[envs.default.matrix]]\npython = [3.13]', "envs.default.matrix[0].python", id="numeric-axis"),
+        pytest.param('[[envs.default.matrix]]\nversion = ["bad name"]', "invalid environment name", id="unsafe-name"),
+        pytest.param(
+            '[[envs.default.matrix]]\nversion = ["same", "same"]',
+            "duplicate environment name",
+            id="duplicate-name",
+        ),
+        pytest.param('[envs.default]\ntemplate = "other"', "envs.default.template", id="inheritance"),
+        pytest.param(
+            '[envs.default]\nmatrix-name-format = "{variable}-{value}"',
+            "envs.default.matrix-name-format",
+            id="custom-naming",
+        ),
+        pytest.param('[env.collectors.custom]\npath = "hatch_plugin.py"', "env.collectors", id="custom-collector"),
+        pytest.param('[envs.extra]\ntest-env = true', "envs.extra", id="named-test-environment"),
+        pytest.param(
+            '[envs.default.overrides]\nenv.PYTHON.python = { value = "3.11" }',
+            "envs.default.overrides.env.PYTHON.python",
+            id="dynamic-python",
+        ),
+        pytest.param(
+            '[envs.default.overrides]\nname.special.platforms = ["windows"]',
+            "envs.default.overrides.name.special.platforms",
+            id="dynamic-platforms",
+        ),
+        pytest.param('[envs.default', "sample/hatch.toml", id="invalid-toml"),
+    ],
+)
+def test_hatch_environments_report_unreliable_discovery(tmp_path: Path, config: str, field: str):
+    integration = integration_with_config(tmp_path, config)
+
+    with pytest.raises(PlanningError, match=re.escape(field)) as error:
+        HatchEnvironmentProvider("3.13")(integration, [PlatformName.LINUX])
+
+    assert "sample/hatch.toml" in str(error.value)


### PR DESCRIPTION
### What does this PR do?

Reimplements `HatchEnvironmentProvider` to read `hatch.toml` instead of invoking `hatch env show`. It keeps the existing provider interface and removes the planning-host dependency. The Hatch implementation lives in `hatch_environments.py`, with a frozen `HatchEnvironmentSettings` for parsed E2E and platform settings.

Supports default matrices, Python versions, literal platform restrictions, and the `os` matrix convention, including SQL Server's literal platform mapping. Default unit tests must stay enabled; `test-env=false` and `test-env` overrides are planning errors. Conditional E2E availability stays enabled for the worker to resolve. Unsupported discovery-affecting configuration fails with the target and field named in the error; there is no Hatch fallback or general override engine.

### Motivation

[AI-7127](https://datadoghq.atlassian.net/browse/AI-7127). Hatch environment inspection loads project plugins, which is unsafe for PR-controlled configuration in the credentialed Dispatcher job. Runtime test commands continue using Hatch. Legacy CI is unchanged.

Validation:
- 75 focused tests passed across environment discovery, batching, and the CLI, including rejection of named-environment inheritance and unsupported unit-test availability.
- Formatting, lint, and type checks passed through ddev.
- The module/settings refactor produces identical candidate output for all 226 target configurations.
- Read all 226 target configurations with subprocess creation blocked: no discovery errors and no missing explicit legacy environment names. The full plan with minimum-base-package replicas contains 853 jobs in 4 batches. This was planning only, not test execution.

Cross-checked the provider against `python -m hatch env show --json` for all 226 target configurations, using Hatch 1.18.0 on macOS. Compared names and Python versions after filtering Hatch's output to test-enabled, macOS-compatible environments.

| Check | Result |
| --- | --- |
| Successful Hatch commands | 226/226 |
| Native-platform environments | 402 from each provider |
| Missing or extra environments | 0 |
| Python-version mismatches | 0 |
| E2E-flag differences | 8 |
| Stages enabled by Hatch but suppressed by the static reader | 0 |

All eight differences are static `true` versus Hatch `false`, intentionally leaving the decision to the worker. They occur in `azure_iot_edge`, `cilium`, `dell_powerflex`, `esxi`, `fly_io`, `octopus_deploy`, `openstack_controller`, and `teradata`. This validates native macOS discovery, not Linux/Windows runtime parity.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7127]: https://datadoghq.atlassian.net/browse/AI-7127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


