### PR TITLE
Include short help in ddev size so it fits in the terminal

### DIFF
--- a/ddev/changelog.d/25146.fixed
+++ b/ddev/changelog.d/25146.fixed
@@ -1,0 +1,1 @@
+Include short help in ddev size so it fits in the terminal

--- a/ddev/src/ddev/cli/size/__init__.py
+++ b/ddev/src/ddev/cli/size/__init__.py
@@ -9,7 +9,7 @@ from ddev.cli.size.status import status
 from ddev.cli.size.timeline import timeline
 
 
-@click.group()
+@click.group(short_help='Analyze integration and dependency sizes')
 def size():
     """
     Analyze the download size of integrations and dependencies in various modes.

--- a/ddev/src/ddev/cli/size/diff.py
+++ b/ddev/src/ddev/cli/size/diff.py
@@ -36,7 +36,7 @@ MINIMUM_DATE = datetime.strptime("Sep 17 2024", "%b %d %Y").date()
 MINIMUM_LENGTH_COMMIT = 7
 
 
-@click.command()
+@click.command(short_help='Compare sizes between two commits')
 @click.argument("first_commit")
 @click.argument("second_commit")
 @click.option("--python", "version", help="Python version (e.g 3.12).  If not specified, all versions will be analyzed")

--- a/ddev/src/ddev/cli/size/status.py
+++ b/ddev/src/ddev/cli/size/status.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     )
 
 
-@click.command()
+@click.command(short_help='Show current integration and dependency sizes')
 @click.option("--to-dd-org", type=str, help="Send metrics to Datadog using the specified organization name.")
 @click.option("--to-dd-key", type=str, help="Send metrics to datadoghq.com using the specified API key.")
 @click.option("--python", "version", help="Python version (e.g 3.12).  If not specified, all versions will be analyzed")

--- a/ddev/src/ddev/cli/size/timeline.py
+++ b/ddev/src/ddev/cli/size/timeline.py
@@ -42,7 +42,7 @@ MINIMUM_LENGTH_COMMIT = 7
 console = Console(stderr=True)
 
 
-@click.command()
+@click.command(short_help='Show size evolution over time')
 @click.argument("type", type=click.Choice(["integration", "dependency"]))
 @click.argument("name")
 @click.option("--initial-commit", help="Initial commit to analyze. If not specified, will start from the first commit")


### PR DESCRIPTION
### What does this PR do?
Includes short help in ddev size and its subcommands so now everything fits in the terminal:
<img width="455" height="41" alt="image" src="https://github.com/user-attachments/assets/d1adb9fa-fbba-4538-98f7-cf379659811c" />
<img width="476" height="74" alt="image" src="https://github.com/user-attachments/assets/80eba5ad-4546-49e4-9776-1bafbd82d715" />


### Motivation
When executing ddev -h and ddev size -h, every help string was truncated:

<img width="614" height="54" alt="image" src="https://github.com/user-attachments/assets/8527a2bb-6cff-4e5e-a998-6c17da7096c4" />
<img width="628" height="84" alt="image" src="https://github.com/user-attachments/assets/daecfd1c-16b8-4e4d-9b43-541833808aa4" />


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
