### PR TITLE
Retry license downloads and make validation tests offline

### DIFF
--- a/ddev/changelog.d/25142.fixed
+++ b/ddev/changelog.d/25142.fixed
@@ -1,0 +1,1 @@
+Retry interrupted license archive downloads and make license validation tests independent of live HTTP requests.

--- a/ddev/src/ddev/cli/validate/licenses.py
+++ b/ddev/src/ddev/cli/validate/licenses.py
@@ -19,6 +19,8 @@ _OP_SPLIT = re.compile(r'\s*(?:(?<!-)\b(?:AND|OR)\b(?!-)|/|\+|\band/or\b)\s*', r
 # and may appear as LicenseRef-* / DocumentRef-*:LicenseRef-*
 _ID = re.compile(r"(DocumentRef-[A-Za-z0-9.+-]+:)?LicenseRef-[A-Za-z0-9.+-]+|[A-Za-z0-9.+-]+")
 
+DOWNLOAD_RETRIES = 2
+
 
 def format_attribution_line(package_name, license_id, package_copyright):
     if ',' in package_copyright:
@@ -70,18 +72,34 @@ def collect_source_url(package_data):
     return combined[0]
 
 
-def scrape_copyright_data(url_path):
-    """
-    Scrapes each tarfile for copyright attributions.
-    """
+def scrape_copyright_data(url_path: str) -> str | None:
+    """Download an archive with bounded connection retries and extract its copyright."""
+    import time
+
     import httpx
 
-    with httpx.stream('GET', url_path, follow_redirects=True) as resp:
-        resp.read()
-        for fcontents in pick_file_generator(url_path)(resp):
-            if cp := find_cpy(fcontents):
-                return cp
-    return None
+    attempt = 0
+    while True:
+        try:
+            # Keep the httpx.stream defaults so environment proxy support is preserved.
+            with httpx.stream('GET', url_path, follow_redirects=True) as resp:
+                resp.raise_for_status()
+                resp.read()
+                for fcontents in pick_file_generator(url_path)(resp):
+                    if cp := find_cpy(fcontents):
+                        return cp
+            return None
+        except (
+            httpx.ConnectError,
+            httpx.ConnectTimeout,
+            httpx.ReadError,
+            httpx.ReadTimeout,
+            httpx.RemoteProtocolError,
+        ):
+            if attempt == DOWNLOAD_RETRIES:
+                raise
+            time.sleep(2**attempt)
+            attempt += 1
 
 
 def find_cpy(data):

--- a/ddev/tests/cli/validate/conftest.py
+++ b/ddev/tests/cli/validate/conftest.py
@@ -1,8 +1,12 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from unittest.mock import MagicMock
+
+import httpx
 import pytest
 from datadog_checks.dev.tooling.constants import set_root
+from pytest_mock import MockerFixture
 
 from ddev.repo.core import Repository
 from tests.helpers.api import write_file
@@ -76,6 +80,16 @@ def _fake_repo(tmp_path_factory, config_file, name, files_to_write):
         write_file(repo_path / file_path, file_name, content)
 
     return repo
+
+
+@pytest.fixture
+def mock_http(mocker: MockerFixture) -> MagicMock:
+    """Default-deny mock at the `httpx.HTTPTransport.handle_request` boundary."""
+
+    def reject_unexpected_request(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f'Unexpected HTTP request in test: {request.url}')
+
+    return mocker.patch.object(httpx.HTTPTransport, 'handle_request', side_effect=reject_unexpected_request)
 
 
 @pytest.fixture

--- a/ddev/tests/cli/validate/test_licenses.py
+++ b/ddev/tests/cli/validate/test_licenses.py
@@ -1,32 +1,138 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import os
+from __future__ import annotations
 
+import io
+import tarfile
+import time
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+import httpx
 import pytest
 
+from ddev.cli.validate import licenses_utils
+from ddev.cli.validate.licenses import DOWNLOAD_RETRIES, scrape_copyright_data
+from ddev.utils.fs import Path
 from ddev.utils.toml import dump_toml_data, load_toml_file
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+# The mock transport rejects any request without an installed handler, so the early-error
+# and extras-skip cases are covered against accidental network access too.
+pytestmark = pytest.mark.usefixtures('mock_http')
+
+PACKAGE_NAME = 'fake-package'
+PACKAGE_VERSION = '1.2.3'
+TARBALL_URL = f'https://files.pythonhosted.org/packages/{PACKAGE_NAME}-{PACKAGE_VERSION}.tar.gz'
+PYPI_URL = f'https://pypi.org/pypi/{PACKAGE_NAME}/{PACKAGE_VERSION}/json'
+SPDX_URL = 'https://raw.githubusercontent.com/spdx/license-list-data/v3.13/json/licenses.json'
+COPYRIGHT = 'Copyright (c) 2020 Fake Author'
+EXPECTED_CSV = """Component,Origin,License,Copyright
+fake-package,PyPI,MIT,Copyright (c) 2020 Fake Author
+"""
+
+
+def build_tar_gz(files: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode='w:gz') as archive:
+        for name, content in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            archive.addfile(info, io.BytesIO(content))
+    return buffer.getvalue()
+
+
+def archive_bytes() -> bytes:
+    return build_tar_gz({f'{PACKAGE_NAME}-{PACKAGE_VERSION}/LICENSE': f'# {COPYRIGHT}\n'.encode()})
+
+
+def tarball_response() -> httpx.Response:
+    return httpx.Response(200, content=archive_bytes())
+
+
+class InterruptedStream(httpx.SyncByteStream):
+    """Yields part of a response body, then raises like an interrupted download."""
+
+    def __init__(self, error: httpx.ReadError | httpx.ReadTimeout | httpx.RemoteProtocolError) -> None:
+        self.error = error
+
+    def __iter__(self) -> Iterator[bytes]:
+        yield archive_bytes()[:64]
+        raise self.error
+
+
+def interrupted_response(error: httpx.ReadError | httpx.ReadTimeout | httpx.RemoteProtocolError) -> httpx.Response:
+    return httpx.Response(200, stream=InterruptedStream(error))
+
+
+def pypi_response() -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            'info': {
+                'name': PACKAGE_NAME,
+                'version': PACKAGE_VERSION,
+                'author': '',
+                'maintainer': '',
+                'author_email': '',
+                'maintainer_email': '',
+                'home_page': '',
+                'license': '',
+                'license_expression': 'MIT',
+                'classifiers': [],
+            },
+            'urls': [{'url': TARBALL_URL}],
+        },
+    )
+
+
+def spdx_response() -> httpx.Response:
+    return httpx.Response(200, json={'licenses': [{'licenseId': 'Apache-2.0'}, {'licenseId': 'MIT'}]})
+
+
+def install_license_handlers(mock_http: MagicMock) -> None:
+    def respond(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url == PYPI_URL:
+            return pypi_response()
+        elif url == SPDX_URL:
+            return spdx_response()
+        elif url == TARBALL_URL:
+            return tarball_response()
+        raise AssertionError(f'Unexpected HTTP request in test: {url}')
+
+    mock_http.side_effect = respond
+
+
+def write_requirements(repo_path: Path, *lines: str) -> None:
+    path = repo_path / 'agent_requirements.in'
+    path.write_text(''.join(lines) or f'{PACKAGE_NAME}=={PACKAGE_VERSION}\n', encoding='utf-8')
 
 
 @pytest.mark.parametrize(
-    "name, contents, expected_error_output",
+    'name, contents, expected_error_output',
     [
         pytest.param(
-            "licenses",
+            'licenses',
             {'dummy_package': 'dummy_license'},
-            "EXPLICIT_LICENSES contains additional package not in agent",
-            id="explicit licenses",
+            'EXPLICIT_LICENSES contains additional package not in agent',
+            id='explicit licenses',
         ),
         pytest.param(
-            "repo",
+            'repo',
             {'dummy_package': 'https://github.com/dummy_package'},
-            "PACKAGE_REPO_OVERRIDES contains additional package not in agent",
-            id="package repo overrides",
+            'PACKAGE_REPO_OVERRIDES contains additional package not in agent',
+            id='package repo overrides',
         ),
     ],
 )
-def test_error_extra_dependency(name, contents, expected_error_output, ddev, repository, helpers):
-    ddev_config_path = repository.path / '.ddev' / 'config.toml'
+def test_error_extra_dependency(name, contents, expected_error_output, ddev, fake_repo, helpers):
+    write_requirements(fake_repo.path)
+
+    ddev_config_path = fake_repo.path / '.ddev' / 'config.toml'
 
     data = load_toml_file(ddev_config_path)
 
@@ -43,49 +149,162 @@ def test_error_extra_dependency(name, contents, expected_error_output, ddev, rep
 
 
 @pytest.mark.parametrize(
-    "repo, expected_message",
+    'repo_fixture, expected_exit_code, expected_message',
     [
-        pytest.param("core", "Passed: 1", id="Core integrations"),
+        pytest.param('fake_repo', 0, 'Passed: 1', id='Core integrations'),
         pytest.param(
-            "extras",
-            "License validation is only available for repo `core`, skipping for repo `extras`",
-            id="Extras integrations",
+            'fake_extras_repo',
+            1,
+            'License validation is only available for repo `core`, skipping for repo `extras`',
+            id='Extras integrations',
         ),
     ],
 )
-@pytest.mark.requires_ci
-def test_validate_repo(repo, expected_message, ddev, helpers, config_file):
-    config_file.model.repo = repo
-    config_file.save()
+def test_validate_repo(
+    repo_fixture, expected_exit_code, expected_message, ddev, helpers, config_file, monkeypatch, mock_http, request
+):
+    repo = request.getfixturevalue(repo_fixture)
 
-    result = ddev("validate", "licenses")
+    if repo.name == 'core':
+        write_requirements(repo.path)
+        (repo.path / 'LICENSE-3rdparty.csv').write_text(EXPECTED_CSV, encoding='utf-8')
+        # Replace the production extras with a controlled empty set so the expected CSV
+        # only depends on this test's fixture data.
+        monkeypatch.setattr(licenses_utils, 'ADDITIONAL_LICENSES', set())
+        install_license_handlers(mock_http)
 
+    result = ddev('validate', 'licenses')
+
+    assert result.exit_code == expected_exit_code, result.output
     assert expected_message in helpers.remove_trailing_spaces(result.output)
 
 
-def test_error_no_requirements_file(repository, ddev, helpers):
-    agent_requirements_path = repository.path / 'agent_requirements.in'
-    os.remove(agent_requirements_path)
+def test_error_no_requirements_file(fake_repo, ddev, helpers):
+    result = ddev('validate', 'licenses')
 
-    result = ddev("validate", "licenses")
+    assert result.exit_code == 1
 
     expected_error_output = 'Requirements file is not found. Out of sync, run'
     assert expected_error_output in helpers.remove_trailing_spaces(result.output)
 
 
-def test_invalid_requirement(repository, ddev, helpers):
-    agent_requirements_path = repository.path / 'agent_requirements.in'
+def test_invalid_requirement(fake_repo, ddev, helpers):
+    write_requirements(fake_repo.path, "aerospike==^4.0.0; sys_platform != 'win32' and sys_platform != 'darwin'\n")
 
-    with agent_requirements_path.open(encoding='utf-8') as file:
-        requirements = file.readlines()
+    result = ddev('validate', 'licenses')
 
-    requirements[0] = "aerospike==^4.0.0; sys_platform != 'win32' and sys_platform != 'darwin'\n"
-
-    with agent_requirements_path.open(mode='w', encoding='utf-8') as file:
-        file.writelines(requirements[:3])
-
-    result = ddev("validate", "licenses")
+    assert result.exit_code == 1
 
     expected_error_output = 'InvalidRequirement error'
     assert expected_error_output in helpers.remove_trailing_spaces(result.output)
     assert 'aerospike==^4.0.0' in helpers.remove_trailing_spaces(result.output)
+
+
+@pytest.mark.parametrize(
+    'error',
+    [
+        pytest.param(httpx.ConnectError('[WinError 10054] connection reset'), id='connect error'),
+        pytest.param(httpx.ConnectTimeout('connection timed out'), id='connect timeout'),
+    ],
+)
+def test_scrape_recovers_from_transient_connection_failure(
+    monkeypatch: pytest.MonkeyPatch, mock_http: MagicMock, error: httpx.ConnectError | httpx.ConnectTimeout
+):
+    attempts: list[httpx.Request] = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        assert (request.method, str(request.url)) == ('GET', TARBALL_URL)
+        attempts.append(request)
+        if len(attempts) == 1:
+            raise error
+        return tarball_response()
+
+    mock_http.side_effect = respond
+    monkeypatch.setattr(time, 'sleep', lambda _: None)
+
+    assert scrape_copyright_data(TARBALL_URL) == COPYRIGHT
+    assert len(attempts) == 2
+
+
+def test_scrape_persistent_connection_failure_raises(monkeypatch: pytest.MonkeyPatch, mock_http: MagicMock):
+    attempts: list[httpx.Request] = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        assert (request.method, str(request.url)) == ('GET', TARBALL_URL)
+        attempts.append(request)
+        assert len(attempts) <= DOWNLOAD_RETRIES + 1, f'unbounded retries: {len(attempts)} attempts'
+        raise httpx.ConnectError('[WinError 10054] connection reset')
+
+    mock_http.side_effect = respond
+    monkeypatch.setattr(time, 'sleep', lambda _: None)
+
+    with pytest.raises(httpx.ConnectError):
+        scrape_copyright_data(TARBALL_URL)
+
+    assert len(attempts) == DOWNLOAD_RETRIES + 1
+
+
+@pytest.mark.parametrize(
+    'error',
+    [
+        pytest.param(httpx.ReadError('read error'), id='read error'),
+        pytest.param(httpx.ReadTimeout('read timed out'), id='read timeout'),
+        pytest.param(
+            httpx.RemoteProtocolError('peer closed connection without sending complete message body'),
+            id='remote protocol error',
+        ),
+    ],
+)
+def test_scrape_recovers_from_interruption_during_response(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_http: MagicMock,
+    error: httpx.ReadError | httpx.ReadTimeout | httpx.RemoteProtocolError,
+):
+    attempts: list[httpx.Request] = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        assert (request.method, str(request.url)) == ('GET', TARBALL_URL)
+        attempts.append(request)
+        if len(attempts) == 1:
+            return interrupted_response(error)
+        return tarball_response()
+
+    mock_http.side_effect = respond
+    monkeypatch.setattr(time, 'sleep', lambda _: None)
+
+    assert scrape_copyright_data(TARBALL_URL) == COPYRIGHT
+    assert len(attempts) == 2
+
+
+def test_scrape_persistent_interruption_during_response_raises(monkeypatch: pytest.MonkeyPatch, mock_http: MagicMock):
+    attempts: list[httpx.Request] = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        assert (request.method, str(request.url)) == ('GET', TARBALL_URL)
+        attempts.append(request)
+        assert len(attempts) <= DOWNLOAD_RETRIES + 1, f'unbounded retries: {len(attempts)} attempts'
+        return interrupted_response(httpx.ReadError('read error'))
+
+    mock_http.side_effect = respond
+    monkeypatch.setattr(time, 'sleep', lambda _: None)
+
+    with pytest.raises(httpx.ReadError):
+        scrape_copyright_data(TARBALL_URL)
+
+    assert len(attempts) == DOWNLOAD_RETRIES + 1
+
+
+def test_scrape_http_status_error_is_actionable(mock_http: MagicMock):
+    attempts: list[httpx.Request] = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        assert (request.method, str(request.url)) == ('GET', TARBALL_URL)
+        attempts.append(request)
+        return httpx.Response(404, text='Not Found')
+
+    mock_http.side_effect = respond
+
+    with pytest.raises(httpx.HTTPStatusError):
+        scrape_copyright_data(TARBALL_URL)
+
+    assert len(attempts) == 1


### PR DESCRIPTION
### What does this PR do?

Retries package archive downloads on connection failures, read errors/timeouts and interrupted responses, with at most two retries and 1s/2s waits. Read-side tests interrupt the response after headers and partial archive bytes arrive. Persistent failures still raise. HTTP status errors are reported before archive parsing, and the existing proxy, redirect and TLS behavior is preserved.

License tests use a small fake repository and mocked HTTP responses instead of the real checkout and live downloads. They still exercise metadata interpretation, archive extraction and CSV validation. Unexpected HTTP requests fail immediately, and the tests no longer need the CI-only marker.

### Motivation

A [Windows ddev test run](https://github.com/DataDog/integrations-core/actions/runs/34139101261/job/101796790291?pr=25129) failed when an archive connection was reset during TLS setup. This affected an unrelated Dispatcher PR.

The full live license audit stays in the separate validation workflow. Retries also help that production path without retrying the entire test or hiding persistent errors.

Validation: 14 focused license tests passed, with one existing assertion-rewrite warning. Formatting, lint and type checks passed through ddev. No full suite or live license audit was run locally.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
