### PR TITLE
[SEC-37069][k9] Add TAXII integration account config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -105,6 +105,10 @@ manifest.json         @DataDog/documentation @DataDog/agent-integrations
 /podman/                                        @DataDog/container-integrations @DataDog/agent-integrations
 /podman/*.md                                    @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /podman/manifest.json                           @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/taxii/                                                    @DataDog/cloud-siem
+/taxii/*.md                                                @DataDog/cloud-siem @DataDog/documentation
+/taxii/manifest.json                                       @DataDog/cloud-siem @DataDog/documentation
+
 /tcp_queue_length/                              @DataDog/container-integrations @DataDog/agent-integrations
 /tcp_queue_length/*.md                          @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /tcp_queue_length/manifest.json                 @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation

--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -1469,6 +1469,10 @@ integration/tanium:
 - changed-files:
   - any-glob-to-any-file:
     - tanium/**/*
+integration/taxii:
+- changed-files:
+  - any-glob-to-any-file:
+    - taxii/**/*
 integration/tcp_check:
 - changed-files:
   - any-glob-to-any-file:

--- a/taxii/CHANGELOG.md
+++ b/taxii/CHANGELOG.md
@@ -1,0 +1,5 @@
+# TAXII change log
+
+## 1.0.0 / Unreleased
+
+- Initial release of the TAXII integration for Generic AMS.

--- a/taxii/README.md
+++ b/taxii/README.md
@@ -44,4 +44,4 @@ Most TAXII problems are server-side. Include these from the Configure tab so sup
 
 **Connection timeout or TLS handshake failed.** Usually a network path or certificate problem on the server side, not something Datadog can retry around.
 
-For questions about the TAXII standard itself rather than this integration, see the [OASIS CTI documentation](https://docs.oasis-open.org/cti/).
+For questions about the TAXII standard itself rather than this integration, see the [OASIS CTI documentation](https://oasis-open.github.io/cti-documentation/).

--- a/taxii/README.md
+++ b/taxii/README.md
@@ -22,7 +22,7 @@ Add each collection you want to ingest by its ID. Objects are mapped to STIX 2.1
 
 ## Troubleshooting
 
-Need help? Contact Datadog support.
+Need help? Contact [Datadog support](https://www.datadoghq.com/support/).
 
 ### Before you open a ticket
 

--- a/taxii/README.md
+++ b/taxii/README.md
@@ -1,4 +1,4 @@
-# STIX/TAXII
+# TAXII
 
 ## Overview
 

--- a/taxii/README.md
+++ b/taxii/README.md
@@ -14,7 +14,7 @@ STIX 2.1 is the standard format for describing threat intelligence: indicators, 
 
 Datadog acts as a TAXII client. It authenticates to a server you supply and polls the collections you add by ID, fetching new objects on the interval you choose. Because both are open standards, this one tile covers any vendor or community feed that speaks TAXII 2.1, with no per-vendor integration required.
 
-## Installation
+## Setup
 
 Click "New" and enter the TAXII server's API root URL and its credentials.
 

--- a/taxii/README.md
+++ b/taxii/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-STIX/TAXII enables you to:
+TAXII enables you to:
 
 - Pull threat intelligence from any TAXII 2.1 server into Cloud SIEM.
 - Poll several collections from one TAXII feed, each on its own schedule.
@@ -14,10 +14,34 @@ STIX 2.1 is the standard format for describing threat intelligence: indicators, 
 
 Datadog acts as a TAXII client. It authenticates to a server you supply and polls the collections you add by ID, fetching new objects on the interval you choose. Because both are open standards, this one tile covers any vendor or community feed that speaks TAXII 2.1, with no per-vendor integration required.
 
-## Setup
+## Installation
 
-Configuration is managed through the Cloud SIEM interface. For more information, see the [TAXII Configuration UX Requirements](https://datadoghq.atlassian.net/wiki/spaces/CSiem/pages/7117537982/TAXII+Configuration+UX+Requirements).
+Click "New" and enter the TAXII server's API root URL and its credentials.
+
+Add each collection you want to ingest by its ID. Objects are mapped to STIX 2.1 and made available to Cloud SIEM detection rules.
 
 ## Troubleshooting
 
-Contact [Datadog support](mailto:help@datadoghq.com).
+Need help? Contact Datadog support.
+
+### Before you open a ticket
+
+Most TAXII problems are server-side. Include these from the Configure tab so support can reproduce the failure:
+
+- The TAXII feed's API root URL and authentication method (never the credentials themselves).
+- The collection ID, if the problem is scoped to one collection.
+- The exact status and failure detail shown on the feed or collection row.
+
+### Things to check first
+
+**Feed status is Pending.** Nothing has been contacted yet. A feed is only reached when the next poll of a polling collection runs; add a collection and turn polling on.
+
+**Authentication failed.** The credentials were rejected. Use Update credentials on the feed and wait for the next poll.
+
+**Every collection on a feed is failing.** The feed's status is Error because none of its polling collections succeeded. When they all fail at once, the credentials are the usual cause: use Update credentials on the feed and wait for the next poll.
+
+**Server does not support STIX 2.1.** Datadog only ingests STIX 2.1. TAXII 1.x and STIX 1.x servers are not supported.
+
+**Connection timeout or TLS handshake failed.** Usually a network path or certificate problem on the server side, not something Datadog can retry around.
+
+For questions about the TAXII standard itself rather than this integration, see the [OASIS CTI documentation](https://docs.oasis-open.org/cti/).

--- a/taxii/README.md
+++ b/taxii/README.md
@@ -1,12 +1,22 @@
-# TAXII
+# STIX/TAXII
 
 ## Overview
 
-Poll TAXII 2.1 servers for STIX 2.1 threat intelligence indicators and enrich your Cloud SIEM logs.
+STIX/TAXII enables you to:
+
+- Pull threat intelligence from any TAXII 2.1 server into Cloud SIEM.
+- Poll several collections from one TAXII feed, each on its own schedule.
+- Match and enrich your logs with ingested indicators.
+
+### About STIX and TAXII
+
+STIX 2.1 is the standard format for describing threat intelligence: indicators, malware, campaigns, and the relationships between them. TAXII 2.1 is the HTTPS API used to exchange those objects, where a server groups its objects into named collections that clients poll.
+
+Datadog acts as a TAXII client. It authenticates to a server you supply and polls the collections you add by ID, fetching new objects on the interval you choose. Because both are open standards, this one tile covers any vendor or community feed that speaks TAXII 2.1, with no per-vendor integration required.
 
 ## Setup
 
-Configuration is managed through the Cloud SIEM interface. See the [TAXII Configuration UX Requirements](https://datadoghq.atlassian.net/wiki/spaces/CSiem/pages/7117537982/TAXII+Configuration+UX+Requirements).
+Configuration is managed through the Cloud SIEM interface. For more information, see the [TAXII Configuration UX Requirements](https://datadoghq.atlassian.net/wiki/spaces/CSiem/pages/7117537982/TAXII+Configuration+UX+Requirements).
 
 ## Troubleshooting
 

--- a/taxii/README.md
+++ b/taxii/README.md
@@ -1,0 +1,13 @@
+# TAXII
+
+## Overview
+
+Poll TAXII 2.1 servers for STIX 2.1 threat intelligence indicators and enrich your Cloud SIEM logs.
+
+## Setup
+
+Configuration is managed through the Cloud SIEM interface. See the [TAXII Configuration UX Requirements](https://datadoghq.atlassian.net/wiki/spaces/CSiem/pages/7117537982/TAXII+Configuration+UX+Requirements).
+
+## Troubleshooting
+
+Contact [Datadog support](mailto:help@datadoghq.com).

--- a/taxii/assets/account_config.json
+++ b/taxii/assets/account_config.json
@@ -1,0 +1,61 @@
+{
+  "supported_auth_methods": [],
+  "additional_config_fields": [
+    {
+      "key": "api_root_url",
+      "label": "TAXII API Root URL",
+      "help": "Full HTTPS URL of the TAXII API root endpoint.",
+      "editable": false,
+      "required": true,
+      "url": {
+        "pattern": "^https://[^\\s]+$"
+      }
+    },
+    {
+      "key": "auth_mode",
+      "label": "Authentication Mode",
+      "help": "Authentication method used to access the TAXII server.",
+      "editable": false,
+      "required": true,
+      "dropdown": {
+        "options": [
+          {
+            "value": "none",
+            "label": "No Authentication"
+          },
+          {
+            "value": "basic",
+            "label": "HTTP Basic"
+          }
+        ],
+        "default": "none"
+      }
+    },
+    {
+      "key": "basic_username",
+      "label": "Basic Username",
+      "help": "Username or API token for HTTP Basic authentication.",
+      "editable": true,
+      "required": false,
+      "password": {}
+    },
+    {
+      "key": "basic_password",
+      "label": "Basic Password",
+      "help": "Password or API token for HTTP Basic authentication.",
+      "editable": true,
+      "required": false,
+      "password": {}
+    }
+  ],
+  "dataflow_config": [
+    {
+      "dataflow_id": "taxii-collection-ingestion",
+      "additional_config_fields": []
+    }
+  ],
+  "v2_endpoints": {
+    "enabled": false,
+    "interface_id_slug": "taxii"
+  }
+}

--- a/taxii/assets/dataflows.yaml
+++ b/taxii/assets/dataflows.yaml
@@ -1,0 +1,6 @@
+provides:
+  - id: taxii-collection-ingestion
+    always_on: true
+    granular: true
+    data_type: threat_intel_feed
+    direction: inbound

--- a/taxii/manifest.json
+++ b/taxii/manifest.json
@@ -9,8 +9,8 @@
         "configuration": "README.md#Setup",
         "support": "README.md#Troubleshooting",
         "changelog": "CHANGELOG.md",
-        "description": "Poll TAXII 2.1 servers for STIX threat intelligence and enrich Cloud SIEM logs.",
-        "title": "TAXII",
+        "description": "Pull threat intelligence from any TAXII 2.1 server into Cloud SIEM.",
+        "title": "STIX/TAXII",
         "media": [],
         "classifier_tags": [
             "Category::Cloud",

--- a/taxii/manifest.json
+++ b/taxii/manifest.json
@@ -1,0 +1,37 @@
+{
+    "manifest_version": "2.0.0",
+    "app_uuid": "b7e8f4a2-3c5d-4a6b-9e1f-8d2c7a5b4e3f",
+    "app_id": "taxii",
+    "owner": "cloud-siem",
+    "display_on_public_website": false,
+    "tile": {
+        "overview": "README.md#Overview",
+        "configuration": "README.md#Setup",
+        "support": "README.md#Troubleshooting",
+        "changelog": "CHANGELOG.md",
+        "description": "Poll TAXII 2.1 servers for STIX threat intelligence and enrich Cloud SIEM logs.",
+        "title": "TAXII",
+        "media": [],
+        "classifier_tags": [
+            "Category::Cloud",
+            "Category::Security",
+            "Offering::Integration"
+        ]
+    },
+    "assets": {
+        "integration": {
+            "auto_install": false,
+            "source_type_id": 0,
+            "source_type_name": "TAXII",
+            "events": {
+                "creates_events": false
+            }
+        }
+    },
+    "author": {
+        "support_email": "help@datadoghq.com",
+        "name": "Datadog",
+        "homepage": "https://www.datadoghq.com",
+        "sales_email": "info@datadoghq.com"
+    }
+}

--- a/taxii/manifest.json
+++ b/taxii/manifest.json
@@ -21,7 +21,7 @@
     "assets": {
         "integration": {
             "auto_install": false,
-            "source_type_id": 0,
+            "source_type_id": 84000000,
             "source_type_name": "TAXII",
             "events": {
                 "creates_events": false

--- a/taxii/manifest.json
+++ b/taxii/manifest.json
@@ -10,7 +10,7 @@
         "support": "README.md#Troubleshooting",
         "changelog": "CHANGELOG.md",
         "description": "Pull threat intelligence from any TAXII 2.1 server into Cloud SIEM.",
-        "title": "STIX/TAXII",
+        "title": "TAXII",
         "media": [],
         "classifier_tags": [
             "Category::Cloud",


### PR DESCRIPTION
## Changes
Related to [SEC-37069](https://datadoghq.atlassian.net/browse/SEC-37069).

Adds TAXII integration assets for Generic AMS.
Both Basic credential fields are password-typed so they land in Enclave.

Disabled for v2_endpoints, it will later be enabled via the https://mosaic.us1.ddbuild.io/feature-flags/saas-integrations-public-api-v2 experiment for staging orgs.

Related RFC: https://datadoghq.atlassian.net/wiki/spaces/CSiem/pages/7162593878/RFC+TAXII+Configuration+and+Status

[SEC-37069]: https://datadoghq.atlassian.net/browse/SEC-37069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ