### PR TITLE
[SEC-37324] Improve Anomali ThreatStream configuration instructions

### DIFF
--- a/anomali_threatstream/README.md
+++ b/anomali_threatstream/README.md
@@ -12,20 +12,22 @@ Integrate Anomali ThreatStream with Datadog to enhance your security logs with t
 
 ## Setup
 
-### Obtaining Anomali ThreatStream API credentials and domain
+### Obtain Anomali ThreatStream API credentials and API domain
 
 1. Log in to the Anomali ThreatStream instance.
 2. Navigate to **Settings** > **My profile**.
 3. Under **Account Information**, click **Reveal** next to the **API Key** and copy it. Also, copy your **Email**.
-4. Identify your Anomali ThreatStream Domain using the URL of your Anomali ThreatStream instance.
-   - For example, if your Anomali ThreatStream instance URL is `https://ui.threatstream.com/`, then your Anomali ThreatStream domain is `ui.threatstream.com`.
+4. Identify your API domain from the [Anomali ThreatStream access documentation][3]:
+   - For US Cloud, use `api.threatstream.com`.
+   - For EU Cloud, use `api-eu.threatstream.com`.
+   - Enter only the API domain, without `https://` or an `/api/...` path. Do not enter the platform domain (`ui.threatstream.com` or `ui-eu.threatstream.com`).
 
 ### Connect your Anomali ThreatStream account to Datadog
 
 1. Provide the following details:
    | Parameter | Description |
    | ---------- | ---------------------------------------------- |
-   | Domain | Your Anomali ThreatStream domain. |
+   | API Domain | Your Anomali ThreatStream API domain; for example, `api.threatstream.com` for US Cloud or `api-eu.threatstream.com` for EU Cloud. |
    | Email | Email address associated with your ThreatStream account. |
    | API Key | API key of your Anomali ThreatStream account. |
    | Collect IPv4 IOCs | Enable to collect IPv4 IOCs. The default value is `true`. |
@@ -39,3 +41,4 @@ Need help? Contact [Datadog support][2].
 
 [1]: https://www.anomali.com/products/threatstream
 [2]: https://docs.datadoghq.com/help/
+[3]: https://docs.anomali.com/Content/Getting%20Started%20with%20ThreatStream/access_optic.htm

--- a/anomali_threatstream/assets/account_config.json
+++ b/anomali_threatstream/assets/account_config.json
@@ -3,7 +3,8 @@
   "additional_config_fields": [
     {
       "key": "api_domain",
-      "label": "Domain",
+      "label": "API Domain",
+      "help": "Use api.threatstream.com for US Cloud or api-eu.threatstream.com for EU Cloud.",
       "editable": true,
       "required": true,
       "domain": {


### PR DESCRIPTION
### What does this PR do?

Clarifies the Anomali ThreatStream account configuration by:

- Renaming the `Domain` field to `API Domain` and adding US and EU Cloud examples.
- Updating the setup instructions to follow Anomali's access documentation.
- Telling customers to enter only `api.threatstream.com` or `api-eu.threatstream.com`, without a scheme or API path, instead of the ThreatStream UI domain.

### Motivation

The previous instructions were unclear on what kind of domain customers were supposed to enter. Now, examples are provided as well as documentation from Anomali ThreatStream.

Reference: https://docs.anomali.com/Content/Getting%20Started%20with%20ThreatStream/access_optic.htm

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
