### PR TITLE
Optimize SQL Server query metrics collection

### DIFF
--- a/sqlserver/changelog.d/25194.fixed
+++ b/sqlserver/changelog.d/25194.fixed
@@ -1,0 +1,1 @@
+Improve SQL Server query metrics collection efficiency.

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -48,6 +48,11 @@ SQL_SERVER_QUERY_METRICS_COLUMNS = [
     "total_spills",
 ]
 
+# The aggregate queries keep the representative plan handle and offsets as one
+# binary value so MAX cannot mix offsets from a different handle. They rebuild
+# the historical hexadecimal helper column after aggregation to preserve the
+# raw cursor schema. Stored-procedure rows reuse the database ID already exposed
+# by dm_exec_procedure_stats; other plan types fall back to plan attributes.
 STATEMENT_METRICS_QUERY = """\
 with qstats as (
     select
@@ -55,13 +60,15 @@ with qstats as (
         qs.query_plan_hash,
         qs.last_execution_time,
         qs.last_elapsed_time,
-        CONCAT(
-            CONVERT(VARCHAR(64), CONVERT(binary(64), qs.plan_handle), 1),
-            CONVERT(VARCHAR(10), CONVERT(varbinary(4), qs.statement_start_offset), 1),
-            CONVERT(VARCHAR(10), CONVERT(varbinary(4), qs.statement_end_offset), 1)) as plan_handle_and_offsets,
-           (select value from sys.dm_exec_plan_attributes(qs.plan_handle) where attribute = 'dbid') as dbid,
-           eps.object_id as sproc_object_id,
-           {query_metrics_columns}
+        CONVERT(binary(64), qs.plan_handle)
+            + CONVERT(binary(4), qs.statement_start_offset)
+            + CONVERT(binary(4), qs.statement_end_offset) as plan_handle_and_offsets,
+        CASE WHEN eps.database_id IS NOT NULL THEN eps.database_id
+            ELSE CAST((select value from sys.dm_exec_plan_attributes(qs.plan_handle)
+                where attribute = 'dbid') AS int)
+        END as dbid,
+        eps.object_id as sproc_object_id,
+        {query_metrics_columns}
     from sys.dm_exec_query_stats qs
     left join sys.dm_exec_procedure_stats eps ON eps.plan_handle = qs.plan_handle
 ),
@@ -82,10 +89,22 @@ qstats_aggr as (
 ),
 qstats_aggr_split as (
     select TOP {limit}
-        convert(varbinary(64), convert(binary(64), substring(plan_handle_and_offsets, 1, 64), 1)) as plan_handle,
-        convert(int, convert(varbinary(10), substring(plan_handle_and_offsets, 64+1, 10), 1)) as statement_start_offset,
-        convert(int, convert(varbinary(10), substring(plan_handle_and_offsets, 64+11, 10), 1)) as statement_end_offset,
-        *
+        convert(varbinary(64), substring(plan_handle_and_offsets, 1, 64)) as plan_handle,
+        convert(int, substring(plan_handle_and_offsets, 64+1, 4)) as statement_start_offset,
+        convert(int, substring(plan_handle_and_offsets, 64+5, 4)) as statement_end_offset,
+        query_hash,
+        query_plan_hash,
+        dbid,
+        database_name,
+        CONCAT(
+            CONVERT(VARCHAR(64), SUBSTRING(plan_handle_and_offsets, 1, 64), 1),
+            CONVERT(VARCHAR(10), SUBSTRING(plan_handle_and_offsets, 64+1, 4), 1),
+            CONVERT(VARCHAR(10), SUBSTRING(plan_handle_and_offsets, 64+5, 4), 1)
+        ) as plan_handle_and_offsets,
+        last_execution_time,
+        last_elapsed_time,
+        sproc_object_id,
+        {query_metrics_column_names}
     from qstats_aggr
     where DATEADD(ms, last_elapsed_time / 1000, last_execution_time) > dateadd(second, -?, getdate())
 )
@@ -147,13 +166,15 @@ with qstats as (
         qs.query_plan_hash,
         qs.last_execution_time,
         qs.last_elapsed_time,
-        CONCAT(
-            CONVERT(VARCHAR(64), CONVERT(binary(64), qs.plan_handle), 1),
-            CONVERT(VARCHAR(10), CONVERT(varbinary(4), qs.statement_start_offset), 1),
-            CONVERT(VARCHAR(10), CONVERT(varbinary(4), qs.statement_end_offset), 1)) as plan_handle_and_offsets,
-           (select value from sys.dm_exec_plan_attributes(qs.plan_handle) where attribute = 'dbid') as dbid,
-           eps.object_id as sproc_object_id,
-           {query_metrics_columns}
+        CONVERT(binary(64), qs.plan_handle)
+            + CONVERT(binary(4), qs.statement_start_offset)
+            + CONVERT(binary(4), qs.statement_end_offset) as plan_handle_and_offsets,
+        CASE WHEN eps.database_id IS NOT NULL THEN eps.database_id
+            ELSE CAST((select value from sys.dm_exec_plan_attributes(qs.plan_handle)
+                where attribute = 'dbid') AS int)
+        END as dbid,
+        eps.object_id as sproc_object_id,
+        {query_metrics_columns}
     from sys.dm_exec_query_stats qs
     left join sys.dm_exec_procedure_stats eps ON eps.plan_handle = qs.plan_handle
 ),
@@ -173,10 +194,22 @@ qstats_aggr as (
 ),
 qstats_aggr_split as (
     select TOP {limit}
-        convert(varbinary(64), convert(binary(64), substring(plan_handle_and_offsets, 1, 64), 1)) as plan_handle,
-        convert(int, convert(varbinary(10), substring(plan_handle_and_offsets, 64+1, 10), 1)) as statement_start_offset,
-        convert(int, convert(varbinary(10), substring(plan_handle_and_offsets, 64+11, 10), 1)) as statement_end_offset,
-        *
+        convert(varbinary(64), substring(plan_handle_and_offsets, 1, 64)) as plan_handle,
+        convert(int, substring(plan_handle_and_offsets, 64+1, 4)) as statement_start_offset,
+        convert(int, substring(plan_handle_and_offsets, 64+5, 4)) as statement_end_offset,
+        query_hash,
+        query_plan_hash,
+        dbid,
+        database_name,
+        CONCAT(
+            CONVERT(VARCHAR(64), SUBSTRING(plan_handle_and_offsets, 1, 64), 1),
+            CONVERT(VARCHAR(10), SUBSTRING(plan_handle_and_offsets, 64+1, 4), 1),
+            CONVERT(VARCHAR(10), SUBSTRING(plan_handle_and_offsets, 64+5, 4), 1)
+        ) as plan_handle_and_offsets,
+        last_execution_time,
+        last_elapsed_time,
+        sproc_object_id,
+        {query_metrics_column_names}
     from qstats_aggr
     where DATEADD(ms, last_elapsed_time / 1000, last_execution_time) > dateadd(second, -?, getdate())
 )
@@ -348,6 +381,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         self._statement_metrics_query = statements_query.format(
             query_metrics_columns=', '.join(['qs.{} as {}'.format(col, col) for col in available_columns]),
             query_metrics_column_sums=', '.join(['sum(qs.{}) as {}'.format(c, c) for c in available_columns]),
+            query_metrics_column_names=', '.join(available_columns),
             limit=self.dm_exec_query_stats_row_limit,
             proc_char_limit=self._config.stored_procedure_characters_limit,
             database_name_column=database_name_column,


### PR DESCRIPTION
### What does this PR do?

This PR reduces per-row work in the SQL Server query-metrics collection query while preserving its result schema and collection semantics.

- Keep the representative plan handle and statement offsets as one fixed-width binary tuple during aggregation, then reconstruct the historical hexadecimal helper value in the final projection.
- Reuse `sys.dm_exec_procedure_stats.database_id` for stored-procedure rows and retain `sys.dm_exec_plan_attributes` as the fallback for ad hoc and prepared plans.
- Project aggregate columns explicitly so column names, order, types, and values remain compatible with the existing collector.
- Apply the same query change to self-hosted SQL Server and Azure SQL Database.

### Motivation

The previous query hex-encoded the plan handle and offsets for every qualifying DMV row before `MAX()` selected a representative tuple. Hex text is about twice the size of the packed binary value and requires binary-to-character conversion plus character comparisons during aggregation. Keeping the 64-byte handle and two 4-byte offsets binary avoids that hot-path work and still guarantees that the selected offsets belong to the selected handle.

For stored-procedure plans, the existing left join already exposes the database ID. Calling `sys.dm_exec_plan_attributes` again for those rows is redundant, so the query now uses the joined ID when available and performs the plan-attribute lookup only as a compatibility fallback.

A dedicated direct-SQL experiment deterministically populated `sys.dm_exec_query_stats` with 5,000 stored procedures, each producing a distinct query text and query hash. Five repetitions produced these averages:

| Cache mode | Production CPU | Candidate CPU | CPU change | Production elapsed | Candidate elapsed | Elapsed change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| All 5,000 hot | 330.3 ms | 312.7 ms | -5.3% | 411.4 ms | 386.3 ms | -6.1% |
| 500 of 5,000 hot | 94.9 ms | 79.9 ms | -15.8% | 174.9 ms | 165.9 ms | -5.1% |

Logical reads were effectively unchanged: 15,128 to 15,136 in the all-hot case and 1,628 to 1,636 in the sparse-hot case. Every raw result column was compared with bidirectional `EXCEPT`, and the production and candidate queries returned identical results.

Validation performed:

- `ddev test --lint sqlserver`
- `ddev --no-interactive test sqlserver:py3.13-linux-odbc-2022-single -- -k test_statement_basic_metrics_query` (1 passed)
- `ddev --no-interactive test sqlserver:py3.13-linux-odbc-2022-single -- -k test_statement_metrics_and_plans` (13 passed, covering stored procedures, encrypted procedures, parameterized queries, and ad hoc queries)

The profiling and benchmark tooling remains uncommitted in the separate dbm repository and is intentionally not part of this PR.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged