### PR TITLE
Retry transient connection failures on registry reads

### DIFF
--- a/ddev/changelog.d/25157.fixed
+++ b/ddev/changelog.d/25157.fixed
@@ -1,0 +1,1 @@
+Retry transient connection failures on registry reads

--- a/ddev/src/ddev/cli/validate/licenses.py
+++ b/ddev/src/ddev/cli/validate/licenses.py
@@ -19,8 +19,6 @@ _OP_SPLIT = re.compile(r'\s*(?:(?<!-)\b(?:AND|OR)\b(?!-)|/|\+|\band/or\b)\s*', r
 # and may appear as LicenseRef-* / DocumentRef-*:LicenseRef-*
 _ID = re.compile(r"(DocumentRef-[A-Za-z0-9.+-]+:)?LicenseRef-[A-Za-z0-9.+-]+|[A-Za-z0-9.+-]+")
 
-DOWNLOAD_RETRIES = 2
-
 
 def format_attribution_line(package_name, license_id, package_copyright):
     if ',' in package_copyright:
@@ -72,34 +70,29 @@ def collect_source_url(package_data):
     return combined[0]
 
 
-def scrape_copyright_data(url_path: str) -> str | None:
-    """Download an archive with bounded connection retries and extract its copyright."""
-    import time
-
+def download_copyright_data(url_path: str) -> str | None:
+    """Download an archive once and extract its copyright."""
     import httpx
 
-    attempt = 0
-    while True:
-        try:
-            # Keep the httpx.stream defaults so environment proxy support is preserved.
-            with httpx.stream('GET', url_path, follow_redirects=True) as resp:
-                resp.raise_for_status()
-                resp.read()
-                for fcontents in pick_file_generator(url_path)(resp):
-                    if cp := find_cpy(fcontents):
-                        return cp
-            return None
-        except (
-            httpx.ConnectError,
-            httpx.ConnectTimeout,
-            httpx.ReadError,
-            httpx.ReadTimeout,
-            httpx.RemoteProtocolError,
-        ):
-            if attempt == DOWNLOAD_RETRIES:
-                raise
-            time.sleep(2**attempt)
-            attempt += 1
+    # Keep the httpx.stream defaults so environment proxy support is preserved.
+    with httpx.stream('GET', url_path, follow_redirects=True) as resp:
+        resp.raise_for_status()
+        resp.read()
+        for fcontents in pick_file_generator(url_path)(resp):
+            if cp := find_cpy(fcontents):
+                return cp
+    return None
+
+
+def scrape_copyright_data(url_path: str) -> str | None:
+    """Download an archive with bounded connection retries and extract its copyright."""
+    from functools import partial
+
+    from ddev.utils.network import request_with_retries
+
+    # The whole download is replayed, not just the connect, because the body is consumed
+    # inside the stream context and a reset mid-transfer surfaces there.
+    return request_with_retries(partial(download_copyright_data, url_path))
 
 
 def find_cpy(data):

--- a/ddev/src/ddev/utils/docker_registry.py
+++ b/ddev/src/ddev/utils/docker_registry.py
@@ -11,7 +11,11 @@ They are intentionally narrow: manifest existence checks and tag listings with
 
 from __future__ import annotations
 
+from functools import partial
+
 import httpx
+
+from ddev.utils.network import request_with_retries
 
 DEFAULT_REGISTRY_HOST = 'registry.datadoghq.com'
 
@@ -40,11 +44,14 @@ def manifest_exists(
     timeout: float = 10.0,
 ) -> bool:
     """Return True if `<host>/v2/<repository>/manifests/<tag>` resolves, False on 404."""
-    response = httpx.head(
-        f'https://{host}/v2/{repository}/manifests/{tag}',
-        headers={'Accept': MANIFEST_ACCEPT},
-        follow_redirects=True,
-        timeout=timeout,
+    response = request_with_retries(
+        partial(
+            httpx.head,
+            f'https://{host}/v2/{repository}/manifests/{tag}',
+            headers={'Accept': MANIFEST_ACCEPT},
+            follow_redirects=True,
+            timeout=timeout,
+        )
     )
     if response.status_code == 404:
         return False
@@ -68,7 +75,7 @@ def list_tags(
     url: str | None = f'https://{host}/v2/{repository}/tags/list?n={page_size}'
     tags: list[str] = []
     while url is not None:
-        response = httpx.get(url, timeout=timeout)
+        response = request_with_retries(partial(httpx.get, url, timeout=timeout))
         response.raise_for_status()
         try:
             payload = response.json()

--- a/ddev/src/ddev/utils/network.py
+++ b/ddev/src/ddev/utils/network.py
@@ -1,7 +1,42 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import httpx
+import stamina
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Failures that say nothing about what the server would have served: the connection was
+# refused, timed out, or was reset before a complete response arrived. Windows CI runners
+# in particular reset connections mid-handshake (`[WinError 10054]`, a `ConnectError`).
+TRANSIENT_ERRORS = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.ReadError,
+    httpx.ReadTimeout,
+    httpx.RemoteProtocolError,
+)
+
+REQUEST_ATTEMPTS = 3
+
+
+@stamina.retry(on=TRANSIENT_ERRORS, attempts=REQUEST_ATTEMPTS)
+def request_with_retries[T](send: Callable[[], T]) -> T:
+    """Call `send`, retrying transient connection failures with backoff.
+
+    Only connection-level failures are retried, and the last one propagates once the
+    attempts are spent. A response the server actually served is handed straight back, so
+    a real 404 is never retried as if it were a network blip.
+
+    `send` is replayed wholesale, so it must be safe to repeat: a read against an
+    idempotent endpoint qualifies, a mutation does not.
+    """
+    return send()
 
 
 def download_file(path, *args, **kwargs):

--- a/ddev/tests/cli/validate/test_licenses.py
+++ b/ddev/tests/cli/validate/test_licenses.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import io
 import tarfile
-import time
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
@@ -13,8 +12,9 @@ import httpx
 import pytest
 
 from ddev.cli.validate import licenses_utils
-from ddev.cli.validate.licenses import DOWNLOAD_RETRIES, scrape_copyright_data
+from ddev.cli.validate.licenses import scrape_copyright_data
 from ddev.utils.fs import Path
+from ddev.utils.network import REQUEST_ATTEMPTS
 from ddev.utils.toml import dump_toml_data, load_toml_file
 
 if TYPE_CHECKING:
@@ -220,7 +220,6 @@ def test_scrape_recovers_from_transient_connection_failure(
         return tarball_response()
 
     mock_http.side_effect = respond
-    monkeypatch.setattr(time, 'sleep', lambda _: None)
 
     assert scrape_copyright_data(TARBALL_URL) == COPYRIGHT
     assert len(attempts) == 2
@@ -232,16 +231,15 @@ def test_scrape_persistent_connection_failure_raises(monkeypatch: pytest.MonkeyP
     def respond(request: httpx.Request) -> httpx.Response:
         assert (request.method, str(request.url)) == ('GET', TARBALL_URL)
         attempts.append(request)
-        assert len(attempts) <= DOWNLOAD_RETRIES + 1, f'unbounded retries: {len(attempts)} attempts'
+        assert len(attempts) <= REQUEST_ATTEMPTS, f'unbounded retries: {len(attempts)} attempts'
         raise httpx.ConnectError('[WinError 10054] connection reset')
 
     mock_http.side_effect = respond
-    monkeypatch.setattr(time, 'sleep', lambda _: None)
 
     with pytest.raises(httpx.ConnectError):
         scrape_copyright_data(TARBALL_URL)
 
-    assert len(attempts) == DOWNLOAD_RETRIES + 1
+    assert len(attempts) == REQUEST_ATTEMPTS
 
 
 @pytest.mark.parametrize(
@@ -270,7 +268,6 @@ def test_scrape_recovers_from_interruption_during_response(
         return tarball_response()
 
     mock_http.side_effect = respond
-    monkeypatch.setattr(time, 'sleep', lambda _: None)
 
     assert scrape_copyright_data(TARBALL_URL) == COPYRIGHT
     assert len(attempts) == 2
@@ -282,16 +279,15 @@ def test_scrape_persistent_interruption_during_response_raises(monkeypatch: pyte
     def respond(request: httpx.Request) -> httpx.Response:
         assert (request.method, str(request.url)) == ('GET', TARBALL_URL)
         attempts.append(request)
-        assert len(attempts) <= DOWNLOAD_RETRIES + 1, f'unbounded retries: {len(attempts)} attempts'
+        assert len(attempts) <= REQUEST_ATTEMPTS, f'unbounded retries: {len(attempts)} attempts'
         return interrupted_response(httpx.ReadError('read error'))
 
     mock_http.side_effect = respond
-    monkeypatch.setattr(time, 'sleep', lambda _: None)
 
     with pytest.raises(httpx.ReadError):
         scrape_copyright_data(TARBALL_URL)
 
-    assert len(attempts) == DOWNLOAD_RETRIES + 1
+    assert len(attempts) == REQUEST_ATTEMPTS
 
 
 def test_scrape_http_status_error_is_actionable(mock_http: MagicMock):

--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 import random
+import sys
 from collections.abc import AsyncIterator
 from contextlib import ExitStack, asynccontextmanager
 from typing import Any, Generator
 
 import pytest
+import stamina
 import vcr
 from datadog_checks.dev.tooling.utils import set_root
 from pytest_mock import MockerFixture
@@ -256,6 +258,20 @@ def default_hostname():
     import socket
 
     return socket.gethostname().lower()
+
+
+# Only stamina's backoff waits should go, not anyone's retry policy. Test mode requires an
+# attempt count, and `cap=True` applies it as `min(this, the caller's own attempts)`, so a
+# ceiling no policy can reach leaves every one of them exactly as configured. Plain
+# `set_testing(True)` would instead force `attempts=1` and disable every retry under test.
+NEVER_CLAMP_ATTEMPTS = sys.maxsize
+
+
+@pytest.fixture(autouse=True)
+def instant_retry_backoff() -> Generator[None, None, None]:
+    """Run every `stamina.retry` in the suite without its real backoff waits."""
+    with stamina.set_testing(True, attempts=NEVER_CLAMP_ATTEMPTS, cap=True):
+        yield
 
 
 @pytest.fixture

--- a/ddev/tests/utils/test_docker_registry.py
+++ b/ddev/tests/utils/test_docker_registry.py
@@ -10,6 +10,17 @@ import pytest
 from pytest_mock import MockerFixture
 
 from ddev.utils import docker_registry
+from ddev.utils.network import REQUEST_ATTEMPTS
+
+TRANSIENT_ERROR_PARAMS = [
+    pytest.param(httpx.ConnectError('[WinError 10054] connection forcibly closed'), id='connect-error'),
+    pytest.param(httpx.ConnectTimeout('connect timed out'), id='connect-timeout'),
+    pytest.param(httpx.ReadError('read error'), id='read-error'),
+    pytest.param(httpx.ReadTimeout('read timed out'), id='read-timeout'),
+    pytest.param(httpx.RemoteProtocolError('peer closed connection'), id='remote-protocol-error'),
+]
+
+ATTEMPTS = REQUEST_ATTEMPTS
 
 
 def _response(
@@ -50,19 +61,49 @@ def test_manifest_exists_raises_on_other_errors(mocker: MockerFixture, status: i
         docker_registry.manifest_exists('agent', '7.80.0-rc.1')
 
 
-@pytest.mark.parametrize(
-    'exc',
-    [
-        pytest.param(httpx.ConnectError('connection refused'), id='connect-error'),
-        pytest.param(httpx.ReadTimeout('read timed out'), id='read-timeout'),
-        pytest.param(httpx.ConnectTimeout('connect timed out'), id='connect-timeout'),
-    ],
-)
+@pytest.mark.parametrize('exc', TRANSIENT_ERROR_PARAMS)
 def test_manifest_exists_propagates_network_errors(mocker: MockerFixture, exc: Exception) -> None:
-    mocker.patch('httpx.head', side_effect=exc)
+    """A failure that outlives the retries still surfaces, and the retries stay bounded."""
+    head = mocker.patch('httpx.head', side_effect=exc)
 
     with pytest.raises(type(exc)):
         docker_registry.manifest_exists('agent', '7.80.0-rc.1')
+
+    assert head.call_count == ATTEMPTS
+
+
+@pytest.mark.parametrize('exc', TRANSIENT_ERROR_PARAMS)
+def test_manifest_exists_retries_a_transient_failure(mocker: MockerFixture, exc: Exception) -> None:
+    head = mocker.patch('httpx.head', side_effect=[exc, _response(200, method='HEAD')])
+
+    assert docker_registry.manifest_exists('agent', '7.80.0-rc.1') is True
+    assert head.call_count == 2
+
+
+@pytest.mark.parametrize(
+    'status, expected',
+    [
+        pytest.param(404, False, id='withdrawn-tag'),
+        pytest.param(500, None, id='server-error'),
+    ],
+)
+def test_manifest_exists_does_not_retry_a_served_response(
+    mocker: MockerFixture, status: int, expected: bool | None
+) -> None:
+    """A status the registry actually served is final; only connection failures are retried.
+
+    Retrying a 404 would let a withdrawn tag look like a network blip and cost three
+    round trips to reach the same answer.
+    """
+    head = mocker.patch('httpx.head', return_value=_response(status, method='HEAD'))
+
+    if expected is None:
+        with pytest.raises(httpx.HTTPStatusError):
+            docker_registry.manifest_exists('agent', '7.80.0-rc.1')
+    else:
+        assert docker_registry.manifest_exists('agent', '7.80.0-rc.1') is expected
+
+    assert head.call_count == 1
 
 
 def test_manifest_exists_uses_custom_host(mocker: MockerFixture) -> None:
@@ -155,15 +196,43 @@ def test_list_tags_ignores_non_next_link_relations(mocker: MockerFixture) -> Non
     assert get.call_count == 1
 
 
-@pytest.mark.parametrize(
-    'exc',
-    [
-        pytest.param(httpx.ConnectError('connection refused'), id='connect-error'),
-        pytest.param(httpx.ReadTimeout('read timed out'), id='read-timeout'),
-    ],
-)
+@pytest.mark.parametrize('exc', TRANSIENT_ERROR_PARAMS)
 def test_list_tags_propagates_network_errors(mocker: MockerFixture, exc: Exception) -> None:
-    mocker.patch('httpx.get', side_effect=exc)
+    get = mocker.patch('httpx.get', side_effect=exc)
 
     with pytest.raises(type(exc)):
         docker_registry.list_tags('agent')
+
+    assert get.call_count == ATTEMPTS
+
+
+@pytest.mark.parametrize('exc', TRANSIENT_ERROR_PARAMS)
+def test_list_tags_retries_a_transient_failure(mocker: MockerFixture, exc: Exception) -> None:
+    get = mocker.patch('httpx.get', side_effect=[exc, _response(200, json_body={'name': 'agent', 'tags': ['a']})])
+
+    assert docker_registry.list_tags('agent') == ['a']
+    assert get.call_count == 2
+
+
+def test_list_tags_retries_each_page_independently(mocker: MockerFixture) -> None:
+    """A blip while fetching page 2 must not discard page 1 or restart pagination."""
+    page_1 = _response(
+        200,
+        json_body={'name': 'agent', 'tags': ['a']},
+        headers={'Link': '</v2/agent/tags/list?last=a>; rel="next"'},
+    )
+    page_2 = _response(200, json_body={'name': 'agent', 'tags': ['b']})
+    get = mocker.patch('httpx.get', side_effect=[page_1, httpx.ConnectError('connection reset'), page_2])
+
+    assert docker_registry.list_tags('agent') == ['a', 'b']
+    assert get.call_count == 3
+    assert get.call_args_list[2].args[0] == 'https://registry.datadoghq.com/v2/agent/tags/list?last=a'
+
+
+def test_list_tags_does_not_retry_a_served_error(mocker: MockerFixture) -> None:
+    get = mocker.patch('httpx.get', return_value=_response(503))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        docker_registry.list_tags('agent')
+
+    assert get.call_count == 1


### PR DESCRIPTION
### What does this PR do?

- Adds a shared `request_with_retries` helper to `ddev.utils.network` that retries transient httpx connection failures (`ConnectError`, `ConnectTimeout`, `ReadError`, `ReadTimeout`, `RemoteProtocolError`) with bounded backoff. It is built on `stamina`, already used for retries elsewhere in ddev, so no backoff arithmetic is reimplemented.
- Routes both Docker Registry v2 reads, `manifest_exists` and `list_tags`, through that helper. Neither had any retry before.
- Retries only connection-level failures. A status the registry actually served stays final, so a withdrawn or mistyped tag still fails on the first attempt rather than costing three round trips to reach the same answer. In `list_tags` the retry sits inside the pagination loop, so a blip on one page neither discards earlier pages nor restarts the walk.
- Replaces the hand-rolled retry loop that [#25142](https://github.com/DataDog/integrations-core/pull/25142) added to `ddev validate licenses` with the same helper, removing the duplicated error tuple and backoff arithmetic. The retried unit there remains the whole download and extract, because the body is consumed inside the `httpx.stream` context and a reset mid-transfer surfaces there.
- Grows the registry tests from 20 to 39 cases, covering recovery on a later attempt, a bounded attempt count, per-page retries during pagination, and no retry on a served 404 or 5xx.

### Motivation

The Windows job on [this pipeline](https://app.datadoghq.com/ci/ci-cd/explorer?query=ci_level%3Ajob%20%40ci.status%3Aerror%20%40git.commit.sha%3A15ae7e6cab7f43a62e190d30c7b1929a010fe90f&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=pipelines&index=cipipeline&tab=logs) failed on commit `15ae7e6` of [#25150](https://github.com/DataDog/integrations-core/pull/25150):

```
FAILED tests/e2e/test_agent_images.py::test_every_image_in_the_manifest_is_published
    - httpx.ConnectError: [WinError 10054] An existing connection was forcibly closed by the remote host
```

This is the same class of flake that [#25142](https://github.com/DataDog/integrations-core/pull/25142) fixed for license downloads, but only half of that fix transfers here (we cannot test this offline mocking the httpx transport).

So this PR keeps the live check intact and instead adds the retries the registry helpers never had, then reuses the resulting helper to consolidate the one from #25142.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required. Developer tooling only; `qa/skip-qa`.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged