### PR TITLE
DO NOT MERGE: Verify disk-usage diff comment

### DIFF
--- a/silverstripe_cms/datadog_checks/silverstripe_cms/__about__.py
+++ b/silverstripe_cms/datadog_checks/silverstripe_cms/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = "1.9.0"
+__version__ = "1.9.1"

--- a/silverstripe_cms/datadog_checks/silverstripe_cms/check.py
+++ b/silverstripe_cms/datadog_checks/silverstripe_cms/check.py
@@ -16,6 +16,8 @@ from .database_client import DatabaseClient
 
 
 class SilverstripeCMSCheck(AgentCheck):
+    """Collects health and performance metrics from a Silverstripe CMS instance and its database."""
+
     # This will be the prefix of every metric and service check the integration sends
     __NAMESPACE__ = "silverstripe_cms"
 


### PR DESCRIPTION
### What does this PR do?

Not a real change — this PR exists only to verify that the disk-usage diff comment (added in #24895) actually works end-to-end now that #24895 is merged to master. It adds a trivial class docstring to `SilverstripeCMSCheck` and bumps its patch version, which should change that integration's measured size and produce a fresh "Disk usage change" comment on this PR.

A follow-up commit will bump a dependency version to also exercise the "Dependency" row of the diff.

**This PR should not be merged** — it will be closed once verified.

### Motivation

Validating that `Measure Disk Usage Trigger` → `Measure Disk Usage` → `post-pr-comment.yml` fires correctly for a real PR against master's now-merged workflow.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
