### PR TITLE
Stop verbose environment installation in CI tests

### DIFF
--- a/.github/actions/setup-test-target-scripts/src/run-unit-integration-tests.sh
+++ b/.github/actions/setup-test-target-scripts/src/run-unit-integration-tests.sh
@@ -26,6 +26,9 @@ else
   EXTRA_FLAGS=""
   COV_FLAG="--cov"
   VERBOSE_FLAG="-v"
+  # ddev -v sets HATCH_VERBOSE=2, which makes Hatch pass -v to its native uv commands;
+  # HATCH_QUIET=1 offsets that to net verbosity 1, so uv stays quiet but ddev/pytest verbosity is kept.
+  export HATCH_QUIET=1
 fi
 
 # Parse INPUT_PYTEST_ARGS with proper quote handling using eval


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Keep `ddev -v` for standard unit and integration jobs, but set `HATCH_QUIET=1` before running it. This keeps Hatch at verbosity 1, so it no longer adds `-v` to its uv commands. The minimum-base-package path is unchanged.

### Motivation
<!-- What inspired you to submit this pull request? -->

Keep detailed ddev and pytest output without dumping uv resolver DEBUG logs during environment setup.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
