### PR TITLE
Fix MongoDB process CPU collection on Windows and for idle nodes

### DIFF
--- a/mongo/changelog.d/25200.fixed
+++ b/mongo/changelog.d/25200.fixed
@@ -1,0 +1,1 @@
+Fix MongoDB process CPU collection, which reported nothing on Windows and never submitted ``mongodb.system.cpu.percent`` on any platform.

--- a/mongo/datadog_checks/mongo/collectors/process_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/process_stats.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from pathlib import PureWindowsPath
+
 import psutil
 from pymongo.errors import OperationFailure
 
@@ -18,7 +20,6 @@ class ProcessStatsCollector(MongoCollector):
     def __init__(self, check, tags):
         super(ProcessStatsCollector, self).__init__(check, tags)
         self._clean_server_name = check._config.clean_server_name
-        self._process = None
 
     @property
     def is_localhost(self):
@@ -34,12 +35,21 @@ class ProcessStatsCollector(MongoCollector):
         )
         return deployment.hosting_type == HostingType.SELF_HOSTED and self.is_localhost
 
+    @staticmethod
+    def _executable_name(process_name):
+        """Reduce the serverStatus `process` field to a bare executable name."""
+        if not process_name:
+            return None
+        # MongoDB derives that field from argv[0] but only strips POSIX separators, so on Windows
+        # it can be a full path where psutil reports just the executable name.
+        return PureWindowsPath(process_name).name
+
     def _get_pid_and_process_name(self, api):
         """Fetch PID and process name from MongoDB serverStatus."""
         try:
             server_status = api.server_status()
             pid = server_status.get("pid")
-            process_name = server_status.get("process")
+            process_name = self._executable_name(server_status.get("process"))
             if not pid or not process_name:
                 self.log.warning("PID or process name not found in serverStatus.")
             return pid, process_name
@@ -68,8 +78,10 @@ class ProcessStatsCollector(MongoCollector):
 
     def _get_mongo_process(self, api):
         """Retrieve the MongoDB process using either PID or process name."""
-        if self._process:
-            return self._process
+        cached_process = self.check._mongo_process
+        # is_running() compares creation time, so a restarted mongod or a reused PID is rejected.
+        if cached_process is not None and cached_process.is_running():
+            return cached_process, False
 
         # Try to get the PID and process name from serverStatus
         pid, process_name = self._get_pid_and_process_name(api)
@@ -84,20 +96,22 @@ class ProcessStatsCollector(MongoCollector):
         if not process:
             self.log.warning("Unable to retrieve MongoDB process.")
 
-        self._process = process
-        return self._process
+        self.check._mongo_process = process
+        return process, True
 
     def collect(self, api):
-        process = self._get_mongo_process(api)
+        process, newly_resolved = self._get_mongo_process(api)
         if not process:
             return
 
         try:
-            if (cpu_percent := process.cpu_percent()) != 0:
-                # the first call of cpu_percent is 0.0 and should be ignored
-                # the cpu_percent can be > 100% if the process has multiple threads
-                self._submit_payload({"system": {"cpu_percent": cpu_percent}})
-            else:
-                self.log.warning("The MongoDB process with PID %s is not consuming CPU", process.pid)
+            cpu_percent = process.cpu_percent()
+            if newly_resolved:
+                # psutil returns 0.0 the first time a process is sampled, so skip that run rather
+                # than the value, which lets a genuinely idle node report 0%.
+                self.log.debug("Ignoring first CPU sample for MongoDB process with PID %s", process.pid)
+                return
+            # the cpu_percent can be > 100% if the process has multiple threads
+            self._submit_payload({"system": {"cpu_percent": cpu_percent}})
         except Exception as e:
             self.log.error("Failed to collect process stats for MongoDB process with PID %s: %s", process.pid, e)

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -98,6 +98,8 @@ class MongoDb(AgentCheck):
         self.collectors = []
         self.last_states_by_server = {}
         self.metrics_last_collection_timestamp = {}
+        # Held here rather than on ProcessStatsCollector, which is rebuilt every run.
+        self._mongo_process = None
 
         self.deployment_type = None
         self._mongo_version = None

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -1208,6 +1208,9 @@ def test_integration_localhost_process_stats(instance_integration, aggregator, c
             with mock.patch('psutil.Process') as mock_process:
                 mock_process.return_value.name.return_value = 'mongos'
                 mock_process.return_value.cpu_percent.return_value = 20.0
+                # psutil's first cpu_percent() sample on a process is meaningless and is skipped,
+                # so process CPU is only reported from the run after the process is resolved.
+                dd_run_check(mongo_check)
                 dd_run_check(mongo_check)
 
     metrics_categories = [

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -16,7 +16,7 @@ from pymongo.errors import ConnectionFailure, OperationFailure
 from datadog_checks.base import ConfigurationError
 from datadog_checks.base.utils.db.sql import compute_exec_plan_signature
 from datadog_checks.mongo.api import CRITICAL_FAILURE, MongoApi
-from datadog_checks.mongo.collectors import MongoCollector
+from datadog_checks.mongo.collectors import MongoCollector, ProcessStatsCollector
 from datadog_checks.mongo.common import MongosDeployment, ReplicaSetDeployment, get_state_name
 from datadog_checks.mongo.dbm.utils import get_explain_plan, should_explain_operation
 from datadog_checks.mongo.mongo import HostingType, MongoDb, metrics
@@ -1024,3 +1024,123 @@ def test_get_explain_plan_adds_cursor_for_aggregate(command, expected_cursor):
             assert captured_command["cursor"] == command["cursor"]
         else:
             assert "cursor" not in captured_command, f"cursor should not be added for {command}"
+
+
+class FakePsutilProcess:
+    """
+    Stand-in for `psutil.Process`: `cpu_percent()` returns 0.0 the first time it is called on a
+    given object, and a real measurement afterwards.
+    """
+
+    def __init__(self, pid, name, cpu_percent=12.5, running=True):
+        self.pid = pid
+        self._name = name
+        self._cpu_percent = cpu_percent
+        self._running = running
+        self._sampled = False
+
+    def name(self):
+        return self._name
+
+    def is_running(self):
+        return self._running
+
+    def as_dict(self, attrs=None, ad_value=None):
+        # process_iter() populates `info` through as_dict.
+        return {'pid': self.pid, 'name': self._name}
+
+    def cpu_percent(self):
+        if not self._sampled:
+            self._sampled = True
+            return 0.0
+        return self._cpu_percent
+
+
+def run_process_stats(mongo_check, api, times=1):
+    """Collect `times` times, rebuilding the collector each run as `_collect_metrics` does."""
+    for _ in range(times):
+        ProcessStatsCollector(mongo_check, []).collect(api)
+
+
+@pytest.mark.parametrize(
+    ('reported_process', 'psutil_name'),
+    [
+        pytest.param('mongod', 'mongod', id='posix-bare-name'),
+        pytest.param('mongos', 'mongos', id='posix-mongos'),
+        pytest.param(r'C:\GetSmart\CE_MongoDB\bin\mongod.exe', 'mongod.exe', id='windows-absolute-path'),
+        pytest.param(r'C:\Program Files\MongoDB\Server\8.0\bin\mongod.exe', 'mongod.exe', id='windows-path-with-space'),
+    ],
+)
+def test_process_stats_resolves_process_regardless_of_reported_path(
+    check, instance_integration, aggregator, reported_process, psutil_name
+):
+    """
+    The process is resolved whether serverStatus reports a bare name or a Windows absolute path.
+    """
+    mongo_check = check(instance_integration)
+    api = mock.MagicMock()
+    api.server_status.return_value = {'pid': 4321, 'process': reported_process}
+
+    with mock.patch('psutil.Process', return_value=FakePsutilProcess(4321, psutil_name)):
+        run_process_stats(mongo_check, api, times=2)
+
+    aggregator.assert_metric('mongodb.system.cpu.percent', value=12.5, count=1)
+
+
+def test_process_stats_survives_collector_rebuild(check, instance_integration, aggregator):
+    """
+    The resolved process outlives the collector, which the check rebuilds on every run.
+    """
+    mongo_check = check(instance_integration)
+    api = mock.MagicMock()
+    api.server_status.return_value = {'pid': 4321, 'process': 'mongod'}
+    process = FakePsutilProcess(4321, 'mongod')
+
+    with mock.patch('psutil.Process', return_value=process) as process_ctor:
+        run_process_stats(mongo_check, api, times=1)
+        aggregator.assert_metric('mongodb.system.cpu.percent', count=0)  # first sample is 0%
+
+        run_process_stats(mongo_check, api, times=3)
+
+    aggregator.assert_metric('mongodb.system.cpu.percent', value=12.5, count=3)
+    assert process_ctor.call_count == 1, 'the process should be resolved once, not once per run'
+
+
+def test_process_stats_recovers_after_mongod_restart(check, instance_integration, aggregator):
+    """
+    CPU collection moves onto the new PID after mongod restarts.
+    """
+    mongo_check = check(instance_integration)
+    api = mock.MagicMock()
+    api.server_status.return_value = {'pid': 111, 'process': 'mongod'}
+    old_process = FakePsutilProcess(111, 'mongod')
+    new_process = FakePsutilProcess(222, 'mongod', cpu_percent=44.0)
+
+    with mock.patch('psutil.Process', return_value=old_process):
+        run_process_stats(mongo_check, api, times=2)
+    aggregator.assert_metric('mongodb.system.cpu.percent', value=12.5, count=1)
+
+    # mongod restarts: the cached process is gone and serverStatus reports the new PID.
+    old_process._running = False
+    api.server_status.return_value = {'pid': 222, 'process': 'mongod'}
+    with mock.patch('psutil.Process', return_value=new_process):
+        run_process_stats(mongo_check, api, times=2)
+
+    aggregator.assert_metric('mongodb.system.cpu.percent', value=44.0, count=1)
+    assert mongo_check._mongo_process is new_process
+
+
+def test_process_stats_reports_genuinely_idle_node_as_zero(check, instance_integration, aggregator):
+    """
+    Only the first sample after resolving a process is discarded, so an idle node reports 0%.
+    """
+    mongo_check = check(instance_integration)
+    api = mock.MagicMock()
+    api.server_status.return_value = {'pid': 4321, 'process': 'mongod'}
+    idle_process = FakePsutilProcess(4321, 'mongod', cpu_percent=0.0)
+
+    with mock.patch('psutil.Process', return_value=idle_process):
+        run_process_stats(mongo_check, api, times=4)
+
+    # The first run is the discarded sample; the rest are real 0% measurements.
+    aggregator.assert_metric('mongodb.system.cpu.percent', value=0.0, count=3)


### PR DESCRIPTION
### What does this PR do?

Fixes MongoDB process CPU collection, which did not work on Windows and could not be reporting on other platforms. There are four related defects in `ProcessStatsCollector`, all confirmed on a Windows Server 2022 host running MongoDB as a service, and on Linux:

1. **The process is never resolved on Windows.** MongoDB builds `serverStatus.process` from `argv[0]` but strips POSIX path separators only ([`server_options_server_helpers.cpp#L63-L67`](https://github.com/mongodb/mongo/blob/master/src/mongo/db/server_options_server_helpers.cpp#L63-L67), surfaced at [`server_status_command.cpp#L136`](https://github.com/mongodb/mongo/blob/master/src/mongo/db/commands/server_status/server_status_command.cpp#L136)). A service launched as `C:\...\mongod.exe` contains no `/`, so the strip is a no-op and the full path is returned, while `psutil` reports `mongod.exe`. The names never match, the lookup falls through to a name search that also fails, and two warnings are logged on every run. The reported name is now reduced to a bare executable name, which is a no-op for the names POSIX nodes already report.

2. **`mongodb.system.cpu.percent` is never submitted on the primary path** `refresh_collectors()` runs on every check run and rebuilds `ProcessStatsCollector`, so `self._process` was reset each time and `psutil.cpu_percent()` was always a first call, which always returns `0.0`. The resolved process is now held on the check, which does outlive a single run.

3. **A process held across runs goes stale.** mongod restarts independently of the Agent and returns under a new PID. Without revalidation the collector stays pinned to the dead PID and logs an **error** every run until the Agent itself restarts, which is noisier than the bug being fixed. `is_running()` also compares process creation time, so it rejects a reused PID.

4. **Idle nodes were invisible and noisy.** `cpu_percent()` returns `0.0` both for "not sampled yet" and for "genuinely idle". The check gated on the *value* (`!= 0`) as a proxy for provenance, because a collector rebuilt every run could not know whether it had sampled before. Now that the process persists, the first sample after resolving one is skipped on that basis instead, so a genuinely idle node reports `0%` rather than warning. This matches [`process/datadog_checks/process/process.py#L330-L336`](https://github.com/DataDog/integrations-core/blob/master/process/datadog_checks/process/process.py#L330-L336), which uses a `new_process` flag for the same psutil behaviour.

Process CPU is no longer reported on the first check run after a process is resolved (Agent start, or mongod restart). A newly resolved process has no baseline to measure against, so that sample was never meaningful; the existing integration test asserted otherwise only because it mocked `psutil.Process` to return a constant.

### Motivation

A customer reported Reported there were many noisy logs:

```
(process_stats.py:66) | No process found with the name C:\GetSmart\CE_MongoDB\bin\mongod.exe.
(process_stats.py:85) | Unable to retrieve MongoDB process.
```

Looking into this, I found that `mongodb.system.cpu.percent` was not reporting - this PR fixes both.

Verified end-to-end on a Windows Server 2022 VM with MongoDB installed as a service at a path matching the report, and on Linux:

- both warnings gone, and no warning of any kind replaces them, on a busy **and** an idle node
- `mongodb.system.cpu.percent` reported continuously where it previously never appeared
- CPU collection recovers onto the new PID after a mongod restart, with no error loop
- on Linux the reported process name is already bare, so the normalization is a no-op and behaviour is unchanged

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Add `qa/required` if this PR needs QA validation, or `qa/skip-qa` if it does not. Exactly one of the two is required.
- [ ] If you need to backport this PR to another branch, you can add the `backport/<branch-name>` label to the PR and it will automatically open a backport PR once this one is merged
