### PR TITLE
AI-6486 Add a buffered Datadog log handler

### DIFF
--- a/ddev/changelog.d/25179.added
+++ b/ddev/changelog.d/25179.added
@@ -1,0 +1,1 @@
+Add a buffered Datadog log handler to the monitoring runtime.

--- a/ddev/src/ddev/monitoring/datadog.py
+++ b/ddev/src/ddev/monitoring/datadog.py
@@ -1,0 +1,204 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""A buffered logging handler for Datadog Logs."""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import threading
+import time
+from collections.abc import Callable
+from contextlib import suppress
+from typing import NamedTuple, Protocol
+
+from datadog_api_client import ApiClient, Configuration
+from datadog_api_client.v2.api.logs_api import LogsApi
+from datadog_api_client.v2.model.http_log import HTTPLog
+from datadog_api_client.v2.model.http_log_item import HTTPLogItem
+
+# Datadog's documented intake limits are 1,000 entries and 5 MiB per request, and 1 MiB per log
+# (https://docs.datadoghq.com/api/latest/logs/). The handler stays below all three to leave room
+# for request encoding overhead.
+ENTRY_SIZE_LIMIT = 256 * 1024
+REQUEST_ENTRIES_LIMIT = 500
+REQUEST_BYTES_LIMIT = 4 * 1024 * 1024
+
+WORKER_POLL_SECONDS = 0.2
+DIAGNOSTIC_WINDOW_SECONDS = 60.0
+
+type DiagnosticSink = Callable[[str], None]
+
+
+class LogSubmitter(Protocol):
+    def submit_log(self, body: HTTPLog) -> object: ...
+
+
+class QueuedLog(NamedTuple):
+    item: HTTPLogItem
+    size: int
+
+
+class DatadogLogHandler(logging.Handler):
+    """Deliver formatter-produced JSON objects to Datadog Logs without blocking emitters."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        site: str = 'datadoghq.com',
+        level: int = logging.DEBUG,
+        diagnostics: DiagnosticSink | None = None,
+        queue_size: int = 10_000,
+        submitter: LogSubmitter | None = None,
+    ) -> None:
+        super().__init__(level=level)
+        self._diagnostics = diagnostics
+        self._queue: queue.Queue[QueuedLog | None] = queue.Queue(maxsize=queue_size)
+        if submitter is None:
+            configuration = Configuration(
+                api_key={'apiKeyAuth': api_key},
+                server_index=0,
+                server_variables={'site': site},
+                request_timeout=(5.0, 15.0),
+                enable_retry=True,
+                max_retries=2,
+                retry_backoff_factor=2.0,
+            )
+            self._api_client: ApiClient | None = ApiClient(configuration)
+            self._submitter: LogSubmitter = LogsApi(self._api_client)
+        else:
+            self._api_client = None
+            self._submitter = submitter
+        self._closed = False
+        self._close_lock = threading.Lock()
+        self._diagnostic_lock = threading.Lock()
+        self._diagnostic_at: float | None = None
+        self._diagnostic_skipped = 0
+        self._worker = threading.Thread(target=self._work, name='datadog-log-handler', daemon=True)
+        try:
+            self._worker.start()
+        except Exception:
+            self._close_api_client()
+            raise
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if self._closed:
+            return
+        try:
+            rendered = self.format(record)
+            item = self._log_item(rendered)
+            size = len(rendered.encode('utf-8'))
+        except Exception as error:
+            self._diagnose(f'a log could not be formatted and was dropped: {type(error).__name__}: {error}')
+            return
+        if size > ENTRY_SIZE_LIMIT:
+            self._diagnose(f'a {size}-byte log exceeded the {ENTRY_SIZE_LIMIT}-byte entry limit and was dropped')
+            return
+        try:
+            self._queue.put_nowait(QueuedLog(item, size))
+        except queue.Full:
+            self._diagnose('the export queue is full; logs are being dropped')
+
+    def close(self, timeout: float = 10.0) -> None:
+        """Stop accepting records and drain the queue within *timeout*."""
+        if timeout < 0:
+            raise ValueError('timeout must not be negative')
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+        with suppress(queue.Full):
+            self._queue.put_nowait(None)
+        self._worker.join(timeout=max(0.0, timeout))
+        if self._worker.is_alive():
+            dropped = self._drop_queued_logs()
+            self._diagnose(f'export did not finish within its deadline; {dropped} queued log(s) were dropped')
+        super().close()
+
+    def _work(self) -> None:
+        pending: list[QueuedLog] = []
+        pending_bytes = 0
+        try:
+            while True:
+                try:
+                    entry = self._queue.get(timeout=WORKER_POLL_SECONDS)
+                except queue.Empty:
+                    if pending:
+                        self._submit(pending)
+                        pending = []
+                        pending_bytes = 0
+                    if self._closed:
+                        break
+                    continue
+                if entry is None:  # Shutdown sentinel.
+                    self._submit(pending)
+                    break
+                if pending and (
+                    len(pending) >= REQUEST_ENTRIES_LIMIT or pending_bytes + entry.size > REQUEST_BYTES_LIMIT
+                ):
+                    self._submit(pending)
+                    pending = []
+                    pending_bytes = 0
+                pending.append(entry)
+                pending_bytes += entry.size
+                if len(pending) >= REQUEST_ENTRIES_LIMIT or pending_bytes >= REQUEST_BYTES_LIMIT:
+                    self._submit(pending)
+                    pending = []
+                    pending_bytes = 0
+        finally:
+            self._close_api_client()
+
+    def _drop_queued_logs(self) -> int:
+        dropped = 0
+        while True:
+            try:
+                entry = self._queue.get_nowait()
+            except queue.Empty:
+                return dropped
+            if entry is not None:
+                dropped += 1
+
+    def _submit(self, entries: list[QueuedLog]) -> None:
+        if not entries:
+            return
+        try:
+            self._submitter.submit_log(body=HTTPLog([entry.item for entry in entries]))
+        except Exception as error:
+            self._diagnose(f'submitting {len(entries)} log(s) failed: {type(error).__name__}: {error}')
+
+    def _close_api_client(self) -> None:
+        api_client, self._api_client = self._api_client, None
+        if api_client is not None:
+            api_client.close()
+
+    @staticmethod
+    def _log_item(rendered: str) -> HTTPLogItem:
+        attributes = json.loads(rendered)
+        if not isinstance(attributes, dict):
+            raise TypeError('the formatter must produce a JSON object')
+        if not isinstance(attributes.get('message'), str):
+            raise TypeError('the formatted JSON object must contain a string message')
+        if any(not isinstance(key, str) or not isinstance(value, str) for key, value in attributes.items()):
+            raise TypeError('Datadog log attributes must be strings')
+        return HTTPLogItem(**attributes)
+
+    def _diagnose(self, text: str) -> None:
+        """Report delivery failures outside logging, limiting repeated notices."""
+        now = time.monotonic()
+        with self._diagnostic_lock:
+            if self._diagnostic_at is not None and now - self._diagnostic_at < DIAGNOSTIC_WINDOW_SECONDS:
+                self._diagnostic_skipped += 1
+                return
+            self._diagnostic_at = now
+            skipped, self._diagnostic_skipped = self._diagnostic_skipped, 0
+        if skipped:
+            text = f'{text} (plus {skipped} earlier notices suppressed)'
+        if self._diagnostics is None:
+            return
+        try:
+            self._diagnostics(text)
+        except Exception:
+            pass  # Diagnostics cannot interrupt logging.

--- a/ddev/tests/helpers/datadog.py
+++ b/ddev/tests/helpers/datadog.py
@@ -1,0 +1,68 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Test support for code that submits Datadog logs."""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from collections.abc import Mapping
+from pprint import pformat
+
+from datadog_api_client.v2.model.http_log import HTTPLog
+
+type SubmittedLog = dict[str, object]
+
+
+class FakeLogSubmitter:
+    """Record submitted logs with optional failures and blocking."""
+
+    def __init__(self) -> None:
+        self.requests: list[list[SubmittedLog]] = []
+        self._failures: deque[Exception] = deque()
+        self._submission_gate = threading.Event()
+        self._submission_gate.set()
+        self._submission_started = threading.Semaphore(0)
+
+    @property
+    def logs(self) -> list[SubmittedLog]:
+        return [log for request in self.requests for log in request]
+
+    def submit_log(self, body: HTTPLog) -> object:
+        self._submission_started.release()
+        if not self._submission_gate.wait(timeout=5):
+            raise RuntimeError('test intake remained blocked')
+        if self._failures:
+            raise self._failures.popleft()
+        self.requests.append([item.to_dict() for item in body.value])
+        return {}
+
+    def fail_next(self, error: Exception, *, count: int = 1) -> None:
+        if count < 0:
+            raise ValueError('count must not be negative')
+        self._failures.extend(error for _ in range(count))
+
+    def block_submissions(self) -> None:
+        self._submission_gate.clear()
+
+    def resume_submissions(self) -> None:
+        self._submission_gate.set()
+
+    def wait_for_submission(self, timeout: float = 5) -> bool:
+        return self._submission_started.acquire(timeout=timeout)
+
+    def assert_logs(self, *expected: Mapping[str, object]) -> None:
+        actual = self.logs
+        expected_logs = [dict(log) for log in expected]
+        assert actual == expected_logs, f'expected logs:\n{pformat(expected_logs)}\nactual logs:\n{pformat(actual)}'
+
+    def assert_log_matches(self, expected: Mapping[str, object]) -> SubmittedLog:
+        matches = [log for log in self.logs if all(log.get(key) == value for key, value in expected.items())]
+        assert len(matches) == 1, (
+            f'expected one log matching:\n{pformat(dict(expected))}\nfound {len(matches)} in:\n{pformat(self.logs)}'
+        )
+        return matches[0]
+
+    def assert_no_logs(self) -> None:
+        self.assert_logs()

--- a/ddev/tests/monitoring/test_datadog.py
+++ b/ddev/tests/monitoring/test_datadog.py
@@ -1,0 +1,222 @@
+# (C) Datadog, Inc. 2026-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""Observable behavior of the buffered Datadog log handler."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+import pytest
+
+import ddev.monitoring.datadog as datadog_module
+from ddev.monitoring.datadog import ENTRY_SIZE_LIMIT, REQUEST_ENTRIES_LIMIT, DatadogLogHandler
+from tests.helpers.datadog import FakeLogSubmitter
+
+
+class JsonLogFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        return json.dumps(record.msg, separators=(',', ':'), ensure_ascii=False)
+
+
+def make_handler(submitter: FakeLogSubmitter, diagnostics: list[str], **kwargs: Any) -> DatadogLogHandler:
+    handler = DatadogLogHandler(api_key='test-api-key', submitter=submitter, diagnostics=diagnostics.append, **kwargs)
+    handler.setFormatter(JsonLogFormatter())
+    return handler
+
+
+def log_record(payload: object) -> logging.LogRecord:
+    return logging.LogRecord('ddev.monitoring', logging.INFO, __file__, 1, payload, None, None)
+
+
+def payload(message: str, **attributes: object) -> dict[str, object]:
+    return {'message': message, 'status': 'info', 'service': 'test-service', **attributes}
+
+
+def emit_many(handler: DatadogLogHandler, count: int) -> None:
+    for index in range(count):
+        handler.emit(log_record(payload(f'Log {index}', sequence=str(index))))
+
+
+def test_the_queued_log_is_the_payload_as_it_was_formatted():
+    submitter = FakeLogSubmitter()
+    diagnostics: list[str] = []
+    handler = make_handler(submitter, diagnostics)
+    attributes = payload('Batch dispatched', batch_id='batch-01')
+
+    handler.emit(log_record(attributes))
+    attributes['batch_id'] = 'changed-after-emission'
+    handler.close()
+
+    submitter.assert_log_matches({'message': 'Batch dispatched', 'batch_id': 'batch-01'})
+    assert not diagnostics
+
+
+def test_queued_logs_are_batched_under_the_request_limit_and_drained_on_close():
+    submitter = FakeLogSubmitter()
+    diagnostics: list[str] = []
+    handler = make_handler(submitter, diagnostics)
+
+    emit_many(handler, 1200)
+    handler.close()
+
+    assert len(submitter.logs) == 1200
+    assert all(len(request) <= REQUEST_ENTRIES_LIMIT for request in submitter.requests)
+    handler.close()
+    assert len(submitter.logs) == 1200
+    assert not diagnostics
+
+
+def test_delivery_failures_are_diagnosed_once_and_never_escape_close():
+    submitter = FakeLogSubmitter()
+    submitter.fail_next(RuntimeError('intake unavailable'), count=100)
+    diagnostics: list[str] = []
+    handler = make_handler(submitter, diagnostics)
+
+    emit_many(handler, 1200)
+    handler.close()
+
+    submitter.assert_no_logs()
+    assert len(diagnostics) == 1
+    assert 'failed' in diagnostics[0]
+
+
+def test_a_full_queue_drops_logs_instead_of_blocking_the_emitter():
+    submitter = FakeLogSubmitter()
+    submitter.block_submissions()
+    diagnostics: list[str] = []
+    handler = make_handler(submitter, diagnostics, queue_size=2)
+
+    emit_many(handler, 1)
+    assert submitter.wait_for_submission()
+    emit_many(handler, 50)
+
+    assert any('queue is full' in notice for notice in diagnostics)
+    submitter.resume_submissions()
+    handler.close()
+
+
+def test_shutdown_returns_at_its_deadline_while_intake_is_blocked():
+    submitter = FakeLogSubmitter()
+    submitter.block_submissions()
+    diagnostics: list[str] = []
+    handler = make_handler(submitter, diagnostics)
+    emit_many(handler, 1)
+    assert submitter.wait_for_submission()
+
+    started = time.monotonic()
+    handler.close(timeout=0.01)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5
+    assert any('deadline' in notice for notice in diagnostics)
+    submitter.resume_submissions()
+
+
+def test_a_negative_shutdown_timeout_is_rejected_without_closing_the_handler():
+    submitter = FakeLogSubmitter()
+    diagnostics: list[str] = []
+    handler = make_handler(submitter, diagnostics)
+
+    with pytest.raises(ValueError, match='timeout must not be negative'):
+        handler.close(timeout=-1)
+
+    handler.emit(log_record(payload('Delivered after invalid close')))
+    handler.close()
+    submitter.assert_logs(payload('Delivered after invalid close'))
+    assert not diagnostics
+
+
+def test_the_owned_api_client_is_closed_after_the_worker_stops(monkeypatch: pytest.MonkeyPatch):
+    clients = []
+    submitter = FakeLogSubmitter()
+
+    class FakeApiClient:
+        def __init__(self, _configuration: object) -> None:
+            self.closed = False
+            clients.append(self)
+
+        def close(self) -> None:
+            self.closed = True
+
+    def make_submitter(_client: FakeApiClient) -> FakeLogSubmitter:
+        return submitter
+
+    monkeypatch.setattr(datadog_module, 'ApiClient', FakeApiClient)
+    monkeypatch.setattr(datadog_module, 'LogsApi', make_submitter)
+    handler = DatadogLogHandler(api_key='test-api-key')
+    handler.setFormatter(JsonLogFormatter())
+
+    handler.emit(log_record(payload('Delivered')))
+    handler.close()
+
+    submitter.assert_logs(payload('Delivered'))
+    assert clients[0].closed
+
+
+@pytest.mark.parametrize(
+    'invalid_payload',
+    [
+        ['not', 'an', 'object'],
+        {'status': 'info'},
+        {'message': 'Numeric attribute', 'attempt': 1},
+    ],
+    ids=['not-an-object', 'missing-message', 'non-string-attribute'],
+)
+def test_invalid_formatter_output_is_dropped_with_a_diagnostic(invalid_payload: object):
+    submitter = FakeLogSubmitter()
+    diagnostics: list[str] = []
+    handler = make_handler(submitter, diagnostics)
+
+    handler.emit(log_record(invalid_payload))
+    handler.close()
+
+    submitter.assert_no_logs()
+    assert any('could not be formatted' in notice for notice in diagnostics)
+
+
+def test_formatter_failures_do_not_escape_the_logging_handler():
+    class Unserializable:
+        pass
+
+    submitter = FakeLogSubmitter()
+    diagnostics: list[str] = []
+    handler = make_handler(submitter, diagnostics)
+
+    handler.emit(log_record(payload('Invalid value', metadata=Unserializable())))
+    handler.close()
+
+    submitter.assert_no_logs()
+    assert any('could not be formatted' in notice for notice in diagnostics)
+
+
+def test_requests_stay_below_the_intake_payload_limit():
+    submitter = FakeLogSubmitter()
+    diagnostics: list[str] = []
+    handler = make_handler(submitter, diagnostics)
+
+    for index in range(20):
+        handler.emit(log_record(payload(f'Large log {index}', blob='x' * (240 * 1024))))
+    handler.close()
+
+    assert len(submitter.logs) == 20
+    assert all(
+        len(json.dumps(request, separators=(',', ':'), ensure_ascii=False).encode()) < 5 * 1024 * 1024
+        for request in submitter.requests
+    )
+    assert not diagnostics
+
+
+def test_an_oversized_log_is_dropped_with_a_notice():
+    submitter = FakeLogSubmitter()
+    diagnostics: list[str] = []
+    handler = make_handler(submitter, diagnostics)
+
+    handler.emit(log_record(payload('Huge', blob='x' * (ENTRY_SIZE_LIMIT + 1))))
+    handler.close()
+
+    submitter.assert_no_logs()
+    assert any('entry limit' in notice for notice in diagnostics)


### PR DESCRIPTION
### What does this PR do?

Adds a reusable `DatadogLogHandler` to the ddev monitoring runtime. The handler accepts formatter-produced Datadog log objects and provides bounded queueing, request batching, delivery retries, diagnostics, and deadline-bounded shutdown without embedding command-specific fields.

### Motivation

[AI-6486](https://datadoghq.atlassian.net/browse/AI-6486) needs structured Dispatcher records delivered to Datadog Logs. Keeping transport separate from Dispatcher formatting makes the handler usable by other monitoring runtime clients.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged


[AI-6486]: https://datadoghq.atlassian.net/browse/AI-6486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ