### PR TITLE
Stop passing hatch verbosity to uv install commands

### DIFF
--- a/ddev/changelog.d/25170.fixed
+++ b/ddev/changelog.d/25170.fixed
@@ -1,0 +1,1 @@
+Stop passing hatch's verbosity to the ``uv pip install`` commands ddev injects, so CI environment creation no longer dumps uv's resolver DEBUG output.

--- a/ddev/src/ddev/plugin/external/hatch/environment_collector.py
+++ b/ddev/src/ddev/plugin/external/hatch/environment_collector.py
@@ -118,7 +118,7 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
 
     @staticmethod
     def uv_install_command(*args):
-        return f'uv pip install {{verbosity:flag:-1}} {" ".join(args)}'
+        return f'uv pip install {" ".join(args)}'
 
     def finalize_config(self, config):
         for env_name, env_config in config.items():

--- a/ddev/tests/plugin/external/hatch/test_environment_collector.py
+++ b/ddev/tests/plugin/external/hatch/test_environment_collector.py
@@ -12,7 +12,7 @@ from ddev.plugin.external.hatch.environment_collector import DatadogChecksEnviro
 
 def tokenize(command):
     """Tokenize a generated command the way a POSIX shell does (Hatch runs scripts with ``shell=True``)."""
-    return shlex.split(command.replace('{verbosity:flag:-1}', '-q'))
+    return shlex.split(command)
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?
Removes the `{verbosity:flag:-1}` template from the `uv pip install` commands that ddev injects as hatch post-install commands, so uv always runs at its default log level.

### Motivation
CI invokes tests with `ddev -v test`, which ddev translates to `HATCH_VERBOSE=2`. The `{verbosity:flag:-1}` template in the generated install commands then renders as `-v`, putting uv in DEBUG mode during environment creation. A single job dumps over 1000 DEBUG lines of uv resolver output, including the long `Unnecessary package:` lists. uv's default output (resolution and install summary, plus errors) is enough; the resolver trace only adds noise.

This changes nothing for a plain local `ddev test`, where the template already rendered to an empty flag.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
