### PR TITLE
[TXP-352] Move account-level credential fields into supported_auth_methods

### DIFF
--- a/anthropic_compliance_logs/assets/account_config.json
+++ b/anthropic_compliance_logs/assets/account_config.json
@@ -1,11 +1,16 @@
 {
-  "additional_config_fields": [
+  "supported_auth_methods": [
     {
-      "key": "api_key",
-      "label": "Admin API key",
-      "editable": true,
-      "required": true,
-      "password": {}
+      "auth_name": "Admin API key",
+      "bearer_token": {
+        "password_setting": {
+          "key": "api_key",
+          "label": "Admin API key",
+          "editable": true,
+          "required": true,
+          "password": {}
+        }
+      }
     }
   ],
   "dataflow_config": [

--- a/anthropic_usage_and_costs/assets/account_config.json
+++ b/anthropic_usage_and_costs/assets/account_config.json
@@ -1,12 +1,17 @@
 {
-  "additional_config_fields": [
+  "supported_auth_methods": [
     {
-      "key": "api_key",
-      "label": "Admin API key",
-      "help": "An Anthropic Admin API key with permission to read usage and cost data. Generate one in the Anthropic Console under Settings > Admin Keys.",
-      "editable": true,
-      "required": true,
-      "password": {}
+      "auth_name": "Admin API key",
+      "bearer_token": {
+        "password_setting": {
+          "key": "api_key",
+          "label": "Admin API key",
+          "help": "An Anthropic Admin API key with permission to read usage and cost data. Generate one in the Anthropic Console under Settings > Admin Keys.",
+          "editable": true,
+          "required": true,
+          "password": {}
+        }
+      }
     }
   ],
   "dataflow_config": [

--- a/proofpoint_on_demand/assets/account_config.json
+++ b/proofpoint_on_demand/assets/account_config.json
@@ -1,4 +1,19 @@
 {
+  "supported_auth_methods": [
+    {
+      "auth_name": "API Key",
+      "bearer_token": {
+        "password_setting": {
+          "key": "api_key",
+          "label": "API Key",
+          "help": "The API key of your Proofpoint On-Demand instance.",
+          "editable": true,
+          "required": true,
+          "password": {}
+        }
+      }
+    }
+  ],
   "additional_config_fields": [
     {
       "key": "cluster_id",
@@ -7,14 +22,6 @@
       "editable": true,
       "required": true,
       "text": {}
-    },
-    {
-      "key": "api_key",
-      "label": "API Key",
-      "help": "The API key of your Proofpoint On-Demand instance.",
-      "editable": true,
-      "required": true,
-      "password": {}
     }
   ]
 }

--- a/zerofox_cloud_platform/assets/account_config.json
+++ b/zerofox_cloud_platform/assets/account_config.json
@@ -1,21 +1,25 @@
 {
-  "supported_auth_methods": [],
-  "additional_config_fields": [
+  "supported_auth_methods": [
     {
-      "text": {},
-      "key": "username",
-      "label": "Username",
-      "help": "ZeroFox Username.",
-      "editable": true,
-      "required": true
-    },
-    {
-      "password": {},
-      "key": "password",
-      "label": "password",
-      "help": "ZeroFox Password.",
-      "editable": true,
-      "required": true
+      "auth_name": "Username & Password",
+      "basic": {
+        "user_setting": {
+          "text": {},
+          "key": "username",
+          "label": "Username",
+          "help": "ZeroFox Username.",
+          "editable": true,
+          "required": true
+        },
+        "password_setting": {
+          "password": {},
+          "key": "password",
+          "label": "password",
+          "help": "ZeroFox Password.",
+          "editable": true,
+          "required": true
+        }
+      }
     }
   ],
   "dataflow_config": [


### PR DESCRIPTION
Four tiles declared account-level credential fields as raw entries in `additional_config_fields`. Credential fields belong in the `supported_auth_methods` block, so this declares each one as a proper auth method instead, matching the expected account config structure.

### Changes

| Integration | Field(s) moved | Auth method | `auth_name` |
|---|---|---|---|
| `anthropic_compliance_logs` | `api_key` | `bearer_token` | Admin API key |
| `anthropic_usage_and_costs` | `api_key` | `bearer_token` | Admin API key |
| `proofpoint_on_demand` | `api_key` | `bearer_token` | API Key |
| `zerofox_cloud_platform` | `username` + `password` | `basic` | Username & Password |

Notes:

- `proofpoint_on_demand` keeps `cluster_id` in `additional_config_fields` — it is not a credential, and `text` is an allowed account-level field type. It is the only one of the four that retains a top-level `additional_config_fields` block; in the other three the array was left empty by the move and has been removed.
- `zerofox_cloud_platform` uses the `basic` arm rather than `bearer_token`, since it is a username/password pair, and populates its already-present empty `supported_auth_methods` array.
- `proofpoint_on_demand` has no `dataflow_config`. In the other three files `dataflow_config` is unchanged, including the nested per-dataflow fields.
- Each `auth_name` reuses the tile's existing field label. Existing integrations in this repo are inconsistent here — some use display strings, others snake_case slugs — so happy to align if there is a preferred convention.

### Existing accounts

Every field `key` is deliberately unchanged: `api_key` on the three bearer-token tiles, `username` / `password` on zerofox, and proofpoint's retained `cluster_id`. Credentials are resolved by key rather than by position in the document, so already-configured accounts keep resolving the same stored credential and no backfill is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)