### PR TITLE
Move the devcontainer images to Debian 12 after bullseye EOL

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # This dockerfile is used to build the devcontainer environment.
 # more info about vscode devcontainer: https://code.visualstudio.com/docs/devcontainers/containers
-FROM mcr.microsoft.com/devcontainers/python:1-3.13-bullseye
+FROM mcr.microsoft.com/devcontainers/python:1-3.13-bookworm
 RUN rm -f /etc/apt/sources.list.d/yarn.list && \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y liblz4-dev libunwind-dev ca-certificates curl gnupg
 # Docker and docker-compose installation

--- a/.devcontainer/dbm/Dockerfile
+++ b/.devcontainer/dbm/Dockerfile
@@ -1,7 +1,8 @@
 # This dockerfile is used to build the devcontainer environment.
 # more info about vscode devcontainer: https://code.visualstudio.com/docs/devcontainers/containers
-FROM mcr.microsoft.com/devcontainers/python:1-3.13-bullseye
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y liblz4-dev libunwind-dev ca-certificates curl gnupg
+FROM mcr.microsoft.com/devcontainers/python:1-3.13-bookworm
+RUN rm -f /etc/apt/sources.list.d/yarn.list && \
+    apt update && DEBIAN_FRONTEND=noninteractive apt install -y liblz4-dev libunwind-dev ca-certificates curl gnupg
 # Docker and docker-compose installation
 RUN install -m 0755 -d /etc/apt/keyrings
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
@@ -12,8 +13,10 @@ RUN echo \
   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 # Install msodbcsql18, sqlcmd psql, mysql
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc
-RUN curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-release.list
+# The Debian 12 prod.list pins signed-by=/usr/share/keyrings/microsoft-prod.gpg, so the
+# key has to be dearmored to that exact path rather than dropped in trusted.gpg.d.
+RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+RUN curl -fsSL https://packages.microsoft.com/config/debian/12/prod.list | tee /etc/apt/sources.list.d/mssql-release.list
 RUN DEBIAN_FRONTEND=noninteractive apt update && ACCEPT_EULA=Y apt install -y msodbcsql18=18.3.3.1-1 mssql-tools18 unixodbc-dev libgssapi-krb5-2 postgresql-client default-mysql-client
 RUN echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
 # Install mongosh


### PR DESCRIPTION
### What does this PR do?

Moves both devcontainer images from `bullseye` to `bookworm`, and fixes two further failures in the dbm image that this uncovered:

- `.devcontainer/Dockerfile` — base image bumped to `mcr.microsoft.com/devcontainers/python:1-3.13-bookworm`. This is the only file the `test build devcontainer image` workflow builds, and the bump is the whole fix for it.
- `.devcontainer/dbm/Dockerfile` — same base image bump, `config/debian/11/prod.list` → `12`, plus:
  - Removes the legacy yarn apt source, whose public key is no longer available so the repo reads as unsigned. This is a **pre-existing failure unrelated to the bullseye bump** — the same one #22644 fixed for the main image on 2026-02-16. The dbm file has not been touched since 2025-09-30 (`3497caba45`), so it never received that fix and the image has been unbuildable ever since. Because the workflow hardcodes `file: .devcontainer/Dockerfile` and nothing else in the repo references the dbm image, this went unnoticed; it is only built when someone opens that devcontainer config in VS Code.
  - Dearmors the Microsoft signing key to `/usr/share/keyrings/microsoft-prod.gpg`. This one *is* introduced by the bump: the Debian 12 `prod.list` pins `signed-by=` that path, whereas the Debian 11 one carried no `signed-by` and relied on `trusted.gpg.d`, so the mssql repo fails with `NO_PUBKEY EB3E94ADBE1229CF`.
  - The `msodbcsql18=18.3.3.1-1` pin is kept — that version is present in the Debian 12 feed.

### Motivation

Debian bullseye reached end of LTS on 2026-08-31, so `bullseye-security`'s `InRelease` is now expired. `apt-get update` treats that as a hard error and exits 100, which fails the build before `apt-get install` ever runs. This breaks the `test build devcontainer image` workflow on every push to master, e.g. [this run](https://github.com/DataDog/integrations-core/actions/runs/34453701925/job/102795053489):

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 2d 10h 58min 14s). Updates for this repository will not be applied.
```

Same root cause as #25160 (Velero kubectl image) and #25169 (nfsstat e2e client). These two files were the last remaining bullseye references in the repository.

Building the dbm image from master reproduces both of its errors in a single `apt update` — the expired bullseye-security release *and* the older unsigned yarn repository — which is how the seven-month-old breakage came to light.

Both images were built locally on `linux/amd64` to confirm the fix. In the dbm image the installed tooling was verified afterwards: Debian 12 (bookworm), `msodbcsql18` 18.3.3.1-1, sqlcmd 18.7.0001.1, mongosh 2.10.0, psql 15.19, mysql (MariaDB) 10.11.18.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)