### PR TITLE
AI-7149 Mark Dispatcher batch statuses as non-blocking

### DIFF
--- a/.github/workflows/test-batch.yml
+++ b/.github/workflows/test-batch.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           set -euo pipefail
           gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
-            -f "context=test-batch/${BATCH_ID}" \
+            -f "context=Dispatcher / ${BATCH_ID} (beta, non-blocking)" \
             -f "state=pending" \
             -f "description=Running ${JOB_COUNT} job(s)" \
             -f "target_url=${RUN_URL}" \
@@ -418,7 +418,7 @@ jobs:
           esac
 
           gh api --method POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
-            -f "context=test-batch/${BATCH_ID}" \
+            -f "context=Dispatcher / ${BATCH_ID} (beta, non-blocking)" \
             -f "state=${state}" \
             -f "description=${description}" \
             -f "target_url=${RUN_URL}" \


### PR DESCRIPTION
### What does this PR do?

Names pending and final batch commit statuses `Dispatcher / <batch_id> (beta, non-blocking)`. Workflow and job names, outcomes, descriptions and run links stay unchanged.

### Motivation

The batch portion of [AI-7149](https://datadoghq.atlassian.net/browse/AI-7149): make shadow-mode results clearly informational without renaming workflows or adding duplicate checks. Aggregate-status wording remains for the [Dispatcher workflow](https://datadoghq.atlassian.net/browse/AI-7129).

Validation: YAML, shell syntax and zizmor checks passed. A local fake-gh harness asserted the context, tested SHA, run URL, state and description for six cases: pending, success, failure, cancelled, skipped and an unknown/empty result. No real status writes or workflow dispatches were made during validation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7149]: https://datadoghq.atlassian.net/browse/AI-7149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ