### PR TITLE
AI-7152 Link running Dispatcher comments to workflow

### DIFF
--- a/ddev/changelog.d/25178.fixed
+++ b/ddev/changelog.d/25178.fixed
@@ -1,0 +1,1 @@
+Link running Dispatcher comments to their workflow run.

--- a/ddev/src/ddev/cli/ci/tests/pr_comment.py
+++ b/ddev/src/ddev/cli/ci/tests/pr_comment.py
@@ -101,8 +101,8 @@ RUN_SUMMARY_COMMENT_FAILED_NOTE = (
     "> See the workflow logs for why the comment write failed."
 )
 
-# Said in both the alert and the footer, so a reader who skips one still learns the comment is live.
-FOOTER_RUNNING_NOTE = "This comment updates automatically as jobs progress and results are collected."
+# The alert explains that unfinished results keep updating; the footer links to the run.
+ALERT_RUNNING_NOTE = "This comment updates automatically as jobs progress and results are collected."
 
 STATUS_CHIP = {
     Status.SUCCESS: "✅ passed",
@@ -250,7 +250,7 @@ def _alert(
         return _shutdown_alert(shutdown)
     if not progress.done:
         phase = "Tests finished; collecting results." if _collecting_results(progress) else "Tests are still running."
-        return f"> [!NOTE]\n> **{phase}** {_outstanding(progress)}\n> {FOOTER_RUNNING_NOTE}"
+        return f"> [!NOTE]\n> **{phase}** {_outstanding(progress)}\n> {ALERT_RUNNING_NOTE}"
 
     unavailable = _unavailable_count(progress)
     if _has_failure(progress):
@@ -558,7 +558,10 @@ def _footer(progress: DispatcherProgress | None, *, shutdown: ShutdownRequest | 
     commit was tested and where Dispatcher itself ran, so that is what this says.
     """
     if shutdown is None and (progress is None or not progress.done):
-        return f"<sub>\n⏳ {FOOTER_RUNNING_NOTE}\n</sub>"
+        note = "⏳ Dispatcher running"
+        if run_url := get_workflow_run_url():
+            note += f' — <a href="{html.escape(run_url, quote=True)}">GitHub Run</a>'
+        return f"<sub>\n{note}.\n</sub>"
 
     note = "Dispatcher finished" if shutdown is None else f"Dispatcher {shutdown.kind.value}"
     if sha := get_commit_sha():

--- a/ddev/tests/cli/ci/tests/conftest.py
+++ b/ddev/tests/cli/ci/tests/conftest.py
@@ -1,0 +1,14 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def github_actions_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide the GitHub Actions metadata required to render running comments."""
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "DataDog/integrations-core")
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")

--- a/ddev/tests/cli/ci/tests/preview_pr_comment.py
+++ b/ddev/tests/cli/ci/tests/preview_pr_comment.py
@@ -14,6 +14,7 @@ Named ``preview_`` so pytest does not collect it.
 
 from __future__ import annotations
 
+import os
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -135,6 +136,11 @@ def mixed() -> DispatcherProgress:
 
 
 def main(destination: Path):
+    # Simulate the Dispatcher metadata required by the running footer.
+    os.environ.setdefault("GITHUB_SERVER_URL", "https://github.com")
+    os.environ.setdefault("GITHUB_REPOSITORY", "DataDog/integrations-core")
+    os.environ.setdefault("GITHUB_RUN_ID", "12345")
+
     destination.mkdir(parents=True, exist_ok=True)
     scenarios = (
         ("01-initial", initial()),

--- a/ddev/tests/cli/ci/tests/test_dispatcher.py
+++ b/ddev/tests/cli/ci/tests/test_dispatcher.py
@@ -40,9 +40,9 @@ from ddev.cli.ci.tests.messages import (
     UpdatePRComment,
 )
 from ddev.cli.ci.tests.pr_comment import (
+    ALERT_RUNNING_NOTE,
     CANCELLED_HEADING,
     FAILED_HEADING,
-    FOOTER_RUNNING_NOTE,
     TIMED_OUT_HEADING,
 )
 from ddev.cli.ci.tests.progress import DispatcherProgress, ExecutionState
@@ -432,7 +432,7 @@ def test_a_timed_out_run_reports_itself_and_cancels_what_it_started(
     assert TIMED_OUT_HEADING in terminal_body
     assert "max_timeout" in terminal_body
     assert "Dispatcher tests · in progress" not in terminal_body
-    assert FOOTER_RUNNING_NOTE not in terminal_body
+    assert ALERT_RUNNING_NOTE not in terminal_body
     assert TIMED_OUT_HEADING.removeprefix("## ") in step_summary.read_text(encoding="utf-8")
 
 
@@ -505,7 +505,7 @@ def test_a_fatal_response_failure_cancels_every_dispatched_run(
     terminal_body = client.last_call("update_issue_comment").kwargs["body"]
     assert FAILED_HEADING in terminal_body
     assert "Dispatcher tests · in progress" not in terminal_body
-    assert FOOTER_RUNNING_NOTE not in terminal_body
+    assert ALERT_RUNNING_NOTE not in terminal_body
     assert "listing workflow jobs (batch batch-02, run 456)" in terminal_body
     summary = step_summary.read_text(encoding="utf-8")
     assert FAILED_HEADING in summary

--- a/ddev/tests/cli/ci/tests/test_pr_comment.py
+++ b/ddev/tests/cli/ci/tests/test_pr_comment.py
@@ -18,12 +18,12 @@ import pytest
 from markdown_it import MarkdownIt
 
 from ddev.cli.ci.tests.pr_comment import (
+    ALERT_RUNNING_NOTE,
     CANCELLED_HEADING,
     CANCELLED_NOTE,
     CANCELLED_WITHOUT_RESULTS_NOTE,
     COMMENT_MARKER,
     FAILED_HEADING,
-    FOOTER_RUNNING_NOTE,
     PROGRESS_BAR_WIDTH,
     SHUTDOWN_HEADINGS,
     SHUTDOWN_REASON_LIMIT,
@@ -747,6 +747,33 @@ def test_the_footer_says_what_it_can_outside_github_actions(monkeypatch):
     assert "GitHub Run" not in footer
 
 
+@pytest.mark.parametrize(
+    ("run_id", "expected"),
+    [
+        pytest.param(
+            "12345",
+            '⏳ Dispatcher running — <a href="https://github.com/DataDog/integrations-core/actions/runs/12345">'
+            "GitHub Run</a>.",
+            id="linked",
+        ),
+        pytest.param(None, "⏳ Dispatcher running.", id="url-unavailable"),
+    ],
+)
+def test_the_footer_of_an_unfinished_run_identifies_the_dispatcher(
+    run_id: str | None, expected: str, monkeypatch: pytest.MonkeyPatch
+):
+    """The running footer links when possible and still renders when the URL is unavailable."""
+    if run_id is None:
+        monkeypatch.delenv("GITHUB_RUN_ID")
+    else:
+        monkeypatch.setenv("GITHUB_RUN_ID", run_id)
+    progress = DispatcherProgress(
+        batches=(batch_progress("batch-01", job_progress(attempt()), job_progress()),), done=False
+    )
+
+    assert render_comment(progress).endswith(f"<sub>\n{expected}\n</sub>")
+
+
 def test_summary_line_reports_state_and_counts():
     progress = DispatcherProgress(
         batches=(batch_progress("batch-01", job_progress(attempt()), job_progress()),), done=False
@@ -1051,7 +1078,7 @@ def test_a_stopped_run_keeps_what_it_gathered_without_still_reading_as_running(k
     assert SHUTDOWN_HEADINGS[kind] in body
     assert "Dispatcher tests · in progress" not in body
     assert "Tests are still running" not in body
-    assert FOOTER_RUNNING_NOTE not in body
+    assert ALERT_RUNNING_NOTE not in body
     # Per-batch rows keep their own last-known state, which the alert explains stopped with the run.
     assert "batch-01" in body
 


### PR DESCRIPTION
### What does this PR do?

Links the running Dispatcher comment footer directly to the `test-dispatch` workflow run instead of repeating that the comment updates automatically. If workflow metadata is temporarily unavailable, the footer still renders without the link.

The preview utility and tests provide representative GitHub Actions metadata for linked rendering.

### Motivation

The running PR comment shows batch progress but did not provide a direct path to the Dispatcher workflow producing those updates. This keeps that run available from the comment throughout execution.

[AI-7152](https://datadoghq.atlassian.net/browse/AI-7152)

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required. CI developer tooling; `qa/skip-qa`.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-7152]: https://datadoghq.atlassian.net/browse/AI-7152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ