### PR TITLE
Simplify the disk usage diff PR comment format

### DIFF
--- a/.github/workflows/measure-disk-usage.yml
+++ b/.github/workflows/measure-disk-usage.yml
@@ -128,25 +128,31 @@ jobs:
         run: |
           section() {
             local title=$1 file=$2 outcome=$3
-            printf '<details>\n<summary><strong>%s</strong></summary>\n\n' "$title"
             if [ -f "$file" ]; then
-              tail -n +3 "$file"
-            elif [ "$outcome" = "success" ]; then
-              printf 'No integration or dependency changed size.\n'
-            else
+              cat "$file"
+              printf '\n'
+            elif [ "$outcome" != "success" ]; then
               printf ':warning: The %s measurement failed, so no size difference is available. ' "${title,,}"
-              printf 'See [the workflow run](%s).\n' "$RUN_URL"
+              printf 'See [the workflow run](%s).\n\n' "$RUN_URL"
             fi
-            printf '\n</details>\n\n'
           }
 
           mkdir -p pr-comment
+          sections=$(mktemp)
+          {
+            section 'Uncompressed' diff_uncompressed.md "$UNCOMPRESSED_OUTCOME"
+            section 'Compressed' diff_compressed.md "$COMPRESSED_OUTCOME"
+          } > "$sections"
+
           {
             printf '<!-- pr-comment:measure-disk-usage -->\n\n'
             printf '## Disk usage change\n\n'
             printf 'Commit `%s` compared against `%s`.\n\n' "${SHA:0:7}" "${BASE_SHA:0:7}"
-            section 'Uncompressed' diff_uncompressed.md "$UNCOMPRESSED_OUTCOME"
-            section 'Compressed' diff_compressed.md "$COMPRESSED_OUTCOME"
+            if grep -q ':warning:' "$sections" || grep -qE '[+-][0-9]' "$sections"; then
+              cat "$sections"
+            else
+              printf 'No integration or dependency changed size.\n'
+            fi
           } > pr-comment/body.md
 
       - name: Get token via dd-octo-sts

--- a/ddev/changelog.d/25195.added
+++ b/ddev/changelog.d/25195.added
@@ -1,0 +1,1 @@
+Show a per-platform totals table and pivot the per-module table by platform in the ``ddev size diff`` markdown output and PR comment.

--- a/ddev/src/ddev/cli/size/diff.py
+++ b/ddev/src/ddev/cli/size/diff.py
@@ -134,7 +134,16 @@ def diff(
                         )
                     )
                 if format:
-                    export_format(app, format, modules_plat_ver, "diff", platform, version, compressed)
+                    export_format(
+                        app,
+                        format,
+                        modules_plat_ver,
+                        "diff",
+                        platform,
+                        version,
+                        compressed,
+                        platforms=list(platforms),
+                    )
                 if (to_dd_org or to_dd_key) and modules_plat_ver:
                     send_diff_metrics_to_dd(app, second_commit, modules_plat_ver, to_dd_org, to_dd_key, compressed)
             except Exception as e:

--- a/ddev/src/ddev/cli/size/utils/common_funcs.py
+++ b/ddev/src/ddev/cli/size/utils/common_funcs.py
@@ -527,7 +527,11 @@ def build_section_label(header: str, total: str | None) -> str:
 
 def _signed_human_size(size_bytes: int) -> str:
     human = convert_to_human_readable_size(size_bytes)
-    return f"+{human}" if size_bytes > 0 else human
+    if size_bytes > 0:
+        return f"\U0001f53a +{human}"
+    elif size_bytes < 0:
+        return f"\U0001f7e2 {human}"
+    return human
 
 
 def save_markdown_diff(

--- a/ddev/src/ddev/cli/size/utils/common_funcs.py
+++ b/ddev/src/ddev/cli/size/utils/common_funcs.py
@@ -525,21 +525,81 @@ def build_section_label(header: str, total: str | None) -> str:
     return f"{header} ({total})" if total is not None else header
 
 
+def _signed_human_size(size_bytes: int) -> str:
+    human = convert_to_human_readable_size(size_bytes)
+    return f"+{human}" if size_bytes > 0 else human
+
+
+def save_markdown_diff(
+    app: Application,
+    modules: list[FileDataEntryPlatformVersion],
+    file_path: str,
+    platforms: list[str],
+    compressed: bool,
+) -> None:
+    heading = "Compressed" if compressed else "Uncompressed"
+    sorted_platforms = sorted(set(platforms))
+
+    totals = dict.fromkeys(sorted_platforms, 0)
+    for module in modules:
+        platform = module.get("Platform", "")
+        if platform in totals:
+            totals[platform] += int(module.get("Size_Bytes", 0) or 0)
+
+    lines = [f"### {heading}", ""]
+    lines.append("| " + " | ".join(sorted_platforms) + " |")
+    lines.append("| " + " | ".join("---" for _ in sorted_platforms) + " |")
+    lines.append("| " + " | ".join(_signed_human_size(totals[platform]) for platform in sorted_platforms) + " |")
+    lines.append("")
+
+    pivoted: dict[tuple[str, str], dict[str, int]] = {}
+    versions: dict[tuple[str, str], str] = {}
+    for module in modules:
+        key = (module["Name"], module["Type"])
+        versions.setdefault(key, str(module.get("Version", "")))
+        pivoted.setdefault(key, {})[module.get("Platform", "")] = int(module.get("Size_Bytes", 0) or 0)
+
+    if not pivoted:
+        lines.append("<details>")
+        lines.append("<summary>Details — no dependency changed size</summary>")
+        lines.append("</details>")
+    else:
+        lines.append("<details>")
+        lines.append("<summary>Details</summary>")
+        lines.append("")
+        headers = ["Name", "Version", "Type", *sorted_platforms]
+        lines.append("| " + " | ".join(headers) + " |")
+        lines.append("| " + " | ".join("---" for _ in headers) + " |")
+        for (name, type_), sizes in sorted(pivoted.items(), key=lambda item: item[0][0]):
+            row = [name, versions[(name, type_)], type_]
+            row.extend(_signed_human_size(sizes.get(platform, 0)) for platform in sorted_platforms)
+            lines.append("| " + " | ".join(row) + " |")
+        lines.append("")
+        lines.append("</details>")
+
+    lines.append("")
+    markdown = "\n".join(lines)
+
+    with open(file_path, "a", encoding="utf-8") as f:
+        f.write(markdown)
+    app.display(f"Markdown table saved to {file_path}")
+
+
 def save_markdown(
     app: Application,
     title: str,
     modules: list[FileDataEntryPlatformVersion] | list[CommitEntryWithDelta] | list[CommitEntryPlatformWithDelta],
     file_path: str,
-    section_total: Literal["none", "absolute", "delta"] = "none",
+    section_total: Literal["none", "absolute"] = "none",
 ) -> None:
     """
     Writes the modules as one collapsible markdown section per platform and Python version.
 
     Args:
-        section_total: Whether to summarize each section with the sum of its Size_Bytes, and how.
-            `absolute` for plain sizes, `delta` to also sign a positive sum. Defaults to `none`
-            because summing is only meaningful when the rows partition a single total; timeline
-            rows, for instance, are the size at successive commits, so their sum means nothing.
+        section_total: Whether to summarize each section with the sum of its Size_Bytes. Defaults
+            to `none` because summing is only meaningful when the rows partition a single total;
+            timeline rows, for instance, are the size at successive commits, so their sum means
+            nothing.
     """
     if modules == []:
         return
@@ -579,8 +639,6 @@ def save_markdown(
         if section_total != "none":
             total = sum(int(row.get("Size_Bytes", 0) or 0) for row in group)
             readable_total = convert_to_human_readable_size(total)
-            if section_total == "delta" and total > 0:
-                readable_total = f"+{readable_total}"
         label = build_section_label(label, readable_total)
 
         lines.append("<details>")
@@ -626,6 +684,7 @@ def export_format(
     platform: Optional[str],
     version: Optional[str],
     compressed: bool,
+    platforms: Optional[list[str]] = None,
 ) -> None:
     size_type = "compressed" if compressed else "uncompressed"
     name = f"{mode}_{size_type}"
@@ -644,13 +703,16 @@ def export_format(
 
         elif output_format == "markdown":
             markdown_filename = f"{name}.md"
-            save_markdown(
-                app,
-                mode.capitalize(),
-                modules,
-                markdown_filename,
-                section_total="delta" if mode == "diff" else "absolute",
-            )
+            if mode == "diff":
+                save_markdown_diff(app, modules, markdown_filename, platforms or [], compressed)
+            else:
+                save_markdown(
+                    app,
+                    mode.capitalize(),
+                    modules,
+                    markdown_filename,
+                    section_total="absolute",
+                )
 
 
 def plot_treemap(

--- a/ddev/tests/size/test_common.py
+++ b/ddev/tests/size/test_common.py
@@ -459,10 +459,10 @@ def test_save_markdown_diff_always_shows_totals_table():
     written_content = "".join(call.args[0] for call in mock_file().write.call_args_list)
     assert "### Uncompressed" in written_content
     assert "| linux-x86_64 | macos-x86_64 | windows-x86_64 |" in written_content
-    assert "| +1000 B | -400 B | 0 B |" in written_content
+    assert "| \U0001f53a +1000 B | \U0001f7e2 -400 B | 0 B |" in written_content
     assert "<summary>Details</summary>" in written_content
-    assert "| module1 |  | Dependency | +1000 B | 0 B | 0 B |" in written_content
-    assert "| module2 |  | Dependency | 0 B | -400 B | 0 B |" in written_content
+    assert "| module1 |  | Dependency | \U0001f53a +1000 B | 0 B | 0 B |" in written_content
+    assert "| module2 |  | Dependency | 0 B | \U0001f7e2 -400 B | 0 B |" in written_content
 
 
 def test_save_markdown_diff_no_changes_collapses_details():

--- a/ddev/tests/size/test_common.py
+++ b/ddev/tests/size/test_common.py
@@ -29,6 +29,7 @@ from ddev.cli.size.utils.common_funcs import (
     save_csv,
     save_json,
     save_markdown,
+    save_markdown_diff,
     send_diff_metrics_to_dd,
     wheel_url_candidates,
 )
@@ -398,56 +399,84 @@ def test_save_markdown():
     assert written_content == expected_writes
 
 
-@pytest.mark.parametrize(
-    ("mode", "expected_title", "expected_total"),
-    [
-        pytest.param("status", "Status", "absolute", id="status"),
-        pytest.param("diff", "Diff", "delta", id="diff"),
-    ],
-)
-def test_export_format_titles_markdown_by_mode(mode, expected_title, expected_total):
+def test_export_format_status_uses_save_markdown():
     modules = [
         {"Name": "module1", "Size_Bytes": 123, "Size": "2 B", "Type": "Integration", "Platform": "linux-x86_64"},
     ]
 
     with patch("ddev.cli.size.utils.common_funcs.save_markdown") as mock_save:
-        export_format(MagicMock(), ["markdown"], modules, mode, None, None, False)
+        export_format(MagicMock(), ["markdown"], modules, "status", None, None, False)
 
     _, title, _, filename = mock_save.call_args.args
-    assert title == expected_title
-    assert filename == f"{mode}_uncompressed.md"
-    assert mock_save.call_args.kwargs["section_total"] == expected_total
+    assert title == "Status"
+    assert filename == "status_uncompressed.md"
+    assert mock_save.call_args.kwargs["section_total"] == "absolute"
 
 
-def test_save_markdown_signs_positive_totals_for_deltas():
+@pytest.mark.parametrize(
+    "compressed, expected_filename",
+    [
+        pytest.param(False, "diff_uncompressed.md", id="uncompressed"),
+        pytest.param(True, "diff_compressed.md", id="compressed"),
+    ],
+)
+def test_export_format_diff_uses_save_markdown_diff(compressed, expected_filename):
+    modules = [
+        {"Name": "module1", "Size_Bytes": 123, "Size": "2 B", "Type": "Integration", "Platform": "linux-x86_64"},
+    ]
+
+    with patch("ddev.cli.size.utils.common_funcs.save_markdown_diff") as mock_save:
+        export_format(
+            MagicMock(),
+            ["markdown"],
+            modules,
+            "diff",
+            None,
+            None,
+            compressed,
+            platforms=["linux-x86_64", "macos-x86_64"],
+        )
+
+    app, saved_modules, filename, platforms, saved_compressed = mock_save.call_args.args
+    assert saved_modules == modules
+    assert filename == expected_filename
+    assert platforms == ["linux-x86_64", "macos-x86_64"]
+    assert saved_compressed is compressed
+
+
+def test_save_markdown_diff_always_shows_totals_table():
     mock_app = MagicMock()
     mock_file = mock_open()
 
     modules = [
         {"Name": "module1", "Size_Bytes": 1000, "Size": "+1000 B", "Type": "Dependency", "Platform": "linux-x86_64"},
-        {"Name": "module2", "Size_Bytes": -400, "Size": "-400 B", "Type": "Dependency", "Platform": "linux-x86_64"},
+        {"Name": "module2", "Size_Bytes": -400, "Size": "-400 B", "Type": "Dependency", "Platform": "macos-x86_64"},
     ]
 
     with patch("ddev.cli.size.utils.common_funcs.open", mock_file):
-        save_markdown(mock_app, "Diff", modules, "output.md", section_total="delta")
+        save_markdown_diff(mock_app, modules, "output.md", ["linux-x86_64", "macos-x86_64", "windows-x86_64"], False)
 
     written_content = "".join(call.args[0] for call in mock_file().write.call_args_list)
-    assert "<summary>linux-x86_64 (+600 B)</summary>" in written_content
+    assert "### Uncompressed" in written_content
+    assert "| linux-x86_64 | macos-x86_64 | windows-x86_64 |" in written_content
+    assert "| +1000 B | -400 B | 0 B |" in written_content
+    assert "<summary>Details</summary>" in written_content
+    assert "| module1 |  | Dependency | +1000 B | 0 B | 0 B |" in written_content
+    assert "| module2 |  | Dependency | 0 B | -400 B | 0 B |" in written_content
 
 
-def test_save_markdown_leaves_negative_totals_unsigned():
+def test_save_markdown_diff_no_changes_collapses_details():
     mock_app = MagicMock()
     mock_file = mock_open()
 
-    modules = [
-        {"Name": "module1", "Size_Bytes": -1000, "Size": "-1000 B", "Type": "Dependency", "Platform": "linux-x86_64"},
-    ]
-
     with patch("ddev.cli.size.utils.common_funcs.open", mock_file):
-        save_markdown(mock_app, "Diff", modules, "output.md", section_total="delta")
+        save_markdown_diff(mock_app, [], "output.md", ["linux-x86_64", "macos-x86_64"], True)
 
     written_content = "".join(call.args[0] for call in mock_file().write.call_args_list)
-    assert "<summary>linux-x86_64 (-1000 B)</summary>" in written_content
+    assert "### Compressed" in written_content
+    assert "| 0 B | 0 B |" in written_content
+    assert "<summary>Details — no dependency changed size</summary>" in written_content
+    assert "| Name | Version | Type |" not in written_content
 
 
 def test_save_markdown_one_section_per_platform_and_version():
@@ -499,7 +528,7 @@ def test_save_markdown_orders_sections_deterministically():
 
     mock_file = mock_open()
     with patch("ddev.cli.size.utils.common_funcs.open", mock_file):
-        save_markdown(MagicMock(), "Diff", modules, "output.md", section_total="delta")
+        save_markdown(MagicMock(), "Status", modules, "output.md", section_total="absolute")
 
     written_content = "".join(call.args[0] for call in mock_file().write.call_args_list)
     assert re.findall(r"<summary>(\S+), Python", written_content) == sorted(platforms)


### PR DESCRIPTION
### What does this PR do?
Reworks the "Measure disk usage" workflow's PR comment for `ddev size diff`:

- Each size type (Uncompressed/Compressed) now renders its per-module diff as a table with one column per platform, instead of one collapsible section per platform.
- Each size type always shows a per-platform totals table up front, so the size impact is visible without expanding anything.
- The per-module detail stays behind a collapsible "Details" section.
- The workflow's comment-assembly step now just concatenates the two self-contained markdown files it already produces.

### Motivation
The previous format nested one collapsible section per platform per size type, making it hard to see the overall size impact at a glance. The new format surfaces totals immediately and pivots platforms into columns for easier comparison.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)