### PR TITLE
[SCI2-5941] OCSF - Palo Alto Networks Firewall pipeline

### DIFF
--- a/pan_firewall/assets/logs/pan.firewall.yaml
+++ b/pan_firewall/assets/logs/pan.firewall.yaml
@@ -532,6 +532,18 @@ pipeline:
         query: "*"
       processors:
         - type: grok-parser
+          name: Parse the `timestamp` attribute into `ocsf.time`
+          enabled: true
+          source: timestamp
+          samples:
+            - "2025/09/03 19:44:00"
+            - "2025-09-03T19:44:00Z"
+          grok:
+            supportRules: ""
+            matchRules: |-
+              slash_fmt %{date("yyyy/MM/dd HH:mm:ss"):ocsf.time}
+              iso_fmt %{date("yyyy-MM-dd'T'HH:mm:ss'Z'"):ocsf.time}
+        - type: grok-parser
           name: Parse the PAN-OS event time into `ocsf.time`
           enabled: true
           source: message
@@ -543,17 +555,6 @@ pipeline:
             matchRules: |-
               event_time %{data}time_generated=%{date("yyyy/MM/dd HH:mm:ss"):ocsf.time}%{data}
               receive_time %{data}timestamp=%{date("yyyy/MM/dd HH:mm:ss"):ocsf.time}%{data}
-        - type: attribute-remapper
-          name: Map `time_generated`, `timestamp` to `ocsf.time`
-          enabled: true
-          sources:
-            - time_generated
-            - timestamp
-          sourceType: attribute
-          target: ocsf.time
-          targetType: attribute
-          preserveSource: true
-          overrideOnConflict: false
         - type: string-builder-processor
           name: Add product name
           enabled: true

--- a/pan_firewall/assets/logs/pan.firewall.yaml
+++ b/pan_firewall/assets/logs/pan.firewall.yaml
@@ -645,16 +645,16 @@ pipeline:
               preserveSource: true
               overrideOnConflict: true
             - type: schema-remapper
-              name: Map `network.bytes_read` to `ocsf.traffic.bytes_in`
+              name: Map `network.bytes_written` to `ocsf.traffic.bytes_in`
               sources:
-                - network.bytes_read
+                - network.bytes_written
               target: ocsf.traffic.bytes_in
               preserveSource: true
               overrideOnConflict: true
             - type: schema-remapper
-              name: Map `network.bytes_written` to `ocsf.traffic.bytes_out`
+              name: Map `network.bytes_read` to `ocsf.traffic.bytes_out`
               sources:
-                - network.bytes_written
+                - network.bytes_read
               target: ocsf.traffic.bytes_out
               preserveSource: true
               overrideOnConflict: true

--- a/pan_firewall/assets/logs/pan.firewall.yaml
+++ b/pan_firewall/assets/logs/pan.firewall.yaml
@@ -428,11 +428,6 @@ facets:
     type: integer
   - groups:
       - OCSF
-    name: Auth Protocol
-    path: ocsf.auth_protocol
-    source: log
-  - groups:
-      - OCSF
     name: Disposition
     path: ocsf.disposition
     source: log
@@ -442,11 +437,6 @@ facets:
     path: ocsf.disposition_id
     source: log
     type: integer
-  - groups:
-      - OCSF
-    name: Dst Endpoint Hostname
-    path: ocsf.dst_endpoint.hostname
-    source: log
   - groups:
       - OCSF
     name: Finding Info Title
@@ -461,26 +451,6 @@ facets:
       - OCSF
     name: Firewall Rule Unique ID
     path: ocsf.firewall_rule.uid
-    source: log
-  - groups:
-      - OCSF
-    name: Logon Type
-    path: ocsf.logon_type
-    source: log
-  - groups:
-      - OCSF
-    name: Service Name
-    path: ocsf.service.name
-    source: log
-  - groups:
-      - OCSF
-    name: Target Name
-    path: ocsf.user.name
-    source: log
-  - groups:
-      - OCSF
-    name: User Alternate ID
-    path: ocsf.user.uid_alt
     source: log
 pipeline:
   type: pipeline
@@ -1106,197 +1076,6 @@ pipeline:
             profiles:
               - security_control
     - type: pipeline
-      name: OCSF sub pipeline for class Authentication [3002]
-      enabled: true
-      ocsf:
-        isOcsf: true
-      filter:
-        query: "@type:AUTHENTICATION"
-      processors:
-        - type: schema-processor
-          name: Apply OCSF schema for 3002
-          enabled: true
-          mappers:
-            - type: schema-remapper
-              name: Map `ocsf.time` to `ocsf.time`
-              sources:
-                - ocsf.time
-              target: ocsf.time
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
-              sources:
-                - ocsf.metadata.product.name
-              target: ocsf.metadata.product.name
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
-              sources:
-                - ocsf.metadata.product.vendor_name
-              target: ocsf.metadata.product.vendor_name
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `ocsf.metadata.product.uid` to `ocsf.metadata.product.uid`
-              sources:
-                - ocsf.metadata.product.uid
-              target: ocsf.metadata.product.uid
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `ocsf.metadata.sequence` to `ocsf.metadata.sequence`
-              sources:
-                - ocsf.metadata.sequence
-              target: ocsf.metadata.sequence
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `ocsf.metadata.event_code` to `ocsf.metadata.event_code`
-              sources:
-                - ocsf.metadata.event_code
-              target: ocsf.metadata.event_code
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `usr.id` to `ocsf.user.name`
-              sources:
-                - usr.id
-              target: ocsf.user.name
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `normalize_user` to `ocsf.user.uid_alt`
-              sources:
-                - normalize_user
-              target: ocsf.user.uid_alt
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `network.client.ip` to `ocsf.src_endpoint.ip`
-              sources:
-                - network.client.ip
-              target: ocsf.src_endpoint.ip
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `device_name` to `ocsf.dst_endpoint.hostname`
-              sources:
-                - device_name
-              target: ocsf.dst_endpoint.hostname
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `serverprofile`, `device_name` to `ocsf.service.name`
-              sources:
-                - serverprofile
-                - device_name
-              target: ocsf.service.name
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `evt.name` to `ocsf.auth_protocol`
-              sources:
-                - evt.name
-              target: ocsf.auth_protocol
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `clienttype` to `ocsf.logon_type`
-              sources:
-                - clienttype
-              target: ocsf.logon_type
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-category-mapper
-              name: ocsf.activity_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Logon
-                  id: 1
-              targets:
-                name: ocsf.activity_name
-                id: ocsf.activity_id
-            - type: schema-category-mapper
-              name: ocsf.status_id
-              categories:
-                - filter:
-                    query: "@evt.outcome:(success OR succeeded OR allow)"
-                  name: Success
-                  id: 1
-                - filter:
-                    query: "@evt.outcome:(failure OR failed OR deny)"
-                  name: Failure
-                  id: 2
-                - filter:
-                    query: "-@evt.outcome:*"
-                  name: Unknown
-                  id: 0
-                - filter:
-                    query: "*"
-                  name: Other
-                  id: 99
-              targets:
-                name: ocsf.status
-                id: ocsf.status_id
-              fallback:
-                values:
-                  ocsf.status: Other
-                  ocsf.status_id: "99"
-                sources:
-                  ocsf.status:
-                    - evt.outcome
-            - type: schema-category-mapper
-              name: ocsf.severity_id
-              categories:
-                - filter:
-                    query: "@severity:informational"
-                  name: Informational
-                  id: 1
-                - filter:
-                    query: "@severity:low"
-                  name: Low
-                  id: 2
-                - filter:
-                    query: "@severity:medium"
-                  name: Medium
-                  id: 3
-                - filter:
-                    query: "@severity:high"
-                  name: High
-                  id: 4
-                - filter:
-                    query: "@severity:critical"
-                  name: Critical
-                  id: 5
-                - filter:
-                    query: "-@severity:*"
-                  name: Unknown
-                  id: 0
-                - filter:
-                    query: "*"
-                  name: Other
-                  id: 99
-              targets:
-                name: ocsf.severity
-                id: ocsf.severity_id
-              fallback:
-                values:
-                  ocsf.severity: Other
-                  ocsf.severity_id: "99"
-                sources:
-                  ocsf.severity:
-                    - severity
-          schema:
-            schemaType: ocsf
-            version: 1.5.0
-            className: Authentication
-            classUid: 3002
-            extensions: []
-            profiles: []
-    - type: pipeline
       name: OCSF sub pipeline for class Network Activity [4001]
       enabled: true
       ocsf:
@@ -1611,7 +1390,7 @@ pipeline:
       ocsf:
         isOcsf: true
       filter:
-        query: "-@type:(TRAFFIC OR THREAT OR AUTHENTICATION)"
+        query: "-@type:(TRAFFIC OR THREAT)"
       processors:
         - type: schema-processor
           name: Apply OCSF schema for 0

--- a/pan_firewall/assets/logs/pan.firewall.yaml
+++ b/pan_firewall/assets/logs/pan.firewall.yaml
@@ -189,6 +189,189 @@ facets:
     name: Security Rule
     path: rule
     source: log
+  - groups:
+      - OCSF
+    name: Activity ID
+    path: ocsf.activity_id
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Activity Name
+    path: ocsf.activity_name
+    source: log
+  - groups:
+      - OCSF
+    name: Category
+    path: ocsf.category_name
+    source: log
+  - groups:
+      - OCSF
+    name: Category ID
+    path: ocsf.category_uid
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Class
+    path: ocsf.class_name
+    source: log
+  - groups:
+      - OCSF
+    name: Class ID
+    path: ocsf.class_uid
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Type Name
+    path: ocsf.type_name
+    source: log
+  - groups:
+      - OCSF
+    name: Type ID
+    path: ocsf.type_uid
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Severity
+    path: ocsf.severity
+    source: log
+  - groups:
+      - OCSF
+    name: Severity ID
+    path: ocsf.severity_id
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Status
+    path: ocsf.status
+    source: log
+  - groups:
+      - OCSF
+    name: Status ID
+    path: ocsf.status_id
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Status Detail
+    path: ocsf.status_detail
+    source: log
+  - groups:
+      - OCSF
+    name: Is Alert
+    path: ocsf.is_alert
+    source: log
+  - groups:
+      - OCSF
+    name: Event Code
+    path: ocsf.metadata.event_code
+    source: log
+  - groups:
+      - OCSF
+    name: Product Name
+    path: ocsf.metadata.product.name
+    source: log
+  - groups:
+      - OCSF
+    name: Vendor Name
+    path: ocsf.metadata.product.vendor_name
+    source: log
+  - groups:
+      - OCSF
+    name: Product UID
+    path: ocsf.metadata.product.uid
+    source: log
+  - groups:
+      - OCSF
+    name: Source IP Address
+    path: ocsf.src_endpoint.ip
+    source: log
+  - groups:
+      - OCSF
+    name: Source Port
+    path: ocsf.src_endpoint.port
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Destination IP Address
+    path: ocsf.dst_endpoint.ip
+    source: log
+  - groups:
+      - OCSF
+    name: Destination Port
+    path: ocsf.dst_endpoint.port
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Connection Direction
+    path: ocsf.connection_info.direction
+    source: log
+  - groups:
+      - OCSF
+    name: Protocol Name
+    path: ocsf.connection_info.protocol_name
+    source: log
+  - groups:
+      - OCSF
+    name: Session ID
+    path: ocsf.connection_info.session.uid
+    source: log
+  - groups:
+      - OCSF
+    name: Traffic Bytes
+    path: ocsf.traffic.bytes
+    source: log
+  - groups:
+      - OCSF
+    name: Traffic Bytes In
+    path: ocsf.traffic.bytes_in
+    source: log
+  - groups:
+      - OCSF
+    name: Traffic Bytes Out
+    path: ocsf.traffic.bytes_out
+    source: log
+  - groups:
+      - OCSF
+    name: Traffic Packets
+    path: ocsf.traffic.packets
+    source: log
+  - groups:
+      - OCSF
+    name: Traffic Packets In
+    path: ocsf.traffic.packets_in
+    source: log
+  - groups:
+      - OCSF
+    name: Traffic Packets Out
+    path: ocsf.traffic.packets_out
+    source: log
+  - groups:
+      - OCSF
+    name: Finding UID
+    path: ocsf.finding_info.uid
+    source: log
+  - groups:
+      - OCSF
+    name: Analytic Name
+    path: ocsf.finding_info.analytic.name
+    source: log
+  - groups:
+      - OCSF
+    name: Analytic Category
+    path: ocsf.finding_info.analytic.category
+    source: log
+  - groups:
+      - OCSF
+    name: Evidences
+    path: ocsf.evidences
+    source: log
 pipeline:
   type: pipeline
   name: Palo Alto Networks Firewall
@@ -230,4 +413,814 @@ pipeline:
       target: title
       template: '%{usr.id} performed event %{evt.name} from %{network.client.geoip.country.name}'
       replaceMissing: false
+    - type: pipeline
+      name: OCSF pre transformations
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "*"
+      processors:
+        - type: grok-parser
+          name: Parse the PAN-OS event time into `ocsf.time`
+          enabled: true
+          source: message
+          samples:
+            - "<14>Sep  3 19:40:32 PA-3220 timestamp=2025/09/03 19:40:32, serial=016201026426, type=TRAFFIC, subtype=end, time_generated=2025/09/03 19:40:32, network.client.ip=172.16.28.190"
+            - "timestamp=2019/05/06 16:43:53, serial=001801010877, type=AUTHENTICATION, subtype=virus, vsys=testVM"
+          grok:
+            supportRules: ""
+            matchRules: |-
+              event_time %{data}time_generated=%{date("yyyy/MM/dd HH:mm:ss"):ocsf.time}%{data}
+              receive_time %{data}timestamp=%{date("yyyy/MM/dd HH:mm:ss"):ocsf.time}%{data}
+        - type: string-builder-processor
+          name: Add product name
+          enabled: true
+          template: Palo Alto Networks Firewall
+          target: ocsf.metadata.product.name
+          replaceMissing: false
+        - type: string-builder-processor
+          name: Add product vendor
+          enabled: true
+          template: Palo Alto Networks
+          target: ocsf.metadata.product.vendor_name
+          replaceMissing: false
+        - type: attribute-remapper
+          name: Map `serial` to `ocsf.metadata.product.uid`
+          enabled: true
+          sources:
+            - serial
+          sourceType: attribute
+          target: ocsf.metadata.product.uid
+          targetType: attribute
+          targetFormat: string
+          preserveSource: true
+          overrideOnConflict: true
+        - type: attribute-remapper
+          name: Map `seqno` to `ocsf.metadata.sequence`
+          enabled: true
+          sources:
+            - seqno
+          sourceType: attribute
+          target: ocsf.metadata.sequence
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: true
+        - type: attribute-remapper
+          name: Map `type` to `ocsf.metadata.event_code`
+          enabled: true
+          sources:
+            - type
+          sourceType: attribute
+          target: ocsf.metadata.event_code
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: true
+    - type: pipeline
+      name: OCSF sub pipeline for class Network Activity [4001]
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "@type:TRAFFIC"
+      processors:
+        - type: arithmetic-processor
+          name: Calculate total packets
+          enabled: true
+          expression: (pkts_sent + pkts_received)
+          target: ocsf.traffic.packets
+          isReplaceMissing: false
+        - type: schema-processor
+          name: Apply OCSF schema for 4001
+          enabled: true
+          mappers:
+            - type: schema-remapper
+              name: Map `ocsf.time`, `time_generated`, `timestamp` to `ocsf.time`
+              sources:
+                - ocsf.time
+                - time_generated
+                - timestamp
+              target: ocsf.time
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
+              sources:
+                - ocsf.metadata.product.name
+              target: ocsf.metadata.product.name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
+              sources:
+                - ocsf.metadata.product.vendor_name
+              target: ocsf.metadata.product.vendor_name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.uid` to `ocsf.metadata.product.uid`
+              sources:
+                - ocsf.metadata.product.uid
+              target: ocsf.metadata.product.uid
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.sequence` to `ocsf.metadata.sequence`
+              sources:
+                - ocsf.metadata.sequence
+              target: ocsf.metadata.sequence
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.event_code` to `ocsf.metadata.event_code`
+              sources:
+                - ocsf.metadata.event_code
+              target: ocsf.metadata.event_code
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `sessionid` to `ocsf.connection_info.session.uid`
+              sources:
+                - sessionid
+              sourceType: attribute
+              target: ocsf.connection_info.session.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `network.client.ip` to `ocsf.src_endpoint.ip`
+              sources:
+                - network.client.ip
+              target: ocsf.src_endpoint.ip
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `network.client.port` to `ocsf.src_endpoint.port`
+              sources:
+                - network.client.port
+              target: ocsf.src_endpoint.port
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `network.destination.ip` to `ocsf.dst_endpoint.ip`
+              sources:
+                - network.destination.ip
+              target: ocsf.dst_endpoint.ip
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `network.destination.port` to `ocsf.dst_endpoint.port`
+              sources:
+                - network.destination.port
+              target: ocsf.dst_endpoint.port
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `proto` to `ocsf.connection_info.protocol_name`
+              sources:
+                - proto
+              target: ocsf.connection_info.protocol_name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `bytes` to `ocsf.traffic.bytes`
+              sources:
+                - bytes
+              target: ocsf.traffic.bytes
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `network.bytes_read` to `ocsf.traffic.bytes_in`
+              sources:
+                - network.bytes_read
+              target: ocsf.traffic.bytes_in
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `network.bytes_written` to `ocsf.traffic.bytes_out`
+              sources:
+                - network.bytes_written
+              target: ocsf.traffic.bytes_out
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `packets`, `ocsf.traffic.packets` to `ocsf.traffic.packets`
+              sources:
+                - packets
+                - ocsf.traffic.packets
+              target: ocsf.traffic.packets
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `pkts_received` to `ocsf.traffic.packets_in`
+              sources:
+                - pkts_received
+              target: ocsf.traffic.packets_in
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `pkts_sent` to `ocsf.traffic.packets_out`
+              sources:
+                - pkts_sent
+              target: ocsf.traffic.packets_out
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `chunks` to `ocsf.traffic.chunks`
+              sources:
+                - chunks
+              target: ocsf.traffic.chunks
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `chunks_received` to `ocsf.traffic.chunks_in`
+              sources:
+                - chunks_received
+              target: ocsf.traffic.chunks_in
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `chunks_sent` to `ocsf.traffic.chunks_out`
+              sources:
+                - chunks_sent
+              target: ocsf.traffic.chunks_out
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-category-mapper
+              name: ocsf.activity_id
+              categories:
+                - filter:
+                    query: "@subtype:start"
+                  name: Open
+                  id: 1
+                - filter:
+                    query: "@subtype:end"
+                  name: Close
+                  id: 2
+                - filter:
+                    query: "@subtype:drop"
+                  name: Reset
+                  id: 3
+                - filter:
+                    query: "@subtype:deny"
+                  name: Refuse
+                  id: 5
+                - filter:
+                    query: "*"
+                  name: Other
+                  id: 99
+              targets:
+                name: ocsf.activity_name
+                id: ocsf.activity_id
+            - type: schema-category-mapper
+              name: ocsf.connection_info.direction_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.connection_info.direction
+                id: ocsf.connection_info.direction_id
+            - type: schema-category-mapper
+              name: ocsf.severity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Informational
+                  id: 1
+              targets:
+                name: ocsf.severity
+                id: ocsf.severity_id
+          schema:
+            schemaType: ocsf
+            version: 1.5.0
+            className: Network Activity
+            classUid: 4001
+            extensions: []
+            profiles: []
+    - type: pipeline
+      name: misc field filename extraction
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "@type:THREAT @subtype:(file OR virus OR wildfire-virus OR wildfire)"
+      processors:
+        - type: attribute-remapper
+          name: Map `misc` to `ocsf.evidence.file.name`
+          enabled: true
+          sources:
+            - misc
+          sourceType: attribute
+          target: ocsf.evidence.file.name
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: true
+        - type: string-builder-processor
+          name: Add type_id
+          enabled: true
+          template: "1"
+          target: ocsf.evidence.file.type_id
+          replaceMissing: false
+        - type: attribute-remapper
+          name: Cast `ocsf.evidence.file.type_id` to integer
+          enabled: true
+          sources:
+            - ocsf.evidence.file.type_id
+          sourceType: attribute
+          target: ocsf.evidence.file.type_id
+          targetType: attribute
+          targetFormat: integer
+          preserveSource: false
+          overrideOnConflict: true
+        - type: string-builder-processor
+          name: Add type
+          enabled: true
+          template: "Regular File"
+          target: ocsf.evidence.file.type
+          replaceMissing: false
+    - type: pipeline
+      name: OCSF sub pipeline for class Detection Finding [2004]
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "@type:THREAT"
+      processors:
+        - type: string-builder-processor
+          name: Set is_alert to boolean true
+          enabled: true
+          template: "true"
+          target: ocsf.is_alert
+          replaceMissing: false
+        - type: grok-parser
+          name: Convert `ocsf.is_alert` string to boolean
+          enabled: true
+          source: ocsf.is_alert
+          samples:
+            - "true"
+          grok:
+            supportRules: ""
+            matchRules: to_bool %{boolean("true","false"):ocsf.is_alert}
+        - type: attribute-remapper
+          name: Map `sessionid` to `ocsf.evidence.actor.session.uid`
+          enabled: true
+          sources:
+            - sessionid
+          sourceType: attribute
+          target: ocsf.evidence.actor.session.uid
+          targetType: attribute
+          targetFormat: string
+          preserveSource: true
+          overrideOnConflict: true
+        - type: attribute-remapper
+          name: Map `source_zone`, `from` to `ocsf.evidence.src_endpoint.zone`
+          enabled: true
+          sources:
+            - source_zone
+            - from
+          sourceType: attribute
+          target: ocsf.evidence.src_endpoint.zone
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: true
+        - type: attribute-remapper
+          name: Map `destination_zone`, `to` to `ocsf.evidence.dst_endpoint.zone`
+          enabled: true
+          sources:
+            - destination_zone
+            - to
+          sourceType: attribute
+          target: ocsf.evidence.dst_endpoint.zone
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: true
+        - type: attribute-remapper
+          name: Map `usr.id` to `ocsf.evidence.actor.user.name`
+          enabled: true
+          sources:
+            - usr.id
+          sourceType: attribute
+          target: ocsf.evidence.actor.user.name
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: true
+        - type: attribute-remapper
+          name: Map `app` to `ocsf.evidence.actor.app_name`
+          enabled: true
+          sources:
+            - app
+          sourceType: attribute
+          target: ocsf.evidence.actor.app_name
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: true
+        - type: attribute-remapper
+          name: Map `proto` to `ocsf.evidence.connection_info.protocol_name`
+          enabled: true
+          sources:
+            - proto
+          sourceType: attribute
+          target: ocsf.evidence.connection_info.protocol_name
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: true
+        - type: attribute-remapper
+          name: Map `network.client.ip` to `ocsf.evidence.src_endpoint.ip`
+          enabled: true
+          sources:
+            - network.client.ip
+          sourceType: attribute
+          target: ocsf.evidence.src_endpoint.ip
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: true
+        - type: attribute-remapper
+          name: Map `network.client.port` to `ocsf.evidence.src_endpoint.port`
+          enabled: true
+          sources:
+            - network.client.port
+          sourceType: attribute
+          target: ocsf.evidence.src_endpoint.port
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: true
+        - type: attribute-remapper
+          name: Map `network.destination.ip` to `ocsf.evidence.dst_endpoint.ip`
+          enabled: true
+          sources:
+            - network.destination.ip
+          sourceType: attribute
+          target: ocsf.evidence.dst_endpoint.ip
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: true
+        - type: attribute-remapper
+          name: Map `network.destination.port` to `ocsf.evidence.dst_endpoint.port`
+          enabled: true
+          sources:
+            - network.destination.port
+          sourceType: attribute
+          target: ocsf.evidence.dst_endpoint.port
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: true
+        - type: attribute-remapper
+          name: Map `device_name` to `ocsf.evidence.device.name`
+          enabled: true
+          sources:
+            - device_name
+          sourceType: attribute
+          target: ocsf.evidence.device.name
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: true
+        - type: string-builder-processor
+          name: Add direction_id
+          enabled: true
+          template: "0"
+          target: ocsf.evidence.connection_info.direction_id
+          replaceMissing: false
+        - type: attribute-remapper
+          name: Cast `ocsf.evidence.connection_info.direction_id` to integer
+          enabled: true
+          sources:
+            - ocsf.evidence.connection_info.direction_id
+          sourceType: attribute
+          target: ocsf.evidence.connection_info.direction_id
+          targetType: attribute
+          targetFormat: integer
+          preserveSource: false
+          overrideOnConflict: true
+        - type: string-builder-processor
+          name: Add direction
+          enabled: true
+          template: "Unknown"
+          target: ocsf.evidence.connection_info.direction
+          replaceMissing: false
+        - type: string-builder-processor
+          name: Add type_id
+          enabled: true
+          template: "9"
+          target: ocsf.evidence.device.type_id
+          replaceMissing: false
+        - type: attribute-remapper
+          name: Cast `ocsf.evidence.device.type_id` to integer
+          enabled: true
+          sources:
+            - ocsf.evidence.device.type_id
+          sourceType: attribute
+          target: ocsf.evidence.device.type_id
+          targetType: attribute
+          targetFormat: integer
+          preserveSource: false
+          overrideOnConflict: true
+        - type: string-builder-processor
+          name: Add type
+          enabled: true
+          template: "Firewall"
+          target: ocsf.evidence.device.type
+          replaceMissing: false
+        - type: array-processor
+          name: Move `ocsf.evidence` into the `ocsf.evidences` array
+          enabled: true
+          operation:
+            source: ocsf.evidence
+            target: ocsf.evidences
+            preserveSource: false
+            type: append
+        - type: schema-processor
+          name: Apply OCSF schema for 2004
+          enabled: true
+          mappers:
+            - type: schema-remapper
+              name: Map `ocsf.time`, `time_generated`, `timestamp` to `ocsf.time`
+              sources:
+                - ocsf.time
+                - time_generated
+                - timestamp
+              target: ocsf.time
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
+              sources:
+                - ocsf.metadata.product.name
+              target: ocsf.metadata.product.name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
+              sources:
+                - ocsf.metadata.product.vendor_name
+              target: ocsf.metadata.product.vendor_name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.uid` to `ocsf.metadata.product.uid`
+              sources:
+                - ocsf.metadata.product.uid
+              target: ocsf.metadata.product.uid
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.sequence` to `ocsf.metadata.sequence`
+              sources:
+                - ocsf.metadata.sequence
+              target: ocsf.metadata.sequence
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.event_code` to `ocsf.metadata.event_code`
+              sources:
+                - ocsf.metadata.event_code
+              target: ocsf.metadata.event_code
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.is_alert` to `ocsf.is_alert`
+              sources:
+                - ocsf.is_alert
+              target: ocsf.is_alert
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.evidences` to `ocsf.evidences`
+              sources:
+                - ocsf.evidences
+              target: ocsf.evidences
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.name` to `ocsf.finding_info.product.name`
+              sources:
+                - ocsf.metadata.product.name
+              target: ocsf.finding_info.product.name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.vendor_name` to `ocsf.finding_info.product.vendor_name`
+              sources:
+                - ocsf.metadata.product.vendor_name
+              target: ocsf.finding_info.product.vendor_name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `seqno` to `ocsf.finding_info.uid`
+              sources:
+                - seqno
+              sourceType: attribute
+              target: ocsf.finding_info.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `rule_uuid` to `ocsf.finding_info.analytic.uid`
+              sources:
+                - rule_uuid
+              target: ocsf.finding_info.analytic.uid
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `rule` to `ocsf.finding_info.analytic.name`
+              sources:
+                - rule
+              target: ocsf.finding_info.analytic.name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `subtype` to `ocsf.finding_info.analytic.category`
+              sources:
+                - subtype
+              target: ocsf.finding_info.analytic.category
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `evt.name` to `ocsf.status_detail`
+              sources:
+                - evt.name
+              target: ocsf.status_detail
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-category-mapper
+              name: ocsf.activity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Create
+                  id: 1
+              targets:
+                name: ocsf.activity_name
+                id: ocsf.activity_id
+            - type: schema-category-mapper
+              name: ocsf.status_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: New
+                  id: 1
+              targets:
+                name: ocsf.status
+                id: ocsf.status_id
+            - type: schema-category-mapper
+              name: ocsf.confidence_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.confidence
+                id: ocsf.confidence_id
+            - type: schema-category-mapper
+              name: ocsf.finding_info.analytic.type_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Rule
+                  id: 1
+              targets:
+                name: ocsf.finding_info.analytic.type
+                id: ocsf.finding_info.analytic.type_id
+            - type: schema-category-mapper
+              name: ocsf.severity_id
+              categories:
+                - filter:
+                    query: "@severity:informational"
+                  name: Informational
+                  id: 1
+                - filter:
+                    query: "@severity:low"
+                  name: Low
+                  id: 2
+                - filter:
+                    query: "@severity:medium"
+                  name: Medium
+                  id: 3
+                - filter:
+                    query: "@severity:high"
+                  name: High
+                  id: 4
+                - filter:
+                    query: "@severity:critical"
+                  name: Critical
+                  id: 5
+                - filter:
+                    query: "*"
+                  name: Informational
+                  id: 1
+              targets:
+                name: ocsf.severity
+                id: ocsf.severity_id
+          schema:
+            schemaType: ocsf
+            version: 1.5.0
+            className: Detection Finding
+            classUid: 2004
+            extensions: []
+            profiles: []
+    - type: pipeline
+      name: OCSF sub pipeline for class Base Event [0]
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "-@type:(TRAFFIC OR THREAT)"
+      processors:
+        - type: schema-processor
+          name: Apply OCSF schema for 0
+          enabled: true
+          mappers:
+            - type: schema-remapper
+              name: Map `ocsf.time`, `time_generated`, `timestamp` to `ocsf.time`
+              sources:
+                - ocsf.time
+                - time_generated
+                - timestamp
+              target: ocsf.time
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
+              sources:
+                - ocsf.metadata.product.name
+              target: ocsf.metadata.product.name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
+              sources:
+                - ocsf.metadata.product.vendor_name
+              target: ocsf.metadata.product.vendor_name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.uid` to `ocsf.metadata.product.uid`
+              sources:
+                - ocsf.metadata.product.uid
+              target: ocsf.metadata.product.uid
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.sequence` to `ocsf.metadata.sequence`
+              sources:
+                - ocsf.metadata.sequence
+              target: ocsf.metadata.sequence
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.event_code` to `ocsf.metadata.event_code`
+              sources:
+                - ocsf.metadata.event_code
+              target: ocsf.metadata.event_code
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-category-mapper
+              name: ocsf.activity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Other
+                  id: 99
+              targets:
+                name: ocsf.activity_name
+                id: ocsf.activity_id
+            - type: schema-category-mapper
+              name: ocsf.severity_id
+              categories:
+                - filter:
+                    query: "@severity:informational"
+                  name: Informational
+                  id: 1
+                - filter:
+                    query: "@severity:low"
+                  name: Low
+                  id: 2
+                - filter:
+                    query: "@severity:medium"
+                  name: Medium
+                  id: 3
+                - filter:
+                    query: "@severity:high"
+                  name: High
+                  id: 4
+                - filter:
+                    query: "@severity:critical"
+                  name: Critical
+                  id: 5
+                - filter:
+                    query: "*"
+                  name: Informational
+                  id: 1
+              targets:
+                name: ocsf.severity
+                id: ocsf.severity_id
+          schema:
+            schemaType: ocsf
+            version: 1.5.0
+            className: Base Event
+            classUid: 0
+            extensions: []
+            profiles: []
 

--- a/pan_firewall/assets/logs/pan.firewall.yaml
+++ b/pan_firewall/assets/logs/pan.firewall.yaml
@@ -262,12 +262,6 @@ facets:
     source: log
   - groups:
       - OCSF
-    name: Alert
-    path: ocsf.is_alert
-    source: log
-    type: boolean
-  - groups:
-      - OCSF
     name: Event Code
     path: ocsf.metadata.event_code
     source: log
@@ -312,12 +306,12 @@ facets:
     type: integer
   - groups:
       - OCSF
-    name: Connection Direction
+    name: Connection Info Direction
     path: ocsf.connection_info.direction
     source: log
   - groups:
       - OCSF
-    name: Connection Info Protocol Name
+    name: Protocol Name
     path: ocsf.connection_info.protocol_name
     source: log
   - groups:
@@ -330,37 +324,31 @@ facets:
     name: Traffic Bytes
     path: ocsf.traffic.bytes
     source: log
-    type: integer
   - groups:
       - OCSF
     name: Traffic Bytes In
     path: ocsf.traffic.bytes_in
     source: log
-    type: integer
   - groups:
       - OCSF
     name: Traffic Bytes Out
     path: ocsf.traffic.bytes_out
     source: log
-    type: integer
   - groups:
       - OCSF
     name: Traffic Packets
     path: ocsf.traffic.packets
     source: log
-    type: integer
   - groups:
       - OCSF
     name: Traffic Packets In
     path: ocsf.traffic.packets_in
     source: log
-    type: integer
   - groups:
       - OCSF
     name: Traffic Packets Out
     path: ocsf.traffic.packets_out
     source: log
-    type: integer
   - groups:
       - OCSF
     name: Finding Info Unique ID
@@ -368,7 +356,7 @@ facets:
     source: log
   - groups:
       - OCSF
-    name: Finding Information Analytic Name
+    name: Finding Info Analytic Name
     path: ocsf.finding_info.analytic.name
     source: log
   - groups:
@@ -396,7 +384,7 @@ facets:
     type: integer
   - groups:
       - OCSF
-    name: Finding Information Product Name
+    name: Finding Info Product Name
     path: ocsf.finding_info.product.name
     source: log
   - groups:
@@ -406,7 +394,7 @@ facets:
     source: log
   - groups:
       - OCSF
-    name: Finding Information Analytic Unique ID
+    name: Finding Info Analytic UID
     path: ocsf.finding_info.analytic.uid
     source: log
   - groups:

--- a/pan_firewall/assets/logs/pan.firewall.yaml
+++ b/pan_firewall/assets/logs/pan.firewall.yaml
@@ -262,9 +262,10 @@ facets:
     source: log
   - groups:
       - OCSF
-    name: Is Alert
+    name: Alert
     path: ocsf.is_alert
     source: log
+    type: boolean
   - groups:
       - OCSF
     name: Event Code
@@ -282,7 +283,7 @@ facets:
     source: log
   - groups:
       - OCSF
-    name: Product UID
+    name: Metadata Product Unique ID
     path: ocsf.metadata.product.uid
     source: log
   - groups:
@@ -290,9 +291,10 @@ facets:
     name: Source IP Address
     path: ocsf.src_endpoint.ip
     source: log
-  - groups:
+  - facetType: range
+    groups:
       - OCSF
-    name: Source Port
+    name: Src Endpoint Port
     path: ocsf.src_endpoint.port
     source: log
     type: integer
@@ -301,9 +303,10 @@ facets:
     name: Destination IP Address
     path: ocsf.dst_endpoint.ip
     source: log
-  - groups:
+  - facetType: range
+    groups:
       - OCSF
-    name: Destination Port
+    name: Dst Endpoint Port
     path: ocsf.dst_endpoint.port
     source: log
     type: integer
@@ -314,12 +317,12 @@ facets:
     source: log
   - groups:
       - OCSF
-    name: Protocol Name
+    name: Connection Info Protocol Name
     path: ocsf.connection_info.protocol_name
     source: log
   - groups:
       - OCSF
-    name: Session ID
+    name: Connection Info Session Unique ID
     path: ocsf.connection_info.session.uid
     source: log
   - groups:
@@ -327,44 +330,50 @@ facets:
     name: Traffic Bytes
     path: ocsf.traffic.bytes
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Traffic Bytes In
     path: ocsf.traffic.bytes_in
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Traffic Bytes Out
     path: ocsf.traffic.bytes_out
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Traffic Packets
     path: ocsf.traffic.packets
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Traffic Packets In
     path: ocsf.traffic.packets_in
     source: log
+    type: integer
   - groups:
       - OCSF
     name: Traffic Packets Out
     path: ocsf.traffic.packets_out
     source: log
+    type: integer
   - groups:
       - OCSF
-    name: Finding UID
+    name: Finding Info Unique ID
     path: ocsf.finding_info.uid
     source: log
   - groups:
       - OCSF
-    name: Analytic Name
+    name: Finding Information Analytic Name
     path: ocsf.finding_info.analytic.name
     source: log
   - groups:
       - OCSF
-    name: Analytic Category
+    name: Finding Information Analytic Category
     path: ocsf.finding_info.analytic.category
     source: log
   - groups:
@@ -372,6 +381,52 @@ facets:
     name: Evidences
     path: ocsf.evidences
     source: log
+  - facetType: range
+    groups:
+      - OCSF
+    name: Event Time
+    path: ocsf.time
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Metadata Sequence Number
+    path: ocsf.metadata.sequence
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Finding Information Product Name
+    path: ocsf.finding_info.product.name
+    source: log
+  - groups:
+      - OCSF
+    name: Finding Information Product Vendor Name
+    path: ocsf.finding_info.product.vendor_name
+    source: log
+  - groups:
+      - OCSF
+    name: Finding Information Analytic Unique ID
+    path: ocsf.finding_info.analytic.uid
+    source: log
+  - groups:
+      - OCSF
+    name: Traffic Chunks
+    path: ocsf.traffic.chunks
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Traffic Chunks In
+    path: ocsf.traffic.chunks_in
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Traffic Chunks Out
+    path: ocsf.traffic.chunks_out
+    source: log
+    type: integer
 pipeline:
   type: pipeline
   name: Palo Alto Networks Firewall
@@ -672,6 +727,13 @@ pipeline:
               targets:
                 name: ocsf.activity_name
                 id: ocsf.activity_id
+              fallback:
+                values:
+                  ocsf.activity_name: Other
+                  ocsf.activity_id: "99"
+                sources:
+                  ocsf.activity_name:
+                    - subtype
             - type: schema-category-mapper
               name: ocsf.connection_info.direction_id
               categories:
@@ -724,7 +786,7 @@ pipeline:
           target: ocsf.evidence.file.type_id
           replaceMissing: false
         - type: attribute-remapper
-          name: Cast `ocsf.evidence.file.type_id` to integer
+          name: Map `ocsf.evidence.file.type_id` to `ocsf.evidence.file.type_id`
           enabled: true
           sources:
             - ocsf.evidence.file.type_id
@@ -883,7 +945,7 @@ pipeline:
           target: ocsf.evidence.connection_info.direction_id
           replaceMissing: false
         - type: attribute-remapper
-          name: Cast `ocsf.evidence.connection_info.direction_id` to integer
+          name: Map `ocsf.evidence.connection_info.direction_id` to `ocsf.evidence.connection_info.direction_id`
           enabled: true
           sources:
             - ocsf.evidence.connection_info.direction_id
@@ -906,7 +968,7 @@ pipeline:
           target: ocsf.evidence.device.type_id
           replaceMissing: false
         - type: attribute-remapper
-          name: Cast `ocsf.evidence.device.type_id` to integer
+          name: Map `ocsf.evidence.device.type_id` to `ocsf.evidence.device.type_id`
           enabled: true
           sources:
             - ocsf.evidence.device.type_id
@@ -1107,12 +1169,23 @@ pipeline:
                   name: Critical
                   id: 5
                 - filter:
+                    query: "-@severity:*"
+                  name: Unknown
+                  id: 0
+                - filter:
                     query: "*"
-                  name: Informational
-                  id: 1
+                  name: Other
+                  id: 99
               targets:
                 name: ocsf.severity
                 id: ocsf.severity_id
+              fallback:
+                values:
+                  ocsf.severity: Other
+                  ocsf.severity_id: "99"
+                sources:
+                  ocsf.severity:
+                    - severity
           schema:
             schemaType: ocsf
             version: 1.5.0
@@ -1186,6 +1259,13 @@ pipeline:
               targets:
                 name: ocsf.activity_name
                 id: ocsf.activity_id
+              fallback:
+                values:
+                  ocsf.activity_name: Other
+                  ocsf.activity_id: "99"
+                sources:
+                  ocsf.activity_name:
+                    - type
             - type: schema-category-mapper
               name: ocsf.severity_id
               categories:
@@ -1210,12 +1290,23 @@ pipeline:
                   name: Critical
                   id: 5
                 - filter:
+                    query: "-@severity:*"
+                  name: Unknown
+                  id: 0
+                - filter:
                     query: "*"
-                  name: Informational
-                  id: 1
+                  name: Other
+                  id: 99
               targets:
                 name: ocsf.severity
                 id: ocsf.severity_id
+              fallback:
+                values:
+                  ocsf.severity: Other
+                  ocsf.severity_id: "99"
+                sources:
+                  ocsf.severity:
+                    - severity
           schema:
             schemaType: ocsf
             version: 1.5.0

--- a/pan_firewall/assets/logs/pan.firewall.yaml
+++ b/pan_firewall/assets/logs/pan.firewall.yaml
@@ -415,6 +415,73 @@ facets:
     path: ocsf.traffic.chunks_out
     source: log
     type: integer
+  - groups:
+      - OCSF
+    name: Action
+    path: ocsf.action
+    source: log
+  - groups:
+      - OCSF
+    name: Action ID
+    path: ocsf.action_id
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Auth Protocol
+    path: ocsf.auth_protocol
+    source: log
+  - groups:
+      - OCSF
+    name: Disposition
+    path: ocsf.disposition
+    source: log
+  - groups:
+      - OCSF
+    name: Disposition ID
+    path: ocsf.disposition_id
+    source: log
+    type: integer
+  - groups:
+      - OCSF
+    name: Dst Endpoint Hostname
+    path: ocsf.dst_endpoint.hostname
+    source: log
+  - groups:
+      - OCSF
+    name: Finding Info Title
+    path: ocsf.finding_info.title
+    source: log
+  - groups:
+      - OCSF
+    name: Firewall Rule Name
+    path: ocsf.firewall_rule.name
+    source: log
+  - groups:
+      - OCSF
+    name: Firewall Rule Unique ID
+    path: ocsf.firewall_rule.uid
+    source: log
+  - groups:
+      - OCSF
+    name: Logon Type
+    path: ocsf.logon_type
+    source: log
+  - groups:
+      - OCSF
+    name: Service Name
+    path: ocsf.service.name
+    source: log
+  - groups:
+      - OCSF
+    name: Target Name
+    path: ocsf.user.name
+    source: log
+  - groups:
+      - OCSF
+    name: User Alternate ID
+    path: ocsf.user.uid_alt
+    source: log
 pipeline:
   type: pipeline
   name: Palo Alto Networks Firewall
@@ -476,6 +543,17 @@ pipeline:
             matchRules: |-
               event_time %{data}time_generated=%{date("yyyy/MM/dd HH:mm:ss"):ocsf.time}%{data}
               receive_time %{data}timestamp=%{date("yyyy/MM/dd HH:mm:ss"):ocsf.time}%{data}
+        - type: attribute-remapper
+          name: Map `time_generated`, `timestamp` to `ocsf.time`
+          enabled: true
+          sources:
+            - time_generated
+            - timestamp
+          sourceType: attribute
+          target: ocsf.time
+          targetType: attribute
+          preserveSource: true
+          overrideOnConflict: false
         - type: string-builder-processor
           name: Add product name
           enabled: true
@@ -520,235 +598,23 @@ pipeline:
           preserveSource: true
           overrideOnConflict: true
     - type: pipeline
-      name: OCSF sub pipeline for class Network Activity [4001]
+      name: misc field URL extraction
       enabled: true
       ocsf:
         isOcsf: true
       filter:
-        query: "@type:TRAFFIC"
+        query: "@type:THREAT @subtype:url"
       processors:
-        - type: arithmetic-processor
-          name: Calculate total packets
+        - type: grok-parser
+          name: Parse `misc` to `ocsf.evidence.url.url_string`
           enabled: true
-          expression: (pkts_sent + pkts_received)
-          target: ocsf.traffic.packets
-          isReplaceMissing: false
-        - type: schema-processor
-          name: Apply OCSF schema for 4001
-          enabled: true
-          mappers:
-            - type: schema-remapper
-              name: Map `ocsf.time`, `time_generated`, `timestamp` to `ocsf.time`
-              sources:
-                - ocsf.time
-                - time_generated
-                - timestamp
-              target: ocsf.time
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
-              sources:
-                - ocsf.metadata.product.name
-              target: ocsf.metadata.product.name
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
-              sources:
-                - ocsf.metadata.product.vendor_name
-              target: ocsf.metadata.product.vendor_name
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `ocsf.metadata.product.uid` to `ocsf.metadata.product.uid`
-              sources:
-                - ocsf.metadata.product.uid
-              target: ocsf.metadata.product.uid
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `ocsf.metadata.sequence` to `ocsf.metadata.sequence`
-              sources:
-                - ocsf.metadata.sequence
-              target: ocsf.metadata.sequence
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `ocsf.metadata.event_code` to `ocsf.metadata.event_code`
-              sources:
-                - ocsf.metadata.event_code
-              target: ocsf.metadata.event_code
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `sessionid` to `ocsf.connection_info.session.uid`
-              sources:
-                - sessionid
-              sourceType: attribute
-              target: ocsf.connection_info.session.uid
-              targetFormat: string
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `network.client.ip` to `ocsf.src_endpoint.ip`
-              sources:
-                - network.client.ip
-              target: ocsf.src_endpoint.ip
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `network.client.port` to `ocsf.src_endpoint.port`
-              sources:
-                - network.client.port
-              target: ocsf.src_endpoint.port
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `network.destination.ip` to `ocsf.dst_endpoint.ip`
-              sources:
-                - network.destination.ip
-              target: ocsf.dst_endpoint.ip
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `network.destination.port` to `ocsf.dst_endpoint.port`
-              sources:
-                - network.destination.port
-              target: ocsf.dst_endpoint.port
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `proto` to `ocsf.connection_info.protocol_name`
-              sources:
-                - proto
-              target: ocsf.connection_info.protocol_name
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `bytes` to `ocsf.traffic.bytes`
-              sources:
-                - bytes
-              target: ocsf.traffic.bytes
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `network.bytes_written` to `ocsf.traffic.bytes_in`
-              sources:
-                - network.bytes_written
-              target: ocsf.traffic.bytes_in
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `network.bytes_read` to `ocsf.traffic.bytes_out`
-              sources:
-                - network.bytes_read
-              target: ocsf.traffic.bytes_out
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `packets`, `ocsf.traffic.packets` to `ocsf.traffic.packets`
-              sources:
-                - packets
-                - ocsf.traffic.packets
-              target: ocsf.traffic.packets
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `pkts_received` to `ocsf.traffic.packets_in`
-              sources:
-                - pkts_received
-              target: ocsf.traffic.packets_in
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `pkts_sent` to `ocsf.traffic.packets_out`
-              sources:
-                - pkts_sent
-              target: ocsf.traffic.packets_out
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `chunks` to `ocsf.traffic.chunks`
-              sources:
-                - chunks
-              target: ocsf.traffic.chunks
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `chunks_received` to `ocsf.traffic.chunks_in`
-              sources:
-                - chunks_received
-              target: ocsf.traffic.chunks_in
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-remapper
-              name: Map `chunks_sent` to `ocsf.traffic.chunks_out`
-              sources:
-                - chunks_sent
-              target: ocsf.traffic.chunks_out
-              preserveSource: true
-              overrideOnConflict: true
-            - type: schema-category-mapper
-              name: ocsf.activity_id
-              categories:
-                - filter:
-                    query: "@subtype:start"
-                  name: Open
-                  id: 1
-                - filter:
-                    query: "@subtype:end"
-                  name: Close
-                  id: 2
-                - filter:
-                    query: "@subtype:drop"
-                  name: Reset
-                  id: 3
-                - filter:
-                    query: "@subtype:deny"
-                  name: Refuse
-                  id: 5
-                - filter:
-                    query: "*"
-                  name: Other
-                  id: 99
-              targets:
-                name: ocsf.activity_name
-                id: ocsf.activity_id
-              fallback:
-                values:
-                  ocsf.activity_name: Other
-                  ocsf.activity_id: "99"
-                sources:
-                  ocsf.activity_name:
-                    - subtype
-            - type: schema-category-mapper
-              name: ocsf.connection_info.direction_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Unknown
-                  id: 0
-              targets:
-                name: ocsf.connection_info.direction
-                id: ocsf.connection_info.direction_id
-            - type: schema-category-mapper
-              name: ocsf.severity_id
-              categories:
-                - filter:
-                    query: "*"
-                  name: Informational
-                  id: 1
-              targets:
-                name: ocsf.severity
-                id: ocsf.severity_id
-          schema:
-            schemaType: ocsf
-            version: 1.5.0
-            className: Network Activity
-            classUid: 4001
-            extensions: []
-            profiles: []
+          source: message
+          samples:
+            - "<14>Sep  3 19:41:10 PA-3220 timestamp=2025/09/03 19:41:10, type=THREAT, subtype=url, evt.name=block-url, misc=http://malware.example.com/payload.bin, threatid=Suspicious URL"
+          grok:
+            supportRules: ""
+            matchRules: |-
+              misc_url %{data}misc=%{regex("[^,]*"):ocsf.evidence.url.url_string}%{data}
     - type: pipeline
       name: misc field filename extraction
       enabled: true
@@ -985,11 +851,9 @@ pipeline:
           enabled: true
           mappers:
             - type: schema-remapper
-              name: Map `ocsf.time`, `time_generated`, `timestamp` to `ocsf.time`
+              name: Map `ocsf.time` to `ocsf.time`
               sources:
                 - ocsf.time
-                - time_generated
-                - timestamp
               target: ocsf.time
               preserveSource: true
               overrideOnConflict: true
@@ -1093,6 +957,64 @@ pipeline:
               target: ocsf.status_detail
               preserveSource: true
               overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `threatid` to `ocsf.finding_info.title`
+              sources:
+                - threatid
+              target: ocsf.finding_info.title
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `rule` to `ocsf.firewall_rule.name`
+              sources:
+                - rule
+              target: ocsf.firewall_rule.name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `rule_uuid` to `ocsf.firewall_rule.uid`
+              sources:
+                - rule_uuid
+              target: ocsf.firewall_rule.uid
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-category-mapper
+              name: ocsf.disposition_id
+              categories:
+                - filter:
+                    query: "@evt.name:allow"
+                  name: Allowed
+                  id: 1
+                - filter:
+                    query: "@evt.name:(deny OR block OR block-url OR block-ip OR block-continue OR sinkhole)"
+                  name: Blocked
+                  id: 2
+                - filter:
+                    query: "@evt.name:drop"
+                  name: Dropped
+                  id: 6
+                - filter:
+                    query: "@evt.name:(reset-both OR reset-client OR reset-server)"
+                  name: Reset
+                  id: 21
+                - filter:
+                    query: "@evt.name:alert"
+                  name: Alert
+                  id: 19
+                - filter:
+                    query: "*"
+                  name: Other
+                  id: 99
+              targets:
+                name: ocsf.disposition
+                id: ocsf.disposition_id
+              fallback:
+                values:
+                  ocsf.disposition: Other
+                  ocsf.disposition_id: "99"
+                sources:
+                  ocsf.disposition:
+                    - evt.name
             - type: schema-category-mapper
               name: ocsf.activity_id
               categories:
@@ -1180,25 +1102,524 @@ pipeline:
             className: Detection Finding
             classUid: 2004
             extensions: []
+            profiles:
+              - security_control
+    - type: pipeline
+      name: OCSF sub pipeline for class Authentication [3002]
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "@type:AUTHENTICATION"
+      processors:
+        - type: schema-processor
+          name: Apply OCSF schema for 3002
+          enabled: true
+          mappers:
+            - type: schema-remapper
+              name: Map `ocsf.time` to `ocsf.time`
+              sources:
+                - ocsf.time
+              target: ocsf.time
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
+              sources:
+                - ocsf.metadata.product.name
+              target: ocsf.metadata.product.name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
+              sources:
+                - ocsf.metadata.product.vendor_name
+              target: ocsf.metadata.product.vendor_name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.uid` to `ocsf.metadata.product.uid`
+              sources:
+                - ocsf.metadata.product.uid
+              target: ocsf.metadata.product.uid
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.sequence` to `ocsf.metadata.sequence`
+              sources:
+                - ocsf.metadata.sequence
+              target: ocsf.metadata.sequence
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.event_code` to `ocsf.metadata.event_code`
+              sources:
+                - ocsf.metadata.event_code
+              target: ocsf.metadata.event_code
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `usr.id` to `ocsf.user.name`
+              sources:
+                - usr.id
+              target: ocsf.user.name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `normalize_user` to `ocsf.user.uid_alt`
+              sources:
+                - normalize_user
+              target: ocsf.user.uid_alt
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `network.client.ip` to `ocsf.src_endpoint.ip`
+              sources:
+                - network.client.ip
+              target: ocsf.src_endpoint.ip
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `device_name` to `ocsf.dst_endpoint.hostname`
+              sources:
+                - device_name
+              target: ocsf.dst_endpoint.hostname
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `serverprofile`, `device_name` to `ocsf.service.name`
+              sources:
+                - serverprofile
+                - device_name
+              target: ocsf.service.name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `evt.name` to `ocsf.auth_protocol`
+              sources:
+                - evt.name
+              target: ocsf.auth_protocol
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `clienttype` to `ocsf.logon_type`
+              sources:
+                - clienttype
+              target: ocsf.logon_type
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-category-mapper
+              name: ocsf.activity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Logon
+                  id: 1
+              targets:
+                name: ocsf.activity_name
+                id: ocsf.activity_id
+            - type: schema-category-mapper
+              name: ocsf.status_id
+              categories:
+                - filter:
+                    query: "@evt.outcome:(success OR succeeded OR allow)"
+                  name: Success
+                  id: 1
+                - filter:
+                    query: "@evt.outcome:(failure OR failed OR deny)"
+                  name: Failure
+                  id: 2
+                - filter:
+                    query: "-@evt.outcome:*"
+                  name: Unknown
+                  id: 0
+                - filter:
+                    query: "*"
+                  name: Other
+                  id: 99
+              targets:
+                name: ocsf.status
+                id: ocsf.status_id
+              fallback:
+                values:
+                  ocsf.status: Other
+                  ocsf.status_id: "99"
+                sources:
+                  ocsf.status:
+                    - evt.outcome
+            - type: schema-category-mapper
+              name: ocsf.severity_id
+              categories:
+                - filter:
+                    query: "@severity:informational"
+                  name: Informational
+                  id: 1
+                - filter:
+                    query: "@severity:low"
+                  name: Low
+                  id: 2
+                - filter:
+                    query: "@severity:medium"
+                  name: Medium
+                  id: 3
+                - filter:
+                    query: "@severity:high"
+                  name: High
+                  id: 4
+                - filter:
+                    query: "@severity:critical"
+                  name: Critical
+                  id: 5
+                - filter:
+                    query: "-@severity:*"
+                  name: Unknown
+                  id: 0
+                - filter:
+                    query: "*"
+                  name: Other
+                  id: 99
+              targets:
+                name: ocsf.severity
+                id: ocsf.severity_id
+              fallback:
+                values:
+                  ocsf.severity: Other
+                  ocsf.severity_id: "99"
+                sources:
+                  ocsf.severity:
+                    - severity
+          schema:
+            schemaType: ocsf
+            version: 1.5.0
+            className: Authentication
+            classUid: 3002
+            extensions: []
             profiles: []
+    - type: pipeline
+      name: OCSF sub pipeline for class Network Activity [4001]
+      enabled: true
+      ocsf:
+        isOcsf: true
+      filter:
+        query: "@type:TRAFFIC"
+      processors:
+        - type: arithmetic-processor
+          name: Calculate total packets
+          enabled: true
+          expression: (pkts_sent + pkts_received)
+          target: ocsf.traffic.packets
+          isReplaceMissing: false
+        - type: schema-processor
+          name: Apply OCSF schema for 4001
+          enabled: true
+          mappers:
+            - type: schema-remapper
+              name: Map `ocsf.time` to `ocsf.time`
+              sources:
+                - ocsf.time
+              target: ocsf.time
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.name` to `ocsf.metadata.product.name`
+              sources:
+                - ocsf.metadata.product.name
+              target: ocsf.metadata.product.name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.vendor_name` to `ocsf.metadata.product.vendor_name`
+              sources:
+                - ocsf.metadata.product.vendor_name
+              target: ocsf.metadata.product.vendor_name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.product.uid` to `ocsf.metadata.product.uid`
+              sources:
+                - ocsf.metadata.product.uid
+              target: ocsf.metadata.product.uid
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.sequence` to `ocsf.metadata.sequence`
+              sources:
+                - ocsf.metadata.sequence
+              target: ocsf.metadata.sequence
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `ocsf.metadata.event_code` to `ocsf.metadata.event_code`
+              sources:
+                - ocsf.metadata.event_code
+              target: ocsf.metadata.event_code
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `sessionid` to `ocsf.connection_info.session.uid`
+              sources:
+                - sessionid
+              sourceType: attribute
+              target: ocsf.connection_info.session.uid
+              targetFormat: string
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `network.client.ip` to `ocsf.src_endpoint.ip`
+              sources:
+                - network.client.ip
+              target: ocsf.src_endpoint.ip
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `network.client.port` to `ocsf.src_endpoint.port`
+              sources:
+                - network.client.port
+              target: ocsf.src_endpoint.port
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `network.destination.ip` to `ocsf.dst_endpoint.ip`
+              sources:
+                - network.destination.ip
+              target: ocsf.dst_endpoint.ip
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `network.destination.port` to `ocsf.dst_endpoint.port`
+              sources:
+                - network.destination.port
+              target: ocsf.dst_endpoint.port
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `proto` to `ocsf.connection_info.protocol_name`
+              sources:
+                - proto
+              target: ocsf.connection_info.protocol_name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `bytes` to `ocsf.traffic.bytes`
+              sources:
+                - bytes
+              target: ocsf.traffic.bytes
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `network.bytes_written` to `ocsf.traffic.bytes_in`
+              sources:
+                - network.bytes_written
+              target: ocsf.traffic.bytes_in
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `network.bytes_read` to `ocsf.traffic.bytes_out`
+              sources:
+                - network.bytes_read
+              target: ocsf.traffic.bytes_out
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `packets`, `ocsf.traffic.packets` to `ocsf.traffic.packets`
+              sources:
+                - packets
+                - ocsf.traffic.packets
+              target: ocsf.traffic.packets
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `pkts_received` to `ocsf.traffic.packets_in`
+              sources:
+                - pkts_received
+              target: ocsf.traffic.packets_in
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `pkts_sent` to `ocsf.traffic.packets_out`
+              sources:
+                - pkts_sent
+              target: ocsf.traffic.packets_out
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `chunks` to `ocsf.traffic.chunks`
+              sources:
+                - chunks
+              target: ocsf.traffic.chunks
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `chunks_received` to `ocsf.traffic.chunks_in`
+              sources:
+                - chunks_received
+              target: ocsf.traffic.chunks_in
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `chunks_sent` to `ocsf.traffic.chunks_out`
+              sources:
+                - chunks_sent
+              target: ocsf.traffic.chunks_out
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `rule` to `ocsf.firewall_rule.name`
+              sources:
+                - rule
+              target: ocsf.firewall_rule.name
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-remapper
+              name: Map `rule_uuid` to `ocsf.firewall_rule.uid`
+              sources:
+                - rule_uuid
+              target: ocsf.firewall_rule.uid
+              preserveSource: true
+              overrideOnConflict: true
+            - type: schema-category-mapper
+              name: ocsf.disposition_id
+              categories:
+                - filter:
+                    query: "@evt.name:allow"
+                  name: Allowed
+                  id: 1
+                - filter:
+                    query: "@evt.name:(deny OR block OR block-url OR block-ip OR block-continue OR sinkhole)"
+                  name: Blocked
+                  id: 2
+                - filter:
+                    query: "@evt.name:drop"
+                  name: Dropped
+                  id: 6
+                - filter:
+                    query: "@evt.name:(reset-both OR reset-client OR reset-server)"
+                  name: Reset
+                  id: 21
+                - filter:
+                    query: "@evt.name:alert"
+                  name: Alert
+                  id: 19
+                - filter:
+                    query: "*"
+                  name: Other
+                  id: 99
+              targets:
+                name: ocsf.disposition
+                id: ocsf.disposition_id
+              fallback:
+                values:
+                  ocsf.disposition: Other
+                  ocsf.disposition_id: "99"
+                sources:
+                  ocsf.disposition:
+                    - evt.name
+            - type: schema-category-mapper
+              name: ocsf.action_id
+              categories:
+                - filter:
+                    query: "@evt.name:allow"
+                  name: Allowed
+                  id: 1
+                - filter:
+                    query: "@evt.name:(deny OR drop OR block OR block-url OR block-ip OR block-continue OR sinkhole OR reset-both OR reset-client OR reset-server)"
+                  name: Denied
+                  id: 2
+                - filter:
+                    query: "@evt.name:alert"
+                  name: Observed
+                  id: 3
+                - filter:
+                    query: "*"
+                  name: Other
+                  id: 99
+              targets:
+                name: ocsf.action
+                id: ocsf.action_id
+              fallback:
+                values:
+                  ocsf.action: Other
+                  ocsf.action_id: "99"
+                sources:
+                  ocsf.action:
+                    - evt.name
+            - type: schema-category-mapper
+              name: ocsf.activity_id
+              categories:
+                - filter:
+                    query: "@subtype:start"
+                  name: Open
+                  id: 1
+                - filter:
+                    query: "@subtype:end"
+                  name: Close
+                  id: 2
+                - filter:
+                    query: "@subtype:drop"
+                  name: Reset
+                  id: 3
+                - filter:
+                    query: "@subtype:deny"
+                  name: Refuse
+                  id: 5
+                - filter:
+                    query: "*"
+                  name: Other
+                  id: 99
+              targets:
+                name: ocsf.activity_name
+                id: ocsf.activity_id
+              fallback:
+                values:
+                  ocsf.activity_name: Other
+                  ocsf.activity_id: "99"
+                sources:
+                  ocsf.activity_name:
+                    - subtype
+            - type: schema-category-mapper
+              name: ocsf.connection_info.direction_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Unknown
+                  id: 0
+              targets:
+                name: ocsf.connection_info.direction
+                id: ocsf.connection_info.direction_id
+            - type: schema-category-mapper
+              name: ocsf.severity_id
+              categories:
+                - filter:
+                    query: "*"
+                  name: Informational
+                  id: 1
+              targets:
+                name: ocsf.severity
+                id: ocsf.severity_id
+          schema:
+            schemaType: ocsf
+            version: 1.5.0
+            className: Network Activity
+            classUid: 4001
+            extensions: []
+            profiles:
+              - security_control
     - type: pipeline
       name: OCSF sub pipeline for class Base Event [0]
       enabled: true
       ocsf:
         isOcsf: true
       filter:
-        query: "-@type:(TRAFFIC OR THREAT)"
+        query: "-@type:(TRAFFIC OR THREAT OR AUTHENTICATION)"
       processors:
         - type: schema-processor
           name: Apply OCSF schema for 0
           enabled: true
           mappers:
             - type: schema-remapper
-              name: Map `ocsf.time`, `time_generated`, `timestamp` to `ocsf.time`
+              name: Map `ocsf.time` to `ocsf.time`
               sources:
                 - ocsf.time
-                - time_generated
-                - timestamp
               target: ocsf.time
               preserveSource: true
               overrideOnConflict: true

--- a/pan_firewall/assets/logs/pan.firewall_tests.yaml
+++ b/pan_firewall/assets/logs/pan.firewall_tests.yaml
@@ -119,7 +119,7 @@ tests:
           ip: "10.2.75.414"
       ocsf:
         activity_id: 99
-        activity_name: "Other"
+        activity_name: "AUTHENTICATION"
         category_uid: 0
         class_name: "Base Event"
         class_uid: 0
@@ -131,8 +131,8 @@ tests:
             vendor_name: "Palo Alto Networks"
           sequence: 486021038
           version: "1.5.0"
-        severity: "Informational"
-        severity_id: 1
+        severity: "Unknown"
+        severity_id: 0
         time: 1557161033000
       repeatcnt: 1
       seqno: 486021038
@@ -146,7 +146,7 @@ tests:
       vsys: "testVM"
       vsys_id: 786
       vsys_name: "JVM"
-    message: "timestamp=2019/05/06 16:43:53, serial=001801010877, type=AUTHENTICATION, subtype=virus, vsys=testVM,  network.client.ip=10.2.75.414, usr.id=Jaydeep,  normalize_user=,  object=,  authpolicy=authpolicy, repeatcnt=1, authid=68376, vendor=Symentic, logset=testForwarder, serverprofile=serverprofile, message=thisIsSampleMessage, \tclienttype=securityApp, evt.name=alert, factorno=687383, seqno=486021038, actionflags=0xa0000 00000000000, vsys_name=JVM, device_name=tab,  vsys_id=786,\tauthproto=authproto"
+    message: "timestamp=2019/05/06 16:43:53, serial=001801010877, type=AUTHENTICATION, subtype=virus, vsys=testVM,  network.client.ip=10.2.75.414, usr.id=Jaydeep,  normalize_user=,  object=,  authpolicy=authpolicy, repeatcnt=1, authid=68376, vendor=Symentic, logset=testForwarder, serverprofile=serverprofile, message=thisIsSampleMessage, 	clienttype=securityApp, evt.name=alert, factorno=687383, seqno=486021038, actionflags=0xa0000 00000000000, vsys_name=JVM, device_name=tab,  vsys_id=786,	authproto=authproto"
     tags:
      - "source:LOGS_SOURCE"
     timestamp: 1

--- a/pan_firewall/assets/logs/pan.firewall_tests.yaml
+++ b/pan_firewall/assets/logs/pan.firewall_tests.yaml
@@ -38,6 +38,46 @@ tests:
         destination:
           ip: "35.184.126.116"
           port: 443
+      ocsf:
+        activity_id: 2
+        activity_name: "Close"
+        category_name: "Network Activity"
+        category_uid: 4
+        class_name: "Network Activity"
+        class_uid: 4001
+        connection_info:
+          direction: "Unknown"
+          direction_id: 0
+          protocol_name: "tcp"
+          session:
+            uid: "92244"
+        dst_endpoint:
+          ip: "35.184.126.116"
+          port: 443
+        metadata:
+          event_code: "TRAFFIC"
+          product:
+            name: "Palo Alto Networks Firewall"
+            uid: "012001018742"
+            vendor_name: "Palo Alto Networks"
+          sequence: 977161987
+          version: "1.5.0"
+        severity: "Informational"
+        severity_id: 1
+        src_endpoint:
+          ip: "10.70.255.70"
+          port: 42799
+        time: 1620102277000
+        traffic:
+          bytes: 16680918
+          bytes_in: 16415457
+          bytes_out: 265461
+          chunks: 0
+          chunks_in: 0
+          chunks_out: 0
+          packets: 15555
+          packets_in: 3644
+          packets_out: 11911
       parent_session_id: 0
       pkts_received: 3644
       pkts_sent: 11911
@@ -77,6 +117,23 @@ tests:
           geoip:
             invalidAddress: "10.2.75.414"
           ip: "10.2.75.414"
+      ocsf:
+        activity_id: 99
+        activity_name: "Other"
+        category_uid: 0
+        class_name: "Base Event"
+        class_uid: 0
+        metadata:
+          event_code: "AUTHENTICATION"
+          product:
+            name: "Palo Alto Networks Firewall"
+            uid: "001801010877"
+            vendor_name: "Palo Alto Networks"
+          sequence: 486021038
+          version: "1.5.0"
+        severity: "Informational"
+        severity_id: 1
+        time: 1557161033000
       repeatcnt: 1
       seqno: 486021038
       serial: "001801010877"
@@ -90,6 +147,306 @@ tests:
       vsys_id: 786
       vsys_name: "JVM"
     message: "timestamp=2019/05/06 16:43:53, serial=001801010877, type=AUTHENTICATION, subtype=virus, vsys=testVM,  network.client.ip=10.2.75.414, usr.id=Jaydeep,  normalize_user=,  object=,  authpolicy=authpolicy, repeatcnt=1, authid=68376, vendor=Symentic, logset=testForwarder, serverprofile=serverprofile, message=thisIsSampleMessage, \tclienttype=securityApp, evt.name=alert, factorno=687383, seqno=486021038, actionflags=0xa0000 00000000000, vsys_name=JVM, device_name=tab,  vsys_id=786,\tauthproto=authproto"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1
+ -
+  sample: "<14>Sep  3 19:40:32 PA-3220 timestamp=2025/09/03 19:40:32, serial=016201026426, type=THREAT, subtype=virus, time_generated=2025/09/03 19:40:32, network.client.ip=172.16.28.190, network.destination.ip=93.184.216.34, natsrc=72.138.81.50, natdst=93.184.216.34, rule=L3_Orca to L3_Untrust, usr.id=jdoe, dstuser=, app=web-browsing, vsys=vsys1, source_zone=L3_Orca, destination_zone=L3_Untrust, logset=datadog-forwarder, sessionid=393715, repeatcnt=1, network.client.port=51022, network.destination.port=80, flags=0x40407a, proto=tcp, evt.name=block-url, misc=invoice_2025.pdf, threatid=Eicar Test File, category=malware, severity=medium, direction=client-to-server, seqno=7489817491394537149, actionflags=0x0, dstloc=United States, device_name=PA-3220"
+  result:
+    custom:
+      actionflags: "0x0"
+      app: "web-browsing"
+      category: "malware"
+      destination_zone: "L3_Untrust"
+      device_name: "PA-3220"
+      direction: "client-to-server"
+      dstloc: "United States"
+      evt:
+        name: "block-url"
+      flags: "0x40407a"
+      logset: "datadog-forwarder"
+      misc: "invoice_2025.pdf"
+      natdst: "93.184.216.34"
+      natsrc: "72.138.81.50"
+      network:
+        client:
+          geoip: {}
+          ip: "172.16.28.190"
+          port: 51022
+        destination:
+          ip: "93.184.216.34"
+          port: 80
+      ocsf:
+        activity_id: 1
+        activity_name: "Create"
+        category_name: "Findings"
+        category_uid: 2
+        class_name: "Detection Finding"
+        class_uid: 2004
+        confidence: "Unknown"
+        confidence_id: 0
+        evidences:
+          - actor:
+              app_name: "web-browsing"
+              session:
+                uid: "393715"
+              user:
+                name: "jdoe"
+            connection_info:
+              direction: "Unknown"
+              direction_id: 0
+              protocol_name: "tcp"
+            device:
+              name: "PA-3220"
+              type: "Firewall"
+              type_id: 9
+            dst_endpoint:
+              ip: "93.184.216.34"
+              port: 80
+              zone: "L3_Untrust"
+            file:
+              name: "invoice_2025.pdf"
+              type: "Regular File"
+              type_id: 1
+            src_endpoint:
+              ip: "172.16.28.190"
+              port: 51022
+              zone: "L3_Orca"
+        finding_info:
+          analytic:
+            category: "virus"
+            name: "L3_Orca to L3_Untrust"
+            type: "Rule"
+            type_id: 1
+          product:
+            name: "Palo Alto Networks Firewall"
+            vendor_name: "Palo Alto Networks"
+          uid: "7489817491394537149"
+        is_alert: true
+        metadata:
+          event_code: "THREAT"
+          product:
+            name: "Palo Alto Networks Firewall"
+            uid: "16201026426"
+            vendor_name: "Palo Alto Networks"
+          sequence: 7489817491394537149
+          version: "1.5.0"
+        severity: "Medium"
+        severity_id: 3
+        status: "New"
+        status_detail: "block-url"
+        status_id: 1
+        time: 1756928432000
+      proto: "tcp"
+      repeatcnt: 1
+      rule: "L3_Orca to L3_Untrust"
+      seqno: 7489817491394537149
+      serial: 16201026426
+      sessionid: 393715
+      severity: "medium"
+      source_zone: "L3_Orca"
+      subtype: "virus"
+      threatid: "Eicar Test File"
+      type: "THREAT"
+      usr:
+        id: "jdoe"
+      vsys: "vsys1"
+    message: "<14>Sep  3 19:40:32 PA-3220 timestamp=2025/09/03 19:40:32, serial=016201026426, type=THREAT, subtype=virus, time_generated=2025/09/03 19:40:32, network.client.ip=172.16.28.190, network.destination.ip=93.184.216.34, natsrc=72.138.81.50, natdst=93.184.216.34, rule=L3_Orca to L3_Untrust, usr.id=jdoe, dstuser=, app=web-browsing, vsys=vsys1, source_zone=L3_Orca, destination_zone=L3_Untrust, logset=datadog-forwarder, sessionid=393715, repeatcnt=1, network.client.port=51022, network.destination.port=80, flags=0x40407a, proto=tcp, evt.name=block-url, misc=invoice_2025.pdf, threatid=Eicar Test File, category=malware, severity=medium, direction=client-to-server, seqno=7489817491394537149, actionflags=0x0, dstloc=United States, device_name=PA-3220"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1
+ -
+  sample: "<14>Sep  3 19:41:10 PA-3220 timestamp=2025/09/03 19:41:10, serial=716201026426, type=THREAT, subtype=url, time_generated=2025/09/03 19:41:10, network.client.ip=172.16.28.191, network.destination.ip=93.184.216.35, rule=L3_Orca to L3_Untrust, usr.id=asmith, dstuser=, app=web-browsing, vsys=vsys1, source_zone=L3_Orca, destination_zone=L3_Untrust, logset=datadog-forwarder, sessionid=393801, repeatcnt=1, network.client.port=51099, network.destination.port=443, flags=0x40407a, proto=tcp, evt.name=block-url, misc=http://malware.example.com/payload.bin, threatid=Suspicious URL, category=malware, severity=high, direction=client-to-server, seqno=7489817491394537150, actionflags=0x0, device_name=PA-3220"
+  result:
+    custom:
+      actionflags: "0x0"
+      app: "web-browsing"
+      category: "malware"
+      destination_zone: "L3_Untrust"
+      device_name: "PA-3220"
+      direction: "client-to-server"
+      evt:
+        name: "block-url"
+      flags: "0x40407a"
+      logset: "datadog-forwarder"
+      network:
+        client:
+          geoip: {}
+          ip: "172.16.28.191"
+          port: 51099
+        destination:
+          ip: "93.184.216.35"
+          port: 443
+      ocsf:
+        activity_id: 1
+        activity_name: "Create"
+        category_name: "Findings"
+        category_uid: 2
+        class_name: "Detection Finding"
+        class_uid: 2004
+        confidence: "Unknown"
+        confidence_id: 0
+        evidences:
+          - actor:
+              app_name: "web-browsing"
+              session:
+                uid: "393801"
+              user:
+                name: "asmith"
+            connection_info:
+              direction: "Unknown"
+              direction_id: 0
+              protocol_name: "tcp"
+            device:
+              name: "PA-3220"
+              type: "Firewall"
+              type_id: 9
+            dst_endpoint:
+              ip: "93.184.216.35"
+              port: 443
+              zone: "L3_Untrust"
+            src_endpoint:
+              ip: "172.16.28.191"
+              port: 51099
+              zone: "L3_Orca"
+        finding_info:
+          analytic:
+            category: "url"
+            name: "L3_Orca to L3_Untrust"
+            type: "Rule"
+            type_id: 1
+          product:
+            name: "Palo Alto Networks Firewall"
+            vendor_name: "Palo Alto Networks"
+          uid: "7489817491394537150"
+        is_alert: true
+        metadata:
+          event_code: "THREAT"
+          product:
+            name: "Palo Alto Networks Firewall"
+            uid: "716201026426"
+            vendor_name: "Palo Alto Networks"
+          sequence: 7489817491394537150
+          version: "1.5.0"
+        severity: "High"
+        severity_id: 4
+        status: "New"
+        status_detail: "block-url"
+        status_id: 1
+        time: 1756928470000
+      proto: "tcp"
+      repeatcnt: 1
+      rule: "L3_Orca to L3_Untrust"
+      seqno: 7489817491394537150
+      serial: 716201026426
+      sessionid: 393801
+      severity: "high"
+      source_zone: "L3_Orca"
+      subtype: "url"
+      threatid: "Suspicious URL"
+      type: "THREAT"
+      usr:
+        id: "asmith"
+      vsys: "vsys1"
+    message: "<14>Sep  3 19:41:10 PA-3220 timestamp=2025/09/03 19:41:10, serial=716201026426, type=THREAT, subtype=url, time_generated=2025/09/03 19:41:10, network.client.ip=172.16.28.191, network.destination.ip=93.184.216.35, rule=L3_Orca to L3_Untrust, usr.id=asmith, dstuser=, app=web-browsing, vsys=vsys1, source_zone=L3_Orca, destination_zone=L3_Untrust, logset=datadog-forwarder, sessionid=393801, repeatcnt=1, network.client.port=51099, network.destination.port=443, flags=0x40407a, proto=tcp, evt.name=block-url, misc=http://malware.example.com/payload.bin, threatid=Suspicious URL, category=malware, severity=high, direction=client-to-server, seqno=7489817491394537150, actionflags=0x0, device_name=PA-3220"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1
+ -
+  sample: "<14>Sep  3 19:42:05 PA-3220 timestamp=2025/09/03 19:42:05, serial=816201026426, type=THREAT, subtype=spyware, time_generated=2025/09/03 19:42:05, network.client.ip=172.16.28.192, network.destination.ip=93.184.216.36, rule=L3_Orca to L3_Untrust, usr.id=bchen, dstuser=, app=dns, vsys=vsys1, from=L3_Orca, to=L3_Untrust, logset=datadog-forwarder, sessionid=393902, repeatcnt=1, network.client.port=53001, network.destination.port=53, flags=0x40407a, proto=udp, evt.name=sinkhole, threatid=Suspicious DNS Query, category=command-and-control, severity=critical, seqno=7489817491394537151, actionflags=0x0, device_name=PA-3220, rule_uuid=d6e5f4a3-3333-4444-5555-666677778888"
+  result:
+    custom:
+      actionflags: "0x0"
+      app: "dns"
+      category: "command-and-control"
+      device_name: "PA-3220"
+      evt:
+        name: "sinkhole"
+      flags: "0x40407a"
+      from: "L3_Orca"
+      logset: "datadog-forwarder"
+      network:
+        client:
+          geoip: {}
+          ip: "172.16.28.192"
+          port: 53001
+        destination:
+          ip: "93.184.216.36"
+          port: 53
+      ocsf:
+        activity_id: 1
+        activity_name: "Create"
+        category_name: "Findings"
+        category_uid: 2
+        class_name: "Detection Finding"
+        class_uid: 2004
+        confidence: "Unknown"
+        confidence_id: 0
+        evidences:
+          - actor:
+              app_name: "dns"
+              session:
+                uid: "393902"
+              user:
+                name: "bchen"
+            connection_info:
+              direction: "Unknown"
+              direction_id: 0
+              protocol_name: "udp"
+            device:
+              name: "PA-3220"
+              type: "Firewall"
+              type_id: 9
+            dst_endpoint:
+              ip: "93.184.216.36"
+              port: 53
+              zone: "L3_Untrust"
+            src_endpoint:
+              ip: "172.16.28.192"
+              port: 53001
+              zone: "L3_Orca"
+        finding_info:
+          analytic:
+            category: "spyware"
+            name: "L3_Orca to L3_Untrust"
+            type: "Rule"
+            type_id: 1
+            uid: "d6e5f4a3-3333-4444-5555-666677778888"
+          product:
+            name: "Palo Alto Networks Firewall"
+            vendor_name: "Palo Alto Networks"
+          uid: "7489817491394537151"
+        is_alert: true
+        metadata:
+          event_code: "THREAT"
+          product:
+            name: "Palo Alto Networks Firewall"
+            uid: "816201026426"
+            vendor_name: "Palo Alto Networks"
+          sequence: 7489817491394537151
+          version: "1.5.0"
+        severity: "Critical"
+        severity_id: 5
+        status: "New"
+        status_detail: "sinkhole"
+        status_id: 1
+        time: 1756928525000
+      proto: "udp"
+      repeatcnt: 1
+      rule: "L3_Orca to L3_Untrust"
+      rule_uuid: "d6e5f4a3-3333-4444-5555-666677778888"
+      seqno: 7489817491394537151
+      serial: 816201026426
+      sessionid: 393902
+      severity: "critical"
+      subtype: "spyware"
+      threatid: "Suspicious DNS Query"
+      to: "L3_Untrust"
+      type: "THREAT"
+      usr:
+        id: "bchen"
+      vsys: "vsys1"
+    message: "<14>Sep  3 19:42:05 PA-3220 timestamp=2025/09/03 19:42:05, serial=816201026426, type=THREAT, subtype=spyware, time_generated=2025/09/03 19:42:05, network.client.ip=172.16.28.192, network.destination.ip=93.184.216.36, rule=L3_Orca to L3_Untrust, usr.id=bchen, dstuser=, app=dns, vsys=vsys1, from=L3_Orca, to=L3_Untrust, logset=datadog-forwarder, sessionid=393902, repeatcnt=1, network.client.port=53001, network.destination.port=53, flags=0x40407a, proto=udp, evt.name=sinkhole, threatid=Suspicious DNS Query, category=command-and-control, severity=critical, seqno=7489817491394537151, actionflags=0x0, device_name=PA-3220, rule_uuid=d6e5f4a3-3333-4444-5555-666677778888"
     tags:
      - "source:LOGS_SOURCE"
     timestamp: 1

--- a/pan_firewall/assets/logs/pan.firewall_tests.yaml
+++ b/pan_firewall/assets/logs/pan.firewall_tests.yaml
@@ -70,8 +70,8 @@ tests:
         time: 1620102277000
         traffic:
           bytes: 16680918
-          bytes_in: 16415457
-          bytes_out: 265461
+          bytes_in: 265461
+          bytes_out: 16415457
           chunks: 0
           chunks_in: 0
           chunks_out: 0

--- a/pan_firewall/assets/logs/pan.firewall_tests.yaml
+++ b/pan_firewall/assets/logs/pan.firewall_tests.yaml
@@ -39,6 +39,8 @@ tests:
           ip: "35.184.126.116"
           port: 443
       ocsf:
+        action: "Allowed"
+        action_id: 1
         activity_id: 2
         activity_name: "Close"
         category_name: "Network Activity"
@@ -51,15 +53,21 @@ tests:
           protocol_name: "tcp"
           session:
             uid: "92244"
+        disposition: "Allowed"
+        disposition_id: 1
         dst_endpoint:
           ip: "35.184.126.116"
           port: 443
+        firewall_rule:
+          name: "Permit all outbound"
         metadata:
           event_code: "TRAFFIC"
           product:
             name: "Palo Alto Networks Firewall"
             uid: "012001018742"
             vendor_name: "Palo Alto Networks"
+          profiles:
+           - "security_control"
           sequence: 977161987
           version: "1.5.0"
         severity: "Informational"
@@ -98,7 +106,7 @@ tests:
      - "source:LOGS_SOURCE"
     timestamp: 1
  -
-  sample: "timestamp=2019/05/06 16:43:53, serial=001801010877, type=AUTHENTICATION, subtype=virus, vsys=testVM,  network.client.ip=10.2.75.414, usr.id=Jaydeep,  normalize_user=,  object=,  authpolicy=authpolicy, repeatcnt=1, authid=68376, vendor=Symentic, logset=testForwarder, serverprofile=serverprofile, message=thisIsSampleMessage, \tclienttype=securityApp, evt.name=alert, factorno=687383, seqno=486021038, actionflags=0xa0000 00000000000, vsys_name=JVM, device_name=tab,  vsys_id=786,\tauthproto=authproto"
+  sample: "timestamp=2019/05/06 16:43:53, serial=001801010877, type=AUTHENTICATION, subtype=virus, vsys=testVM,  network.client.ip=10.2.75.41, usr.id=Jaydeep,  normalize_user=,  object=,  authpolicy=authpolicy, repeatcnt=1, authid=68376, vendor=Symentic, logset=testForwarder, serverprofile=serverprofile, message=thisIsSampleMessage, \tclienttype=securityApp, evt.name=alert, factorno=687383, seqno=486021038, actionflags=0xa0000 00000000000, vsys_name=JVM, device_name=tab,  vsys_id=786,\tauthproto=authproto"
   result:
     custom:
       actionflags: "0xa0000 00000000000"
@@ -114,15 +122,19 @@ tests:
       message: "thisIsSampleMessage"
       network:
         client:
-          geoip:
-            invalidAddress: "10.2.75.414"
-          ip: "10.2.75.414"
+          geoip: {}
+          ip: "10.2.75.41"
       ocsf:
-        activity_id: 99
-        activity_name: "AUTHENTICATION"
-        category_uid: 0
-        class_name: "Base Event"
-        class_uid: 0
+        activity_id: 1
+        activity_name: "Logon"
+        auth_protocol: "alert"
+        category_name: "Identity & Access Management"
+        category_uid: 3
+        class_name: "Authentication"
+        class_uid: 3002
+        dst_endpoint:
+          hostname: "tab"
+        logon_type: "securityApp"
         metadata:
           event_code: "AUTHENTICATION"
           product:
@@ -131,9 +143,17 @@ tests:
             vendor_name: "Palo Alto Networks"
           sequence: 486021038
           version: "1.5.0"
+        service:
+          name: "serverprofile"
         severity: "Unknown"
         severity_id: 0
+        src_endpoint:
+          ip: "10.2.75.41"
+        status: "Unknown"
+        status_id: 0
         time: 1557161033000
+        user:
+          name: "Jaydeep"
       repeatcnt: 1
       seqno: 486021038
       serial: "001801010877"
@@ -146,7 +166,7 @@ tests:
       vsys: "testVM"
       vsys_id: 786
       vsys_name: "JVM"
-    message: "timestamp=2019/05/06 16:43:53, serial=001801010877, type=AUTHENTICATION, subtype=virus, vsys=testVM,  network.client.ip=10.2.75.414, usr.id=Jaydeep,  normalize_user=,  object=,  authpolicy=authpolicy, repeatcnt=1, authid=68376, vendor=Symentic, logset=testForwarder, serverprofile=serverprofile, message=thisIsSampleMessage, 	clienttype=securityApp, evt.name=alert, factorno=687383, seqno=486021038, actionflags=0xa0000 00000000000, vsys_name=JVM, device_name=tab,  vsys_id=786,	authproto=authproto"
+    message: "timestamp=2019/05/06 16:43:53, serial=001801010877, type=AUTHENTICATION, subtype=virus, vsys=testVM,  network.client.ip=10.2.75.41, usr.id=Jaydeep,  normalize_user=,  object=,  authpolicy=authpolicy, repeatcnt=1, authid=68376, vendor=Symentic, logset=testForwarder, serverprofile=serverprofile, message=thisIsSampleMessage, 	clienttype=securityApp, evt.name=alert, factorno=687383, seqno=486021038, actionflags=0xa0000 00000000000, vsys_name=JVM, device_name=tab,  vsys_id=786,	authproto=authproto"
     tags:
      - "source:LOGS_SOURCE"
     timestamp: 1
@@ -185,6 +205,8 @@ tests:
         class_uid: 2004
         confidence: "Unknown"
         confidence_id: 0
+        disposition: "Blocked"
+        disposition_id: 2
         evidences:
           - actor:
               app_name: "web-browsing"
@@ -221,7 +243,10 @@ tests:
           product:
             name: "Palo Alto Networks Firewall"
             vendor_name: "Palo Alto Networks"
+          title: "Eicar Test File"
           uid: "7489817491394537149"
+        firewall_rule:
+          name: "L3_Orca to L3_Untrust"
         is_alert: true
         metadata:
           event_code: "THREAT"
@@ -229,6 +254,8 @@ tests:
             name: "Palo Alto Networks Firewall"
             uid: "16201026426"
             vendor_name: "Palo Alto Networks"
+          profiles:
+           - "security_control"
           sequence: 7489817491394537149
           version: "1.5.0"
         severity: "Medium"
@@ -286,6 +313,8 @@ tests:
         class_uid: 2004
         confidence: "Unknown"
         confidence_id: 0
+        disposition: "Blocked"
+        disposition_id: 2
         evidences:
           - actor:
               app_name: "web-browsing"
@@ -309,6 +338,8 @@ tests:
               ip: "172.16.28.191"
               port: 51099
               zone: "L3_Orca"
+            url:
+              url_string: "http://malware.example.com/payload.bin"
         finding_info:
           analytic:
             category: "url"
@@ -318,7 +349,10 @@ tests:
           product:
             name: "Palo Alto Networks Firewall"
             vendor_name: "Palo Alto Networks"
+          title: "Suspicious URL"
           uid: "7489817491394537150"
+        firewall_rule:
+          name: "L3_Orca to L3_Untrust"
         is_alert: true
         metadata:
           event_code: "THREAT"
@@ -326,6 +360,8 @@ tests:
             name: "Palo Alto Networks Firewall"
             uid: "716201026426"
             vendor_name: "Palo Alto Networks"
+          profiles:
+           - "security_control"
           sequence: 7489817491394537150
           version: "1.5.0"
         severity: "High"
@@ -382,6 +418,8 @@ tests:
         class_uid: 2004
         confidence: "Unknown"
         confidence_id: 0
+        disposition: "Blocked"
+        disposition_id: 2
         evidences:
           - actor:
               app_name: "dns"
@@ -415,7 +453,11 @@ tests:
           product:
             name: "Palo Alto Networks Firewall"
             vendor_name: "Palo Alto Networks"
+          title: "Suspicious DNS Query"
           uid: "7489817491394537151"
+        firewall_rule:
+          name: "L3_Orca to L3_Untrust"
+          uid: "d6e5f4a3-3333-4444-5555-666677778888"
         is_alert: true
         metadata:
           event_code: "THREAT"
@@ -423,6 +465,8 @@ tests:
             name: "Palo Alto Networks Firewall"
             uid: "816201026426"
             vendor_name: "Palo Alto Networks"
+          profiles:
+           - "security_control"
           sequence: 7489817491394537151
           version: "1.5.0"
         severity: "Critical"
@@ -447,6 +491,43 @@ tests:
         id: "bchen"
       vsys: "vsys1"
     message: "<14>Sep  3 19:42:05 PA-3220 timestamp=2025/09/03 19:42:05, serial=816201026426, type=THREAT, subtype=spyware, time_generated=2025/09/03 19:42:05, network.client.ip=172.16.28.192, network.destination.ip=93.184.216.36, rule=L3_Orca to L3_Untrust, usr.id=bchen, dstuser=, app=dns, vsys=vsys1, from=L3_Orca, to=L3_Untrust, logset=datadog-forwarder, sessionid=393902, repeatcnt=1, network.client.port=53001, network.destination.port=53, flags=0x40407a, proto=udp, evt.name=sinkhole, threatid=Suspicious DNS Query, category=command-and-control, severity=critical, seqno=7489817491394537151, actionflags=0x0, device_name=PA-3220, rule_uuid=d6e5f4a3-3333-4444-5555-666677778888"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1
+ -
+  sample: "<14>Sep  3 19:43:20 PA-3220 timestamp=2025/09/03 19:43:20, serial=916201026426, type=SYSTEM, subtype=general, vsys=vsys1, evt.name=general, object=, module=general, severity=informational, opaque=Config installed successfully, seqno=7489817491394537152, actionflags=0x0, vsys_name=, device_name=PA-3220"
+  result:
+    custom:
+      actionflags: "0x0"
+      device_name: "PA-3220"
+      evt:
+        name: "general"
+      module: "general"
+      ocsf:
+        activity_id: 99
+        activity_name: "SYSTEM"
+        category_uid: 0
+        class_name: "Base Event"
+        class_uid: 0
+        metadata:
+          event_code: "SYSTEM"
+          product:
+            name: "Palo Alto Networks Firewall"
+            uid: "916201026426"
+            vendor_name: "Palo Alto Networks"
+          sequence: 7489817491394537152
+          version: "1.5.0"
+        severity: "Informational"
+        severity_id: 1
+        time: 1756928600000
+      opaque: "Config installed successfully"
+      seqno: 7489817491394537152
+      serial: 916201026426
+      severity: "informational"
+      subtype: "general"
+      type: "SYSTEM"
+      vsys: "vsys1"
+    message: "<14>Sep  3 19:43:20 PA-3220 timestamp=2025/09/03 19:43:20, serial=916201026426, type=SYSTEM, subtype=general, vsys=vsys1, evt.name=general, object=, module=general, severity=informational, opaque=Config installed successfully, seqno=7489817491394537152, actionflags=0x0, vsys_name=, device_name=PA-3220"
     tags:
      - "source:LOGS_SOURCE"
     timestamp: 1

--- a/pan_firewall/assets/logs/pan.firewall_tests.yaml
+++ b/pan_firewall/assets/logs/pan.firewall_tests.yaml
@@ -125,16 +125,11 @@ tests:
           geoip: {}
           ip: "10.2.75.41"
       ocsf:
-        activity_id: 1
-        activity_name: "Logon"
-        auth_protocol: "alert"
-        category_name: "Identity & Access Management"
-        category_uid: 3
-        class_name: "Authentication"
-        class_uid: 3002
-        dst_endpoint:
-          hostname: "tab"
-        logon_type: "securityApp"
+        activity_id: 99
+        activity_name: "AUTHENTICATION"
+        category_uid: 0
+        class_name: "Base Event"
+        class_uid: 0
         metadata:
           event_code: "AUTHENTICATION"
           product:
@@ -143,17 +138,9 @@ tests:
             vendor_name: "Palo Alto Networks"
           sequence: 486021038
           version: "1.5.0"
-        service:
-          name: "serverprofile"
         severity: "Unknown"
         severity_id: 0
-        src_endpoint:
-          ip: "10.2.75.41"
-        status: "Unknown"
-        status_id: 0
         time: 1557161033000
-        user:
-          name: "Jaydeep"
       repeatcnt: 1
       seqno: 486021038
       serial: "001801010877"
@@ -916,4 +903,5 @@ tests:
     tags:
      - "source:LOGS_SOURCE"
     timestamp: 1
+
 

--- a/pan_firewall/assets/logs/pan.firewall_tests.yaml
+++ b/pan_firewall/assets/logs/pan.firewall_tests.yaml
@@ -531,4 +531,389 @@ tests:
     tags:
      - "source:LOGS_SOURCE"
     timestamp: 1
+ -
+  sample: "<14>Sep  3 15:51:58 PA-1001 timestamp=2025/09/03 19:40:32, serial=677910583345, type=CONFIG, subtype=0, network.client.ip=10.45.129.55, vsys=, evt.name=edit, usr.id=Id-4, client=Client-1, evt.outcome=Outcome-1, path=Path-1, before_change_detail=Detail-1, after_change_detail=Detail-1, seqno=259645837095713, actionflags=0x0, vsys_name=, device_name=PA-1001"
+  result:
+    custom:
+      actionflags: "0x0"
+      after_change_detail: "Detail-1"
+      before_change_detail: "Detail-1"
+      client: "Client-1"
+      device_name: "PA-1001"
+      evt:
+        name: "edit"
+        outcome: "Outcome-1"
+      network:
+        client:
+          geoip: {}
+          ip: "10.45.129.55"
+      ocsf:
+        activity_id: 99
+        activity_name: "CONFIG"
+        category_uid: 0
+        class_name: "Base Event"
+        class_uid: 0
+        metadata:
+          event_code: "CONFIG"
+          product:
+            name: "Palo Alto Networks Firewall"
+            uid: "677910583345"
+            vendor_name: "Palo Alto Networks"
+          sequence: 259645837095713
+          version: "1.5.0"
+        severity: "Unknown"
+        severity_id: 0
+        time: 1756928432000
+      path: "Path-1"
+      seqno: 259645837095713
+      serial: 677910583345
+      subtype: 0
+      type: "CONFIG"
+      usr:
+        id: "Id-4"
+    message: "<14>Sep  3 15:51:58 PA-1001 timestamp=2025/09/03 19:40:32, serial=677910583345, type=CONFIG, subtype=0, network.client.ip=10.45.129.55, vsys=, evt.name=edit, usr.id=Id-4, client=Client-1, evt.outcome=Outcome-1, path=Path-1, before_change_detail=Detail-1, after_change_detail=Detail-1, seqno=259645837095713, actionflags=0x0, vsys_name=, device_name=PA-1001"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1
+ -
+  sample: "<14>Sep 11 00:50:45 PA-1001 timestamp=2025/09/03 19:40:32, serial=677910583345, type=TRAFFIC, subtype=drop, time_generated=2025/09/03 19:40:32, network.client.ip=198.51.100.14, network.destination.ip=198.51.100.16, natsrc=198.51.100.7, natdst=198.51.100.11, rule=Rule-11, usr.id=, dstuser=, app=App-8, vsys=vsys1, from=From-8, to=To-1, inbound_if=If-10, outbound_if=, logset=Logset-1, sessionid=22, repeatcnt=1, network.client.port=14376, network.destination.port=7015, natsport=0 natdport=0, flags=Flags-10, proto=tcp, evt.name=drop, bytes=16, network.bytes_read=16, network.bytes_written=0, start=2025/09/03 19:40:32, elapsed=0, category=Category-1, seqno=254601692706818, actionflags=0x0, network.client.geoip.country.name=Name-5, dstloc=Dstloc-2, pkts_sent=1, pkts_received=0, session_end_reason=policy-deny, device_name=PA-1001, action_source=from-policy, src_uuid=, dst_uuid=, tunnelid=0, imsi= 0, monitortag=, imei=, parent_session_id=0, parent_start_time=, tunnel=N/A, assoc_id=0, chunks=0 chunks_sent=0 chunks_received=0"
+  result:
+    custom:
+      action_source: "from-policy"
+      actionflags: "0x0"
+      app: "App-8"
+      assoc_id: 0
+      bytes: 16
+      category: "Category-1"
+      chunks: 0
+      chunks_received: 0
+      chunks_sent: 0
+      device_name: "PA-1001"
+      dstloc: "Dstloc-2"
+      elapsed: 0
+      evt:
+        name: "drop"
+      flags: "Flags-10"
+      from: "From-8"
+      imsi: 0
+      inbound_if: "If-10"
+      logset: "Logset-1"
+      natdport: 0
+      natdst: "198.51.100.11"
+      natsport: 0
+      natsrc: "198.51.100.7"
+      network:
+        bytes_read: 16
+        bytes_written: 0
+        client:
+          geoip: {}
+          ip: "198.51.100.14"
+          port: 14376
+        destination:
+          ip: "198.51.100.16"
+          port: 7015
+      ocsf:
+        action: "Denied"
+        action_id: 2
+        activity_id: 3
+        activity_name: "Reset"
+        category_name: "Network Activity"
+        category_uid: 4
+        class_name: "Network Activity"
+        class_uid: 4001
+        connection_info:
+          direction: "Unknown"
+          direction_id: 0
+          protocol_name: "tcp"
+          session:
+            uid: "22"
+        disposition: "Dropped"
+        disposition_id: 6
+        dst_endpoint:
+          ip: "198.51.100.16"
+          port: 7015
+        firewall_rule:
+          name: "Rule-11"
+        metadata:
+          event_code: "TRAFFIC"
+          product:
+            name: "Palo Alto Networks Firewall"
+            uid: "677910583345"
+            vendor_name: "Palo Alto Networks"
+          profiles:
+           - "security_control"
+          sequence: 254601692706818
+          version: "1.5.0"
+        severity: "Informational"
+        severity_id: 1
+        src_endpoint:
+          ip: "198.51.100.14"
+          port: 14376
+        time: 1756928432000
+        traffic:
+          bytes: 16
+          bytes_in: 0
+          bytes_out: 16
+          chunks: 0
+          chunks_in: 0
+          chunks_out: 0
+          packets: 1
+          packets_in: 0
+          packets_out: 1
+      parent_session_id: 0
+      pkts_received: 0
+      pkts_sent: 1
+      proto: "tcp"
+      repeatcnt: 1
+      rule: "Rule-11"
+      seqno: 254601692706818
+      serial: 677910583345
+      session_end_reason: "policy-deny"
+      sessionid: 22
+      subtype: "drop"
+      to: "To-1"
+      tunnelid: 0
+      type: "TRAFFIC"
+      vsys: "vsys1"
+    message: "<14>Sep 11 00:50:45 PA-1001 timestamp=2025/09/03 19:40:32, serial=677910583345, type=TRAFFIC, subtype=drop, time_generated=2025/09/03 19:40:32, network.client.ip=198.51.100.14, network.destination.ip=198.51.100.16, natsrc=198.51.100.7, natdst=198.51.100.11, rule=Rule-11, usr.id=, dstuser=, app=App-8, vsys=vsys1, from=From-8, to=To-1, inbound_if=If-10, outbound_if=, logset=Logset-1, sessionid=22, repeatcnt=1, network.client.port=14376, network.destination.port=7015, natsport=0 natdport=0, flags=Flags-10, proto=tcp, evt.name=drop, bytes=16, network.bytes_read=16, network.bytes_written=0, start=2025/09/03 19:40:32, elapsed=0, category=Category-1, seqno=254601692706818, actionflags=0x0, network.client.geoip.country.name=Name-5, dstloc=Dstloc-2, pkts_sent=1, pkts_received=0, session_end_reason=policy-deny, device_name=PA-1001, action_source=from-policy, src_uuid=, dst_uuid=, tunnelid=0, imsi= 0, monitortag=, imei=, parent_session_id=0, parent_start_time=, tunnel=N/A, assoc_id=0, chunks=0 chunks_sent=0 chunks_received=0"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1
+ -
+  sample: "<13>Sep 11 00:26:15 PA-1001 timestamp=2025/09/03 19:40:32, serial=677910583345, type=THREAT, subtype=vulnerability, time_generated=2025/09/03 19:40:32, network.client.ip=198.51.100.37, network.destination.ip=198.51.100.19, natsrc=198.51.100.15, natdst=10.28.127.52, rule=Rule-22, usr.id=, dstuser=, app=ssl, vsys=vsys1, from=From-8, to=To-1, inbound_if=If-5, outbound_if=If-12, logset=Logset-1, sessionid=536484, repeatcnt=1, network.client.port=7221, network.destination.port=443, natsport=10246, natdport=76807, flags=Flags-22, proto=tcp, evt.name=alert, misc=, threatid=Threatid-7, category=Category-1, severity=low, direction=client-to-server, seqno=188476845303802, actionflags=0x0, network.client.geoip.country.name=Name-10, dstloc=Dstloc-2, contenttype=, pcap_id=0, filedigest=, cloud=, url_idx=0, http.useragent=, filetype=, xff= referer=, sender=, subject=, recipient=, reportid=0, vsys_name=, device_name=PA-1001, src_uuid=, dst_uuid=, http_method=, tunnel_id=N/A_id, imsi=0, monitortag=, imei=, parent_session_id=0, parent_start_time=, tunnel=N/A, thr_category=hacktool, contentver=Contentver-3, assoc_id=0, ppid=4294967295, http_headers="
+  result:
+    custom:
+      actionflags: "0x0"
+      app: "ssl"
+      assoc_id: 0
+      category: "Category-1"
+      contentver: "Contentver-3"
+      device_name: "PA-1001"
+      direction: "client-to-server"
+      dstloc: "Dstloc-2"
+      evt:
+        name: "alert"
+      flags: "Flags-22"
+      from: "From-8"
+      imsi: 0
+      inbound_if: "If-5"
+      logset: "Logset-1"
+      natdport: 76807
+      natdst: "10.28.127.52"
+      natsport: 10246
+      natsrc: "198.51.100.15"
+      network:
+        client:
+          geoip: {}
+          ip: "198.51.100.37"
+          port: 7221
+        destination:
+          ip: "198.51.100.19"
+          port: 443
+      ocsf:
+        activity_id: 1
+        activity_name: "Create"
+        category_name: "Findings"
+        category_uid: 2
+        class_name: "Detection Finding"
+        class_uid: 2004
+        confidence: "Unknown"
+        confidence_id: 0
+        disposition: "Alert"
+        disposition_id: 19
+        evidences:
+          - actor:
+              app_name: "ssl"
+              session:
+                uid: "536484"
+            connection_info:
+              direction: "Unknown"
+              direction_id: 0
+              protocol_name: "tcp"
+            device:
+              name: "PA-1001"
+              type: "Firewall"
+              type_id: 9
+            dst_endpoint:
+              ip: "198.51.100.19"
+              port: 443
+              zone: "To-1"
+            src_endpoint:
+              ip: "198.51.100.37"
+              port: 7221
+              zone: "From-8"
+        finding_info:
+          analytic:
+            category: "vulnerability"
+            name: "Rule-22"
+            type: "Rule"
+            type_id: 1
+          product:
+            name: "Palo Alto Networks Firewall"
+            vendor_name: "Palo Alto Networks"
+          title: "Threatid-7"
+          uid: "188476845303802"
+        firewall_rule:
+          name: "Rule-22"
+        is_alert: true
+        metadata:
+          event_code: "THREAT"
+          product:
+            name: "Palo Alto Networks Firewall"
+            uid: "677910583345"
+            vendor_name: "Palo Alto Networks"
+          profiles:
+           - "security_control"
+          sequence: 188476845303802
+          version: "1.5.0"
+        severity: "Low"
+        severity_id: 2
+        status: "New"
+        status_detail: "alert"
+        status_id: 1
+        time: 1756928432000
+      outbound_if: "If-12"
+      parent_session_id: 0
+      pcap_id: 0
+      ppid: 4294967295
+      proto: "tcp"
+      repeatcnt: 1
+      reportid: 0
+      rule: "Rule-22"
+      seqno: 188476845303802
+      serial: 677910583345
+      sessionid: 536484
+      severity: "low"
+      subtype: "vulnerability"
+      thr_category: "hacktool"
+      threatid: "Threatid-7"
+      to: "To-1"
+      type: "THREAT"
+      url_idx: 0
+      vsys: "vsys1"
+    message: "<13>Sep 11 00:26:15 PA-1001 timestamp=2025/09/03 19:40:32, serial=677910583345, type=THREAT, subtype=vulnerability, time_generated=2025/09/03 19:40:32, network.client.ip=198.51.100.37, network.destination.ip=198.51.100.19, natsrc=198.51.100.15, natdst=10.28.127.52, rule=Rule-22, usr.id=, dstuser=, app=ssl, vsys=vsys1, from=From-8, to=To-1, inbound_if=If-5, outbound_if=If-12, logset=Logset-1, sessionid=536484, repeatcnt=1, network.client.port=7221, network.destination.port=443, natsport=10246, natdport=76807, flags=Flags-22, proto=tcp, evt.name=alert, misc=, threatid=Threatid-7, category=Category-1, severity=low, direction=client-to-server, seqno=188476845303802, actionflags=0x0, network.client.geoip.country.name=Name-10, dstloc=Dstloc-2, contenttype=, pcap_id=0, filedigest=, cloud=, url_idx=0, http.useragent=, filetype=, xff= referer=, sender=, subject=, recipient=, reportid=0, vsys_name=, device_name=PA-1001, src_uuid=, dst_uuid=, http_method=, tunnel_id=N/A_id, imsi=0, monitortag=, imei=, parent_session_id=0, parent_start_time=, tunnel=N/A, thr_category=hacktool, contentver=Contentver-3, assoc_id=0, ppid=4294967295, http_headers="
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1
+ -
+  sample: "<12>Sep  4 17:47:22 fw13.example.invalid timestamp=2025/09/03 19:40:32, serial=199382820997315, type=THREAT, subtype=virus, time_generated=2025/09/03 19:40:32, network.client.ip=198.51.100.32, network.destination.ip=10.29.236.100, natsrc=198.51.100.12, natdst=10.23.74.101, rule=Rule-18, usr.id=, dstuser=, app=web-browsing, vsys=vsys1, from=From-13, to=To-10, inbound_if=If-6, outbound_if=If-9, logset=Logset-7, sessionid=8661436, repeatcnt=1, network.client.port=71356, network.destination.port=443, natsport=12296, natdport=76807, flags=Flags-17, proto=tcp, evt.name=reset-both, misc=Misc-7, threatid=Threatid-2, category=Category-5, severity=medium, direction=client-to-server, seqno=201724979983366, actionflags=0x8000000000000000, network.client.geoip.country.name=Name-13, dstloc=Dstloc-4, contenttype=, pcap_id=24291084202541, filedigest=, cloud=, url_idx=1, http.useragent=, filetype=, xff= referer=, sender=, subject=, recipient=, reportid=0, vsys_name=, device_name=PA-1012, src_uuid=, dst_uuid=, http_method=, tunnel_id=N/A_id, imsi=0, monitortag=, imei=, parent_session_id=0, parent_start_time=, tunnel=N/A, thr_category=java-class, contentver=Contentver-2, assoc_id=0, ppid=4294967295, http_headers="
+  result:
+    custom:
+      actionflags: "0x8000000000000000"
+      app: "web-browsing"
+      assoc_id: 0
+      category: "Category-5"
+      contentver: "Contentver-2"
+      device_name: "PA-1012"
+      direction: "client-to-server"
+      dstloc: "Dstloc-4"
+      evt:
+        name: "reset-both"
+      flags: "Flags-17"
+      from: "From-13"
+      imsi: 0
+      inbound_if: "If-6"
+      logset: "Logset-7"
+      misc: "Misc-7"
+      natdport: 76807
+      natdst: "10.23.74.101"
+      natsport: 12296
+      natsrc: "198.51.100.12"
+      network:
+        client:
+          geoip: {}
+          ip: "198.51.100.32"
+          port: 71356
+        destination:
+          ip: "10.29.236.100"
+          port: 443
+      ocsf:
+        activity_id: 1
+        activity_name: "Create"
+        category_name: "Findings"
+        category_uid: 2
+        class_name: "Detection Finding"
+        class_uid: 2004
+        confidence: "Unknown"
+        confidence_id: 0
+        disposition: "Reset"
+        disposition_id: 21
+        evidences:
+          - actor:
+              app_name: "web-browsing"
+              session:
+                uid: "8661436"
+            connection_info:
+              direction: "Unknown"
+              direction_id: 0
+              protocol_name: "tcp"
+            device:
+              name: "PA-1012"
+              type: "Firewall"
+              type_id: 9
+            dst_endpoint:
+              ip: "10.29.236.100"
+              port: 443
+              zone: "To-10"
+            file:
+              name: "Misc-7"
+              type: "Regular File"
+              type_id: 1
+            src_endpoint:
+              ip: "198.51.100.32"
+              port: 71356
+              zone: "From-13"
+        finding_info:
+          analytic:
+            category: "virus"
+            name: "Rule-18"
+            type: "Rule"
+            type_id: 1
+          product:
+            name: "Palo Alto Networks Firewall"
+            vendor_name: "Palo Alto Networks"
+          title: "Threatid-2"
+          uid: "201724979983366"
+        firewall_rule:
+          name: "Rule-18"
+        is_alert: true
+        metadata:
+          event_code: "THREAT"
+          product:
+            name: "Palo Alto Networks Firewall"
+            uid: "199382820997315"
+            vendor_name: "Palo Alto Networks"
+          profiles:
+           - "security_control"
+          sequence: 201724979983366
+          version: "1.5.0"
+        severity: "Medium"
+        severity_id: 3
+        status: "New"
+        status_detail: "reset-both"
+        status_id: 1
+        time: 1756928432000
+      outbound_if: "If-9"
+      parent_session_id: 0
+      pcap_id: 24291084202541
+      ppid: 4294967295
+      proto: "tcp"
+      repeatcnt: 1
+      reportid: 0
+      rule: "Rule-18"
+      seqno: 201724979983366
+      serial: 199382820997315
+      sessionid: 8661436
+      severity: "medium"
+      subtype: "virus"
+      thr_category: "java-class"
+      threatid: "Threatid-2"
+      to: "To-10"
+      type: "THREAT"
+      url_idx: 1
+      vsys: "vsys1"
+    message: "<12>Sep  4 17:47:22 fw13.example.invalid timestamp=2025/09/03 19:40:32, serial=199382820997315, type=THREAT, subtype=virus, time_generated=2025/09/03 19:40:32, network.client.ip=198.51.100.32, network.destination.ip=10.29.236.100, natsrc=198.51.100.12, natdst=10.23.74.101, rule=Rule-18, usr.id=, dstuser=, app=web-browsing, vsys=vsys1, from=From-13, to=To-10, inbound_if=If-6, outbound_if=If-9, logset=Logset-7, sessionid=8661436, repeatcnt=1, network.client.port=71356, network.destination.port=443, natsport=12296, natdport=76807, flags=Flags-17, proto=tcp, evt.name=reset-both, misc=Misc-7, threatid=Threatid-2, category=Category-5, severity=medium, direction=client-to-server, seqno=201724979983366, actionflags=0x8000000000000000, network.client.geoip.country.name=Name-13, dstloc=Dstloc-4, contenttype=, pcap_id=24291084202541, filedigest=, cloud=, url_idx=1, http.useragent=, filetype=, xff= referer=, sender=, subject=, recipient=, reportid=0, vsys_name=, device_name=PA-1012, src_uuid=, dst_uuid=, http_method=, tunnel_id=N/A_id, imsi=0, monitortag=, imei=, parent_session_id=0, parent_start_time=, tunnel=N/A, thr_category=java-class, contentver=Contentver-2, assoc_id=0, ppid=4294967295, http_headers="
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1
 


### PR DESCRIPTION
### What does this PR do?

Adds OCSF 1.5.0 normalization to the Palo Alto Networks Firewall (`pan.firewall`) pipeline, covering the PAN-OS log types the integration ingests:

| Class | Filter |
|---|---|
| Network Activity [4001] | `@type:TRAFFIC` |
| Detection Finding [2004] | `@type:THREAT` |
| Base Event [0] | everything else |

Mappings use `schema-processor`, so class/category/type UIDs and names plus `metadata.version` derive from the `schema:` block rather than being hand-set.

### Motivation

OCSF coverage for `pan.firewall`. Jira: SCI2-5941

### Event time

The pipeline's keyvalue matcher drops any value containing `/`, so `timestamp` and `time_generated` never materialize as attributes and the existing `timestamp` date-remapper is inert today. Widening that matcher would activate the remapper and shift every PAN log's official date to local-time-read-as-UTC — so it is deliberately left untouched. `ocsf.time` is parsed straight out of the raw message instead, and **no log's official date changes**. `time_generated` is preferred over `timestamp` because PAN-OS THREAT logs set `timestamp=$receive_time`.

### Field names verified against production

A structure-only probe (key paths + value types + counts, no customer values) over **1192 events across 6 orgs** (of 180 ingesting) drove several mapping decisions:

- Orgs are **split** between `source_zone`/`destination_zone` (the README form) and the stock PAN-OS `from`/`to`, with one org sending both — so the zone mappings list both sources. Mapping only the documented form would have dropped zone data for a third of sampled orgs.
- `packets` is a real field in some orgs; it falls back to `pkts_sent + pkts_received` elsewhere.
- `srcuser`, `action`, `bytes_in`, `bytes_out` and `pkts` appear in **0 of 6** orgs — the live equivalents are `usr.id` and `evt.name`.
- Every org carrying a parseable event time uses `yyyy/MM/dd HH:mm:ss` (no ISO). Orgs whose raw message carries neither key fall back to the parsed attribute.

Nested `evidences[]` objects carry their own required fields (`connection_info.direction_id`, `device.type_id`, `file.type_id`), set before the array-processor move because a category-mapper cannot target inside an array. `device.type_id` is 9 (Firewall).

### Testing

Five fixtures — one per OCSF class, both zone variants, and a URL-subtype THREAT. All validate at **100% required-field coverage**:

```
bzl run //domains/event-platform/libs/ocsf-validator-cli:ocsf-validator -- \
  --input pan_firewall/assets/logs/pan.firewall_tests.yaml --check-all
```

```
Log 1 VALID  Network Activity   Required: 100.0% (9/9)
Log 2 VALID  Base Event         Required: 100.0% (8/8)
Log 3 VALID  Detection Finding  Required: 100.0% (15/15)
Log 4 VALID  Detection Finding  Required: 100.0% (13/13)
Log 5 VALID  Detection Finding  Required: 100.0% (13/13)
```

### Reviewer notes / follow-ups

- **One sampled org already emits its own `ocsf.*`** (`observables[]`, `metadata.*`, `category_uid`, `activity_id`, `severity`) on 100% of its events, from a custom pipeline. These mappers use `overrideOnConflict: true` and will overwrite those values, leaving their `ocsf.observables[]` alongside ours. Worth a heads-up to that account team before this rolls out.
- **URL evidence is not mapped.** `misc` carries the URL for `@subtype:url`, but the keyvalue matcher drops values containing `:` and `/`, so it never survives parsing. Recovering it means widening that matcher, which carries the date-remapper risk above and deserves its own change.
- **NAT fields are unmapped** — `natsrc`/`natdst`/`natsport`/`natdport` appear in 5 of 6 orgs (~900 events each) and have OCSF endpoint equivalents.
- Base Event emits `activity_name: "Other"` with `activity_id: 99`, which raises a benign `attribute_enum_sibling_suspicious_other` warning. "Other" is the correct caption for 99; substituting the raw PAN `type` would trade the warning for an enum-mismatch error.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
