### PR TITLE
Deduplicate Kafka consumer membership snapshots

### DIFF
--- a/kafka_consumer/README.md
+++ b/kafka_consumer/README.md
@@ -67,6 +67,8 @@ When `enable_cluster_monitoring` is enabled, the integration collects cluster-wi
 - **Consumer groups**: Member details, group state, rebalance detection, membership-change counting, and metadata exposed as tags (`partition_assignor`, `consumer_group_type`, `is_simple_consumer_group`, and `group_instance_id`). Empty groups are visible through the `consumer_group_state:EMPTY` tag on `kafka.consumer_group.members`.
 - **Schema registry**: Schema metadata (requires `schema_registry_url`).
 
+Consumer membership snapshots are sent when a group is first observed, when its members or their details and partition assignments change, and hourly while unchanged. Consumer group metrics continue to be collected on every check run.
+
 #### Batched collection
 
 Broker configurations, topic configurations, and schema registry version checks are collected in batches across multiple agent runs rather than all at once. This reduces load on large Kafka clusters but means that not all metrics are emitted in every check run. On a cluster with many brokers, topics, or schema subjects, the integration spreads the work over successive runs so that each run stays fast and does not overload the cluster.

--- a/kafka_consumer/changelog.d/25168.fixed
+++ b/kafka_consumer/changelog.d/25168.fixed
@@ -1,0 +1,1 @@
+Deduplicate consumer membership snapshots while preserving payload changes and hourly refreshes.

--- a/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/cluster_metadata.py
@@ -68,6 +68,7 @@ class ClusterMetadataCollector:
         # Cache size limits
         self.BROKER_CONFIG_CACHE_MAX_SIZE = 1_000
         self.TOPIC_CONFIG_CACHE_MAX_SIZE = 20_000
+        self.CONSUMER_MEMBERSHIP_EVENT_CACHE_MAX_SIZE = 20_000
         self.SCHEMA_VERSION_CHECK_CACHE_MAX_SIZE = 20_000
         self.SCHEMA_COMPATIBILITY_FETCH_CACHE_MAX_SIZE = 20_000
         self.SCHEMA_ID_CACHE_MAX_SIZE = 20_000
@@ -84,6 +85,7 @@ class ClusterMetadataCollector:
         self.TOPIC_CONFIG_FETCH_CACHE_KEY = 'kafka_topic_config_fetch_cache'
         self.TOPIC_HWM_SUM_CACHE_KEY = 'kafka_topic_hwm_sum_cache'
         self.CONSUMER_GROUP_MEMBERS_CACHE_KEY = 'kafka_consumer_group_members_cache'
+        self.CONSUMER_MEMBERSHIP_EVENT_CACHE_KEY = 'kafka_consumer_membership_event_cache'
         self.SCHEMA_CACHE_KEY = 'kafka_schema_cache'
         self.SCHEMA_VERSION_CHECK_CACHE_KEY = 'kafka_schema_version_check_cache'
         self.SCHEMA_COMPATIBILITY_FETCH_CACHE_KEY = 'kafka_schema_compatibility_fetch_cache'
@@ -800,6 +802,7 @@ class ClusterMetadataCollector:
 
         prev_member_hashes = self._load_member_hashes_cache()
         current_member_hashes = {}
+        membership_contents: dict[str, str] = {}
 
         for group_id, group_info in group_id_to_info.items():
             group_tags = self.config._get_tags(cluster_id) + [f'consumer_group:{group_id}']
@@ -825,7 +828,17 @@ class ClusterMetadataCollector:
             member_hash = hashlib.sha256(json.dumps(member_ids, separators=(',', ':')).encode()).hexdigest()
             current_member_hashes[group_id] = member_hash
 
-            self._emit_consumer_membership_event(cluster_id, group_id, member_ids, members)
+            membership_contents[group_id] = json.dumps(
+                {
+                    'kafka_cluster_id': cluster_id,
+                    **self.config._original_cluster_id_field(),
+                    'config_type': 'consumer_membership',
+                    'group_id': group_id,
+                    'member_ids': member_ids,
+                    'members': self._build_members_detail(members),
+                },
+                sort_keys=True,
+            )
 
             if prev_member_hashes is not None:
                 prev_hash = prev_member_hashes.get(group_id)
@@ -852,29 +865,31 @@ class ClusterMetadataCollector:
                     self.check.gauge('consumer_group.member.partitions', partition_count, tags=member_tags)
 
         self._save_member_hashes_cache(current_member_hashes)
+        self._emit_consumer_membership_events(membership_contents)
 
-    def _emit_consumer_membership_event(self, cluster_id, group_id, member_ids, members) -> None:
-        self.check.event_platform_event(
-            json.dumps(
-                {
-                    'collection_timestamp': int(time.time() * 1000),
-                    'kafka_cluster_id': cluster_id,
-                    **self.config._original_cluster_id_field(),
-                    'config_type': 'consumer_membership',
-                    'group_id': group_id,
-                    'member_ids': member_ids,
-                    'members': self._build_members_detail(members),
-                }
-            ),
-            "data-streams-message",
+    def _emit_consumer_membership_events(self, membership_contents: dict[str, str]) -> None:
+        """Send new or changed snapshots, refreshing unchanged groups on the event-cache TTL."""
+        groups_to_emit = self.cache.get_events_to_send(
+            self.CONSUMER_MEMBERSHIP_EVENT_CACHE_KEY,
+            membership_contents,
+            max_cache_size=self.CONSUMER_MEMBERSHIP_EVENT_CACHE_MAX_SIZE,
         )
+        # Add the timestamp after hashing so each check run does not invalidate the cache.
+        collection_timestamp = int(time.time() * 1000)
+        for group_id in groups_to_emit:
+            event = json.loads(membership_contents[group_id])
+            event['collection_timestamp'] = collection_timestamp
+            self.check.event_platform_event(json.dumps(event), 'data-streams-message')
 
     def _build_members_detail(self, members) -> list[dict[str, Any]]:
         members_detail = []
         for member in members:
             assignment = getattr(member, 'assignment', None)
             topic_partitions = (
-                [{'topic': tp.topic, 'partition': tp.partition} for tp in assignment.topic_partitions]
+                [
+                    {'topic': tp.topic, 'partition': tp.partition}
+                    for tp in sorted(assignment.topic_partitions, key=lambda tp: (tp.topic, tp.partition))
+                ]
                 if assignment
                 else []
             )

--- a/kafka_consumer/tests/test_cluster_metadata.py
+++ b/kafka_consumer/tests/test_cluster_metadata.py
@@ -7,11 +7,15 @@ import hashlib
 import json
 import logging
 import time
+from collections.abc import Callable
+from typing import Any
 from unittest import mock
 
 import pytest
 from confluent_kafka.admin import BrokerMetadata, PartitionMetadata, TopicMetadata
 
+from datadog_checks.base.stubs.aggregator import AggregatorStub
+from datadog_checks.kafka_consumer import KafkaCheck
 from datadog_checks.kafka_consumer.cache import EVENT_CACHE_TTL
 from datadog_checks.kafka_consumer.client import KafkaClient
 
@@ -2007,6 +2011,118 @@ def test_consumer_membership_members_sorted_by_member_id(check):
     assert len(events) == 1
     assert events[0]['member_ids'] == ['m-c1', 'm-c2']
     assert [m['member_id'] for m in events[0]['members']] == ['m-c1', 'm-c2']
+
+
+def test_consumer_membership_unchanged_snapshot_keeps_collecting_metrics(
+    check: Callable[..., KafkaCheck], aggregator: AggregatorStub
+):
+    members = [
+        _make_member(client_id='c1', assignment_tps=[('orders', 1), ('orders', 0), ('payments', 0)]),
+        _make_member(client_id='c2'),
+    ]
+    describe_result = _make_group_describe(members=members)
+    with mock.patch('time.time', return_value=1000.0) as clock:
+        kafka_consumer_check = _collect_groups_with_cache(check, describe_result)
+        collector = kafka_consumer_check.metadata_collector
+
+        # Broker response ordering is not a change to membership or assignments.
+        describe_result.members.reverse()
+        members[0].assignment.topic_partitions.reverse()
+        clock.return_value += 15
+        collector._collect_consumer_group_metadata(collector.client.kafka_client.list_topics.return_value)
+
+    assert len(consumer_membership_events(kafka_consumer_check)) == 1
+    aggregator.assert_metric('kafka.consumer_group.count', value=1, count=2)
+    aggregator.assert_metric('kafka.consumer_group.members', value=2, count=2)
+    aggregator.assert_metric('kafka.consumer_group.rebalancing', value=0, count=2)
+    aggregator.assert_metric('kafka.consumer_group.member.partitions', count=4)
+    aggregator.assert_metric('kafka.consumer_group.membership_changes', count=0)
+
+
+@pytest.mark.parametrize(
+    'attribute, value, event_field, expected',
+    [
+        pytest.param('member_id', 'm-new', 'member_id', 'm-new', id='member-id'),
+        pytest.param('client_id', 'new-client', 'client_id', 'new-client', id='client-id'),
+        pytest.param('host', 'new-host', 'member_host', 'new-host', id='host'),
+        pytest.param(
+            'assignment',
+            _make_assignment([('other-topic', 1)]),
+            'topic_partitions',
+            [{'topic': 'other-topic', 'partition': 1}],
+            id='assignment',
+        ),
+        pytest.param('assignment', None, 'topic_partitions', [], id='assignment-removed'),
+    ],
+)
+def test_consumer_membership_changed_snapshot(
+    check: Callable[..., KafkaCheck],
+    aggregator: AggregatorStub,
+    attribute: str,
+    value: Any,
+    event_field: str,
+    expected: Any,
+):
+    member = _make_member()
+    describe_result = _make_group_describe(members=[member])
+    kafka_consumer_check = _collect_groups_with_cache(check, describe_result)
+    collector = kafka_consumer_check.metadata_collector
+
+    setattr(member, attribute, value)
+    collector._collect_consumer_group_metadata(collector.client.kafka_client.list_topics.return_value)
+
+    events = consumer_membership_events(kafka_consumer_check)
+    assert len(events) == 2
+    assert events[1]['members'][0][event_field] == expected
+    assert events[1]['member_ids'] == [member.member_id]
+    aggregator.assert_metric('kafka.consumer_group.membership_changes', count=int(attribute == 'member_id'))
+
+
+def test_consumer_membership_empty_and_repopulated_group(check: Callable[..., KafkaCheck]):
+    member = _make_member()
+    describe_result = _make_group_describe(members=[member])
+    kafka_consumer_check = _collect_groups_with_cache(check, describe_result)
+    collector = kafka_consumer_check.metadata_collector
+    metadata = collector.client.kafka_client.list_topics.return_value
+
+    describe_result.members = []
+    describe_result.state.name = 'EMPTY'
+    collector._collect_consumer_group_metadata(metadata)
+    collector._collect_consumer_group_metadata(metadata)
+
+    events = consumer_membership_events(kafka_consumer_check)
+    assert len(events) == 2
+    assert events[1]['member_ids'] == []
+    assert events[1]['members'] == []
+
+    describe_result.members = [member]
+    describe_result.state.name = 'STABLE'
+    collector._collect_consumer_group_metadata(metadata)
+
+    events = consumer_membership_events(kafka_consumer_check)
+    assert len(events) == 3
+    assert events[2]['members'] == events[0]['members']
+    assert events[2]['member_ids'] == events[0]['member_ids']
+
+
+@pytest.mark.parametrize('empty', [False, True], ids=['populated', 'empty'])
+def test_consumer_membership_snapshot_refresh(check: Callable[..., KafkaCheck], empty: bool):
+    describe_result = _make_group_describe(members=[] if empty else [_make_member()])
+    with mock.patch('time.time', return_value=1000.0) as clock:
+        kafka_consumer_check = _collect_groups_with_cache(check, describe_result)
+        collector = kafka_consumer_check.metadata_collector
+        metadata = collector.client.kafka_client.list_topics.return_value
+
+        clock.return_value = 1000.0 + EVENT_CACHE_TTL - 1
+        collector._collect_consumer_group_metadata(metadata)
+        assert len(consumer_membership_events(kafka_consumer_check)) == 1
+
+        clock.return_value += 1
+        collector._collect_consumer_group_metadata(metadata)
+
+    events = consumer_membership_events(kafka_consumer_check)
+    assert len(events) == 2
+    assert events[1] == {**events[0], 'collection_timestamp': (1000 + EVENT_CACHE_TTL) * 1000}
 
 
 def test_heartbeat_connect_api_status_present_when_urls_configured(check):


### PR DESCRIPTION
### What does this PR do?

Deduplicates Kafka consumer membership snapshots using the existing persistent event cache. Snapshots are emitted when a group is first observed, when its membership, member details, or partition assignments change, and after the one-hour refresh TTL.

- Hashes the full stable payload, excluding the collection timestamp, and canonicalizes member and topic/partition ordering.
- Batches event-cache lookups across groups and bounds the cache to 20,000 entries.
- Preserves empty-group transitions, per-run consumer group metrics, and the member-ID-based membership-change counter.
- Documents the emission cadence and adds tests for deduplication, payload changes, empty/repopulated groups, and periodic refresh.

Validation:
- `ddev --no-interactive test kafka_consumer`: 215 passed and 1 E2E test skipped in each of the SSL, Kerberos, and no-auth environments.
- `ddev --no-interactive test --lint kafka_consumer`: passed.
- E2E validation has not been run.

### Motivation

The integration currently emits one consumer membership snapshot per group on every check run, even when nothing changes. At the default 15-second interval, that is about 240 events per group per hour. Deduplication reduces unchanged, cached groups to about one snapshot per hour without slowing metric collection or delaying observed membership and assignment changes.

**Pending QA before merge:** confirm that the DSM backend's membership freshness and expiry contract accepts hourly refreshes for unchanged groups. The one-hour TTL matches the existing event cache, but compatibility with the membership consumer has not been verified. Validate that stable groups remain visible and that membership and assignment changes, including transitions to empty groups, update correctly.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required. Selected: `qa/required`.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
