### PR TITLE
AI-7144 Resolve Dispatcher PRs from workflow head metadata

### DIFF
--- a/ddev/changelog.d/25133.fixed
+++ b/ddev/changelog.d/25133.fixed
@@ -1,0 +1,1 @@
+Resolve Dispatcher pull requests from workflow head metadata and preserve expected-head validation.

--- a/ddev/src/ddev/cli/ci/dispatch_run.py
+++ b/ddev/src/ddev/cli/ci/dispatch_run.py
@@ -1,0 +1,190 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Resolve the commit or pull request a Dispatcher invocation tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ddev.cli.application import Application
+    from ddev.utils.git import ChangedFile
+    from ddev.utils.github_async import AsyncGitHubClient
+    from ddev.utils.github_async.models import PullRequest, PullRequestRef, PullRequestSimple
+
+
+@dataclass(frozen=True)
+class PullRequestResolver:
+    """A validated PR number or complete head identity, with optional matching constraints."""
+
+    owner: str
+    repo: str
+    number: int | None = None
+    head_repo: str | None = None
+    head_ref: str | None = None
+    head_sha: str | None = None
+    base_ref: str | None = None
+
+    async def resolve(self, client: AsyncGitHubClient) -> PullRequest | None:
+        """Return the matching open PR, or None if it is closed, missing from lookup, or superseded."""
+        from ddev.cli.ci.tests.changes import ChangeResolutionError
+        from ddev.utils.github_async import PaginationData
+
+        number = self.number
+        if number is None:
+            assert self.head_repo is not None and self.head_ref is not None and self.head_sha is not None, (
+                'PR lookup requires a number or complete head identity.'
+            )
+            head_owner = self.head_repo.partition('/')[0]
+            response = await client.list_pull_requests(
+                self.owner, self.repo, state='open', head=f'{head_owner}:{self.head_ref}', base=self.base_ref
+            )
+            if PaginationData.from_header(response.headers.get('link')).next is not None:
+                raise ChangeResolutionError(
+                    'Pull request lookup returned more than one page. '
+                    'Pass `--pr` with `--pr-head-sha` to identify the pull request.'
+                )
+            matches = [pull for pull in response.data if self._matches(pull)]
+            if not matches:
+                return None
+            if len(matches) > 1:
+                listed = '\n'.join(pull.html_url for pull in sorted(matches, key=lambda pull: pull.number))
+                raise ChangeResolutionError(
+                    f'Cannot run tests: {len(matches)} open pull requests were found for the commit that '
+                    f'triggered this workflow ({self.head_sha}):\n{listed}\n'
+                    'A single open pull request is required to run tests.'
+                )
+            number = matches[0].number
+
+        pull = (await client.get_pull_request(self.owner, self.repo, number)).data
+        if pull.head is None or pull.base is None:
+            raise ChangeResolutionError(f'Pull request {pull.number} reports no branch references.')
+        return pull if self._matches(pull) else None
+
+    def _matches(self, pull: PullRequestSimple) -> bool:
+        from ddev.utils.github_async.models import PullRequestState
+
+        if pull.state is not PullRequestState.OPEN or pull.head is None or pull.base is None:
+            return False
+        if self.head_sha is not None and not pull.head.sha.startswith(self.head_sha):
+            return False
+        if self.head_repo is not None and (
+            pull.head.repo is None or pull.head.repo.full_name.casefold() != self.head_repo.casefold()
+        ):
+            return False
+        if self.head_ref is not None and pull.head.ref != self.head_ref:
+            return False
+        return self.base_ref is None or pull.base.ref == self.base_ref
+
+
+@dataclass(frozen=True)
+class ResolvedRun:
+    """What the run is testing, and the changes it is responsible for.
+
+    ``changed_files`` is None when the plan does not come from a comparison, which is `--all`.
+    """
+
+    base_sha: str
+    checkout_sha: str
+    branch: str
+    changed_files: list[ChangedFile] | None
+    pr_number: int | None = None
+    target_branch: str | None = None
+    is_fork: bool = False
+
+
+def resolve_run(
+    app: Application,
+    *,
+    pr_resolver: PullRequestResolver | None,
+    commit: str | None,
+    token: str,
+    all_targets: bool,
+) -> ResolvedRun | None:
+    """Resolve what to test, reporting why a run has nothing left to test before returning None."""
+    if pr_resolver is not None:
+        return resolve_pull_request_run(app, resolver=pr_resolver, token=token, all_targets=all_targets)
+
+    tested_commit = commit or app.repo.git.latest_commit().sha
+    changed_files = None
+    if not all_targets:
+        from ddev.cli.ci.tests.changes import ChangeResolutionError, changes_in_commit
+
+        try:
+            changed_files = changes_in_commit(app.repo.git, tested_commit)
+        except ChangeResolutionError as error:
+            app.abort(str(error))
+
+    return ResolvedRun(
+        base_sha=tested_commit,
+        checkout_sha=tested_commit,
+        branch=app.repo.git.current_branch(),
+        changed_files=changed_files,
+    )
+
+
+def head_is_fork(head: PullRequestRef, *, owner: str, repo: str) -> bool:
+    """Whether a pull request's head branch lives outside the repository being tested.
+
+    A deleted head repository reads as a fork: the value decides whether credentials are withheld, so
+    the unknown case is the restrictive one.
+    """
+    if head.repo is None:
+        return True
+    return head.repo.full_name.casefold() != f"{owner}/{repo}".casefold()
+
+
+def resolve_pull_request_run(
+    app: Application,
+    *,
+    resolver: PullRequestResolver,
+    token: str,
+    all_targets: bool,
+) -> ResolvedRun | None:
+    """Read the pull request and its changed files from the API, in one client session."""
+    import asyncio
+
+    import httpx
+    from pydantic import ValidationError
+
+    from ddev.cli.ci.tests.changes import ChangeResolutionError, changes_in_pull_request
+    from ddev.utils.github_async import async_github_client
+    from ddev.utils.github_errors import GitHubAuthenticationError
+
+    async def resolve() -> ResolvedRun | None:
+        async with async_github_client(token=token) as client:
+            pull = await resolver.resolve(client)
+            if pull is None:
+                app.display_info('No open pull request matches the requested revision, so there is nothing to test.')
+                return None
+            assert pull.head is not None and pull.base is not None, 'Resolved PRs have branch references.'
+
+            changed_files = None
+            if not all_targets:
+                if pull.changed_files == 0:
+                    app.display_info(f'Pull request {pull.number} changes no file, so there is nothing to test.')
+                    return None
+                changed_files = await changes_in_pull_request(
+                    client, resolver.owner, resolver.repo, pull.number, pull.changed_files
+                )
+
+            return ResolvedRun(
+                base_sha=pull.head.sha,
+                checkout_sha=f'refs/pull/{pull.number}/merge',
+                branch=pull.head.ref,
+                changed_files=changed_files,
+                pr_number=pull.number,
+                target_branch=pull.base.ref,
+                is_fork=head_is_fork(pull.head, owner=resolver.owner, repo=resolver.repo),
+            )
+
+    try:
+        return asyncio.run(resolve())
+    except GitHubAuthenticationError as error:
+        app.abort(str(error))
+    except ChangeResolutionError as error:
+        app.abort(str(error))
+    except (httpx.HTTPError, ValidationError) as error:
+        app.abort(f'Could not read the pull request to test: {error}')

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -5,10 +5,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import click
+
+from ddev.cli.ci.dispatch_run import PullRequestResolver, resolve_run
 
 if TYPE_CHECKING:
     from ddev.cli.application import Application
@@ -17,8 +18,6 @@ if TYPE_CHECKING:
     from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
     from ddev.cli.ci.tests.messages import TestBatch
     from ddev.utils.git import ChangedFile
-    from ddev.utils.github_async import AsyncGitHubClient
-    from ddev.utils.github_async.models import PullRequestRef
 
 DEFAULT_OUTPUT_DIRECTORY = ".dispatcher"
 
@@ -30,25 +29,37 @@ DEFAULT_OUTPUT_DIRECTORY = ".dispatcher"
     'pull_request',
     metavar='PR_NUMBER_OR_URL',
     default=None,
-    help='Pull request to test, as a number or a URL. Everything else about the run is read from GitHub.',
+    help='PR number or URL. Supplied head/base options constrain this PR; otherwise its context comes from GitHub.',
 )
 @click.option(
     '--pr-head-sha',
     default=None,
     metavar='SHA',
-    help='Head commit of the pull request to test, resolved to its pull request. What `workflow_run` provides.',
+    help='Expected PR head commit. Required for head-based PR lookup; use with `--pr` to skip stale revisions.',
+)
+@click.option(
+    '--pr-head-repo',
+    default=None,
+    metavar='OWNER/NAME',
+    help='Expected PR head repository. Required for head-based PR lookup; optional with `--pr`.',
+)
+@click.option(
+    '--pr-head-ref',
+    default=None,
+    metavar='BRANCH',
+    help='Expected PR head branch. Required for head-based PR lookup; optional with `--pr`.',
 )
 @click.option(
     '--pr-base-ref',
     default=None,
     metavar='BRANCH',
-    help='Base branch of the pull request, when a head commit heads more than one.',
+    help='Optional base branch to narrow or verify the pull request. Otherwise read from the resolved PR.',
 )
 @click.option(
     '--commit',
     default=None,
     metavar='SHA',
-    help='Commit on the default branch to test, compared with its first parent. Defaults to the local HEAD.',
+    help='Commit to compare with its first parent. Cannot be combined with PR options. Defaults to local HEAD.',
 )
 @click.option(
     '--tags',
@@ -76,11 +87,13 @@ DEFAULT_OUTPUT_DIRECTORY = ".dispatcher"
     default=None,
     help='Where the run writes what it produces: artifacts, coverage and test results.',
 )
-@click.option('--dry-run', is_flag=True, help='Show the plan and the resolved context without calling GitHub.')
+@click.option('--dry-run', is_flag=True, help='Show the plan without dispatching jobs. PR runs still read GitHub.')
 def dispatch_tests(
     app: Application,
     pull_request: str | None,
     pr_head_sha: str | None,
+    pr_head_repo: str | None,
+    pr_head_ref: str | None,
     pr_base_ref: str | None,
     commit: str | None,
     tags: str | None,
@@ -96,9 +109,10 @@ def dispatch_tests(
     """Plan the tests a commit requires, run them as parallel batches of GitHub Actions jobs, and
     report the result to the pull request and to the run summary.
 
-    Which commit to test is the only thing that has to be said. `--pr` and `--pr-head-sha` name a
-    pull request, whose branch, commits and diff are then read from GitHub; `--commit` names a
-    commit on the default branch, compared with its first parent using local git.
+    Pass `--pr` when the number is known, with `--pr-head-sha` to reject superseded revisions.
+    Otherwise use the head SHA, repository and branch from `workflow_run` to resolve the PR.
+    Its base and diff come from GitHub; `--commit` instead compares a default-branch commit
+    with its first parent using local git.
     """
     import logging
     from pathlib import Path
@@ -108,10 +122,15 @@ def dispatch_tests(
     from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
     from ddev.utils.github import resolve_owner_repo
 
-    requested_pr, token = validate_options(
+    owner, repo = resolve_owner_repo(app, repository)
+    pr_resolver, token = validate_options(
         app,
+        owner=owner,
+        repo=repo,
         pull_request=pull_request,
         pr_head_sha=pr_head_sha,
+        pr_head_repo=pr_head_repo,
+        pr_head_ref=pr_head_ref,
         pr_base_ref=pr_base_ref,
         commit=commit,
         dry_run=dry_run,
@@ -121,19 +140,8 @@ def dispatch_tests(
     logging.getLogger('httpx').setLevel(logging.WARNING)
 
     config = DispatcherConfig.from_repo_config(app.repo.config)
-    owner, repo = resolve_owner_repo(app, repository)
 
-    run = resolve_run(
-        app,
-        owner=owner,
-        repo=repo,
-        requested_pr=requested_pr,
-        pr_head_sha=pr_head_sha,
-        pr_base_ref=pr_base_ref,
-        commit=commit,
-        token=token,
-        all_targets=all_targets,
-    )
+    run = resolve_run(app, pr_resolver=pr_resolver, commit=commit, token=token, all_targets=all_targets)
     if run is None:
         return
 
@@ -196,234 +204,63 @@ def dispatch_tests(
 def validate_options(
     app: Application,
     *,
+    owner: str,
+    repo: str,
     pull_request: str | None,
     pr_head_sha: str | None,
+    pr_head_repo: str | None,
+    pr_head_ref: str | None,
     pr_base_ref: str | None,
     commit: str | None,
     dry_run: bool,
-) -> tuple[int | None, str]:
-    """Check every input before the run does any work, and return what checking them resolved.
-
-    That is the pull request ``--pr`` names, if any, and the GitHub token, empty when the run needs
-    none. Only a dry run of a commit on the default branch needs none: it plans from local git and
-    talks to nobody. A pull request needs one even for a dry run, because both its own fields and
-    its diff are read from the API.
-
-    A malformed invocation raises `UsageError` (exit code 2), so a caller can tell it from a run
-    that started and failed. A missing token is not one: the options were right.
-    """
+) -> tuple[PullRequestResolver | None, str]:
+    """Validate run selection and authentication, returning a PR resolver when needed."""
     from ddev.utils.github import parse_pull_request_reference
 
-    named = [name for name, value in (('`--pr`', pull_request), ('`--pr-head-sha`', pr_head_sha)) if value is not None]
-    if commit is not None:
-        named.append('`--commit`')
-    if len(named) > 1:
-        raise click.UsageError(f'{", ".join(named)} name different runs, so only one can be passed.')
+    pr_options = {
+        '--pr': pull_request,
+        '--pr-head-repo': pr_head_repo,
+        '--pr-head-ref': pr_head_ref,
+        '--pr-head-sha': pr_head_sha,
+        '--pr-base-ref': pr_base_ref,
+    }
+    is_pr_run = any(value is not None for value in pr_options.values())
+    if commit is not None and is_pr_run:
+        raise click.UsageError('`--commit` cannot be combined with PR options.')
 
-    if pr_base_ref is not None and pr_head_sha is None:
-        raise click.UsageError('`--pr-base-ref` only narrows which pull request `--pr-head-sha` resolves to.')
-
-    requested_pr = None
-    if pull_request is not None:
-        requested_pr = parse_pull_request_reference(pull_request)
-        if requested_pr is None:
-            raise click.UsageError(f'`{pull_request}` is neither a pull request number nor a pull request URL.')
-
-    tests_a_pull_request = pull_request is not None or pr_head_sha is not None
     token = app.config.github.token
-    if not token and (tests_a_pull_request or not dry_run):
+    needs_token = is_pr_run or not dry_run
+    if needs_token and not token:
         app.abort('A GitHub token is required. Set `github.token` in your ddev config.')
+    if not is_pr_run:
+        return None, token
 
-    return requested_pr, token
+    for option, value in pr_options.items():
+        if value == '':
+            raise click.UsageError(f'`{option}` must not be empty.')
 
+    number = None
+    if pull_request is not None:
+        number = parse_pull_request_reference(pull_request)
+        if number is None:
+            raise click.UsageError(f'`{pull_request}` is neither a pull request number nor a pull request URL.')
+    elif not all((pr_head_repo, pr_head_ref, pr_head_sha)):
+        raise click.UsageError('Specify `--pr` or all of `--pr-head-repo`, `--pr-head-ref`, and `--pr-head-sha`.')
 
-@dataclass(frozen=True)
-class ResolvedRun:
-    """What the run is testing, and the changes it is responsible for.
+    if pr_head_repo is not None:
+        head_owner, _, head_name = pr_head_repo.partition('/')
+        if not head_owner or not head_name or '/' in head_name:
+            raise click.UsageError('`--pr-head-repo` must have the form OWNER/NAME.')
 
-    ``changed_files`` is None when the plan does not come from a comparison, which is `--all`.
-    """
-
-    base_sha: str
-    checkout_sha: str
-    branch: str
-    changed_files: list[ChangedFile] | None
-    pr_number: int | None = None
-    target_branch: str | None = None
-    is_fork: bool = False
-
-
-def resolve_run(
-    app: Application,
-    *,
-    owner: str,
-    repo: str,
-    requested_pr: int | None,
-    pr_head_sha: str | None,
-    pr_base_ref: str | None,
-    commit: str | None,
-    token: str,
-    all_targets: bool,
-) -> ResolvedRun | None:
-    """Resolve what to test, or None when there is nothing left to test or report to.
-
-    Every None outcome says which one it was before returning.
-    """
-    if requested_pr is not None or pr_head_sha is not None:
-        return resolve_pull_request_run(
-            app,
-            owner=owner,
-            repo=repo,
-            requested_pr=requested_pr,
-            pr_head_sha=pr_head_sha,
-            pr_base_ref=pr_base_ref,
-            token=token,
-            all_targets=all_targets,
-        )
-
-    tested_commit = commit or app.repo.git.latest_commit().sha
-    changed_files = None
-    if not all_targets:
-        from ddev.cli.ci.tests.changes import ChangeResolutionError, changes_in_commit
-
-        try:
-            changed_files = changes_in_commit(app.repo.git, tested_commit)
-        except ChangeResolutionError as error:
-            app.abort(str(error))
-
-    return ResolvedRun(
-        base_sha=tested_commit,
-        checkout_sha=tested_commit,
-        branch=app.repo.git.current_branch(),
-        changed_files=changed_files,
-    )
-
-
-def head_is_fork(head: PullRequestRef, *, owner: str, repo: str) -> bool:
-    """Whether a pull request's head branch lives outside the repository being tested.
-
-    A deleted head repository reads as a fork: the value decides whether credentials are withheld, so
-    the unknown case is the restrictive one.
-    """
-    if head.repo is None:
-        return True
-    return head.repo.full_name.casefold() != f"{owner}/{repo}".casefold()
-
-
-def resolve_pull_request_run(
-    app: Application,
-    *,
-    owner: str,
-    repo: str,
-    requested_pr: int | None,
-    pr_head_sha: str | None,
-    pr_base_ref: str | None,
-    token: str,
-    all_targets: bool,
-) -> ResolvedRun | None:
-    """Read the pull request and its changed files from the API, in one client session."""
-    import asyncio
-
-    import httpx
-    from pydantic import ValidationError
-
-    from ddev.cli.ci.tests.changes import ChangeResolutionError, changes_in_pull_request
-    from ddev.utils.github_async import async_github_client
-    from ddev.utils.github_async.models import PullRequestState
-    from ddev.utils.github_errors import GitHubAuthenticationError
-
-    async def resolve() -> ResolvedRun | None:
-        async with async_github_client(token=token) as client:
-            number = requested_pr
-            if number is None:
-                assert pr_head_sha is not None, (
-                    'A pull request run needs either a number or a head commit, and this run reported '
-                    'neither. `resolve_run` dispatched to the wrong resolver.'
-                )
-                numbers = await resolve_pull_requests_headed_by(client, owner, repo, pr_head_sha, pr_base_ref)
-                if not numbers:
-                    app.display_info(
-                        f'{pr_head_sha} heads no open pull request, so there is nothing to test. A commit that '
-                        'later commits have superseded reports here too, since testing it would plan the newer '
-                        'revision against the older one.'
-                    )
-                    return None
-                if len(numbers) > 1:
-                    listed = ', '.join(f'#{number}' for number in sorted(numbers))
-                    app.abort(
-                        f'{pr_head_sha} heads {len(numbers)} open pull requests ({listed}), so which one this run '
-                        'is testing is ambiguous. Pass `--pr-base-ref` to name the base branch.'
-                    )
-                number = numbers[0]
-
-            pull = (await client.get_pull_request(owner, repo, number)).data
-            if pull.head is None or pull.base is None:
-                app.abort(f'Pull request {pull.number} reports no branch references.')
-            if pull.state is not PullRequestState.OPEN:
-                app.display_info(f'Pull request {pull.number} is not open, so there is nothing to test.')
-                return None
-            # A commit pushed between resolving the number and reading the pull request would leave
-            # this describing a newer revision than the one asked for.
-            if pr_head_sha is not None and not pull.head.sha.startswith(pr_head_sha):
-                app.display_info(
-                    f'Pull request {pull.number} has moved on from {pr_head_sha} to {pull.head.sha}, so there is '
-                    'nothing to test: the run for the newer commit covers it.'
-                )
-                return None
-
-            changed_files = None
-            if not all_targets:
-                # Listing the files of an empty diff would meet a count of 0 and read it as the
-                # truncation the count exists to catch.
-                if pull.changed_files == 0:
-                    app.display_info(f'Pull request {pull.number} changes no file, so there is nothing to test.')
-                    return None
-                changed_files = await changes_in_pull_request(client, owner, repo, pull.number, pull.changed_files)
-
-            return ResolvedRun(
-                base_sha=pull.head.sha,
-                checkout_sha=f'refs/pull/{pull.number}/merge',
-                branch=pull.head.ref,
-                changed_files=changed_files,
-                pr_number=pull.number,
-                target_branch=pull.base.ref,
-                is_fork=head_is_fork(pull.head, owner=owner, repo=repo),
-            )
-
-    try:
-        return asyncio.run(resolve())
-    except GitHubAuthenticationError as error:
-        app.abort(str(error))
-    except ChangeResolutionError as error:
-        app.abort(str(error))
-    except (httpx.HTTPError, ValidationError) as error:
-        app.abort(f'Could not read the pull request to test: {error}')
-
-
-async def resolve_pull_requests_headed_by(
-    client: AsyncGitHubClient, owner: str, repo: str, head_sha: str, base_ref: str | None
-) -> list[int]:
-    """Return the open pull requests whose head *is* `head_sha`, narrowed to `base_ref` when given.
-
-    A commit stays associated with its pull request after later commits land on the branch, so a
-    pull request whose head has moved on is not a match: testing it would plan the newer revision
-    while reporting against the older one. A fork's head resolves too, because the base repository
-    keeps it as `refs/pull/<n>/head`.
-    """
-    from ddev.utils.github_async.models import PullRequestState
-
-    matches = []
-    async for page in client.list_commit_pulls(owner, repo, head_sha):
-        for pull in page.data:
-            if pull.state is not PullRequestState.OPEN or pull.head is None or pull.base is None:
-                continue
-            if not pull.head.sha.startswith(head_sha):
-                continue
-            if base_ref is not None and pull.base.ref != base_ref:
-                continue
-            matches.append(pull.number)
-
-    return matches
+    return PullRequestResolver(
+        owner=owner,
+        repo=repo,
+        number=number,
+        head_repo=pr_head_repo,
+        head_ref=pr_head_ref,
+        head_sha=pr_head_sha,
+        base_ref=pr_base_ref,
+    ), token
 
 
 def build_plan(

--- a/ddev/tests/cli/ci/helpers.py
+++ b/ddev/tests/cli/ci/helpers.py
@@ -1,0 +1,36 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Pull request list responses shared by Dispatcher CLI and resolution tests."""
+
+from ddev.utils.github_async import GitHubResponse
+from ddev.utils.github_async.models import PullRequestSimple
+
+PR_NUMBER = 4242
+HEAD_SHA = 'head-sha-aaa'
+
+
+def listed_pull_request(
+    number: int = PR_NUMBER,
+    head_sha: str = HEAD_SHA,
+    base_ref: str = 'a-target-branch',
+    state: str = 'open',
+    head_repo: str | None = 'DataDog/integrations-core',
+    head_ref: str = 'hs/a-branch',
+) -> PullRequestSimple:
+    """List endpoints omit diff totals, so they cannot stand in for the full form."""
+    return PullRequestSimple(
+        number=number,
+        html_url=f'https://github.com/DataDog/integrations-core/pull/{number}',
+        state=state,
+        head={
+            'ref': head_ref,
+            'sha': head_sha,
+            'repo': {'full_name': head_repo} if head_repo is not None else None,
+        },
+        base={'ref': base_ref, 'sha': 'base-sha-bbb'},
+    )
+
+
+def pulls_page(*pulls: PullRequestSimple) -> GitHubResponse[list[PullRequestSimple]]:
+    return GitHubResponse[list[PullRequestSimple]].model_validate({'data': list(pulls), 'headers': {}})

--- a/ddev/tests/cli/ci/test_dispatch_run.py
+++ b/ddev/tests/cli/ci/test_dispatch_run.py
@@ -1,0 +1,79 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ddev.cli.ci.dispatch_run import PullRequestResolver, head_is_fork
+from ddev.cli.ci.tests.changes import ChangeResolutionError
+from ddev.utils.github_async.models import PullRequestRef
+from tests.cli.ci.helpers import HEAD_SHA, listed_pull_request, pulls_page
+
+if TYPE_CHECKING:
+    from tests.helpers.github_async import FakeAsyncGitHubClient
+
+
+@pytest.mark.parametrize(
+    ('field', 'value'),
+    [
+        ('head_repo', 'DataDog/other-fork'),
+        ('head_repo', None),
+        ('head_ref', 'another-branch'),
+        ('head_sha', 'a-newer-sha'),
+        ('state', 'closed'),
+    ],
+    ids=['different-repository', 'deleted-repository', 'different-branch', 'stale-sha', 'closed'],
+)
+async def test_head_lookup_excludes_nonmatching_pull_requests(
+    fake_async_github: FakeAsyncGitHubClient, field: str, value: str | None
+):
+    fake_async_github.mock_response('list_pull_requests', pulls_page(listed_pull_request(**{field: value})))
+
+    resolver = PullRequestResolver(
+        owner='DataDog',
+        repo='integrations-core',
+        head_repo='DataDog/integrations-core',
+        head_ref='hs/a-branch',
+        head_sha=HEAD_SHA,
+    )
+
+    assert await resolver.resolve(fake_async_github) is None
+
+
+async def test_head_lookup_refuses_incomplete_results(fake_async_github: FakeAsyncGitHubClient):
+    response = pulls_page(listed_pull_request())
+    response.headers['link'] = '<https://api.github.com/repos/DataDog/integrations-core/pulls?page=2>; rel="next"'
+    fake_async_github.mock_response('list_pull_requests', response)
+
+    resolver = PullRequestResolver(
+        owner='DataDog',
+        repo='integrations-core',
+        head_repo='DataDog/integrations-core',
+        head_ref='hs/a-branch',
+        head_sha=HEAD_SHA,
+    )
+
+    with pytest.raises(ChangeResolutionError, match='more than one page'):
+        await resolver.resolve(fake_async_github)
+
+
+@pytest.mark.parametrize(
+    ('head_repo', 'expected'),
+    [
+        pytest.param('DataDog/integrations-core', False, id='same-repository'),
+        pytest.param('datadog/Integrations-Core', False, id='same-repository-other-casing'),
+        pytest.param('attacker/integrations-core', True, id='fork'),
+        pytest.param('DataDog/integrations-core-evil', True, id='name-that-only-starts-the-same'),
+        pytest.param(None, True, id='deleted-head-repository'),
+    ],
+)
+def test_head_is_fork(head_repo: str | None, expected: bool):
+    """A fork must not receive same-repository credentials."""
+    head = PullRequestRef(
+        ref='a-branch', sha=HEAD_SHA, repo={'full_name': head_repo} if head_repo is not None else None
+    )
+
+    assert head_is_fork(head, owner='DataDog', repo='integrations-core') is expected

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -10,20 +10,27 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from ddev.cli.ci.dispatch_tests import head_is_fork
 from ddev.utils.github_async import GitHubResponse
-from ddev.utils.github_async.models import PullRequest, PullRequestFile, PullRequestSimple
+from ddev.utils.github_async.models import PullRequest, PullRequestFile
+from tests.cli.ci.helpers import HEAD_SHA, PR_NUMBER, listed_pull_request, pulls_page
 from tests.cli.ci.tests.helpers import make_batch, make_job
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from unittest.mock import MagicMock
 
     from ddev.config.file import ConfigFileWithOverrides
     from tests.helpers.github_async import FakeAsyncGitHubClient
     from tests.helpers.runner import CliRunner
 
-PR_NUMBER = 4242
-HEAD_SHA = 'head-sha-aaa'
+HEAD_LOOKUP_OPTIONS = (
+    '--pr-head-sha',
+    HEAD_SHA,
+    '--pr-head-repo',
+    'DataDog/integrations-core',
+    '--pr-head-ref',
+    'hs/a-branch',
+)
 
 
 def pull_request(
@@ -48,28 +55,8 @@ def pull_request(
     )
 
 
-def listed_pull_request(
-    number: int = PR_NUMBER,
-    head_sha: str = HEAD_SHA,
-    base_ref: str = 'a-target-branch',
-    state: str = 'open',
-) -> PullRequestSimple:
-    """What `list_commit_pulls` returns: no diff totals, so it cannot stand in for the full form."""
-    return PullRequestSimple(
-        number=number,
-        html_url=f'https://github.com/DataDog/integrations-core/pull/{number}',
-        state=state,
-        head={'ref': 'hs/a-branch', 'sha': head_sha},
-        base={'ref': base_ref, 'sha': 'base-sha-bbb'},
-    )
-
-
 def files_page(*files: PullRequestFile) -> GitHubResponse[list[PullRequestFile]]:
     return GitHubResponse[list[PullRequestFile]].model_validate({'data': list(files), 'headers': {}})
-
-
-def pulls_page(*pulls: PullRequestSimple) -> GitHubResponse[list[PullRequestSimple]]:
-    return GitHubResponse[list[PullRequestSimple]].model_validate({'data': list(pulls), 'headers': {}})
 
 
 @pytest.fixture
@@ -106,13 +93,19 @@ def github(fake_async_github):
 
 
 @pytest.mark.parametrize(
-    'reference',
-    [PR_NUMBER, f'https://github.com/DataDog/integrations-core/pull/{PR_NUMBER}'],
-    ids=['number', 'url'],
+    'options',
+    [
+        ['--pr', str(PR_NUMBER)],
+        ['--pr', f'https://github.com/DataDog/integrations-core/pull/{PR_NUMBER}'],
+        ['--pr', str(PR_NUMBER), '--pr-head-sha', HEAD_SHA],
+        ['--pr', str(PR_NUMBER), '--pr-head-ref', 'hs/a-branch'],
+        ['--pr', str(PR_NUMBER), '--pr-base-ref', 'a-target-branch'],
+    ],
+    ids=['number', 'url', 'number-with-expected-head', 'number-with-head-constraint', 'number-with-base-constraint'],
 )
-def test_a_pull_request_supplies_the_whole_run_context(ddev, github, planned, reference):
-    """`--pr` is the only input a pull request run should need: everything else comes from the API."""
-    result = ddev('ci', 'dispatch-tests', '--pr', str(reference), '--dry-run')
+def test_a_pull_request_supplies_the_whole_run_context(ddev, github, planned, options: list[str]):
+    """The PR supplies the context; an optional expected head constrains which revision is accepted."""
+    result = ddev('ci', 'dispatch-tests', *options, '--dry-run')
 
     assert result.exit_code == 0, result.output
     assert 'hs/a-branch' in result.output
@@ -143,96 +136,163 @@ def test_dispatch_tests_plans_from_hatch_toml(
     assert '\n    ntp\n' in result.output
 
 
-def test_a_head_sha_resolves_to_its_pull_request(ddev, github, planned):
-    """`workflow_run` carries the head commit, not reliably a number, so the run resolves it."""
-    github.mock_response('list_commit_pulls', pulls_page(listed_pull_request()))
+def test_a_head_belonging_to_no_open_pull_request_dispatches_nothing(ddev, github, planned):
+    github.mock_response('list_pull_requests', pulls_page())
 
-    result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA, '--dry-run')
-
-    assert result.exit_code == 0, result.output
-    assert str(PR_NUMBER) in result.output
-    assert github.last_call('list_commit_pulls').kwargs['commit_sha'] == HEAD_SHA
-
-
-def test_a_head_sha_belonging_to_no_open_pull_request_dispatches_nothing(ddev, github, planned):
-    github.mock_response('list_commit_pulls', pulls_page())
-
-    result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA)
+    result = ddev('ci', 'dispatch-tests', *HEAD_LOOKUP_OPTIONS)
 
     assert result.exit_code == 0, result.output
-    assert 'heads no open pull request' in result.output
+    assert 'No open pull request matches the requested revision' in result.output
     planned.assert_not_called()
     github.assert_not_called('create_workflow_dispatch')
 
 
-def test_a_commit_that_is_no_longer_the_head_dispatches_nothing(ddev, github, planned):
-    """A commit stays associated with its pull request once later commits land on the branch.
-
-    Testing it anyway would read the newer head and diff while reporting against the older commit,
-    so the run would test one revision and attribute it to another.
-    """
-    github.mock_response('list_commit_pulls', pulls_page(listed_pull_request(head_sha='a-newer-sha')))
-
-    result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA)
-
-    assert result.exit_code == 0, result.output
-    assert 'heads no open pull request' in result.output
-    planned.assert_not_called()
-    github.assert_not_called('create_workflow_dispatch')
-
-
-def test_a_head_that_moves_while_the_pull_request_is_read_dispatches_nothing(ddev, github, planned):
-    """The number is resolved from one response and the pull request read from another.
-
-    A commit pushed in between leaves the second describing a newer revision, whose diff and head
-    would then be tested and reported against the commit this run was asked for.
-    """
-    github.mock_response('list_commit_pulls', pulls_page(listed_pull_request()))
+@pytest.mark.parametrize(
+    'options',
+    [HEAD_LOOKUP_OPTIONS, ('--pr', str(PR_NUMBER), '--pr-head-sha', HEAD_SHA)],
+    ids=['lookup', 'explicit-pr'],
+)
+def test_a_head_that_moves_while_the_pull_request_is_read_dispatches_nothing(
+    ddev, github, planned, options: tuple[str, ...]
+):
+    github.mock_response('list_pull_requests', pulls_page(listed_pull_request()))
     github.mock_response('get_pull_request', pull_request(head_sha='a-newer-sha'))
 
-    result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA)
+    result = ddev('ci', 'dispatch-tests', *options)
 
     assert result.exit_code == 0, result.output
-    assert f'has moved on from {HEAD_SHA}' in result.output
+    assert 'No open pull request matches the requested revision' in result.output
     planned.assert_not_called()
     github.assert_not_called('create_workflow_dispatch')
 
 
-def test_a_head_sha_heading_several_pull_requests_is_refused(ddev, github, planned):
-    """Choosing one would plan against its base and comment on it, so a run that cannot say which
-    pull request it is testing must not run.
-    """
+def test_a_head_heading_several_pull_requests_is_refused(
+    ddev: CliRunner, github: FakeAsyncGitHubClient, planned: MagicMock
+):
     github.mock_response(
-        'list_commit_pulls',
+        'list_pull_requests',
         pulls_page(listed_pull_request(number=1), listed_pull_request(number=2, base_ref='7.62.x')),
     )
 
-    result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA)
+    result = ddev('ci', 'dispatch-tests', *HEAD_LOOKUP_OPTIONS)
 
     assert result.exit_code == 1
-    assert 'heads 2 open pull requests (#1, #2)' in result.output
+    assert '2 open pull requests were found' in result.output
+    assert HEAD_SHA in result.output
+    assert 'https://github.com/DataDog/integrations-core/pull/1' in result.output
+    assert 'https://github.com/DataDog/integrations-core/pull/2' in result.output
+    assert 'A single open pull request is required to run tests.' in result.output
     planned.assert_not_called()
     github.assert_not_called('create_workflow_dispatch')
 
 
-def test_a_base_ref_narrows_an_ambiguous_head_sha(ddev, github, planned):
+def test_a_base_ref_narrows_an_ambiguous_head(ddev, github, planned):
     github.mock_response(
-        'list_commit_pulls',
+        'list_pull_requests',
         pulls_page(listed_pull_request(number=1), listed_pull_request(number=2, base_ref='7.62.x')),
     )
     github.mock_response('get_pull_request', pull_request(number=2, base_ref='7.62.x'))
 
-    result = ddev('ci', 'dispatch-tests', '--pr-head-sha', HEAD_SHA, '--pr-base-ref', '7.62.x', '--dry-run')
+    result = ddev('ci', 'dispatch-tests', *HEAD_LOOKUP_OPTIONS, '--pr-base-ref', '7.62.x', '--dry-run')
 
     assert result.exit_code == 0, result.output
     assert github.last_call('get_pull_request').kwargs['pull_number'] == 2
 
 
-def test_a_base_ref_without_a_head_sha_is_refused(ddev, github, planned):
-    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--pr-base-ref', 'master', '--dry-run')
+@pytest.mark.parametrize(
+    ('head_repo', 'base_ref'),
+    [('DataDog/integrations-core', 'a-target-branch'), ('contributor/integrations-core', 'another-base')],
+    ids=['same-repository', 'fork'],
+)
+def test_head_metadata_resolves_a_pull_request(
+    ddev: CliRunner, github: FakeAsyncGitHubClient, planned: MagicMock, head_repo: str, base_ref: str
+):
+    github.mock_response(
+        'list_pull_requests',
+        pulls_page(listed_pull_request(head_repo=head_repo.upper(), base_ref=base_ref)),
+        state='open',
+        head=f'{head_repo.split("/")[0]}:hs/a-branch',
+        base=None,
+    )
+    github.mock_response('get_pull_request', pull_request(head_repo=head_repo, base_ref=base_ref))
+
+    result = ddev(
+        'ci',
+        'dispatch-tests',
+        '--pr-head-sha',
+        HEAD_SHA,
+        '--pr-head-repo',
+        head_repo,
+        '--pr-head-ref',
+        'hs/a-branch',
+        '--dry-run',
+    )
+
+    assert result.exit_code == 0, result.output
+    assert f'refs/pull/{PR_NUMBER}/merge' in result.output
+    assert HEAD_SHA in result.output
+    assert base_ref in result.output
+
+
+def test_a_head_repository_that_changes_after_lookup_dispatches_nothing(
+    ddev: CliRunner, github: FakeAsyncGitHubClient, planned: MagicMock
+):
+    github.mock_response('list_pull_requests', pulls_page(listed_pull_request()))
+    github.mock_response('get_pull_request', pull_request(head_repo='DataDog/another-fork'))
+
+    result = ddev('ci', 'dispatch-tests', *HEAD_LOOKUP_OPTIONS, '--dry-run')
+
+    assert result.exit_code == 0, result.output
+    assert 'No open pull request matches the requested revision' in result.output
+    github.assert_not_called('list_pull_request_files')
+    planned.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ('options', 'message'),
+    [
+        (['--pr-head-sha', HEAD_SHA], 'Specify `--pr` or all of'),
+        (['--pr-head-sha', HEAD_SHA, '--pr-head-repo', 'DataDog/integrations-core'], 'Specify `--pr` or all of'),
+        (['--pr-head-sha', HEAD_SHA, '--pr-head-ref', 'hs/a-branch'], 'Specify `--pr` or all of'),
+        (
+            ['--pr-head-repo', 'DataDog/integrations-core', '--pr-head-ref', 'hs/a-branch'],
+            'Specify `--pr` or all of',
+        ),
+        (
+            ['--pr-head-sha', HEAD_SHA, '--pr-head-repo', 'integrations-core', '--pr-head-ref', 'hs/a-branch'],
+            'OWNER/NAME',
+        ),
+        (
+            ['--pr-head-sha', HEAD_SHA, '--pr-head-repo', 'DataDog/integrations-core', '--pr-head-ref', ''],
+            '`--pr-head-ref` must not be empty',
+        ),
+        (['--pr', str(PR_NUMBER), '--pr-head-sha', ''], '`--pr-head-sha` must not be empty'),
+    ],
+    ids=[
+        'sha-only',
+        'missing-branch',
+        'missing-repository',
+        'missing-sha',
+        'invalid-repository',
+        'empty-branch',
+        'empty-sha',
+    ],
+)
+def test_incomplete_head_identity_is_refused(
+    ddev: CliRunner, github: FakeAsyncGitHubClient, planned: MagicMock, options: list[str], message: str
+):
+    result = ddev('ci', 'dispatch-tests', *options, '--dry-run')
 
     assert result.exit_code == 2
-    assert 'only narrows which pull request' in result.output
+    assert message in result.output
+    planned.assert_not_called()
+
+
+def test_a_numbered_pull_request_must_match_its_base_constraint(ddev, github, planned):
+    result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER), '--pr-base-ref', 'another-base', '--dry-run')
+
+    assert result.exit_code == 0, result.output
+    assert 'No open pull request matches the requested revision' in result.output
     planned.assert_not_called()
 
 
@@ -243,7 +303,7 @@ def test_a_pull_request_that_is_no_longer_open_dispatches_nothing(ddev, github, 
     result = ddev('ci', 'dispatch-tests', '--pr', str(PR_NUMBER))
 
     assert result.exit_code == 0, result.output
-    assert 'is not open' in result.output
+    assert 'No open pull request matches the requested revision' in result.output
     planned.assert_not_called()
     github.assert_not_called('create_workflow_dispatch')
 
@@ -273,20 +333,14 @@ def test_a_pull_request_that_changes_no_file_dispatches_nothing(ddev, github, pl
 
 
 @pytest.mark.parametrize(
-    'options',
-    [
-        ['--pr', str(PR_NUMBER), '--pr-head-sha', HEAD_SHA],
-        ['--pr', str(PR_NUMBER), '--commit', 'a-sha'],
-        ['--pr-head-sha', HEAD_SHA, '--commit', 'a-sha'],
-    ],
-    ids=['pr-and-head-sha', 'pr-and-commit', 'head-sha-and-commit'],
+    'pr_option',
+    ['--pr', '--pr-head-sha', '--pr-head-repo', '--pr-head-ref', '--pr-base-ref'],
 )
-def test_only_one_run_can_be_named(ddev, github, planned, options: list[str]):
-    """Taking one and ignoring the rest would test one commit and report against another."""
-    result = ddev('ci', 'dispatch-tests', *options, '--dry-run')
+def test_commit_and_pr_options_cannot_be_combined(ddev, github, planned, pr_option: str):
+    result = ddev('ci', 'dispatch-tests', '--commit', 'a-sha', pr_option, 'a-value', '--dry-run')
 
     assert result.exit_code == 2
-    assert 'name different runs' in result.output
+    assert '`--commit` cannot be combined with PR options' in result.output
     planned.assert_not_called()
 
 
@@ -330,7 +384,7 @@ def test_a_dry_run_dispatches_nothing(ddev, github, planned):
     github.assert_not_called('create_issue_comment')
 
 
-def test_a_reference_that_is_neither_a_number_nor_a_url_is_refused(ddev, planned):
+def test_a_reference_that_is_neither_a_number_nor_a_url_is_refused(ddev, github, planned):
     result = ddev('ci', 'dispatch-tests', '--pr', 'not-a-pull-request', '--dry-run')
 
     assert result.exit_code == 2
@@ -347,25 +401,6 @@ def test_an_empty_plan_is_not_dispatched(ddev, fake_async_github, local_changes,
     assert result.exit_code == 0, result.output
     assert 'No affected target to test.' in result.output
     fake_async_github.assert_not_called('create_workflow_dispatch')
-
-
-@pytest.mark.parametrize(
-    ('head_repo', 'expected'),
-    [
-        pytest.param('DataDog/integrations-core', False, id='same-repository'),
-        pytest.param('datadog/Integrations-Core', False, id='same-repository-other-casing'),
-        pytest.param('attacker/integrations-core', True, id='fork'),
-        pytest.param('DataDog/integrations-core-evil', True, id='name-that-only-starts-the-same'),
-        pytest.param(None, True, id='deleted-head-repository'),
-    ],
-)
-def test_head_is_fork(head_repo: str | None, expected: bool):
-    """This decides whether the batch is given credentials, so reading a fork as the repository itself
-    hands a fork's code the Datadog key and the Docker credentials.
-    """
-    head = pull_request(head_repo=head_repo).head
-    assert head is not None
-    assert head_is_fork(head, owner='DataDog', repo='integrations-core') is expected
 
 
 def test_pytest_args_are_shown_in_the_plan(ddev, github, planned):


### PR DESCRIPTION
### What does this PR do?

Adds two PR selection modes, shared by forks and non-forks:
- `--pr NUMBER_OR_URL` reads the PR directly. Supplied head/base fields are matching constraints; workflow handoffs include `--pr-head-sha` to reject superseded revisions.
- Without `--pr`, all three of `--pr-head-repo`, `--pr-head-ref`, and `--pr-head-sha` are required. Lookup uses the head-branch list endpoint. The base comes from the PR unless explicitly constrained.

Commit runs use `--commit` or default to local HEAD, without PR resolution. Commit and PR options cannot be combined. PR runs and non-dry runs require a token.

A frozen `PullRequestResolver` in the sibling `dispatch_run.py` module owns lookup and matching through `resolve(client)`. Stale or closed PRs are skipped. Ambiguous matches fail with the triggering commit, PR links, and a message that a single open PR is required to run tests. The trigger and `workflow_run` receiver are separate changes.

### Motivation

[AI-7144](https://datadoghq.atlassian.net/browse/AI-7144). Fork workflow runs can have an empty `pull_requests` array and no commit-to-PR associations, so the SHA-only lookup can silently skip their tests.

Validation:
- 48 focused CLI/resolution tests passed. Formatting, lint, and type checks passed through ddev.
- Read-only check using [fork run 32924880065](https://github.com/DataDog/integrations-core/actions/runs/32924880065): both head-identity lookup and number + SHA resolved [PR #24968](https://github.com/DataDog/integrations-core/pull/24968).
- Head-identity lookup resolved this same-repository PR. Number + an older expected SHA returned no match. No base filter was supplied and no workflows were dispatched.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7144]: https://datadoghq.atlassian.net/browse/AI-7144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
