### PR TITLE
AI-7161 Add a shared Dispatcher monitoring runtime

### DIFF
--- a/ddev/changelog.d/25159.added
+++ b/ddev/changelog.d/25159.added
@@ -1,0 +1,1 @@
+Add a shared monitoring runtime for Dispatcher context, console logging, and metric sinks.

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "pluggy",
     "rich>=12.5.1",
     "stamina==26.1.0",
+    "structlog==26.1.0",
     "tomli; python_version < '3.11'",
     "tomli-w",
     "tomlkit",

--- a/ddev/src/ddev/cli/application.py
+++ b/ddev/src/ddev/cli/application.py
@@ -54,8 +54,10 @@ class AppLoggingHandler(logging.Handler):
             self._app.display_error(msg)
         elif record.levelno >= logging.WARNING:
             self._app.display_warning(msg)
-        else:
+        elif record.levelno >= logging.INFO:
             self._app.display_info(msg)
+        else:
+            self._app.display_debug(msg)
 
 
 class Application(Terminal):

--- a/ddev/src/ddev/cli/ci/dispatch_run.py
+++ b/ddev/src/ddev/cli/ci/dispatch_run.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ddev.cli.application import Application
+    from ddev.monitoring import ComponentMonitor
     from ddev.utils.git import ChangedFile
     from ddev.utils.github_async import AsyncGitHubClient
     from ddev.utils.github_async.models import PullRequest, PullRequestRef, PullRequestSimple
@@ -102,6 +103,7 @@ def resolve_run(
     commit: str | None,
     token: str,
     all_targets: bool,
+    monitor: ComponentMonitor | None = None,
 ) -> ResolvedRun | None:
     """Resolve what to test, reporting why a run has nothing left to test before returning None."""
     if pr_resolver is not None:

--- a/ddev/src/ddev/cli/ci/dispatch_tests.py
+++ b/ddev/src/ddev/cli/ci/dispatch_tests.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import click
@@ -17,6 +18,7 @@ if TYPE_CHECKING:
     from ddev.cli.ci.tests.dispatcher import DispatcherContext
     from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
     from ddev.cli.ci.tests.messages import TestBatch
+    from ddev.monitoring import ComponentMonitor
     from ddev.utils.git import ChangedFile
 
 DEFAULT_OUTPUT_DIRECTORY = ".dispatcher"
@@ -114,91 +116,121 @@ def dispatch_tests(
     Its base and diff come from GitHub; `--commit` instead compares a default-branch commit
     with its first parent using local git.
     """
-    import logging
     from pathlib import Path
 
+    from ddev.cli.application import AppLoggingHandler
     from ddev.cli.ci.tests.batching.hatch_environments import HatchEnvironmentProvider
-    from ddev.cli.ci.tests.dispatcher import DispatcherContext, build_dispatcher
+    from ddev.cli.ci.tests.dispatcher import (
+        PROTECTED_RUN_FIELDS,
+        DispatcherContext,
+        build_dispatcher,
+        run_fields,
+        tag_fields,
+    )
     from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
+    from ddev.monitoring import MonitoringRuntime, console_formatter
     from ddev.utils.github import resolve_owner_repo
 
     owner, repo = resolve_owner_repo(app, repository)
-    pr_resolver, token = validate_options(
-        app,
-        owner=owner,
-        repo=repo,
-        pull_request=pull_request,
-        pr_head_sha=pr_head_sha,
-        pr_head_repo=pr_head_repo,
-        pr_head_ref=pr_head_ref,
-        pr_base_ref=pr_base_ref,
-        commit=commit,
-        dry_run=dry_run,
-    )
 
-    # One INFO line per request would bury the Dispatcher's own progress.
-    logging.getLogger('httpx').setLevel(logging.WARNING)
+    caller_tags = tuple(tags.split()) if tags else ()
 
-    config = DispatcherConfig.from_repo_config(app.repo.config)
-
-    run = resolve_run(app, pr_resolver=pr_resolver, commit=commit, token=token, all_targets=all_targets)
-    if run is None:
-        return
-
-    batches = build_plan(
-        app,
-        config=config,
-        changed_files=run.changed_files,
-        all_targets=all_targets,
-        minimum_base_package=minimum_base_package,
-        environment_provider=HatchEnvironmentProvider(default_python_version=config.default_python_version),
-    )
-    if not batches:
-        app.display_info('No affected target to test.')
-        return
-
-    context = DispatcherContext(
-        owner=owner,
-        repo=repo,
-        tags=tuple(tags.split()) if tags else (),
-        pytest_args=pytest_args or '',
-        checkout_sha=run.checkout_sha,
-        base_sha=run.base_sha,
-        branch=run.branch,
-        is_fork=run.is_fork,
-        workflow=workflow or config.workflow,
-        workflow_ref=workflow_ref or config.workflow_ref,
-        target_branch=run.target_branch,
-        pr_number=run.pr_number,
-    )
-
-    display_plan(app, context, batches)
-    if dry_run:
-        app.display_info('Dry run: nothing was dispatched.')
-        return
-
-    base_path = Path(output_dir) if output_dir else app.repo.path / DEFAULT_OUTPUT_DIRECTORY
-    dispatcher = build_dispatcher(
-        batches=batches,
-        context=context,
-        config=config,
-        token=token,
-        artifacts_path=base_path / 'artifacts',
-        output_path=base_path / 'results',
-        run_logger=app.logger,
-    )
-    # A fatal processor or hook failure leaves the bus by raising out of `run`. `on_finalize` has
-    # already published whatever it knew by then, so a message is more use here than a traceback.
+    console_handler = AppLoggingHandler(app)
+    console_handler.setFormatter(console_formatter(hidden_fields=PROTECTED_RUN_FIELDS | set(tag_fields(caller_tags))))
+    monitoring = MonitoringRuntime(console_handler=console_handler, protected_fields=PROTECTED_RUN_FIELDS)
     try:
-        dispatcher.run()
-    except Exception as error:
-        app.abort(f'Dispatcher execution failed: {error}')
+        monitoring.set_run_fields(**{**tag_fields(caller_tags), 'repo': f'{owner}/{repo}'})
 
-    outcome = dispatcher.outcome
-    if outcome is None or not outcome.successful:
-        app.abort('Dispatcher tests failed.')
+        pr_resolver, token = validate_options(
+            app,
+            owner=owner,
+            repo=repo,
+            pull_request=pull_request,
+            pr_head_sha=pr_head_sha,
+            pr_head_repo=pr_head_repo,
+            pr_head_ref=pr_head_ref,
+            pr_base_ref=pr_base_ref,
+            commit=commit,
+            dry_run=dry_run,
+        )
 
-    app.display_success('Dispatcher tests passed.')
+        # One INFO line per request would bury the Dispatcher's own progress.
+        logging.getLogger('httpx').setLevel(logging.WARNING)
+
+        config = DispatcherConfig.from_repo_config(app.repo.config)
+
+        run = resolve_run(
+            app,
+            pr_resolver=pr_resolver,
+            commit=commit,
+            token=token,
+            all_targets=all_targets,
+            monitor=monitoring.component('resolution'),
+        )
+        if run is None:
+            return
+
+        context = DispatcherContext(
+            owner=owner,
+            repo=repo,
+            tags=caller_tags,
+            pytest_args=pytest_args or '',
+            checkout_sha=run.checkout_sha,
+            base_sha=run.base_sha,
+            branch=run.branch,
+            is_fork=run.is_fork,
+            workflow=workflow or config.workflow,
+            workflow_ref=workflow_ref or config.workflow_ref,
+            target_branch=run.target_branch,
+            pr_number=run.pr_number,
+        )
+
+        # Resolved identity binds before planning, so a bad plan is still reported on its own run.
+        monitoring.set_run_fields(**run_fields(context))
+
+        batches = build_plan(
+            app,
+            config=config,
+            changed_files=run.changed_files,
+            all_targets=all_targets,
+            minimum_base_package=minimum_base_package,
+            environment_provider=HatchEnvironmentProvider(default_python_version=config.default_python_version),
+            monitor=monitoring.component('planner'),
+        )
+        if not batches:
+            app.display_info('No affected target to test.')
+            return
+
+        display_plan(app, context, batches)
+        if dry_run:
+            app.display_info('Dry run: nothing was dispatched.')
+            return
+
+        base_path = Path(output_dir) if output_dir else app.repo.path / DEFAULT_OUTPUT_DIRECTORY
+        dispatcher = build_dispatcher(
+            batches=batches,
+            context=context,
+            config=config,
+            token=token,
+            artifacts_path=base_path / 'artifacts',
+            output_path=base_path / 'results',
+            run_logger=app.logger,
+            monitoring=monitoring,
+        )
+        # A fatal processor or hook failure leaves the bus by raising out of `run`. `on_finalize` has
+        # already published whatever it knew by then, so a message is more use here than a traceback.
+        try:
+            dispatcher.run()
+        except Exception as error:
+            app.abort(f'Dispatcher execution failed: {error}')
+
+        outcome = dispatcher.outcome
+        if outcome is None or not outcome.successful:
+            app.abort('Dispatcher tests failed.')
+
+        app.display_success('Dispatcher tests passed.')
+    finally:
+        monitoring.close()
 
 
 def validate_options(
@@ -271,6 +303,7 @@ def build_plan(
     all_targets: bool,
     minimum_base_package: bool,
     environment_provider: EnvironmentProvider,
+    monitor: ComponentMonitor | None = None,
 ) -> list[TestBatch]:
     """Build the batches this run must execute, aborting with a readable message on a bad plan.
 

--- a/ddev/src/ddev/cli/ci/tests/dispatcher.py
+++ b/ddev/src/ddev/cli/ci/tests/dispatcher.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import signal
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ddev.cli.ci.tests.messages import BatchFinished, BatchProgressUpdate, TestBatch, UpdatePRComment
 from ddev.cli.ci.tests.pr_comment import render_run_summary, summary_line
@@ -18,7 +19,10 @@ from ddev.cli.ci.tests.status import Status
 from ddev.cli.ci.tests.task_run_reporter import RunReporterOptions, TaskRunReporter
 from ddev.cli.ci.tests.task_test_gatherer import TaskTestGatherer
 from ddev.cli.ci.tests.task_test_runner import TaskTestRunner, TestRunnerOptions
-from ddev.event_bus.orchestrator import BaseMessage, EventBusOrchestrator
+from ddev.event_bus.orchestrator import BaseMessage, EventBusOrchestrator, MessageScope
+from ddev.monitoring import ComponentMonitor
+from ddev.monitoring.context import MonitorContext
+from ddev.monitoring.runtime import MonitoringRuntime
 from ddev.utils.github_actions import write_step_summary
 from ddev.utils.rate_limiting import RelaxedRateLimits
 
@@ -39,7 +43,7 @@ CANCELLED_RATE_LIMITS = RelaxedRateLimits(max_wait_seconds=2.0, max_rate=10_000.
 @dataclass(frozen=True)
 class DispatcherContext:
     """The run being tested. `build_dispatcher` consumes part of it; the rest describes the run
-    for the plan header and, once metrics land, for their tags.
+    for the plan header and for the monitoring run context (see `run_fields`).
 
     `base_sha` and `checkout_sha` are deliberately separate: a pull request is tested at the merge
     commit (`refs/pull/<n>/merge`) but its checks belong to the head commit. Outside a pull request
@@ -86,6 +90,57 @@ class DispatcherOutcome:
         )
 
 
+def tag_fields(tags: tuple[str, ...]) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    for tag in tags:
+        key, _, value = tag.partition(':')
+        if key:
+            fields[key] = value
+    return fields
+
+
+PROTECTED_RUN_FIELDS = frozenset({'repo', 'branch', 'commit', 'context', 'pr_number', 'target-branch'})
+
+
+def run_fields(context: DispatcherContext) -> dict[str, Any]:
+    """Resolved identity wins; non-PR context uses the caller's tag or defaults to master."""
+    fields = tag_fields(context.tags)
+    fields.update(
+        {
+            # The head revision the run reports on. `checkout_sha` is deliberately not used: for a
+            # pull request it is a merge ref, not a SHA.
+            'commit': context.base_sha,
+            'branch': context.branch,
+            'pr_number': context.pr_number,
+            'target-branch': context.target_branch,
+            'repo': f'{context.owner}/{context.repo}',
+        }
+    )
+    if context.pr_number is not None:
+        fields['context'] = 'pr'
+    elif 'context' not in fields:
+        fields['context'] = 'master'
+    return fields
+
+
+def message_fields(message: BaseMessage) -> dict[str, Any]:
+    """Run-wide reports must not inherit the identity of the batch that triggered them."""
+    match message:
+        case TestBatch(batch_id=batch_id):
+            return {'batch_id': batch_id}
+        case BatchProgressUpdate(batch_id=batch_id, run_id=run_id) | BatchFinished(batch_id=batch_id, run_id=run_id):
+            return {'batch_id': batch_id, 'run_id': run_id}
+        case _:
+            return {}
+
+
+def message_scope(context: MonitorContext) -> MessageScope:
+    def scope(message: BaseMessage) -> AbstractContextManager[None]:
+        return context.scope(message_fields(message))
+
+    return scope
+
+
 class Dispatcher(EventBusOrchestrator):
     """Runs a batching plan to completion and publishes its result.
 
@@ -104,8 +159,15 @@ class Dispatcher(EventBusOrchestrator):
         max_timeout: float | None,
         grace_period: float,
         run_logger: logging.Logger | None = None,
+        monitor: ComponentMonitor | None = None,
+        message_scope: MessageScope | None = None,
     ):
-        super().__init__(run_logger or logger, max_timeout=max_timeout, grace_period=grace_period)
+        super().__init__(
+            run_logger or logger,
+            max_timeout=max_timeout,
+            grace_period=grace_period,
+            message_scope=message_scope,
+        )
         self._batches = batches
         self._client = client
         self._runner = runner
@@ -113,6 +175,7 @@ class Dispatcher(EventBusOrchestrator):
         self._reporter = reporter
         self._outcome: DispatcherOutcome | None = None
         self._cancelled = False
+        self._monitor = monitor
 
         self.register_processor(runner, [TestBatch])
         self.register_processor(gatherer, [BatchFinished, BatchProgressUpdate])
@@ -132,7 +195,11 @@ class Dispatcher(EventBusOrchestrator):
         self.submit_message(self._gatherer.build_initial_update())
         for batch in self._batches:
             self.submit_message(batch)
-        self._logger.info("Dispatched %s batches", len(self._batches))
+        if self._monitor is None:
+            self._logger.info('Dispatched %s batches', len(self._batches))
+        else:
+            # Queued, not dispatched: the workflows start when the runner's messages are processed.
+            self._monitor.logger.info('Queued planned batches', batch_count=len(self._batches))
 
     def on_shutdown_signal(self, received: signal.Signals) -> None:
         """Record that the run was cancelled, then size what is left for the seconds it has.
@@ -162,7 +229,10 @@ class Dispatcher(EventBusOrchestrator):
                 progress=progress,
                 final_report_published=self._reporter.final_report_published,
             )
-            self._logger.info(summary_line(progress))
+            if self._monitor is None:
+                self._logger.info(summary_line(progress))
+            else:
+                self._monitor.logger.info(summary_line(progress))
             if (body := self._reporter.latest_body) is not None:
                 write_step_summary(render_run_summary(body, pr_comment_failed=self._reporter.pr_comment_failed))
         finally:
@@ -204,13 +274,19 @@ def build_dispatcher(
     artifacts_path: Path,
     output_path: Path,
     run_logger: logging.Logger | None = None,
+    monitoring: MonitoringRuntime | None = None,
 ) -> Dispatcher:
     """Assemble the client, the three tasks and the Dispatcher from a plan and its run context.
 
     One HTTP pool is shared by every task. Artifact collection uses its own local bucket;
     all buckets share the provider's budget and pauses.
+
+    The caller owns ``monitoring``; omitting it retains stdlib logging.
     """
     from ddev.utils.github_async import AsyncGitHubClient
+
+    def view(name: str) -> ComponentMonitor | None:
+        return monitoring.component(name) if monitoring is not None else None
 
     active_logger = run_logger or logger
     integrations = frozenset(integration for batch in batches for integration in batch.integrations)
@@ -234,12 +310,14 @@ def build_dispatcher(
             pytest_args=context.pytest_args,
         ),
         artifact_client=client.with_rate_limit(rate_limiters.artifacts),
+        monitor=view('test-runner'),
     )
-    gatherer = TaskTestGatherer("test-gatherer", output_path, batches)
+    gatherer = TaskTestGatherer("test-gatherer", output_path, batches, monitor=view('test-gatherer'))
     reporter = TaskRunReporter(
         "run-reporter",
         client,
         RunReporterOptions(owner=context.owner, repo=context.repo, pr_number=context.pr_number),
+        monitor=view('run-reporter'),
     )
 
     return Dispatcher(
@@ -251,4 +329,6 @@ def build_dispatcher(
         max_timeout=config.global_timeout_seconds,
         grace_period=config.grace_period_seconds,
         run_logger=active_logger,
+        monitor=view('dispatcher'),
+        message_scope=message_scope(monitoring.context) if monitoring is not None else None,
     )

--- a/ddev/src/ddev/cli/ci/tests/task_run_reporter.py
+++ b/ddev/src/ddev/cli/ci/tests/task_run_reporter.py
@@ -20,6 +20,7 @@ from ddev.cli.ci.tests.pr_comment import (
     summary_line,
 )
 from ddev.event_bus.orchestrator import AsyncProcessor
+from ddev.monitoring import ComponentMonitor
 from ddev.utils.github_errors import GitHubBodyTooLongError
 
 if TYPE_CHECKING:
@@ -83,7 +84,14 @@ class TaskRunReporter(AsyncProcessor["UpdatePRComment"]):
     not prove ownership, though, so an edit GitHub refuses means "not our comment".
     """
 
-    def __init__(self, name: str, client: AsyncGitHubClient, options: RunReporterOptions):
+    def __init__(
+        self,
+        name: str,
+        client: AsyncGitHubClient,
+        options: RunReporterOptions,
+        *,
+        monitor: ComponentMonitor | None = None,
+    ):
         super().__init__(name)
         self._client = client
         self._options = options
@@ -100,6 +108,7 @@ class TaskRunReporter(AsyncProcessor["UpdatePRComment"]):
         self._final_report_published = False
         self._lock = asyncio.Lock()
         self._logger = logging.getLogger(f"{__name__}.{name}")
+        self.monitor = monitor
 
     @property
     def latest_body(self) -> str | None:

--- a/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_gatherer.py
@@ -29,6 +29,7 @@ from ddev.cli.ci.tests.progress import (
 )
 from ddev.cli.ci.tests.status import Status, conclusion_to_status
 from ddev.event_bus.orchestrator import SyncProcessor
+from ddev.monitoring import ComponentMonitor
 from ddev.utils.github_async.models.workflow import WorkflowJobStatus
 from ddev.utils.junit import parse_junit_dir
 
@@ -58,7 +59,9 @@ class TaskTestGatherer(SyncProcessor[BatchFinished | BatchProgressUpdate]):
     Registries are keyed by ``batch_id``: it is stable across workflow attempts, ``run_id`` is not.
     """
 
-    def __init__(self, name: str, output_base_path: Path, batches: list[TestBatch]) -> None:
+    def __init__(
+        self, name: str, output_base_path: Path, batches: list[TestBatch], *, monitor: ComponentMonitor | None = None
+    ) -> None:
         super().__init__(name)
         self._output_base_path = output_base_path
         self._revision = 0
@@ -71,6 +74,7 @@ class TaskTestGatherer(SyncProcessor[BatchFinished | BatchProgressUpdate]):
         }
         self._lock = threading.Lock()
         self._logger = logging.getLogger(f"{__name__}.{name}")
+        self.monitor = monitor
 
     def process_message(self, message: BatchFinished | BatchProgressUpdate) -> None:
         if isinstance(message, BatchProgressUpdate):

--- a/ddev/src/ddev/cli/ci/tests/task_test_runner.py
+++ b/ddev/src/ddev/cli/ci/tests/task_test_runner.py
@@ -18,6 +18,7 @@ from ddev.cli.ci.tests.messages import BatchFinished, BatchJob, BatchJobResult, 
 from ddev.cli.ci.tests.progress import ExecutionState
 from ddev.cli.ci.tests.status import conclusion_to_status
 from ddev.event_bus.orchestrator import AsyncProcessor
+from ddev.monitoring import ComponentMonitor
 from ddev.utils.github_async import AsyncGitHubClient, GitHubResponse
 from ddev.utils.github_async.models import Artifact, WorkflowJob, WorkflowRun
 from ddev.utils.github_async.models.workflow import WorkflowJobStatus
@@ -87,6 +88,7 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
         options: TestRunnerOptions,
         *,
         artifact_client: AsyncGitHubClient,
+        monitor: ComponentMonitor | None = None,
     ):
         super().__init__(name)
         self._client = client
@@ -94,6 +96,7 @@ class TaskTestRunner(AsyncProcessor[TestBatch]):
         self._options = options
         self._runs_in_flight: dict[str, int] = {}
         self._logger = logging.getLogger(f"{__name__}.{name}")
+        self.monitor = monitor
 
     async def process_message(self, message: TestBatch):
         log_extra: dict[str, Any] = {"batch_id": message.batch_id}

--- a/ddev/src/ddev/event_bus/orchestrator.py
+++ b/ddev/src/ddev/event_bus/orchestrator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import contextvars
 import logging
 import math
 import signal
@@ -13,6 +14,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from concurrent.futures import wait as wait_for_futures
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from types import FrameType
 from typing import assert_never, cast
@@ -31,6 +33,7 @@ type ErrorHandler[E: Exception] = Callable[[E], Awaitable[None]]
 # What `signal.getsignal` hands back: a Python callable, one of the `SIG_*` constants, or None for a
 # handler installed outside Python.
 type SignalHandler = Callable[[int, FrameType | None], object] | int | signal.Handlers | None
+type MessageScope = Callable[[BaseMessage], AbstractContextManager[None]]
 
 DEFAULT_ORCHESTRATOR_MAX_TIMEOUT = 300.0
 # How long the loop may block before re-reading the timeout and the stop flag.
@@ -144,6 +147,7 @@ class EventBusOrchestrator(ABC):
         grace_period: float = 10,
         executor: Executor | None = None,
         fail_fast: bool = False,
+        message_scope: MessageScope | None = None,
     ):
         """
         Args:
@@ -163,6 +167,8 @@ class EventBusOrchestrator(ABC):
                        the orchestrator. If False (default), such exceptions are logged
                        and processing continues. ``FatalProcessingError`` always stops the
                        orchestrator regardless of this flag.
+            message_scope: Context manager for each processor invocation, including success/error
+                           hooks. Derive context from the message; queues do not transfer it.
         """
         resolved_max_timeout = max_timeout if max_timeout is not None else math.inf
         self.__validate_parameters(resolved_max_timeout, grace_period)
@@ -178,6 +184,7 @@ class EventBusOrchestrator(ABC):
         self._sync_work: set[Future] = set()
         self._sync_work_lock = threading.Lock()
         self._stop_claim = threading.Lock()
+        self._message_scope = message_scope
         self._fail_fast = fail_fast
         self._subscribers: dict[type[BaseMessage], list[Processor]] = {}
         self._processors: list[Processor] = []
@@ -412,8 +419,11 @@ class EventBusOrchestrator(ABC):
 
         Tracked through the pool's own future rather than this call, because cancelling the caller
         only cancels work the pool has not started yet; anything already running carries on.
+
+        Executor submission does not propagate contextvars; each invocation needs its own copy.
         """
-        future = self._executor.submit(work, message)
+        context = contextvars.copy_context()
+        future = self._executor.submit(context.run, work, message)
         with self._sync_work_lock:
             self._sync_work.add(future)
         future.add_done_callback(self._forget_sync_work)
@@ -777,29 +787,31 @@ class EventBusOrchestrator(ABC):
             )
             return
 
-        try:
-            match processor:
-                case AsyncProcessor():
-                    await cast(AsyncProcessor, processor).process_message(message)
-                case SyncProcessor():
-                    await self._run_in_worker(processor.process_message, message)
-                case _:
-                    assert_never(processor)
-        except (FatalProcessingError, asyncio.CancelledError):
-            raise
-        except Exception as processing_error:
-            await self._apply_error_policy(
-                MessageProcessingError(processor.name, message, processing_error),
-                processor.on_error,
-            )
-            return
+        scope = self._message_scope(message) if self._message_scope is not None else nullcontext()
+        with scope:
+            try:
+                match processor:
+                    case AsyncProcessor():
+                        await cast(AsyncProcessor, processor).process_message(message)
+                    case SyncProcessor():
+                        await self._run_in_worker(processor.process_message, message)
+                    case _:
+                        assert_never(processor)
+            except (FatalProcessingError, asyncio.CancelledError):
+                raise
+            except Exception as processing_error:
+                await self._apply_error_policy(
+                    MessageProcessingError(processor.name, message, processing_error),
+                    processor.on_error,
+                )
+                return
 
-        try:
-            await processor.on_success(message)
-        except (FatalProcessingError, asyncio.CancelledError):
-            raise
-        except Exception as e:
-            await self._apply_error_policy(
-                ProcessorHookError(HookName.ON_SUCCESS, processor.name, message, e),
-                processor.on_error,
-            )
+            try:
+                await processor.on_success(message)
+            except (FatalProcessingError, asyncio.CancelledError):
+                raise
+            except Exception as e:
+                await self._apply_error_policy(
+                    ProcessorHookError(HookName.ON_SUCCESS, processor.name, message, e),
+                    processor.on_error,
+                )

--- a/ddev/src/ddev/monitoring/__init__.py
+++ b/ddev/src/ddev/monitoring/__init__.py
@@ -1,0 +1,20 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Shared logging and metrics context for command-scoped monitoring."""
+
+from ddev.monitoring.context import MonitorContext
+from ddev.monitoring.logger import console_formatter
+from ddev.monitoring.metrics import MetricKind, MetricRecord, Metrics, MetricsSink
+from ddev.monitoring.runtime import ComponentMonitor, MonitoringRuntime
+
+__all__ = [
+    'ComponentMonitor',
+    'MetricKind',
+    'MetricRecord',
+    'Metrics',
+    'MetricsSink',
+    'MonitorContext',
+    'MonitoringRuntime',
+    'console_formatter',
+]

--- a/ddev/src/ddev/monitoring/context.py
+++ b/ddev/src/ddev/monitoring/context.py
@@ -1,0 +1,67 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""The run context: one source of fields for every log record and metric a run emits."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from types import MappingProxyType
+from typing import Any
+
+EMPTY_FIELDS: Mapping[str, Any] = MappingProxyType({})
+
+
+def enrich(
+    base: Mapping[str, Any], scope: Mapping[str, Any], call: Mapping[str, Any], protected: Collection[str] = ()
+) -> dict[str, Any]:
+    """Apply local overrides without changing protected run identity."""
+    fields = {**base, **scope, **call}
+    for key in protected:
+        if key in base:
+            fields[key] = base[key]
+    return fields
+
+
+class MonitorContext:
+    """Run metadata and task-local scopes, shared by logs and metrics."""
+
+    def __init__(self, protected: Collection[str] = ()) -> None:
+        self._base: dict[str, Any] = {}
+        self._protected = frozenset(protected)
+        # A module-level variable would leak scopes between runtimes.
+        self._scope: ContextVar[Mapping[str, Any]] = ContextVar('ddev_monitoring_scope', default=EMPTY_FIELDS)
+
+    @property
+    def protected_fields(self) -> frozenset[str]:
+        return self._protected
+
+    def set_fields(self, **fields: Any) -> None:
+        """Updates affect subsequent records, not already-emitted snapshots."""
+        self._base.update(fields)
+
+    @property
+    def base_fields(self) -> Mapping[str, Any]:
+        return MappingProxyType(dict(self._base))
+
+    @property
+    def scoped(self) -> Mapping[str, Any]:
+        return self._scope.get()
+
+    @property
+    def fields(self) -> Mapping[str, Any]:
+        return MappingProxyType(enrich(self._base, self._scope.get(), EMPTY_FIELDS, self._protected))
+
+    @contextmanager
+    def scope(self, fields: Mapping[str, Any] | None = None) -> Iterator[None]:
+        """Restore the enclosing scope on exit, including cancellation."""
+        if not fields:
+            yield
+            return
+        token = self._scope.set({**self._scope.get(), **fields})
+        try:
+            yield
+        finally:
+            self._scope.reset(token)

--- a/ddev/src/ddev/monitoring/logger.py
+++ b/ddev/src/ddev/monitoring/logger.py
@@ -1,0 +1,52 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Shared-context enrichment and per-handler rendering for structlog."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Collection
+from typing import Any
+
+import structlog
+from structlog.typing import EventDict, Processor
+
+from ddev.monitoring.context import MonitorContext, enrich
+
+
+def logger_processors(context: MonitorContext, is_closed: Callable[[], bool]) -> tuple[Processor, ...]:
+    """Resolve context and ``exc_info=True`` before deferred handlers leave the emitting frame."""
+
+    def enrich_and_gate(_logger: Any, _method_name: str, event_dict: EventDict) -> EventDict:
+        if is_closed():
+            raise structlog.DropEvent
+        base = context.base_fields
+        return enrich(base, context.scoped, event_dict, context.protected_fields)
+
+    return (
+        enrich_and_gate,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.format_exc_info,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+    )
+
+
+def console_formatter(hidden_fields: Collection[str] = ()) -> structlog.stdlib.ProcessorFormatter:
+    """Hide metadata on the formatter's copy, but always retain the message and traceback."""
+    hidden = frozenset(hidden_fields) - {'event', 'exception', 'stack'}
+
+    def project(_logger: Any, _method_name: str, event_dict: EventDict) -> EventDict:
+        for key in hidden:
+            event_dict.pop(key, None)
+        # Level presentation belongs to the application display methods, not the line.
+        event_dict.pop('level', None)
+        return event_dict
+
+    return structlog.stdlib.ProcessorFormatter(
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            project,
+            structlog.dev.ConsoleRenderer(colors=False),
+        ],
+    )

--- a/ddev/src/ddev/monitoring/metrics.py
+++ b/ddev/src/ddev/monitoring/metrics.py
@@ -1,0 +1,92 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""The public metrics interface: count, gauge and distribution, enriched and handed to a sink."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any, Protocol
+
+from ddev.monitoring.context import EMPTY_FIELDS, MonitorContext, enrich
+
+EMPTY_TAGS: Mapping[str, str] = MappingProxyType({})
+
+
+class MetricKind(StrEnum):
+    COUNT = 'count'
+    GAUGE = 'gauge'
+    DISTRIBUTION = 'distribution'
+
+
+@dataclass(frozen=True)
+class MetricRecord:
+    """An emission-time snapshot; fields include tags after identity protection."""
+
+    name: str
+    kind: MetricKind
+    value: float
+    tags: Mapping[str, str]
+    fields: Mapping[str, Any]
+
+
+class MetricsSink(Protocol):
+    """Accept records without blocking the emitting thread."""
+
+    def record(self, record: MetricRecord) -> None: ...
+
+
+class Metrics:
+    """No export occurs without a sink or after the runtime closes."""
+
+    def __init__(
+        self,
+        context: MonitorContext,
+        *,
+        sink: MetricsSink | None = None,
+        fields: Mapping[str, Any] = EMPTY_FIELDS,
+        is_closed: Callable[[], bool] | None = None,
+    ) -> None:
+        self._context = context
+        self._sink = sink
+        self._is_closed = is_closed if is_closed is not None else (lambda: False)
+        self._fields = dict(fields)
+
+    def bind(self, **fields: Any) -> Metrics:
+        return Metrics(self._context, sink=self._sink, fields={**self._fields, **fields}, is_closed=self._is_closed)
+
+    def count(self, name: str, value: float = 1, *, tags: Mapping[str, str] | None = None, **fields: Any) -> None:
+        self._emit(MetricKind.COUNT, name, value, tags, fields)
+
+    def gauge(self, name: str, value: float, *, tags: Mapping[str, str] | None = None, **fields: Any) -> None:
+        self._emit(MetricKind.GAUGE, name, value, tags, fields)
+
+    def distribution(self, name: str, value: float, *, tags: Mapping[str, str] | None = None, **fields: Any) -> None:
+        self._emit(MetricKind.DISTRIBUTION, name, value, tags, fields)
+
+    def _emit(
+        self,
+        kind: MetricKind,
+        name: str,
+        value: float,
+        tags: Mapping[str, str] | None,
+        fields: Mapping[str, Any],
+    ) -> None:
+        if self._is_closed() or self._sink is None:
+            return
+        context = self._context
+        protected = context.protected_fields
+        kept_tags = {key: value for key, value in tags.items() if key not in protected} if tags else {}
+        call = {**self._fields, **fields, **kept_tags}
+        self._sink.record(
+            MetricRecord(
+                name=name,
+                kind=kind,
+                value=value,
+                tags=MappingProxyType(kept_tags) if kept_tags else EMPTY_TAGS,
+                fields=enrich(context.base_fields, context.scoped, call, protected),
+            )
+        )

--- a/ddev/src/ddev/monitoring/runtime.py
+++ b/ddev/src/ddev/monitoring/runtime.py
@@ -1,0 +1,100 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""The monitoring runtime: one shared context, logger, metrics interface and lifetime per command."""
+
+from __future__ import annotations
+
+import itertools
+import logging
+from collections.abc import Collection, Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import structlog
+from structlog.stdlib import BoundLogger
+
+from ddev.monitoring.context import MonitorContext
+from ddev.monitoring.logger import logger_processors
+from ddev.monitoring.metrics import Metrics, MetricsSink
+
+_runtime_names = itertools.count()
+
+
+class ComponentMonitor:
+    """A component view sharing the runtime's context and lifetime."""
+
+    def __init__(self, logger: BoundLogger, metrics: Metrics, context: MonitorContext) -> None:
+        self._logger = logger
+        self._metrics = metrics
+        self._context = context
+
+    @property
+    def logger(self) -> BoundLogger:
+        return self._logger
+
+    @property
+    def metrics(self) -> Metrics:
+        return self._metrics
+
+    def bind(self, **fields: Any) -> ComponentMonitor:
+        """Bind fields to this view's logs and metrics without changing other components."""
+        return ComponentMonitor(self._logger.bind(**fields), self._metrics.bind(**fields), self._context)
+
+    @contextmanager
+    def scope(self, **fields: Any) -> Iterator[None]:
+        """Task-local fields shared with every component view of the runtime inside the block."""
+        with self._context.scope(fields):
+            yield
+
+
+class MonitoringRuntime:
+    """Owned by the entry point; component views share its context and lifetime."""
+
+    def __init__(
+        self,
+        *,
+        console_handler: logging.Handler | None = None,
+        metrics_sink: MetricsSink | None = None,
+        protected_fields: Collection[str] = (),
+    ) -> None:
+        self._closed = False
+        self._context = MonitorContext(protected_fields)
+        # An unregistered logger isolates handlers from other command invocations, and the
+        # NullHandler keeps stdlib from writing to `lastResort` when no console handler was supplied.
+        self._stdlib_logger = logging.Logger(f'ddev.monitoring.{next(_runtime_names)}', level=logging.DEBUG)
+        self._stdlib_logger.propagate = False
+        self._stdlib_logger.addHandler(logging.NullHandler())
+        if console_handler is not None:
+            self._stdlib_logger.addHandler(console_handler)
+        self._logger = structlog.wrap_logger(
+            self._stdlib_logger,
+            processors=logger_processors(self._context, lambda: self._closed),
+            wrapper_class=structlog.stdlib.BoundLogger,
+            context_class=dict,
+        ).bind()
+        self._metrics = Metrics(self._context, sink=metrics_sink, is_closed=lambda: self._closed)
+
+    @property
+    def context(self) -> MonitorContext:
+        return self._context
+
+    def set_run_fields(self, **fields: Any) -> None:
+        self._context.set_fields(**fields)
+
+    def add_log_handler(self, handler: logging.Handler) -> None:
+        """Attach a caller-owned handler using a ProcessorFormatter to render structured ``record.msg``."""
+        self._stdlib_logger.addHandler(handler)
+
+    def component(self, name: str, **fields: Any) -> ComponentMonitor:
+        return ComponentMonitor(
+            logger=self._logger.bind(component=name, **fields),
+            metrics=self._metrics.bind(component=name, **fields),
+            context=self._context,
+        )
+
+    def close(self) -> None:
+        """Stop all emissions, detach attached handlers, and leave caller-owned streams open."""
+        self._closed = True
+        for handler in list(self._stdlib_logger.handlers):
+            self._stdlib_logger.removeHandler(handler)

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -6,20 +6,27 @@
 from __future__ import annotations
 
 import subprocess
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from ddev.monitoring import MonitoringRuntime
 from ddev.utils.github_async import GitHubResponse
 from ddev.utils.github_async.models import PullRequest, PullRequestFile
 from tests.cli.ci.helpers import HEAD_SHA, PR_NUMBER, listed_pull_request, pulls_page
 from tests.cli.ci.tests.helpers import make_batch, make_job
+from tests.helpers.monitoring import RecordingJsonHandler, RecordingSink
 
 if TYPE_CHECKING:
     from pathlib import Path
     from unittest.mock import MagicMock
 
+    from pytest_mock import MockerFixture
+
+    from ddev.cli.application import Application
+    from ddev.cli.ci.tests.messages import TestBatch
     from ddev.config.file import ConfigFileWithOverrides
+    from ddev.monitoring import ComponentMonitor
     from tests.helpers.github_async import FakeAsyncGitHubClient
     from tests.helpers.runner import CliRunner
 
@@ -417,3 +424,108 @@ def test_all_targets_plans_without_reading_a_diff(ddev, github, planned):
     assert result.exit_code == 0, result.output
     github.assert_not_called('list_pull_request_files')
     assert planned.call_args.kwargs['changed_files'] is None
+
+
+@pytest.mark.parametrize(
+    ('extra_options', 'asserted_output'),
+    [
+        (['--dry-run'], 'Dry run: nothing was dispatched.'),
+        ([*HEAD_LOOKUP_OPTIONS], 'No open pull request matches the requested revision'),
+    ],
+    ids=['dry-run', 'no-open-pull-request'],
+)
+def test_an_early_exit_still_closes_the_monitoring_runtime(
+    ddev: CliRunner, github: FakeAsyncGitHubClient, planned: MagicMock, mocker, extra_options, asserted_output
+):
+    if [*HEAD_LOOKUP_OPTIONS] == extra_options:
+        github.mock_response('list_pull_requests', pulls_page())
+
+    closed: list[MonitoringRuntime] = []
+
+    class SpyRuntime(MonitoringRuntime):
+        def close(self) -> None:
+            closed.append(self)
+            super().close()
+
+    mocker.patch('ddev.monitoring.MonitoringRuntime', SpyRuntime)
+
+    result = ddev('ci', 'dispatch-tests', *extra_options)
+
+    assert result.exit_code == 0, result.output
+    assert asserted_output in result.output
+    assert len(closed) == 1
+
+
+def test_resolved_identity_reaches_planning_even_when_there_are_no_targets(ddev, local_changes, mocker):
+    sink = RecordingSink()
+
+    def make_runtime(**kwargs: Any) -> MonitoringRuntime:
+        return MonitoringRuntime(metrics_sink=sink, **kwargs)
+
+    def observe_plan(app: Application, *, monitor: ComponentMonitor, **kwargs: Any) -> list[TestBatch]:
+        monitor.metrics.count('plan')
+        return []
+
+    mocker.patch('ddev.monitoring.MonitoringRuntime', make_runtime)
+    mocker.patch('ddev.cli.ci.dispatch_tests.build_plan', observe_plan)
+
+    result = ddev(
+        'ci',
+        'dispatch-tests',
+        '--commit',
+        'a-sha',
+        '--dry-run',
+        '--tags',
+        'repo:contributor/other commit:sneaky team:platform',
+    )
+
+    assert result.exit_code == 0, result.output
+    assert 'No affected target to test.' in result.output
+    [record] = sink.records
+    assert record.fields['repo'] == 'DataDog/integrations-core'
+    assert record.fields['commit'] == 'a-sha'
+    assert record.fields['team'] == 'platform'
+    assert record.fields['component'] == 'planner'
+
+
+@pytest.mark.usefixtures('local_changes')
+@pytest.mark.parametrize('global_options', [(), ('-qq',)], ids=['normal', 'quiet'])
+def test_console_visibility_does_not_change_structured_events(
+    ddev: CliRunner, mocker: MockerFixture, global_options: tuple[str, ...]
+):
+    json_handler = RecordingJsonHandler()
+
+    def make_runtime(**kwargs: Any) -> MonitoringRuntime:
+        runtime = MonitoringRuntime(**kwargs)
+        runtime.add_log_handler(json_handler)
+        return runtime
+
+    def observe_plan(app: Application, *, monitor: ComponentMonitor, **kwargs: Any) -> list[TestBatch]:
+        monitor.logger.info('planning batches')
+        return []
+
+    mocker.patch('ddev.monitoring.MonitoringRuntime', make_runtime)
+    mocker.patch('ddev.cli.ci.dispatch_tests.build_plan', observe_plan)
+
+    result = ddev(
+        *global_options,
+        'ci',
+        'dispatch-tests',
+        '--commit',
+        'a-sha',
+        '--dry-run',
+        '--tags',
+        'repo:contributor/other commit:sneaky team:platform',
+    )
+
+    assert result.exit_code == 0, result.output
+    assert ('planning batches' in result.output) == (not global_options)
+    assert 'repo=' not in result.output
+    assert 'commit=' not in result.output
+    assert 'team=' not in result.output
+    [event] = json_handler.events
+    assert event['repo'] == 'DataDog/integrations-core'
+    assert event['commit'] == 'a-sha'
+    assert event['team'] == 'platform'
+    assert event['component'] == 'planner'
+    assert event['event'] == 'planning batches'

--- a/ddev/tests/cli/ci/test_dispatch_tests.py
+++ b/ddev/tests/cli/ci/test_dispatch_tests.py
@@ -434,26 +434,36 @@ def test_all_targets_plans_without_reading_a_diff(ddev, github, planned):
     ],
     ids=['dry-run', 'no-open-pull-request'],
 )
-def test_an_early_exit_still_closes_the_monitoring_runtime(
-    ddev: CliRunner, github: FakeAsyncGitHubClient, planned: MagicMock, mocker, extra_options, asserted_output
+def test_early_exit_disables_monitoring(
+    ddev: CliRunner,
+    github: FakeAsyncGitHubClient,
+    planned: MagicMock,
+    mocker: MockerFixture,
+    extra_options: list[str],
+    asserted_output: str,
 ):
     if [*HEAD_LOOKUP_OPTIONS] == extra_options:
         github.mock_response('list_pull_requests', pulls_page())
 
-    closed: list[MonitoringRuntime] = []
+    sink = RecordingSink()
+    monitors: list[ComponentMonitor] = []
 
-    class SpyRuntime(MonitoringRuntime):
-        def close(self) -> None:
-            closed.append(self)
-            super().close()
+    def make_runtime(**kwargs: Any) -> MonitoringRuntime:
+        runtime = MonitoringRuntime(metrics_sink=sink, **kwargs)
+        monitor = runtime.component('dispatcher')
+        monitor.metrics.count('before-exit')
+        monitors.append(monitor)
+        return runtime
 
-    mocker.patch('ddev.monitoring.MonitoringRuntime', SpyRuntime)
+    mocker.patch('ddev.monitoring.MonitoringRuntime', make_runtime)
 
     result = ddev('ci', 'dispatch-tests', *extra_options)
 
     assert result.exit_code == 0, result.output
     assert asserted_output in result.output
-    assert len(closed) == 1
+    [monitor] = monitors
+    monitor.metrics.count('after-exit')
+    assert [record.name for record in sink.records] == ['before-exit']
 
 
 def test_resolved_identity_reaches_planning_even_when_there_are_no_targets(ddev, local_changes, mocker):

--- a/ddev/tests/cli/ci/tests/test_dispatcher.py
+++ b/ddev/tests/cli/ci/tests/test_dispatcher.py
@@ -7,30 +7,45 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import logging
 import os
 import signal
 import sys
 import time
 from collections.abc import AsyncIterator
+from io import StringIO
 from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
 
+from ddev.cli.ci.tests import dispatcher as dispatcher_module
 from ddev.cli.ci.tests import rate_limiting
 from ddev.cli.ci.tests.dispatcher import (
     CANCELLED_RATE_LIMITS,
+    PROTECTED_RUN_FIELDS,
     Dispatcher,
     DispatcherContext,
     build_dispatcher,
+    message_fields,
+    run_fields,
 )
 from ddev.cli.ci.tests.dispatcher_config import DispatcherConfig
-from ddev.cli.ci.tests.messages import BatchJob, TestBatch
+from ddev.cli.ci.tests.messages import (
+    BatchFinished,
+    BatchJob,
+    BatchProgressUpdate,
+    TestBatch,
+    UpdatePRComment,
+)
 from ddev.cli.ci.tests.pr_comment import CANCELLED_HEADING
+from ddev.cli.ci.tests.progress import DispatcherProgress, ExecutionState
+from ddev.cli.ci.tests.status import Status
 from ddev.cli.ci.tests.task_run_reporter import RunReporterOptions, TaskRunReporter
 from ddev.cli.ci.tests.task_test_gatherer import TaskTestGatherer
 from ddev.cli.ci.tests.task_test_runner import TaskTestRunner, TestRunnerOptions
+from ddev.monitoring import MonitoringRuntime, console_formatter
 from ddev.utils.github_async import AsyncGitHubClient, GitHubResponse
 from ddev.utils.github_async.models import (
     ArtifactsList,
@@ -43,6 +58,7 @@ from ddev.utils.github_async.models import (
 from ddev.utils.rate_limiting import BucketEvent, InstrumentedAsyncLimiter, RateLimitEvent
 from tests.cli.ci.tests.helpers import jobs_reported, make_batch, make_job
 from tests.helpers.github_async import FakeAsyncGitHubClient
+from tests.helpers.monitoring import RecordingSink
 
 # Every test here runs a Dispatcher to completion, and `on_finalize` writes the run summary. Without
 # this the reports land in the real job summary whenever the suite runs inside a workflow.
@@ -391,3 +407,126 @@ def test_a_run_still_winds_down_when_shutdown_mode_cannot_be_entered(client, tmp
     # The bus's own timeout is 30s, so anything near it means the stop never arrived.
     assert elapsed < 5
     assert [call.kwargs["run_id"] for call in client.calls_to("cancel_workflow_run")] == [123]
+
+
+class ObservingGatherer(TaskTestGatherer):
+    def process_message(self, message: BatchFinished | BatchProgressUpdate) -> None:
+        self.monitor.metrics.count("observed", tags={"tag": message.batch_id})
+        super().process_message(message)
+
+
+@pytest.mark.parametrize(
+    ('context', 'fields'),
+    [
+        (
+            CONTEXT,
+            {
+                'commit': 'head-sha',
+                'branch': 'a-branch',
+                'context': 'pr',
+                'pr_number': 42,
+                'target-branch': 'master',
+                'repo': 'DataDog/integrations-core',
+            },
+        ),
+        (
+            dataclasses.replace(
+                CONTEXT, pr_number=None, target_branch=None, checkout_sha='a-master-sha', base_sha='a-master-sha'
+            ),
+            {
+                'commit': 'a-master-sha',
+                'branch': 'a-branch',
+                'context': 'master',
+                'pr_number': None,
+                'target-branch': None,
+                'repo': 'DataDog/integrations-core',
+            },
+        ),
+        (
+            dataclasses.replace(CONTEXT, tags=('commit:sneaky', 'team:platform')),
+            {
+                'commit': 'head-sha',
+                'branch': 'a-branch',
+                'context': 'pr',
+                'pr_number': 42,
+                'target-branch': 'master',
+                'repo': 'DataDog/integrations-core',
+                'team': 'platform',
+            },
+        ),
+        (
+            dataclasses.replace(CONTEXT, pr_number=None, tags=('context:release',)),
+            {
+                'commit': 'head-sha',
+                'branch': 'a-branch',
+                'context': 'release',
+                'pr_number': None,
+                'target-branch': 'master',
+                'repo': 'DataDog/integrations-core',
+            },
+        ),
+    ],
+    ids=['pull-request', 'default-branch', 'caller-tags', 'caller-context'],
+)
+def test_run_fields(context, fields):
+    assert run_fields(context) == fields
+
+
+def test_message_fields_carry_batch_identity_only_where_a_message_has_one():
+    batch = make_batch()
+    progress = BatchProgressUpdate(
+        id="progress",
+        batch_id=batch.batch_id,
+        run_id=123,
+        workflow_url="https://example.com/run/123",
+        state=ExecutionState.RUNNING,
+        sequence=1,
+    )
+    finished = BatchFinished(
+        id="finished",
+        batch_id=batch.batch_id,
+        status=Status.SUCCESS,
+        run_id=123,
+        workflow_url="https://example.com/run/123",
+        artifacts_path="a-path",
+    )
+    report = UpdatePRComment(id="report", revision=0, progress=DispatcherProgress(batches=(), done=True))
+
+    assert message_fields(batch) == {"batch_id": "batch-01"}
+    assert message_fields(progress) == {"batch_id": "batch-01", "run_id": 123}
+    assert message_fields(finished) == {"batch_id": "batch-01", "run_id": 123}
+    assert message_fields(report) == {}
+
+
+def test_the_shared_runtime_is_wired_through_build_dispatcher(client, tmp_path, monkeypatch):
+    monkeypatch.setattr("ddev.utils.github_async.AsyncGitHubClient", lambda token, rate_limiter=None, **kwargs: client)
+    monkeypatch.setattr(dispatcher_module, "TaskTestGatherer", ObservingGatherer)
+    job = make_job()
+    mock_job_result(client, job, "success")
+    sink = RecordingSink()
+    stream = StringIO()
+    console_handler = logging.StreamHandler(stream)
+    console_handler.setFormatter(console_formatter(hidden_fields=PROTECTED_RUN_FIELDS))
+    monitoring = MonitoringRuntime(console_handler=console_handler, metrics_sink=sink)
+    monitoring.set_run_fields(**run_fields(CONTEXT))
+
+    dispatcher = build_dispatcher(
+        batches=[make_batch(job)],
+        context=CONTEXT,
+        config=DispatcherConfig(grace_period_seconds=0.1, global_timeout_seconds=5),
+        token="test-token",
+        artifacts_path=tmp_path / "artifacts",
+        output_path=tmp_path / "results",
+        monitoring=monitoring,
+    )
+
+    dispatcher.run()
+
+    assert sink.records
+    for record in sink.records:
+        assert record.fields["batch_id"] == record.tags["tag"]
+        assert record.fields["component"] == "test-gatherer"
+    queued = [line for line in stream.getvalue().splitlines() if "Queued planned batches" in line]
+    assert len(queued) == 1
+    assert "component=dispatcher" in queued[0]
+    assert "batch_count=1" in queued[0]

--- a/ddev/tests/cli/test_application.py
+++ b/ddev/tests/cli/test_application.py
@@ -3,12 +3,15 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
+import logging
+
 import click
 import httpx
 import pytest
 
 from ddev.cli import ddev as ddev_command
-from ddev.cli.application import Application, DdevGroup
+from ddev.cli.application import Application, AppLoggingHandler, DdevGroup
+from ddev.config.constants import VerbosityLevels
 from ddev.utils.ci import AnnotationLevel, escape_workflow_data, escape_workflow_property
 from ddev.utils.github_errors import GitHubAuthenticationError
 from tests.helpers.runner import CliRunner
@@ -264,3 +267,28 @@ def test_github_authentication_error_uses_registered_cli_handler(ddev: CliRunner
     assert 'GitHub denied the requested operation (HTTP 403)' in result.output
     assert 'ddev config set github.token' in result.output
     assert 'Traceback' not in result.output
+
+
+@pytest.mark.parametrize(
+    ('verbosity', 'expected'),
+    [
+        (VerbosityLevels.ERROR - 1, []),
+        (VerbosityLevels.ERROR, ['error event']),
+        (VerbosityLevels.WARNING, ['warning event', 'error event']),
+        (VerbosityLevels.INFO, ['info event', 'warning event', 'error event']),
+        (VerbosityLevels.DEBUG, ['DEBUG: debug event', 'info event', 'warning event', 'error event']),
+    ],
+    ids=['silent', 'error', 'warning', 'info', 'debug'],
+)
+def test_app_logging_handler_uses_application_verbosity_and_formatting(
+    verbosity: int, expected: list[str], capsys: pytest.CaptureFixture[str]
+):
+    app = Application(lambda code: None, verbosity, False, False)
+    logger = logging.Logger('test-app', level=logging.DEBUG)
+    logger.addHandler(AppLoggingHandler(app))
+    for level in ('debug', 'info', 'warning', 'error'):
+        getattr(logger, level)('%s event', level)
+
+    captured = capsys.readouterr()
+    assert captured.err.splitlines() == expected
+    assert captured.out == ''

--- a/ddev/tests/event_bus/test_event_bus.py
+++ b/ddev/tests/event_bus/test_event_bus.py
@@ -11,7 +11,7 @@ import signal
 import sys
 import threading
 import time
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from concurrent.futures import Executor, ThreadPoolExecutor
 from contextlib import AbstractContextManager, contextmanager, suppress
 from contextlib import nullcontext as does_not_raise
@@ -36,8 +36,11 @@ from ddev.event_bus.orchestrator import (
     AsyncProcessor,
     BaseMessage,
     EventBusOrchestrator,
+    MessageScope,
     SyncProcessor,
 )
+from ddev.monitoring import ComponentMonitor, MonitoringRuntime
+from tests.helpers.monitoring import RecordingSink
 
 # Test Structure Documentation
 # --------------------------
@@ -156,6 +159,7 @@ class MockOrchestrator(EventBusOrchestrator):
         grace_period: float = 10,
         fail_fast: bool = False,
         executor: Executor | None = None,
+        message_scope: MessageScope | None = None,
     ):
         super().__init__(
             logger=logger,
@@ -163,6 +167,7 @@ class MockOrchestrator(EventBusOrchestrator):
             grace_period=grace_period,
             fail_fast=fail_fast,
             executor=executor,
+            message_scope=message_scope,
         )
         self.events: list[str] = []
         self.received_messages: list[BaseMessage] = []
@@ -1483,3 +1488,77 @@ def test_a_hook_waiting_on_io_does_not_hold_up_a_requested_stop(secretary: Secre
     assert "finalize" in orchestrator.events
     # Abandoned before dispatch, so the message it was about never reaches a processor.
     assert secretary.delivered_memos == []
+
+
+class ScopedProcessor(AsyncProcessor[Memo]):
+    def __init__(self, name: str, monitor: ComponentMonitor):
+        super().__init__(name)
+        self.monitor = monitor
+
+    async def process_message(self, message: Memo):
+        self.monitor.metrics.count("attempted", tags={"tag": message.id})
+        if message.content.startswith("fail_processing"):
+            raise ValueError("Processing failed intentionally")
+
+    async def on_success(self, message: Memo):
+        self.monitor.metrics.count("confirmed", tags={"tag": message.id})
+
+    async def on_error(self, error: MessageProcessingError | ProcessorHookError):
+        self.monitor.metrics.count("handled", tags={"tag": error.message.id})
+
+
+def make_memo_scope(runtime: MonitoringRuntime) -> Callable[[BaseMessage], AbstractContextManager[None]]:
+    context = runtime.context
+
+    def scope(message: BaseMessage) -> AbstractContextManager[None]:
+        return context.scope({"memo_id": message.id})
+
+    return scope
+
+
+def test_a_message_scope_covers_processing_and_the_success_and_error_hooks():
+    sink = RecordingSink()
+    runtime = MonitoringRuntime(metrics_sink=sink)
+    orchestrator = MockOrchestrator(
+        logging.getLogger("test_scope"), grace_period=0.1, message_scope=make_memo_scope(runtime)
+    )
+    orchestrator.register_processor(ScopedProcessor("scoped", runtime.component("scoped")), [Memo])
+    orchestrator.submit_message(Memo("failing_memo", content="fail_processing"))
+    orchestrator.submit_message(Memo("ok_memo"))
+    orchestrator.run()
+
+    assert [record.name for record in sink.records] == ["attempted", "handled", "attempted", "confirmed"]
+    for record in sink.records:
+        assert record.fields["memo_id"] == record.tags["tag"]
+    assert runtime.context.fields == {}
+
+
+def test_concurrent_sync_processors_keep_their_message_scopes_apart():
+    sink = RecordingSink()
+    runtime = MonitoringRuntime(metrics_sink=sink)
+    overlap = threading.Barrier(2, timeout=5)
+
+    class OverlappingWorker(SyncProcessor[Memo]):
+        def __init__(self, name: str, monitor: ComponentMonitor):
+            super().__init__(name)
+            self.monitor = monitor
+
+        def process_message(self, message: Memo):
+            overlap.wait()
+            self.monitor.metrics.count("worked", tags={"tag": message.id})
+
+    with ThreadPoolExecutor(max_workers=2) as lent:
+        orchestrator = MockOrchestrator(
+            logging.getLogger("test_scoped_sync"),
+            grace_period=0.1,
+            executor=lent,
+            message_scope=make_memo_scope(runtime),
+        )
+        orchestrator.register_processor(OverlappingWorker("worker", runtime.component("worker")), [Memo])
+        orchestrator.submit_message(Memo("memo1"))
+        orchestrator.submit_message(Memo("memo2"))
+        orchestrator.run()
+
+    observed = {(record.fields["memo_id"], record.tags["tag"]) for record in sink.records}
+    assert observed == {("memo1", "memo1"), ("memo2", "memo2")}
+    assert len(sink.records) == 2

--- a/ddev/tests/helpers/monitoring.py
+++ b/ddev/tests/helpers/monitoring.py
@@ -1,0 +1,48 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Test doubles for the monitoring runtime: a metrics sink and logging handlers that keep records."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import structlog
+
+from ddev.monitoring.metrics import MetricRecord
+
+
+class RecordingSink:
+    """A ``MetricsSink`` collecting every record it is handed."""
+
+    def __init__(self) -> None:
+        self.records: list[MetricRecord] = []
+
+    def record(self, record: MetricRecord) -> None:
+        self.records.append(record)
+
+    def records_named(self, name: str) -> list[MetricRecord]:
+        return [record for record in self.records if record.name == name]
+
+    def field_values(self, name: str, key: str) -> list[Any]:
+        """The values one field took on the records named *name*, in emission order."""
+        return [record.fields.get(key) for record in self.records_named(name)]
+
+
+class RecordingJsonHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.events: list[dict[str, Any]] = []
+        self.setFormatter(
+            structlog.stdlib.ProcessorFormatter(
+                processors=[
+                    structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                    structlog.processors.JSONRenderer(),
+                ],
+            )
+        )
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.events.append(json.loads(self.format(record)))

--- a/ddev/tests/monitoring/__init__.py
+++ b/ddev/tests/monitoring/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Observation seams shared by the monitoring and event bus tests."""

--- a/ddev/tests/monitoring/test_monitoring.py
+++ b/ddev/tests/monitoring/test_monitoring.py
@@ -1,0 +1,331 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from io import StringIO
+
+import pytest
+
+from ddev.monitoring import MonitoringRuntime, console_formatter
+from tests.helpers.monitoring import RecordingJsonHandler, RecordingSink
+
+PROTECTED = frozenset({'repo', 'commit', 'context'})
+HIDDEN = PROTECTED | {'branch', 'pr_number'}
+
+
+@pytest.fixture
+def sink() -> RecordingSink:
+    return RecordingSink()
+
+
+@pytest.fixture
+def handler() -> RecordingJsonHandler:
+    return RecordingJsonHandler()
+
+
+@pytest.fixture
+def stream() -> StringIO:
+    return StringIO()
+
+
+@pytest.fixture
+def console(stream: StringIO) -> logging.Handler:
+    console_handler = logging.StreamHandler(stream)
+    console_handler.setFormatter(console_formatter(hidden_fields=HIDDEN))
+    return console_handler
+
+
+def lines(stream: StringIO) -> list[str]:
+    return stream.getvalue().splitlines()
+
+
+def test_component_binding_and_shared_scopes_enrich_logs_and_metrics(
+    handler: RecordingJsonHandler, sink: RecordingSink
+):
+    runtime = MonitoringRuntime(metrics_sink=sink)
+    runtime.add_log_handler(handler)
+    runtime.set_run_fields(repo='DataDog/integrations-core')
+    monitor = runtime.component('planner').bind(operation='dispatch')
+
+    with runtime.component('dispatcher').scope(batch_id='batch-01'):
+        monitor.logger.info('Dispatching %s', 'batch')
+        monitor.metrics.count('jobs')
+
+    [event] = handler.events
+    [record] = sink.records
+    assert record.fields == {
+        'repo': 'DataDog/integrations-core',
+        'component': 'planner',
+        'operation': 'dispatch',
+        'batch_id': 'batch-01',
+    }
+    assert event == {**record.fields, 'event': 'Dispatching batch', 'level': 'info'}
+
+
+def test_resolving_run_fields_affects_future_events_not_emitted_ones(handler: RecordingJsonHandler):
+    runtime = MonitoringRuntime()
+    runtime.add_log_handler(handler)
+    monitor = runtime.component('resolution')
+    monitor.logger.info('Resolving run')
+
+    runtime.set_run_fields(commit='head-sha')
+    monitor.logger.info('Resolved run')
+
+    assert [event.get('commit') for event in handler.events] == [None, 'head-sha']
+
+
+@pytest.mark.parametrize('error', [ValueError('boom'), asyncio.CancelledError()])
+def test_a_scope_is_reset_even_when_the_block_fails(error):
+    runtime = MonitoringRuntime()
+    with pytest.raises(type(error)):
+        with runtime.context.scope({'batch_id': 'batch-01'}):
+            raise error
+
+    assert runtime.context.fields == {}
+
+
+def test_a_nested_scope_refines_then_restores_the_enclosing_one(sink: RecordingSink):
+    runtime = MonitoringRuntime(metrics_sink=sink)
+    monitor = runtime.component('test-runner')
+
+    with runtime.context.scope({'batch_id': 'batch-01'}):
+        with runtime.context.scope({'job': 'ntp'}):
+            monitor.metrics.count('inner')
+        monitor.metrics.count('outer')
+
+    [inner, outer] = sink.records
+    assert inner.fields['batch_id'] == 'batch-01'
+    assert inner.fields['job'] == 'ntp'
+    assert 'job' not in outer.fields
+    assert outer.fields['batch_id'] == 'batch-01'
+
+
+def test_a_scope_does_not_cross_runtime_boundaries(sink):
+    first = MonitoringRuntime(metrics_sink=sink)
+    second = MonitoringRuntime(metrics_sink=sink)
+
+    with first.context.scope({'batch_id': 'batch-01'}):
+        first.component('test-runner').metrics.count('scoped')
+        second.component('test-runner').metrics.count('unscoped')
+
+    [scoped, unscoped] = sink.records
+    assert scoped.fields['batch_id'] == 'batch-01'
+    assert 'batch_id' not in unscoped.fields
+    assert 'batch_id' not in second.context.fields
+
+
+def test_concurrent_scopes_do_not_contaminate_each_other(handler, sink):
+    runtime = MonitoringRuntime(metrics_sink=sink)
+    runtime.add_log_handler(handler)
+
+    async def process(batch_id: str):
+        monitor = runtime.component('test-runner')
+        with runtime.context.scope({'batch_id': batch_id}):
+            await asyncio.sleep(0.01)
+            monitor.metrics.count('processed', tags={'tag': batch_id})
+            monitor.logger.info('processed')
+
+    async def run_both():
+        await asyncio.gather(process('batch-a'), process('batch-b'))
+
+    asyncio.run(run_both())
+
+    records = sink.records_named('processed')
+    assert len(records) == 2
+    assert {(record.fields['batch_id'], record.tags['tag']) for record in records} == {
+        ('batch-a', 'batch-a'),
+        ('batch-b', 'batch-b'),
+    }
+    assert sorted(event['batch_id'] for event in handler.events) == ['batch-a', 'batch-b']
+
+
+@pytest.mark.parametrize(
+    ('scope', 'emit', 'expected_fields', 'expected_tags'),
+    [
+        (
+            {'stage': 'from-scope'},
+            lambda monitor: monitor.metrics.count('a record'),
+            {'stage': 'from-scope', 'commit': 'actual-head'},
+            {},
+        ),
+        (
+            {'stage': 'from-scope'},
+            lambda monitor: monitor.metrics.count('a record', stage='from-call'),
+            {'stage': 'from-call', 'commit': 'actual-head'},
+            {},
+        ),
+        (
+            {'stage': 'from-scope'},
+            lambda monitor: monitor.metrics.count('a record', tags={'stage': 'from-tag'}),
+            {'stage': 'from-tag', 'commit': 'actual-head'},
+            {'stage': 'from-tag'},
+        ),
+        (
+            {'commit': 'wrong-head'},
+            lambda monitor: monitor.metrics.count('a record'),
+            {'commit': 'actual-head'},
+            {},
+        ),
+        (
+            {},
+            lambda monitor: monitor.metrics.count('a record', tags={'commit': 'sneaky', 'job': 'ntp'}),
+            {'commit': 'actual-head'},
+            {'job': 'ntp'},
+        ),
+        (
+            {},
+            lambda monitor: monitor.logger.info('a record', commit='other-head', stage='from-log'),
+            {'commit': 'actual-head', 'stage': 'from-log'},
+            None,
+        ),
+    ],
+    ids=[
+        'scope-refines-ordinary',
+        'call-beats-scope',
+        'tag-beats-scope',
+        'scope-cannot-relabel-identity',
+        'tag-cannot-relabel-identity',
+        'log-call-cannot-relabel-identity',
+    ],
+)
+def test_lower_layers_refine_everything_but_identity(sink, handler, scope, emit, expected_fields, expected_tags):
+    runtime = MonitoringRuntime(metrics_sink=sink, protected_fields=PROTECTED)
+    runtime.add_log_handler(handler)
+    runtime.set_run_fields(repo='DataDog/integrations-core', commit='actual-head', context='pr', stage='from-run')
+    monitor = runtime.component('test-runner')
+
+    with runtime.context.scope(scope):
+        emit(monitor)
+
+    if expected_tags is None:
+        [event] = handler.events
+        fields = event
+    else:
+        [record] = sink.records
+        fields = record.fields
+        assert record.tags == expected_tags
+    assert {key: fields[key] for key in expected_fields} == expected_fields
+
+
+def test_context_inspection_agrees_with_emitted_records(sink):
+    runtime = MonitoringRuntime(metrics_sink=sink, protected_fields=PROTECTED)
+    runtime.set_run_fields(commit='actual-head', stage='default')
+
+    with runtime.context.scope({'commit': 'wrong-head', 'stage': 'scoped'}):
+        fields = dict(runtime.context.fields)
+        runtime.component('test-runner').metrics.count('jobs')
+
+    [record] = sink.records
+    assert fields == {'commit': 'actual-head', 'stage': 'scoped'}
+    assert record.fields == {**fields, 'component': 'test-runner'}
+
+
+def test_console_projection_preserves_the_full_event_for_other_handlers(
+    stream: StringIO, console: logging.Handler, handler: RecordingJsonHandler
+):
+    runtime = MonitoringRuntime(console_handler=console)
+    runtime.add_log_handler(handler)
+    runtime.set_run_fields(repo='DataDog/integrations-core', commit='head-sha', branch='a-branch', pr_number=42)
+
+    with runtime.component('dispatcher').scope(batch_id='batch-01'):
+        runtime.component('dispatcher').logger.info('Queued planned batches', batch_count=1)
+
+    [line] = lines(stream)
+    assert 'Queued planned batches' in line
+    assert 'component=dispatcher' in line
+    assert 'batch_id=batch-01' in line
+    assert 'batch_count=1' in line
+    assert 'repo' not in line
+    assert 'commit' not in line
+
+    [event] = handler.events
+    assert event == {
+        'repo': 'DataDog/integrations-core',
+        'commit': 'head-sha',
+        'branch': 'a-branch',
+        'pr_number': 42,
+        'component': 'dispatcher',
+        'batch_id': 'batch-01',
+        'batch_count': 1,
+        'event': 'Queued planned batches',
+        'level': 'info',
+    }
+
+
+def test_hidden_metadata_cannot_hide_the_message_or_traceback(
+    stream: StringIO, console: logging.Handler, handler: RecordingJsonHandler
+):
+    console.setFormatter(console_formatter(hidden_fields={'event', 'exception', '_record', '_from_structlog'}))
+    runtime = MonitoringRuntime(console_handler=console)
+    runtime.add_log_handler(handler)
+
+    try:
+        raise ValueError('boom')
+    except ValueError:
+        runtime.component('dispatcher').logger.exception('dispatch failed')
+
+    rendered = stream.getvalue()
+    assert 'dispatch failed' in rendered
+    assert 'ValueError: boom' in rendered
+    [event] = handler.events
+    assert event['event'] == 'dispatch failed'
+    assert 'ValueError: boom' in event['exception']
+
+
+def test_a_runtime_without_handlers_is_silent(capsys: pytest.CaptureFixture[str]):
+    runtime = MonitoringRuntime()
+    runtime.component('dispatcher').logger.warning('a warning')
+    runtime.close()
+
+    assert capsys.readouterr() == ('', '')
+
+
+def test_repeated_runtimes_do_not_duplicate_or_interfere_with_each_other(stream):
+    def handler_for_runtime() -> logging.Handler:
+        console_handler = logging.StreamHandler(stream)
+        console_handler.setFormatter(console_formatter())
+        return console_handler
+
+    first = MonitoringRuntime(console_handler=handler_for_runtime())
+    first.component('dispatcher').logger.info('from the first runtime')
+    first.close()
+
+    second = MonitoringRuntime(console_handler=handler_for_runtime())
+    second.component('dispatcher').logger.info('from the second runtime')
+
+    assert stream.getvalue().count('from the first runtime') == 1
+    assert stream.getvalue().count('from the second runtime') == 1
+
+
+def test_records_emitted_after_close_are_dropped(stream, console, sink, capsys):
+    runtime = MonitoringRuntime(console_handler=console, metrics_sink=sink)
+    before = runtime.component('dispatcher')
+    before.logger.info('before close')
+    before.metrics.count('before')
+
+    runtime.close()
+    before.logger.warning('still holding the old view')
+    runtime.component('dispatcher').bind(operation='dispatch').logger.warning('derived after close')
+    before.metrics.count('after')
+    runtime.close()
+
+    rendered = lines(stream)
+    assert len(rendered) == 1
+    assert 'before close' in rendered[0]
+    assert [record.name for record in sink.records] == ['before']
+    assert capsys.readouterr().err == ''
+
+
+def test_closing_the_runtime_leaves_the_callers_stream_open(stream):
+    console_handler = logging.StreamHandler(stream)
+    console_handler.setFormatter(console_formatter())
+    runtime = MonitoringRuntime(console_handler=console_handler)
+
+    runtime.close()
+
+    stream.write('still usable\n')
+    assert stream.getvalue().endswith('still usable\n')


### PR DESCRIPTION
### What does this PR do?

- Add a command-scoped context shared by Dispatcher logs and metrics.
- Use native structlog bound loggers, ddev's existing console handler, and one structured event with independent handler formatting.
- Give components shared `bind()` and `scope()` methods. Carry message context through async processors and threaded gathering.
- Preserve resolved run identity while allowing local metadata overrides.

```python
monitor = monitoring.component('test-runner').bind(operation='dispatch')
with monitor.scope(batch_id=batch.batch_id):
    monitor.logger.info('Dispatching batch')
    monitor.metrics.count('batches')
```

This is the runtime foundation only. Metrics have no exporter by default; Datadog delivery and operational metric calls follow separately.

Validated with filtered ddev tests (226 passed, 2198 deselected), ddev lint, and `git diff --check`.

### Motivation

First implementation step for [AI-7161](https://datadoghq.atlassian.net/browse/AI-7161), under [AI-6476](https://datadoghq.atlassian.net/browse/AI-6476). Give Dispatcher one logging and metrics context before adding backend delivery.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required. `qa/skip-qa`: developer tooling only.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7161]: https://datadoghq.atlassian.net/browse/AI-7161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-6476]: https://datadoghq.atlassian.net/browse/AI-6476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ