### PR TITLE
Use bookworm for the Velero custom kubectl image

### DIFF
--- a/velero/tests/kind/kubectl.Dockerfile
+++ b/velero/tests/kind/kubectl.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends wget gnupg coreutils ca-certificates && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### What does this PR do?
Bumps the base image of the custom kubectl image used by the Velero E2E environment from `debian:bullseye-slim` to `debian:bookworm-slim` (one-line change in `velero/tests/kind/kubectl.Dockerfile`).

### Motivation
Debian bullseye reached end of LTS on 2026-08-31. The `bullseye-security` InRelease file on `deb.debian.org` is no longer regenerated and its validity expired on 2026-09-07, so `apt-get update` inside the Dockerfile fails with exit code 100 on every build. This breaks the Velero E2E job (`test_check_velero_e2e`) on every CI run since Sep 8, for example https://github.com/DataDog/integrations-core/actions/runs/34333948947/job/102408998256.

Bookworm (Debian 12) is fully supported, so the security repo stays fresh. The image builds again and the downloaded kubectl binary runs:

```
$ docker build -t custom-kubectl -f velero/tests/kind/kubectl.Dockerfile .
Successfully built d72bf8c0f5e1
$ docker run --rm custom-kubectl kubectl version --client
Client Version: v1.28.0
```

No changelog entry needed since this is a test-only asset. QA not required: no agent-impacting changes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
