### PR TITLE
Accept both cases for win32_event_log filters.type

### DIFF
--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -184,6 +184,12 @@ files:
             - information
             - success audit
             - failure audit
+            - Success
+            - Error
+            - Warning
+            - Information
+            - Success Audit
+            - Failure Audit
         - name: id
           type: array
           items:

--- a/win32_event_log/changelog.d/25167.fixed
+++ b/win32_event_log/changelog.d/25167.fixed
@@ -1,0 +1,1 @@
+Accept both lowercase and capitalized values for the ``filters.type`` config option.

--- a/win32_event_log/datadog_checks/win32_event_log/config_models/instance.py
+++ b/win32_event_log/datadog_checks/win32_event_log/config_models/instance.py
@@ -36,6 +36,12 @@ class Filters(BaseModel):
                 'information',
                 'success audit',
                 'failure audit',
+                'Success',
+                'Error',
+                'Warning',
+                'Information',
+                'Success Audit',
+                'Failure Audit',
             ], ...
         ]
     ] = None


### PR DESCRIPTION
### What does this PR do?
Widens the `filters.type` enum in `win32_event_log`'s config spec to accept both lowercase and capitalized values (e.g. both `error` and `Error`), instead of lowercase only.

### Motivation
https://datadoghq.atlassian.net/browse/SPFA-182

Customers editing an existing `win32_event_log` config through Fleet Automation's Edit & Replace flow hit a validation error on `filters.type` when their config uses capitalized values (`Error`, `Warning`, etc.).

### Evidence
- [`win32_event_log/assets/configuration/spec.yaml`](https://github.com/DataDog/integrations-core/blob/master/win32_event_log/assets/configuration/spec.yaml#L180-L186) declares the `filters.type` `enum` as lowercase only.
- [`win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example`](https://github.com/DataDog/integrations-core/blob/master/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example#L147-L151) documents the same option with capitalized values (`Error`, `Warning`, `Information`, `Success Audit`, `Failure Audit`).

These two disagree, and customers who follow our own documented example end up with a config that Fleet Automation rejects.

This does not change Agent runtime behavior: `config_models/validators.py` already lowercases every `filters.type` entry in a `mode='before'` validator before the enum/`Literal` check runs, so the running Agent has always accepted any casing. Only Fleet Automation's static schema validation (which has no equivalent normalization step) was rejecting the capitalized values.

### Changes
For now, allow both casings in the config spec so customers can keep using either the lowercase or capitalized values (matching what's currently documented) without their existing configs breaking in Fleet Automation.

### Follow-up
Make `spec.yaml` and `conf.yaml.example` match on a single casing (lowercase is more idiomatic here) and remove the now-redundant duplicate enum values, in a separate PR.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged