### PR TITLE
[nfsstat] Fix Fleet Automation binary resolution

### DIFF
--- a/nfsstat/changelog.d/25138.fixed
+++ b/nfsstat/changelog.d/25138.fixed
@@ -1,0 +1,1 @@
+Fix nfsiostat resolution and invocation on Fleet Automation-managed hosts.

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -8,6 +8,22 @@ from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'nfsstat'
 
+BUNDLED_NFSIOSTAT_PATHS = (
+    '/opt/datadog-agent/embedded/sbin/nfsiostat',
+    '/opt/datadog-packages/datadog-agent/stable/embedded/sbin/nfsiostat',
+)
+SOURCE_NFSIOSTAT_PATH = '/usr/local/sbin/nfsiostat'
+
+
+def _build_bundled_nfsiostat_command(nfsiostat_path: str) -> list[str]:
+    """Build the command for an Agent-bundled nfsiostat script."""
+    embedded_path = os.path.dirname(os.path.dirname(nfsiostat_path))
+    python_path = os.path.join(embedded_path, 'bin', 'python')
+    if os.path.exists(python_path):
+        return [python_path, nfsiostat_path, '1', '2']
+
+    return [nfsiostat_path, '1', '2']
+
 
 class NfsStatCheck(AgentCheck):
     metric_prefix = 'system.nfs.'
@@ -18,17 +34,18 @@ class NfsStatCheck(AgentCheck):
         if init_config.get('nfsiostat_path'):
             self.nfs_cmd = init_config['nfsiostat_path'].split() + ['1', '2']
         else:
-            # if not, check if it's installed in the opt dir, if so use that
-            if os.path.exists('/opt/datadog-agent/embedded/sbin/nfsiostat'):
-                self.nfs_cmd = ['/opt/datadog-agent/embedded/sbin/nfsiostat', '1', '2']
-            # if not, then check if it is in the default place
-            elif os.path.exists('/usr/local/sbin/nfsiostat'):
-                self.nfs_cmd = ['/usr/local/sbin/nfsiostat', '1', '2']
+            for nfsiostat_path in BUNDLED_NFSIOSTAT_PATHS:
+                if os.path.exists(nfsiostat_path):
+                    self.nfs_cmd = _build_bundled_nfsiostat_command(nfsiostat_path)
+                    break
             else:
-                raise Exception(
-                    'nfsstat check requires nfsiostat be installed, please install it '
-                    '(through nfs-utils) or set the path to the installed version'
-                )
+                if os.path.exists(SOURCE_NFSIOSTAT_PATH):
+                    self.nfs_cmd = [SOURCE_NFSIOSTAT_PATH, '1', '2']
+                else:
+                    raise Exception(
+                        'nfsstat check requires nfsiostat be installed, please install it '
+                        '(through nfs-utils) or set the path to the installed version'
+                    )
         self.autofs_enabled = is_affirmative(init_config.get('autofs_enabled', False))
         self.disable_missing_mountpoints_warning = is_affirmative(
             self.instance.get('disable_missing_mountpoints_warning', False)

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -58,6 +58,10 @@ class NfsStatCheck(AgentCheck):
         custom_tags = instance.get("tags", [])
         stats = stat_out.splitlines()
 
+        def add_device(device_data: list[list[str]]) -> None:
+            if len(device_data) >= 7:
+                all_devices.append(Device(device_data, self.log))
+
         if 'No NFS mount point' in stats[0]:
             if not self.autofs_enabled:
                 if not self.disable_missing_mountpoints_warning:
@@ -71,14 +75,12 @@ class NfsStatCheck(AgentCheck):
                 continue
             elif l.find('mounted on') >= 0 and len(this_device) > 0:
                 # if it's a new device, create the device and add it to the array
-                device = Device(this_device, self.log)
-                all_devices.append(device)
+                add_device(this_device)
                 this_device = []
             this_device.append(l.strip().split())
 
         # Add the last device into the array
-        device = Device(this_device, self.log)
-        all_devices.append(device)
+        add_device(this_device)
 
         # Disregard the first half of device stats (report 1 of 2)
         # as that is the moving average
@@ -105,8 +107,7 @@ class Device(object):
         self.log.info(self._device_header)
         self.device_name = self._device_header[0]
         self.mount = self._device_header[-1][:-1]
-        self.nfs_server = self.device_name.split(':')[0]
-        self.nfs_export = self.device_name.split(':')[1]
+        self.nfs_server, _, self.nfs_export = self.device_name.partition(':')
 
     def _parse_ops(self):
         ops = self._device_data[2]

--- a/nfsstat/tests/test_nfsstat.py
+++ b/nfsstat/tests/test_nfsstat.py
@@ -6,15 +6,27 @@ import os
 from copy import deepcopy
 
 import mock
+import pytest
 
 from datadog_checks.base import ensure_unicode
 from datadog_checks.nfsstat import NfsStatCheck
+from datadog_checks.nfsstat.nfsstat import SOURCE_NFSIOSTAT_PATH
 
 from .common import METRICS
 
 FIXTURE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'fixtures')
 
 log = logging.getLogger(__name__)
+
+OMNIBUS_NFSIOSTAT_PATH = '/opt/datadog-agent/embedded/sbin/nfsiostat'
+OMNIBUS_PYTHON_PATH = '/opt/datadog-agent/embedded/bin/python'
+FLEET_NFSIOSTAT_PATH = '/opt/datadog-packages/datadog-agent/stable/embedded/sbin/nfsiostat'
+FLEET_PYTHON_PATH = '/opt/datadog-packages/datadog-agent/stable/embedded/bin/python'
+
+
+def make_check(init_config: dict[str, str], present_paths: set[str]) -> NfsStatCheck:
+    with mock.patch('datadog_checks.nfsstat.nfsstat.os.path.exists', side_effect=lambda path: path in present_paths):
+        return NfsStatCheck('nfsstat', init_config, [{}])
 
 
 class TestNfsstat:
@@ -75,3 +87,38 @@ class TestNfsstat:
             aggregator.assert_metric(metric, tags=tags_unicode)
 
         assert aggregator.metrics_asserted_pct == 100.0
+
+
+@pytest.mark.unit
+class TestNfsiostatPathResolution:
+    def test_explicit_path_is_used_verbatim(self) -> None:
+        check = make_check({'nfsiostat_path': '/custom/nfsiostat --debug'}, set())
+
+        assert check.nfs_cmd == ['/custom/nfsiostat', '--debug', '1', '2']
+
+    def test_fleet_automation_path_uses_its_embedded_python(self) -> None:
+        check = make_check({}, {FLEET_NFSIOSTAT_PATH, FLEET_PYTHON_PATH})
+
+        assert check.nfs_cmd == [FLEET_PYTHON_PATH, FLEET_NFSIOSTAT_PATH, '1', '2']
+
+    def test_bundled_path_without_embedded_python_runs_directly(self) -> None:
+        check = make_check({}, {FLEET_NFSIOSTAT_PATH})
+
+        assert check.nfs_cmd == [FLEET_NFSIOSTAT_PATH, '1', '2']
+
+    def test_omnibus_path_takes_precedence(self) -> None:
+        check = make_check(
+            {},
+            {OMNIBUS_NFSIOSTAT_PATH, OMNIBUS_PYTHON_PATH, FLEET_NFSIOSTAT_PATH, FLEET_PYTHON_PATH},
+        )
+
+        assert check.nfs_cmd == [OMNIBUS_PYTHON_PATH, OMNIBUS_NFSIOSTAT_PATH, '1', '2']
+
+    def test_source_path_runs_directly(self) -> None:
+        check = make_check({}, {SOURCE_NFSIOSTAT_PATH})
+
+        assert check.nfs_cmd == [SOURCE_NFSIOSTAT_PATH, '1', '2']
+
+    def test_missing_nfsiostat_raises(self) -> None:
+        with pytest.raises(Exception, match='nfsstat check requires nfsiostat be installed'):
+            make_check({}, set())

--- a/nfsstat/tests/test_nfsstat.py
+++ b/nfsstat/tests/test_nfsstat.py
@@ -10,7 +10,7 @@ import pytest
 
 from datadog_checks.base import ensure_unicode
 from datadog_checks.nfsstat import NfsStatCheck
-from datadog_checks.nfsstat.nfsstat import SOURCE_NFSIOSTAT_PATH
+from datadog_checks.nfsstat.nfsstat import SOURCE_NFSIOSTAT_PATH, Device
 
 from .common import METRICS
 
@@ -87,6 +87,38 @@ class TestNfsstat:
             aggregator.assert_metric(metric, tags=tags_unicode)
 
         assert aggregator.metrics_asserted_pct == 100.0
+
+    @pytest.mark.unit
+    def test_device_without_export_path(self) -> None:
+        device = Device(
+            [
+                ['nfs-server', 'mounted', 'on', '/test1:'],
+                [],
+                ['0.0', '0.0'],
+                [],
+                ['0.0', '0.0', '0.0', '0.0', '(0.0%)', '0.0', '0.0'],
+                [],
+                ['0.0', '0.0', '0.0', '0.0', '(0.0%)', '0.0', '0.0'],
+            ],
+            mock.MagicMock(),
+        )
+
+        assert device.nfs_server == 'nfs-server'
+        assert device.nfs_export == ''
+
+    @pytest.mark.unit
+    def test_check_skips_incomplete_initial_sample(self, aggregator) -> None:
+        instance = self.INSTANCES['main']
+        check = NfsStatCheck(self.CHECK_NAME, self.INIT_CONFIG, [instance])
+
+        with open(os.path.join(FIXTURE_DIR, 'nfsiostat'), 'rb') as f:
+            mock_output = ensure_unicode(f.read())
+
+        mock_output = 'nfs-server mounted on /test1:\n\n' + mock_output
+        with mock.patch('datadog_checks.nfsstat.nfsstat.get_subprocess_output', return_value=(mock_output, '', 0)):
+            check.check(instance)
+
+        aggregator.assert_metric('system.nfs.ops')
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What does this PR do?

Adds the Datadog Installer/Fleet Automation stable path when resolving the Agent-bundled nfsiostat script. Bundled scripts run through their matching embedded Python interpreter, avoiding the legacy shebang path that is invalid in the Fleet Automation layout.

The NFS source parser now accepts a source without an export path and skips incomplete initial nfsiostat samples. This occurs in the Compose NFS fixture, which can first report only the server name and mount header. Normal server:/export sources retain their existing tags, while sources without an export receive an empty nfs_export tag.

### Motivation

Fleet Automation-managed Agents install under /opt/datadog-packages/datadog-agent/stable, so nfsstat currently fails to initialize when nfsiostat_path is unset. This addresses AGENT-16938 while preserving explicit overrides and source-install behavior.

### Validation

- ddev --no-interactive test -fs nfsstat
- ddev --no-interactive test nfsstat
- ddev --no-interactive test nfsstat -- -m unit
- Hosted CI passed, including NFS E2E, minimum-package, static analysis, CodeQL, changelog, repository validation, and external GitLab pipeline checks.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the qa/skip-qa label if the PR does not need to be tested during QA.
- [ ] If you need to backport this PR to another branch, add the backport/<branch-name> label after merge.