### PR TITLE
AI-7152 Add a separate API allowance for artifacts

### DIFF
--- a/ddev/changelog.d/25148.fixed
+++ b/ddev/changelog.d/25148.fixed
@@ -1,0 +1,1 @@
+Give Dispatcher artifact requests a configurable API allowance separate from polling while sharing GitHub backpressure.

--- a/ddev/src/ddev/cli/ci/tests/rate_limiting.py
+++ b/ddev/src/ddev/cli/ci/tests/rate_limiting.py
@@ -42,7 +42,7 @@ def event_logger(logger: logging.Logger) -> Callable[[RateLimitEvent], None]:
 
 
 class RateLimiterConfig(BaseModel):
-    """Rate limit configuration for a single limiter tier."""
+    """A local bucket with an initial ``max_rate`` burst, refilled over ``time_period``."""
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
@@ -51,26 +51,27 @@ class RateLimiterConfig(BaseModel):
 
     @property
     def hourly_rate(self) -> float:
-        """Effective rate expressed in requests per hour."""
+        """Sustained refill rate expressed in requests per hour, excluding the initial burst."""
         return self.max_rate / self.time_period * SECONDS_PER_HOUR
 
 
 class RateLimiterFactoryConfig(BaseModel):
-    """Configuration for the Dispatcher's two-tier rate limiter factory.
+    """Configuration for the Dispatcher's shared rate limiter tiers.
 
-    Each tier defines its own max_rate and time_period. The combined hourly rate of
-    both tiers must not exceed total_hourly_max_rate.
+    The sum of sustained refill rates must not exceed ``total_hourly_max_rate``.
+    Initially full buckets allow additional bursts, so this is not a hard request
+    count in a rolling hour. The shared governor honors GitHub's actual budget and pauses.
 
-    Default values:
-    - default: 360 req/hr — typical integrations
-    - slow: 120 req/hr — integrations with long-running tests
-    - total_hourly_max_rate: 1,500 req/hr — = 15k octo-sts budget / 10 max concurrent runs
+    Default refill rates are 360/hour for polling, 120/hour for slow integrations,
+    and 1,000/hour for artifacts. The 1,500/hour ceiling is a per-run sharing guideline
+    based on a 15,000/hour installation budget and ten concurrent runs.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     default: RateLimiterConfig = RateLimiterConfig(max_rate=360.0)
     slow: RateLimiterConfig = RateLimiterConfig(max_rate=120.0)
+    artifacts: RateLimiterConfig = RateLimiterConfig(max_rate=1000.0)
     total_hourly_max_rate: float = Field(default=1500.0, gt=0)
     slow_integrations: frozenset[str] = frozenset()
     reserve_fraction: float = Field(default=0.15, gt=0, le=1)
@@ -78,10 +79,11 @@ class RateLimiterFactoryConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_combined_rate(self) -> RateLimiterFactoryConfig:
-        combined = self.default.hourly_rate + self.slow.hourly_rate
+        combined = self.default.hourly_rate + self.slow.hourly_rate + self.artifacts.hourly_rate
         if combined > self.total_hourly_max_rate:
             raise ValueError(
-                f"default ({self.default.hourly_rate} req/hr) + slow ({self.slow.hourly_rate} req/hr) = "
+                f"default ({self.default.hourly_rate} req/hr) + slow ({self.slow.hourly_rate} req/hr) + "
+                f"artifacts ({self.artifacts.hourly_rate} req/hr) = "
                 f"{combined} exceeds total_hourly_max_rate ({self.total_hourly_max_rate} req/hr)"
             )
         return self
@@ -90,10 +92,8 @@ class RateLimiterFactoryConfig(BaseModel):
 class RateLimiterFactory:
     """Creates and vends rate limiters for the Dispatcher.
 
-    Holds exactly two shared InstrumentedAsyncLimiter instances — one for
-    the default tier and one for the slow tier. All processors in a dispatcher
-    run share the same factory, so they compete for the same token buckets and
-    the per-run combined rate stays bounded.
+    One bucket per tier, shared across the run. All tiers share the same governor
+    so a provider pause or exhausted budget constrains every kind of request.
     """
 
     def __init__(
@@ -120,6 +120,12 @@ class RateLimiterFactory:
             on_event=on_event,
             budget_governor=budget_governor,
             name="slow",
+        )
+        self.artifacts = InstrumentedAsyncLimiter(
+            AsyncLimiter(cfg.artifacts.max_rate, cfg.artifacts.time_period),
+            on_event=on_event,
+            budget_governor=budget_governor,
+            name="artifacts",
         )
 
     def get_limiter(self, integrations: frozenset[str]) -> InstrumentedAsyncLimiter:

--- a/ddev/src/ddev/utils/github_async/client.py
+++ b/ddev/src/ddev/utils/github_async/client.py
@@ -11,6 +11,7 @@ import re
 import zipfile
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager, suppress
+from copy import copy
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Literal, Self, overload
@@ -286,6 +287,7 @@ class AsyncGitHubClient:
             "X-GitHub-Api-Version": GITHUB_API_VERSION,
             "Accept": "application/vnd.github+json",
         }
+        self._owns_client = True
         self._client = httpx.AsyncClient(
             base_url=DEFAULT_BASE_URL,
             headers=self._headers,
@@ -293,9 +295,21 @@ class AsyncGitHubClient:
             transport=transport,
         )
 
+    def with_rate_limit(self, rate_limiter: InstrumentedAsyncLimiter) -> Self:
+        """Borrow this client's connection pool and configuration with a different limiter.
+
+        The original client owns the pool. Stop or cancel all views' requests before closing it.
+        Closing a view does nothing; later shutdown flags are not propagated to it.
+        """
+        view = copy(self)
+        view._rate_limiter = rate_limiter
+        view._owns_client = False
+        return view
+
     async def aclose(self) -> None:
-        """Close the underlying HTTP client and release connections."""
-        await self._client.aclose()
+        """Release owned connections; borrowed views leave the pool open."""
+        if self._owns_client:
+            await self._client.aclose()
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/ddev/tests/cli/ci/tests/test_rate_limiting.py
+++ b/ddev/tests/cli/ci/tests/test_rate_limiting.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from functools import partial
 
 import pytest
 from pydantic import ValidationError
 
+from ddev.cli.ci.tests import rate_limiting
 from ddev.cli.ci.tests.rate_limiting import RateLimiterConfig, RateLimiterFactory, RateLimiterFactoryConfig
+from ddev.utils.rate_limiting import BudgetGovernor, BudgetSnapshot
+from tests.helpers.clock import FakeClock, advance_clock_on_sleep
 
 # ---------------------------------------------------------------------------
 # RateLimiterConfig field validation
@@ -56,22 +61,29 @@ def test_factory_config_raises_when_combined_rate_exceeds_total():
 
 
 def test_factory_config_raises_when_combined_rate_exceeds_total_mixed_periods():
-    # default: 6 req/min = 360 req/hr, slow: 6 req/min = 360 req/hr, combined = 720 > 500
+    # 360 + 360 + 600 = 1320 requests/hour, above the shared budget.
     with pytest.raises(ValidationError, match="exceeds total_hourly_max_rate"):
         RateLimiterFactoryConfig(
             default=RateLimiterConfig(max_rate=6.0, time_period=60.0),
             slow=RateLimiterConfig(max_rate=6.0, time_period=60.0),
-            total_hourly_max_rate=500.0,
+            artifacts=RateLimiterConfig(max_rate=10.0, time_period=60.0),
+            total_hourly_max_rate=1300.0,
         )
 
 
 def test_factory_config_accepts_combined_rate_at_limit():
     """The boundary is inclusive, so a config that exactly spends the budget is legal."""
     assert RateLimiterFactoryConfig(
-        default=RateLimiterConfig(max_rate=750.0),
-        slow=RateLimiterConfig(max_rate=750.0),
+        default=RateLimiterConfig(max_rate=360.0),
+        slow=RateLimiterConfig(max_rate=120.0),
+        artifacts=RateLimiterConfig(max_rate=17.0, time_period=60.0),
         total_hourly_max_rate=1500.0,
     )
+
+
+def test_factory_config_rejects_an_artifact_tier_that_overspends_the_budget():
+    with pytest.raises(ValidationError, match="exceeds total_hourly_max_rate"):
+        RateLimiterFactoryConfig(artifacts=RateLimiterConfig(max_rate=18.0, time_period=60.0))
 
 
 def test_factory_config_defaults_satisfy_their_own_combined_rate_check():
@@ -130,14 +142,31 @@ def test_get_limiter_slow_tier_returns_same_object():
 # ---------------------------------------------------------------------------
 
 
-def test_factory_shares_budget_governor_across_both_tiers():
-    factory = RateLimiterFactory()
+@pytest.mark.parametrize(
+    "sender, receiver", [("artifacts", "default"), ("default", "artifacts"), ("artifacts", "slow")]
+)
+async def test_a_provider_pause_applies_across_tiers(
+    sender: str, receiver: str, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    clock = FakeClock()
+    advance_clock_on_sleep(clock, monkeypatch)
+    monkeypatch.setattr(rate_limiting, "BudgetGovernor", partial(BudgetGovernor, now=clock))
+    factory = RateLimiterFactory(logger=logging.getLogger("test-factory"))
+    started = clock.current
 
-    assert factory.default.budget_governor is factory.slow.budget_governor
+    with caplog.at_level(logging.DEBUG, logger="test-factory"):
+        getattr(factory, sender).observe(BudgetSnapshot(retry_after=5))
+        async with getattr(factory, receiver):
+            admitted = clock.current
+
+    assert admitted >= started + 5
+    assert "secondary rate limit" in caplog.text
 
 
-def test_factory_shares_on_event_across_governor_and_both_limiters():
-    factory = RateLimiterFactory(logger=logging.getLogger("test"))
+async def test_artifacts_can_proceed_when_the_polling_allowance_is_spent():
+    factory = RateLimiterFactory(RateLimiterFactoryConfig(default=RateLimiterConfig(max_rate=1)))
+    async with factory.default:
+        pass
 
-    assert factory.default.on_event is factory.slow.on_event
-    assert factory.default.on_event is factory.default.budget_governor.on_event
+    async with asyncio.timeout(5), factory.artifacts:
+        pass

--- a/ddev/tests/helpers/github_async.py
+++ b/ddev/tests/helpers/github_async.py
@@ -36,9 +36,10 @@ Quick reference:
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Callable
+from copy import copy
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 import httpx
 
@@ -59,7 +60,7 @@ from ddev.utils.github_async.models import (
 )
 from ddev.utils.github_async.retry import RetryPolicy
 from ddev.utils.github_errors import GitHubBodyTooLongError, github_body_too_long_message
-from ddev.utils.rate_limiting import RelaxedRateLimits
+from ddev.utils.rate_limiting import InstrumentedAsyncLimiter, RelaxedRateLimits
 
 # Stable URL baked into the default `create_workflow_dispatch` response. Exported so tests
 # that assert on the URL can reference the helper rather than duplicating the literal.
@@ -720,6 +721,10 @@ class FakeAsyncGitHubClient:
             raise response
         Path(dest_path).mkdir(parents=True, exist_ok=True)
         return None
+
+    def with_rate_limit(self, rate_limiter: InstrumentedAsyncLimiter) -> Self:
+        self._record('with_rate_limit', rate_limiter=rate_limiter)
+        return copy(self)
 
     async def aclose(self) -> None:
         return None

--- a/ddev/tests/test_fake_github_async.py
+++ b/ddev/tests/test_fake_github_async.py
@@ -13,10 +13,11 @@ from typing import Any
 
 import httpx
 import pytest
+from aiolimiter import AsyncLimiter
 
 from ddev.utils.github_async import AsyncGitHubClient, GitHubResponse
 from ddev.utils.github_async.models import Artifact, ArtifactsList, IssueComment, PullRequest
-from ddev.utils.rate_limiting import RelaxedRateLimits
+from ddev.utils.rate_limiting import InstrumentedAsyncLimiter, RelaxedRateLimits
 from tests.cli.ci.tests.helpers import comment_page
 from tests.helpers.github_async import FakeAsyncGitHubClient
 from tests.utils.github_async.helpers import first_page
@@ -311,6 +312,7 @@ async def test_calls_are_recorded_regardless_of_response(fake: FakeAsyncGitHubCl
 # here: `test_every_mirror_is_in_the_call_table` fails when one is added without being registered,
 # which is the case a hand-written test per method cannot catch.
 SHUTDOWN_RATE_LIMITS = RelaxedRateLimits(max_wait_seconds=2.0, max_rate=10_000.0)
+VIEW_RATE_LIMITER = InstrumentedAsyncLimiter(AsyncLimiter(10))
 
 MIRROR_CALLS = [
     ('get_pull_request', lambda f, _: f.get_pull_request('o', 'r', 5), {'pull_number': 5}),
@@ -340,6 +342,7 @@ MIRROR_CALLS = [
         {'workflow_id': 'wf.yml'},
     ),
     ('get_workflow_run', lambda f, _: f.get_workflow_run('o', 'r', 42), {'run_id': 42}),
+    ('with_rate_limit', lambda f, _: f.with_rate_limit(VIEW_RATE_LIMITER), {'rate_limiter': VIEW_RATE_LIMITER}),
     ('cancel_workflow_run', lambda f, _: f.cancel_workflow_run('o', 'r', 42), {'run_id': 42}),
     (
         'create_pr_review_comment',

--- a/ddev/tests/utils/github_async/test_client_core.py
+++ b/ddev/tests/utils/github_async/test_client_core.py
@@ -7,11 +7,13 @@ from typing import Any
 
 import httpx
 import pytest
+from aiolimiter import AsyncLimiter
 
 from ddev.utils.github_async import GITHUB_API_VERSION, AsyncGitHubClient, PaginationData, async_github_client
 from ddev.utils.github_async.client import QUERY_MASK, SHUTDOWN_REQUEST_TIMEOUT, failure_reason, with_query_masked
-from ddev.utils.github_async.retry import NO_RETRY
-from tests.utils.github_async.helpers import TOKEN, json_response, make_client
+from ddev.utils.github_async.retry import NO_RETRY, RetryPolicies
+from ddev.utils.rate_limiting import BucketEvent, InstrumentedAsyncLimiter, RateLimitEvent
+from tests.utils.github_async.helpers import TOKEN, json_response, make_client, recording_transport
 from tests.utils.github_async.payloads import artifact, workflow_run_payload
 
 BASE = "https://api.github.com"
@@ -78,6 +80,48 @@ async def test_context_manager_closes_on_exit() -> None:
         inner = client._client
     # After exit the underlying client is closed; a new request would fail
     assert inner.is_closed
+
+
+async def test_client_view_uses_its_limiter_and_preserves_request_configuration():
+    events: list[RateLimitEvent] = []
+    polling = InstrumentedAsyncLimiter(AsyncLimiter(10), on_event=events.append, name="polling")
+    artifacts = InstrumentedAsyncLimiter(AsyncLimiter(10), on_event=events.append, name="artifacts")
+    transport, calls = recording_transport(
+        [json_response(workflow_run_payload()), httpx.Response(503), json_response(workflow_run_payload())]
+    )
+    async with async_github_client(
+        token=TOKEN,
+        rate_limiter=polling,
+        default_timeout=7,
+        retry_policies=RetryPolicies(safe=NO_RETRY, mutating=NO_RETRY),
+        transport=transport,
+    ) as client:
+        view = client.with_rate_limit(artifacts)
+        await client.get_workflow_run("o", "r", 42)
+        with pytest.raises(httpx.HTTPStatusError):
+            await view.get_workflow_run("o", "r", 42)
+        assert len(calls) == 2
+        result = await view.get_workflow_run("o", "r", 42)
+
+    assert result.data.id == 42
+    assert [event.name for event in events if isinstance(event, BucketEvent)] == ["polling", "artifacts", "artifacts"]
+    for request in calls:
+        assert request.headers["authorization"] == f"Bearer {TOKEN}"
+        assert request.headers["x-github-api-version"] == GITHUB_API_VERSION
+        assert request.extensions["timeout"] == dict.fromkeys(("connect", "read", "write", "pool"), 7)
+
+
+async def test_client_view_borrows_the_owners_connection_lifetime():
+    async with async_github_client(
+        token=TOKEN, transport=httpx.MockTransport(lambda _: json_response(workflow_run_payload()))
+    ) as client:
+        view = client.with_rate_limit(InstrumentedAsyncLimiter(AsyncLimiter(10)))
+        await view.aclose()
+        assert (await client.get_workflow_run("o", "r", 42)).data.id == 42
+        assert (await view.get_workflow_run("o", "r", 42)).data.id == 42
+
+    with pytest.raises(RuntimeError, match="client has been closed"):
+        await view.get_workflow_run("o", "r", 42)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?

Adds non-owning GitHub client views with a different rate limiter and a configurable artifact tier shared across a Dispatcher run.

The artifact bucket starts with 1,000 tokens and refills at 1,000/hour. The combined sustained rate is 1,480/hour, below the configured 1,500/hour ceiling. That ceiling is not a hard first-hour quota: startup bursts add to the refill allowance. All tiers share GitHub budget observations and secondary-limit pauses.

This is the first PR in the stack. It adds the tooling without changing the runner yet.

### Motivation

[AI-7152](https://datadoghq.atlassian.net/browse/AI-7152). Artifact URL requests currently compete with polling and reporting, delaying results after tests finish.

Validated with 176 focused client, download, rate-limit, Dispatcher-config and mock-compatibility tests, plus ddev formatting, lint and types. The shared-backpressure tests fail when the artifact governor is disconnected from the other tiers.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required. Developer tooling; `qa/skip-qa`.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7152]: https://datadoghq.atlassian.net/browse/AI-7152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ