### PR TITLE
Declare dbm option as fleet_configurable for Oracle

### DIFF
--- a/oracle/assets/configuration/spec.yaml
+++ b/oracle/assets/configuration/spec.yaml
@@ -83,5 +83,14 @@ files:
       value:
         type: string
       fleet_configurable: false
+    - name: dbm
+      display_priority: 0
+      fleet_configurable: true
+      description: |
+        Set to `true` to enable Database Monitoring.
+      value:
+        type: boolean
+        example: false
+        display_default: false
     - template: instances/db
     - template: instances/default

--- a/oracle/assets/configuration/spec.yaml
+++ b/oracle/assets/configuration/spec.yaml
@@ -1,4 +1,5 @@
 name: Oracle Database
+fleet_configurable: true
 files:
 - name: oracle.yaml
   options:


### PR DESCRIPTION
## What does this PR do?
Declares the `dbm` option in `oracle/assets/configuration/spec.yaml` with `fleet_configurable: true`, mirroring the existing pattern in mysql, postgres, and sqlserver's spec.yaml files.

## Motivation
Customer-reported (Zendesk 3013499): Fleet Automation's remote-config editor rejects `dbm` when configuring the Oracle integration, even though `dbm: true` is a real, documented, working option (see the shipped `conf.yaml.example` in `datadog-agent`'s `cmd/agent/dist/conf.d/oracle.d/`, and the Oracle check's `pkg/collector/corechecks/oracle/config/config.go`, which parses `DBM bool `yaml:"dbm"``).

Oracle's `spec.yaml` in this repo never declared `dbm` at all, unlike the other DBM-enabled integrations.

Note: mongo has no `dbm` option in its spec.yaml at all, and clickhouse declares `dbm` with `fleet_configurable: false` (off by default there, for reasons specific to that integration, not applicable to Oracle) — neither is a counter-example against this change.

## What I verified locally
Using a temporary local package scaffold (`__about__.py`, `__init__.py`, `data/`) — since Oracle's actual check implementation is a Go core check in `datadog-agent`, not a Python package living in this repo — I ran:
- `ddev validate config oracle -s`: generates a `conf.yaml.example` `dbm` block that is character-for-character identical to the one already shipped in `datadog-agent`.
- `ddev validate models oracle -s`: generates a valid pydantic config model including `dbm: Optional[bool] = None`.

I also confirmed that since Oracle has no `datadog_checks/oracle` package in this repo, it isn't part of `ddev`'s `get_valid_checks()` set, so the `config`/`models` CI validators skip Oracle entirely and will not attempt to regenerate or validate a `conf.yaml.example`/`config_models` that don't exist. No CI breakage expected from this change.

## How this reaches Fleet Automation
Traced the actual sync mechanism in `dd-source/domains/fleet-automation/apps/fleet-sync-worker`: a scheduled workflow lists every top-level directory in this repo, fetches each `<name>/assets/configuration/spec.yaml` directly (independent of any Python packaging), converts `fleet_configurable: true` fields into the `INSTALLER_CONFIG` JSON schema, diffs against what's currently committed in `dd-source`, and opens a bot PR only when something changed. Oracle isn't in any exclusion list; it simply never had a `fleet_configurable` field before, so every prior run produced identical output and no PR was ever opened for it. Once this PR merges, the next scheduled run should produce a real diff for `oracle.json` and open a `dd-source` PR from `dd-octo-sts[bot]` — that PR is the thing to watch for and review to confirm this closes the loop end-to-end.

## Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)