### PR TITLE
AI-7150 Mark Dispatcher PR reports as informational

### DIFF
--- a/ddev/changelog.d/25136.fixed
+++ b/ddev/changelog.d/25136.fixed
@@ -1,0 +1,1 @@
+Mark Dispatcher pull request reports as informational during shadow mode.

--- a/ddev/src/ddev/cli/ci/tests/pr_comment.py
+++ b/ddev/src/ddev/cli/ci/tests/pr_comment.py
@@ -56,6 +56,15 @@ CANCELLED_NOTE = "Anything below is what had been gathered by then, and batches 
 # Said instead when no batch ever reported, where the note above would point at results that are absent.
 CANCELLED_WITHOUT_RESULTS_NOTE = "The run was cancelled before any batch reported, so there are no results to show."
 
+# Said in every report while Dispatcher runs in shadow mode: it does not decide merges yet, so its
+# result must not be mistaken for the merge signal.
+SHADOW_NOTICE = (
+    "> **Dispatcher beta: informational only**\n"
+    ">\n"
+    "> Dispatcher is running alongside existing CI while we validate it. You can ignore this report "
+    "and its statuses. Existing CI remains the merge signal."
+)
+
 # Blocks are joined by a blank line, so each one costs two bytes beyond its own length. Newlines are
 # one byte in UTF-8, so this is the same number in either unit.
 SECTION_SEPARATOR = 2
@@ -157,7 +166,7 @@ def render_cancelled_notice() -> str:
     There is no snapshot to render, and the comment is the only place a reader learns the run existed.
     """
     footer = _footer(None, cancelled=True)
-    return f"{COMMENT_MARKER}\n\n{CANCELLED_HEADING}\n\n{CANCELLED_WITHOUT_RESULTS_NOTE}\n\n{footer}"
+    return f"{COMMENT_MARKER}\n\n{CANCELLED_HEADING}\n\n{SHADOW_NOTICE}\n\n{CANCELLED_WITHOUT_RESULTS_NOTE}\n\n{footer}"
 
 
 def render_run_summary(body: str, *, pr_comment_failed: bool) -> str:
@@ -189,8 +198,8 @@ def summary_line(progress: DispatcherProgress) -> str:
 
 
 def _header(progress: DispatcherProgress, *, shows_unavailable: bool, cancelled: bool = False) -> str:
-    """Marker, heading, in-progress alert and totals: the part that must never be truncated."""
-    blocks = [COMMENT_MARKER, _heading(progress, cancelled=cancelled)]
+    """Marker, heading, notice, in-progress alert and totals: the part that must never be truncated."""
+    blocks = [COMMENT_MARKER, _heading(progress, cancelled=cancelled), SHADOW_NOTICE]
     alert = _alert(progress, shows_unavailable=shows_unavailable, cancelled=cancelled)
     if alert is not None:
         blocks.append(alert)

--- a/ddev/tests/cli/ci/tests/test_pr_comment.py
+++ b/ddev/tests/cli/ci/tests/test_pr_comment.py
@@ -577,7 +577,8 @@ def test_large_run_stays_within_budget_and_says_what_was_dropped():
     # targets. The body is dense with three-byte emoji and block-drawing characters, so a character
     # count would understate it.
     assert len(body.encode("utf-8")) <= GITHUB_COMMENT_HARD_LIMIT
-    # The header survives intact: totals and every batch row are the highest-priority content.
+    # The header survives intact: the notice, totals and every batch row are the top content.
+    assert "Dispatcher beta: informational only" in body
     assert "**240/240 jobs**" in body
     assert body.count("<tr><td><code>batch-") == 10
     assert "not shown — the comment reached its size limit" in body
@@ -840,6 +841,25 @@ FALLBACK_TIERS = [
     pytest.param(render_minimal_comment, id="minimal"),
 ]
 
+NOTICE_TIERS = [
+    pytest.param(render_comment, id="full"),
+    *FALLBACK_TIERS,
+]
+
+
+@pytest.mark.parametrize("render", NOTICE_TIERS)
+def test_every_tier_reports_itself_as_informational(render: Callable[[DispatcherProgress], str]):
+    """The report runs alongside the CI that decides merges, so it must say it is advisory."""
+    progress = DispatcherProgress(batches=(batch_progress("batch-01", job_progress(attempt())),), done=True)
+
+    body = render(progress)
+
+    heading = body.index("## ")
+    notice = body.index("Dispatcher beta: informational only")
+    assert heading < notice < body.index("### Batches")
+    assert "You can ignore this report and its statuses" in body
+    assert "Existing CI remains the merge signal" in body
+
 
 @pytest.mark.parametrize("render", FALLBACK_TIERS)
 def test_a_fallback_tier_does_not_point_at_the_section_it_dropped(render: Callable[[DispatcherProgress], str]):
@@ -927,6 +947,7 @@ def test_a_cancelled_run_with_nothing_gathered_still_says_it_ran(monkeypatch):
 
     assert body.startswith(COMMENT_MARKER)
     assert CANCELLED_HEADING in body
+    assert "Dispatcher beta: informational only" in body
     assert "https://github.com/DataDog/integrations-core/actions/runs/12345" in body
 
 


### PR DESCRIPTION
### What does this PR do?

Adds a prominent notice that Dispatcher reports and statuses are informational during shadow mode and can be ignored. Existing CI remains the merge signal.

The notice stays in full, compact and minimal reports, including cancellation before results arrive. It is included in the comment size budget and carried into the run summary. Result details, links and the existing comment marker stay intact.

### Motivation

[AI-7150](https://datadoghq.atlassian.net/browse/AI-7150), a prerequisite for [shadow evaluation](https://datadoghq.atlassian.net/browse/AI-7145). No workflow/job renaming or required-check changes.

Validation: 65 renderer tests and 17 filtered reporter tests passed. The notice assertions failed before implementation. Formatting, lint and type checks passed through ddev. No live PR comment was posted during validation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7150]: https://datadoghq.atlassian.net/browse/AI-7150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ