### PR TITLE
Move nfsstat e2e client to Debian 12 after bullseye EOL

### DIFF
--- a/nfsstat/tests/compose/client/setup.sh
+++ b/nfsstat/tests/compose/client/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Install NFS client
-apt update && apt install -y nfs-common=1:1.3.4-6+deb11u1
+apt update && apt install -y nfs-common
 
 # Make the directory to mount
 mkdir /test1

--- a/nfsstat/tests/compose/compose.yaml
+++ b/nfsstat/tests/compose/compose.yaml
@@ -11,7 +11,7 @@ services:
       - ./nfs-share:/nfs-share
 
   nfs-client:
-    image: debian:11
+    image: debian:12
     # The container must be privileged to mount a volume
     # cap_add: sys_admin is not enough for the CI
     privileged: true


### PR DESCRIPTION
### What does this PR do?
Moves the `nfsstat` e2e client container from `debian:11` to `debian:12` and drops the pinned `nfs-common` version so `apt` installs the bookworm package.

### Motivation
The NFSstat e2e job has been failing on every PR that runs the full matrix since roughly Sep 7. Bullseye LTS ended on Aug 31, 2026 and the last `bullseye-security` Release file has since expired, so `apt update` exits non-zero in the `debian:11` client. Because `setup.sh` chains `apt update && apt install nfs-common=1:1.3.4-6+deb11u1`, the package never installs: the client has no `nfsiostat` and no NFS mount. The check then runs `docker exec nfs-client /usr/sbin/nfsiostat`, docker prints the exec failure to stdout, and the check crashes with `IndexError: list index out of range` while parsing it as `nfsiostat` output.

The exact version pin also does not exist in bookworm; it has already required one fixup in the past (#18498), so it is removed rather than updated.

Validated locally: the mount succeeds, `nfsiostat 1 2` produces the expected output, the check emits all expected metrics, and the unit tests pass.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
