### PR TITLE
Add to AGENTS.md that new integrations must not include a manifest.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Some directories have their own `AGENTS.md`/`CLAUDE.md` with narrower, directory
 - [Python Code Style](#python-code-style)
 - [Configuration Models](#configuration-models)
 - [Service Checks](#service-checks)
+- [Manifest Files](#manifest-files)
 - [Development Workflow](#development-workflow)
 - [Pull Requests](#pull-requests)
 - [Documentation](#documentation)
@@ -98,6 +99,18 @@ ddev validate models -s <INTEGRATION_NAME>
 New integrations should not add their own service checks. Use metrics and metric-based monitors instead. Existing integrations that already submit service checks may continue to do so for backward compatibility.
 
 The one exception is the OpenMetrics base check, which still emits a service check (e.g. `<check>.openmetrics.health`) itself. This is inherited automatically from the base class rather than something an integration author chooses to add, and is expected to change in the future. It is not a reason to add further, integration-specific service checks on top of it.
+
+## Manifest Files
+
+New integrations must not include a `manifest.json`. Instead, add the following to `.ddev/config.toml`, keyed by the integration's directory name:
+
+- Display name under `[overrides.display-name]`.
+- Metrics prefix (matching the prefix used in `metadata.csv`) under `[overrides.metrics-prefix]`.
+- Supported platforms under `[overrides.manifest.platforms]`.
+
+`assets/configuration/spec.yaml`, `metadata.csv`, and `assets/service_checks.json` are unaffected and still live at their normal paths regardless of whether the integration has a manifest.
+
+Existing integrations that already have a `manifest.json` should keep it — there's no need to migrate them away from it.
 
 ## Development Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,21 +96,21 @@ ddev validate models -s <INTEGRATION_NAME>
 
 ## Service Checks
 
-New integrations should not add their own service checks. Use metrics and metric-based monitors instead. Existing integrations that already submit service checks may continue to do so for backward compatibility.
+**Applicable to:** newly created integrations. Existing integrations that already submit service checks are exempt.
+
+New integrations should not add their own service checks. Use metrics and metric-based monitors instead.
 
 The one exception is the OpenMetrics base check, which still emits a service check (e.g. `<check>.openmetrics.health`) itself. This is inherited automatically from the base class rather than something an integration author chooses to add, and is expected to change in the future. It is not a reason to add further, integration-specific service checks on top of it.
 
 ## Manifest Files
+
+**Applicable to:** newly created integrations. Existing integrations that already have a `manifest.json` are exempt.
 
 New integrations must not include a `manifest.json`. Instead, add the following to `.ddev/config.toml`, keyed by the integration's directory name:
 
 - Display name under `[overrides.display-name]`.
 - Metrics prefix (matching the prefix used in `metadata.csv`) under `[overrides.metrics-prefix]`.
 - Supported platforms under `[overrides.manifest.platforms]`.
-
-`assets/configuration/spec.yaml`, `metadata.csv`, and `assets/service_checks.json` are unaffected and still live at their normal paths regardless of whether the integration has a manifest.
-
-Existing integrations that already have a `manifest.json` should keep it — there's no need to migrate them away from it.
 
 ## Development Workflow
 


### PR DESCRIPTION

### What does this PR do?
Adds a "Manifest Files" section to `AGENTS.md` stating that new integrations must not include a `manifest.json`, and lists the `.ddev/config.toml` override sections (`overrides.display-name`, `overrides.metrics-prefix`, `overrides.manifest.platforms`) that replace it.

### Motivation
New integrations already rely on `ddev create`'s manifest-less default and the corresponding `.ddev/config.toml` overrides instead of a `manifest.json`, but this convention was undocumented anywhere in the repo. As a result, both human contributors and AI coding agents working from `AGENTS.md` had no way to know a manifest shouldn't be added to a new integration.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged