### PR TITLE
Wire phase tests to the event bus instead of a bare queue

### DIFF
--- a/ddev/tests/ai/phases/helpers.py
+++ b/ddev/tests/ai/phases/helpers.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import asyncio
 import json
 from collections.abc import Callable
 from typing import Any
@@ -17,7 +18,18 @@ from ddev.ai.react.process import ReActProcess
 from ddev.ai.runtime.agent_log import AgentLogger
 from ddev.ai.runtime.checkpoints import CheckpointManager
 from ddev.ai.tools.registry import ToolRegistry
+from ddev.event_bus.orchestrator import BaseMessage
 from tests.ai.config.utils import make_agent_config
+
+
+class StubBus:
+    """Stands in for the event bus, forwarding what a phase submits to *queue*."""
+
+    def __init__(self, queue: asyncio.Queue[BaseMessage]) -> None:
+        self.queue = queue
+
+    def submit_message(self, message: BaseMessage) -> None:
+        self.queue.put_nowait(message)
 
 
 def make_response(
@@ -178,7 +190,7 @@ def make_agent_phase(
         agent_config=effective_agent_config,
         process_factory=process_factory,
     )
-    phase.queue = message_queue
+    phase.bus = StubBus(message_queue)
     return phase, checkpoint_manager
 
 

--- a/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
+++ b/ddev/tests/ai/phases/openmetrics/test_inspect_endpoint.py
@@ -30,6 +30,8 @@ from ddev.ai.phases.openmetrics.inspect_endpoint import (
 from ddev.ai.runtime.checkpoints import CheckpointManager, CheckpointTokenInfo, FailedCheckpoint, SuccessCheckpoint
 from ddev.event_bus.exceptions import MessageProcessingError
 
+from ..helpers import StubBus
+
 ENDPOINT_URL = "http://example.test:9100/metrics"
 ENDPOINT_NAME = "main"
 PHASE_ID = "inspect_endpoint"
@@ -137,7 +139,7 @@ def _make_phase(
         checkpoint_manager=checkpoint_mgr,
         context=context,
     )
-    phase.queue = message_queue
+    phase.bus = StubBus(message_queue)
     return phase, checkpoint_mgr
 
 

--- a/ddev/tests/ai/phases/test_agentic_phase.py
+++ b/ddev/tests/ai/phases/test_agentic_phase.py
@@ -29,7 +29,7 @@ from ddev.ai.tools.fs.file_access_policy import FileAccessPolicy
 from ddev.ai.tools.registry import ToolRegistry
 from tests.ai.config.utils import make_agent_config
 
-from .helpers import MockAgent, make_agent_phase, make_goal_verdict, make_response
+from .helpers import MockAgent, StubBus, make_agent_phase, make_goal_verdict, make_response
 
 
 def read_jsonl(path: Path) -> list[dict]:
@@ -400,7 +400,7 @@ async def test_spawn_subagent_wiring(flow_dir, flow_context, monkeypatch, messag
         checkpoint_manager=checkpoint_manager,
         context=flow_context,
     )
-    phase.queue = message_queue
+    phase.bus = StubBus(message_queue)
 
     await phase.process_message(PhaseTrigger(id="start", phase_id=None))
 

--- a/ddev/tests/ai/phases/test_base.py
+++ b/ddev/tests/ai/phases/test_base.py
@@ -17,6 +17,8 @@ from ddev.ai.runtime.checkpoints import (
 )
 from ddev.event_bus.exceptions import HookName, MessageProcessingError, ProcessorHookError
 
+from .helpers import StubBus
+
 
 class _StubPhase(Phase):
     """Concrete Phase for lifecycle tests; execute() returns a deterministic PhaseOutcome."""
@@ -47,7 +49,7 @@ def _make_stub_phase(
         context=flow_context,
         outcome=outcome,
     )
-    phase.queue = message_queue
+    phase.bus = StubBus(message_queue)
     return phase, checkpoint_manager
 
 


### PR DESCRIPTION
### What does this PR do?

Points the phase unit tests at a processor's `bus` instead of the `queue` attribute they were still setting. `tests/ai/phases/helpers.py` gains a small `StubBus` that forwards `submit_message` into the existing `message_queue` fixture, so no test body or assertion changes.

### Motivation

#24962 replaced the processor's `queue` with `bus`. Four test modules under `ddev/tests/ai/phases/` still assigned `phase.queue`, which nothing reads any more, so `bus` stayed `None` and every lifecycle test that emits a message failed with `ProcessorQueueError: This processor has not been added to an active event bus` — 20 failures.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged