### PR TITLE
kueue: enable collection of histograms as distributions by default

### DIFF
--- a/kueue/assets/configuration/spec.yaml
+++ b/kueue/assets/configuration/spec.yaml
@@ -11,6 +11,7 @@ files:
     - template: instances/openmetrics
       overrides:
         openmetrics_endpoint.value.example: http://localhost:8080/metrics
+        histogram_buckets_as_distributions.value.example: true
         openmetrics_endpoint.description: |
           Endpoint exposing Kueue's Prometheus metrics.
     - name: cluster_check

--- a/kueue/changelog.d/25196.changed
+++ b/kueue/changelog.d/25196.changed
@@ -1,0 +1,1 @@
+Enable collection of histogram buckets as distribution metrics by default.

--- a/kueue/datadog_checks/kueue/config_models/defaults.py
+++ b/kueue/datadog_checks/kueue/config_models/defaults.py
@@ -65,7 +65,7 @@ def instance_enable_legacy_tags_normalization():
 
 
 def instance_histogram_buckets_as_distributions():
-    return False
+    return True
 
 
 def instance_ignore_connection_errors():

--- a/kueue/datadog_checks/kueue/data/conf.yaml.example
+++ b/kueue/datadog_checks/kueue/data/conf.yaml.example
@@ -537,8 +537,8 @@ instances:
     #   - TLSv1.3
 
     ## @param tls_ciphers - list of strings - optional
-    ## The list of ciphers suites to use when connecting to an endpoint. If not specified,
-    ## `ALL` ciphers are used. For list of ciphers see:
+    ## The list of ciphers suites to use when connecting to an endpoint. If not specified, 
+    ## `ALL` ciphers are used. For list of ciphers see: 
     ## https://www.openssl.org/docs/man1.0.2/man1/ciphers.html
     #
     # tls_ciphers:

--- a/kueue/datadog_checks/kueue/data/conf.yaml.example
+++ b/kueue/datadog_checks/kueue/data/conf.yaml.example
@@ -195,14 +195,14 @@ instances:
     #
     # non_cumulative_histogram_buckets: false
 
-    ## @param histogram_buckets_as_distributions - boolean - optional - default: false
+    ## @param histogram_buckets_as_distributions - boolean - optional - default: true
     ## Whether or not to send histogram buckets as Datadog distribution metrics. This implicitly
     ## enables the `collect_histogram_buckets` and `non_cumulative_histogram_buckets` options.
     ##
     ## Learn more about distribution metrics:
     ## https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#metric-types
     #
-    # histogram_buckets_as_distributions: false
+    # histogram_buckets_as_distributions: true
 
     ## @param collect_counters_with_distributions - boolean - optional - default: false
     ## Whether or not to also collect the observation counter metrics ending in `.sum` and `.count`
@@ -537,8 +537,8 @@ instances:
     #   - TLSv1.3
 
     ## @param tls_ciphers - list of strings - optional
-    ## The list of ciphers suites to use when connecting to an endpoint. If not specified, 
-    ## `ALL` ciphers are used. For list of ciphers see: 
+    ## The list of ciphers suites to use when connecting to an endpoint. If not specified,
+    ## `ALL` ciphers are used. For list of ciphers see:
     ## https://www.openssl.org/docs/man1.0.2/man1/ciphers.html
     #
     # tls_ciphers:


### PR DESCRIPTION
### What does this PR do?

Enables collection of histograms as distributions by default in the Kueue integration.

### Motivation

The UI for capacity planning requires more advanced metrics that can only be enabled when collecting distributions.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
