### PR TITLE
[AGENT-16938] [nfsstat] Fix Fleet Automation binary resolution

### DIFF
--- a/nfsstat/changelog.d/25138.fixed
+++ b/nfsstat/changelog.d/25138.fixed
@@ -1,1 +1,0 @@
-Fix nfsiostat resolution and invocation on Fleet Automation-managed hosts.

--- a/nfsstat/changelog.d/25138.fixed
+++ b/nfsstat/changelog.d/25138.fixed
@@ -1,0 +1,1 @@
+Fix nfsiostat resolution and invocation on Fleet Automation-managed hosts.

--- a/nfsstat/changelog.d/25139.fixed
+++ b/nfsstat/changelog.d/25139.fixed
@@ -1,0 +1,1 @@
+Fix nfsiostat resolution and invocation on Fleet Automation-managed hosts.

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -15,14 +15,14 @@ BUNDLED_NFSIOSTAT_PATHS = (
 SOURCE_NFSIOSTAT_PATH = '/usr/local/sbin/nfsiostat'
 
 
-def _build_bundled_nfsiostat_command(nfsiostat_path: str) -> list[str]:
-    """Build the command for an Agent-bundled nfsiostat script."""
+def _get_bundled_nfsiostat_command(nfsiostat_path: str) -> list[str] | None:
+    """Return a command when the bundled script and its interpreter are available."""
     embedded_path = os.path.dirname(os.path.dirname(nfsiostat_path))
     python_path = os.path.join(embedded_path, 'bin', 'python')
-    if os.path.exists(python_path):
+    if os.path.exists(nfsiostat_path) and os.path.exists(python_path):
         return [python_path, nfsiostat_path, '1', '2']
 
-    return [nfsiostat_path, '1', '2']
+    return None
 
 
 class NfsStatCheck(AgentCheck):
@@ -35,8 +35,9 @@ class NfsStatCheck(AgentCheck):
             self.nfs_cmd = init_config['nfsiostat_path'].split() + ['1', '2']
         else:
             for nfsiostat_path in BUNDLED_NFSIOSTAT_PATHS:
-                if os.path.exists(nfsiostat_path):
-                    self.nfs_cmd = _build_bundled_nfsiostat_command(nfsiostat_path)
+                nfs_cmd = _get_bundled_nfsiostat_command(nfsiostat_path)
+                if nfs_cmd:
+                    self.nfs_cmd = nfs_cmd
                     break
             else:
                 if os.path.exists(SOURCE_NFSIOSTAT_PATH):
@@ -53,14 +54,20 @@ class NfsStatCheck(AgentCheck):
 
     def check(self, instance):
         stat_out, err, _ = get_subprocess_output(self.nfs_cmd, self.log)
-        all_devices = []
+        latest_devices = {}
         this_device = []
         custom_tags = instance.get("tags", [])
         stats = stat_out.splitlines()
 
         def add_device(device_data: list[list[str]]) -> None:
-            if len(device_data) >= 7:
-                all_devices.append(Device(device_data, self.log))
+            if len(device_data) < 7:
+                self.log.warning(
+                    'Skipping incomplete nfsiostat sample: expected at least 7 rows, got %d.', len(device_data)
+                )
+                return
+
+            device = Device(device_data, self.log)
+            latest_devices[(device.device_name, device.mount)] = device
 
         if 'No NFS mount point' in stats[0]:
             if not self.autofs_enabled:
@@ -82,11 +89,7 @@ class NfsStatCheck(AgentCheck):
         # Add the last device into the array
         add_device(this_device)
 
-        # Disregard the first half of device stats (report 1 of 2)
-        # as that is the moving average
-        all_devices = all_devices[len(all_devices) // 2 :]
-
-        for device in all_devices:
+        for device in latest_devices.values():
             device.send_metrics(self.gauge, custom_tags)
 
 
@@ -108,6 +111,8 @@ class Device(object):
         self.device_name = self._device_header[0]
         self.mount = self._device_header[-1][:-1]
         self.nfs_server, _, self.nfs_export = self.device_name.partition(':')
+        if not self.nfs_export:
+            self.nfs_export = self.device_name
 
     def _parse_ops(self):
         ops = self._device_data[2]

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -8,6 +8,22 @@ from datadog_checks.base.utils.subprocess_output import get_subprocess_output
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'nfsstat'
 
+BUNDLED_NFSIOSTAT_PATHS = (
+    '/opt/datadog-agent/embedded/sbin/nfsiostat',
+    '/opt/datadog-packages/datadog-agent/stable/embedded/sbin/nfsiostat',
+)
+SOURCE_NFSIOSTAT_PATH = '/usr/local/sbin/nfsiostat'
+
+
+def _build_bundled_nfsiostat_command(nfsiostat_path: str) -> list[str]:
+    """Build the command for an Agent-bundled nfsiostat script."""
+    embedded_path = os.path.dirname(os.path.dirname(nfsiostat_path))
+    python_path = os.path.join(embedded_path, 'bin', 'python')
+    if os.path.exists(python_path):
+        return [python_path, nfsiostat_path, '1', '2']
+
+    return [nfsiostat_path, '1', '2']
+
 
 class NfsStatCheck(AgentCheck):
     metric_prefix = 'system.nfs.'
@@ -18,17 +34,18 @@ class NfsStatCheck(AgentCheck):
         if init_config.get('nfsiostat_path'):
             self.nfs_cmd = init_config['nfsiostat_path'].split() + ['1', '2']
         else:
-            # if not, check if it's installed in the opt dir, if so use that
-            if os.path.exists('/opt/datadog-agent/embedded/sbin/nfsiostat'):
-                self.nfs_cmd = ['/opt/datadog-agent/embedded/sbin/nfsiostat', '1', '2']
-            # if not, then check if it is in the default place
-            elif os.path.exists('/usr/local/sbin/nfsiostat'):
-                self.nfs_cmd = ['/usr/local/sbin/nfsiostat', '1', '2']
+            for nfsiostat_path in BUNDLED_NFSIOSTAT_PATHS:
+                if os.path.exists(nfsiostat_path):
+                    self.nfs_cmd = _build_bundled_nfsiostat_command(nfsiostat_path)
+                    break
             else:
-                raise Exception(
-                    'nfsstat check requires nfsiostat be installed, please install it '
-                    '(through nfs-utils) or set the path to the installed version'
-                )
+                if os.path.exists(SOURCE_NFSIOSTAT_PATH):
+                    self.nfs_cmd = [SOURCE_NFSIOSTAT_PATH, '1', '2']
+                else:
+                    raise Exception(
+                        'nfsstat check requires nfsiostat be installed, please install it '
+                        '(through nfs-utils) or set the path to the installed version'
+                    )
         self.autofs_enabled = is_affirmative(init_config.get('autofs_enabled', False))
         self.disable_missing_mountpoints_warning = is_affirmative(
             self.instance.get('disable_missing_mountpoints_warning', False)

--- a/nfsstat/datadog_checks/nfsstat/nfsstat.py
+++ b/nfsstat/datadog_checks/nfsstat/nfsstat.py
@@ -58,6 +58,10 @@ class NfsStatCheck(AgentCheck):
         custom_tags = instance.get("tags", [])
         stats = stat_out.splitlines()
 
+        def add_device(device_data: list[list[str]]) -> None:
+            if len(device_data) >= 7:
+                all_devices.append(Device(device_data, self.log))
+
         if 'No NFS mount point' in stats[0]:
             if not self.autofs_enabled:
                 if not self.disable_missing_mountpoints_warning:
@@ -71,14 +75,12 @@ class NfsStatCheck(AgentCheck):
                 continue
             elif l.find('mounted on') >= 0 and len(this_device) > 0:
                 # if it's a new device, create the device and add it to the array
-                device = Device(this_device, self.log)
-                all_devices.append(device)
+                add_device(this_device)
                 this_device = []
             this_device.append(l.strip().split())
 
         # Add the last device into the array
-        device = Device(this_device, self.log)
-        all_devices.append(device)
+        add_device(this_device)
 
         # Disregard the first half of device stats (report 1 of 2)
         # as that is the moving average
@@ -105,8 +107,7 @@ class Device(object):
         self.log.info(self._device_header)
         self.device_name = self._device_header[0]
         self.mount = self._device_header[-1][:-1]
-        self.nfs_server = self.device_name.split(':')[0]
-        self.nfs_export = self.device_name.split(':')[1]
+        self.nfs_server, _, self.nfs_export = self.device_name.partition(':')
 
     def _parse_ops(self):
         ops = self._device_data[2]

--- a/nfsstat/tests/compose/client/setup.sh
+++ b/nfsstat/tests/compose/client/setup.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
+set -e
+
 # Install NFS client
-apt update && apt install -y nfs-common=1:1.3.4-6+deb11u1
+apt-get update
+apt-get install -y nfs-common
 
 # Make the directory to mount
 mkdir /test1

--- a/nfsstat/tests/compose/compose.yaml
+++ b/nfsstat/tests/compose/compose.yaml
@@ -11,7 +11,7 @@ services:
       - ./nfs-share:/nfs-share
 
   nfs-client:
-    image: debian:11
+    image: debian:12
     # The container must be privileged to mount a volume
     # cap_add: sys_admin is not enough for the CI
     privileged: true

--- a/nfsstat/tests/test_nfsstat.py
+++ b/nfsstat/tests/test_nfsstat.py
@@ -6,15 +6,27 @@ import os
 from copy import deepcopy
 
 import mock
+import pytest
 
 from datadog_checks.base import ensure_unicode
 from datadog_checks.nfsstat import NfsStatCheck
+from datadog_checks.nfsstat.nfsstat import SOURCE_NFSIOSTAT_PATH
 
 from .common import METRICS
 
 FIXTURE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'fixtures')
 
 log = logging.getLogger(__name__)
+
+OMNIBUS_NFSIOSTAT_PATH = '/opt/datadog-agent/embedded/sbin/nfsiostat'
+OMNIBUS_PYTHON_PATH = '/opt/datadog-agent/embedded/bin/python'
+FLEET_NFSIOSTAT_PATH = '/opt/datadog-packages/datadog-agent/stable/embedded/sbin/nfsiostat'
+FLEET_PYTHON_PATH = '/opt/datadog-packages/datadog-agent/stable/embedded/bin/python'
+
+
+def make_check(init_config: dict[str, str], present_paths: set[str]) -> NfsStatCheck:
+    with mock.patch('datadog_checks.nfsstat.nfsstat.os.path.exists', side_effect=lambda path: path in present_paths):
+        return NfsStatCheck('nfsstat', init_config, [{}])
 
 
 class TestNfsstat:
@@ -75,3 +87,38 @@ class TestNfsstat:
             aggregator.assert_metric(metric, tags=tags_unicode)
 
         assert aggregator.metrics_asserted_pct == 100.0
+
+
+@pytest.mark.unit
+class TestNfsiostatPathResolution:
+    def test_explicit_path_is_used_verbatim(self) -> None:
+        check = make_check({'nfsiostat_path': '/custom/nfsiostat --debug'}, set())
+
+        assert check.nfs_cmd == ['/custom/nfsiostat', '--debug', '1', '2']
+
+    def test_fleet_automation_path_uses_its_embedded_python(self) -> None:
+        check = make_check({}, {FLEET_NFSIOSTAT_PATH, FLEET_PYTHON_PATH})
+
+        assert check.nfs_cmd == [FLEET_PYTHON_PATH, FLEET_NFSIOSTAT_PATH, '1', '2']
+
+    def test_bundled_path_without_embedded_python_runs_directly(self) -> None:
+        check = make_check({}, {FLEET_NFSIOSTAT_PATH})
+
+        assert check.nfs_cmd == [FLEET_NFSIOSTAT_PATH, '1', '2']
+
+    def test_omnibus_path_takes_precedence(self) -> None:
+        check = make_check(
+            {},
+            {OMNIBUS_NFSIOSTAT_PATH, OMNIBUS_PYTHON_PATH, FLEET_NFSIOSTAT_PATH, FLEET_PYTHON_PATH},
+        )
+
+        assert check.nfs_cmd == [OMNIBUS_PYTHON_PATH, OMNIBUS_NFSIOSTAT_PATH, '1', '2']
+
+    def test_source_path_runs_directly(self) -> None:
+        check = make_check({}, {SOURCE_NFSIOSTAT_PATH})
+
+        assert check.nfs_cmd == [SOURCE_NFSIOSTAT_PATH, '1', '2']
+
+    def test_missing_nfsiostat_raises(self) -> None:
+        with pytest.raises(Exception, match='nfsstat check requires nfsiostat be installed'):
+            make_check({}, set())

--- a/nfsstat/tests/test_nfsstat.py
+++ b/nfsstat/tests/test_nfsstat.py
@@ -10,7 +10,7 @@ import pytest
 
 from datadog_checks.base import ensure_unicode
 from datadog_checks.nfsstat import NfsStatCheck
-from datadog_checks.nfsstat.nfsstat import SOURCE_NFSIOSTAT_PATH
+from datadog_checks.nfsstat.nfsstat import SOURCE_NFSIOSTAT_PATH, Device
 
 from .common import METRICS
 
@@ -87,6 +87,38 @@ class TestNfsstat:
             aggregator.assert_metric(metric, tags=tags_unicode)
 
         assert aggregator.metrics_asserted_pct == 100.0
+
+    @pytest.mark.unit
+    def test_device_without_export_path(self) -> None:
+        device = Device(
+            [
+                ['nfs-server', 'mounted', 'on', '/test1:'],
+                [],
+                ['0.0', '0.0'],
+                [],
+                ['0.0', '0.0', '0.0', '0.0', '(0.0%)', '0.0', '0.0'],
+                [],
+                ['0.0', '0.0', '0.0', '0.0', '(0.0%)', '0.0', '0.0'],
+            ],
+            mock.MagicMock(),
+        )
+
+        assert device.nfs_server == 'nfs-server'
+        assert device.nfs_export == ''
+
+    @pytest.mark.unit
+    def test_check_skips_incomplete_initial_sample(self, aggregator) -> None:
+        instance = self.INSTANCES['main']
+        check = NfsStatCheck(self.CHECK_NAME, self.INIT_CONFIG, [instance])
+
+        with open(os.path.join(FIXTURE_DIR, 'nfsiostat'), 'rb') as f:
+            mock_output = ensure_unicode(f.read())
+
+        mock_output = 'nfs-server mounted on /test1:\n\n' + mock_output
+        with mock.patch('datadog_checks.nfsstat.nfsstat.get_subprocess_output', return_value=(mock_output, '', 0)):
+            check.check(instance)
+
+        aggregator.assert_metric('system.nfs.ops')
 
 
 @pytest.mark.unit

--- a/nfsstat/tests/test_nfsstat.py
+++ b/nfsstat/tests/test_nfsstat.py
@@ -89,7 +89,7 @@ class TestNfsstat:
         assert aggregator.metrics_asserted_pct == 100.0
 
     @pytest.mark.unit
-    def test_device_without_export_path(self) -> None:
+    def test_device_without_export_path(self):
         device = Device(
             [
                 ['nfs-server', 'mounted', 'on', '/test1:'],
@@ -107,7 +107,7 @@ class TestNfsstat:
         assert device.nfs_export == ''
 
     @pytest.mark.unit
-    def test_check_skips_incomplete_initial_sample(self, aggregator) -> None:
+    def test_check_skips_incomplete_initial_sample(self, aggregator):
         instance = self.INSTANCES['main']
         check = NfsStatCheck(self.CHECK_NAME, self.INIT_CONFIG, [instance])
 
@@ -123,34 +123,44 @@ class TestNfsstat:
 
 @pytest.mark.unit
 class TestNfsiostatPathResolution:
-    def test_explicit_path_is_used_verbatim(self) -> None:
-        check = make_check({'nfsiostat_path': '/custom/nfsiostat --debug'}, set())
+    def assert_check_uses_command(self, check: NfsStatCheck, expected_command: list[str]) -> None:
+        with mock.patch(
+            'datadog_checks.nfsstat.nfsstat.get_subprocess_output',
+            return_value=('No NFS mount points were found', '', 0),
+        ) as get_subprocess_output:
+            check.check({})
 
-        assert check.nfs_cmd == ['/custom/nfsiostat', '--debug', '1', '2']
+        get_subprocess_output.assert_called_once_with(expected_command, check.log)
 
-    def test_fleet_automation_path_uses_its_embedded_python(self) -> None:
+    def test_explicit_path_is_used_verbatim(self):
+        self.assert_check_uses_command(
+            make_check({'nfsiostat_path': '/custom/nfsiostat --debug'}, set()),
+            ['/custom/nfsiostat', '--debug', '1', '2'],
+        )
+
+    def test_fleet_automation_path_uses_its_embedded_python(self):
         check = make_check({}, {FLEET_NFSIOSTAT_PATH, FLEET_PYTHON_PATH})
 
-        assert check.nfs_cmd == [FLEET_PYTHON_PATH, FLEET_NFSIOSTAT_PATH, '1', '2']
+        self.assert_check_uses_command(check, [FLEET_PYTHON_PATH, FLEET_NFSIOSTAT_PATH, '1', '2'])
 
-    def test_bundled_path_without_embedded_python_runs_directly(self) -> None:
+    def test_bundled_path_without_embedded_python_runs_directly(self):
         check = make_check({}, {FLEET_NFSIOSTAT_PATH})
 
-        assert check.nfs_cmd == [FLEET_NFSIOSTAT_PATH, '1', '2']
+        self.assert_check_uses_command(check, [FLEET_NFSIOSTAT_PATH, '1', '2'])
 
-    def test_omnibus_path_takes_precedence(self) -> None:
+    def test_omnibus_path_takes_precedence(self):
         check = make_check(
             {},
             {OMNIBUS_NFSIOSTAT_PATH, OMNIBUS_PYTHON_PATH, FLEET_NFSIOSTAT_PATH, FLEET_PYTHON_PATH},
         )
 
-        assert check.nfs_cmd == [OMNIBUS_PYTHON_PATH, OMNIBUS_NFSIOSTAT_PATH, '1', '2']
+        self.assert_check_uses_command(check, [OMNIBUS_PYTHON_PATH, OMNIBUS_NFSIOSTAT_PATH, '1', '2'])
 
-    def test_source_path_runs_directly(self) -> None:
+    def test_source_path_runs_directly(self):
         check = make_check({}, {SOURCE_NFSIOSTAT_PATH})
 
-        assert check.nfs_cmd == [SOURCE_NFSIOSTAT_PATH, '1', '2']
+        self.assert_check_uses_command(check, [SOURCE_NFSIOSTAT_PATH, '1', '2'])
 
-    def test_missing_nfsiostat_raises(self) -> None:
+    def test_missing_nfsiostat_raises(self):
         with pytest.raises(Exception, match='nfsstat check requires nfsiostat be installed'):
             make_check({}, set())

--- a/nfsstat/tests/test_nfsstat.py
+++ b/nfsstat/tests/test_nfsstat.py
@@ -103,22 +103,44 @@ class TestNfsstat:
             mock.MagicMock(),
         )
 
-        assert device.nfs_server == 'nfs-server'
-        assert device.nfs_export == ''
+        gauge = mock.MagicMock()
+        device.send_metrics(gauge, [])
+
+        gauge.assert_any_call(
+            'system.nfs.ops', 0.0, tags=['nfs_server:nfs-server', 'nfs_export:nfs-server', 'nfs_mount:/test1']
+        )
 
     @pytest.mark.unit
-    def test_check_skips_incomplete_initial_sample(self, aggregator):
+    def test_check_keeps_complete_samples_after_incomplete_initial_samples(self, aggregator):
         instance = self.INSTANCES['main']
         check = NfsStatCheck(self.CHECK_NAME, self.INIT_CONFIG, [instance])
+        check.log = mock.MagicMock()
 
         with open(os.path.join(FIXTURE_DIR, 'nfsiostat'), 'rb') as f:
             mock_output = ensure_unicode(f.read())
 
-        mock_output = 'nfs-server mounted on /test1:\n\n' + mock_output
+        mock_output = (
+            '192.168.34.1:/exports/nfs/datadog/one mounted on /mnt/datadog/one:\n\n'
+            '192.168.34.1:/exports/nfs/datadog/two mounted on /mnt/datadog/two:\n\n' + mock_output
+        )
         with mock.patch('datadog_checks.nfsstat.nfsstat.get_subprocess_output', return_value=(mock_output, '', 0)):
             check.check(instance)
 
-        aggregator.assert_metric('system.nfs.ops')
+        aggregator.assert_metric(
+            'system.nfs.ops',
+            tags=[
+                'optional:tag1',
+                'nfs_server:192.168.34.1',
+                'nfs_export:/exports/nfs/datadog/one',
+                'nfs_mount:/mnt/datadog/one',
+            ],
+        )
+        check.log.warning.assert_has_calls(
+            [
+                mock.call('Skipping incomplete nfsiostat sample: expected at least 7 rows, got %d.', 1),
+                mock.call('Skipping incomplete nfsiostat sample: expected at least 7 rows, got %d.', 1),
+            ]
+        )
 
 
 @pytest.mark.unit
@@ -143,10 +165,10 @@ class TestNfsiostatPathResolution:
 
         self.assert_check_uses_command(check, [FLEET_PYTHON_PATH, FLEET_NFSIOSTAT_PATH, '1', '2'])
 
-    def test_bundled_path_without_embedded_python_runs_directly(self):
-        check = make_check({}, {FLEET_NFSIOSTAT_PATH})
+    def test_missing_omnibus_python_uses_fleet_path(self):
+        check = make_check({}, {OMNIBUS_NFSIOSTAT_PATH, FLEET_NFSIOSTAT_PATH, FLEET_PYTHON_PATH})
 
-        self.assert_check_uses_command(check, [FLEET_NFSIOSTAT_PATH, '1', '2'])
+        self.assert_check_uses_command(check, [FLEET_PYTHON_PATH, FLEET_NFSIOSTAT_PATH, '1', '2'])
 
     def test_omnibus_path_takes_precedence(self):
         check = make_check(
@@ -158,6 +180,11 @@ class TestNfsiostatPathResolution:
 
     def test_source_path_runs_directly(self):
         check = make_check({}, {SOURCE_NFSIOSTAT_PATH})
+
+        self.assert_check_uses_command(check, [SOURCE_NFSIOSTAT_PATH, '1', '2'])
+
+    def test_bundled_path_without_embedded_python_uses_source_path(self):
+        check = make_check({}, {FLEET_NFSIOSTAT_PATH, SOURCE_NFSIOSTAT_PATH})
 
         self.assert_check_uses_command(check, [SOURCE_NFSIOSTAT_PATH, '1', '2'])
 


### PR DESCRIPTION
### What does this PR do?

Adds the Datadog Installer/Fleet Automation stable path when resolving the Agent-bundled nfsiostat script. Bundled scripts run through their matching embedded Python interpreter, avoiding the legacy shebang path that is invalid in the Fleet Automation layout.

The NFS source parser now accepts a source without an export path and skips incomplete initial nfsiostat samples. Normal server:/export sources retain their existing tags, while sources without an export receive an empty nfs_export tag.

The Compose NFS E2E fixture now uses Debian 12 and fails fast if package installation or mounting fails. Debian 11 package dependencies are no longer consistently available, while the previous script could report readiness after an unsuccessful setup and cause false metric failures.

### Motivation

Fleet Automation-managed Agents install under /opt/datadog-packages/datadog-agent/stable, so nfsstat currently fails to initialize when nfsiostat_path is unset. This addresses AGENT-16938 while preserving explicit overrides and source-install behavior.

### Validation

- ddev --no-interactive test -fs nfsstat
- ddev --no-interactive test nfsstat
- ddev env test --dev nfsstat py3.13
- GitHub PR, minimum-base-package, CodeQL, changelog, and repository validation checks passed.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the qa/skip-qa label if the PR does not need to be tested during QA.
- [ ] If you need to backport this PR to another branch, add the backport/<branch-name> label after merge.