### PR TITLE
ci: cache the kind node image for kind-based E2E jobs

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -2394,6 +2394,7 @@ jobs:
       runner: '["ubuntu-22.04"]'
       e2e-image-cache-key: kuma-2.10.6
       e2e-image-cache-images: "kumahq/kuma-cp:2.10.6 kumahq/kumactl:2.10.6"
+      e2e-cache-kind-node: true
       repo: "${{ inputs.repo }}"
       context: ${{ inputs.context }}
       python-version: "${{ inputs.python-version }}"

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -99,6 +99,11 @@ on:
         required: false
         default: ""
         type: string
+      e2e-cache-kind-node:
+        description: "Cache the kind node image (kindest/node) between runs"
+        required: false
+        default: false
+        type: boolean
 
 defaults:
   run:
@@ -339,6 +344,22 @@ jobs:
           [ -e "$f" ] && docker load -i "$f"
         done
 
+    - name: Compute kind node cache key
+      if: runner.os == 'Linux' && inputs.e2e-cache-kind-node
+      run: echo "KIND_NODE_CACHE_KEY=kindest-node-$(kind version -q)" >> "$GITHUB_ENV"
+
+    - name: Restore cached kind node image
+      if: runner.os == 'Linux' && inputs.e2e-cache-kind-node
+      id: restore-kind-node
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.temp }}/kind-node
+        key: ${{ env.KIND_NODE_CACHE_KEY }}
+
+    - name: Load cached kind node image into Docker
+      if: runner.os == 'Linux' && inputs.e2e-cache-kind-node && steps.restore-kind-node.outputs.cache-hit == 'true'
+      run: docker load -i "${RUNNER_TEMP}/kind-node/node.tar"
+
     - name: Run Unit & Integration tests
       if: inputs.latest != true
       timeout-minutes: ${{ inputs.step-timeout-minutes }}
@@ -369,6 +390,28 @@ jobs:
       with:
         path: ${{ runner.temp }}/e2e-images
         key: e2e-images-${{ inputs.e2e-image-cache-key }}
+
+    - name: Save kind node image for cache
+      if: >-
+        runner.os == 'Linux' && inputs.e2e-cache-kind-node
+        && steps.restore-kind-node.outputs.cache-hit != 'true'
+        && ((inputs.repo == 'core' && !inputs.minimum-base-package) || inputs.repo != 'core')
+      id: save-kind-node
+      run: |
+        # kind pins its node image by digest, so it shows up untagged; find it by repository.
+        node_image_id="$(docker images --format '{{.Repository}} {{.ID}}' | awk '$1 == "kindest/node" {print $2; exit}')"
+        if [ -n "$node_image_id" ]; then
+          mkdir -p "${RUNNER_TEMP}/kind-node"
+          docker save --platform linux/"$(docker version --format '{{.Server.Arch}}')" "$node_image_id" -o "${RUNNER_TEMP}/kind-node/node.tar"
+          echo "saved=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Cache kind node image
+      if: runner.os == 'Linux' && inputs.e2e-cache-kind-node && steps.save-kind-node.outputs.saved == 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ runner.temp }}/kind-node
+        key: ${{ env.KIND_NODE_CACHE_KEY }}
 
     - name: Run benchmarks
       if: inputs.benchmark


### PR DESCRIPTION
## What does this PR do?

Caches the **kind node image** (`kindest/node`, ~1.5 GB) between CI runs, so kind-based E2E jobs stop re-downloading it from Docker Hub on every ephemeral runner. **21 targets** use `kind_run` in their E2E (argocd, cilium, fluxcd, istio, kuma, velero, ...), and today every one of those jobs pays this pull on every run.

Stacked on #24939 (touches the same `test-target.yml` sections).

## Changes

- `test-target.yml`: new opt-in input `e2e-cache-kind-node`. When enabled:
  - **Before the tests**: `actions/cache/restore` + `docker load` the node image, so `kind create cluster` finds the content locally and pulls nothing.
  - **After the E2E run**: discover the node image and `docker save` it into the cache (skipped on cache hit).
  - The cache key is the **kind version** (`kindest-node-$(kind version -q)`). kind embeds the digest-pinned default node image in its binary, so a kind upgrade changes the key and reseeds once, automatically — nothing to bump by hand.
- `test-all.yml`: the Kuma job opts in as the pilot. Other kind-based targets can flip the same input on.
- kind pulls its node image **pinned by digest** (`kindest/node:v1.32.2@sha256:...`), so it appears untagged in the daemon — the save step therefore finds it by repository and saves a single-platform archive by image ID.

## Measured (locally, on this machine)

| Step | Time |
|---|---|
| `kind create cluster`, node image in daemon (warm) | **18s** |
| `kind create cluster`, must pull 1.49 GB (cold — every CI runner today) | **36s** |
| `docker save` the node image (cache seed, once per kind version) | 10s → **416 MB** tar |
| `docker load` (per job on cache hit) | **13s** |
| kind's pinned-digest pull after `docker load` | **"Image is up to date"** — no transfer |

So a cache-hit job replaces a ~18–40s Docker Hub download with a ~416 MB cache restore (a few seconds on runners) + 13s of local load — roughly **par-to-faster per job**, and the largest single Docker Hub pull in these jobs no longer depends on Hub availability/rate limits. One cache entry is shared by all 21 kind-based targets.

## Caveats

- The cache entry is ~0.4 GB (containerd image store preserves compressed blobs; classic-store runners save an uncompressed ~1.5 GB tar which `actions/cache` compresses on upload). Well within the repo's 10 GB cache budget, but the largest single entry.
- First run after a kind version bump reseeds (one cache-miss run).
- `latest` runs are excluded, mirroring #24939.
