### PR TITLE
Make the error logging when issues are encountered while running the slurm binaries less noisy

### DIFF
--- a/slurm/changelog.d/25154.fixed
+++ b/slurm/changelog.d/25154.fixed
@@ -1,0 +1,1 @@
+Make logging when encountering binary calls issues less noisy

--- a/slurm/datadog_checks/slurm/check.py
+++ b/slurm/datadog_checks/slurm/check.py
@@ -20,6 +20,8 @@ from .constants import (
     PARTITION_MAP,
     SACCT_MAP,
     SACCT_PARAMS,
+    SCONTROL_MISSING_SPOOLDIR_MSG,
+    SCONTROL_NO_STEPS_MSG,
     SCONTROL_PARAMS,
     SCONTROL_TAG_MAPPING,
     SDIAG_MAP,
@@ -41,6 +43,30 @@ def get_subprocess_output(cmd):
         return result.stdout, result.stderr, result.returncode
     except Exception as e:
         return None, f"Error running {cmd}: {e}", 1
+
+
+def classify_scontrol_failure(err: str) -> str:
+    """Classify a non-zero `scontrol listpid` exit as 'benign', 'config' or 'error'.
+
+    Every failure inside slurm's stepd_available() returns an empty step list, so scontrol
+    prints SCONTROL_NO_STEPS_MSG for an idle node, for a missing spool directory and for an
+    unreadable one alike. Only the idle node has that line as the whole of stderr, so it is
+    matched exactly: a substring match would also swallow EACCES, leaving the check
+    collecting nothing while reporting nothing.
+
+    The spool directory check must stay ahead of the fallthrough for the same reason -- its
+    stderr carries the no-steps line too.
+    """
+    stripped = (err or "").strip()
+    if stripped == SCONTROL_NO_STEPS_MSG:
+        return 'benign'
+    if SCONTROL_MISSING_SPOOLDIR_MSG in stripped:
+        return 'config'
+    return 'error'
+
+
+# Commands whose non-zero exits are not always failures. Anything absent stays an error.
+COMMAND_FAILURE_CLASSIFIERS = {'scontrol': classify_scontrol_failure}
 
 
 def parse_duration(time_str):
@@ -129,6 +155,10 @@ class SlurmCheck(AgentCheck, ConfigMixin):
             self.scontrol_cmd = self.get_slurm_command('scontrol', SCONTROL_PARAMS)
             self.squeue_enrich_cmd = self.get_slurm_command('squeue', ["-j"])
 
+        # Commands that have already reported a static configuration problem, so that it
+        # is logged once rather than on every collection interval.
+        self._reported_config_failures = set()
+
         # Metric and Tag configuration
         self.last_run_time = None
         self.tags = self.instance.get('tags', [])
@@ -177,12 +207,32 @@ class SlurmCheck(AgentCheck, ConfigMixin):
             self.log.debug("Running %s command: %s", name, cmd)
             out, err, ret = get_subprocess_output(cmd)
             if ret != 0:
-                self.log.error("Error running %s: %s", name, err)
+                self._log_command_failure(name, err)
             elif out:
                 self.log.debug("Processing %s output", name)
                 process_func(out)
             else:
                 self.log.debug("No output from %s", name)
+
+    def _log_command_failure(self, name: str, err: str) -> None:
+        """Log a non-zero command exit at a severity matching what actually went wrong."""
+        classifier = COMMAND_FAILURE_CLASSIFIERS.get(name)
+        outcome = classifier(err) if classifier else 'error'
+
+        if outcome == 'benign':
+            self.log.debug("Nothing for %s to collect on this node: %s", name, err.strip())
+        elif outcome == 'config':
+            if name in self._reported_config_failures:
+                self.log.debug("%s still cannot collect on this node: %s", name, err.strip())
+            else:
+                self._reported_config_failures.add(name)
+                self.log.warning(
+                    "%s cannot collect on this node until the configuration is corrected: %s",
+                    name,
+                    err.strip(),
+                )
+        else:
+            self.log.error("Error running %s: %s", name, err)
 
     def process_sinfo_partition(self, output):
         # test-queue*|N/A|1/2/0/3

--- a/slurm/datadog_checks/slurm/constants.py
+++ b/slurm/datadog_checks/slurm/constants.py
@@ -22,6 +22,15 @@ SACCT_PARAMS = [
 ]
 SCONTROL_PARAMS = ["listpid"]
 
+# `scontrol listpid` exits 1 whenever it finds no job steps. This bare message, printed
+# without slurm's "scontrol: error:" prefix, is the whole of stderr only when the node is
+# genuinely idle -- every failure inside stepd_available() also returns an empty step list
+# and so prints it too, after its own prefixed error line.
+SCONTROL_NO_STEPS_MSG = "No job steps exist on this node."
+# stepd_available() failing to stat SlurmdSpoolDir. A static property of the host rather
+# than a per-interval event: the node is not running slurmd.
+SCONTROL_MISSING_SPOOLDIR_MSG = "Domain socket directory"
+
 PARTITION_MAP = {
     "tags": [
         {"name": "slurm_partition_name", "index": 0},

--- a/slurm/tests/common.py
+++ b/slurm/tests/common.py
@@ -15,6 +15,20 @@ from datadog_checks.slurm.constants import (
 SLURM_VERSION = '21.08.6'
 DEFAULT_SINFO_PATH = ['/usr/bin/sinfo']
 
+# stderr captured verbatim from Slurm 25.05.9. `scontrol listpid` exits 1 in all three
+# cases below; only the first is a node that simply has nothing to report. The other two
+# also carry the "no job steps" line because every failure inside stepd_available()
+# returns an empty step list.
+SCONTROL_IDLE_STDERR = "No job steps exist on this node.\n"
+SCONTROL_MISSING_SPOOLDIR_STDERR = (
+    "scontrol: error: Domain socket directory /var/spool/definitely-not-here: No such file or directory\n"
+    "No job steps exist on this node.\n"
+)
+SCONTROL_UNREADABLE_SPOOLDIR_STDERR = (
+    "scontrol: error: Unable to open directory: Permission denied\nNo job steps exist on this node.\n"
+)
+SINFO_CONTROLLER_DOWN_STDERR = "slurm_load_partitions: Unable to contact slurm controller (connect failure)\n"
+
 # Testing for params addition in sinfo
 SINFO_1_F = SINFO_PARTITION_PARAMS
 SINFO_2_F = SINFO_NODE_PARAMS

--- a/slurm/tests/test_unit.py
+++ b/slurm/tests/test_unit.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2024-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
 import time
 from unittest.mock import patch
 
@@ -13,7 +14,10 @@ from datadog_checks.slurm.constants import SACCT_PARAMS
 from .common import (
     DEFAULT_SINFO_PATH,
     SACCT_MAP,
+    SCONTROL_IDLE_STDERR,
     SCONTROL_MAP,
+    SCONTROL_MISSING_SPOOLDIR_STDERR,
+    SCONTROL_UNREADABLE_SPOOLDIR_STDERR,
     SDIAG_MAP,
     SINFO_1_F,
     SINFO_1_T,
@@ -21,6 +25,7 @@ from .common import (
     SINFO_2_T,
     SINFO_3_F,
     SINFO_3_T,
+    SINFO_CONTROLLER_DOWN_STDERR,
     SINFO_LEVEL_2_MAP,
     SINFO_MAP,
     SLURM_VERSION,
@@ -526,3 +531,66 @@ def test_sacct_running_job_skips_none_avgcpu(instance, aggregator):
     aggregator.assert_metric('slurm.sacct.slurm_job_avgcpu', count=0)
     aggregator.assert_metric('slurm.sacct.job.duration', value=12, count=1)
     aggregator.assert_metric('slurm.sacct.job.info', value=1, count=1)
+
+
+def command_records(caplog, level, command):
+    """Log records emitted at `level` that name the given slurm command."""
+    return [r for r in caplog.records if r.levelno == level and command in r.getMessage()]
+
+
+@patch('datadog_checks.slurm.check.get_subprocess_output')
+def test_scontrol_given_idle_node_logs_debug_instead_of_error(mock_get_subprocess_output, instance, caplog):
+    instance['collect_scontrol_stats'] = True
+    check = SlurmCheck('slurm', {}, [instance])
+    mock_get_subprocess_output.side_effect = [("", SCONTROL_IDLE_STDERR, 1)]
+
+    check.check(None)
+
+    assert not command_records(caplog, logging.ERROR, 'scontrol')
+
+
+@patch('datadog_checks.slurm.check.get_subprocess_output')
+def test_scontrol_given_missing_spool_dir_warns_once_across_runs(mock_get_subprocess_output, instance, caplog):
+    instance['collect_scontrol_stats'] = True
+    check = SlurmCheck('slurm', {}, [instance])
+    mock_get_subprocess_output.side_effect = [
+        ("", SCONTROL_MISSING_SPOOLDIR_STDERR, 1),
+        ("", SCONTROL_MISSING_SPOOLDIR_STDERR, 1),
+    ]
+
+    check.check(None)
+    check.check(None)
+
+    assert len(command_records(caplog, logging.WARNING, 'scontrol')) == 1
+    assert not command_records(caplog, logging.ERROR, 'scontrol')
+
+
+@patch('datadog_checks.slurm.check.get_subprocess_output')
+def test_scontrol_given_unreadable_spool_dir_still_logs_error(mock_get_subprocess_output, instance, caplog):
+    # EACCES prints the same "no job steps" line as an idle node, so it must not be
+    # mistaken for one. The check would otherwise collect nothing and say nothing.
+    instance['collect_scontrol_stats'] = True
+    check = SlurmCheck('slurm', {}, [instance])
+    mock_get_subprocess_output.side_effect = [("", SCONTROL_UNREADABLE_SPOOLDIR_STDERR, 1)]
+
+    check.check(None)
+
+    assert command_records(caplog, logging.ERROR, 'scontrol')
+
+
+@patch('datadog_checks.slurm.check.get_subprocess_output')
+def test_sinfo_given_unreachable_controller_still_logs_error(mock_get_subprocess_output, instance, caplog):
+    # Commands with no benign-failure classifier must keep reporting every non-zero exit.
+    instance['collect_sinfo_stats'] = True
+    instance['sinfo_collection_level'] = 1
+    instance['collect_gpu_stats'] = False
+    check = SlurmCheck('slurm', {}, [instance])
+    mock_get_subprocess_output.side_effect = [
+        ("", "", 0),
+        ("", SINFO_CONTROLLER_DOWN_STDERR, 1),
+        ("", SINFO_CONTROLLER_DOWN_STDERR, 1),
+    ]
+
+    check.check(None)
+
+    assert command_records(caplog, logging.ERROR, 'sinfo')


### PR DESCRIPTION
### What does this PR do?
https://github.com/DataDog/integrations-core/issues/25101

Make the error logging when issues are encountered while running the slurm binaries less noisy.

```
┌────────────────────────┬──────────────────────┬──────────────────────────────────┐
│       Condition        │        Today         │              After               │
├────────────────────────┼──────────────────────┼──────────────────────────────────┤
│ Idle worker            │ ERROR ×1440/day      │ debug                            │
├────────────────────────┼──────────────────────┼──────────────────────────────────┤
│ Missing SlurmdSpoolDir │ ERROR ×1440/day      │ 1× WARNING, then debug           │
├────────────────────────┼──────────────────────┼──────────────────────────────────┤
```