### PR TITLE
AI-7152 Report Dispatcher progress before artifact collection

### DIFF
--- a/ddev/changelog.d/25150.fixed
+++ b/ddev/changelog.d/25150.fixed
@@ -1,0 +1,1 @@
+Report Dispatcher run links and job progress before artifact collection, using a separate API allowance for collection.

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -11,7 +11,7 @@ import signal
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from ddev.cli.ci.tests.messages import BatchFinished, TestBatch, UpdatePRComment
+from ddev.cli.ci.tests.messages import BatchFinished, BatchProgressUpdate, TestBatch, UpdatePRComment
 from ddev.cli.ci.tests.pr_comment import render_run_summary, summary_line
 from ddev.cli.ci.tests.rate_limiting import RateLimiterFactory
 from ddev.cli.ci.tests.status import Status
@@ -90,7 +90,7 @@ class Dispatcher(EventBusOrchestrator):
     """Runs a batching plan to completion and publishes its result.
 
     The whole plan is known before the bus starts, so `on_initialize` queues the initial update and
-    every batch: `TestBatch` -> runner -> `BatchFinished` -> gatherer -> `UpdatePRComment` -> reporter.
+    every batch: `TestBatch` -> runner -> progress/results -> gatherer -> `UpdatePRComment` -> reporter.
     """
 
     def __init__(
@@ -115,7 +115,7 @@ class Dispatcher(EventBusOrchestrator):
         self._cancelled = False
 
         self.register_processor(runner, [TestBatch])
-        self.register_processor(gatherer, [BatchFinished])
+        self.register_processor(gatherer, [BatchFinished, BatchProgressUpdate])
         self.register_processor(reporter, [UpdatePRComment])
 
     @property
@@ -207,16 +207,15 @@ def build_dispatcher(
 ) -> Dispatcher:
     """Assemble the client, the three tasks and the Dispatcher from a plan and its run context.
 
-    One client and one rate limiter are shared by every task, so the run's request rate is bounded
-    as a whole rather than per task. The limiter tier is chosen from every integration in the plan,
-    which is the slowest thing the run will wait on.
+    One HTTP pool is shared by every task. Artifact collection uses its own local bucket;
+    all buckets share the provider's budget and pauses.
     """
     from ddev.utils.github_async import AsyncGitHubClient
 
     active_logger = run_logger or logger
     integrations = frozenset(integration for batch in batches for integration in batch.integrations)
-    rate_limiter = RateLimiterFactory(config.github_rate_limits, active_logger).get_limiter(integrations)
-    client = AsyncGitHubClient(token, rate_limiter=rate_limiter)
+    rate_limiters = RateLimiterFactory(config.github_rate_limits, active_logger)
+    client = AsyncGitHubClient(token, rate_limiter=rate_limiters.get_limiter(integrations))
 
     runner = TaskTestRunner(
         "test-runner",
@@ -234,6 +233,7 @@ def build_dispatcher(
             poll_interval_seconds=config.poll_interval_seconds,
             pytest_args=context.pytest_args,
         ),
+        artifact_client=client.with_rate_limit(rate_limiters.artifacts),
     )
     gatherer = TaskTestGatherer("test-gatherer", output_path, batches)
     reporter = TaskRunReporter(

--- a/ddev/src/ddev/cli/ci/tests/messages.py
+++ b/ddev/src/ddev/cli/ci/tests/messages.py
@@ -15,7 +15,7 @@ from ddev.utils.platform import PlatformName
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from ddev.cli.ci.tests.progress import DispatcherProgress
+    from ddev.cli.ci.tests.progress import DispatcherProgress, ExecutionState
     from ddev.utils.github_async.models import WorkflowJob
     from ddev.utils.junit import JUnitReport, JUnitTestCase
 
@@ -182,8 +182,24 @@ class TestBatch(BaseMessage):
 
 
 @dataclass
+class BatchProgressUpdate(BaseMessage):
+    """Cumulative execution observations, before artifact collection and final gathering.
+
+    ``sequence`` increases within a batch run so receivers can discard out-of-order snapshots.
+    """
+
+    batch_id: str
+    run_id: int
+    workflow_url: str
+    state: ExecutionState
+    sequence: int
+    jobs: tuple[WorkflowJob, ...] = ()
+    status: Status | None = None
+
+
+@dataclass
 class BatchFinished(BaseMessage):
-    """Emitted when a GitHub Actions test workflow has completed.
+    """Emitted after a completed workflow's artifact collection finishes.
 
     ``batch_id`` is the identity of the ``TestBatch`` this run came from, so the gatherer can resolve
     it in the plan.
@@ -200,10 +216,10 @@ class BatchFinished(BaseMessage):
 
 @dataclass
 class UpdatePRComment(BaseMessage):
-    """Emitted per finished batch to request a PR comment update.
+    """Request publication of a changed aggregate snapshot.
 
-    ``revision`` is ordering metadata: revision ``0`` is the initial plan, then one per consumed
-    ``BatchFinished``. The run reporter renders the latest and rejects stale revisions. ``progress`` is
+    ``revision`` starts at ``0`` for the initial plan and advances only when progress changes.
+    The run reporter renders the latest and rejects stale revisions. ``progress`` is
     the whole payload, including whether the run is done and every count the comment needs.
     """
 

--- a/ddev/src/ddev/cli/ci/tests/pr_comment.py
+++ b/ddev/src/ddev/cli/ci/tests/pr_comment.py
@@ -88,7 +88,7 @@ RUN_SUMMARY_COMMENT_FAILED_NOTE = (
 )
 
 # Said in both the alert and the footer, so a reader who skips one still learns the comment is live.
-FOOTER_RUNNING_NOTE = "This comment updates automatically as each batch finishes."
+FOOTER_RUNNING_NOTE = "This comment updates automatically as jobs progress and results are collected."
 
 STATUS_CHIP = {
     Status.SUCCESS: "✅ passed",
@@ -231,7 +231,8 @@ def _alert(progress: DispatcherProgress, *, shows_unavailable: bool, cancelled: 
     if cancelled:
         return f"> [!CAUTION]\n> **The run was cancelled before it finished.** {CANCELLED_NOTE}"
     if not progress.done:
-        return f"> [!NOTE]\n> **Tests are still running.** {_outstanding(progress)}\n> {FOOTER_RUNNING_NOTE}"
+        phase = "Tests finished; collecting results." if _collecting_results(progress) else "Tests are still running."
+        return f"> [!NOTE]\n> **{phase}** {_outstanding(progress)}\n> {FOOTER_RUNNING_NOTE}"
 
     unavailable = _unavailable_count(progress)
     if _has_failure(progress):
@@ -246,6 +247,12 @@ def _alert(progress: DispatcherProgress, *, shows_unavailable: bool, cancelled: 
         alert = f"> [!WARNING]\n> **{_unavailable_phrase(unavailable)}.** Nothing failed, but this is not a clean pass."
         return f"{alert}\n> See the unavailable results below." if shows_unavailable else alert
     return None
+
+
+def _collecting_results(progress: DispatcherProgress) -> bool:
+    return any(batch.state is ExecutionState.ARTIFACT_DOWNLOAD for batch in progress.batches) and all(
+        batch.state in (ExecutionState.ARTIFACT_DOWNLOAD, ExecutionState.FINISHED) for batch in progress.batches
+    )
 
 
 def _unavailable_phrase(count: int) -> str:
@@ -290,7 +297,7 @@ def _progress_bar(progress: DispatcherProgress) -> str:
     pending = progress.total - progress.complete
     # Every job in a retrying batch has reported, so `complete == total` is reachable while the run is
     # unfinished, and a full bar there would contradict the heading next to it.
-    if not progress.done and not pending:
+    if not progress.done and not pending and not _collecting_results(progress):
         pending = 1
 
     counts = (progress.passed, progress.failed, progress.skipped, pending)
@@ -339,7 +346,7 @@ def _batch_table(progress: DispatcherProgress) -> str:
 
 
 def _batch_row(batch: BatchProgress) -> str:
-    done = sum(1 for job in batch.jobs_progress if job.latest is not None)
+    done = sum(job.complete for job in batch.jobs_progress)
     workflow = (
         f'<a href="{html.escape(batch.workflow_url, quote=True)}">run {batch.run_id}</a>'
         if batch.workflow_url
@@ -360,8 +367,10 @@ def _batch_chip(batch: BatchProgress) -> str:
     conclusion, so a batch can be failed while every tracked job passed (a setup or upload step).
     Rolling the jobs up here would render that batch as passed and hide a real failure.
     """
+    chip = STATUS_CHIP.get(batch.status) if batch.status is not None else None
+    if batch.state is ExecutionState.ARTIFACT_DOWNLOAD:
+        return f"{chip} · 📥 collecting artifacts" if chip else "📥 collecting artifacts"
     if batch.state is ExecutionState.FINISHED:
-        chip = STATUS_CHIP.get(batch.status) if batch.status is not None else None
         return chip if chip is not None else "❔ no status reported"
     # A rerun is Dispatcher's own business, so at the batch level it is simply unfinished work. Which
     # jobs were retried is reported per job, where it is actionable.
@@ -405,7 +414,9 @@ def _failures(progress: DispatcherProgress, budget: int, *, detail: bool = True)
     entries += [
         f"<code>{html.escape(batch.batch_id)}</code> — the workflow failed with no tracked job failure"
         for batch in progress.batches
-        if batch.status is Status.FAILURE and not any(_is_failed(job) for job in batch.jobs_progress)
+        if batch.status is Status.FAILURE
+        and all(job.complete for job in batch.jobs_progress)
+        and not any(_is_failed(job) for job in batch.jobs_progress)
     ]
     if not entries:
         return None
@@ -423,6 +434,8 @@ def _failures(progress: DispatcherProgress, budget: int, *, detail: bool = True)
 def _failed_job_entry(job: JobProgress, attempt: JobAttemptProgress, *, detail: bool = True) -> str:
     link = f' &nbsp; <a href="{html.escape(attempt.job_url, quote=True)}">view job</a>' if attempt.job_url else ""
     entry = f"<code> {html.escape(_job_label(job))} </code>{link}"
+    if attempt.reports is None:
+        entry += "\n<sub>Test details pending artifact collection.</sub>"
 
     # ``<code>`` rather than a Markdown code span: ``html.escape`` leaves backticks alone, and a
     # backtick in a test id would close a span early and let the rest render as markup.
@@ -434,7 +447,11 @@ def _failed_job_entry(job: JobProgress, attempt: JobAttemptProgress, *, detail: 
         items = "\n".join(f"- <code>{html.escape(step)}</code>" for step in attempt.failed_steps)
         summary = f"{len(attempt.failed_steps)} failed step{'s' if len(attempt.failed_steps) > 1 else ''}"
     else:
-        return f"{entry}\n<sub>No test-level failure was reported for this job.</sub>"
+        return (
+            entry
+            if attempt.reports is None
+            else f"{entry}\n<sub>No test-level failure was reported for this job.</sub>"
+        )
 
     if not detail:
         # The count without the names: enough to see the shape of the failure and open the job.
@@ -474,7 +491,7 @@ def _retried(progress: DispatcherProgress, budget: int) -> str | None:
         attempt = job.latest
         if job.retry_count == 0 or attempt is None:
             continue
-        outcome = STATUS_CHIP.get(attempt.status, "❔ unknown")
+        outcome = STATUS_CHIP[attempt.status] if attempt.status is not None else "🔄 in progress"
         plural = "retries" if job.retry_count > 1 else "retry"
         entries.append(f"- <code>{html.escape(_job_label(job))}</code> — {outcome} after {job.retry_count} {plural}")
     return _list_section("### 🔁 Retried jobs", entries, budget, "retried job")

--- a/ddev/src/ddev/cli/ci/tests/progress.py
+++ b/ddev/src/ddev/cli/ci/tests/progress.py
@@ -38,12 +38,14 @@ class ProgressError(StrEnum):
 class ExecutionState(Enum):
     """Where an execution is in its lifecycle, orthogonal to its outcome (``Status``).
 
-    ``RUNNING`` and ``RETRYING`` become reachable with the retry work.
+    A finished job may still be waiting for its batch's artifact collection.
     """
 
     PLANNED = "planned"
+    QUEUED = "queued"
     RUNNING = "running"
     RETRYING = "retrying"
+    ARTIFACT_DOWNLOAD = "artifact_download"
     FINISHED = "finished"
 
 
@@ -51,26 +53,26 @@ class ExecutionState(Enum):
 class JobAttemptProgress:
     """One observed execution of one planned job.
 
-    An attempt exists only because the job ran, so ``status`` is always known: an undetermined job
-    has no attempt. ``attempt`` is its 1-based position in the job's history. ``job_id``,
-    ``conclusion`` and ``job_url`` are ``None`` when GitHub never reported the job.
+    ``status`` is unknown until execution finishes; ``reports`` is unknown until collection finishes.
+    ``attempt`` is its 1-based position in the job's history. Missing GitHub metadata stays ``None``.
     """
 
     attempt: int
     job_id: int | None
-    status: Status
+    status: Status | None
     conclusion: WorkflowJobConclusion | None
     failed_steps: tuple[str, ...]
     job_url: str | None
-    reports: tuple[JUnitReport, ...]
+    reports: tuple[JUnitReport, ...] | None
     error: ProgressError | None = None
+    state: ExecutionState = ExecutionState.FINISHED
 
     @property
     def failed_tests(self) -> list[JUnitTestCase]:
         """Every failed/errored test case across this execution's reports."""
         return [
             case
-            for report in self.reports
+            for report in self.reports or ()
             for suite in report.test_suites
             for case in suite.test_cases
             if case.status in (TestStatus.FAILED, TestStatus.ERROR)
@@ -93,6 +95,11 @@ class JobProgress:
         return self.attempts[-1] if self.attempts else None
 
     @property
+    def complete(self) -> bool:
+        """Whether the latest execution finished, independently of result collection."""
+        return self.latest is not None and self.latest.state is ExecutionState.FINISHED
+
+    @property
     def retry_count(self) -> int:
         """Executions minus one. Not ``run_attempt - 1``: histories can be sparse."""
         return max(0, len(self.attempts) - 1)
@@ -103,7 +110,7 @@ class BatchProgress:
     """One logical batch, from planning through its terminal outcome.
 
     ``status`` is the workflow's own, not a roll-up of ``jobs_progress``: a workflow can fail in a
-    step no tracked job covers. It stays ``None`` until ``FINISHED``.
+    step no tracked job covers. It becomes known before artifact collection starts.
     """
 
     batch_id: str
@@ -145,8 +152,8 @@ class DispatcherProgress:
 
     @property
     def complete(self) -> int:
-        """Planned jobs that have run."""
-        return sum(1 for job in self._jobs_progress if job.latest is not None)
+        """Planned jobs whose latest execution has finished."""
+        return sum(job.complete for job in self._jobs_progress)
 
     @property
     def total(self) -> int:
@@ -158,4 +165,6 @@ class DispatcherProgress:
         return (job for batch in self.batches for job in batch.jobs_progress)
 
     def _count(self, status: Status) -> int:
-        return sum(1 for job in self._jobs_progress if job.latest is not None and job.latest.status == status)
+        return sum(
+            1 for job in self._jobs_progress if job.complete and job.latest is not None and job.latest.status == status
+        )

--- a/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
@@ -14,6 +14,7 @@ from ddev.cli.ci.tests.messages import (
     BatchFinished,
     BatchJob,
     BatchJobResult,
+    BatchProgressUpdate,
     JobResult,
     UpdatePRComment,
     WorkflowStatus,
@@ -28,11 +29,12 @@ from ddev.cli.ci.tests.progress import (
 )
 from ddev.cli.ci.tests.status import Status, conclusion_to_status
 from ddev.event_bus.orchestrator import SyncProcessor
-from ddev.utils.github_async.models.workflow import WorkflowJobConclusion
+from ddev.utils.github_async.models.workflow import WorkflowJobStatus
 from ddev.utils.junit import parse_junit_dir
 
 if TYPE_CHECKING:
     from ddev.cli.ci.tests.messages import TestBatch
+    from ddev.utils.github_async.models import WorkflowJob
     from ddev.utils.junit import JUnitReport
 
 # Expected layout of the extracted ``test-result.zip`` tree (defined by ``test-batch.yaml``):
@@ -45,14 +47,13 @@ if TYPE_CHECKING:
 # workflow-job conclusion, and a job with no correlated workflow job is a runner bug and raises.
 COVERAGE_GLOB = "coverage*.xml"
 JUNIT_GLOB = "test-*.xml"
-# Every later update borrows the id of the ``BatchFinished`` that caused it. Revision ``0`` has no
+# Every later update borrows the id of the message that changed progress. Revision ``0`` has no
 # cause, so it carries its own.
 INITIAL_UPDATE_MESSAGE_ID = "dispatcher-initial"
 
 
-class TaskTestGatherer(SyncProcessor[BatchFinished]):
-    """Builds each batch's results from the artifacts the runner downloaded, organizes the coverage
-    and JUnit files, and publishes a ``DispatcherProgress`` snapshot per finished batch.
+class TaskTestGatherer(SyncProcessor[BatchFinished | BatchProgressUpdate]):
+    """Publishes changed execution snapshots and enriches them with gathered coverage and JUnit results.
 
     Registries are keyed by ``batch_id``: it is stable across workflow attempts, ``run_id`` is not.
     """
@@ -61,6 +62,7 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         super().__init__(name)
         self._output_base_path = output_base_path
         self._revision = 0
+        self._sequences: dict[str, int] = {}
         self._status_by_batch: dict[str, WorkflowStatus] = {}
         self._results_by_batch: dict[str, list[JobResult]] = {}
         # The whole plan, in planning order, so each snapshot covers batches that have not run yet.
@@ -70,7 +72,11 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         self._lock = threading.Lock()
         self._logger = logging.getLogger(f"{__name__}.{name}")
 
-    def process_message(self, message: BatchFinished) -> None:
+    def process_message(self, message: BatchFinished | BatchProgressUpdate) -> None:
+        if isinstance(message, BatchProgressUpdate):
+            self._observe_progress(message)
+            return
+
         log_extra = {"batch_id": message.batch_id, "run_id": message.run_id}
         if not message.batch_jobs:
             # Still terminal and still worth a revision, or it renders as planned forever.
@@ -82,11 +88,16 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             if not self._accepts(message.batch_id, log_extra):
                 return
 
+        gathered = self._gather_results(message, log_extra)
+        if gathered is not None:
+            self._publish_results(message, gathered, log_extra)
+
+    def _gather_results(
+        self, message: BatchFinished, log_extra: dict[str, Any]
+    ) -> list[tuple[JobResult, JobAttemptProgress]] | None:
         gathered: list[tuple[JobResult, JobAttemptProgress]] = []
         for batch_job_result in message.batch_jobs:
-            # Checked per job because a repository-wide batch has hundreds, and this runs in a thread
-            # the bus cannot interrupt. Abandoned rather than partly registered: the batch stays
-            # planned, so the run reports what it is, unfinished.
+            # Cancellation cannot interrupt this thread; leave the batch unfinished instead.
             if self.stopping:
                 self._logger.warning(
                     "Gathering abandoned after %s of %s jobs: the bus is shutting down",
@@ -94,21 +105,23 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
                     len(message.batch_jobs),
                     extra=log_extra,
                 )
-                return
+                return None
             gathered.append(self._gather_job(batch_job_result, message))
+        return gathered
 
+    def _publish_results(
+        self,
+        message: BatchFinished,
+        gathered: list[tuple[JobResult, JobAttemptProgress]],
+        log_extra: dict[str, Any],
+    ) -> None:
         results = [result for result, _ in gathered]
         status = self._build_workflow_status(message, results)
-
-        # Register, bump the revision, and emit under one lock, so two batches finishing at once
-        # cannot build a comment from half-updated state.
         with self._lock:
-            # The per-job check cannot see a flip during the last job or while the status was built,
-            # and this block is the publish gate: registering now would contradict a cancelled run.
+            # Cancellation or another collector may have won while these results were parsed.
             if self.stopping:
                 self._logger.warning("Batch gathered but left unregistered: the bus is shutting down", extra=log_extra)
                 return
-            # Re-checked: another thread may have gathered this batch while this one parsed.
             if not self._accepts(message.batch_id, log_extra):
                 return
             planned = self._progress_by_batch[message.batch_id]
@@ -116,26 +129,127 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
                 self._results_by_batch[message.batch_id] = results
                 self._status_by_batch[message.batch_id] = status
             self._progress_by_batch[message.batch_id] = self._finished_batch_progress(planned, message, gathered)
-            self._revision += 1
-            revision = self._revision
-            done = self._done()
-            self.submit_message(self.build_update_message(message.id, revision, done))
+            update = self._publish_update(message.id)
 
         self._logger.info(
             "Batch gathered, UpdatePRComment revision %s emitted (done=%s)",
-            revision,
-            done,
+            update.revision,
+            update.progress.done,
             extra=log_extra,
         )
+
+    def _observe_progress(self, message: BatchProgressUpdate) -> None:
+        log_extra = {"batch_id": message.batch_id, "run_id": message.run_id}
+        with self._lock:
+            if self.stopping or not self._accepts(message.batch_id, log_extra):
+                return
+            current = self._progress_by_batch[message.batch_id]
+            if not self._accept_progress(current, message):
+                return
+
+            previous = self._snapshot()
+            self._progress_by_batch[message.batch_id] = self._updated_batch_progress(current, message)
+            # Repeated polls should not trigger identical PR comment updates.
+            if self._snapshot() != previous:
+                self._publish_update(message.id)
+
+    def _accept_progress(self, current: BatchProgress, message: BatchProgressUpdate) -> bool:
+        """Called with the gatherer lock held."""
+        # Otherwise the report could show one workflow run's results under another run's link.
+        if current.run_id is not None and current.run_id != message.run_id:
+            return False
+
+        # Messages can be processed out of order, so an older update must not replace a newer one.
+        if message.sequence <= self._sequences.get(message.batch_id, -1):
+            return False
+
+        # Remember this message even if its state goes backward, so older updates cannot be applied later.
+        self._sequences[message.batch_id] = message.sequence
+
+        # The workflow has finished, but the batch must keep showing collection until its results are ready.
+        if current.state is ExecutionState.ARTIFACT_DOWNLOAD and message.state is not current.state:
+            return False
+
+        # Once a batch has started, a queued update must not make it look like it is waiting to start.
+        return not (current.state is ExecutionState.RUNNING and message.state is ExecutionState.QUEUED)
+
+    def _updated_batch_progress(self, current: BatchProgress, message: BatchProgressUpdate) -> BatchProgress:
+        observed = {job.name: job for job in message.jobs}
+        jobs = []
+        # Count only the planned tests, not the workflow's setup or reporting jobs.
+        for job in current.jobs_progress:
+            workflow_job = observed.get(job.job.name)
+            jobs.append(self._observe_job(job, workflow_job) if workflow_job is not None else job)
+        return dataclasses.replace(
+            current,
+            run_id=message.run_id,
+            workflow_url=message.workflow_url,
+            state=message.state,
+            status=message.status if message.status is not None else current.status,
+            current_attempt=max((job.latest.attempt for job in jobs if job.latest is not None), default=1),
+            jobs_progress=tuple(jobs),
+        )
+
+    def _observe_job(self, job: JobProgress, workflow_job: WorkflowJob) -> JobProgress:
+        if workflow_job.status is WorkflowJobStatus.COMPLETED:
+            state = ExecutionState.FINISHED
+        elif workflow_job.status is WorkflowJobStatus.IN_PROGRESS:
+            state = ExecutionState.RUNNING
+        else:
+            state = ExecutionState.QUEUED
+        latest = job.latest
+        # Reruns get new job IDs, so a job with a new ID is allowed to start from queued again.
+        if latest is not None and latest.job_id == workflow_job.id:
+            if latest.state is ExecutionState.FINISHED and state is not ExecutionState.FINISHED:
+                return job
+            if latest.state is ExecutionState.RUNNING and state is ExecutionState.QUEUED:
+                return job
+        finished = state is ExecutionState.FINISHED
+        attempt = JobAttemptProgress(
+            attempt=1,
+            job_id=workflow_job.id,
+            state=state,
+            status=conclusion_to_status(workflow_job.conclusion) if finished else None,
+            conclusion=workflow_job.conclusion if finished else None,
+            failed_steps=tuple(step.name for step in workflow_job.steps if finished and step.conclusion == "failure"),
+            job_url=workflow_job.html_url,
+            reports=None,
+        )
+        return self._record_attempt(job, attempt, same_run=True)
+
+    def _publish_update(self, message_id: str) -> UpdatePRComment:
+        """Advance the revision and publish its snapshot under the aggregate lock."""
+        self._revision += 1
+        update = self.build_update_message(message_id, self._revision, self._done())
+        self.submit_message(update)
+        return update
+
+    @staticmethod
+    def _record_attempt(job: JobProgress, attempt: JobAttemptProgress, *, same_run: bool) -> JobProgress:
+        latest = job.latest
+        # Collecting results belongs to the same job attempt, even if a timeout left us without its job ID.
+        if latest is not None and same_run and (attempt.job_id is None or latest.job_id == attempt.job_id):
+            # If this update has no collected results yet, keep any reports and errors we already have.
+            updated = dataclasses.replace(
+                attempt,
+                attempt=latest.attempt,
+                job_id=attempt.job_id if attempt.job_id is not None else latest.job_id,
+                job_url=attempt.job_url if attempt.job_url is not None else latest.job_url,
+                reports=attempt.reports if attempt.reports is not None else latest.reports,
+                error=attempt.error if attempt.reports is not None else latest.error,
+            )
+            return dataclasses.replace(job, attempts=(*job.attempts[:-1], updated))
+        numbered = dataclasses.replace(attempt, attempt=len(job.attempts) + 1)
+        return dataclasses.replace(job, attempts=(*job.attempts, numbered))
 
     def _accepts(self, batch_id: str, log_extra: dict[str, Any]) -> bool:
         """Whether this batch is in the plan and not already gathered. Hold ``self._lock``."""
         planned = self._progress_by_batch.get(batch_id)
         if planned is None:
-            self._logger.warning("BatchFinished for an unplanned batch ignored", extra=log_extra)
+            self._logger.warning("Update for an unplanned batch ignored", extra=log_extra)
             return False
         if planned.state is ExecutionState.FINISHED:
-            self._logger.warning("Duplicate BatchFinished ignored", extra=log_extra)
+            self._logger.debug("Update for a gathered batch ignored", extra=log_extra)
             return False
         return True
 
@@ -143,7 +257,11 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
     def progress(self) -> DispatcherProgress:
         """The current aggregate snapshot, for a caller outside the message flow."""
         with self._lock:
-            return DispatcherProgress(batches=tuple(self._progress_by_batch.values()), done=self._done())
+            return self._snapshot()
+
+    def _snapshot(self) -> DispatcherProgress:
+        """Hold the lock while reading the live aggregate."""
+        return DispatcherProgress(batches=tuple(self._progress_by_batch.values()), done=self._done())
 
     def _done(self) -> bool:
         """Whether every batch is terminal. Hold ``self._lock``."""
@@ -193,17 +311,7 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         batch_job = batch_job_result.job
         status, failed_steps = self._job_status(batch_job_result, message)
 
-        error: ProgressError | None = None
-        reports: tuple[JUnitReport, ...] = ()
-        job_artifacts_path = Path(batch_job_result.artifact_name_path) if batch_job_result.artifact_name_path else None
-        if job_artifacts_path is not None:
-            reports = tuple(parse_junit_dir(job_artifacts_path))
-            self._organize_artifacts(job_artifacts_path, batch_job)
-        else:
-            error = ProgressError.NO_ARTIFACTS
-            self._logger.warning(
-                "No artifact directory found for job %s", batch_job.name, extra={"run_id": message.run_id}
-            )
+        reports, error = self._gather_reports(batch_job_result, message.run_id)
 
         result = JobResult(
             integration=batch_job.target,
@@ -220,7 +328,7 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             job_url = workflow_job.html_url
 
         attempt = JobAttemptProgress(
-            # Provisional: the real position is known only when appended to the plan, under the lock.
+            # The execution's position is resolved under the aggregate lock.
             attempt=1,
             job_id=job_id,
             status=status,
@@ -231,6 +339,19 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             error=error,
         )
         return (result, attempt)
+
+    def _gather_reports(
+        self, batch_job_result: BatchJobResult, run_id: int
+    ) -> tuple[tuple[JUnitReport, ...], ProgressError | None]:
+        if not batch_job_result.artifact_name_path:
+            self._logger.warning(
+                "No artifact directory found for job %s", batch_job_result.job.name, extra={"run_id": run_id}
+            )
+            return (), ProgressError.NO_ARTIFACTS
+        path = Path(batch_job_result.artifact_name_path)
+        reports = tuple(parse_junit_dir(path))
+        self._organize_artifacts(path, batch_job_result.job)
+        return reports, None
 
     @staticmethod
     def _job_status(batch_job_result: BatchJobResult, message: BatchFinished) -> tuple[Status, list[str]]:
@@ -248,7 +369,7 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         if workflow_job is None:
             raise ValueError(f"No workflow job correlated for {batch_job_result.job.name!r}")
 
-        failed_steps = [step.name for step in workflow_job.steps if step.conclusion == WorkflowJobConclusion.FAILURE]
+        failed_steps = [step.name for step in workflow_job.steps if step.conclusion == "failure"]
         return (conclusion_to_status(workflow_job.conclusion), failed_steps)
 
     def _organize_artifacts(self, job_artifacts_path: Path, batch_job: BatchJob) -> None:
@@ -277,10 +398,9 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
         message: BatchFinished,
         gathered: list[tuple[JobResult, JobAttemptProgress]],
     ) -> BatchProgress:
-        """The batch's terminal aggregate: the registered plan with this run's executions appended.
+        """Merge collected results into this run's observed executions.
 
-        Built from *planned*, not from the message alone, so a run reporting only a subset — what a
-        failed-job rerun does — adds attempts to the jobs it covers and leaves the rest untouched.
+        A different run adds attempts only to the jobs it covers, preserving sparse rerun histories.
 
         The batch's own status is the workflow's, not a roll-up of these jobs: a workflow also runs
         setup and finalization steps that can fail while every tracked job passes.
@@ -298,9 +418,7 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
             if attempt is None:
                 jobs.append(job)
                 continue
-            # Renumbered here because the position in the job's history is only known now.
-            numbered = dataclasses.replace(attempt, attempt=len(job.attempts) + 1)
-            jobs.append(dataclasses.replace(job, attempts=(*job.attempts, numbered)))
+            jobs.append(self._record_attempt(job, attempt, same_run=planned.run_id == message.run_id))
         for name in attempts:
             # Reported but never planned: recorded so it can be investigated, kept out of the totals.
             self._logger.warning(
@@ -327,7 +445,8 @@ class TaskTestGatherer(SyncProcessor[BatchFinished]):
     def _batch_error(message: BatchFinished, jobs: list[JobProgress]) -> ProgressError | None:
         if message.timed_out:
             return ProgressError.TIMED_OUT
-        if not any(job.latest is not None for job in jobs):
+        # Seeing a job finish does not mean we have collected its results.
+        if not any(job.latest is not None and job.latest.reports is not None for job in jobs):
             return ProgressError.NO_JOB_RESULTS
         return None
 

--- a/ddev/src/ddev/cli/ci/tests/task_test_runner.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_runner.py
@@ -10,14 +10,17 @@ import gzip
 import json
 import logging
 from dataclasses import dataclass
+from itertools import count
 from pathlib import Path
 from typing import Any
 
-from ddev.cli.ci.tests.messages import BatchFinished, BatchJob, BatchJobResult, TestBatch
+from ddev.cli.ci.tests.messages import BatchFinished, BatchJob, BatchJobResult, BatchProgressUpdate, TestBatch
+from ddev.cli.ci.tests.progress import ExecutionState
 from ddev.cli.ci.tests.status import conclusion_to_status
 from ddev.event_bus.orchestrator import AsyncProcessor
 from ddev.utils.github_async import AsyncGitHubClient, GitHubResponse
-from ddev.utils.github_async.models import WorkflowJob, WorkflowRun
+from ddev.utils.github_async.models import Artifact, WorkflowJob, WorkflowRun
+from ddev.utils.github_async.models.workflow import WorkflowJobStatus
 
 # A cancelled job has roughly ten seconds before it is killed, and there may be several runs to stop.
 # The retry policy bounds the ladder, not a socket, so a GitHub that accepts the connection and then
@@ -74,63 +77,76 @@ class TestRunnerOptions:
 
 class TaskTestRunner(AsyncProcessor[TestBatch]):
     """
-    Runs one ``test-batch.yaml`` workflow for a ``TestBatch``: dispatches the run,
-    opens a check run, polls until the workflow completes, downloads its artifacts,
-    and emits a ``BatchFinished``.
+    Dispatches and reports execution progress, then downloads artifacts and emits ``BatchFinished``.
     """
 
-    def __init__(self, name: str, client: AsyncGitHubClient, options: TestRunnerOptions):
+    def __init__(
+        self,
+        name: str,
+        client: AsyncGitHubClient,
+        options: TestRunnerOptions,
+        *,
+        artifact_client: AsyncGitHubClient,
+    ):
         super().__init__(name)
         self._client = client
+        self._artifact_client = artifact_client
         self._options = options
         self._runs_in_flight: dict[str, int] = {}
         self._logger = logging.getLogger(f"{__name__}.{name}")
 
     async def process_message(self, message: TestBatch):
-        inputs = self._build_inputs(message)
         log_extra: dict[str, Any] = {"batch_id": message.batch_id}
+        run_id = await self._dispatch_batch(message, log_extra)
+        run, jobs = await self._poll_until_complete(message, run_id, log_extra)
+        await self._collect_results(message, run_id, run.data, jobs, log_extra)
 
+    async def _dispatch_batch(self, message: TestBatch, log_extra: dict[str, Any]) -> int:
         dispatch = await self._client.create_workflow_dispatch(
             self._options.owner,
             self._options.repo,
             self._options.workflow_id,
             ref=self._options.ref,
-            inputs=inputs,
+            inputs=self._build_inputs(message),
             return_run_details=True,
         )
         run_id = dispatch.data.workflow_run_id
         log_extra["run_id"] = run_id
         self._runs_in_flight[message.batch_id] = run_id
         self._logger.info("Dispatched batch", extra=log_extra)
+        self.submit_message(
+            BatchProgressUpdate(
+                id=f"{message.id}-progress-0",
+                batch_id=message.batch_id,
+                run_id=run_id,
+                workflow_url=dispatch.data.html_url,
+                state=ExecutionState.QUEUED,
+                sequence=0,
+            )
+        )
+        return run_id
 
-        run = await self._client.get_workflow_run(self._options.owner, self._options.repo, run_id)
-        workflow_url = run.data.html_url
-        log_extra["workflow_url"] = workflow_url
-
-        if run.data.status != "completed":
-            run = await self._poll_until_complete(run_id, log_extra)
-        else:
-            self._logger.info("Workflow completed", extra=log_extra)
-
-        # Popped only once the run is known to be over: while it is in flight it is what
-        # `cancel_dispatched_runs` has to reap.
-        self._runs_in_flight.pop(message.batch_id, None)
-
-        raw = run.data.conclusion
-        if raw is None:
+    async def _collect_results(
+        self,
+        message: TestBatch,
+        run_id: int,
+        run: WorkflowRun,
+        jobs: list[WorkflowJob],
+        log_extra: dict[str, Any],
+    ) -> None:
+        conclusion = run.conclusion
+        workflow_url = run.html_url
+        if conclusion is None:
             self._logger.warning("Workflow completed with null conclusion", extra=log_extra)
-
         artifact_dirs = await self._download_artifacts(run_id, log_extra)
         self._logger.info("Artifacts downloaded", extra=log_extra)
-
-        jobs = await self._list_jobs(run_id, log_extra)
+        jobs = await self._reconcile_final_jobs(run_id, jobs, log_extra)
         batch_jobs = BatchJobResult.correlate(message.job_list, jobs, artifact_dirs)
-
         self.submit_message(
             BatchFinished(
                 id=message.id,
                 batch_id=message.batch_id,
-                status=conclusion_to_status(raw),
+                status=conclusion_to_status(conclusion),
                 run_id=run_id,
                 workflow_url=workflow_url,
                 artifacts_path=str(self._options.artifacts_base_path),
@@ -169,19 +185,102 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
             self._runs_in_flight.pop(batch_id, None)
             self._logger.info("Dispatched run cancelled", extra=log_extra)
 
-    async def _poll_until_complete(self, run_id: int, log_extra: dict[str, Any]) -> GitHubResponse[WorkflowRun]:
+    async def _poll_until_complete(
+        self, message: TestBatch, run_id: int, log_extra: dict[str, Any]
+    ) -> tuple[GitHubResponse[WorkflowRun], list[WorkflowJob]]:
+        sequences = count(1)
+        known_jobs: dict[str, WorkflowJob] = {}
         while True:
-            await asyncio.sleep(self._options.poll_interval_seconds)
             run = await self._client.get_workflow_run(self._options.owner, self._options.repo, run_id)
-            if run.data.status == "completed":
+            completed = run.data.is_completed
+            # Shutdown must not try to cancel a completed run while its artifacts are still being collected.
+            if completed:
+                self._runs_in_flight.pop(message.batch_id, None)
+            log_extra["workflow_url"] = run.data.html_url
+
+            # Report workflow progress first. The jobs request may be delayed by the API rate limit.
+            progress = self._publish_workflow_progress(message, run_id, run.data, known_jobs, next(sequences))
+            await self._refresh_jobs(run_id, known_jobs, log_extra)
+            self._publish_job_progress(message.id, progress, known_jobs, next(sequences))
+
+            if completed:
                 self._logger.info("Workflow completed", extra=log_extra)
-                return run
+                return run, list(known_jobs.values())
+            await asyncio.sleep(self._options.poll_interval_seconds)
+
+    def _publish_workflow_progress(
+        self,
+        message: TestBatch,
+        run_id: int,
+        run: WorkflowRun,
+        known_jobs: dict[str, WorkflowJob],
+        sequence: int,
+    ) -> BatchProgressUpdate:
+        if run.is_completed:
+            state = ExecutionState.ARTIFACT_DOWNLOAD
+        elif run.status == "in_progress":
+            state = ExecutionState.RUNNING
+        else:
+            state = ExecutionState.QUEUED
+        progress = BatchProgressUpdate(
+            id=f"{message.id}-progress-{sequence}",
+            batch_id=message.batch_id,
+            run_id=run_id,
+            workflow_url=run.html_url,
+            state=state,
+            status=conclusion_to_status(run.conclusion) if run.is_completed else None,
+            sequence=sequence,
+            jobs=tuple(known_jobs.values()),
+        )
+        self.submit_message(progress)
+        return progress
+
+    async def _refresh_jobs(self, run_id: int, known_jobs: dict[str, WorkflowJob], log_extra: dict[str, Any]) -> None:
+        # A failed or incomplete listing must not remove jobs we already know about.
+        for job in await self._list_jobs(run_id, log_extra):
+            previous = known_jobs.get(job.name)
+            # A rerun has a new job ID. An older state for the same job must not erase its completed result.
+            if (
+                previous is not None
+                and previous.id == job.id
+                and previous.status is WorkflowJobStatus.COMPLETED
+                and job.status is not WorkflowJobStatus.COMPLETED
+            ):
+                continue
+            known_jobs[job.name] = job
+
+    def _publish_job_progress(
+        self,
+        message_id: str,
+        progress: BatchProgressUpdate,
+        known_jobs: dict[str, WorkflowJob],
+        sequence: int,
+    ) -> None:
+        self.submit_message(
+            dataclasses.replace(
+                progress,
+                id=f"{message_id}-progress-{sequence}",
+                sequence=sequence,
+                jobs=tuple(known_jobs.values()),
+            )
+        )
+
+    async def _reconcile_final_jobs(
+        self, run_id: int, observed_jobs: list[WorkflowJob], log_extra: dict[str, Any]
+    ) -> list[WorkflowJob]:
+        known_jobs = {job.name: job for job in observed_jobs}
+        # The jobs response may lag behind the workflow status. Refresh it after downloading artifacts.
+        await self._refresh_jobs(run_id, known_jobs, log_extra)
+        # An unfinished job has no result yet. Do not mistake that for a test failure.
+        return [job for job in known_jobs.values() if job.status is WorkflowJobStatus.COMPLETED]
 
     async def _list_jobs(self, run_id: int, log_extra: dict[str, Any]) -> list[WorkflowJob]:
-        """Fetch the workflow run's jobs; on failure log a warning and return an empty list."""
+        """Fetch the run's jobs. If a later page fails, keep the jobs already fetched."""
         jobs: list[WorkflowJob] = []
         try:
-            async for page in self._client.list_workflow_jobs(self._options.owner, self._options.repo, run_id):
+            async for page in self._client.list_workflow_jobs(
+                self._options.owner, self._options.repo, run_id, per_page=100
+            ):
                 jobs.extend(page.data.jobs)
         except Exception:
             self._logger.warning("Failed to list workflow jobs", extra=log_extra, exc_info=True)
@@ -222,42 +321,21 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
         The map keys on the GitHub artifact name (the contract a ``BatchJob`` reproduces via
         ``artifact_name``), letting the producer resolve each job's directory deterministically.
         """
-        base_path = self._options.artifacts_base_path
         artifact_dirs: dict[str, Path] = {}
         failures: list[tuple[int, str]] = []
         try:
-            async for page in self._client.list_workflow_run_artifacts(self._options.owner, self._options.repo, run_id):
+            async for page in self._artifact_client.list_workflow_run_artifacts(
+                self._options.owner, self._options.repo, run_id, per_page=100
+            ):
                 for artifact in page.data.artifacts:
-                    if artifact.expired:
-                        self._logger.info(
-                            "Skipping expired artifact %s (%s)",
-                            artifact.id,
-                            artifact.name,
-                            extra=log_extra,
-                        )
+                    url = self._artifact_download_url(artifact, log_extra)
+                    if url is None:
                         continue
-                    if not artifact.archive_download_url:
-                        self._logger.info(
-                            "Skipping artifact %s (%s) without download URL",
-                            artifact.id,
-                            artifact.name,
-                            extra=log_extra,
-                        )
-                        continue
-                    target = base_path / artifact.name
-                    try:
-                        await self._client.download_artifact(artifact.archive_download_url, target)
-                        artifact_dirs[artifact.name] = target
-                        self._logger.info("Downloaded artifact %s -> %s", artifact.id, target, extra=log_extra)
-                    except Exception as exc:
-                        self._logger.warning(
-                            "Failed to download artifact %s (%s): %s",
-                            artifact.id,
-                            artifact.name,
-                            exc,
-                            extra=log_extra,
-                        )
+                    target = await self._download_artifact(artifact, url, log_extra)
+                    if target is None:
                         failures.append((artifact.id, artifact.name))
+                    else:
+                        artifact_dirs[artifact.name] = target
         except Exception:
             self._logger.warning("Failed to list workflow run artifacts", extra=log_extra, exc_info=True)
         if failures:
@@ -268,3 +346,26 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
                 extra=log_extra,
             )
         return artifact_dirs
+
+    def _artifact_download_url(self, artifact: Artifact, log_extra: dict[str, Any]) -> str | None:
+        if artifact.expired:
+            self._logger.info("Skipping expired artifact %s (%s)", artifact.id, artifact.name, extra=log_extra)
+            return None
+        if not artifact.archive_download_url:
+            self._logger.info(
+                "Skipping artifact %s (%s) without download URL", artifact.id, artifact.name, extra=log_extra
+            )
+            return None
+        return artifact.archive_download_url
+
+    async def _download_artifact(self, artifact: Artifact, url: str, log_extra: dict[str, Any]) -> Path | None:
+        target = self._options.artifacts_base_path / artifact.name
+        try:
+            await self._artifact_client.download_artifact(url, target)
+            self._logger.info("Downloaded artifact %s -> %s", artifact.id, target, extra=log_extra)
+            return target
+        except Exception as exc:
+            self._logger.warning(
+                "Failed to download artifact %s (%s): %s", artifact.id, artifact.name, exc, extra=log_extra
+            )
+            return None

--- a/ddev/tests/cli/ci/tests/test_dispatcher.py
+++ b/ddev/tests/cli/ci/tests/test_dispatcher.py
@@ -5,25 +5,42 @@
 
 from __future__ import annotations
 
+import asyncio
+import dataclasses
 import os
 import signal
 import sys
 import time
+from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import Any
 
+import httpx
 import pytest
 
+from ddev.cli.ci.tests import rate_limiting
 from ddev.cli.ci.tests.dispatcher import (
     CANCELLED_RATE_LIMITS,
     Dispatcher,
     DispatcherContext,
+    build_dispatcher,
 )
+from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
 from ddev.cli.ci.tests.messages import BatchJob, TestBatch
 from ddev.cli.ci.tests.pr_comment import CANCELLED_HEADING
 from ddev.cli.ci.tests.task_run_reporter import RunReporterOptions, TaskRunReporter
 from ddev.cli.ci.tests.task_test_gatherer import TaskTestGatherer
 from ddev.cli.ci.tests.task_test_runner import TaskTestRunner, TestRunnerOptions
-from ddev.utils.github_async.models import ArtifactsList, WorkflowJob, WorkflowJobsList, WorkflowRun
+from ddev.utils.github_async import AsyncGitHubClient, GitHubResponse
+from ddev.utils.github_async.models import (
+    ArtifactsList,
+    IssueComment,
+    WorkflowJob,
+    WorkflowJobsList,
+    WorkflowJobStatus,
+    WorkflowRun,
+)
+from ddev.utils.rate_limiting import BucketEvent, InstrumentedAsyncLimiter, RateLimitEvent
 from tests.cli.ci.tests.helpers import jobs_reported, make_batch, make_job
 from tests.helpers.github_async import FakeAsyncGitHubClient
 
@@ -65,6 +82,7 @@ def build_bus(
             artifacts_base_path=tmp_path / "artifacts",
             poll_interval_seconds=0.0,
         ),
+        artifact_client=client,  # type: ignore[arg-type]
     )
     gatherer = TaskTestGatherer("test-gatherer", tmp_path / "results", batches)
     reporter = TaskRunReporter(
@@ -131,20 +149,110 @@ def test_a_batch_travels_from_dispatch_to_the_pull_request_comment(client, tmp_p
     assert dispatches[0].kwargs["inputs"]["batch_id"] == "batch-01"
     assert dispatches[0].kwargs["inputs"]["checkout_sha"] == "refs/pull/42/merge"
 
-    # The plan is published before anything runs, then edited once the batch has been gathered.
+    # The initial plan and the final collected result both reach the same comment.
     created = client.calls_to("create_issue_comment")
     edited = client.calls_to("update_issue_comment")
     assert len(created) == 1
     assert created[0].kwargs["issue_number"] == 42
-    assert len(edited) == 1
+    assert edited
     assert jobs_reported(created[0].kwargs["body"]) == 0
-    assert jobs_reported(edited[0].kwargs["body"]) == 1
+    assert jobs_reported(edited[-1].kwargs["body"]) == 1
 
     outcome = dispatcher.outcome
     assert outcome is not None
     assert outcome.successful
     assert outcome.progress.done
     assert outcome.progress.passed == 1
+
+
+def test_dispatcher_assembly_routes_artifact_requests_to_the_artifact_tier(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    events: list[RateLimitEvent] = []
+    requests: dict[str, str] = {}
+    job = make_job()
+    run_url = "https://github.com/DataDog/integrations-core/actions/runs/123"
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        bucket = next(event for event in reversed(events) if isinstance(event, BucketEvent))
+        requests[request.url.path] = bucket.name
+        if request.url.path.endswith("/dispatches"):
+            return httpx.Response(200, json={"workflow_run_id": 123, "run_url": str(request.url), "html_url": run_url})
+        if request.url.path.endswith("/artifacts"):
+            return httpx.Response(200, json={"total_count": 0, "artifacts": []})
+        if request.url.path.endswith("/jobs"):
+            return httpx.Response(
+                200,
+                json={
+                    "total_count": 1,
+                    "jobs": [
+                        {"id": 1, "run_id": 123, "name": job.name, "status": "completed", "conclusion": "success"}
+                    ],
+                },
+            )
+        assert request.url.path == "/repos/DataDog/integrations-core/actions/runs/123"
+        return httpx.Response(
+            200, json={"id": 123, "status": "completed", "conclusion": "success", "html_url": run_url}
+        )
+
+    def make_client(token: str, *, rate_limiter: InstrumentedAsyncLimiter) -> AsyncGitHubClient:
+        return AsyncGitHubClient(token, rate_limiter=rate_limiter, transport=httpx.MockTransport(handle))
+
+    monkeypatch.setattr("ddev.utils.github_async.AsyncGitHubClient", make_client)
+    monkeypatch.setattr(rate_limiting, "event_logger", lambda _: events.append)
+    dispatcher = build_dispatcher(
+        batches=[make_batch(job)],
+        context=dataclasses.replace(CONTEXT, pr_number=None),
+        config=DispatcherConfig(grace_period_seconds=0.1, global_timeout_seconds=5),
+        token="test-token",
+        artifacts_path=tmp_path / "artifacts",
+        output_path=tmp_path / "results",
+    )
+
+    dispatcher.run()
+
+    assert dispatcher.outcome.progress.done
+    prefix = "/repos/DataDog/integrations-core/actions/runs/123"
+    assert requests[f"{prefix}/artifacts"] == "artifacts"
+    assert requests[f"{prefix}/jobs"] == "default"
+    assert requests[prefix] == "default"
+
+
+def test_progress_reaches_the_comment_before_artifact_collection_finishes(
+    client: FakeAsyncGitHubClient, tmp_path: Path
+):
+    job = make_job()
+    mock_job_result(client, job, "success")
+    dispatcher = build_bus(client, tmp_path, [make_batch(job)])
+    collecting_reported = asyncio.Event()
+    collection_released = False
+    update_comment = client.update_issue_comment
+    list_artifacts = client.list_workflow_run_artifacts
+
+    async def record_comment(
+        owner: str, repo: str, comment_id: int, body: str, **kwargs: Any
+    ) -> GitHubResponse[IssueComment]:
+        result = await update_comment(owner, repo, comment_id, body, **kwargs)
+        if "📥 collecting artifacts" in body:
+            collecting_reported.set()
+        return result
+
+    async def collect_after_reporting(*args: Any, **kwargs: Any) -> AsyncIterator[GitHubResponse[ArtifactsList]]:
+        nonlocal collection_released
+        async with asyncio.timeout(3):
+            await collecting_reported.wait()
+        collection_released = True
+        async for page in list_artifacts(*args, **kwargs):
+            yield page
+
+    client.update_issue_comment = record_comment
+    client.list_workflow_run_artifacts = collect_after_reporting
+
+    dispatcher.run()
+
+    assert collection_released
+    assert dispatcher.outcome.progress.done
+    assert dispatcher.outcome.final_report_published
 
 
 @pytest.mark.parametrize("client", ["failure"], indirect=True)
@@ -159,6 +267,30 @@ def test_a_failed_batch_makes_the_run_unsuccessful(client, tmp_path):
     assert outcome is not None
     assert not outcome.successful
     assert outcome.progress.failed == 1
+
+
+def test_missing_final_job_metadata_keeps_the_run_unsuccessful(client: FakeAsyncGitHubClient, tmp_path: Path):
+    job = make_job()
+    client.mock_response(
+        "get_workflow_run",
+        WorkflowRun(id=123, status="in_progress", html_url="https://github.com/o/r/actions/runs/123"),
+        once=True,
+    )
+    client.mock_response(
+        "list_workflow_jobs",
+        WorkflowJobsList(
+            total_count=1,
+            jobs=[WorkflowJob(id=1, run_id=123, name=job.name, status=WorkflowJobStatus.IN_PROGRESS)],
+        ),
+        once=True,
+    )
+    client.mock_response("list_workflow_jobs", RuntimeError("Final job metadata unavailable"))
+    dispatcher = build_bus(client, tmp_path, [make_batch(job)])
+
+    dispatcher.run()
+
+    assert not dispatcher.outcome.progress.done
+    assert not dispatcher.outcome.successful
 
 
 def test_the_report_is_written_to_the_run_summary(client, tmp_path, step_summary):

--- a/ddev/tests/cli/ci/tests/test_pr_comment.py
+++ b/ddev/tests/cli/ci/tests/test_pr_comment.py
@@ -10,6 +10,7 @@ read as success, and nothing is dropped silently.
 
 from __future__ import annotations
 
+import dataclasses
 import re
 from collections.abc import Callable
 
@@ -124,6 +125,60 @@ def test_a_running_batch_and_a_retrying_batch_are_indistinguishable():
 
     assert chips[0] == chips[1]
     assert "🔄 in progress" in chips[0]
+
+
+def test_collection_shows_execution_outcomes_while_test_details_are_pending():
+    failed = dataclasses.replace(attempt(Status.FAILURE), reports=None)
+    passed = dataclasses.replace(attempt(), reports=None)
+    progress = DispatcherProgress(
+        batches=(
+            batch_progress(
+                "batch-01",
+                job_progress(failed),
+                job_progress(passed, target="postgres"),
+                state=ExecutionState.ARTIFACT_DOWNLOAD,
+                status=Status.FAILURE,
+            ),
+        ),
+        done=False,
+    )
+
+    body = render_comment(progress)
+
+    assert "**Tests finished; collecting results.**" in body
+    assert "❌ failed · 📥 collecting artifacts" in body
+    assert "**2/2 jobs**" in body
+    assert 'href="https://github.com/o/r/actions/runs/1/job/9"' in body
+    assert "Test details pending artifact collection." in body
+    assert set(_progress_bar_of(body)) == {"passed", "failed"}
+
+
+@pytest.mark.parametrize("job_finished", [False, True], ids=["awaiting-job-status", "job-passed"])
+def test_workflow_only_failure_requires_observed_job_outcomes(job_finished: bool):
+    job = job_progress(attempt()) if job_finished else job_progress()
+    progress = DispatcherProgress(
+        batches=(batch_progress("batch-01", job, state=ExecutionState.ARTIFACT_DOWNLOAD, status=Status.FAILURE),),
+        done=False,
+    )
+
+    body = render_comment(progress)
+
+    assert "❌ failed · 📥 collecting artifacts" in body
+    assert ("the workflow failed with no tracked job failure" in body) is job_finished
+
+
+def test_running_attempts_remain_pending_in_the_batch_table():
+    running = dataclasses.replace(attempt(), state=ExecutionState.RUNNING, status=None, conclusion=None, reports=None)
+    progress = DispatcherProgress(
+        batches=(batch_progress("batch-01", job_progress(running), state=ExecutionState.RUNNING, status=None),),
+        done=False,
+    )
+
+    body = render_comment(progress)
+
+    assert "**0/1 jobs**" in body
+    assert "<td>0/1</td>" in body
+    assert "⏳ 1 pending" in body
 
 
 def test_final_snapshot_reads_as_complete_with_failures():

--- a/ddev/tests/cli/ci/tests/test_progress.py
+++ b/ddev/tests/cli/ci/tests/test_progress.py
@@ -194,6 +194,17 @@ def test_planned_jobs_count_toward_total_but_not_complete() -> None:
     assert progress.total == 3
 
 
+def test_running_executions_remain_pending_in_the_totals():
+    running = dataclasses.replace(_attempt(), state=ExecutionState.RUNNING, status=None, conclusion=None)
+    progress = DispatcherProgress(
+        batches=(_batch(_job(_attempt(), name="done"), _job(running, name="running"), _job(name="queued")),),
+        done=False,
+    )
+
+    assert (progress.complete, progress.total) == (1, 3)
+    assert (progress.passed, progress.failed, progress.skipped) == (1, 0, 0)
+
+
 def test_an_execution_missing_its_artifacts_still_counts() -> None:
     # Only the artifacts are missing: the error qualifies the execution, it does not erase it.
     attempt = _attempt(status=Status.SUCCESS, error=ProgressError.NO_ARTIFACTS)

--- a/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_gatherer.py
@@ -11,6 +11,7 @@ of every job's result — not just failures.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import shutil
 import threading
@@ -20,6 +21,7 @@ from pathlib import Path
 
 import pytest
 
+from ddev.cli.ci.tests import messages
 from ddev.cli.ci.tests.messages import (
     BatchFinished,
     BatchJob,
@@ -34,7 +36,7 @@ from ddev.cli.ci.tests.status import Status
 from ddev.cli.ci.tests.task_run_reporter import RunReporterOptions, TaskRunReporter
 from ddev.cli.ci.tests.task_test_gatherer import INITIAL_UPDATE_MESSAGE_ID, TaskTestGatherer
 from ddev.event_bus.orchestrator import BaseMessage, EventBusOrchestrator
-from ddev.utils.github_async.models import JobStep, WorkflowJob
+from ddev.utils.github_async.models import JobStep, WorkflowJob, WorkflowJobConclusion, WorkflowJobStatus
 from ddev.utils.junit import TestStatus
 from ddev.utils.platform import PlatformName
 from tests.cli.ci.tests.helpers import RecordingBus, drain_queue, jobs_reported, make_job
@@ -185,6 +187,104 @@ def _find_result(gatherer: TaskTestGatherer, integration: str) -> JobResult:
 # ---------------------------------------------------------------------------
 # process_message
 # ---------------------------------------------------------------------------
+
+
+def _progress_update(
+    *jobs: WorkflowJob,
+    sequence: int = 1,
+    state: ExecutionState = ExecutionState.RUNNING,
+    status: Status | None = None,
+) -> messages.BatchProgressUpdate:
+    return messages.BatchProgressUpdate(
+        id=f"progress-{sequence}",
+        batch_id="batch-1",
+        run_id=100,
+        workflow_url="https://github.com/o/r/actions/runs/100",
+        sequence=sequence,
+        state=state,
+        status=status,
+        jobs=tuple(jobs),
+    )
+
+
+def test_progress_observations_update_planned_jobs_and_suppress_equal_snapshots(tmp_path: Path):
+    gatherer = _make_gatherer(tmp_path, {"batch-1": [_batch_job(name) for name in ("j1", "j2", "j3", "j4")]})
+    update = _progress_update(
+        _workflow_job("j1", "success"),
+        WorkflowJob(id=2, run_id=100, name="j2", status="in_progress"),
+        WorkflowJob(id=4, run_id=100, name="j4", status="queued"),
+        _workflow_job("setup", "failure"),
+    )
+    gatherer.process_message(update)
+    [published] = drain_queue(gatherer.bus.queue)
+    assert (published.progress.complete, published.progress.total) == (1, 4)
+    assert not published.progress.done
+    batch = published.progress.batches[0]
+    assert batch.workflow_url == "https://github.com/o/r/actions/runs/100"
+    assert batch.jobs_progress[1].latest.status is None
+    assert batch.jobs_progress[2].latest is None
+    assert batch.jobs_progress[3].latest.state is ExecutionState.QUEUED
+    assert batch.jobs_progress[3].latest.status is None
+    assert all(job.latest is None or job.latest.error is None for job in batch.jobs_progress)
+
+    gatherer.process_message(dataclasses.replace(update, sequence=3))
+    gatherer.process_message(_progress_update(sequence=4))
+    assert drain_queue(gatherer.bus.queue) == []
+
+    gatherer.process_message(_progress_update(_workflow_job("j1", "failure"), sequence=2))
+    assert gatherer.progress.passed == 1
+    assert drain_queue(gatherer.bus.queue) == []
+
+
+def test_final_gathering_enriches_the_observed_execution_without_a_retry(tmp_path: Path):
+    job = _batch_job("j1")
+    gatherer = _make_gatherer(tmp_path, {"batch-1": [job]})
+    observed = _workflow_job("j1", "failure", failed_step="Run unit tests")
+    update = _progress_update(observed, state=ExecutionState.ARTIFACT_DOWNLOAD, status=Status.FAILURE)
+    gatherer.process_message(update)
+    [collecting] = drain_queue(gatherer.bus.queue)
+    assert collecting.progress.failed == 1
+    assert not collecting.progress.done
+    assert collecting.progress.batches[0].jobs_progress[0].latest.error is None
+    assert collecting.progress.batches[0].jobs_progress[0].latest.failed_steps == ("Run unit tests",)
+
+    artifact_dir = _make_job_tree(tmp_path / "artifacts", "j1", junit=JUNIT_FAILING, e2e=False)
+    gatherer.process_message(
+        _batch_finished(
+            artifact_dir,
+            status=Status.FAILURE,
+            batch_jobs=[_batch_job_result(job, observed, artifact_dir)],
+        )
+    )
+    [finished] = drain_queue(gatherer.bus.queue)
+    assert finished.revision == collecting.revision + 1
+    assert finished.progress.done
+    result = finished.progress.batches[0].jobs_progress[0]
+    assert result.retry_count == 0
+    assert [case.identifier for case in result.latest.failed_tests] == [FAILING_TEST_ID]
+
+    gatherer.process_message(dataclasses.replace(update, sequence=10))
+    assert gatherer.progress == finished.progress
+    assert drain_queue(gatherer.bus.queue) == []
+
+
+def test_progress_does_not_regress_execution_or_collection(tmp_path: Path):
+    gatherer = _make_gatherer(tmp_path)
+    gatherer.process_message(_progress_update(_workflow_job("j1", "success"), sequence=2))
+    drain_queue(gatherer.bus.queue)
+    gatherer.process_message(
+        _progress_update(WorkflowJob(id=1, run_id=100, name="j1", status="in_progress"), sequence=3)
+    )
+    assert gatherer.progress.passed == 1
+    assert drain_queue(gatherer.bus.queue) == []
+
+    gatherer.process_message(
+        _progress_update(sequence=4, state=ExecutionState.ARTIFACT_DOWNLOAD, status=Status.SUCCESS)
+    )
+    [collecting] = drain_queue(gatherer.bus.queue)
+    gatherer.process_message(_progress_update(sequence=5))
+    assert gatherer.progress == collecting.progress
+    assert drain_queue(gatherer.bus.queue) == []
 
 
 def _stopping_before_gathering(gatherer: TaskTestGatherer, bus: RecordingBus) -> None:
@@ -586,20 +686,29 @@ def test_empty_batch_jobs_has_no_entry_in_the_registry(tmp_path: Path) -> None:
     assert _registry(gatherer) == []
 
 
-def test_empty_batch_jobs_still_terminates_the_batch(tmp_path: Path) -> None:
-    # Terminal, unsuccessful, and carrying the reason — and still emitting a revision.
+@pytest.mark.parametrize("observed_status", [None, WorkflowJobStatus.IN_PROGRESS, WorkflowJobStatus.COMPLETED])
+def test_empty_batch_jobs_still_terminates_the_batch(tmp_path: Path, observed_status: WorkflowJobStatus | None):
     gatherer = _make_gatherer(tmp_path)
-    gatherer.process_message(_batch_finished("", status="failure", run_id=100, batch_jobs=[]))
+    if observed_status is not None:
+        observed = WorkflowJob(
+            id=1,
+            run_id=100,
+            name="j1",
+            status=observed_status,
+            conclusion=WorkflowJobConclusion.FAILURE if observed_status is WorkflowJobStatus.COMPLETED else None,
+        )
+        gatherer.process_message(_progress_update(observed))
+        drain_queue(gatherer.bus.queue)
+    gatherer.process_message(_batch_finished("", status=Status.FAILURE, run_id=100, batch_jobs=[]))
 
-    update = drain_queue(gatherer.bus.queue)[0]
-    assert update.revision == 1
+    [update] = drain_queue(gatherer.bus.queue)
     batch = update.progress.batches[0]
-    assert batch.state == ExecutionState.FINISHED
-    assert batch.status == Status.FAILURE
+    assert batch.state is ExecutionState.FINISHED
+    assert batch.status is Status.FAILURE
     assert batch.run_id == 100
-    assert batch.error == ProgressError.NO_JOB_RESULTS
-    # Its planned jobs are still listed, with no execution: 1 planned, 0 complete.
-    assert (update.progress.total, update.progress.complete) == (1, 0)
+    assert batch.error is ProgressError.NO_JOB_RESULTS
+    # Execution can finish without any final results being gathered.
+    assert (update.progress.total, update.progress.complete) == (1, int(observed_status is WorkflowJobStatus.COMPLETED))
 
 
 def test_empty_batch_does_not_block_completion(tmp_path: Path) -> None:

--- a/ddev/tests/cli/ci/tests/test_task_test_runner.py
+++ b/ddev/tests/cli/ci/tests/test_task_test_runner.py
@@ -15,7 +15,9 @@ from typing import Any
 
 import pytest
 
+from ddev.cli.ci.tests import messages
 from ddev.cli.ci.tests.messages import BatchFinished, BatchJob, TestBatch
+from ddev.cli.ci.tests.progress import ExecutionState
 from ddev.cli.ci.tests.status import Status, conclusion_to_status
 from ddev.cli.ci.tests.task_test_runner import (
     CANCEL_REQUEST_TIMEOUT,
@@ -25,9 +27,17 @@ from ddev.cli.ci.tests.task_test_runner import (
     TestRunnerOptions,
 )
 from ddev.utils.github_async import GitHubResponse
-from ddev.utils.github_async.models import Artifact, ArtifactsList, WorkflowJob, WorkflowJobsList, WorkflowRun
+from ddev.utils.github_async.models import (
+    Artifact,
+    ArtifactsList,
+    WorkflowJob,
+    WorkflowJobConclusion,
+    WorkflowJobsList,
+    WorkflowJobStatus,
+    WorkflowRun,
+)
 from tests.cli.ci.tests.helpers import RecordingBus, drain_queue, make_job
-from tests.helpers.github_async import FakeAsyncGitHubClient
+from tests.helpers.github_async import DEFAULT_DISPATCH_HTML_URL, FakeAsyncGitHubClient
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -90,7 +100,11 @@ def mock_jobs(fake: FakeAsyncGitHubClient, jobs: list[WorkflowJob]):
 
 
 def make_runner(
-    client: FakeAsyncGitHubClient, tmp_path: Path, pytest_args: str = "", is_fork: bool = False
+    client: FakeAsyncGitHubClient,
+    tmp_path: Path,
+    pytest_args: str = "",
+    is_fork: bool = False,
+    artifact_client: FakeAsyncGitHubClient | None = None,
 ) -> TaskTestRunner:
     options = TestRunnerOptions(
         owner="DataDog",
@@ -108,6 +122,7 @@ def make_runner(
         name="task-test-runner",
         client=client,  # type: ignore[arg-type]
         options=options,
+        artifact_client=artifact_client or client,  # type: ignore[arg-type]
     )
     runner.bus = RecordingBus()  # type: ignore[assignment]
     return runner
@@ -115,6 +130,10 @@ def make_runner(
 
 def make_batch(batch_id: str = "batch-err") -> TestBatch:
     return TestBatch(id=batch_id, batch_id=batch_id, job_list=[make_job()], jobs_count=1, integrations=["ntp"])
+
+
+def finished_messages(runner: TaskTestRunner) -> list[BatchFinished]:
+    return [message for message in drain_queue(runner.bus.queue) if isinstance(message, BatchFinished)]
 
 
 async def run_happy_path(tmp_path: Path) -> tuple[FakeAsyncGitHubClient, BatchFinished]:
@@ -140,10 +159,9 @@ async def run_happy_path(tmp_path: Path) -> tuple[FakeAsyncGitHubClient, BatchFi
     )
     await runner.process_message(batch)
 
-    submitted = drain_queue(runner.bus.queue)
+    submitted = finished_messages(runner)
     assert len(submitted) == 1
     finished = submitted[0]
-    assert isinstance(finished, BatchFinished)
     return fake, finished
 
 
@@ -174,6 +192,59 @@ def test_conclusion_to_status(conclusion: str | None, expected: Status):
 # ---------------------------------------------------------------------------
 # process_message — happy path (one concern per test)
 # ---------------------------------------------------------------------------
+
+
+async def test_dispatch_publishes_the_link_before_polling(tmp_path: Path):
+    client = FakeAsyncGitHubClient()
+    runner = make_runner(client, tmp_path)
+    get_run = client.get_workflow_run
+
+    async def observe_first_poll(*args: Any, **kwargs: Any) -> GitHubResponse[WorkflowRun]:
+        [dispatched] = drain_queue(runner.bus.queue)
+        assert isinstance(dispatched, messages.BatchProgressUpdate)
+        assert dispatched.run_id == 123
+        assert dispatched.workflow_url == DEFAULT_DISPATCH_HTML_URL
+        assert dispatched.state is ExecutionState.QUEUED
+        return await get_run(*args, **kwargs)
+
+    client.get_workflow_run = observe_first_poll  # type: ignore[method-assign]
+    await runner.process_message(make_batch())
+
+
+async def test_collection_publishes_outcomes_before_a_cancellable_artifact_request(tmp_path: Path):
+    client, artifacts = FakeAsyncGitHubClient(), FakeAsyncGitHubClient()
+    batch = make_batch()
+    mock_jobs(client, [make_workflow_job(batch.job_list[0].name, "failure")])
+    client.mock_response("get_workflow_run", make_workflow_run("completed", "failure"))
+    mock_artifacts(artifacts, [make_artifact(1)])
+    entered = asyncio.Event()
+
+    async def blocked_download(*args: Any, **kwargs: Any) -> None:
+        entered.set()
+        await asyncio.Future()
+
+    artifacts.download_artifact = blocked_download  # type: ignore[method-assign]
+    runner = make_runner(client, tmp_path, artifact_client=artifacts)
+    task = asyncio.create_task(runner.process_message(batch))
+    try:
+        async with asyncio.timeout(5):
+            await entered.wait()
+        published = drain_queue(runner.bus.queue)
+        collecting = published[-1]
+        assert isinstance(collecting, messages.BatchProgressUpdate)
+        assert collecting.state is ExecutionState.ARTIFACT_DOWNLOAD
+        assert collecting.status is Status.FAILURE
+        assert collecting.jobs[0].conclusion == "failure"
+        assert client.last_call("list_workflow_jobs").kwargs["per_page"] == 100
+        assert artifacts.last_call("list_workflow_run_artifacts").kwargs["per_page"] == 100
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    await runner.cancel_dispatched_runs()
+    assert client.calls_to("cancel_workflow_run") == []
+    assert drain_queue(runner.bus.queue) == []
 
 
 @pytest.mark.asyncio
@@ -344,8 +415,7 @@ async def test_uses_batch_id_not_message_id_for_correlation(tmp_path: Path):
 
     assert fake.calls_to("create_workflow_dispatch")[0].kwargs["inputs"]["batch_id"] == "batch-07"
 
-    finished = drain_queue(runner.bus.queue)[0]
-    assert isinstance(finished, BatchFinished)
+    finished = finished_messages(runner)[0]
     assert finished.id == "msg-uuid-xyz"
     assert finished.batch_id == "batch-07"
 
@@ -371,8 +441,7 @@ async def test_process_message_correlates_batch_jobs(tmp_path: Path):
         TestBatch(id="batch-c", batch_id="batch-c", job_list=[j1, j2], jobs_count=2, integrations=["ntp"])
     )
 
-    finished = drain_queue(runner.bus.queue)[0]
-    assert isinstance(finished, BatchFinished)
+    finished = finished_messages(runner)[0]
     assert finished.status == "failure"
 
     results = {r.job.name: r for r in finished.batch_jobs}
@@ -403,8 +472,7 @@ async def test_process_message_batch_job_without_workflow_match(tmp_path: Path):
         TestBatch(id="batch-d", batch_id="batch-d", job_list=[job], jobs_count=1, integrations=["ntp"])
     )
 
-    finished = drain_queue(runner.bus.queue)[0]
-    assert isinstance(finished, BatchFinished)
+    finished = finished_messages(runner)[0]
     [result] = finished.batch_jobs
     assert result.job == job
     assert result.workflow_job is None
@@ -425,8 +493,7 @@ async def test_process_message_batch_job_without_artifacts(tmp_path: Path):
         TestBatch(id="batch-e", batch_id="batch-e", job_list=[job], jobs_count=1, integrations=["ntp"])
     )
 
-    finished = drain_queue(runner.bus.queue)[0]
-    assert isinstance(finished, BatchFinished)
+    finished = finished_messages(runner)[0]
     [result] = finished.batch_jobs
     assert result.workflow_job is not None and result.workflow_job.conclusion == "success"
     assert result.artifact_name_path is None
@@ -449,44 +516,32 @@ async def test_process_message_emits_batch_finished_when_listing_jobs_fails(tmp_
     # correlated job carrying no workflow job.
     await runner.process_message(make_batch())
 
-    finished = drain_queue(runner.bus.queue)[0]
-    assert isinstance(finished, BatchFinished)
+    finished = finished_messages(runner)[0]
     assert finished.status == "success"
     assert all(result.workflow_job is None for result in finished.batch_jobs)
 
 
+@pytest.mark.parametrize(
+    ("conclusion", "expected"),
+    [
+        pytest.param("failure", Status.FAILURE, id="failure"),
+        pytest.param("skipped", Status.SKIPPED, id="skipped"),
+        pytest.param(None, Status.FAILURE, id="missing-conclusion"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_process_message_failure_path(tmp_path: Path):
+async def test_process_message_reports_completed_workflow_status(
+    tmp_path: Path, conclusion: str | None, expected: Status
+):
     fake = FakeAsyncGitHubClient()
-    fake.mock_response("get_workflow_run", make_workflow_run("completed", "failure"))
-    mock_artifacts(fake, [make_artifact(1)])
-    runner = make_runner(fake, tmp_path)
-
-    await runner.process_message(
-        TestBatch(id="batch-2", batch_id="batch-2", job_list=[make_job()], jobs_count=1, integrations=["ntp"])
-    )
-
-    submitted = drain_queue(runner.bus.queue)
-    assert len(submitted) == 1
-    finished = submitted[0]
-    assert isinstance(finished, BatchFinished)
-    assert finished.status == "failure"
-
-
-@pytest.mark.asyncio
-async def test_process_message_skipped_conclusion(tmp_path: Path):
-    fake = FakeAsyncGitHubClient()
-    fake.mock_response("get_workflow_run", make_workflow_run("completed", "skipped"))
+    fake.mock_response("get_workflow_run", make_workflow_run("completed", conclusion))
     mock_artifacts(fake, [])
     runner = make_runner(fake, tmp_path)
 
     await runner.process_message(make_batch())
 
-    submitted = drain_queue(runner.bus.queue)
-    assert len(submitted) == 1
-    finished = submitted[0]
-    assert isinstance(finished, BatchFinished)
-    assert finished.status == "skipped"
+    [finished] = finished_messages(runner)
+    assert finished.status is expected
 
 
 @pytest.mark.asyncio
@@ -503,10 +558,69 @@ async def test_process_message_polls_until_completed(tmp_path: Path):
     )
 
     assert len(fake.calls_to("get_workflow_run")) == 4
-    submitted = drain_queue(runner.bus.queue)
+    submitted = finished_messages(runner)
     assert len(submitted) == 1
-    assert isinstance(submitted[0], BatchFinished)
     assert submitted[0].status == "success"
+
+
+async def test_final_results_use_jobs_available_after_artifact_collection(tmp_path: Path):
+    client = FakeAsyncGitHubClient()
+    batch = make_batch()
+    job = batch.job_list[0]
+    client.mock_response("get_workflow_run", make_workflow_run("in_progress"), once=True)
+    mock_jobs(client, [WorkflowJob(id=1, run_id=123, name=job.name, status=WorkflowJobStatus.IN_PROGRESS)])
+    mock_artifacts(client, [make_artifact_for(1, job)])
+    download_artifact = client.download_artifact
+
+    async def download_with_settled_job(archive_download_url: str, dest_path: Path, **kwargs: Any) -> None:
+        await download_artifact(archive_download_url, dest_path, **kwargs)
+        mock_jobs(client, [make_workflow_job(job.name)])
+
+    client.download_artifact = download_with_settled_job  # type: ignore[method-assign]
+    runner = make_runner(client, tmp_path)
+
+    await runner.process_message(batch)
+
+    [finished] = finished_messages(runner)
+    result = finished.batch_jobs[0]
+    assert result.workflow_job is not None
+    assert result.workflow_job.conclusion is WorkflowJobConclusion.SUCCESS
+
+
+@pytest.mark.parametrize("last_listing", ["empty", "failed", "stale"])
+async def test_final_results_preserve_only_completed_observations(tmp_path: Path, last_listing: str):
+    client = FakeAsyncGitHubClient()
+    batch = make_batch()
+    batch.job_list.append(make_job("unfinished", environment="py3.12"))
+    batch.jobs_count = len(batch.job_list)
+    completed_job = make_workflow_job(batch.job_list[0].name)
+    unfinished_job = WorkflowJob(id=2, run_id=123, name="unfinished", status=WorkflowJobStatus.IN_PROGRESS)
+    client.mock_response("get_workflow_run", make_workflow_run("in_progress"), once=True)
+    client.mock_response(
+        "list_workflow_jobs", WorkflowJobsList(total_count=2, jobs=[completed_job, unfinished_job]), once=True
+    )
+    if last_listing == "failed":
+        client.mock_response("list_workflow_jobs", RuntimeError("listing unavailable"))
+    elif last_listing == "stale":
+        mock_jobs(
+            client,
+            [
+                WorkflowJob(id=1, run_id=123, name=completed_job.name, status=WorkflowJobStatus.IN_PROGRESS),
+                unfinished_job,
+            ],
+        )
+    runner = make_runner(client, tmp_path)
+
+    await runner.process_message(batch)
+
+    published = drain_queue(runner.bus.queue)
+    updates = [message for message in published if isinstance(message, messages.BatchProgressUpdate)]
+    assert updates[-1].jobs[0].conclusion is WorkflowJobConclusion.SUCCESS
+    assert updates[-1].jobs[1].status is WorkflowJobStatus.IN_PROGRESS
+    finished = published[-1]
+    assert isinstance(finished, BatchFinished)
+    assert finished.batch_jobs[0].workflow_job.conclusion is WorkflowJobConclusion.SUCCESS
+    assert finished.batch_jobs[1].workflow_job is None
 
 
 @pytest.mark.asyncio
@@ -534,23 +648,6 @@ async def test_process_message_skips_expired_artifacts(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_process_message_null_conclusion(tmp_path: Path):
-    fake = FakeAsyncGitHubClient()
-    fake.mock_response("get_workflow_run", make_workflow_run("completed", None))
-    mock_artifacts(fake, [])
-    runner = make_runner(fake, tmp_path)
-
-    await runner.process_message(make_batch())
-
-    # A null GitHub conclusion maps to a "failure" BatchFinished and a "neutral" check run.
-    submitted = drain_queue(runner.bus.queue)
-    assert len(submitted) == 1
-    finished = submitted[0]
-    assert isinstance(finished, BatchFinished)
-    assert finished.status == "failure"
-
-
-@pytest.mark.asyncio
 async def test_process_message_emits_batch_finished_when_listing_artifacts_fails(tmp_path: Path):
     fake = FakeAsyncGitHubClient()
     fake.mock_response("get_workflow_run", make_workflow_run("completed", "success"))
@@ -561,10 +658,9 @@ async def test_process_message_emits_batch_finished_when_listing_artifacts_fails
     # emitted, with the workflow's real conclusion.
     await runner.process_message(make_batch())
 
-    submitted = drain_queue(runner.bus.queue)
+    submitted = finished_messages(runner)
     assert len(submitted) == 1
     finished = submitted[0]
-    assert isinstance(finished, BatchFinished)
     assert finished.status == "success"
 
 
@@ -589,9 +685,8 @@ async def test_download_failure_for_one_artifact_does_not_abort_others(tmp_path:
         "https://api.github.com/artifact/2/zip",
         "https://api.github.com/artifact/3/zip",
     ]
-    submitted = drain_queue(runner.bus.queue)
+    submitted = finished_messages(runner)
     assert len(submitted) == 1
-    assert isinstance(submitted[0], BatchFinished)
     assert submitted[0].status == "success"
 
 
@@ -602,10 +697,8 @@ async def test_download_failure_for_one_artifact_does_not_abort_others(tmp_path:
 
 @pytest.mark.parametrize("failure_point", ["create_workflow_dispatch", "get_workflow_run"])
 @pytest.mark.asyncio
-async def test_a_batch_that_failed_before_finishing_emits_nothing(tmp_path: Path, failure_point: str):
-    """A half-run batch must not reach the gatherer: a `BatchFinished` here would report jobs that
-    never ran as absent results.
-    """
+async def test_failed_execution_keeps_only_known_dispatch_progress(tmp_path: Path, failure_point: str):
+    """An interrupted execution retains its run link without claiming collected results."""
     fake = FakeAsyncGitHubClient()
     fake.mock_response(failure_point, RuntimeError(f"boom-{failure_point}"))
     runner = make_runner(fake, tmp_path)
@@ -613,7 +706,14 @@ async def test_a_batch_that_failed_before_finishing_emits_nothing(tmp_path: Path
     with pytest.raises(RuntimeError, match=f"boom-{failure_point}"):
         await runner.process_message(make_batch())
 
-    assert drain_queue(runner.bus.queue) == []
+    published = drain_queue(runner.bus.queue)
+    if failure_point == "create_workflow_dispatch":
+        assert published == []
+    else:
+        [dispatched] = published
+        assert isinstance(dispatched, messages.BatchProgressUpdate)
+        assert dispatched.workflow_url == DEFAULT_DISPATCH_HTML_URL
+        assert dispatched.state is ExecutionState.QUEUED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What does this PR do?

- Publishes batch links immediately after dispatch, then refreshes individual job outcomes while workflows run.
- Compares aggregate progress in the gatherer and publishes only changed snapshots. Cumulative observations and sequence numbers protect against delayed updates.
- Shows artifact collection separately from execution. Final gathering adds JUnit details to the existing execution rather than counting another attempt.
- Reconciles final job metadata after collection and preserves missing-result errors.
- Uses the separate artifact API allowance from [#25148](https://github.com/DataDog/integrations-core/pull/25148), with 100 items per page for job and artifact listings. Artifact requests remain cancellable.
- Separates dispatch, polling, collection and progress merging into focused helpers, keeping the entry points readable.

### Motivation

[AI-7152](https://datadoghq.atlassian.net/browse/AI-7152). The comment currently waits for an entire batch's artifact collection before showing its run link or completed jobs.

Builds on merged [#25148](https://github.com/DataDog/integrations-core/pull/25148) and is now rebased onto master. Validated with focused pipeline, rendering and CLI tests, plus ddev formatting, lint and types. Legacy CI, authentication and the POC are unchanged.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required. Developer tooling; `qa/skip-qa`.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7152]: https://datadoghq.atlassian.net/browse/AI-7152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
