### PR TITLE
AI-7144 Add the Dispatcher pull request trigger

### DIFF
--- a/.github/workflows/test-dispatch-trigger.yml
+++ b/.github/workflows/test-dispatch-trigger.yml
@@ -1,0 +1,25 @@
+name: Test Dispatch Trigger
+
+# Completion signal for the Test Dispatch receiver, which watches for successful completed
+# runs of this workflow by name and then plans and runs the pull request's tests. Reruns
+# start another attempt. This workflow carries no privileges and runs nothing from the PR.
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions: {}
+
+jobs:
+  trigger:
+    name: Trigger the test dispatch
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Trigger only
+        run: echo "The Test Dispatch receiver runs from this workflow's completion."


### PR DESCRIPTION
### What does this PR do?

Adds `Test Dispatch Trigger`, a minimal `pull_request` workflow for PRs targeting master. It signals the trusted Dispatcher receiver for opened, synchronize and reopened events, without path filtering.

The job has no token permissions, checkout, secrets or artifacts. Test selection belongs to Dispatcher. An empty plan dispatches no batches; the receiver should still publish a successful aggregate result.

### Motivation

Part of [AI-7144](https://datadoghq.atlassian.net/browse/AI-7144). This can land before the receiver in [AI-7129](https://datadoghq.atlassian.net/browse/AI-7129); it does not dispatch tests on its own. Legacy CI and required checks stay unchanged.

Signaling regardless of changed paths avoids GitHub's native path-filter diff limit and, when the aggregate becomes required, avoids leaving docs-only PRs waiting for a status that was never produced. The receiver still needs to handle empty plans and incomplete change data explicitly.

Validation: parsed the actual YAML, verified the event/branch settings and single unprivileged job, and ran zizmor. No live receiver or fork handoff was exercised.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7144]: https://datadoghq.atlassian.net/browse/AI-7144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-7129]: https://datadoghq.atlassian.net/browse/AI-7129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ