### PR TITLE
Clarify that wheel promotion is maintainer-only

### DIFF
--- a/.github/workflows/dependency-wheel-promotion-gate.yaml
+++ b/.github/workflows/dependency-wheel-promotion-gate.yaml
@@ -116,7 +116,7 @@ jobs:
           > 1. Wait for the resolution workflow to finish and commit the lockfiles to this branch.
           > 2. Review the Agent build triggered by that commit (`default-pipeline` in GitLab), especially `static_quality_gate`.
           > 3. Get the PR approved.
-          > 4. Promote the wheels:
+          > 4. Ask an `agent-integrations` maintainer to promote the wheels. Promotion dispatches a workflow that requires write access to this repository, so only a maintainer can run it (an outside contributor cannot):
           >    ```
           >    ddev dep promote ${{ env.PR_URL }}
           >    ```


### PR DESCRIPTION
### What does this PR do?
Updates the promotion step in the `dependency-wheel-promotion-gate` PR notice to state that promoting the wheels requires repository write access, so an `agent-integrations` maintainer must run it and an outside contributor cannot.

### Motivation
The notice previously listed `ddev dep promote` as a step without noting who can actually run it. Promotion dispatches the `dependency-wheel-promotion` workflow (`workflow_dispatch`), which requires write access to the repository. Making this explicit avoids external contributors expecting to run it themselves and clarifies who to ask.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add \`qa/required\` if this PR needs QA validation, or \`qa/skip-qa\` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the \`backport/<branch-name>\` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)