### PR TITLE
Run Velero E2E with Kubernetes Agent

### DIFF
--- a/velero/tests/conftest.py
+++ b/velero/tests/conftest.py
@@ -1,20 +1,22 @@
 # (C) Datadog, Inc. 2025-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
 import os
-from contextlib import ExitStack, contextmanager
+from contextlib import contextmanager
 
 import pytest
 
 from datadog_checks.dev import TempDir, run_command
+from datadog_checks.dev._env import get_state, save_state
 from datadog_checks.dev.fs import path_join
 from datadog_checks.dev.kind import KindLoad, kind_run
-from datadog_checks.dev.kube_port_forward import port_forward
 
 from .common import MOCKED_INSTANCE, PORT
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 KIND_DIR = os.path.join(HERE, 'kind')
+NODE_AGENT_IP_STATE = 'velero_node_agent_ip'
 
 
 @contextmanager
@@ -57,16 +59,40 @@ def setup_velero():
         check=True,
     )
 
+    # This only runs once, when the Kind cluster is created, so the resolved pod IP is cached here
+    # rather than re-resolved by `dd_environment` on every invocation.
+    save_state(NODE_AGENT_IP_STATE, get_node_agent_pod_ip())
 
-def get_instances(velero_host, velero_port, node_agent_host, node_agent_port):
+
+def get_node_agent_pod_ip():
+    # There is no Service for the node-agent DaemonSet, so the pod IP is fetched directly.
+    result = run_command(
+        ['kubectl', 'get', 'pods', '--namespace', 'velero', '--output', 'json'],
+        capture='out',
+        check=True,
+    )
+    node_agent_pods = [
+        pod
+        for pod in json.loads(result.stdout)['items']
+        if any(
+            owner.get('kind') == 'DaemonSet' and owner.get('name') == 'node-agent'
+            for owner in pod['metadata'].get('ownerReferences', [])
+        )
+    ]
+    if len(node_agent_pods) != 1 or not node_agent_pods[0].get('status', {}).get('podIP'):
+        raise RuntimeError(f'Expected one ready Velero node-agent pod, found {len(node_agent_pods)}')
+    return node_agent_pods[0]['status']['podIP']
+
+
+def get_instances(node_agent_ip):
     return {
         'instances': [
             {
-                'openmetrics_endpoint': f"http://{velero_host}:{velero_port}/metrics",
+                'openmetrics_endpoint': f"http://velero.velero.svc.cluster.local:{PORT}/metrics",
                 'tags': ['test:tag'],
             },
             {
-                'openmetrics_endpoint': f"http://{node_agent_host}:{node_agent_port}/metrics",
+                'openmetrics_endpoint': f"http://{node_agent_ip}:{PORT}/metrics",
                 'tags': ['test:tag'],
             },
         ]
@@ -75,28 +101,26 @@ def get_instances(velero_host, velero_port, node_agent_host, node_agent_port):
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    kind_config = os.path.join(KIND_DIR, 'kind-config.yaml')
     custom_kubectl_image_tag = "custom-kubectl:latest"
 
     with TempDir('helm_dir') as helm_dir:
         with kind_run(
             wrappers=[build_and_load_kubectl_image(custom_kubectl_image_tag)],
             conditions=[KindLoad(custom_kubectl_image_tag), setup_velero],
-            kind_config=kind_config,
             env_vars={
                 "HELM_CACHE_HOME": path_join(helm_dir, 'Caches'),
                 "HELM_CONFIG_HOME": path_join(helm_dir, 'Preferences'),
             },
         ) as kubeconfig:
-            with ExitStack() as stack:
-                ip_ports = [
-                    stack.enter_context(port_forward(kubeconfig, 'velero', PORT, ressource, name))
-                    for ressource, name in [('service', 'velero'), ('daemonset', 'node-agent')]
-                ]
+            instances = get_instances(get_state(NODE_AGENT_IP_STATE))
+            metadata = {
+                'agent_type': 'kubernetes',
+                'kubernetes': {
+                    'kubeconfig': kubeconfig,
+                },
+            }
 
-            instances = get_instances(ip_ports[0][0], ip_ports[0][1], ip_ports[1][0], ip_ports[1][1])
-
-            yield instances
+            yield instances, metadata
 
 
 @pytest.fixture

--- a/velero/tests/conftest.py
+++ b/velero/tests/conftest.py
@@ -64,7 +64,7 @@ def setup_velero():
     save_state(NODE_AGENT_IP_STATE, get_node_agent_pod_ip())
 
 
-def get_node_agent_pod_ip():
+def get_node_agent_pod_ip() -> str:
     # There is no Service for the node-agent DaemonSet, so the pod IP is fetched directly.
     result = run_command(
         ['kubectl', 'get', 'pods', '--namespace', 'velero', '--output', 'json'],

--- a/velero/tests/kind/kind-config.yaml
+++ b/velero/tests/kind/kind-config.yaml
@@ -1,7 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-nodes:
-- role: control-plane
-  extraPortMappings:
-  - containerPort: 8085
-    hostPort: 8085 


### PR DESCRIPTION
### What does this PR do?
Runs the Velero E2E test with the in-cluster Kubernetes Agent backend instead of `kubectl port-forward` and a locally-running Agent. The Velero server instance now scrapes the `velero` Service through its in-cluster DNS name, and the node-agent instance scrapes the node-agent pod IP directly since there is no Service for the DaemonSet.

### Motivation
Port-forwarding every endpoint to the host keeps the E2E environment from exercising the same network path as a real in-cluster Agent deployment, and the Kubernetes Agent E2E backend (#24639) is the supported way to run these tests, as already done for Argo CD in #24670. It's required for adding config discovery support.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
