### PR TITLE
Wait for n8n readiness before starting worker

### DIFF
--- a/n8n/tests/docker/docker-compose.yaml
+++ b/n8n/tests/docker/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:5678/healthz"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:5678/healthz/readiness"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
### What does this PR do?
Wait for n8n's readiness endpoint, rather than its liveness endpoint, before Docker Compose starts the queue worker.

### Motivation
The n8n 2.19.5 test environment can report `/healthz` before database initialization is complete. This lets the worker start against the shared Postgres database too early and race migrations, causing workflow import to fail with `column "versionCounter" of relation "workflow_entity" already exists`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged