### PR TITLE
Declare warning/critical properties for process check's thresholds spec

### DIFF
--- a/process/assets/configuration/spec.yaml
+++ b/process/assets/configuration/spec.yaml
@@ -133,6 +133,17 @@ files:
                          use `.inf` for the upper bound.
         value:
           type: object
+          properties:
+          - name: warning
+            type: array
+            items:
+              type: number
+            minItems: 2
+          - name: critical
+            type: array
+            items:
+              type: number
+            minItems: 2
           compact_example: true
           example:
             warning: [<BELOW_VALUE> , <TOP_VALUE>]

--- a/process/changelog.d/25140.fixed
+++ b/process/changelog.d/25140.fixed
@@ -1,0 +1,1 @@
+Explicitly declare `warning`/`critical` as named properties of the `thresholds` option so it can be validated when configured remotely via Fleet Automation.

--- a/process/datadog_checks/process/config_models/instance.py
+++ b/process/datadog_checks/process/config_models/instance.py
@@ -9,10 +9,9 @@
 
 from __future__ import annotations
 
-from types import MappingProxyType
-from typing import Any, Optional
+from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -30,6 +29,15 @@ class MetricPatterns(BaseModel):
     )
     exclude: Optional[tuple[str, ...]] = None
     include: Optional[tuple[str, ...]] = None
+
+
+class Thresholds(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    critical: Optional[tuple[float, ...]] = Field(None, min_length=2)
+    warning: Optional[tuple[float, ...]] = Field(None, min_length=2)
 
 
 class InstanceConfig(BaseModel):
@@ -53,7 +61,7 @@ class InstanceConfig(BaseModel):
     search_string: Optional[tuple[str, ...]] = None
     service: Optional[str] = None
     tags: Optional[tuple[str, ...]] = None
-    thresholds: Optional[MappingProxyType[str, Any]] = None
+    thresholds: Optional[Thresholds] = None
     try_sudo: Optional[bool] = None
     use_oneshot: Optional[bool] = None
     user: Optional[str] = None


### PR DESCRIPTION
## What does this PR do?
Adds explicit `warning`/`critical` `properties` to the `thresholds` option in the `process` check's `spec.yaml`, instead of leaving it typed as a bare `object`.

## Motivation
Follow-up to #25073, which set `fleet_configurable: true` on `thresholds` but didn't change its type. Per feedback in #25073's Slack thread: `fleet_configurable: true` alone isn't enough for Fleet Automation's remote-config editor to validate the value, since a bare `object` type accepts any keys/values. This PR declares `warning` and `critical` as named properties (each a numeric array with `minItems: 2`, matching the documented low/high bound semantics) so remote-config can actually validate the shape.

Note: this repo's spec validator disallows `minItems == maxItems` (no fixed-length arrays), so only `minItems: 2` is set — it won't cap array length at exactly 2, but does guarantee the low/high pair is present.

**Behavior change:** configs where `thresholds.warning`/`thresholds.critical` are malformed (fewer than 2 elements, or not numeric) previously loaded silently (the field was untyped) and will now fail config validation. Requesting QA to confirm this doesn't break any existing valid configs.

## Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged