### PR TITLE
Add Thermal integration tile

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -48,6 +48,7 @@ hpe_aruba_edgeconnect = "HPE Aruba EdgeConnect"
 control_m = "Control-M"
 nifi = "Apache NiFi"
 dell_powerflex = "Dell Powerflex"
+thermal = "Thermal"
 
 [overrides.metrics-prefix]
 krakend = "krakend.api."
@@ -59,6 +60,7 @@ control_m = "control_m."
 nifi = "nifi."
 dell_powerflex = "dell_powerflex."
 hpe_aruba_edgeconnect = "hpe_aruba_edgeconnect."
+thermal = "system.thermal."
 
 [overrides.ci.ddev]
 platforms = ["linux", "windows"]
@@ -277,4 +279,4 @@ control_m = ["linux", "windows", "mac_os"]
 nifi = ["linux", "windows", "mac_os"]
 dell_powerflex = ["linux", "windows", "mac_os"]
 hpe_aruba_edgeconnect = ["linux", "windows", "mac_os"]
-
+thermal = ["windows", "mac_os"]

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -225,6 +225,8 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /pdh_check/                                                          @DataDog/windows-products @DataDog/agent-integrations
 /pdh_check/*.md                                                      @DataDog/windows-products @DataDog/agent-integrations @DataDog/documentation
 /pdh_check/manifest.json                                             @DataDog/windows-products @DataDog/agent-integrations @DataDog/documentation
+/thermal/                                                            @DataDog/windows-products @DataDog/agent-integrations
+/thermal/*.md                                                        @DataDog/windows-products @DataDog/agent-integrations @DataDog/documentation
 /win32_event_log/                                                    @DataDog/windows-products @DataDog/agent-integrations
 /win32_event_log/*.md                                                @DataDog/windows-products @DataDog/agent-integrations @DataDog/documentation
 /win32_event_log/manifest.json                                       @DataDog/windows-products @DataDog/agent-integrations @DataDog/documentation

--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -1513,6 +1513,10 @@ integration/terraform:
 - changed-files:
   - any-glob-to-any-file:
     - terraform/**/*
+integration/thermal:
+- changed-files:
+  - any-glob-to-any-file:
+    - thermal/**/*
 integration/tibco_ems:
 - changed-files:
   - any-glob-to-any-file:

--- a/thermal/CHANGELOG.md
+++ b/thermal/CHANGELOG.md
@@ -1,0 +1,7 @@
+# CHANGELOG - thermal
+
+## 1.0.0 / 2026-09-09
+
+***Added***:
+
+* Initial Release

--- a/thermal/README.md
+++ b/thermal/README.md
@@ -1,0 +1,81 @@
+# Thermal Integration
+
+## Overview
+
+This check monitors hardware temperatures and thermal constraints on Windows and macOS hosts.
+
+On Windows, the check collects the temperature and passive performance limit for each thermal zone exposed by the operating system. On macOS, it collects available CPU, GPU, SSD, and battery temperatures from AppleSMC, along with the system thermal pressure level.
+
+Sensors that are unavailable on a host are omitted rather than reported as zero. The set of available metrics can vary by hardware model.
+
+**Minimum Agent version:** 7.82.0 on Windows and 7.84.0 on macOS.
+
+## Setup
+
+### Installation
+
+The Thermal integration is included in the [Datadog Agent][1] package. No additional installation is needed.
+
+### Configuration
+
+The Thermal check is not enabled by default.
+
+1. Copy the [sample `thermal.d/conf.yaml`][2] to `thermal.d/conf.yaml` in the `conf.d` folder at the root of the Agent's [configuration directory][3]. No check-specific options are required:
+
+   ```yaml
+   init_config:
+
+   instances:
+     - {}
+   ```
+
+2. [Restart the Agent][4].
+
+### Validation
+
+[Run the Agent's status subcommand][5] and look for `thermal` under the **Checks** section.
+
+On Windows hosts without thermal zones, such as some virtual machines, the check runs without submitting metrics. On macOS, the check submits only the sensors exposed by the hardware.
+
+## Data Collected
+
+### Metrics
+
+See [metadata.csv][6] for a list of metrics provided by this integration.
+
+### Tags
+
+On Windows, each metric is tagged with `thermal_zone:<instance>`, where `<instance>` identifies the thermal zone reported by Windows.
+
+On macOS, hardware temperature metrics have the `macos` and `smc` tags and a tag identifying the sensor type: `cpu`, `gpu`, `ssd`, or `battery`. The `system.thermal.pressure_level` metric has the `macos` tag and a `pressure_level:<name>` tag. The possible pressure levels are:
+
+| Value | Tag | Description |
+| --- | --- | --- |
+| `0` | `pressure_level:nominal` | No thermal constraint. |
+| `1` | `pressure_level:moderate` | Mild thermal pressure. |
+| `2` | `pressure_level:heavy` | Substantial thermal pressure. |
+| `3` | `pressure_level:trapping` | Severe thermal pressure that requires the system to limit work. |
+| `4` | `pressure_level:sleeping` | Critical thermal pressure that may force the system to sleep. |
+
+The check uses `pressure_level:unknown` if macOS returns an unrecognized pressure value.
+
+### Events
+
+The Thermal integration does not include any events.
+
+### Service Checks
+
+The Thermal integration does not include any service checks.
+
+## Troubleshooting
+
+Need help? Contact [Datadog support][7] with an [Agent Flare][8].
+
+[1]: https://app.datadoghq.com/account/settings/agent/latest
+[2]: https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/conf.d/thermal.d/conf.yaml.example
+[3]: https://docs.datadoghq.com/agent/configuration/agent-configuration-files/#agent-configuration-directory
+[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#restart-the-agent
+[5]: https://docs.datadoghq.com/agent/configuration/agent-commands/#agent-information
+[6]: https://github.com/DataDog/integrations-core/blob/master/thermal/metadata.csv
+[7]: https://docs.datadoghq.com/help/
+[8]: https://docs.datadoghq.com/agent/troubleshooting/send_a_flare/?tab=agentv6v7

--- a/thermal/assets/dataflows.yaml
+++ b/thermal/assets/dataflows.yaml
@@ -1,0 +1,5 @@
+provides:
+  - id: thermal-metrics
+    always_on: true
+    data_type: metrics
+    direction: inbound

--- a/thermal/metadata.csv
+++ b/thermal/metadata.csv
@@ -1,0 +1,8 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric,sample_tags
+system.thermal.passive_limit,gauge,,percent,,[Windows] The percentage of maximum performance currently permitted by passive thermal throttling for the thermal zone.,1,thermal,passive limit,,thermal_zone:tz.thm0
+system.thermal.pressure_level,gauge,,,,"[macOS] The system thermal pressure level: 0 nominal, 1 moderate, 2 heavy, 3 trapping, or 4 sleeping.",-1,thermal,pressure level,,pressure_level:nominal
+system.thermal.temperature,gauge,,degree celsius,,[Windows] The current temperature of the thermal zone.,0,thermal,temperature,,thermal_zone:tz.thm0
+system.thermal.temperature.battery,gauge,,degree celsius,,[macOS] The highest available battery temperature reported by AppleSMC.,0,thermal,battery temperature,,macos smc battery
+system.thermal.temperature.cpu,gauge,,degree celsius,,[macOS] The highest available CPU temperature reported by AppleSMC.,0,thermal,cpu temperature,,macos smc cpu
+system.thermal.temperature.gpu,gauge,,degree celsius,,[macOS] The highest available GPU temperature reported by AppleSMC.,0,thermal,gpu temperature,,macos smc gpu
+system.thermal.temperature.ssd,gauge,,degree celsius,,[macOS] The highest available SSD temperature reported by AppleSMC.,0,thermal,ssd temperature,,macos smc ssd


### PR DESCRIPTION
### What does this PR do?

Adds a manifest-less integration tile for the Thermal Agent core check on Windows and macOS.

The tile documents setup, platform-specific behavior, tags, and macOS thermal pressure levels. It also defines metadata for the seven default metrics and registers the display name, metric prefix, supported platforms, ownership, automatic PR labeling, and metric data flow.

### Motivation

Make the Thermal core check discoverable and document the metrics introduced by DataDog/datadog-agent#52090 and DataDog/datadog-agent#54504.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged