### PR TITLE
Use the Dispatcher dd-sts policy in test-batch

### DIFF
--- a/.github/workflows/test-batch.yml
+++ b/.github/workflows/test-batch.yml
@@ -213,7 +213,7 @@ jobs:
         id: dd-sts
         uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
         with:
-          policy: integrations-test-target-api-key
+          policy: integrations-dispatcher-api-key
 
       - name: Set up Python ${{ matrix.python_version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
### What does this PR do?

Switches `test-batch.yml` to the `integrations-dispatcher-api-key` dd-sts policy.

### Motivation

The current policy is scoped to `test-target.yml`, so the batch workflow gets a 401 when fetching Datadog credentials. The dedicated Dispatcher policy is now merged in [dd-source#83150](https://github.com/ddoghq/dd-source/pull/83150).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
