### PR TITLE
Post the disk-usage diff comment directly from Measure Disk Usage

### DIFF
--- a/.github/chainguard/self.measure-disk-usage.workflow-run.sts.yaml
+++ b/.github/chainguard/self.measure-disk-usage.workflow-run.sts.yaml
@@ -1,0 +1,55 @@
+# Trust policy for Measure Disk Usage's own PR-comment posting
+#
+# This policy grants a scoped, ephemeral token for posting the disk-usage
+# diff comment directly from measure-disk-usage.yml. It is only reachable
+# from the version of that workflow committed to master; workflow_run
+# always runs the default-branch version of the workflow, so fork-PR
+# modifications cannot reach this policy.
+#
+# Naming convention:
+#   self:                Only this repository (DataDog/integrations-core) can use this policy
+#   measure-disk-usage:  The workflow this policy is scoped to
+#   workflow-run:        Triggered by workflow_run events
+#
+# Security model:
+#   - event_name pinned to workflow_run (runs on master by design).
+#   - ref / ref_protected pinned to master so a rogue fork PR cannot mint this token
+#     even if it manages to invoke something else.
+#   - job_workflow_ref pinned to measure-disk-usage.yml on master so unrelated
+#     workflow_run-triggered workflows cannot reuse this policy.
+#
+# Permissions granted:
+#   - pull_requests: write - Create and update the disk-usage diff comment. Although
+#                            PR conversation comments are served by the Issues API
+#                            endpoint (/repos/.../issues/{n}/comments), the endpoint
+#                            accepts either issues:write or pull_requests:write, and
+#                            we only ever comment on pull requests, never on plain
+#                            issues. pull_requests:write also subsumes the PR-number
+#                            lookup (commits/{sha}/pulls).
+#
+# Why this workflow posts directly instead of going through post-pr-comment.yml:
+#   post-pr-comment.yml is itself workflow_run-triggered, so by the time it fired
+#   off this job's completion it would only see this job's own head_sha/head_branch,
+#   which GitHub attributes to the default branch rather than to the PR that started
+#   the chain two hops back. Posting here instead resolves the PR from this job's own
+#   workflow_run event, which correctly carries the original PR's head SHA.
+#
+# Usage in workflows:
+#   - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+#     with:
+#       scope: DataDog/integrations-core
+#       policy: self.measure-disk-usage.workflow-run
+
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/integrations-core:ref:refs/heads/master
+
+claim_pattern:
+  event_name: workflow_run
+  ref: refs/heads/master
+  ref_protected: "true"
+  job_workflow_ref: DataDog/integrations-core/\.github/workflows/measure-disk-usage\.yml@refs/heads/master
+  repository: DataDog/integrations-core
+
+permissions:
+  pull_requests: write

--- a/.github/chainguard/self.measure-disk-usage.workflow-run.sts.yaml
+++ b/.github/chainguard/self.measure-disk-usage.workflow-run.sts.yaml
@@ -1,40 +1,14 @@
-# Trust policy for Measure Disk Usage's own PR-comment posting
+# Trust policy for Measure Disk Usage's own PR-comment posting.
 #
-# This policy grants a scoped, ephemeral token for posting the disk-usage
-# diff comment directly from measure-disk-usage.yml. It is only reachable
-# from the version of that workflow committed to master; workflow_run
-# always runs the default-branch version of the workflow, so fork-PR
-# modifications cannot reach this policy.
+# Scoped token for posting the disk-usage diff comment directly from
+# measure-disk-usage.yml. Pinned to that workflow on master, same model as
+# self.post-pr-comment.workflow-run: workflow_run always runs the
+# default-branch version, so fork PRs can't reach this policy.
 #
-# Naming convention:
-#   self:                Only this repository (DataDog/integrations-core) can use this policy
-#   measure-disk-usage:  The workflow this policy is scoped to
-#   workflow-run:        Triggered by workflow_run events
+# pull_requests: write covers both posting/updating the comment and the
+# PR-number lookup (commits/{sha}/pulls).
 #
-# Security model:
-#   - event_name pinned to workflow_run (runs on master by design).
-#   - ref / ref_protected pinned to master so a rogue fork PR cannot mint this token
-#     even if it manages to invoke something else.
-#   - job_workflow_ref pinned to measure-disk-usage.yml on master so unrelated
-#     workflow_run-triggered workflows cannot reuse this policy.
-#
-# Permissions granted:
-#   - pull_requests: write - Create and update the disk-usage diff comment. Although
-#                            PR conversation comments are served by the Issues API
-#                            endpoint (/repos/.../issues/{n}/comments), the endpoint
-#                            accepts either issues:write or pull_requests:write, and
-#                            we only ever comment on pull requests, never on plain
-#                            issues. pull_requests:write also subsumes the PR-number
-#                            lookup (commits/{sha}/pulls).
-#
-# Why this workflow posts directly instead of going through post-pr-comment.yml:
-#   post-pr-comment.yml is itself workflow_run-triggered, so by the time it fired
-#   off this job's completion it would only see this job's own head_sha/head_branch,
-#   which GitHub attributes to the default branch rather than to the PR that started
-#   the chain two hops back. Posting here instead resolves the PR from this job's own
-#   workflow_run event, which correctly carries the original PR's head SHA.
-#
-# Usage in workflows:
+# Usage:
 #   - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
 #     with:
 #       scope: DataDog/integrations-core

--- a/.github/chainguard/self.measure-disk-usage.workflow-run.sts.yaml
+++ b/.github/chainguard/self.measure-disk-usage.workflow-run.sts.yaml
@@ -1,19 +1,3 @@
-# Trust policy for Measure Disk Usage's own PR-comment posting.
-#
-# Scoped token for posting the disk-usage diff comment directly from
-# measure-disk-usage.yml. Pinned to that workflow on master, same model as
-# self.post-pr-comment.workflow-run: workflow_run always runs the
-# default-branch version, so fork PRs can't reach this policy.
-#
-# pull_requests: write covers both posting/updating the comment and the
-# PR-number lookup (commits/{sha}/pulls).
-#
-# Usage:
-#   - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
-#     with:
-#       scope: DataDog/integrations-core
-#       policy: self.measure-disk-usage.workflow-run
-
 issuer: https://token.actions.githubusercontent.com
 
 subject: repo:DataDog/integrations-core:ref:refs/heads/master

--- a/.github/workflows/measure-disk-usage.yml
+++ b/.github/workflows/measure-disk-usage.yml
@@ -149,8 +149,6 @@ jobs:
             section 'Compressed' diff_compressed.md "$COMPRESSED_OUTCOME"
           } > pr-comment/body.md
 
-      # Posted directly rather than via post-pr-comment.yml, which would only see this
-      # job's own head_sha (attributed to the default branch), not the original PR's.
       - name: Get token via dd-octo-sts
         id: octo-sts
         if: github.event.workflow_run.event == 'pull_request'

--- a/.github/workflows/measure-disk-usage.yml
+++ b/.github/workflows/measure-disk-usage.yml
@@ -157,37 +157,22 @@ jobs:
           scope: DataDog/integrations-core
           policy: self.measure-disk-usage.workflow-run
 
-      - name: Resolve PR number
-        id: pr
-        if: github.event.workflow_run.event == 'pull_request'
-        env:
-          PULL_REQUESTS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
-        run: |
-          set -euo pipefail
-          number=$(echo "$PULL_REQUESTS" | jq -r '.[0].number // empty')
-          if [[ -z "$number" ]]; then
-            echo "No PR associated with this workflow_run; nothing to post." >&2
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "number=$number" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Find existing comment
-        if: github.event.workflow_run.event == 'pull_request' && steps.pr.outputs.skip != 'true'
+        if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0]
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find_comment
         with:
           token: ${{ steps.octo-sts.outputs.token }}
-          issue-number: ${{ steps.pr.outputs.number }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           body-includes: '<!-- pr-comment:measure-disk-usage -->'
           comment-author: 'dd-octo-sts[bot]'
 
       - name: Post comment
-        if: github.event.workflow_run.event == 'pull_request' && steps.pr.outputs.skip != 'true'
+        if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0]
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ steps.octo-sts.outputs.token }}
-          issue-number: ${{ steps.pr.outputs.number }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           body-path: pr-comment/body.md
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           edit-mode: replace

--- a/.github/workflows/measure-disk-usage.yml
+++ b/.github/workflows/measure-disk-usage.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-      # needed for dd-sts
+      # needed for dd-sts (push) and dd-octo-sts (pull_request)
       id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -142,19 +142,63 @@ jobs:
 
           mkdir -p pr-comment
           {
+            printf '<!-- pr-comment:measure-disk-usage -->\n\n'
             printf '## Disk usage change\n\n'
             printf 'Commit `%s` compared against `%s`.\n\n' "${SHA:0:7}" "${BASE_SHA:0:7}"
             section 'Uncompressed' diff_uncompressed.md "$UNCOMPRESSED_OUTCOME"
             section 'Compressed' diff_compressed.md "$COMPRESSED_OUTCOME"
           } > pr-comment/body.md
 
-      - name: Upload PR comment artifact
+      # Posted directly rather than via post-pr-comment.yml: that workflow is itself
+      # workflow_run-triggered, so by the time it fired off this job's completion it would
+      # only see this job's own head_sha/head_branch, which GitHub attributes to the default
+      # branch rather than to the PR that started this chain. Posting here instead means the
+      # PR is resolved from this job's own (correctly PR-scoped) workflow_run event.
+      - name: Get token via dd-octo-sts
+        id: octo-sts
         if: github.event.workflow_run.event == 'pull_request'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         with:
-          name: pr-comment
-          path: pr-comment/body.md
-          if-no-files-found: error
+          scope: DataDog/integrations-core
+          policy: self.measure-disk-usage.workflow-run
+
+      - name: Resolve PR number from head SHA
+        id: pr
+        if: github.event.workflow_run.event == 'pull_request'
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          number=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+            --jq '[.[] | select(.state == "open")][0].number // empty')
+          if [[ -z "$number" ]]; then
+            echo "No open PR matches head SHA ${HEAD_SHA}; nothing to post." >&2
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=$number" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Find existing comment
+        if: github.event.workflow_run.event == 'pull_request' && steps.pr.outputs.skip != 'true'
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+        id: find_comment
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          body-includes: '<!-- pr-comment:measure-disk-usage -->'
+          comment-author: 'dd-octo-sts[bot]'
+
+      - name: Post comment
+        if: github.event.workflow_run.event == 'pull_request' && steps.pr.outputs.skip != 'true'
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          body-path: pr-comment/body.md
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          edit-mode: replace
 
       - name: Upload JSON uncompressed sizes artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/measure-disk-usage.yml
+++ b/.github/workflows/measure-disk-usage.yml
@@ -157,19 +157,16 @@ jobs:
           scope: DataDog/integrations-core
           policy: self.measure-disk-usage.workflow-run
 
-      - name: Resolve PR number from head SHA
+      - name: Resolve PR number
         id: pr
         if: github.event.workflow_run.event == 'pull_request'
         env:
-          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          REPO: ${{ github.repository }}
+          PULL_REQUESTS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
         run: |
           set -euo pipefail
-          number=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
-            --jq '[.[] | select(.state == "open")][0].number // empty')
+          number=$(echo "$PULL_REQUESTS" | jq -r '.[0].number // empty')
           if [[ -z "$number" ]]; then
-            echo "No open PR matches head SHA ${HEAD_SHA}; nothing to post." >&2
+            echo "No PR associated with this workflow_run; nothing to post." >&2
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "number=$number" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/measure-disk-usage.yml
+++ b/.github/workflows/measure-disk-usage.yml
@@ -149,11 +149,8 @@ jobs:
             section 'Compressed' diff_compressed.md "$COMPRESSED_OUTCOME"
           } > pr-comment/body.md
 
-      # Posted directly rather than via post-pr-comment.yml: that workflow is itself
-      # workflow_run-triggered, so by the time it fired off this job's completion it would
-      # only see this job's own head_sha/head_branch, which GitHub attributes to the default
-      # branch rather than to the PR that started this chain. Posting here instead means the
-      # PR is resolved from this job's own (correctly PR-scoped) workflow_run event.
+      # Posted directly rather than via post-pr-comment.yml, which would only see this
+      # job's own head_sha (attributed to the default branch), not the original PR's.
       - name: Get token via dd-octo-sts
         id: octo-sts
         if: github.event.workflow_run.event == 'pull_request'

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -49,7 +49,6 @@ on:
   workflow_run:
     workflows:
       - 'Validate skip QA label'
-      - 'Measure Disk Usage'
     types: [completed]
 
 permissions:


### PR DESCRIPTION
### What does this PR do?

Fixes PR-comment resolution for `Measure Disk Usage`, discovered while verifying #24895 post-merge: it runs on `workflow_run` (listening to `Measure Disk Usage Trigger`), so by the time it completed and fired `post-pr-comment.yml`, `github.event.workflow_run.head_sha` in *that* workflow's context referred to `Measure Disk Usage`'s own run — and GitHub attributes a `workflow_run`-triggered run's `head_sha`/`head_branch` to the default branch, not to the PR commit that started the chain two hops back. `post-pr-comment.yml` was resolving the PR to comment on using that wrong SHA (always master's tip), so it never found an open PR and silently skipped — the comment was never actually posted for any PR.

Rather than relaying the correct SHA through an artifact (tried in an earlier version of this PR, and correctly flagged in review as weakening the "PR number never comes from the artifact" invariant the poster relies on to prevent cross-PR comment injection), this posts the comment directly from `measure-disk-usage.yml` instead:

- Mints its own `dd-octo-sts` token (new policy: `self.measure-disk-usage.workflow-run`, mirroring the existing `post-pr-comment.yml` one, scoped to `pull_requests: write` and pinned to `measure-disk-usage.yml@refs/heads/master`).
- Resolves the PR number from its own (correctly PR-scoped) `github.event.workflow_run.head_sha` — no relay needed, since this job already has the right value.
- Finds/updates its own comment via `peter-evans/find-comment` + `create-or-update-comment`, keyed by a hardcoded marker (`<!-- pr-comment:measure-disk-usage -->`) and the `dd-octo-sts[bot]` author, same pattern `post-pr-comment.yml` already used.

`Measure Disk Usage` is removed from `post-pr-comment.yml`'s producer list, and the artifact-based hand-off (`pr-comment` upload) is dropped entirely — `post-pr-comment.yml` goes back to serving only `Validate skip QA label`, which remains correct since that producer is triggered directly by `pull_request` (single-hop, no attribution issue).

### Motivation

Verifying #24895 post-merge showed the comment never lands on real PRs going through the automatic `workflow_run` chain — `post-pr-comment.yml`'s logs showed `No open PR matches head SHA <master's tip>; nothing to post.` on every run.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
